### PR TITLE
feat(design-tokens): publish module accent rgb as single source of truth

### DIFF
--- a/apps/web/src/shared/components/layout/ModuleAccentProvider.test.tsx
+++ b/apps/web/src/shared/components/layout/ModuleAccentProvider.test.tsx
@@ -1,0 +1,103 @@
+/** @vitest-environment jsdom */
+import { afterEach, describe, it, expect } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import {
+  moduleAccentRgb,
+  type ModuleAccent,
+} from "@sergeant/design-tokens/tokens";
+import { ModuleAccentProvider, useModuleAccent } from "./ModuleAccentProvider";
+
+const MODULES: ModuleAccent[] = ["finyk", "fizruk", "routine", "nutrition"];
+
+function AccentProbe() {
+  const accent = useModuleAccent();
+  return <span data-testid="probe">{accent ?? "none"}</span>;
+}
+
+afterEach(cleanup);
+
+describe("ModuleAccentProvider", () => {
+  it.each(MODULES)(
+    "публікує --module-accent-rgb + --module-accent-strong-rgb для %s",
+    (mod) => {
+      const { container } = render(
+        <ModuleAccentProvider module={mod}>
+          <AccentProbe />
+        </ModuleAccentProvider>,
+      );
+      const wrapper = container.firstChild as HTMLElement;
+
+      // Значення тягнуться з design-tokens SSOT — guard від drift
+      // between React and Tailwind.
+      expect(wrapper.style.getPropertyValue("--module-accent-rgb")).toBe(
+        moduleAccentRgb[mod].default,
+      );
+      expect(wrapper.style.getPropertyValue("--module-accent-strong-rgb")).toBe(
+        moduleAccentRgb[mod].strong,
+      );
+    },
+  );
+
+  it.each(MODULES)("ставить data-module-accent=%s на wrapper", (mod) => {
+    const { container } = render(
+      <ModuleAccentProvider module={mod}>
+        <AccentProbe />
+      </ModuleAccentProvider>,
+    );
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.getAttribute("data-module-accent")).toBe(mod);
+  });
+
+  it.each(MODULES)("useModuleAccent() повертає поточний %s", (mod) => {
+    const { getByTestId } = render(
+      <ModuleAccentProvider module={mod}>
+        <AccentProbe />
+      </ModuleAccentProvider>,
+    );
+    expect(getByTestId("probe").textContent).toBe(mod);
+  });
+
+  it("useModuleAccent() повертає null поза провайдером", () => {
+    const { getByTestId } = render(<AccentProbe />);
+    expect(getByTestId("probe").textContent).toBe("none");
+  });
+
+  it("asShellRoot додає flex-column viewport класи", () => {
+    const { container } = render(
+      <ModuleAccentProvider module="finyk" asShellRoot>
+        <AccentProbe />
+      </ModuleAccentProvider>,
+    );
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.className).toContain("h-dvh");
+    expect(wrapper.className).toContain("flex");
+    expect(wrapper.className).toContain("flex-col");
+  });
+});
+
+describe("moduleAccentRgb (design-tokens SSOT)", () => {
+  it("defines a default + strong triplet for every module", () => {
+    for (const mod of MODULES) {
+      expect(moduleAccentRgb[mod]).toMatchObject({
+        default: expect.stringMatching(/^\d+\s+\d+\s+\d+$/),
+        strong: expect.stringMatching(/^\d+\s+\d+\s+\d+$/),
+      });
+    }
+  });
+
+  it("strong triplet is darker than default (sum of channels)", () => {
+    // Heuristic rather than a full WCAG calc — if this flips, someone
+    // swapped `default` and `strong` by accident.
+    for (const mod of MODULES) {
+      const sumDefault = moduleAccentRgb[mod].default
+        .split(/\s+/)
+        .reduce((acc, n) => acc + Number(n), 0);
+      const sumStrong = moduleAccentRgb[mod].strong
+        .split(/\s+/)
+        .reduce((acc, n) => acc + Number(n), 0);
+      expect(sumStrong, `expected ${mod} strong to be darker`).toBeLessThan(
+        sumDefault,
+      );
+    }
+  });
+});

--- a/apps/web/src/shared/components/layout/ModuleAccentProvider.tsx
+++ b/apps/web/src/shared/components/layout/ModuleAccentProvider.tsx
@@ -6,6 +6,7 @@ import {
   type ReactNode,
 } from "react";
 import type { ModuleAccent } from "@sergeant/design-tokens";
+import { moduleAccentRgb } from "@sergeant/design-tokens/tokens";
 import { cn } from "@shared/lib/cn";
 
 /**
@@ -18,13 +19,18 @@ import { cn } from "@shared/lib/cn";
  *
  * Two ways to consume:
  *
- * 1. **CSS variable** — `--module-accent-rgb` is written on the wrapper
- *    `<div>`. Use it directly in Tailwind arbitrary values:
+ * 1. **CSS variables** — two are written on the wrapper `<div>`:
+ *      • `--module-accent-rgb` — the saturated `-500` shade.
+ *      • `--module-accent-strong-rgb` — the WCAG-AA `-strong` companion
+ *        for use behind `text-white` (CTAs, Badges, Tabs).
+ *
+ *    Use them in Tailwind arbitrary values:
  *
  *        className="bg-[rgb(var(--module-accent-rgb))]"
  *        className="border-[rgb(var(--module-accent-rgb)/0.4)]"
+ *        className="bg-[rgb(var(--module-accent-strong-rgb))] text-white"
  *
- *    This works everywhere inside the provider, including portaled
+ *    Both work everywhere inside the provider, including portaled
  *    overlays that re-mount inside the same DOM subtree.
  *
  * 2. **React hook** — `useModuleAccent()` returns the active accent
@@ -35,14 +41,12 @@ import { cn } from "@shared/lib/cn";
  * The accent is intentionally `null` outside of a provider. Hub-level
  * chrome (header, dashboard, hub-chat) is module-agnostic and should
  * keep using `bg-brand-*` tokens directly.
+ *
+ * The RGB triplets are sourced from `@sergeant/design-tokens/tokens`
+ * (`moduleAccentRgb`) — the single source of truth shared with Tailwind
+ * `bg-{module}` / `bg-{module}-strong` utilities. Never hardcode RGB
+ * values here; extend `moduleAccentRgb` instead.
  */
-
-const MODULE_ACCENT_RGB: Record<ModuleAccent, string> = {
-  finyk: "16 185 129", // emerald-500
-  fizruk: "20 184 166", // teal-500
-  routine: "249 112 102", // coral-500
-  nutrition: "132 204 22", // lime-500
-};
 
 const ModuleAccentContext = createContext<ModuleAccent | null>(null);
 
@@ -61,13 +65,13 @@ export function ModuleAccentProvider({
   asShellRoot = false,
   className,
 }: ModuleAccentProviderProps) {
-  const style = useMemo<CSSProperties>(
-    () =>
-      ({
-        "--module-accent-rgb": MODULE_ACCENT_RGB[module],
-      }) as CSSProperties,
-    [module],
-  );
+  const style = useMemo<CSSProperties>(() => {
+    const rgb = moduleAccentRgb[module];
+    return {
+      "--module-accent-rgb": rgb.default,
+      "--module-accent-strong-rgb": rgb.strong,
+    } as CSSProperties;
+  }, [module]);
 
   return (
     <ModuleAccentContext.Provider value={module}>

--- a/docs/design/MODULE-ACCENT.md
+++ b/docs/design/MODULE-ACCENT.md
@@ -1,0 +1,215 @@
+# Module accent — canonical reference
+
+> Sergeant — 4 модулі з власним брендовим кольором. Замість того, щоб
+> кожен компонент отримував пропс `module="finyk"` / `module="fizruk"`
+> й мапив це у `bg-finyk` / `bg-fizruk`, ми публікуємо активний акцент
+> як CSS-variable на дереві модуля і маємо одну Tailwind-утиліту, що
+> тягне цей колір у будь-яку поверхню всередині модуля.
+
+## TL;DR
+
+```tsx
+<ModuleShell module="finyk" ...>
+  <div className="bg-module-accent/10 border border-module-accent/30" />
+  <button className="bg-module-accent-strong text-white">CTA</button>
+</ModuleShell>
+```
+
+- `bg-module-accent` → активний module-колір (`finyk`=emerald-500,
+  `fizruk`=teal-500, `routine`=coral-500, `nutrition`=lime-500).
+- `bg-module-accent-strong` → WCAG-AA `-strong` companion для фонів під
+  `text-white` (clears 4.5 : 1).
+- Використовується у спільних компонентах, які живуть у 4 модулях —
+  без hardcoded `bg-finyk` / `bg-fizruk` лукапів.
+
+## Three layers
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  packages/design-tokens/tokens.js  (single source)     │
+│  └─ moduleAccentRgb = {                                │
+│       finyk:     { default: "16 185 129", strong: …}   │
+│       fizruk:    { default: "20 184 166", strong: …}   │
+│       routine:   { default: "249 112 102", strong: …}  │
+│       nutrition: { default: "146 204 23", strong: …}   │
+│     }                                                   │
+└─────────────────────────────────────────────────────────┘
+                         │
+                         ▼
+┌─────────────────────────────────────────────────────────┐
+│  ModuleAccentProvider / ModuleShell                    │
+│  └─ writes:                                            │
+│       --module-accent-rgb: <default>                   │
+│       --module-accent-strong-rgb: <strong>             │
+└─────────────────────────────────────────────────────────┘
+                         │
+                         ▼
+┌─────────────────────────────────────────────────────────┐
+│  Tailwind preset                                        │
+│  └─ registers:                                         │
+│       module-accent: rgb(var(--module-accent-rgb)/…)   │
+│       module-accent-strong: rgb(var(--…-strong-rgb)/…) │
+└─────────────────────────────────────────────────────────┘
+                         │
+                         ▼
+              `bg-module-accent/10`
+              `text-module-accent`
+              `bg-module-accent-strong text-white`
+              `border-module-accent/30`
+              … any Tailwind color utility works
+```
+
+## Rules
+
+1. **Edit RGB triplets only in `packages/design-tokens/tokens.js`.** They
+   must match `moduleColors.{module}.primary` (for `default`) and the
+   WCAG-AA companion shade (for `strong` — typically `-700`, except
+   nutrition/lime which uses `-800`). Never re-declare these in React
+   components.
+
+2. **`bg-module-accent*` works only inside a `ModuleAccentProvider` or
+   `ModuleShell` with `module` prop.** Outside, `--module-accent-rgb`
+   is undefined and the utility resolves to `rgb( )` — effectively
+   transparent. If you're designing a component that might render
+   standalone (e.g. Storybook, hub-level page loader), keep the
+   explicit `module` prop + `bg-{module}/10` fallback.
+
+3. **Use `-strong` behind `text-white`.** Saturated `-500` shades
+   regress to ~2.4–2.8 : 1 against white. See
+   [`docs/design/BRANDBOOK.md`](./BRANDBOOK.md) § WCAG-AA `-strong` Tier
+   for the per-family contrast table.
+
+4. **Hub chrome stays neutral.** `HubHeader`, `HubTabs`, `HubDashboard`,
+   HubChat, dashboards with all 4 modules side-by-side — these must
+   keep `bg-brand-*` tokens (neutral Sergeant palette) or mix
+   per-module tokens by name. Do NOT use `bg-module-accent*` here;
+   there is no ambient module.
+
+## Migration (incremental, no big-bang)
+
+`bg-module-accent*` is **additive**. Existing `bg-finyk` / `bg-fizruk`
+/ etc. still work. Migrate one surface at a time when the surface is
+already themed by `ModuleAccentProvider`:
+
+```diff
+  // Inside FinykApp.tsx, NutritionApp.tsx, etc.
+- <div className="rounded-2xl bg-finyk-soft/40 dark:bg-finyk-surface-dark/8" />
++ <div className="rounded-2xl bg-module-accent/8 dark:bg-module-accent/10" />
+```
+
+Good migration candidates:
+
+- Shared `Skeleton*` placeholders with `module` prop — drop the prop
+  once the skeleton always renders inside `ModuleAccentProvider`.
+- `ModulePageLoader` sub-sections (`FinykLoader`, `FizrukLoader`, …) —
+  unify into one `ModuleLoader` that reads the ambient accent.
+- Tint washes on `Card` / `Sheet` overlays — consistent 8 % / 10 % /
+  15 % opacity across modules.
+
+Do NOT migrate:
+
+- `WelcomeScreen.tsx`, `ModuleChecklist.tsx`, `moduleConfigs.tsx`,
+  `HubInsightsPanel.tsx` — these show multiple modules side-by-side.
+  Each card must carry its own hardcoded module token (`bg-finyk-soft`,
+  `bg-fizruk-soft`, …) because there is no ambient accent.
+- `Button` module variants (`variant="finyk"` / `module="finyk"`) —
+  these explicitly pick a module; the API is clearer that way.
+- Anywhere inside `core/**` (hub-level). Hub is module-agnostic.
+
+## Anti-patterns
+
+```tsx
+// ❌ BAD — hardcoded RGB triplet in React; will drift from Tailwind
+<div style={{ backgroundColor: "rgb(16 185 129 / 0.1)" }} />
+
+// ❌ BAD — lookup table that re-invents what Tailwind already provides
+const TINT = {
+  finyk: "bg-finyk/10",
+  fizruk: "bg-fizruk/10",
+  /* ... */
+};
+<div className={TINT[module]} />
+
+// ❌ BAD — `bg-module-accent/10` outside a `ModuleAccentProvider`
+// (renders transparent; debug-hours ahead)
+<HubDashboard>
+  <div className="bg-module-accent/10" />  {/* ← no ambient accent */}
+</HubDashboard>
+
+// ✅ GOOD — ambient accent inside a module surface
+<ModuleShell module="routine">
+  <Card className="bg-module-accent/8 border-module-accent/20" />
+  <Button className="bg-module-accent-strong text-white">Зберегти</Button>
+</ModuleShell>
+```
+
+## API
+
+### Design tokens (`@sergeant/design-tokens/tokens`)
+
+```ts
+export const moduleAccentRgb: Record<
+  ModuleAccent,
+  {
+    default: string; // "R G B" (saturated -500)
+    strong: string; // "R G B" (WCAG-AA -700/-800)
+  }
+>;
+```
+
+### React (`@shared/components/layout`)
+
+```ts
+// Writes CSS vars + provides useModuleAccent() context.
+<ModuleAccentProvider module="finyk">...</ModuleAccentProvider>
+<ModuleShell module="finyk" header={…} nav={…}>...</ModuleShell>
+
+// Active accent ("finyk" | "fizruk" | "routine" | "nutrition" | null).
+const accent = useModuleAccent();
+```
+
+### Tailwind
+
+```
+bg-module-accent           bg-module-accent-strong
+bg-module-accent/10        bg-module-accent-strong/90
+text-module-accent         text-module-accent-strong
+border-module-accent       border-module-accent-strong
+ring-module-accent         ring-module-accent-strong
+```
+
+All standard Tailwind opacity modifiers from the registered scale
+(`0, 5, 8, 10, 15, 20, 25, …`) work. Non-registered steps (`/12`, `/18`)
+are silently dropped — see `AGENTS.md` hard rule #8.
+
+## Testing
+
+```ts
+import { moduleAccentRgb } from "@sergeant/design-tokens/tokens";
+import { ModuleAccentProvider } from "@shared/components/layout";
+
+it("публікує --module-accent-rgb + strong для finyk", () => {
+  const { container } = render(
+    <ModuleAccentProvider module="finyk">
+      <div />
+    </ModuleAccentProvider>,
+  );
+  const wrapper = container.firstChild as HTMLElement;
+  expect(wrapper.style.getPropertyValue("--module-accent-rgb")).toBe(
+    moduleAccentRgb.finyk.default,
+  );
+  expect(wrapper.style.getPropertyValue("--module-accent-strong-rgb")).toBe(
+    moduleAccentRgb.finyk.strong,
+  );
+});
+```
+
+`ModuleAccentProvider.test.tsx` covers all 4 modules + data attribute.
+
+## Related docs
+
+- [`docs/design/BRANDBOOK.md`](./BRANDBOOK.md) — WCAG-AA `-strong` Tier
+  - full per-family contrast table.
+- [`docs/design/brand-palette-wcag-aa-proposal.md`](./brand-palette-wcag-aa-proposal.md) — migration history (PRs #854 / #855 / #857).
+- `AGENTS.md` hard rule #8 — Tailwind opacity scale.
+- `AGENTS.md` hard rule #9 — `-strong` companion behind `text-white`.

--- a/packages/design-tokens/__snapshots__/tokens.test.js.snap
+++ b/packages/design-tokens/__snapshots__/tokens.test.js.snap
@@ -139,6 +139,27 @@ exports[`@sergeant/design-tokens — tokens.js > chartPalette / chartPaletteList
 }
 `;
 
+exports[`@sergeant/design-tokens — tokens.js > moduleAccentRgb is stable (snapshot) 1`] = `
+{
+  "finyk": {
+    "default": "16 185 129",
+    "strong": "4 120 87",
+  },
+  "fizruk": {
+    "default": "20 184 166",
+    "strong": "15 118 110",
+  },
+  "nutrition": {
+    "default": "146 204 23",
+    "strong": "70 98 18",
+  },
+  "routine": {
+    "default": "249 112 102",
+    "strong": "194 58 58",
+  },
+}
+`;
+
 exports[`@sergeant/design-tokens — tokens.js > moduleColors define canonical finyk/fizruk/routine/nutrition primary+surface 1`] = `
 {
   "finyk": {

--- a/packages/design-tokens/index.d.ts
+++ b/packages/design-tokens/index.d.ts
@@ -50,6 +50,21 @@ export declare const moduleColors: Readonly<
   Record<ModuleAccent, Readonly<Record<string, string>>>
 >;
 
+/**
+ * RGB triplet ("R G B", space-separated) per module for the
+ * `--module-accent-rgb` and `--module-accent-strong-rgb` CSS variables
+ * published by `ModuleAccentProvider`. The `strong` shade is the
+ * WCAG-AA companion (`-700` / `-800`).
+ */
+export interface ModuleAccentRgb {
+  readonly default: string;
+  readonly strong: string;
+}
+
+export declare const moduleAccentRgb: Readonly<
+  Record<ModuleAccent, ModuleAccentRgb>
+>;
+
 /** Status / semantic colours, keyed by `StatusColor`. */
 export declare const statusColors: Readonly<Record<StatusColor, string>>;
 

--- a/packages/design-tokens/tailwind-preset.js
+++ b/packages/design-tokens/tailwind-preset.js
@@ -72,6 +72,20 @@ const preset = {
         accent: "rgb(var(--c-accent) / <alpha-value>)",
         ring: "rgb(var(--c-accent) / <alpha-value>)",
 
+        // Ambient module accent — picks up the current module's brand
+        // color from `--module-accent-rgb` published by
+        // `ModuleAccentProvider` / `ModuleShell`. Inside a module, use
+        // `bg-module-accent/10`, `text-module-accent`, `border-module-accent-strong`
+        // etc. — no hardcoded `bg-finyk` / `bg-fizruk` per surface.
+        // The `-strong` variant is the WCAG-AA companion for solid
+        // fills behind `text-white`. Outside the provider both vars
+        // are undefined and the utility falls back to `rgb()` with
+        // empty channels (effectively transparent); only use inside a
+        // module subtree. See docs/design/MODULE-ACCENT.md.
+        "module-accent": "rgb(var(--module-accent-rgb) / <alpha-value>)",
+        "module-accent-strong":
+          "rgb(var(--module-accent-strong-rgb) / <alpha-value>)",
+
         // ═══════════════════════════════════════════════════════════════════
         // BRAND COLORS — Soft & Organic palette with Emerald/Teal accent
         // ═══════════════════════════════════════════════════════════════════

--- a/packages/design-tokens/tokens.js
+++ b/packages/design-tokens/tokens.js
@@ -124,6 +124,31 @@ export const moduleColors = {
   },
 };
 
+/**
+ * Module-accent RGB triplets for the `--module-accent-rgb` and
+ * `--module-accent-strong-rgb` CSS variables exposed by
+ * `ModuleAccentProvider`. Kept here (not in the React component) so
+ * the triplets stay in lockstep with `moduleColors.primary` and
+ * `brandColors.{emerald,teal,coral,lime}[700|800]` — the single source
+ * of truth for Sergeant module branding.
+ *
+ * Shape: "R G B" (space-separated, no commas) so the value is directly
+ * usable inside `rgb(…)` + Tailwind arbitrary values:
+ *
+ *   className="bg-[rgb(var(--module-accent-rgb)/0.1)]"
+ *   className="bg-[rgb(var(--module-accent-strong-rgb))] text-white"
+ *
+ * The `strong` triplet is the WCAG-AA companion shade (`-700` for most
+ * modules; `-800` for nutrition/lime where `-700` still regresses on
+ * white). It matches the `bg-{module}-strong` Tailwind utility.
+ */
+export const moduleAccentRgb = {
+  finyk: { default: "16 185 129", strong: "4 120 87" }, // emerald-500 / -700
+  fizruk: { default: "20 184 166", strong: "15 118 110" }, // teal-500 / -700
+  routine: { default: "249 112 102", strong: "194 58 58" }, // coral-500 / -700
+  nutrition: { default: "146 204 23", strong: "70 98 18" }, // lime-500 / -800
+};
+
 /** Status/semantic colors — consistent across app. */
 export const statusColors = {
   success: "#10b981", // emerald-500

--- a/packages/design-tokens/tokens.test.js
+++ b/packages/design-tokens/tokens.test.js
@@ -14,6 +14,7 @@ import {
   chartHex,
   chartPalette,
   chartPaletteList,
+  moduleAccentRgb,
   moduleColors,
   statusColors,
   statusHex,
@@ -31,6 +32,27 @@ describe("@sergeant/design-tokens — tokens.js", () => {
 
   it("moduleColors define canonical finyk/fizruk/routine/nutrition primary+surface", () => {
     expect(moduleColors).toMatchSnapshot();
+  });
+
+  it("moduleAccentRgb triplets match moduleColors.primary hex values", () => {
+    // Guard: the RGB triplets published by `ModuleAccentProvider` must
+    // stay in lockstep with `moduleColors.{module}.primary`. Any drift
+    // means the Tailwind `bg-{module}` utility and the ambient
+    // `bg-module-accent` utility paint different colours — a class of
+    // hard-to-spot visual bug.
+    const hexToTriplet = (hex) => {
+      const h = hex.replace("#", "");
+      return [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16)).join(" ");
+    };
+    for (const module of ["finyk", "fizruk", "routine", "nutrition"]) {
+      expect(moduleAccentRgb[module].default).toBe(
+        hexToTriplet(moduleColors[module].primary),
+      );
+    }
+  });
+
+  it("moduleAccentRgb is stable (snapshot)", () => {
+    expect(moduleAccentRgb).toMatchSnapshot();
   });
 
   it("statusColors + statusHex pair matches `statusColors.<name>.primary → statusHex.<name>`", () => {


### PR DESCRIPTION
## What changed

Wave 5 PR 5.1 — foundational. Лише інфраструктура module-accent. Міграція поверхонь — окремими PR-ами далі.

1. **`packages/design-tokens/tokens.js`** — новий експорт `moduleAccentRgb: { default, strong }` per module. `default` = `moduleColors.{module}.primary` у RGB-форматі `"R G B"`. `strong` = WCAG-AA companion (`emerald/teal/coral -700`, `lime -800`). Фікс drift: nutrition було `132 204 22` (default Tailwind lime-500), стало `146 204 23` (Sergeant lime-500 = `#92cc17`).

2. **`packages/design-tokens/index.d.ts`** — типи `ModuleAccentRgb`, `moduleAccentRgb` declaration.

3. **`packages/design-tokens/tailwind-preset.js`** — нові tokens `module-accent` + `module-accent-strong`. Дають `bg-module-accent/10`, `text-module-accent`, `border-module-accent-strong/30`, повний suite — через ambient CSS-var замість hardcoded `bg-finyk` per поверхня.

4. **`apps/web/src/shared/components/layout/ModuleAccentProvider.tsx`** — імпортує `moduleAccentRgb` з SSOT замість hardcode. Публікує дві CSS-змінні: `--module-accent-rgb` (legacy) + нову `--module-accent-strong-rgb`.

5. **`apps/web/src/shared/components/layout/ModuleAccentProvider.test.tsx`** (new) — 16 тестів: публікація CSS-vars по 4 модулях, `data-module-accent`, `useModuleAccent()` hook, `asShellRoot` classes, SSOT shape guard + darkness heuristic (`strong < default`).

6. **`packages/design-tokens/tokens.test.js`** — новий guard `moduleAccentRgb.{module}.default === hexToTriplet(moduleColors.{module}.primary)`. Ловить drift між SSOT та Tailwind `bg-{module}` utility.

7. **`docs/design/MODULE-ACCENT.md`** (new) — TL;DR recipe, 3-layer architecture diagram (tokens → provider → Tailwind), 4 правила, incremental migration guidance (good/bad candidates), anti-patterns, testing recipe, sister-doc до BRANDBOOK.md.

## Why

Попередня реалізація `ModuleAccentProvider` існувала, але:

- RGB triplets були hardcoded у React — drift-risk з design-tokens SSOT. (nutrition мав drift: `132` vs правильне `146`.)
- Тільки `default` shade публікувався — `-strong` доводилось писати `bg-finyk-strong` явно, що ламає ambient-accent pattern.
- Немає Tailwind utility — потрібні були verbose arbitrary values `rgb(var(--module-accent-rgb)/0.1)` замість `bg-module-accent/10`.

Після цього PR:

- SSOT у `@sergeant/design-tokens` з guard-тестом проти drift.
- `-strong` публікується автоматично для будь-якого module-subtree.
- Повна Tailwind utility surface: `bg/text/border/ring` + `-strong` + `/<opacity>`.
- Shared-компоненти можуть дропнути module-prop лукап таблиці й писати `bg-module-accent/10` (коли рендеряться всередині `ModuleAccentProvider`).

## How to test

1. Огляд `ModuleShell` / `ModuleAccentProvider` у будь-якому з 4 модулів — CSS-vars в dev-tools:
   ```
   --module-accent-rgb: 16 185 129
   --module-accent-strong-rgb: 4 120 87
   ```
2. У будь-який module-surface додати `<div className="bg-module-accent/10 border-module-accent/30 h-10" />` — має рендеритись у кольорі модуля.
3. `pnpm --filter @sergeant/web exec vitest run src/shared/components/layout/ModuleAccentProvider.test.tsx` → 16/16 ✓
4. `pnpm --filter @sergeant/design-tokens exec vitest run tokens.test.js` → 11/11 ✓ (новий snapshot).

---

## How AI-tested this PR

- [x] Vitest — web: 16/16 (`ModuleAccentProvider.test.tsx`); design-tokens: 11/11 (`tokens.test.js` з новим SSOT guard).
- [x] `pnpm exec prettier` / `pnpm exec eslint` / `pnpm --filter @sergeant/web exec tsc -p tsconfig.json --noEmit` — всі clean.
- [x] Нема нових `AI-DANGER` маркерів.
- [x] Docs прозу укр. (`docs/design/MODULE-ACCENT.md`).

## AGENTS.md updated?

- [ ] Ні — нових permanent rules не додано. `bg-module-accent*` — additive Tailwind utility, працює поверх існуючих правил (#8 opacity scale, #9 `-strong` companion).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes `moduleAccentRgb` as the single source of truth for module accent colors and wires it into `ModuleAccentProvider` and the Tailwind preset. Enables ambient `bg-module-accent` and `-strong` utilities across module surfaces, removes hardcoded RGBs, and adds guard tests and docs.

- **New Features**
  - `packages/design-tokens/tokens.js`: add `moduleAccentRgb` per module with `{ default, strong }` RGB triplets ("R G B"); `strong` = WCAG‑AA companion.
  - `packages/design-tokens/index.d.ts`: add `ModuleAccentRgb` types and `moduleAccentRgb` declaration.
  - `packages/design-tokens/tailwind-preset.js`: add `module-accent` and `module-accent-strong` color tokens for `bg/text/border/ring` with opacity.
  - `apps/web/src/shared/components/layout/ModuleAccentProvider.tsx`: consume `moduleAccentRgb`; publish `--module-accent-rgb` and `--module-accent-strong-rgb`; remove hardcoded triplets.
  - Tests: add provider tests (CSS vars, hook, shell classes) and SSOT guards (triplet matches `moduleColors.primary`; `strong` darker).
  - Docs: add `docs/design/MODULE-ACCENT.md` (usage, rules, incremental migration).
  - Fix: correct nutrition default to `146 204 23` (`#92cc17`) to align with tokens and prevent drift.

<sup>Written for commit d739b24365c7ec55d8f00c1f187bf1850e0cdf6b. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1141?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Module-scoped accent color theming with default and WCAG-AA accessibility variants
  * New Tailwind color utilities for dynamic module-based styling

* **Documentation**
  * Added design specification for module accent theming patterns and usage guidelines

* **Tests**
  * Added comprehensive test coverage for accent theming and color token validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->