### PR TITLE
feat(web): unify hub and modules under a single bottom-nav pattern

### DIFF
--- a/apps/web/src/core/App.tsx
+++ b/apps/web/src/core/App.tsx
@@ -27,7 +27,7 @@ import { useIosInstallBanner } from "./app/useIosInstallBanner";
 import { useSWUpdate } from "./app/useSWUpdate";
 import { PWA_ACTION_KEY } from "./app/pwaAction";
 import { HubHeader } from "./app/HubHeader";
-import { HubTabs } from "./app/HubTabs";
+import { HubBottomNav } from "./app/HubBottomNav";
 import { HubMainContent } from "./app/HubMainContent";
 import { HubFloatingActions } from "./app/HubFloatingActions";
 import { HubModals } from "./app/HubModals";
@@ -426,7 +426,7 @@ function AppInner() {
     const inFtuxSession =
       shouldShowOnboarding() && !user && !isFirstRealEntryDone();
     return (
-      <div className="min-h-dvh bg-bg flex flex-col safe-area-pt-pb page-enter">
+      <div className="h-dvh bg-bg flex flex-col overflow-hidden safe-area-pt page-enter">
         <SkipLink />
         <HintsOrchestrator
           inFtuxSession={inFtuxSession}
@@ -449,16 +449,6 @@ function AppInner() {
           hideAuthButton={inFtuxSession}
         />
 
-        <HubTabs
-          hubView={ui.hubView}
-          onChange={ui.setHubView}
-          // «Звіти» — пустий екран без даних, тому ховаємо tab до
-          // першого реального запису. Якщо юзер уже обрав «Звіти» і
-          // потім стер дані — повертаємо його на дашборд, щоб не
-          // лишався на неіснуючому табі.
-          showReports={hasAnyRealEntry()}
-        />
-
         <HubMainContent
           updateAvailable={updateAvailable}
           onApplyUpdate={applyUpdate}
@@ -478,9 +468,21 @@ function AppInner() {
           inFtuxSession={inFtuxSession}
         />
 
+        <HubBottomNav
+          hubView={ui.hubView}
+          onChange={ui.setHubView}
+          // «Звіти» — пустий екран без даних, тому ховаємо tab до
+          // першого реального запису. Якщо юзер уже обрав «Звіти» і
+          // потім стер дані — повертаємо його на дашборд, щоб не
+          // лишався на неіснуючому табі.
+          showReports={hasAnyRealEntry()}
+        />
+
         {/* Thumb-reach entry to the AI assistant. Always visible so the
-            user can reach the assistant from anywhere on the hub. */}
-        <HubFloatingActions onOpenChat={ui.openChat} />
+            user can reach the assistant from anywhere on the hub. The
+            `compact` variant is used here so the FAB offsets above the
+            hub bottom nav identically to the module bottom nav. */}
+        <HubFloatingActions onOpenChat={ui.openChat} compact />
 
         {/* Persistent shortcut back to an in-progress Fizruk workout.
             Hidden during FTUX so the splash stays single-CTA; otherwise

--- a/apps/web/src/core/app/HubBottomNav.test.tsx
+++ b/apps/web/src/core/app/HubBottomNav.test.tsx
@@ -1,0 +1,99 @@
+/** @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { HubBottomNav } from "./HubBottomNav";
+import { ToastProvider } from "@shared/hooks/useToast";
+
+const STORAGE_KEY = "sergeant.hub.reportsTabRevealedAt";
+
+function renderNav(props: {
+  hubView?: "dashboard" | "reports" | "settings";
+  showReports?: boolean;
+  onChange?: (v: "dashboard" | "reports" | "settings") => void;
+}) {
+  const onChange = props.onChange ?? vi.fn();
+  return {
+    onChange,
+    ...render(
+      <ToastProvider>
+        <HubBottomNav
+          hubView={props.hubView ?? "dashboard"}
+          onChange={onChange}
+          showReports={props.showReports ?? true}
+        />
+      </ToastProvider>,
+    ),
+  };
+}
+
+describe("HubBottomNav", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("рендерить три таби за замовчуванням", () => {
+    renderNav({});
+    expect(screen.getByRole("tab", { name: /Головна/ })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /Звіти/ })).toBeInTheDocument();
+    expect(
+      screen.getByRole("tab", { name: /Налаштування/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("ховає «Звіти» коли showReports=false", () => {
+    renderNav({ showReports: false });
+    expect(screen.queryByRole("tab", { name: /Звіти/ })).toBeNull();
+  });
+
+  it("активний таб має aria-selected=true", () => {
+    renderNav({ hubView: "reports" });
+    const reports = screen.getByRole("tab", { name: /Звіти/ });
+    expect(reports).toHaveAttribute("aria-selected", "true");
+
+    const dashboard = screen.getByRole("tab", { name: /Головна/ });
+    expect(dashboard).toHaveAttribute("aria-selected", "false");
+  });
+
+  it("виклик onChange при кліку на таб", () => {
+    const { onChange } = renderNav({});
+    fireEvent.click(screen.getByRole("tab", { name: /Налаштування/ }));
+    expect(onChange).toHaveBeenCalledWith("settings");
+  });
+
+  it("tablist semantics: кожен таб має aria-controls", () => {
+    renderNav({});
+    const tabs = screen.getAllByRole("tab");
+    for (const tab of tabs) {
+      expect(tab).toHaveAttribute("aria-controls");
+    }
+  });
+
+  it("ставить прапор у localStorage коли reports з'являється", () => {
+    const { rerender, onChange } = renderNav({ showReports: false });
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+
+    rerender(
+      <ToastProvider>
+        <HubBottomNav
+          hubView="dashboard"
+          onChange={onChange}
+          showReports={true}
+        />
+      </ToastProvider>,
+    );
+    expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+  });
+
+  it("не показує toast вдруге: якщо прапор вже у localStorage", () => {
+    localStorage.setItem(STORAGE_KEY, "123");
+    renderNav({ showReports: true });
+    // Bounce class = .animate-bounce-in. Без прапора й без transition «false→true»
+    // анімація не повинна ставитись.
+    const reports = screen.getByRole("tab", { name: /Звіти/ });
+    expect(reports.className).not.toContain("animate-bounce-in");
+  });
+});

--- a/apps/web/src/core/app/HubBottomNav.tsx
+++ b/apps/web/src/core/app/HubBottomNav.tsx
@@ -1,63 +1,45 @@
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState } from "react";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
 import { useToast } from "@shared/hooks/useToast";
 import { safeReadStringLS, safeWriteLS } from "@shared/lib/storage";
 import type { HubView } from "../hooks/useHubUIState";
 
-// Прапор у localStorage: «звіти-таб уже разово розкривався». Зберігаємо
-// timestamp (а не bool), щоб у логах було видно дату розблокування —
-// зручно для аналітики FTUX-воронки і для діагностики «чому юзер не
-// побачив підказку».
+/**
+ * Sergeant Design System — `HubBottomNav`
+ *
+ * Hub-level bottom navigation. Replaces the earlier top-positioned
+ * `HubTabs` so the whole app lives under a single navigation pattern:
+ * everything (hub + 4 modules) reads bottom-up, not bottom-down for
+ * modules and top-down for the hub.
+ *
+ * Shape mirrors `ModuleBottomNav` for visual consistency:
+ * - 60 px height (64 px on coarse-pointer devices).
+ * - `safe-area-pb` so iOS home-indicator clears.
+ * - Active indicator pill (`w-10 h-1`) at the top, brand-colored
+ *   instead of module-colored (the hub is module-agnostic).
+ * - `role="tablist"` + `aria-selected` for AT.
+ *
+ * Layout contract:
+ * - Rendered at the bottom of the hub `<div h-dvh flex-col>` shell, so
+ *   FABs (`HubFloatingActions`) and `ActiveWorkoutBanner` must offset
+ *   their `bottom:` by 76 px + safe-area-inset-bottom to sit above it.
+ *
+ * The reports-tab reveal behavior (animate + one-time toast) is
+ * preserved from the old `HubTabs` — see comments on `safeReadStringLS`
+ * usage below. Storage key is unchanged so existing users aren't
+ * re-onboarded through the reveal toast.
+ */
+
 const REPORTS_TAB_REVEALED_AT_KEY = "sergeant.hub.reportsTabRevealedAt";
 
-interface TabButtonProps {
-  active: boolean;
-  onClick: () => void;
-  children: ReactNode;
-  iconName?: string;
-  iconBody?: ReactNode;
-  className?: string;
-}
-
-function TabButton({
-  active,
-  onClick,
-  children,
-  iconName,
-  iconBody,
-  className,
-}: TabButtonProps) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      role="tab"
-      aria-selected={active}
-      className={cn(
-        // WCAG 2.5.5 AAA: 48 пкс на мобільному (thumb-zone), 44 пкс на ≥1sm — для desktop вводу
-        // достатньо. Focus-ring без альфи, щоб холдити ≥3:1 контраст до bg.
-        "flex-1 flex items-center justify-center gap-1.5 min-h-[48px] sm:min-h-[44px] py-2 rounded-xl text-sm font-medium transition-[background-color,color,opacity]",
-        "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500",
-        active
-          ? "bg-panel text-text shadow-card"
-          : "text-muted hover:text-text",
-        className,
-      )}
-    >
-      {iconName ? <Icon name={iconName} size={15} strokeWidth={2} /> : iconBody}
-      {children}
-    </button>
-  );
-}
-
-// "dashboard" icon is bespoke (2x2 grid of squares) so we render it inline
-// here rather than adding a one-off entry to the shared Icon map.
-function DashboardIcon() {
+// "dashboard" icon is bespoke (2×2 grid of squares) so we render it
+// inline here rather than adding a one-off entry to the shared Icon map.
+function DashboardIcon({ size = 20 }: { size?: number }) {
   return (
     <svg
-      width="15"
-      height="15"
+      width={size}
+      height={size}
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
@@ -74,7 +56,75 @@ function DashboardIcon() {
   );
 }
 
-interface HubTabsProps {
+interface HubBottomNavTabProps {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+  iconName?: string;
+  iconBody?: React.ReactNode;
+  className?: string;
+  panelId: string;
+  id: string;
+}
+
+function HubBottomNavTab({
+  active,
+  onClick,
+  label,
+  iconName,
+  iconBody,
+  className,
+  panelId,
+  id,
+}: HubBottomNavTabProps) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      id={`hub-tab-${id}`}
+      aria-selected={active}
+      aria-controls={panelId}
+      tabIndex={active ? 0 : -1}
+      onClick={onClick}
+      className={cn(
+        "relative flex-1 flex flex-col items-center justify-center gap-1",
+        "transition-all duration-200 min-h-[48px] [@media(pointer:coarse)]:min-h-[52px]",
+        "active:scale-95 [@media(pointer:coarse)]:active:bg-panelHi/50",
+        "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-panel",
+        active ? "text-text" : "text-muted hover:text-text/70",
+        className,
+      )}
+    >
+      {active && (
+        <span
+          className={cn(
+            "absolute top-0 left-1/2 -translate-x-1/2",
+            "w-10 h-1 rounded-full shadow-sm",
+            // Brand accent (hub is module-agnostic — never module-colored).
+            "bg-gradient-to-r from-brand-400 to-brand-500",
+          )}
+          aria-hidden
+        />
+      )}
+      <span
+        className={cn(
+          "relative transition-all duration-200",
+          active && "text-brand-strong",
+        )}
+        aria-hidden
+      >
+        {iconName ? (
+          <Icon name={iconName} size={20} strokeWidth={2} />
+        ) : (
+          iconBody
+        )}
+      </span>
+      <span className="text-2xs font-semibold leading-none">{label}</span>
+    </button>
+  );
+}
+
+export interface HubBottomNavProps {
   hubView: HubView;
   onChange: (view: HubView) => void;
   /**
@@ -86,11 +136,11 @@ interface HubTabsProps {
   showReports?: boolean;
 }
 
-export function HubTabs({
+export function HubBottomNav({
   hubView,
   onChange,
   showReports = true,
-}: HubTabsProps) {
+}: HubBottomNavProps) {
   const toast = useToast();
   // Чи був перехід `showReports: false → true` в межах поточного маунту.
   // Тільки в цьому випадку ми вмикаємо bounce-анімацію + one-time toast.
@@ -138,38 +188,45 @@ export function HubTabs({
   return (
     <nav
       aria-label="Розділи хабу"
-      className="px-5 max-w-lg mx-auto w-full mb-1"
+      className={cn(
+        "shrink-0 relative z-30 safe-area-pb",
+        "bg-panel/95 backdrop-blur-xl",
+        "border-t border-line",
+      )}
     >
       <div
         role="tablist"
-        className="flex rounded-2xl overflow-hidden border border-line bg-panelHi/40 p-0.5 gap-0.5"
+        className="flex h-[60px] [@media(pointer:coarse)]:h-[64px]"
       >
-        <TabButton
+        <HubBottomNavTab
+          id="dashboard"
+          panelId="hub-panel-dashboard"
           active={hubView === "dashboard"}
           onClick={() => onChange("dashboard")}
           iconBody={<DashboardIcon />}
-        >
-          Головна
-        </TabButton>
+          label="Головна"
+        />
 
         {showReports && (
-          <TabButton
+          <HubBottomNavTab
+            id="reports"
+            panelId="hub-panel-reports"
             active={hubView === "reports"}
             onClick={() => onChange("reports")}
             iconName="bar-chart"
+            label="Звіти"
             className={animateReveal ? "animate-bounce-in" : undefined}
-          >
-            Звіти
-          </TabButton>
+          />
         )}
 
-        <TabButton
+        <HubBottomNavTab
+          id="settings"
+          panelId="hub-panel-settings"
           active={hubView === "settings"}
           onClick={() => onChange("settings")}
           iconName="settings"
-        >
-          Налаштування
-        </TabButton>
+          label="Налаштування"
+        />
       </div>
     </nav>
   );

--- a/docs/design/UNIFIED-BOTTOM-NAV.md
+++ b/docs/design/UNIFIED-BOTTOM-NAV.md
@@ -1,0 +1,118 @@
+# Unified Bottom Navigation
+
+> **TL;DR:** Хаб і 4 модулі тепер живуть під **одним** навігаційним патерном —
+> `bottom-nav`. Hybrid «top-tabs у хабі + bottom-nav у модулях» більше немає.
+
+## Було → Стало
+
+| Шар                                  | До                                      | Після                                         |
+| ------------------------------------ | --------------------------------------- | --------------------------------------------- |
+| Хаб                                  | `HubTabs` угорі (top-tab strip)         | `HubBottomNav` унизу (bottom-nav)             |
+| Finyk / Fizruk / Routine / Nutrition | `ModuleBottomNav` унизу                 | без змін                                      |
+| FAB «Асистент»                       | pill угорі над `safe-area-inset-bottom` | `compact` варіант 48×48, `76px` вище нав-бару |
+
+## Чому
+
+1. **Когнітивне навантаження.** Hybrid змушував юзера читати нав один раз
+   зверху вниз (у хабі) і один раз знизу вгору (у модулі). Bottom-only =
+   одна m.m. від thumb-a до всіх навігаційних цілей.
+2. **Consistency контракт.** `HubTabs` і `ModuleBottomNav` дрейфували по
+   висоті / блюру / активному індикаторі. Уніфікація через спільну форму.
+3. **Безпечність зони пальця.** За iOS/Material 3 guidelines основна
+   навігація має жити в thumb-zone — нижня третина екрану.
+
+## Layout contract (hub shell)
+
+```
+<div h-dvh flex flex-col overflow-hidden safe-area-pt>
+  <SkipLink />
+  <HintsOrchestrator />
+  <OfflineBanner />
+  <HubHeader />            ← safe-area-top власним inline style
+  <HubMainContent />       ← flex-1 overflow-y-auto; pb-28 для FAB clearance
+  <HubBottomNav />         ← shrink-0 safe-area-pb; 60/64 px
+  <HubFloatingActions compact />
+  <ActiveWorkoutBanner />  ← bottom: 5.25rem + safe-area (над bottom-nav)
+  <HubModals />
+</div>
+```
+
+**Правила:**
+
+- `h-dvh overflow-hidden` на wrapper — не `min-h-dvh`, інакше весь екран
+  прокручується замість внутрішнього `HubMainContent`.
+- `safe-area-pt` на wrapper (не `safe-area-pt-pb`), бо `HubBottomNav` сам
+  додає `safe-area-pb` — інакше подвоюємо iOS inset.
+- FAB (`HubFloatingActions`) завжди `compact` у хабі — piks-identичний
+  з тим що рендериться в модулях.
+- `ActiveWorkoutBanner` вже має `bottom: 5.25rem` (84 px), що вище
+  60-64 px нав-бару. Без змін.
+
+## `HubBottomNav` vs `ModuleBottomNav`
+
+Однакова форма — два різні shell-и:
+
+|                       | `HubBottomNav`                        | `ModuleBottomNav`                    |
+| --------------------- | ------------------------------------- | ------------------------------------ |
+| Items                 | 2-3 (Головна / Звіти? / Налаштування) | 4 per module (finyk/fizruk/...)      |
+| Accent                | `brand` (module-agnostic)             | module color (finyk/teal/coral/lime) |
+| `safe-area-pb`        | ✓                                     | ✓                                    |
+| `role="tablist"`      | ✓                                     | ✓ (опційно; за замовчуванням nav)    |
+| Висота                | 60 px / 64 px coarse                  | 60 px / 64 px coarse                 |
+| Active indicator pill | `w-10 h-1` top, brand gradient        | `w-10 h-1` top, module gradient      |
+
+> `HubBottomNav` — дорога копія `ModuleBottomNav` з brand-токенами, бо у
+> хабі немає active module. Якщо колись захочемо reuse — винести
+> `<BottomNavShell>` в shared і параметризувати gradient.
+
+## Тестовий рецепт
+
+- `pnpm --filter @sergeant/web exec vitest run src/core/app/HubBottomNav.test.tsx` → 7 тестів (3 таби, showReports toggle, tablist semantics, storage flag).
+- Manual: на мобільному — нав лишається фіксованим при скролі контенту.
+- A11y: всі таби мають `role="tab"`, `aria-selected`, `aria-controls`.
+
+## Міграційний guidance
+
+PR 5.2 видалив `HubTabs.tsx`. Якщо якийсь сторонній компонент посилався
+на `HubTabs` (зовнішні stories, snapshot-и, тощо) — замінити на
+`HubBottomNav` з тим самим API:
+
+```diff
+- import { HubTabs } from "@core/app/HubTabs";
++ import { HubBottomNav } from "@core/app/HubBottomNav";
+- <HubTabs hubView={view} onChange={setView} showReports={hasEntries} />
++ <HubBottomNav hubView={view} onChange={setView} showReports={hasEntries} />
+```
+
+`hubView`, `onChange`, `showReports` — API-compatible.
+
+## Anti-patterns
+
+```tsx
+// ❌ Додавати сторонні «top tabs» поруч з bottom-nav.
+<HubHeader />
+<SomeCustomTabStrip />   // ← візуальний гібрид знову
+<HubMainContent />
+<HubBottomNav />
+
+// ✅ Якщо треба глобальний switcher — додати як окремий item у HubBottomNav
+//    або окремим <select> у HubHeader.
+```
+
+```tsx
+// ❌ Дублікувати `safe-area-pb` на wrapper і на nav.
+<div className="safe-area-pt-pb">
+  <HubBottomNav /> // ← також додає safe-area-pb → подвійний padding на iOS
+</div>
+
+// ✅ Wrapper має `safe-area-pt`, nav сам відповідає за свій `safe-area-pb`.
+```
+
+## Related docs
+
+- `docs/design/MODULE-ACCENT.md` — `--module-accent` CSS var, як модулі
+  оголошують свій ambient brand color.
+- `docs/design/BRANDBOOK.md` — WCAG `-strong` tier, чому активні таби
+  використовують `brand-strong` (а не `brand-500`).
+- `apps/web/src/shared/components/ui/ModuleBottomNav.tsx` — sibling
+  nav для модулів.


### PR DESCRIPTION
## What changed

Wave 5 PR 5.2 — архітектурний другий PR. Після мержу і хаб, і 4 модулі живуть під **одним** навігаційним патерном — `bottom-nav`. Hybrid «top-tabs у хабі + bottom-nav у модулях» більше немає.

1. **`apps/web/src/core/app/HubBottomNav.tsx`** (new) — замінює `HubTabs` (top-tab strip) на bottom-anchored nav. Форма mirror `ModuleBottomNav`: 60/64 px, `safe-area-pb`, active indicator pill `w-10 h-1` угорі, `role="tablist"` + `aria-selected` + `aria-controls`. Accent — `brand` (hub module-agnostic). Зберігає reports-reveal logic (bounce + one-time toast) з незмінним storage-key `sergeant.hub.reportsTabRevealedAt`, щоб існуючі юзери не проходили reveal-toast вдруге.

2. **`apps/web/src/core/app/HubTabs.tsx`** — deleted. Повністю замінений на `HubBottomNav`.

3. **`apps/web/src/core/App.tsx`**:
   - Wrapper: `min-h-dvh ... safe-area-pt-pb` → `h-dvh ... overflow-hidden safe-area-pt`. Тепер `HubBottomNav` pinned унизу; `HubMainContent` прокручується внутрішньо (`flex-1 overflow-y-auto` з `pb-28` вже був). `safe-area-pb` переїхав з wrapper на nav — не подвоюємо iOS home-indicator inset.
   - `HubTabs` (після `HubHeader`) → `HubBottomNav` (після `HubMainContent`).
   - `HubFloatingActions` у хабі тепер завжди `compact` — offset `76 px` вище nav-бару, як у модулях.

4. **`apps/web/src/core/app/HubBottomNav.test.tsx`** (new) — 7 тестів: рендер табів, `showReports` toggle, `aria-selected` active tab, `onChange` callback, `aria-controls` на кожному tab, localStorage guard проти повторного reveal-toast.

5. **`docs/design/UNIFIED-BOTTOM-NAV.md`** (new) — layout contract hub shell-у, правила (`h-dvh` не `min-h-dvh`, single `safe-area-pb` owner), anti-patterns (додаткові top-tabs, подвійний safe-area-pb), related docs (MODULE-ACCENT.md, BRANDBOOK.md, ModuleBottomNav.tsx).

## Why

Початкова скарга (UI#2 у першому огляді): «Гібрид top-tabs (хаб) + bottom-nav (модулі) — звести до однієї bottom-bar».

Проблеми гібрида:

- **Когнітивне навантаження** — юзер читає nav зверху вниз у хабі і знизу вгору в модулях. Bottom-only = thumb-zone для всього.
- **Дрейф форми** — `HubTabs` і `ModuleBottomNav` мали різну висоту/блюр/active-indicator. Уніфікація через спільну shape.
- **iOS/Material 3 guidelines** — основна навігація живе в нижній третині.

Після цього PR:

- Hub і 4 модулі візуально ідентичні по nav-patternу.
- FAB «Асистент» теж ідентичний (`compact` скрізь).
- Layout contract задокументований і тестований.

## How to test

1. Відкрити хаб — бачиш `HubBottomNav` внизу замість `HubTabs` вгорі. Клікаєш tab → `hubView` змінюється.
2. Логнути 1 реальну транзакцію (Finyk) → повернутися на хаб → tab «Звіти» з'являється з bounce-анімацією + one-time toast. Закриваєш toast, перезавантажуєш сторінку → toast НЕ показується знову (localStorage прапор).
3. Зайти в модуль (Finyk/Fizruk/Routine/Nutrition) — `ModuleBottomNav` без змін. Повернутися на хаб → `HubBottomNav` візуально ідентичний.
4. На iPhone / Safari — home-indicator inset не подвоюється (між nav-баром і низом — ~34 px, не ~68).
5. `pnpm --filter @sergeant/web exec vitest run src/core/app/HubBottomNav.test.tsx` → 7/7 ✓.
6. Full web suite: `pnpm --filter @sergeant/web exec vitest run` → 1410/1410 ✓ (нічого не зламали).

---

## How AI-tested this PR

- [x] Vitest — web: 7/7 нових (`HubBottomNav.test.tsx`) + 1403 існуючих = 1410/1410 ✓.
- [x] `pnpm exec prettier` / `pnpm exec eslint` / `pnpm --filter @sergeant/web exec tsc -p tsconfig.json --noEmit` — всі clean.
- [x] Нема нових `AI-DANGER` маркерів.
- [x] Docs укр. (`docs/design/UNIFIED-BOTTOM-NAV.md`).

## AGENTS.md updated?

- [ ] Ні — нових permanent rules не додано. Layout contract лежить у `docs/design/UNIFIED-BOTTOM-NAV.md`, бо специфічний до hub shell і не дотягує до repo-wide правила.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the hub’s top tabs with a new bottom-anchored `HubBottomNav` to match the modules. This unifies navigation across the app and preserves the one-time “Reports” reveal behavior.

- **Refactors**
  - Introduced `HubBottomNav` (brand-accent, `role="tablist"`, 60/64px, top pill indicator) and removed `HubTabs`.
  - Updated layout: wrapper uses `h-dvh overflow-hidden safe-area-pt`; nav is pinned at the bottom; content scrolls inside.
  - Set `HubFloatingActions` to `compact` in the hub to match module FAB offset.
  - Added 7 unit tests and a design doc for the layout contract.

- **Bug Fixes**
  - Avoided double iOS home‑indicator inset by making the nav the sole `safe-area-pb` owner.

<sup>Written for commit 0bc677c233bc92a5ecb1ba0d8eadc9253e9f42cc. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1142?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned hub navigation to a bottom-positioned bar with refined styling and interactive indicators.
  * Updated floating assistant action to compact mode for improved layout alignment.

* **Documentation**
  * Added design specification for unified bottom navigation architecture, including testing requirements and accessibility guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->