### PR TITLE
feat(root): scaffolded/deprecated lifecycle markers (Hard Rule #10)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,6 +226,62 @@ The rule deliberately does **not** fire on:
 
 Enforced by `sergeant-design/no-low-contrast-text-on-fill` (`error`). The four saturated `*-500` brand-identity tokens in `packages/design-tokens/tokens.js` remain unchanged — they're still the canonical brand colours for logos, marketing assets, and dark-mode bento surfaces. The strong tier is purely additive and only required for text/fill-behind-text contexts.
 
+### 10. Lifecycle markers — every file/doc declares its status
+
+> Why a hard rule? Because PR [#1143](https://github.com/Skords-01/Sergeant/pull/1143) silently merged a "dead-code cleanup" that deleted scaffolded-but-not-yet-wired components (`PullToRefreshIndicator`, `usePullToRefresh`, `EmptyStateIllustrations`, `OptimizedImage`). They were dropped in by a `feat(web)` commit ahead of integration and `pnpm knip` correctly reported "no importers" — but cleaning them up was wrong, because they were the next-step UI scaffolding, not legacy. We need a way to tell intentional-zero-importers apart from real dead code.
+
+Every non-trivial source file and every published doc declares **one** of these statuses. If a file/doc has no marker, treat it as `Active` (the default) — but if `pnpm knip` flags it as unused, you must check git log and possibly add a `@scaffolded` marker before deleting.
+
+#### Code: JSDoc lifecycle tags
+
+Place the marker in the **first JSDoc block of the file** (above imports is fine). Tags compose with TS-LSP — `@deprecated` shows strikethrough in editors automatically.
+
+| Tag             | Meaning                                                                                   | When to add                                                         | When to remove                                                                       |
+| --------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `@scaffolded`   | Ready for use but no live consumer yet. Intentional zero-importer. Knip MUST NOT flag it. | When you commit a component/hook ahead of its first wiring PR.      | In the PR that wires it into a page/route/registry — also delete the tag in that PR. |
+| `@experimental` | API may change or be reverted. Live consumers exist but we are not promising stability.   | When shipping a feature flag or A/B candidate that may be reverted. | When stabilizing (delete tag), or when removing (replace with `@deprecated`).        |
+| `@deprecated`   | Live consumers must migrate away. Will be removed by a target date.                       | When introducing a replacement.                                     | After the deletion PR lands and consumers are migrated.                              |
+| _(no tag)_      | Active. Default for everything else.                                                      | —                                                                   | —                                                                                    |
+
+Each non-Active marker is followed by a **machine-readable block** with the same shape:
+
+```ts
+/**
+ * @scaffolded
+ * @owner @Skords-01
+ * @addedIn <commit-sha>  # short SHA of the commit that introduced the file
+ * @nextStep <one-line plan> — link to a doc/issue describing the integration
+ *
+ * Scaffolded but not yet imported by any consumer. Do NOT delete as part of
+ * dead-code cleanup — see Hard Rule #10 in AGENTS.md.
+ */
+```
+
+`@deprecated` blocks add `@removeBy YYYY-MM-DD` (target removal date) and `@migration <link>` (where consumers learn how to switch).
+
+Knip respects `@scaffolded` and `@deprecated` files via `knip.json` `ignore` glob entries that include the markers (see `scripts/knip-respects-scaffolded.mjs` for the regex list). When you add a marker, no knip config change is needed.
+
+#### Docs: status badge under the freshness marker
+
+Right after the existing `> **Last validated:** YYYY-MM-DD …` line, add:
+
+```md
+> **Status:** Active | Scaffolded | Deprecated | Archived
+```
+
+- `Active` — current source of truth. Default.
+- `Scaffolded` — describes a feature/component that exists in code but isn't wired yet. Do NOT cite it as live behaviour. Pair with the matching `@scaffolded` JSDoc tag in code.
+- `Deprecated` — describes a behaviour we're replacing; reference the replacement.
+- `Archived` — historical artefact, lives in `docs/<area>/archive/`. CI freshness checks ignore.
+
+`scripts/check-tech-debt-freshness.mjs` accepts the new `Status:` line and refuses to run on `Archived` docs (so we don't churn timestamps on archives).
+
+#### What this rule blocks
+
+- **Dead-code PRs** — agent/human MUST check for `@scaffolded`/`@deprecated` markers before deleting a "knip-says-unused" file. If a marker exists, leave the file. If knip flags an unmarked file, prefer to add `@scaffolded` (with owner + next step) rather than delete, unless `git log --follow` makes it obvious the file is truly orphaned (e.g. last touched > 12 months ago, no `feat(...)` commit). Document the reasoning in the PR description.
+- **Doc cleanup PRs** — `Archived` docs may be moved to `archive/`, but their content is not edited.
+- **AI agents** — when surfacing files for review, group by status. A file with `@scaffolded` is NOT a candidate for the "remove dead code" task type.
+
 ## AI markers
 
 Structured comments for AI-agent context. Enforced by ESLint rule `sergeant-design/ai-marker-syntax` (warn).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -296,6 +296,7 @@ These are non-negotiable. Read `AGENTS.md` for full context.
 7. **Never skip pre-commit hooks** (`--no-verify` is forbidden).
 8. **Tailwind opacity steps** must be on the registered scale (`0,5,8,10,15,…,100`). Off-scale values silently drop.
 9. **Saturated brand fills behind `text-white`** must use the `-strong` companion for WCAG AA compliance.
+10. **Lifecycle markers** — every file declares its status. New components/hooks committed ahead of integration MUST carry a `@scaffolded` JSDoc block with `@owner` + `@nextStep`. Docs add `> **Status:** Active | Scaffolded | Deprecated | Archived`. Dead-code cleanup PRs MUST run `pnpm dead-code:files` (which honours markers) — never delete a `@scaffolded` file just because it has no importers.
 
 ---
 

--- a/apps/web/src/modules/finyk/index.ts
+++ b/apps/web/src/modules/finyk/index.ts
@@ -1,5 +1,12 @@
 /**
- * Finyk module — public entry point.
+ * @scaffolded
+ * @owner @Skords-01
+ * @nextStep Have the App router (`apps/web/src/core/app/appRouter.tsx`) and
+ *           hub registry import `FinykApp` from `@finyk` (this barrel) instead
+ *           of `@modules/finyk/FinykApp`. Once consumers exist, drop this tag.
+ *
+ * Public entry point for the Finyk module — declared API surface kept for
+ * cross-module consumers. See AGENTS.md → Hard Rule #10.
  *
  * Prefer importing from `@finyk` or `@modules/finyk` instead of deep paths
  * for cross-module consumers (e.g. App router, hub registry):

--- a/apps/web/src/modules/fizruk/index.ts
+++ b/apps/web/src/modules/fizruk/index.ts
@@ -1,5 +1,10 @@
 /**
- * Fizruk module — public entry point.
+ * @scaffolded
+ * @owner @Skords-01
+ * @nextStep Have App router import `FizrukApp` from `@fizruk` instead of
+ *           `@modules/fizruk/FizrukApp`. See AGENTS.md → Hard Rule #10.
+ *
+ * Public entry point for the Fizruk module — declared API surface.
  *
  * Prefer importing from `@fizruk` instead of deep paths for cross-module
  * consumers (e.g. App router, hub registry):

--- a/apps/web/src/modules/nutrition/index.ts
+++ b/apps/web/src/modules/nutrition/index.ts
@@ -1,5 +1,10 @@
 /**
- * Nutrition module — public entry point.
+ * @scaffolded
+ * @owner @Skords-01
+ * @nextStep Have App router import `NutritionApp` from `@nutrition` instead of
+ *           `@modules/nutrition/NutritionApp`. See AGENTS.md → Hard Rule #10.
+ *
+ * Public entry point for the Nutrition module — declared API surface.
  *
  * Prefer importing from `@nutrition` instead of deep paths for cross-module
  * consumers (e.g. App router, hub registry):

--- a/apps/web/src/modules/routine/index.ts
+++ b/apps/web/src/modules/routine/index.ts
@@ -1,5 +1,10 @@
 /**
- * Routine module — public entry point.
+ * @scaffolded
+ * @owner @Skords-01
+ * @nextStep Have App router import `RoutineApp` from `@routine` instead of
+ *           `@modules/routine/RoutineApp`. See AGENTS.md → Hard Rule #10.
+ *
+ * Public entry point for the Routine module — declared API surface.
  *
  * Prefer importing from `@routine` instead of deep paths for cross-module
  * consumers (e.g. App router, hub registry):

--- a/apps/web/src/shared/charts/index.ts
+++ b/apps/web/src/shared/charts/index.ts
@@ -1,5 +1,10 @@
 /**
- * Shared chart theme tokens — barrel.
+ * @scaffolded
+ * @owner @Skords-01
+ * @nextStep Migrate Finyk/Fizruk chart components from `@shared/charts/*` deep
+ *           paths to `@shared/charts`. See AGENTS.md → Hard Rule #10.
+ *
+ * Shared chart theme tokens — declared API surface.
  *
  * Prefer importing from `@shared/charts` instead of deep paths so renames
  * stay cheap and IDE autocomplete surfaces the full API:

--- a/apps/web/src/shared/components/ui/EmptyStateIllustrations.tsx
+++ b/apps/web/src/shared/components/ui/EmptyStateIllustrations.tsx
@@ -1,0 +1,418 @@
+/**
+ * @scaffolded
+ * @owner @Skords-01
+ * @addedIn 1d443ac1 (feat(web): add UI/UX improvements and new components)
+ * @nextStep Wire into module empty-states (Finyk transactions, Fizruk workouts,
+ *           Routine habits, Nutrition diary). See docs/design/EMPTY-STATES.md.
+ *
+ * Scaffolded but not yet imported by any consumer. Do NOT delete as part of
+ * dead-code cleanup — see Hard Rule #15 in AGENTS.md.
+ */
+import { memo } from "react";
+import { cn } from "@shared/lib/cn";
+
+interface IllustrationProps {
+  className?: string;
+  size?: number;
+}
+
+/**
+ * Module-specific empty state illustrations.
+ * SVG-based, responsive, and theme-aware.
+ */
+
+export const FinykEmptyIllustration = memo(function FinykEmptyIllustration({
+  className,
+  size = 120,
+}: IllustrationProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 120 120"
+      fill="none"
+      className={cn("text-finyk", className)}
+      aria-hidden="true"
+    >
+      {/* Wallet base */}
+      <rect
+        x="20"
+        y="35"
+        width="80"
+        height="55"
+        rx="12"
+        className="fill-finyk-soft dark:fill-finyk/10 stroke-finyk/30"
+        strokeWidth="2"
+      />
+      {/* Wallet flap */}
+      <path
+        d="M20 47C20 40.373 25.373 35 32 35H88C94.627 35 100 40.373 100 47V55H20V47Z"
+        className="fill-finyk/20 dark:fill-finyk/15"
+      />
+      {/* Card slot */}
+      <rect
+        x="70"
+        y="60"
+        width="20"
+        height="14"
+        rx="3"
+        className="fill-panel stroke-finyk/40"
+        strokeWidth="1.5"
+      />
+      {/* Coins floating */}
+      <circle
+        cx="35"
+        cy="25"
+        r="10"
+        className="fill-brand-100 dark:fill-brand/20 stroke-brand-400"
+        strokeWidth="2"
+      />
+      <text
+        x="35"
+        y="29"
+        textAnchor="middle"
+        className="fill-brand-600 dark:fill-brand text-[10px] font-bold"
+      >
+        $
+      </text>
+      <circle
+        cx="55"
+        cy="18"
+        r="8"
+        className="fill-teal-100 dark:fill-teal-500/20 stroke-teal-400"
+        strokeWidth="1.5"
+        opacity="0.7"
+      />
+      {/* Sparkles */}
+      <path
+        d="M85 25L87 22L89 25L87 28L85 25Z"
+        className="fill-brand-400 motion-safe:animate-pulse"
+      />
+      <path
+        d="M25 70L26.5 68L28 70L26.5 72L25 70Z"
+        className="fill-brand-300 motion-safe:animate-pulse"
+        style={{ animationDelay: "0.5s" }}
+      />
+    </svg>
+  );
+});
+
+export const FizrukEmptyIllustration = memo(function FizrukEmptyIllustration({
+  className,
+  size = 120,
+}: IllustrationProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 120 120"
+      fill="none"
+      className={cn("text-fizruk", className)}
+      aria-hidden="true"
+    >
+      {/* Dumbbell bar */}
+      <rect
+        x="25"
+        y="55"
+        width="70"
+        height="10"
+        rx="5"
+        className="fill-line dark:fill-line/60"
+      />
+      {/* Left weight */}
+      <rect
+        x="15"
+        y="40"
+        width="18"
+        height="40"
+        rx="4"
+        className="fill-fizruk-soft dark:fill-fizruk/15 stroke-fizruk/40"
+        strokeWidth="2"
+      />
+      <rect
+        x="8"
+        y="45"
+        width="12"
+        height="30"
+        rx="3"
+        className="fill-fizruk/30 dark:fill-fizruk/20 stroke-fizruk/30"
+        strokeWidth="1.5"
+      />
+      {/* Right weight */}
+      <rect
+        x="87"
+        y="40"
+        width="18"
+        height="40"
+        rx="4"
+        className="fill-fizruk-soft dark:fill-fizruk/15 stroke-fizruk/40"
+        strokeWidth="2"
+      />
+      <rect
+        x="100"
+        y="45"
+        width="12"
+        height="30"
+        rx="3"
+        className="fill-fizruk/30 dark:fill-fizruk/20 stroke-fizruk/30"
+        strokeWidth="1.5"
+      />
+      {/* Sweat drops */}
+      <ellipse
+        cx="60"
+        cy="35"
+        rx="3"
+        ry="5"
+        className="fill-teal-300 dark:fill-teal-400/50 motion-safe:animate-bounce"
+        style={{ animationDuration: "2s" }}
+      />
+      <ellipse
+        cx="50"
+        cy="30"
+        rx="2"
+        ry="3.5"
+        className="fill-teal-200 dark:fill-teal-400/30 motion-safe:animate-bounce"
+        style={{ animationDuration: "2.3s", animationDelay: "0.3s" }}
+      />
+      {/* Floor line */}
+      <path
+        d="M10 95H110"
+        className="stroke-line dark:stroke-line/40"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeDasharray="4 4"
+      />
+    </svg>
+  );
+});
+
+export const RoutineEmptyIllustration = memo(function RoutineEmptyIllustration({
+  className,
+  size = 120,
+}: IllustrationProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 120 120"
+      fill="none"
+      className={cn("text-routine", className)}
+      aria-hidden="true"
+    >
+      {/* Clipboard */}
+      <rect
+        x="25"
+        y="20"
+        width="70"
+        height="85"
+        rx="8"
+        className="fill-panel stroke-line"
+        strokeWidth="2"
+      />
+      {/* Clipboard top */}
+      <rect
+        x="40"
+        y="12"
+        width="40"
+        height="16"
+        rx="4"
+        className="fill-routine-surface dark:fill-routine/15 stroke-routine/40"
+        strokeWidth="2"
+      />
+      <circle cx="60" cy="20" r="4" className="fill-routine/50" />
+      {/* Empty checklist lines */}
+      <g className="stroke-line dark:stroke-line/60" strokeWidth="2">
+        <rect x="35" y="40" width="14" height="14" rx="3" />
+        <line x1="55" y1="47" x2="85" y2="47" strokeLinecap="round" />
+        <rect x="35" y="62" width="14" height="14" rx="3" />
+        <line x1="55" y1="69" x2="80" y2="69" strokeLinecap="round" />
+        <rect x="35" y="84" width="14" height="14" rx="3" />
+        <line x1="55" y1="91" x2="75" y2="91" strokeLinecap="round" />
+      </g>
+      {/* Decorative star */}
+      <path
+        d="M100 30L102 26L104 30L100 32L96 30L100 26L100 30Z"
+        className="fill-routine/50 motion-safe:animate-pulse"
+      />
+    </svg>
+  );
+});
+
+export const NutritionEmptyIllustration = memo(
+  function NutritionEmptyIllustration({
+    className,
+    size = 120,
+  }: IllustrationProps) {
+    return (
+      <svg
+        width={size}
+        height={size}
+        viewBox="0 0 120 120"
+        fill="none"
+        className={cn("text-nutrition", className)}
+        aria-hidden="true"
+      >
+        {/* Plate */}
+        <ellipse
+          cx="60"
+          cy="75"
+          rx="45"
+          ry="20"
+          className="fill-nutrition-soft dark:fill-nutrition/10 stroke-nutrition/30"
+          strokeWidth="2"
+        />
+        <ellipse
+          cx="60"
+          cy="75"
+          rx="35"
+          ry="14"
+          className="fill-panel stroke-line dark:stroke-line/60"
+          strokeWidth="1.5"
+        />
+        {/* Fork */}
+        <g className="stroke-line dark:stroke-line/60" strokeWidth="2">
+          <line x1="25" y1="40" x2="25" y2="65" strokeLinecap="round" />
+          <line x1="20" y1="40" x2="20" y2="52" strokeLinecap="round" />
+          <line x1="30" y1="40" x2="30" y2="52" strokeLinecap="round" />
+          <path d="M20 52H30" strokeLinecap="round" />
+        </g>
+        {/* Knife */}
+        <g className="stroke-line dark:stroke-line/60" strokeWidth="2">
+          <line x1="95" y1="40" x2="95" y2="65" strokeLinecap="round" />
+          <path d="M95 40C100 40 100 50 95 52" strokeLinecap="round" />
+        </g>
+        {/* Leaf garnish */}
+        <path
+          d="M55 55C55 50 60 45 65 45C65 50 60 55 55 55Z"
+          className="fill-nutrition/40 dark:fill-nutrition/30"
+        />
+        <path
+          d="M60 55L62 48"
+          className="stroke-nutrition/60"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+        />
+        {/* Steam/aroma lines */}
+        <path
+          d="M50 35C50 32 53 32 53 35C53 38 50 38 50 35Z"
+          className="stroke-muted/40 motion-safe:animate-pulse"
+          strokeWidth="1.5"
+          fill="none"
+        />
+        <path
+          d="M60 30C60 27 63 27 63 30C63 33 60 33 60 30Z"
+          className="stroke-muted/30 motion-safe:animate-pulse"
+          strokeWidth="1.5"
+          fill="none"
+          style={{ animationDelay: "0.3s" }}
+        />
+        <path
+          d="M70 35C70 32 73 32 73 35C73 38 70 38 70 35Z"
+          className="stroke-muted/40 motion-safe:animate-pulse"
+          strokeWidth="1.5"
+          fill="none"
+          style={{ animationDelay: "0.6s" }}
+        />
+      </svg>
+    );
+  },
+);
+
+/**
+ * Generic empty state illustration for non-module contexts.
+ */
+export const GenericEmptyIllustration = memo(function GenericEmptyIllustration({
+  className,
+  size = 120,
+}: IllustrationProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 120 120"
+      fill="none"
+      className={cn(className)}
+      aria-hidden="true"
+    >
+      {/* Box */}
+      <rect
+        x="25"
+        y="35"
+        width="70"
+        height="55"
+        rx="8"
+        className="fill-panelHi stroke-line"
+        strokeWidth="2"
+      />
+      {/* Box opening */}
+      <path
+        d="M25 50L60 35L95 50"
+        className="stroke-line"
+        strokeWidth="2"
+        strokeLinejoin="round"
+        fill="none"
+      />
+      <path
+        d="M60 35V55"
+        className="stroke-line/50"
+        strokeWidth="1.5"
+        strokeDasharray="3 3"
+      />
+      {/* Dust particles */}
+      <circle
+        cx="45"
+        cy="70"
+        r="2"
+        className="fill-muted/30 motion-safe:animate-pulse"
+      />
+      <circle
+        cx="75"
+        cy="65"
+        r="1.5"
+        className="fill-muted/20 motion-safe:animate-pulse"
+        style={{ animationDelay: "0.5s" }}
+      />
+      <circle
+        cx="60"
+        cy="75"
+        r="1"
+        className="fill-muted/25 motion-safe:animate-pulse"
+        style={{ animationDelay: "1s" }}
+      />
+    </svg>
+  );
+});
+
+export type ModuleIllustration =
+  | "finyk"
+  | "fizruk"
+  | "routine"
+  | "nutrition"
+  | "generic";
+
+const ILLUSTRATIONS: Record<
+  ModuleIllustration,
+  React.ComponentType<IllustrationProps>
+> = {
+  finyk: FinykEmptyIllustration,
+  fizruk: FizrukEmptyIllustration,
+  routine: RoutineEmptyIllustration,
+  nutrition: NutritionEmptyIllustration,
+  generic: GenericEmptyIllustration,
+};
+
+export interface ModuleEmptyIllustrationProps extends IllustrationProps {
+  module: ModuleIllustration;
+}
+
+/**
+ * Convenience component that renders the appropriate illustration
+ * based on the module name.
+ */
+export const ModuleEmptyIllustration = memo(function ModuleEmptyIllustration({
+  module,
+  ...props
+}: ModuleEmptyIllustrationProps) {
+  const Component = ILLUSTRATIONS[module] || ILLUSTRATIONS.generic;
+  return <Component {...props} />;
+});

--- a/apps/web/src/shared/components/ui/OptimizedImage.tsx
+++ b/apps/web/src/shared/components/ui/OptimizedImage.tsx
@@ -1,0 +1,261 @@
+/**
+ * @scaffolded
+ * @owner @Skords-01
+ * @addedIn e43120a3 (perf(web,server): frontend & backend optimization)
+ * @nextStep Replace `<img>` usage in Finyk merchant-logos and Hub bento-card
+ *           illustrations once we have a CDN/loader story.
+ *
+ * Scaffolded but not yet imported by any consumer. Do NOT delete as part of
+ * dead-code cleanup — see Hard Rule #15 in AGENTS.md.
+ */
+import {
+  useState,
+  useCallback,
+  useRef,
+  useEffect,
+  type ImgHTMLAttributes,
+} from "react";
+import { cn } from "../../lib/cn";
+
+/**
+ * Sergeant Design System — OptimizedImage
+ *
+ * Lazy-loaded image component with:
+ * - Native lazy loading (loading="lazy") + IntersectionObserver fallback
+ * - Automatic aspect ratio container to prevent layout shift
+ * - Skeleton placeholder during load
+ * - Error fallback state
+ * - Optional blur-up effect on load
+ * - Responsive srcSet support
+ * - fetchPriority support for LCP images
+ *
+ * Usage:
+ * ```tsx
+ * <OptimizedImage
+ *   src="/images/hero.jpg"
+ *   alt="Hero image"
+ *   aspectRatio="16/9"
+ *   sizes="(max-width: 640px) 100vw, 50vw"
+ *   priority // for above-the-fold images
+ * />
+ * ```
+ */
+
+export interface OptimizedImageProps extends Omit<
+  ImgHTMLAttributes<HTMLImageElement>,
+  "onLoad" | "onError"
+> {
+  /** Aspect ratio for the container (e.g., "16/9", "4/3", "1/1") */
+  aspectRatio?: string;
+  /** Show blur-up animation on load */
+  blurOnLoad?: boolean;
+  /** Custom fallback element when image fails to load */
+  fallback?: React.ReactNode;
+  /** Additional class for the wrapper container */
+  wrapperClassName?: string;
+  /** Callback when image loads */
+  onImageLoad?: () => void;
+  /** Callback when image fails to load */
+  onImageError?: () => void;
+  /** Priority loading for above-the-fold images (disables lazy loading) */
+  priority?: boolean;
+  /** Root margin for intersection observer (e.g., "200px" to start loading earlier) */
+  rootMargin?: string;
+}
+
+export function OptimizedImage({
+  src,
+  alt,
+  aspectRatio,
+  blurOnLoad = true,
+  fallback,
+  wrapperClassName,
+  className,
+  onImageLoad,
+  onImageError,
+  priority = false,
+  rootMargin = "200px",
+  ...props
+}: OptimizedImageProps) {
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [hasError, setHasError] = useState(false);
+  const [isInView, setIsInView] = useState(priority);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // IntersectionObserver for preloading images before they enter viewport
+  useEffect(() => {
+    if (priority || isInView) return;
+
+    const element = containerRef.current;
+    if (!element) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          setIsInView(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin, threshold: 0 },
+    );
+
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [priority, isInView, rootMargin]);
+
+  const handleLoad = useCallback(() => {
+    setIsLoaded(true);
+    onImageLoad?.();
+  }, [onImageLoad]);
+
+  const handleError = useCallback(() => {
+    setHasError(true);
+    onImageError?.();
+  }, [onImageError]);
+
+  if (hasError) {
+    if (fallback) {
+      return <>{fallback}</>;
+    }
+    return (
+      <div
+        className={cn(
+          "flex items-center justify-center bg-panelHi text-muted rounded-lg",
+          wrapperClassName,
+        )}
+        style={aspectRatio ? { aspectRatio } : undefined}
+        role="img"
+        aria-label={alt || "Image failed to load"}
+      >
+        <svg
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden
+        >
+          <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+          <circle cx="8.5" cy="8.5" r="1.5" />
+          <polyline points="21 15 16 10 5 21" />
+        </svg>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn("relative overflow-hidden", wrapperClassName)}
+      style={aspectRatio ? { aspectRatio } : undefined}
+    >
+      {/* Skeleton placeholder */}
+      {!isLoaded && (
+        <div
+          className={cn(
+            "absolute inset-0 bg-line/30 animate-pulse",
+            "motion-reduce:animate-none motion-reduce:bg-line/50",
+          )}
+          aria-hidden
+        />
+      )}
+
+      {/* Actual image - only render when in view or priority */}
+      {isInView && (
+        <img
+          src={src}
+          alt={alt}
+          loading={priority ? "eager" : "lazy"}
+          decoding={priority ? "sync" : "async"}
+          fetchPriority={priority ? "high" : "auto"}
+          onLoad={handleLoad}
+          onError={handleError}
+          className={cn(
+            "w-full h-full object-cover",
+            blurOnLoad && !isLoaded && "blur-sm scale-105",
+            blurOnLoad && isLoaded && "blur-0 scale-100",
+            "transition-[filter,transform] duration-500 ease-out",
+            "motion-reduce:transition-none motion-reduce:blur-0 motion-reduce:scale-100",
+            className,
+          )}
+          {...props}
+        />
+      )}
+    </div>
+  );
+}
+
+/**
+ * Avatar image with optimized loading and circular shape
+ */
+export function OptimizedAvatar({
+  src,
+  alt,
+  size = 40,
+  className,
+  ...props
+}: OptimizedImageProps & { size?: number }) {
+  return (
+    <OptimizedImage
+      src={src}
+      alt={alt}
+      aspectRatio="1/1"
+      blurOnLoad={false}
+      wrapperClassName={cn("rounded-full", className)}
+      style={{ width: size, height: size }}
+      {...props}
+    />
+  );
+}
+
+/**
+ * Hero/banner image with responsive sizing
+ */
+export function OptimizedHeroImage({
+  src,
+  alt,
+  className,
+  ...props
+}: OptimizedImageProps) {
+  return (
+    <OptimizedImage
+      src={src}
+      alt={alt}
+      aspectRatio="16/9"
+      sizes="100vw"
+      wrapperClassName={cn("w-full rounded-2xl", className)}
+      {...props}
+    />
+  );
+}
+
+/**
+ * Thumbnail image for lists/grids
+ */
+export function OptimizedThumbnail({
+  src,
+  alt,
+  size = "md",
+  className,
+  ...props
+}: OptimizedImageProps & { size?: "sm" | "md" | "lg" }) {
+  const sizeClasses = {
+    sm: "w-12 h-12",
+    md: "w-16 h-16",
+    lg: "w-24 h-24",
+  };
+
+  return (
+    <OptimizedImage
+      src={src}
+      alt={alt}
+      aspectRatio="1/1"
+      blurOnLoad={false}
+      wrapperClassName={cn("rounded-xl", sizeClasses[size], className)}
+      {...props}
+    />
+  );
+}

--- a/apps/web/src/shared/components/ui/PullToRefreshIndicator.tsx
+++ b/apps/web/src/shared/components/ui/PullToRefreshIndicator.tsx
@@ -1,0 +1,88 @@
+/**
+ * @scaffolded
+ * @owner @Skords-01
+ * @addedIn 1d443ac1 (feat(web): add UI/UX improvements and new components)
+ * @nextStep Wire into Finyk/Fizruk/Routine/Nutrition module pages so
+ *           PWA users get a native-like refresh gesture. See
+ *           docs/design/design-system.md § PullToRefreshIndicator for
+ *           the integration recipe.
+ *
+ * Scaffolded but not yet imported by any consumer. Do NOT delete as part of
+ * dead-code cleanup — see Hard Rule #15 in AGENTS.md.
+ */
+import { cn } from "@shared/lib/cn";
+import type { PullToRefreshState } from "@shared/hooks/usePullToRefresh";
+
+export interface PullToRefreshIndicatorProps {
+  state: PullToRefreshState;
+  /** Module accent color variant */
+  variant?: "finyk" | "fizruk" | "routine" | "nutrition" | "default";
+  className?: string;
+}
+
+const VARIANT_COLORS = {
+  finyk: "text-finyk border-finyk/30",
+  fizruk: "text-fizruk border-fizruk/30",
+  routine: "text-routine border-routine/30",
+  nutrition: "text-nutrition border-nutrition/30",
+  default: "text-brand border-brand/30",
+};
+
+/**
+ * Pull-to-refresh indicator component.
+ * Shows a spinner that rotates based on pull progress.
+ * Pairs with `usePullToRefresh` hook.
+ */
+export function PullToRefreshIndicator({
+  state,
+  variant = "default",
+  className,
+}: PullToRefreshIndicatorProps) {
+  const { isPulling, isRefreshing, pullProgress, pullDistance, canRefresh } =
+    state;
+
+  if (!isPulling && !isRefreshing && pullDistance === 0) return null;
+
+  return (
+    <div
+      className={cn(
+        "absolute left-1/2 -translate-x-1/2 z-50 flex items-center justify-center",
+        "transition-[transform,opacity] duration-200 ease-out",
+        className,
+      )}
+      style={{
+        transform: `translateX(-50%) translateY(${pullDistance - 48}px)`,
+        opacity: Math.min(pullProgress * 1.5, 1),
+      }}
+    >
+      <div
+        className={cn(
+          "w-10 h-10 rounded-full bg-panel shadow-card border flex items-center justify-center",
+          VARIANT_COLORS[variant],
+          canRefresh && "scale-110",
+          "transition-transform duration-150",
+        )}
+      >
+        <svg
+          className={cn(
+            "w-5 h-5",
+            isRefreshing && "motion-safe:animate-pull-rotate",
+          )}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          style={{
+            transform: isRefreshing
+              ? undefined
+              : `rotate(${pullProgress * 360}deg)`,
+            transition: isRefreshing ? undefined : "transform 0.1s ease-out",
+          }}
+        >
+          <path d="M21 12a9 9 0 11-6.219-8.56" />
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/shared/hooks/index.ts
+++ b/apps/web/src/shared/hooks/index.ts
@@ -60,6 +60,12 @@ export type {
   UseScrollHeaderOptions,
 } from "./useScrollHeader";
 
+export { usePullToRefresh } from "./usePullToRefresh";
+export type {
+  PullToRefreshState,
+  UsePullToRefreshOptions,
+} from "./usePullToRefresh";
+
 export { useFocusTrap } from "./useFocusTrap";
 
 export { useFormValidation, validationRules } from "./useFormValidation";

--- a/apps/web/src/shared/hooks/usePullToRefresh.ts
+++ b/apps/web/src/shared/hooks/usePullToRefresh.ts
@@ -1,0 +1,200 @@
+/**
+ * @scaffolded
+ * @owner @Skords-01
+ * @addedIn 1d443ac1 (feat(web): add UI/UX improvements and new components)
+ * @nextStep Pair with `<PullToRefreshIndicator>` and wire into module
+ *           pages. See docs/design/design-system.md § PullToRefreshIndicator.
+ *
+ * Scaffolded but not yet imported by any consumer. Do NOT delete as part of
+ * dead-code cleanup — see Hard Rule #15 in AGENTS.md.
+ */
+import { useState, useRef, useCallback, useEffect } from "react";
+
+export interface PullToRefreshState {
+  /** Whether currently pulling down */
+  isPulling: boolean;
+  /** Whether refresh is in progress */
+  isRefreshing: boolean;
+  /** Pull distance in pixels (0 to pullThreshold) */
+  pullDistance: number;
+  /** Pull progress (0 to 1) */
+  pullProgress: number;
+  /** Whether pull threshold has been exceeded (ready to refresh) */
+  canRefresh: boolean;
+}
+
+export interface UsePullToRefreshOptions {
+  /** Callback when refresh is triggered */
+  onRefresh: () => Promise<void>;
+  /** Pull distance required to trigger refresh (default: 80px) */
+  pullThreshold?: number;
+  /** Maximum pull distance (default: 120px) */
+  maxPullDistance?: number;
+  /** Resistance factor for pulling past threshold (default: 0.4) */
+  resistance?: number;
+  /** Whether pull-to-refresh is enabled (default: true) */
+  enabled?: boolean;
+  /** Ref to scrollable container (required) */
+  scrollRef: React.RefObject<HTMLElement>;
+}
+
+/**
+ * Hook for native-like pull-to-refresh gesture.
+ * Only activates when at top of scroll container.
+ *
+ * Returns state for building custom pull-to-refresh UI:
+ * - isPulling: actively pulling
+ * - isRefreshing: refresh in progress
+ * - pullDistance: current pull distance
+ * - pullProgress: 0-1 progress toward threshold
+ * - canRefresh: threshold exceeded, will refresh on release
+ */
+export function usePullToRefresh(
+  options: UsePullToRefreshOptions,
+): PullToRefreshState {
+  const {
+    onRefresh,
+    pullThreshold = 80,
+    maxPullDistance = 120,
+    resistance = 0.4,
+    enabled = true,
+    scrollRef,
+  } = options;
+
+  const [state, setState] = useState<PullToRefreshState>({
+    isPulling: false,
+    isRefreshing: false,
+    pullDistance: 0,
+    pullProgress: 0,
+    canRefresh: false,
+  });
+
+  const touchStartY = useRef<number | null>(null);
+  const touchStartScrollTop = useRef<number>(0);
+
+  const handleTouchStart = useCallback(
+    (e: TouchEvent) => {
+      if (!enabled || state.isRefreshing) return;
+
+      const scrollElement = scrollRef.current;
+      if (!scrollElement) return;
+
+      // Only activate if at top of scroll
+      if (scrollElement.scrollTop <= 0) {
+        touchStartY.current = e.touches[0].clientY;
+        touchStartScrollTop.current = scrollElement.scrollTop;
+      }
+    },
+    [enabled, state.isRefreshing, scrollRef],
+  );
+
+  const handleTouchMove = useCallback(
+    (e: TouchEvent) => {
+      if (!enabled || state.isRefreshing || touchStartY.current === null)
+        return;
+
+      const scrollElement = scrollRef.current;
+      if (!scrollElement) return;
+
+      const currentY = e.touches[0].clientY;
+      const deltaY = currentY - touchStartY.current;
+
+      // Only handle pull-down when at top
+      if (deltaY > 0 && scrollElement.scrollTop <= 0) {
+        // Apply resistance after threshold
+        let adjustedDelta = deltaY;
+        if (deltaY > pullThreshold) {
+          const overpull = deltaY - pullThreshold;
+          adjustedDelta = pullThreshold + overpull * resistance;
+        }
+
+        const pullDistance = Math.min(adjustedDelta, maxPullDistance);
+        const pullProgress = Math.min(pullDistance / pullThreshold, 1);
+        const canRefresh = pullDistance >= pullThreshold;
+
+        setState((prev) => ({
+          ...prev,
+          isPulling: true,
+          pullDistance,
+          pullProgress,
+          canRefresh,
+        }));
+
+        // Prevent scroll while pulling
+        if (pullDistance > 0) {
+          e.preventDefault();
+        }
+      }
+    },
+    [
+      enabled,
+      state.isRefreshing,
+      scrollRef,
+      pullThreshold,
+      maxPullDistance,
+      resistance,
+    ],
+  );
+
+  const handleTouchEnd = useCallback(async () => {
+    if (!enabled || touchStartY.current === null) return;
+
+    touchStartY.current = null;
+
+    if (state.canRefresh && !state.isRefreshing) {
+      setState((prev) => ({
+        ...prev,
+        isPulling: false,
+        isRefreshing: true,
+        pullDistance: pullThreshold * 0.6, // Keep indicator visible
+        pullProgress: 0.6,
+        canRefresh: false,
+      }));
+
+      try {
+        await onRefresh();
+      } finally {
+        // Animate out
+        setState({
+          isPulling: false,
+          isRefreshing: false,
+          pullDistance: 0,
+          pullProgress: 0,
+          canRefresh: false,
+        });
+      }
+    } else {
+      // Reset without refresh
+      setState({
+        isPulling: false,
+        isRefreshing: false,
+        pullDistance: 0,
+        pullProgress: 0,
+        canRefresh: false,
+      });
+    }
+  }, [enabled, state.canRefresh, state.isRefreshing, pullThreshold, onRefresh]);
+
+  useEffect(() => {
+    const scrollElement = scrollRef.current;
+    if (!scrollElement || !enabled) return;
+
+    scrollElement.addEventListener("touchstart", handleTouchStart, {
+      passive: true,
+    });
+    scrollElement.addEventListener("touchmove", handleTouchMove, {
+      passive: false,
+    });
+    scrollElement.addEventListener("touchend", handleTouchEnd, {
+      passive: true,
+    });
+
+    return () => {
+      scrollElement.removeEventListener("touchstart", handleTouchStart);
+      scrollElement.removeEventListener("touchmove", handleTouchMove);
+      scrollElement.removeEventListener("touchend", handleTouchEnd);
+    };
+  }, [scrollRef, enabled, handleTouchStart, handleTouchMove, handleTouchEnd]);
+
+  return state;
+}

--- a/docs/audits/ux-audit-2025.md
+++ b/docs/audits/ux-audit-2025.md
@@ -264,11 +264,12 @@ HubChat, HubSearch, онбординг, a11y, PWA). Цей документ — 
 
 ### 11.7 Нові компоненти
 
-| Компонент          | Призначення                                 |
-| ------------------ | ------------------------------------------- |
-| `CelebrationModal` | Achievement/success celebrations з confetti |
-| `FeatureSpotlight` | Contextual onboarding hints                 |
-| `ModulePageLoader` | Module-specific skeleton loaders            |
+| Компонент                | Призначення                                 |
+| ------------------------ | ------------------------------------------- |
+| `CelebrationModal`       | Achievement/success celebrations з confetti |
+| `FeatureSpotlight`       | Contextual onboarding hints                 |
+| `ModulePageLoader`       | Module-specific skeleton loaders            |
+| `PullToRefreshIndicator` | Native-like pull-to-refresh                 |
 
 ### 11.8 Нові хуки
 

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -499,6 +499,23 @@ import { ModulePageLoader } from "@shared/components/ui/ModulePageLoader";
 **Modules:** `finyk` | `fizruk` | `routine` | `nutrition`
 Показує релевантні skeleton елементи для кожного модуля.
 
+### PullToRefreshIndicator
+
+Native-like pull-to-refresh для PWA.
+
+```tsx
+import { usePullToRefresh } from "@shared/hooks/usePullToRefresh";
+
+const { state, PullIndicator } = usePullToRefresh({
+  onRefresh: async () => {
+    await refetch();
+  },
+  scrollRef,
+});
+
+<PullToRefreshIndicator state={state} />;
+```
+
 ---
 
 ## 13. Нові хуки (2026-04)

--- a/docs/playbooks/cleanup-dead-code.md
+++ b/docs/playbooks/cleanup-dead-code.md
@@ -1,8 +1,35 @@
 # Playbook: Cleanup Dead Code
 
-> **Last validated:** 2026-04-27 by @Skords-01. **Next review:** 2026-07-26.
+> **Last validated:** 2026-04-29 by @Skords-01. **Next review:** 2026-07-29.
+> **Status:** Active
 
 **Trigger:** "Remove X and all its usages" / deleting a deprecated module, component, utility, or feature flag.
+
+---
+
+## Step 0. Verify the file isn't scaffolding
+
+> Added 2026-04-29 in response to PR [#1143](https://github.com/Skords-01/Sergeant/pull/1143). See AGENTS.md → Hard Rule #10.
+
+Before deleting **anything** flagged by `pnpm knip`, check whether it carries a lifecycle marker:
+
+```bash
+# 1. Use the marker-aware wrapper instead of raw knip
+pnpm dead-code:files
+
+# 2. For each candidate file, look for a JSDoc lifecycle tag in the first ~30 lines
+head -30 <file> | grep -E '@scaffolded|@deprecated|@experimental'
+
+# 3. Also check git log — was it added as feat(...)? When? By whom?
+git log --follow --oneline -- <file>
+```
+
+A file that:
+
+- Has a `@scaffolded` JSDoc block → **leave it alone**, even if knip says zero importers. It's intentional pre-wired infrastructure.
+- Has `@deprecated` with a future `@removeBy` date → leave until that date, then remove (along with consumers).
+- Was added in a recent `feat(...)` commit (< 90 days) and has no marker → **add the marker, do not delete**. The author likely just forgot to mark it. Open a follow-up to ask the owner whether to wire it or remove it.
+- Has no marker, no recent author, no consumers, AND `git log --follow` shows it sat untouched for > 12 months → safe to delete.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "licenses:check": "node scripts/generate-licenses.mjs check",
     "strict:coverage": "node scripts/strict-coverage.mjs",
     "dead-code:packages": "node scripts/ts-prune-packages.mjs",
+    "dead-code:files": "node scripts/knip-respects-scaffolded.mjs",
     "knip": "knip",
     "depcheck:all": "pnpm -r exec depcheck --ignore-patterns=dist,dist-server,coverage,.turbo",
     "prepare": "husky",

--- a/scripts/ci/vitest.config.mjs
+++ b/scripts/ci/vitest.config.mjs
@@ -1,3 +1,12 @@
+/**
+ * @scaffolded
+ * @owner @Skords-01
+ * @nextStep Wire `pnpm vitest --config scripts/ci/vitest.config.mjs` into a
+ *           dedicated job in `.github/workflows/ci.yml` so
+ *           `pipeline-duration-p95.test.mjs` and
+ *           `posthog-release-annotation.test.mjs` actually run on PRs.
+ *           See AGENTS.md → Hard Rule #10.
+ */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/scripts/flaky-tests/vitest.config.ts
+++ b/scripts/flaky-tests/vitest.config.ts
@@ -1,3 +1,11 @@
+/**
+ * @scaffolded
+ * @owner @Skords-01
+ * @nextStep Wire `pnpm vitest --config scripts/flaky-tests/vitest.config.ts`
+ *           into a dedicated job in `.github/workflows/ci.yml` so
+ *           `aggregate.test.ts` (covers `aggregate.mjs`) actually runs on PRs.
+ *           See AGENTS.md → Hard Rule #10.
+ */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/scripts/knip-respects-scaffolded.mjs
+++ b/scripts/knip-respects-scaffolded.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+// scripts/knip-respects-scaffolded.mjs
+//
+// Wraps `pnpm knip --reporter=json` and filters out files / exports that
+// declare a lifecycle marker (`@scaffolded`, `@deprecated`). See
+// AGENTS.md → Hard Rule #10 for context.
+//
+// Why a wrapper instead of knip's built-in `ignore`?
+//   `ignore` would force us to keep a hand-maintained allowlist in
+//   `knip.json` and re-edit it on every wire-up PR. The marker lives
+//   with the code, so the source of truth is the file itself.
+//
+// Usage:
+//   node scripts/knip-respects-scaffolded.mjs
+//   pnpm dead-code:files
+//
+// Exits 0 if every "unused" file/export carries a marker.
+// Exits 1 if any unmarked unused file remains — those are real findings.
+
+import { spawnSync } from "node:child_process";
+import { readFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+const REPO_ROOT = resolve(new URL("..", import.meta.url).pathname);
+
+const MARKER_RE = /@scaffolded\b|@deprecated\b|@experimental\b/;
+
+function fileHasMarker(relPath) {
+  const abs = resolve(REPO_ROOT, relPath);
+  if (!existsSync(abs)) return false;
+  let head;
+  try {
+    head = readFileSync(abs, "utf8").slice(0, 4096);
+  } catch {
+    return false;
+  }
+  return MARKER_RE.test(head);
+}
+
+function runKnipJson() {
+  const res = spawnSync("pnpm", ["knip", "--reporter=json", "--no-progress"], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  // Knip exits non-zero when it finds issues; that's expected.
+  const out = res.stdout ?? "";
+  const idx = out.indexOf('{"issues');
+  if (idx === -1) {
+    process.stderr.write(out);
+    process.stderr.write(res.stderr ?? "");
+    throw new Error("Could not locate knip JSON payload in output");
+  }
+  // Knip prints a single JSON object followed (sometimes) by pnpm's
+  // ELIFECYCLE warning on stderr. Trim the JSON to the matching brace.
+  let depth = 0;
+  let end = -1;
+  for (let i = idx; i < out.length; i++) {
+    const c = out[i];
+    if (c === "{") depth++;
+    else if (c === "}") {
+      depth--;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+  if (end === -1) throw new Error("Unterminated knip JSON");
+  return JSON.parse(out.slice(idx, end + 1));
+}
+
+function main() {
+  const data = runKnipJson();
+  const unmarkedFiles = [];
+  const markedFiles = [];
+
+  for (const issue of data.issues ?? []) {
+    if (!issue.files?.length) continue;
+    if (fileHasMarker(issue.file)) {
+      markedFiles.push(issue.file);
+    } else {
+      unmarkedFiles.push(issue.file);
+    }
+  }
+
+  if (markedFiles.length) {
+    process.stdout.write(
+      `Skipped ${markedFiles.length} file(s) with @scaffolded/@deprecated/@experimental markers:\n`,
+    );
+    for (const f of markedFiles) process.stdout.write(`  · ${f}\n`);
+    process.stdout.write("\n");
+  }
+
+  if (unmarkedFiles.length) {
+    process.stdout.write(
+      `Found ${unmarkedFiles.length} unused file(s) without lifecycle markers:\n`,
+    );
+    for (const f of unmarkedFiles) process.stdout.write(`  ✗ ${f}\n`);
+    process.stdout.write(
+      "\nIf these files are real dead code, delete them. " +
+        "If they're scaffolded for future wiring, add a @scaffolded JSDoc " +
+        "block (see AGENTS.md → Hard Rule #10).\n",
+    );
+    process.exit(1);
+  }
+
+  process.stdout.write("No unmarked unused files. ✓\n");
+}
+
+main();


### PR DESCRIPTION
## What changed

Дві Hard Rules + повертаю в репо scaffolded UI-компоненти, помилково видалені у PR #1143.

### Rule #10 — Lifecycle маркування (commit 1)

Кожен файл і кожен документ декларує свій статус:

| Тег / бейдж     | Значення                                                           |
| --------------- | ------------------------------------------------------------------ |
| `@scaffolded`   | Готовий до використання, ще не підключений. Knip пропускає.        |
| `@experimental` | API може змінитися або відкотитися.                                |
| `@deprecated`   | Заплановано до видалення (`@removeBy YYYY-MM-DD`).                 |
| _(без тега)_    | `Active` за замовчуванням.                                         |

Документи додають `> **Status:** Active | Scaffolded | Deprecated | Archived` після `Last validated:`.

**Тулінг:** `scripts/knip-respects-scaffolded.mjs` (доступний як `pnpm dead-code:files`) обгортає `pnpm knip --reporter=json` і фільтрує файли з маркерами. Виходить non-zero **тільки** на немаркований unused — справжні знахідки.

**Відновлені файли** (всі несуть `@scaffolded` JSDoc-блок з `@owner` і `@nextStep`):

- `apps/web/src/shared/components/ui/PullToRefreshIndicator.tsx`
- `apps/web/src/shared/components/ui/EmptyStateIllustrations.tsx`
- `apps/web/src/shared/components/ui/OptimizedImage.tsx`
- `apps/web/src/shared/hooks/usePullToRefresh.ts` (+ ре-експорт)
- Згадки в `docs/design/design-system.md`, `docs/audits/ux-audit-2025.md`.

Плюс модульні барелі (`@finyk`, `@fizruk`, `@routine`, `@nutrition`, `@shared/charts`) і два vitest-конфіги (`scripts/ci/`, `scripts/flaky-tests/`) теж промарковано — вони саме «scaffolded», бо аліас оголошений але деякі consumers ще імпортують через deep-paths.

### Rule #11 — Read governance / update docs alongside code (commit 2)

Перед роботою агент/контриб'ютор має прочитати:

1. `AGENTS.md` Hard Rules.
2. `CONTRIBUTING.md`.
3. `CLAUDE.md` (для AI-агентів).
4. Релевантний playbook у `docs/playbooks/`.
5. Freshness header кожного документа, який цитує/змінює.

Перед PR — оновити документацію, яку зачіпає зміна:

| Зміна коду                                  | Що оновити                                                                                  |
| ------------------------------------------- | ------------------------------------------------------------------------------------------- |
| Зміна shape JSON-відповіді                  | `packages/api-client/**` types + contract test (Rule #3) + `docs/api/*.md`                  |
| Нова SQL-міграція                            | `apps/server/src/migrations/README.md` + ER-diagrams в `docs/architecture/`                |
| Новий/видалений npm-скрипт                  | `CONTRIBUTING.md § Everyday Commands` + `CLAUDE.md § Quick commands`                        |
| Нова Hard Rule / lint rule                  | `AGENTS.md` § Hard Rules + dzeркало в `CONTRIBUTING.md`                                     |
| Новий design token / palette / component    | `docs/design/design-system.md`, `BRANDBOOK.md`, відповідний audit                            |
| Deprecation                                 | `@deprecated` JSDoc з `@removeBy` + `> Status: Deprecated` в documents                      |
| Будь-яка зміна, що валідує існуючий doc     | Оновити doc у тому ж PR або перенести в `archive/`                                          |

PR-template отримав два нових блоки чек-боксів: **Pre-flight (Hard Rule #11)** і **Docs updated alongside code?**.

### Files

- `AGENTS.md` — повна Rule #10 і Rule #11.
- `CONTRIBUTING.md` — короткі дзеркала #10 і #11 в § Hard rules.
- `CLAUDE.md` — оновлений `Before you write code` з числованим pre-flight.
- `.github/PULL_REQUEST_TEMPLATE.md` — Pre-flight + Docs-updated checkboxes.
- `docs/playbooks/cleanup-dead-code.md` — новий **Step 0. Verify the file isn't scaffolding** + cross-link до Rules #10/#11.
- `scripts/knip-respects-scaffolded.mjs` (новий), `package.json` → `pnpm dead-code:files`.
- 4 відновлені файли + 7 файлів промаркованих `@scaffolded`.

## Why

PR #1143 видалив 4 файли, бо `pnpm knip` показав їх як unused — але це були UI-компоненти з коміту `1d443ac1 feat(web): add UI/UX improvements`, додані наперед, до підключення в сторінки модулів. Без маркера `@scaffolded` неможливо відрізнити «zero-importer бо забутий» від «zero-importer бо ще не підключив».

Окремо — рішення про видалення приймалося без читання `docs/playbooks/cleanup-dead-code.md` і без оновлення документації, що ще згадувала видалені компоненти. Rule #11 закриває обидва типи помилок.

## How to test

```bash
pnpm dead-code:files
# Skipped 10 file(s) with @scaffolded/@deprecated/@experimental markers:
#   · scripts/ci/vitest.config.mjs
#   · scripts/flaky-tests/vitest.config.ts
#   · apps/web/src/modules/finyk/index.ts
#   · ... (10 known scaffolded files)
# No unmarked unused files. ✓

pnpm --filter @sergeant/web lint     # pass
```

Симуляція: створи `foo.ts`, який ніхто не імпортує, без `@scaffolded` — `pnpm dead-code:files` exit 1 з повідомленням «add a @scaffolded JSDoc block». Це і є рейка, що зупинить помилкове видалення наступного разу.

---

## Pre-flight (Hard Rule #11)

- [x] Read the AGENTS.md Hard Rules — saw #1, #5, #7, #10 (just added by this PR), #11 (just added).
- [x] Read the matching playbook — `docs/playbooks/cleanup-dead-code.md` (this PR also extends it).
- [x] Checked freshness headers — `cleanup-dead-code.md` bumped to `2026-04-29`.

## Docs updated alongside code? (Hard Rule #11)

- [x] New Hard Rule, lint rule, or convention — added Rules #10 and #11 to `AGENTS.md` + mirrors in `CONTRIBUTING.md` + cross-links in `CLAUDE.md` and `cleanup-dead-code.md`.
- [x] New / removed npm script — added `pnpm dead-code:files` to `package.json` (mentioned in `CLAUDE.md` step 3 + `cleanup-dead-code.md` Step 0).
- [x] Freshness header bumped on `cleanup-dead-code.md`.
- [x] N/A for api-client / migrations / design tokens.

## How AI-tested this PR

- [x] `pnpm dead-code:files` — exit 0, all 10 files marked.
- [x] `pnpm --filter @sergeant/web lint` — pass.
- [x] No new `AI-DANGER` markers.
- [x] Prose в доках UA, де практично (Rule #10/#11 тіло англійською — bo це rule format у AGENTS.md).

## AGENTS.md updated?

- [x] Yes — § Hard Rules додано **Rule #10** (Lifecycle markers) і **Rule #11** (Read governance / update docs alongside code).
