### PR TITLE
docs(docs): фінальні фікси — broken refs, freshness, allowlist sync

### DIFF
--- a/docs/design/EMPTY-STATES.md
+++ b/docs/design/EMPTY-STATES.md
@@ -1,5 +1,7 @@
 # Empty states
 
+> **Last validated:** 2026-04-28 by @Skords-01. **Next review:** 2026-07-27.
+
 > **Audience:** anyone writing UI in `apps/web` or `apps/mobile`.
 > **Goal:** consistent treatment of "no data yet" — pick the right
 > tier for the surface, don't invent a one-off.

--- a/docs/design/RADIUS-RHYTHM.md
+++ b/docs/design/RADIUS-RHYTHM.md
@@ -1,5 +1,7 @@
 # Border-radius rhythm
 
+> **Last validated:** 2026-04-28 by @Skords-01. **Next review:** 2026-07-27.
+
 > **Audience:** anyone writing UI in `apps/web` or `apps/mobile`.
 > **Goal:** prevent border-radius drift — pick the right radius from a small,
 > size-driven scale instead of inventing a one-off value.

--- a/docs/design/UNDO-PATTERN.md
+++ b/docs/design/UNDO-PATTERN.md
@@ -1,5 +1,7 @@
 # Undo pattern — soft-delete + 5 s undo toast
 
+> **Last validated:** 2026-04-28 by @Skords-01. **Next review:** 2026-07-27.
+
 > Sergeant's unified destructive-action pattern. Use `showUndoToast`
 > instead of `window.confirm()`, instead of a custom "Are you sure?"
 > dialog, instead of a silent delete. Confirmation dialogs are
@@ -201,5 +203,5 @@ When adopting this pattern in a new module:
 
 - [`apps/web/src/shared/lib/undoToast.tsx`](../../apps/web/src/shared/lib/undoToast.tsx) — implementation.
 - [`apps/web/src/shared/lib/undoToast.test.tsx`](../../apps/web/src/shared/lib/undoToast.test.tsx) — contract tests.
-- [`packages/shared/src/constants/undoToast.ts`](../../packages/shared/src/constants/undoToast.ts) — defaults shared with mobile.
+- [`packages/shared/src/lib/undoToast.ts`](../../packages/shared/src/lib/undoToast.ts) — defaults shared with mobile.
 - `AGENTS.md` § Soft rules — "Destructive UX defaults".

--- a/docs/superpowers/specs/2026-04-25-assistant-capability-catalogue-design.md
+++ b/docs/superpowers/specs/2026-04-25-assistant-capability-catalogue-design.md
@@ -508,7 +508,7 @@ E2E (Playwright smoke):
 
 1. **Чи групувати «Аналітика» окремо від «Кросмодульні» у UI**, навіть якщо в `toolDefs/crossModule.ts` вони разом? Поточна пропозиція — так, бо юзер мислить «графіки і тренди» окремо від «брифінг і підсумок». Але це вимагає `module: "analytics"` явно у реджистрі.
 2. **Tail-секція «Все інше / експериментальне»** для capabilities, що не вписуються в 8 груп. Поки нема таких — но залишимо ментально на майбутнє.
-3. **Feature flag для catalogue?** Не плануємо в v1 — запуск тривіальний, відкат через PR-revert. Якщо хочеш — додамо `assistant_catalogue_enabled` flag через [`featureFlags.ts`](../../apps/web/src/core/lib/featureFlags.ts) у impl-плані.
+3. **Feature flag для catalogue?** Не плануємо в v1 — запуск тривіальний, відкат через PR-revert. Якщо хочеш — додамо `assistant_catalogue_enabled` flag через [`featureFlags.ts`](../../../apps/web/src/core/lib/featureFlags.ts) у impl-плані.
 
 ## See also
 

--- a/scripts/docs/freshness-allowlist.json
+++ b/scripts/docs/freshness-allowlist.json
@@ -12,6 +12,14 @@
     "cadenceDays": 90
   },
   {
+    "path": "docs/adr/0001-monetization-architecture.md",
+    "cadenceDays": 180
+  },
+  {
+    "path": "docs/api/README.md",
+    "cadenceDays": 90
+  },
+  {
     "path": "docs/architecture/api-v1.md",
     "cadenceDays": 90
   },
@@ -28,6 +36,10 @@
     "cadenceDays": 90
   },
   {
+    "path": "docs/architecture/hosting-evolution.md",
+    "cadenceDays": 90
+  },
+  {
     "path": "docs/architecture/platforms.md",
     "cadenceDays": 90
   },
@@ -36,11 +48,51 @@
     "cadenceDays": 180
   },
   {
+    "path": "docs/audits/2026-04-28-implementation-roadmap.md",
+    "cadenceDays": 90
+  },
+  {
+    "path": "docs/audits/2026-04-28-sergeant-comprehensive-audit.md",
+    "cadenceDays": 180
+  },
+  {
+    "path": "docs/audits/UX-IMPROVEMENT-PLAN.md",
+    "cadenceDays": 90
+  },
+  {
+    "path": "docs/audits/UX-UI-AUDIT-2026.md",
+    "cadenceDays": 180
+  },
+  {
+    "path": "docs/audits/ux-audit-2025.md",
+    "cadenceDays": 365
+  },
+  {
     "path": "docs/design/BRANDBOOK.md",
     "cadenceDays": 90
   },
   {
+    "path": "docs/design/EMPTY-STATES.md",
+    "cadenceDays": 90
+  },
+  {
+    "path": "docs/design/RADIUS-RHYTHM.md",
+    "cadenceDays": 90
+  },
+  {
+    "path": "docs/design/UNDO-PATTERN.md",
+    "cadenceDays": 90
+  },
+  {
+    "path": "docs/design/brand-palette-wcag-aa-proposal.md",
+    "cadenceDays": 90
+  },
+  {
     "path": "docs/design/design-system.md",
+    "cadenceDays": 90
+  },
+  {
+    "path": "docs/governance/doc-freshness.md",
     "cadenceDays": 90
   },
   {
@@ -120,6 +172,18 @@
     "cadenceDays": 90
   },
   {
+    "path": "docs/observability/frontend.md",
+    "cadenceDays": 90
+  },
+  {
+    "path": "docs/observability/logging.md",
+    "cadenceDays": 90
+  },
+  {
+    "path": "docs/observability/metrics.md",
+    "cadenceDays": 90
+  },
+  {
     "path": "docs/observability/runbook.md",
     "cadenceDays": 60
   },
@@ -192,6 +256,10 @@
     "cadenceDays": 90
   },
   {
+    "path": "docs/playbooks/fix-failing-ci.md",
+    "cadenceDays": 90
+  },
+  {
     "path": "docs/playbooks/hotfix-prod-regression.md",
     "cadenceDays": 60
   },
@@ -212,6 +280,10 @@
     "cadenceDays": 90
   },
   {
+    "path": "docs/playbooks/prettier-pass-on-docs.md",
+    "cadenceDays": 90
+  },
+  {
     "path": "docs/playbooks/pre-merge-migration-checklist.md",
     "cadenceDays": 60
   },
@@ -224,12 +296,32 @@
     "cadenceDays": 90
   },
   {
+    "path": "docs/playbooks/sync-rn-migration-progress.md",
+    "cadenceDays": 90
+  },
+  {
     "path": "docs/playbooks/tune-system-prompt.md",
     "cadenceDays": 90
   },
   {
     "path": "docs/security/audit-exceptions.md",
     "cadenceDays": 90
+  },
+  {
+    "path": "docs/security/nightly-audit.md",
+    "cadenceDays": 90
+  },
+  {
+    "path": "docs/security/vulnerability-sla.md",
+    "cadenceDays": 90
+  },
+  {
+    "path": "docs/superpowers/specs/2026-04-24-assistant-quick-actions-v1-design.md",
+    "cadenceDays": 180
+  },
+  {
+    "path": "docs/superpowers/specs/2026-04-25-assistant-capability-catalogue-design.md",
+    "cadenceDays": 180
   },
   {
     "path": "docs/tech-debt/backend.md",


### PR DESCRIPTION
## What changed

Фінальні фікси після повного аудиту ліцензій та документації:

1. **2 broken code refs** виправлено:
   - `UNDO-PATTERN.md`: `packages/shared/src/constants/undoToast.ts` → `lib/undoToast.ts`
   - `capability-catalogue-design.md`: `../../apps/web/...` → `../../../apps/web/...`
2. **3 freshness headers** додано: `EMPTY-STATES.md`, `RADIUS-RHYTHM.md`, `UNDO-PATTERN.md`
3. **Freshness allowlist +22 записи** — синхронізовано всі docs з `Last validated:` header

## Why

Фінальний cleanup після аудиту ліцензій. Ліцензії ОК (`pnpm licenses:check` passed), але знайшлись останні broken refs і неповний allowlist.

## How to test

1. `pnpm format:check` — пройшов
2. Перевірити що broken refs у `UNDO-PATTERN.md` і `capability-catalogue` тепер валідні
3. Allowlist JSON валідний, всі 83 записи ведуть на існуючі файли

---

## How AI-tested this PR

- [x] Manual smoke: Python скрипт перевірки broken links — 0 broken refs у docs/ після змін
- [x] Allowlist sync перевірено: 0 docs з freshness header поза allowlist, 0 allowlist записів без файлу
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [x] No — no new permanent rules
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two broken code references and adds freshness metadata to keep docs healthy. Also syncs the freshness allowlist (+22) to match all pages with “Last validated:” headers.

- **Bug Fixes**
  - `docs/design/UNDO-PATTERN.md`: `packages/shared/src/constants/undoToast.ts` → `packages/shared/src/lib/undoToast.ts`.
  - `docs/superpowers/specs/2026-04-25-assistant-capability-catalogue-design.md`: `../../apps/web/...` → `../../../apps/web/...`.

<sup>Written for commit 987aa3a43e0198db0a44e7cac28bd88679d044c0. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1140?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

