### PR TITLE
feat(web): cross-module prompts with anti-nag fatigue tracking (UX wave-4 #4)

### DIFF
--- a/apps/web/src/modules/finyk/FinykApp.tsx
+++ b/apps/web/src/modules/finyk/FinykApp.tsx
@@ -13,6 +13,8 @@ import {
 import { SectionErrorBoundary } from "@shared/components/ui/SectionErrorBoundary";
 import { cn } from "@shared/lib/cn";
 import { useToast } from "@shared/hooks/useToast";
+import { tryShowCrossModulePrompt } from "@shared/lib/crossModulePrompt";
+import { openHubModuleWithAction } from "@shared/lib/hubNav";
 import { Overview } from "./pages/Overview";
 import { Transactions } from "./pages/Transactions";
 import { Budgets } from "./pages/Budgets";
@@ -480,9 +482,34 @@ export default function App({
           if (expense?.id) {
             storage.editManualExpense?.(expense.id, expense);
             toast.success("Витрату оновлено.");
-          } else {
-            storage.addManualExpense(expense);
-            toast.success("Витрату додано.");
+            return;
+          }
+          storage.addManualExpense(expense);
+          toast.success("Витрату додано.");
+
+          // Cross-module nudge (UX wave-4 #4):
+          // After a Кафе/Ресторан/Продукти save, suggest logging the
+          // matching meal in Nutrition. Suppressed automatically after
+          // ≥3 dismissals in 14 days or 12 h after the user accepts —
+          // see `docs/design/CROSS-MODULE-PROMPTS.md`.
+          const cat = String(expense?.category || "");
+          const promptId =
+            cat === "restaurant"
+              ? "finyk-restaurant-to-meal"
+              : cat === "food"
+                ? "finyk-food-to-meal"
+                : null;
+          if (promptId) {
+            const msg =
+              promptId === "finyk-restaurant-to-meal"
+                ? "Додати прийом їжі з ресторану?"
+                : "Додати прийом їжі з продуктів?";
+            tryShowCrossModulePrompt(toast, {
+              id: promptId,
+              msg,
+              acceptLabel: "Додати →",
+              onAccept: () => openHubModuleWithAction("nutrition", "add_meal"),
+            });
           }
         }}
       />

--- a/apps/web/src/modules/fizruk/components/workouts/WorkoutFinishSheets.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/WorkoutFinishSheets.tsx
@@ -4,6 +4,10 @@ import { Button } from "@shared/components/ui/Button";
 import { cn } from "@shared/lib/cn";
 import { useDialogFocusTrap } from "@shared/hooks/useDialogFocusTrap";
 import { openHubModule } from "@shared/lib/hubNav";
+import {
+  isCrossModulePromptSuppressed,
+  recordCrossModulePromptAccepted,
+} from "@shared/lib/crossModulePrompt";
 import { formatDurShort } from "@sergeant/fizruk-domain";
 
 export function WorkoutFinishSheets({
@@ -223,18 +227,27 @@ export function WorkoutFinishSheets({
                 </div>
               )}
             <div className="flex flex-col gap-2 p-3 bg-panel">
-              <button
-                type="button"
-                className="w-full text-xs text-muted hover:text-text transition-colors py-1.5 flex items-center justify-center gap-1.5"
-                onClick={() => {
-                  setFinishFlash(null);
-                  openHubModule("nutrition", "log");
-                }}
-              >
-                <span aria-hidden>🥩</span>
-                <span>Додати білок після тренування</span>
-                <span aria-hidden>→</span>
-              </button>
+              {/* Cross-module nudge → Nutrition. Inline (not a toast)
+                  because the finish-sheet itself is the natural moment
+                  to suggest. Snoozed for 12 h after acceptance so a
+                  user who logged a post-workout meal once today doesn't
+                  see this on a second workout the same evening. See
+                  docs/design/CROSS-MODULE-PROMPTS.md. */}
+              {!isCrossModulePromptSuppressed("fizruk-finish-to-meal") && (
+                <button
+                  type="button"
+                  className="w-full text-xs text-muted hover:text-text transition-colors py-1.5 flex items-center justify-center gap-1.5"
+                  onClick={() => {
+                    recordCrossModulePromptAccepted("fizruk-finish-to-meal");
+                    setFinishFlash(null);
+                    openHubModule("nutrition", "log");
+                  }}
+                >
+                  <span aria-hidden>🥩</span>
+                  <span>Додати білок після тренування</span>
+                  <span aria-hidden>→</span>
+                </button>
+              )}
               <div className="flex gap-2">
                 <Button
                   variant="ghost"

--- a/apps/web/src/shared/lib/crossModulePrompt.test.ts
+++ b/apps/web/src/shared/lib/crossModulePrompt.test.ts
@@ -1,0 +1,189 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { ToastApi } from "@shared/hooks/useToast";
+import {
+  ACCEPT_SNOOZE_MS,
+  FATIGUE_WINDOW_MS,
+  MAX_DISMISSALS,
+  isCrossModulePromptSuppressed,
+  recordCrossModulePromptAccepted,
+  recordCrossModulePromptDismissed,
+  resetCrossModulePromptForTesting,
+  tryShowCrossModulePrompt,
+} from "./crossModulePrompt";
+
+const ID = "finyk-restaurant-to-meal";
+
+interface CapturedAction {
+  label: string;
+  onClick: () => void;
+}
+
+interface MockToast extends ToastApi {
+  readonly _action: CapturedAction | null;
+}
+
+function makeToast(): MockToast {
+  const ref: { current: CapturedAction | null } = { current: null };
+  const api: ToastApi = {
+    show: vi.fn((_msg, _type, _duration, action) => {
+      if (action) ref.current = action;
+      return 7;
+    }),
+    success: vi.fn(() => 1),
+    error: vi.fn(() => 2),
+    info: vi.fn(() => 3),
+    warning: vi.fn(() => 4),
+    dismiss: vi.fn(),
+  };
+  Object.defineProperty(api, "_action", {
+    get: () => ref.current,
+    enumerable: true,
+  });
+  return api as MockToast;
+}
+
+describe("crossModulePrompt — suppression", () => {
+  beforeEach(() => {
+    resetCrossModulePromptForTesting(ID);
+    navigator.vibrate = vi.fn();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    resetCrossModulePromptForTesting(ID);
+  });
+
+  it("not suppressed by default", () => {
+    expect(isCrossModulePromptSuppressed(ID)).toBe(false);
+  });
+
+  it(`suppressed after ${MAX_DISMISSALS} dismissals in window`, () => {
+    for (let i = 0; i < MAX_DISMISSALS; i++) {
+      recordCrossModulePromptDismissed(ID);
+    }
+    expect(isCrossModulePromptSuppressed(ID)).toBe(true);
+  });
+
+  it("dismissals older than window do NOT count", () => {
+    const longAgo = Date.now() - FATIGUE_WINDOW_MS - 1000;
+    for (let i = 0; i < MAX_DISMISSALS; i++) {
+      recordCrossModulePromptDismissed(ID, longAgo);
+    }
+    expect(isCrossModulePromptSuppressed(ID)).toBe(false);
+  });
+
+  it("acceptance snoozes for ACCEPT_SNOOZE_MS, then re-enables", () => {
+    const t0 = 1_000_000;
+    recordCrossModulePromptAccepted(ID, t0);
+    expect(isCrossModulePromptSuppressed(ID, t0 + 1000)).toBe(true);
+    expect(isCrossModulePromptSuppressed(ID, t0 + ACCEPT_SNOOZE_MS + 1)).toBe(
+      false,
+    );
+  });
+
+  it("acceptance resets dismissal counter", () => {
+    const t0 = 2_000_000;
+    for (let i = 0; i < MAX_DISMISSALS; i++) {
+      recordCrossModulePromptDismissed(ID, t0 - 1000 + i);
+    }
+    expect(isCrossModulePromptSuppressed(ID, t0)).toBe(true);
+    recordCrossModulePromptAccepted(ID, t0);
+    // 12h+1ms after accept → snooze elapsed AND counter was wiped
+    expect(isCrossModulePromptSuppressed(ID, t0 + ACCEPT_SNOOZE_MS + 1)).toBe(
+      false,
+    );
+  });
+});
+
+describe("tryShowCrossModulePrompt", () => {
+  beforeEach(() => {
+    resetCrossModulePromptForTesting(ID);
+    navigator.vibrate = vi.fn();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    resetCrossModulePromptForTesting(ID);
+  });
+
+  it("shows the toast and returns true when not suppressed", () => {
+    const toast = makeToast();
+    const onAccept = vi.fn();
+
+    const shown = tryShowCrossModulePrompt(toast, {
+      id: ID,
+      msg: "Додай прийом їжі?",
+      acceptLabel: "Додати",
+      onAccept,
+    });
+
+    expect(shown).toBe(true);
+    expect(toast.show).toHaveBeenCalledTimes(1);
+    const call = (toast.show as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[0]).toBe("Додай прийом їжі?");
+    expect(call[1]).toBe("info");
+    expect(call[3]?.label).toBe("Додати");
+  });
+
+  it("returns false and does NOT call toast.show when suppressed", () => {
+    for (let i = 0; i < MAX_DISMISSALS; i++) {
+      recordCrossModulePromptDismissed(ID);
+    }
+    const toast = makeToast();
+
+    const shown = tryShowCrossModulePrompt(toast, {
+      id: ID,
+      msg: "x",
+      acceptLabel: "y",
+      onAccept: vi.fn(),
+    });
+
+    expect(shown).toBe(false);
+    expect(toast.show).not.toHaveBeenCalled();
+  });
+
+  it("CTA tap → calls onAccept and snoozes the prompt", () => {
+    const toast = makeToast();
+    const onAccept = vi.fn();
+
+    tryShowCrossModulePrompt(toast, {
+      id: ID,
+      msg: "x",
+      acceptLabel: "y",
+      onAccept,
+    });
+
+    toast._action?.onClick();
+    expect(onAccept).toHaveBeenCalledTimes(1);
+    expect(toast.dismiss).toHaveBeenCalledWith(7);
+    // Snoozed immediately after acceptance
+    expect(isCrossModulePromptSuppressed(ID)).toBe(true);
+  });
+
+  it("auto-dismiss (no CTA tap) increments dismissal counter", () => {
+    const toast = makeToast();
+
+    tryShowCrossModulePrompt(toast, {
+      id: ID,
+      msg: "x",
+      acceptLabel: "y",
+      onAccept: vi.fn(),
+      duration: 1000,
+    });
+
+    // Run pending timers — fast-forwards the post-toast dismissal check
+    vi.advanceTimersByTime(2000);
+
+    // Dismissed once; not yet suppressed (need MAX_DISMISSALS).
+    expect(isCrossModulePromptSuppressed(ID)).toBe(false);
+
+    // 2 more dismissals → suppression kicks in.
+    for (let i = 0; i < MAX_DISMISSALS - 1; i++) {
+      recordCrossModulePromptDismissed(ID);
+    }
+    expect(isCrossModulePromptSuppressed(ID)).toBe(true);
+  });
+});

--- a/apps/web/src/shared/lib/crossModulePrompt.ts
+++ b/apps/web/src/shared/lib/crossModulePrompt.ts
@@ -1,0 +1,187 @@
+import type { ToastApi } from "@shared/hooks/useToast";
+import { hapticTap } from "./haptic";
+import { safeReadLS, safeRemoveLS, safeWriteLS } from "./storage";
+
+/**
+ * Cross-module nudges — small, dismissible toast prompts that suggest a
+ * follow-up action in another module after the user does something in
+ * the current module. See `docs/design/CROSS-MODULE-PROMPTS.md` for the
+ * full pattern + decision table.
+ *
+ * Examples:
+ *  - User saves a "🍔 Кафе та ресторани" expense in Finyk
+ *    → suggest "Додай прийом їжі?" toast linking to Nutrition.
+ *  - User finishes a workout in Fizruk
+ *    → suggest "Додати білок після тренування?" linking to Nutrition.
+ *
+ * Hard rules:
+ *  - **Opt-out is one tap.** Same toast that surfaces the prompt also
+ *    has the dismiss / "далі сам" path.
+ *  - **Auto-suppress after fatigue.** If the user dismisses the same
+ *    `id` ≥ `MAX_DISMISSALS` times within `FATIGUE_WINDOW_MS`, stop
+ *    showing it for that window. We don't want Sergeant to nag.
+ *  - **Snooze on accept.** When the user accepts, suppress the same
+ *    prompt for `ACCEPT_SNOOZE_MS` so the next save doesn't re-pop the
+ *    toast they're literally responding to.
+ *  - **Never block flow.** This is a toast (3.5–5 s), never a modal,
+ *    never a sheet. The original action has already succeeded; the
+ *    prompt is a *suggestion*.
+ */
+
+/** localStorage key prefix; one record per prompt id. */
+const STORAGE_PREFIX = "sergeant:cross-prompt:";
+/** Dismiss this many times within the window → suppress. */
+export const MAX_DISMISSALS = 3;
+/** Window (ms) over which dismissals count toward fatigue. */
+export const FATIGUE_WINDOW_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
+/** After acceptance, don't re-show this prompt for this long. */
+export const ACCEPT_SNOOZE_MS = 12 * 60 * 60 * 1000; // 12 hours
+/** Default toast duration for cross-module prompts. */
+export const DEFAULT_PROMPT_DURATION_MS = 6000;
+
+/**
+ * Stable identifier for a prompt class. Add new ids here so the type
+ * system catches typos at every call-site.
+ */
+export type CrossModulePromptId =
+  | "finyk-restaurant-to-meal"
+  | "finyk-food-to-meal"
+  | "fizruk-finish-to-meal";
+
+interface PromptRecord {
+  /** Timestamps (ms) of the last few dismiss events, oldest → newest. */
+  dismissedAt: number[];
+  /** Timestamp (ms) of the last acceptance, or 0 if none. */
+  lastAcceptedAt: number;
+}
+
+const EMPTY_RECORD: PromptRecord = { dismissedAt: [], lastAcceptedAt: 0 };
+
+function readRecord(id: CrossModulePromptId): PromptRecord {
+  const parsed = safeReadLS<Partial<PromptRecord>>(STORAGE_PREFIX + id, null);
+  if (!parsed || typeof parsed !== "object") return { ...EMPTY_RECORD };
+  const dismissedAt = Array.isArray(parsed.dismissedAt)
+    ? parsed.dismissedAt.filter((n): n is number => typeof n === "number")
+    : [];
+  const lastAcceptedAt =
+    typeof parsed.lastAcceptedAt === "number" ? parsed.lastAcceptedAt : 0;
+  return { dismissedAt, lastAcceptedAt };
+}
+
+function writeRecord(id: CrossModulePromptId, record: PromptRecord): void {
+  safeWriteLS(STORAGE_PREFIX + id, record);
+}
+
+/**
+ * Returns true when this prompt should NOT be shown right now (either
+ * fatigue-suppressed or recently accepted). Pure read — no mutation.
+ */
+export function isCrossModulePromptSuppressed(
+  id: CrossModulePromptId,
+  now: number = Date.now(),
+): boolean {
+  const rec = readRecord(id);
+  if (rec.lastAcceptedAt && now - rec.lastAcceptedAt < ACCEPT_SNOOZE_MS) {
+    return true;
+  }
+  const recentDismissals = rec.dismissedAt.filter(
+    (t) => now - t < FATIGUE_WINDOW_MS,
+  );
+  return recentDismissals.length >= MAX_DISMISSALS;
+}
+
+/**
+ * Record an acceptance. Snoozes the prompt for `ACCEPT_SNOOZE_MS`.
+ * Resets the dismissal counter so the user starts "fresh" after they
+ * engaged with it.
+ */
+export function recordCrossModulePromptAccepted(
+  id: CrossModulePromptId,
+  now: number = Date.now(),
+): void {
+  writeRecord(id, { dismissedAt: [], lastAcceptedAt: now });
+}
+
+/**
+ * Record a dismissal. Trims the history to entries within the fatigue
+ * window so suppression is rolling (not lifetime).
+ */
+export function recordCrossModulePromptDismissed(
+  id: CrossModulePromptId,
+  now: number = Date.now(),
+): void {
+  const rec = readRecord(id);
+  const recent = rec.dismissedAt.filter((t) => now - t < FATIGUE_WINDOW_MS);
+  recent.push(now);
+  writeRecord(id, {
+    dismissedAt: recent.slice(-MAX_DISMISSALS),
+    lastAcceptedAt: rec.lastAcceptedAt,
+  });
+}
+
+/** Test-only: clear a single prompt's record. */
+export function resetCrossModulePromptForTesting(
+  id: CrossModulePromptId,
+): void {
+  safeRemoveLS(STORAGE_PREFIX + id);
+}
+
+export interface CrossModulePromptOptions {
+  /** Stable id used for fatigue tracking. */
+  id: CrossModulePromptId;
+  /** Toast body (e.g. "Додай прийом їжі?"). */
+  msg: string;
+  /** CTA label on the toast (e.g. "Додати"). */
+  acceptLabel: string;
+  /** Called when user accepts. Open the target module here. */
+  onAccept: () => void;
+  /** Override toast duration; default `DEFAULT_PROMPT_DURATION_MS`. */
+  duration?: number;
+}
+
+/**
+ * Show a cross-module nudge as an `info` toast with a single CTA.
+ *
+ * Returns `true` if the toast was shown, `false` if suppressed by
+ * fatigue / acceptance snooze. Callers should ignore the return value
+ * — the boolean exists only for tests / metrics.
+ *
+ * The toast auto-dismiss path (timeout) counts as a dismissal: not
+ * showing interest after 6 s is feedback. The explicit-X path is the
+ * same — we treat both as "user said no". This is intentional, since
+ * Sergeant has no third state ("don't ask now but maybe later").
+ */
+export function tryShowCrossModulePrompt(
+  toast: ToastApi,
+  opts: CrossModulePromptOptions,
+): boolean {
+  if (isCrossModulePromptSuppressed(opts.id)) return false;
+
+  let accepted = false;
+  const id = toast.show(
+    opts.msg,
+    "info",
+    opts.duration ?? DEFAULT_PROMPT_DURATION_MS,
+    {
+      label: opts.acceptLabel,
+      onClick: () => {
+        accepted = true;
+        hapticTap();
+        recordCrossModulePromptAccepted(opts.id);
+        toast.dismiss(id);
+        opts.onAccept();
+      },
+    },
+  );
+
+  // Schedule a "did the user act?" check just after the toast's
+  // natural dismissal. If they neither tapped accept nor were still
+  // engaged, we count it as a soft dismissal so the fatigue counter
+  // moves. We add a small buffer so we run after `dismiss()` fires.
+  const checkAfter = (opts.duration ?? DEFAULT_PROMPT_DURATION_MS) + 250;
+  window.setTimeout(() => {
+    if (!accepted) recordCrossModulePromptDismissed(opts.id);
+  }, checkAfter);
+
+  return true;
+}

--- a/docs/design/CROSS-MODULE-PROMPTS.md
+++ b/docs/design/CROSS-MODULE-PROMPTS.md
@@ -1,0 +1,226 @@
+# Cross-module prompts — pattern, fatigue, anti-nag
+
+> Sergeant — це 4 модулі (Finyk · Fizruk · Routine · Nutrition), що
+> часто зустрічаються в одному користувацькому дні. Cross-module
+> prompts перетворюють Sergeant з «4 окремих app-и» на «один інтегрований
+> асистент», пропонуючи next-step у _іншому_ модулі — без переривання
+> поточного flow.
+
+## TL;DR
+
+```ts
+import { tryShowCrossModulePrompt } from "@shared/lib/crossModulePrompt";
+import { openHubModuleWithAction } from "@shared/lib/hubNav";
+
+tryShowCrossModulePrompt(toast, {
+  id: "finyk-restaurant-to-meal",
+  msg: "Додати прийом їжі з ресторану?",
+  acceptLabel: "Додати →",
+  onAccept: () => openHubModuleWithAction("nutrition", "add_meal"),
+});
+```
+
+Toast (info, 6 s) з'являється _після_ успіху основної дії. Auto-dismiss
+
+- trim history. Прокидати ≥3 рази за 14 днів — auto-suppress; tap accept
+  → snooze на 12 годин.
+
+## Чому окрема система, не просто `toast.info`
+
+`toast.info("...")` ідеально підходить для одноразової інфи. Але
+крос-модульний nudge має 3 додаткових вимоги:
+
+1. **Anti-nag.** Якщо користувач 3 рази вже сказав «ні» на «додай прийом
+   їжі», 4-й раз показувати — це мінус довіра до продукту.
+2. **Snooze on accept.** Якщо щойно прийняв, відкрив Nutrition,
+   повернувся до Finyk і додав ще одну витрату — не повторювати той же
+   prompt. Минула дія вже виконана.
+3. **Stable id.** Той самий prompt не змінює свого «лічильника втоми»
+   через рандомну суфіксацію. ID — типізований союз (`CrossModulePromptId`).
+
+## Anti-nag механіка
+
+```
+              ┌─ User dismisses (auto-timeout / X)
+              ▼
+          dismissedAt[] += [now]
+              │
+              ▼
+   if dismissedAt.filter(t > now-14d).length >= 3:
+       → suppress for 14 days from oldest qualifying dismiss
+              │
+              │ ─── User accepts ───
+              ▼
+       lastAcceptedAt = now
+       dismissedAt = []          ← reset, fair start
+       suppress for 12 hours
+```
+
+- **MAX_DISMISSALS = 3** — поріг втоми. Меньше — навʼязливо; більше —
+  pattern не самовидаляється.
+- **FATIGUE_WINDOW_MS = 14 days** — rolling. Раз на місяць забутий
+  prompt — fine, він повертається.
+- **ACCEPT_SNOOZE_MS = 12 hours** — приблизно один день. Захищає від
+  «додав витрату → відкрив meal → повернувся → додав ще витрату» loop.
+- **Acceptance resets dismissal counter** — користувач дає сигнал «це
+  цінно мені», лічильник «cтомленості» обнуляється.
+
+## Шаблон Finyk → Nutrition (реалізовано)
+
+**Trigger:** save manual expense у Finyk з категорією `restaurant`
+(MCC 5812/5813/5814) або `food` (MCC 5411/5412/…).
+
+**Prompt:** info-toast «Додати прийом їжі з ресторану?» + CTA
+«Додати →».
+
+**Action:** `openHubModuleWithAction("nutrition", "add_meal")` —
+переключає Hub в Nutrition + ініціює add-meal-action (PWA-shortcut
+семантика).
+
+**Не trigger:** редагування існуючої витрати (тільки нові). Якщо
+користувач передумав і виправив категорію — це не окрема нова подія,
+prompt би створив шум.
+
+## Шаблон Fizruk finish → Nutrition (вдосконалено)
+
+`WorkoutFinishSheets` уже мав inline-link «Додати білок після тренування
+→». Цей PR додає `isCrossModulePromptSuppressed("fizruk-finish-to-meal")`
+guard:
+
+- Tap accept → 12 h snooze (другий workout того ж вечора не показує
+  prompt вдруге).
+- Acceptance recorded; dismiss-counter не торкається (inline-prompt не
+  має auto-timeout, тому користувач явно ігнорує його кожен раз ≠ tap-X).
+
+Якщо в майбутньому додамо явний "Не зараз" CTA, можна викликати
+`recordCrossModulePromptDismissed()` і отримати full anti-nag.
+
+## API
+
+```ts
+type CrossModulePromptId =
+  | "finyk-restaurant-to-meal"
+  | "finyk-food-to-meal"
+  | "fizruk-finish-to-meal";
+
+// Toast-style — full anti-nag.
+tryShowCrossModulePrompt(toast, {
+  id: CrossModulePromptId,
+  msg: string,
+  acceptLabel: string,
+  onAccept: () => void,
+  duration?: number,
+}): boolean;  // true if shown, false if suppressed
+
+// Inline-style — manual control.
+isCrossModulePromptSuppressed(id, now?): boolean;
+recordCrossModulePromptAccepted(id, now?): void;
+recordCrossModulePromptDismissed(id, now?): void;
+```
+
+> `tryShowCrossModulePrompt` — для toast-style, де користувач реально
+> бачить prompt і має чітке місце "tap accept / let it auto-close".
+> Inline-style API — для UI, що вже існує як persistent element
+> (WorkoutFinishSheets), де ми просто додаємо anti-nag поверх.
+
+## Decision table — коли додавати crossmodule prompt
+
+| Ситуація                                     | Prompt? | Чому                                               |
+| -------------------------------------------- | ------- | -------------------------------------------------- |
+| Витрата у ресторані (Finyk save)             | **Так** | High signal — почали їжу = ймовірний прийом        |
+| Витрата на продукти (Finyk save)             | **Так** | Те саме, slightly weaker signal                    |
+| Завершення тренування (Fizruk finish)        | **Так** | Window of intent: post-workout 30 min              |
+| Витрата на бензин (Finyk save, transport)    | Ні      | До чого це? Не trigger-ить інший модуль            |
+| Виконав звичку «Випив воду» (Routine toggle) | Ні      | Не cross-module — це закінчена дія в одному модулі |
+| Знизив вагу (Fizruk Body)                    | Ні      | Не trigger — нема next-action в іншому модулі      |
+| Створив бюджет (Finyk)                       | Ні      | Не consumer-action — це налаштування, не моментум  |
+
+**Правило:** prompt показується тоді, коли (а) основна дія ЩОЙНО
+завершилась, (б) у іншому модулі є логічний next-step, (в) timing
+window — короткий (хвилини, не години).
+
+## Anti-patterns
+
+```ts
+// ❌ BAD — без anti-nag, prompt буде дратувати
+toast.info("Додати прийом їжі?", 6000, {
+  label: "Додати",
+  onClick: () => openHubModule("nutrition"),
+});
+
+// ❌ BAD — динамічний id ламає лічильник втоми
+tryShowCrossModulePrompt(toast, {
+  id: `finyk-${expense.id}-to-meal`, // generates new id each time
+  ...
+});
+
+// ❌ BAD — prompt замість самої дії
+// "Додати прийом їжі? [Так/Ні]" — це modal-blocker, не nudge
+<ConfirmDialog ... />
+
+// ❌ BAD — prompt при редагуванні (повтори дратують)
+onSave: (expense) => {
+  if (expense.id) editExpense(expense);  // edit
+  else addExpense(expense);              // create
+  // prompt as user expects it only on creation moments
+  tryShowCrossModulePrompt(...);
+}
+
+// ✅ GOOD
+onSave: (expense) => {
+  if (expense.id) {
+    editExpense(expense);
+    return;  // no prompt on edit
+  }
+  addExpense(expense);
+  if (expense.category === "restaurant") {
+    tryShowCrossModulePrompt(toast, {
+      id: "finyk-restaurant-to-meal",
+      ...
+    });
+  }
+}
+```
+
+## Copy guidelines
+
+- **Question form** з `?`: «Додати прийом їжі?» — користувач відчуває,
+  що це opt-in.
+- **Avoid imperative** («Додай!» → дратує).
+- **CTA з → стрілкою**: «Додати →» — натякає на навігацію в інший
+  екран.
+- **Не описуй джерело**, описуй _next action_: «Додати прийом їжі»
+  > > «Ви були у ресторані, додайте прийом їжі» (другий — patronizing).
+
+## Testing
+
+```ts
+import {
+  resetCrossModulePromptForTesting,
+  isCrossModulePromptSuppressed,
+  recordCrossModulePromptDismissed,
+  MAX_DISMISSALS,
+} from "@shared/lib/crossModulePrompt";
+
+beforeEach(() => {
+  resetCrossModulePromptForTesting("finyk-restaurant-to-meal");
+});
+
+it("suppresses after MAX_DISMISSALS in window", () => {
+  for (let i = 0; i < MAX_DISMISSALS; i++) {
+    recordCrossModulePromptDismissed("finyk-restaurant-to-meal");
+  }
+  expect(isCrossModulePromptSuppressed("finyk-restaurant-to-meal")).toBe(true);
+});
+```
+
+`crossModulePrompt.test.ts` покриває 9 кейсів — fatigue, snooze,
+acceptance reset, suppression, CTA-tap → onAccept, auto-dismiss → counter.
+
+## Related docs
+
+- [`apps/web/src/shared/lib/crossModulePrompt.ts`](../../apps/web/src/shared/lib/crossModulePrompt.ts) — implementation.
+- [`apps/web/src/shared/lib/crossModulePrompt.test.ts`](../../apps/web/src/shared/lib/crossModulePrompt.test.ts) — contract tests.
+- [`apps/web/src/shared/lib/hubNav.ts`](../../apps/web/src/shared/lib/hubNav.ts) — `openHubModule` / `openHubModuleWithAction` (cross-module navigation primitive).
+- [`docs/design/UNDO-PATTERN.md`](./UNDO-PATTERN.md) — sister doc для destructive actions.
+- `AGENTS.md` § Soft rules — "Cross-module nudges".


### PR DESCRIPTION
## What changed

Sergeant — 4 модулі (Finyk · Fizruk · Routine · Nutrition), що зустрічаються в одному користувацькому дні. Цей PR робить інтеграційний pattern явним і безпечним.

### 1. `apps/web/src/shared/lib/crossModulePrompt.ts` (new)

Canonical lib для крос-модульних toast/inline nudge-ів з вбудованою **anti-nag** механікою.

```ts
tryShowCrossModulePrompt(toast, {
  id: "finyk-restaurant-to-meal",
  msg: "Додати прийом їжі з ресторану?",
  acceptLabel: "Додати →",
  onAccept: () => openHubModuleWithAction("nutrition", "add_meal"),
});
```

- **Storage** через `safeReadLS` / `safeWriteLS` (rule `no-raw-local-storage`).
- **MAX_DISMISSALS = 3**, **FATIGUE_WINDOW = 14 days** (rolling). Забутий prompt повертається через місяць.
- **ACCEPT_SNOOZE = 12 hours** + reset dismissal counter — acceptance це сильний сигнал «корисно».
- **Auto-dismiss = dismissal** — ігнор toast-а теж feedback, лічильник рухається.
- **`CrossModulePromptId`** — typed union, typo при call-site = compile error.

### 2. `crossModulePrompt.test.ts` (new) — 9 тестів

Покриває: default = не suppressed, fatigue threshold, window expiry, acceptance snooze + counter reset, suppression no-show, CTA-tap → onAccept + dismiss(7), auto-dismiss → counter.

### 3. Adoption #1 — Finyk → Nutrition (toast-style)

`FinykApp.tsx` `onSave`: після **нової** manual-витрати з категорією `restaurant` (MCC 5812/5813/5814) або `food` (5411+), fire prompt:
- «Додати прийом їжі з ресторану?» / «…з продуктів?»
- CTA «Додати →» → `openHubModuleWithAction("nutrition", "add_meal")`.
- НЕ trigger при редагуванні (edit ≠ нова подія, prompt би створив шум).

### 4. Adoption #2 — Fizruk finish → Nutrition (inline-style)

`WorkoutFinishSheets.tsx` уже мав inline-link «Додати білок після тренування →». Цей PR додає `isCrossModulePromptSuppressed("fizruk-finish-to-meal")` guard:
- Tap → `recordCrossModulePromptAccepted` → 12 h snooze (другий workout того ж вечора не показує prompt вдруге).
- Не дратує користувача, що щойно залогував meal.

### 5. `docs/design/CROSS-MODULE-PROMPTS.md` (new)

TL;DR recipe, anti-nag flowchart + рaтioналь магічних чисел (3, 14d, 12h), decision-table (ресторан → meal: ТАК; бензин → ?: НІ; виконав звичку → ?: НІ), 4 anti-patterns, copy guidelines (question form, → стрілка в CTA), testing recipe. Sister doc до `UNDO-PATTERN.md`.

## Why

Sergeant позиціонується як інтегрований асистент, а технічно існує як 4 окремі модулі. Cross-module prompts — найдешевший спосіб закрити цей розрив:
- Користувач у ресторані → витрата → природно хоче залогувати meal.
- Завершив workout → 30-хвилинне вікно інтенту до post-workout meal.

Без anti-nag prompts швидко перетворюються на шум:
- 3 кліки «ні» = система вчиться, що ця конкретна підказка нерелевантна цьому користувачу.
- 14 d rolling — раз на місяць забутий prompt не банить себе назавжди.
- Acceptance — найсильніший сигнал «корисно», counter wipes; 12 h snooze захищає від спаму в межах одного дня.

## How to test

1. **Finyk → Nutrition (toast):** додай нову витрату з категорією «🍔 Кафе та ресторани» → toast «Додати прийом їжі з ресторану? · Додати →» → tap → перемикає в Nutrition + ініціює add_meal.
2. **Anti-nag:** dismiss 3 рази (auto-timeout рахується) → 4-та витрата ресторан-категорії — toast НЕ показується (suppression до закінчення 14d window).
3. **Acceptance reset:** dismiss 3× → acceptance → суцільний slate; 12h snooze; після 12h+1 — prompt знов показується.
4. **Edit doesn't trigger:** редагуй існуючу ресторан-витрату — toast НЕ показується (тільки нові події).
5. **Fizruk finish snooze:** заверши workout → tap «Додати білок» → відкривається Nutrition → завершуй ще один workout у наступний 12 годин — link приховано.

## How AI-tested this PR

- [x] `pnpm exec prettier --write` — pass.
- [x] `pnpm exec eslint` (apps/web) — pass.
- [x] `pnpm --filter @sergeant/web exec tsc -p tsconfig.json --noEmit` — pass.
- [x] `pnpm --filter @sergeant/web exec vitest run src/shared/lib/crossModulePrompt.test.ts` — 9/9 pass.

UX new#4 з [топ-10 next-tier](https://app.devin.ai/sessions/72493af4308545af9a6e9dfcfd4cbaa0) — wave 4 #7 (фінальний).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a cross‑module prompt system with anti‑nag fatigue tracking to connect Finyk, Fizruk, and Nutrition without spamming users. Adopted for Finyk→Nutrition (toast after new restaurant/food expense) and Fizruk→Nutrition (inline link with a 12‑hour snooze).

- **New Features**
  - New shared lib `@shared/lib/crossModulePrompt`: `tryShowCrossModulePrompt`, `isCrossModulePromptSuppressed`, `record*`; MAX_DISMISSALS=3, FATIGUE_WINDOW=14d (rolling), ACCEPT_SNOOZE=12h; auto‑dismiss counts as a dismissal; typed `CrossModulePromptId`.
  - Tests: 9 cases in `@shared/lib/crossModulePrompt.test.ts`.
  - Finyk (`FinykApp.tsx`): on new manual expense with category `restaurant` or `food`, show “Додати прийом їжі…?” toast with “Додати →” → `openHubModuleWithAction("nutrition", "add_meal")`. Not shown on edit.
  - Fizruk (`WorkoutFinishSheets.tsx`): hide “Додати білок…” link when suppressed; on tap, record acceptance and snooze for 12h.
  - Docs: `docs/design/CROSS-MODULE-PROMPTS.md` with pattern, rules, and guidelines.

<sup>Written for commit 0bb38379ccf5194384822cb55a9e6f92ab2d8d6b. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1139?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated cross-module prompts guide users to related features after logging expenses or completing workouts.
  * Smart anti-nag system suppresses repeated prompts through dismissal limits and 12-hour snooze windows after accepting.

* **Tests**
  * Added comprehensive test coverage for prompt suppression logic and user interaction scenarios.

* **Documentation**
  * New design specification detailing cross-module prompt behavior and anti-nag mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->