### PR TITLE
feat(eslint-plugins,web,docs): add no-hex-in-classname + no-foreign-module-accent (Design Wave 1a)

### DIFF
--- a/apps/web/src/modules/fizruk/pages/PlanCalendar.tsx
+++ b/apps/web/src/modules/fizruk/pages/PlanCalendar.tsx
@@ -31,7 +31,7 @@ export function PlanCalendar({
             <button
               type="button"
               onClick={onOpenRoutine}
-              className="block w-full text-xs text-subtle hover:text-text text-center leading-snug min-h-[44px] px-2 py-2 rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-routine"
+              className="block w-full text-xs text-subtle hover:text-text text-center leading-snug min-h-[44px] px-2 py-2 rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fizruk"
             >
               Заплановані тренування відображатимуться у{" "}
               <span className="underline underline-offset-2">

--- a/docs/design/DARK-MODE-AUDIT.md
+++ b/docs/design/DARK-MODE-AUDIT.md
@@ -1,0 +1,168 @@
+# Dark-mode audit
+
+> **Last validated:** 2026-04-29 by @Skords-01.
+> **Audience:** anyone touching `apps/web` Tailwind class strings.
+> **Goal:** catalogue every place that expresses dark mode as an
+> explicit `dark:` override on a raw palette color, so we can migrate
+> those to single-token semantic utilities (`bg-success-soft`,
+> `bg-finyk-surface`, `border-brand-strong`, …) and let the preset own
+> the light/dark pair in **one** place.
+
+## TL;DR
+
+- **306** `dark:` overrides across `apps/web/src/**/*.{ts,tsx}` (excluding tests).
+- **28** of them are the anti-pattern this audit targets: a _raw
+  palette_ background in light mode paired with a hand-tuned _raw
+  palette_ (or ad-hoc `-soft`/`/15`) dark variant —
+  `bg-teal-100 dark:bg-teal-900/30`, `bg-amber-50 … dark:bg-amber-500/15`,
+  `bg-teal-800/10 dark:bg-white/10`, etc.
+- Every anti-pattern is one `dark:` override away from silently falling
+  through on the next palette migration — exactly the class of bug
+  [#814](https://github.com/Skords-01/Sergeant/pull/814) fixed.
+
+## The anti-pattern, concretely
+
+```tsx
+// ❌ Two palette values encoded in the call-site, one per theme.
+<div className="bg-amber-50 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300" />
+
+// ✅ One semantic token; the preset owns the light/dark pair.
+<div className="bg-warning-soft text-warning" />
+```
+
+The fix is always the same: either the token exists (`bg-warning-soft`,
+`bg-brand-soft`, `bg-finyk-surface`, …) and the call-site uses it, or
+the token doesn't exist yet and we extend
+`packages/design-tokens/tailwind-preset.js` to add it.
+
+## Full inventory (28 sites)
+
+Grouped by target token — i.e. the semantic utility the line should
+end up using once migrated.
+
+### → `bg-{module}-surface` (module-tinted hero / list surfaces)
+
+Existing token: `bg-{finyk,fizruk,routine,nutrition}-surface` already
+adapts per theme via the preset. Each of these rows is hand-rolling
+an ad-hoc equivalent.
+
+| File                                                   | Line | Current                                                                                                 | Target                                         |
+| ------------------------------------------------------ | ---- | ------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| `apps/web/src/core/insights/WeeklyDigestCard.tsx`      | 25   | `bg-brand-100 dark:bg-brand-900/30`                                                                     | `bg-finyk-surface`                             |
+| `apps/web/src/core/insights/WeeklyDigestCard.tsx`      | 32   | `bg-teal-100 dark:bg-teal-900/30`                                                                       | `bg-fizruk-surface`                            |
+| `apps/web/src/core/insights/WeeklyDigestCard.tsx`      | 39   | `bg-lime-100 dark:bg-lime-900/30`                                                                       | `bg-nutrition-surface`                         |
+| `apps/web/src/core/insights/WeeklyDigestCard.tsx`      | 46   | `bg-coral-100 dark:bg-coral-900/30`                                                                     | `bg-routine-surface`                           |
+| `apps/web/src/modules/routine/lib/routineConstants.ts` | 21   | `border-coral-100/60 dark:border-routine-border-dark/25 bg-coral-50/50 dark:bg-routine-surface-dark/8`  | `border-routine-border bg-routine-surface`     |
+| `apps/web/src/modules/routine/lib/routineConstants.ts` | 30   | `border-l-routine bg-coral-50/50 dark:bg-routine-surface-dark/10`                                       | `border-l-routine bg-routine-surface`          |
+| `apps/web/src/shared/components/ui/Card.tsx`           | 83   | `border border-brand-100 bg-brand-50/50 backdrop-blur-sm dark:border-brand-500/20 dark:bg-brand-500/10` | `border-finyk-border bg-finyk-surface`         |
+| `apps/web/src/shared/components/ui/Card.tsx`           | 85   | `border border-teal-100 bg-teal-50/50 backdrop-blur-sm dark:border-teal-500/20 dark:bg-teal-500/10`     | `border-fizruk-border bg-fizruk-surface`       |
+| `apps/web/src/shared/components/ui/Card.tsx`           | 87   | `border border-coral-100 bg-coral-50/50 backdrop-blur-sm dark:border-coral-500/20 dark:bg-coral-500/10` | `border-routine-border bg-routine-surface`     |
+| `apps/web/src/shared/components/ui/Card.tsx`           | 89   | `border border-lime-100 bg-lime-50/50 backdrop-blur-sm dark:border-lime-500/20 dark:bg-lime-500/10`     | `border-nutrition-border bg-nutrition-surface` |
+
+### → `bg-brand-soft` (brand accent background)
+
+Existing token: `bg-brand-soft` (light 8 % / dark 15 % wash) ships in
+the preset and is what `Segmented`, `Tabs`, `Button`, `Badge` variants
+should all reuse.
+
+| File                                                 | Line | Current                                                                                                                                        | Target                                                                               |
+| ---------------------------------------------------- | ---- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `apps/web/src/core/insights/AssistantAdviceCard.tsx` | 66   | `bg-brand-50 dark:bg-brand-500/15`                                                                                                             | `bg-brand-soft`                                                                      |
+| `apps/web/src/shared/components/ui/Badge.tsx`        | 54   | `bg-brand-50 text-brand-700 border-brand-200/60 dark:bg-brand/15 dark:text-brand dark:border-brand/30`                                         | `bg-brand-soft text-brand-strong border-brand-soft-border`                           |
+| `apps/web/src/shared/components/ui/Badge.tsx`        | 56   | (same as :54, duplicate success variant)                                                                                                       | `bg-brand-soft text-brand-strong border-brand-soft-border`                           |
+| `apps/web/src/shared/components/ui/Segmented.tsx`    | 71   | `border-brand-200 bg-brand-50 text-brand-700 shadow-sm dark:border-brand/40 dark:bg-brand/15 dark:text-brand`                                  | `border-brand-soft-border bg-brand-soft text-brand-strong`                           |
+| `apps/web/src/shared/components/ui/Tabs.tsx`         | 98   | `bg-brand-50 text-brand-700 dark:bg-brand/15 dark:text-brand`                                                                                  | `bg-brand-soft text-brand-strong`                                                    |
+| `apps/web/src/shared/components/ui/Button.tsx`       | 57   | `bg-brand-50 text-brand-700 border border-brand-200/50 hover:bg-brand-100 dark:bg-brand-500/15 dark:text-brand-300 dark:border-brand-500/30 …` | `bg-brand-soft text-brand-strong border-brand-soft-border hover:bg-brand-soft-hover` |
+
+### → `bg-{status}-soft` (status/notice surfaces)
+
+Existing tokens: `bg-success-soft`, `bg-warning-soft`, `bg-danger-soft`,
+`bg-info-soft` already adapt per theme — documented in
+`docs/design/design-system.md` § 2.4.
+
+| File                                           | Line | Current                                                                                                                        | Target                                                           |
+| ---------------------------------------------- | ---- | ------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
+| `apps/web/src/shared/components/ui/Badge.tsx`  | 58   | `bg-amber-50 text-amber-700 border-amber-200/70 dark:bg-amber-500/15 dark:text-amber-300 dark:border-amber-500/30`             | `bg-warning-soft text-warning-strong border-warning-soft-border` |
+| `apps/web/src/shared/components/ui/Badge.tsx`  | 61   | `bg-blue-50 text-blue-700 border-blue-200/70 dark:bg-info/15 dark:text-blue-300 dark:border-info/30`                           | `bg-info-soft text-info-strong border-info-soft-border`          |
+| `apps/web/src/shared/components/ui/Banner.tsx` | 16   | `border-emerald-200/70 bg-emerald-50 text-emerald-800 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-100` | `bg-success-soft text-success-strong border-success-soft-border` |
+| `apps/web/src/shared/components/ui/Banner.tsx` | 18   | `border-amber-200/70 bg-amber-50 text-amber-800 dark:border-amber-500/35 dark:bg-amber-500/10 dark:text-amber-100`             | `bg-warning-soft text-warning-strong border-warning-soft-border` |
+| `apps/web/src/shared/components/ui/Banner.tsx` | 20   | `border-red-200/70 bg-red-50 text-red-800 dark:border-danger/30 dark:bg-danger/10 dark:text-red-100`                           | `bg-danger-soft text-danger-strong border-danger-soft-border`    |
+
+### → new `WorkoutStatTile` primitive (WorkoutFinishSheets)
+
+These four rows are a repeated "Fizruk workout-complete stat tile"
+pattern — same className soup with `bg-teal-800/10 dark:bg-white/10 …`.
+They shouldn't be fixed by a `dark:` swap — they should be extracted
+into a reusable `<WorkoutStatTile>` primitive in
+`apps/web/src/modules/fizruk/components/workouts/`. The primitive gets
+one semantic token (new `bg-fizruk-tile` or reuse `bg-fizruk-surface`)
+and the four call-sites collapse to `<WorkoutStatTile … />`.
+
+| File                                                                      | Line | Current                                                                                                      |
+| ------------------------------------------------------------------------- | ---- | ------------------------------------------------------------------------------------------------------------ |
+| `apps/web/src/modules/fizruk/components/workouts/WorkoutFinishSheets.tsx` | 174  | `bg-teal-800/10 dark:bg-white/10 text-teal-700 dark:text-white/70 hover:text-teal-900 dark:hover:text-white` |
+| `apps/web/src/modules/fizruk/components/workouts/WorkoutFinishSheets.tsx` | 182  | `bg-teal-800/10 dark:bg-white/10 border border-teal-800/15 dark:border-white/15`                             |
+| `apps/web/src/modules/fizruk/components/workouts/WorkoutFinishSheets.tsx` | 193  | (same)                                                                                                       |
+| `apps/web/src/modules/fizruk/components/workouts/WorkoutFinishSheets.tsx` | 203  | (same)                                                                                                       |
+
+### → chart-palette refactor (chartTheme)
+
+Chart series colors are a special case — the palette is _intentionally_
+expressed as a series of (light, dark) pairs so Recharts can render
+against either theme. The fix is not a token swap; it's to move the
+pairs into `chartGradients` (CSS variables per-theme) so the JS layer
+stops owning them.
+
+| File                                       | Line | Current                                |
+| ------------------------------------------ | ---- | -------------------------------------- |
+| `apps/web/src/shared/charts/chartTheme.ts` | 110  | `bg-coral-200/80 dark:bg-coral-900/55` |
+| `apps/web/src/shared/charts/chartTheme.ts` | 111  | `bg-coral-400/75 dark:bg-coral-600/70` |
+| `apps/web/src/shared/charts/chartTheme.ts` | 112  | `bg-coral-500/90 dark:bg-coral-500/80` |
+
+## What happens next
+
+1. **Wave 1b** (this PR family, next up): extend the preset with the
+   tokens that are _referenced_ in the "Target" columns above but not
+   yet in the preset — `bg-brand-soft-border`,
+   `bg-warning-soft-border`, `bg-info-soft-border`,
+   `bg-success-soft-border`, `bg-danger-soft-border`,
+   `bg-finyk-border`, `bg-fizruk-border`, `bg-routine-border`,
+   `bg-nutrition-border`. Verify each clears WCAG AA against
+   body copy.
+2. **Wave 1c**: migrate the 28 call-sites above to the semantic tokens
+   in small, reviewable batches (one file per commit). Each commit
+   removes a pair of `dark:` overrides — net reduction
+   `~2 × 28 = 56` `dark:` occurrences (~18 %).
+3. **Wave 2+**: the `WorkoutFinishSheets` four-row pattern becomes a
+   real `<WorkoutStatTile>` primitive; the `chartTheme` coral pairs
+   move into CSS variables. After those two moves land, expect to be
+   under `250` total `dark:` occurrences in `apps/web`.
+4. **Final step**: promote a lint rule in
+   `packages/eslint-plugin-sergeant-design` that forbids any
+   `dark:bg-<palette>-<N>` / `dark:text-<palette>-<N>` pattern — the
+   anti-pattern is now zero, so the rule promotes to `error` without
+   breaking anything.
+
+## Legitimate `dark:` uses that STAY
+
+Not every `dark:` is an anti-pattern. These patterns are fine and the
+future lint rule must NOT flag them:
+
+- `dark:bg-surface`, `dark:bg-surface-muted`, `dark:text-fg`,
+  `dark:border-border` — these are semantic tokens that happen to
+  carry the `dark:` prefix because of a specific override
+  (e.g. stacked modal surfaces).
+- `dark:bg-white/5`, `dark:bg-white/10`, `dark:border-white/15` — the
+  "barely-there glass wash on a dark surface" pattern documented in
+  `docs/design/design-system.md` § 2.1; these are semantically
+  "increase contrast on dark" and are correct.
+- Variant overrides on interactive states:
+  `hover:bg-surface-muted dark:hover:bg-surface-muted` — sometimes
+  written explicitly to opt out of a `hover:` fallthrough.
+
+The rule we eventually ship will target the specific raw-palette
+pair: `dark:(bg|text|border)-<PALETTE_COLOR>-<SHADE>` where
+`PALETTE_COLOR ∈ {gray, slate, zinc, neutral, stone, red, orange,
+amber, yellow, lime, green, emerald, teal, cyan, sky, blue, indigo,
+violet, purple, fuchsia, pink, rose, brand, coral}` — **not** the
+semantic tokens.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -73,6 +73,22 @@ export default [
       // surrounding `dark:` / `hover:` override falls through to the
       // light-mode background — this is what bug #814 was.
       "sergeant-design/valid-tailwind-opacity": "error",
+      // Design-system token guardrail — arbitrary hex in className
+      // (`bg-[#10b981]`, `text-[#fff]/50`) bypasses the token layer:
+      // dark-mode adaptation, WCAG-AA `-strong` promotion and future
+      // palette migration all stop working for those literals. Every
+      // color must come from the preset (`bg-surface`, `text-muted`,
+      // `bg-finyk-surface`, `text-brand-strong`, `bg-success-soft`, …)
+      // — if a genuinely new shade is needed, add it to
+      // `packages/design-tokens/tailwind-preset.js` first.
+      "sergeant-design/no-hex-in-classname": "error",
+      // Module-accent containment — inside `apps/<app>/src/modules/<X>/`
+      // subtrees only `<X>`'s accent utilities may appear. A fizruk
+      // component rendering a coral `ring-routine` reads to the user
+      // as "Рутина" — it's a design bug, not stylistic preference.
+      // Cross-module shells (`core/`, `shared/`, `stories/`) remain
+      // free to reference all four module accents.
+      "sergeant-design/no-foreign-module-accent": "error",
       // WCAG-AA `-strong` tier guardrail — every saturated brand `bg-*`
       // utility paired with `text-white` regresses to ~2.4–2.8 : 1
       // contrast (the bug class fixed in PRs #854 / #855). The fix is
@@ -150,12 +166,16 @@ export default [
   // (`bg-finyk/7`, `text-danger/18`, …) into the linter as fixtures — the
   // rule would otherwise self-flag every fixture. The same applies to
   // `no-low-contrast-text-on-fill`, whose test fixtures contain the
-  // very `bg-brand text-white` patterns the rule is meant to flag.
+  // very `bg-brand text-white` patterns the rule is meant to flag, and
+  // to `no-hex-in-classname` / `no-foreign-module-accent`, whose
+  // fixtures are `bg-[#10b981]` / `ring-routine` literals.
   {
     files: ["packages/eslint-plugin-sergeant-design/**/*.{js,mjs}"],
     rules: {
       "sergeant-design/valid-tailwind-opacity": "off",
       "sergeant-design/no-low-contrast-text-on-fill": "off",
+      "sergeant-design/no-hex-in-classname": "off",
+      "sergeant-design/no-foreign-module-accent": "off",
     },
   },
   // Jest setup / test files need jest globals.

--- a/packages/eslint-plugin-sergeant-design/__tests__/no-foreign-module-accent.test.mjs
+++ b/packages/eslint-plugin-sergeant-design/__tests__/no-foreign-module-accent.test.mjs
@@ -1,0 +1,185 @@
+/**
+ * Unit tests for the `sergeant-design/no-foreign-module-accent` rule.
+ *
+ * Inside `apps/<app>/src/modules/<X>/**` only `<X>`'s accent utilities
+ * may appear (`bg-<X>-*`, `text-<X>-*`, `ring-<X>`, …). A fizruk
+ * component accidentally rendering `ring-routine` is a design bug —
+ * the user reads the coral ring as "Рутина". Cross-module shells
+ * (`core/**`, `shared/**`, `stories/**`) are exempt.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { Linter } from "eslint";
+import path from "node:path";
+import plugin from "../index.js";
+
+const linter = new Linter();
+const RULE_ID = "sergeant-design/no-foreign-module-accent";
+
+// ESLint v9 flat config only activates for files matched by `files:` AND
+// located under the linter cwd. We use `path.resolve(process.cwd(), …)`
+// to anchor the synthetic test filenames so the config matches.
+function abs(p) {
+  return path.resolve(process.cwd(), p);
+}
+
+function lint(code, filename) {
+  return linter.verify(
+    code,
+    {
+      files: ["**/*.{js,mjs,cjs,jsx,ts,tsx}"],
+      plugins: { "sergeant-design": plugin },
+      rules: { [RULE_ID]: "error" },
+      languageOptions: {
+        ecmaVersion: "latest",
+        sourceType: "module",
+      },
+    },
+    { filename },
+  );
+}
+
+const FIZRUK_FILE = abs("apps/web/src/modules/fizruk/pages/PlanCalendar.tsx");
+const FINYK_FILE = abs("apps/web/src/modules/finyk/pages/Overview.tsx");
+const ROUTINE_FILE = abs(
+  "apps/web/src/modules/routine/components/HabitCard.tsx",
+);
+const CORE_FILE = abs("apps/web/src/core/hub/HubDashboard.tsx");
+const SHARED_FILE = abs("apps/web/src/shared/components/ui/Button.tsx");
+const MOBILE_FIZRUK_FILE = abs(
+  "apps/mobile/src/modules/fizruk/screens/Workout.tsx",
+);
+const MOBILE_APP_ROUTINE_FILE = abs(
+  "apps/mobile/app/modules/routine/_layout.tsx",
+);
+const TEST_FILE = abs(
+  "apps/web/src/modules/fizruk/pages/PlanCalendar.test.tsx",
+);
+
+describe("no-foreign-module-accent", () => {
+  it("flags `ring-routine` inside modules/fizruk", () => {
+    const messages = lint(
+      `const c = "focus-visible:ring-routine";`,
+      FIZRUK_FILE,
+    );
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].ruleId, RULE_ID);
+    assert.match(messages[0].message, /ring-routine/);
+    assert.match(messages[0].message, /fizruk/);
+  });
+
+  it("flags `bg-nutrition-surface` inside modules/finyk", () => {
+    const messages = lint(
+      `const c = "rounded bg-nutrition-surface p-4";`,
+      FINYK_FILE,
+    );
+    assert.equal(messages.length, 1);
+    assert.match(messages[0].message, /bg-nutrition-surface/);
+  });
+
+  it("flags multiple foreign accents in one soup", () => {
+    const messages = lint(
+      `const c = "bg-fizruk text-finyk border-nutrition";`,
+      ROUTINE_FILE,
+    );
+    assert.equal(messages.length, 3);
+  });
+
+  it("does NOT flag same-module accent utilities", () => {
+    const messages = lint(
+      `const c = "bg-fizruk-surface text-fizruk-strong ring-fizruk hover:bg-fizruk-600";`,
+      FIZRUK_FILE,
+    );
+    assert.equal(messages.length, 0);
+  });
+
+  it("does NOT flag accents in core/** (cross-module shell)", () => {
+    const messages = lint(
+      `const c = "bg-finyk-surface text-fizruk-strong border-routine ring-nutrition";`,
+      CORE_FILE,
+    );
+    assert.equal(messages.length, 0);
+  });
+
+  it("does NOT flag accents in shared/** (primitives)", () => {
+    const messages = lint(
+      `const c = "bg-routine text-finyk ring-fizruk border-nutrition";`,
+      SHARED_FILE,
+    );
+    assert.equal(messages.length, 0);
+  });
+
+  it("flags foreign accents in apps/mobile/src/modules/<X>/**", () => {
+    const messages = lint(
+      `const c = "bg-routine-surface";`,
+      MOBILE_FIZRUK_FILE,
+    );
+    assert.equal(messages.length, 1);
+    assert.match(messages[0].message, /fizruk/);
+  });
+
+  it("flags foreign accents in Expo Router `apps/mobile/app/modules/<X>/**`", () => {
+    const messages = lint(
+      `const c = "text-finyk-strong";`,
+      MOBILE_APP_ROUTINE_FILE,
+    );
+    assert.equal(messages.length, 1);
+    assert.match(messages[0].message, /routine/);
+  });
+
+  it("does NOT run on test files (they reference all modules legitimately)", () => {
+    const messages = lint(`const c = "bg-routine text-finyk";`, TEST_FILE);
+    assert.equal(messages.length, 0);
+  });
+
+  it("handles variant prefixes (`dark:`, `hover:`, `lg:`)", () => {
+    const messages = lint(
+      `const c = "dark:bg-routine hover:text-nutrition lg:border-finyk";`,
+      FIZRUK_FILE,
+    );
+    assert.equal(messages.length, 3);
+  });
+
+  it("handles shade + opacity suffixes (`-500`, `/15`)", () => {
+    const messages = lint(
+      `const c = "bg-routine-500/15 text-nutrition-soft";`,
+      FIZRUK_FILE,
+    );
+    assert.equal(messages.length, 2);
+  });
+
+  it("flags occurrences inside template literals", () => {
+    const messages = lint(
+      `const c = \`\${base} ring-routine \${rest}\`;`,
+      FIZRUK_FILE,
+    );
+    assert.equal(messages.length, 1);
+  });
+
+  it("flags occurrences inside cn() argument soup", () => {
+    const messages = lint(
+      `const c = cn("base", active && "ring-routine", "mt-2");`,
+      FIZRUK_FILE,
+    );
+    assert.equal(messages.length, 1);
+  });
+
+  it("does NOT flag words that merely *contain* a module name", () => {
+    // `bg-finykington` isn't a finyk accent — the regex anchors on
+    // `-<module>` followed by (end of word | shade suffix | opacity).
+    const messages = lint(`const c = "bg-finyksurface-600";`, FIZRUK_FILE);
+    assert.equal(messages.length, 0);
+  });
+
+  it("does NOT flag accents inside `modules/shared/**` (cross-module utility folder)", () => {
+    const messages = lint(
+      `const c = "bg-routine text-finyk bg-fizruk bg-nutrition";`,
+      abs("apps/mobile/src/modules/shared/ModuleErrorBoundary.tsx"),
+    );
+    // Only the four canonical modules (finyk/fizruk/routine/nutrition)
+    // own their accent palette. `modules/shared/` hosts primitives
+    // that legitimately render whichever accent the current module
+    // needs (e.g. ModuleErrorBoundary), so the rule must stay quiet.
+    assert.equal(messages.length, 0);
+  });
+});

--- a/packages/eslint-plugin-sergeant-design/__tests__/no-hex-in-classname.test.mjs
+++ b/packages/eslint-plugin-sergeant-design/__tests__/no-hex-in-classname.test.mjs
@@ -1,0 +1,111 @@
+/**
+ * Unit tests for the `sergeant-design/no-hex-in-classname` rule.
+ *
+ * The rule bans Tailwind arbitrary-value hex colors (`bg-[#...]`,
+ * `text-[#fff]/50`, `ring-[#000]`, …) in className strings because they
+ * bypass the design-system token layer (dark-mode, WCAG tiers, palette
+ * migration all stop working for those literals).
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { Linter } from "eslint";
+import plugin from "../index.js";
+
+const linter = new Linter();
+const RULE_ID = "sergeant-design/no-hex-in-classname";
+
+function lint(code) {
+  return linter.verify(code, {
+    plugins: { "sergeant-design": plugin },
+    rules: { [RULE_ID]: "error" },
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+    },
+  });
+}
+
+describe("no-hex-in-classname", () => {
+  it("flags `bg-[#10b981]`", () => {
+    const messages = lint(`const c = "rounded bg-[#10b981] p-4";`);
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].ruleId, RULE_ID);
+    assert.match(messages[0].message, /bg-\[#10b981\]/);
+  });
+
+  it("flags `text-[#fff]` with variant prefix", () => {
+    const messages = lint(`const c = "hover:text-[#ffffff] dark:text-[#111]";`);
+    assert.equal(messages.length, 2);
+    assert.equal(messages[0].ruleId, RULE_ID);
+  });
+
+  it("flags each hex utility in a soup", () => {
+    const messages = lint(
+      `const c = "bg-[#fff] border-[#000] ring-[#abc] text-sm";`,
+    );
+    assert.equal(messages.length, 3);
+  });
+
+  it("flags 3, 4, 6, and 8 digit hex", () => {
+    for (const hex of ["#fff", "#ffff", "#ffffff", "#ffffffff"]) {
+      const messages = lint(`const c = "bg-[${hex}]";`);
+      assert.equal(
+        messages.length,
+        1,
+        `should flag ${hex} (len ${hex.length - 1})`,
+      );
+    }
+  });
+
+  it("does NOT flag non-color utilities with arbitrary hex-like values", () => {
+    // `w-[#foo]` isn't a color utility; hex in content/URL should also
+    // be ignored.
+    const messages = lint(
+      `const c = "w-[12px] content-['#f'] before:content-['#123']";`,
+    );
+    assert.equal(messages.length, 0);
+  });
+
+  it("does NOT flag valid semantic tokens", () => {
+    const messages = lint(
+      `const c = "bg-surface text-fg border-border bg-finyk-surface text-brand-strong bg-success-soft";`,
+    );
+    assert.equal(messages.length, 0);
+  });
+
+  it("does NOT flag hex literals that aren't className utilities", () => {
+    // Hex in plain strings (e.g. chart config) is not this rule's concern.
+    const messages = lint(`const c = "#10b981";`);
+    assert.equal(messages.length, 0);
+  });
+
+  it("flags hex inside template literal quasi", () => {
+    const messages = lint(`const c = \`rounded \${foo} bg-[#10b981] p-4\`;`);
+    assert.equal(messages.length, 1);
+  });
+
+  it("flags hex inside cn() argument soup", () => {
+    const messages = lint(
+      `const c = cn("base", active && "bg-[#ff0000]", disabled && "text-[#999]");`,
+    );
+    assert.equal(messages.length, 2);
+  });
+
+  it("reports the offending utility prefix in the message", () => {
+    const messages = lint(`const c = "border-[#cafeba]";`);
+    assert.equal(messages.length, 1);
+    assert.match(messages[0].message, /border-\[#cafeba\]/);
+  });
+
+  it("does NOT flag malformed hex lengths (5 or 7 digits)", () => {
+    const messages = lint(`const c = "bg-[#12345] text-[#1234567]";`);
+    assert.equal(messages.length, 0);
+  });
+
+  it("does NOT flag arbitrary-value non-hex colors (oklch, rgb, hsl, var)", () => {
+    const messages = lint(
+      `const c = "bg-[oklch(0.5_0.1_120)] text-[rgb(10,20,30)] border-[var(--accent)]";`,
+    );
+    assert.equal(messages.length, 0);
+  });
+});

--- a/packages/eslint-plugin-sergeant-design/index.js
+++ b/packages/eslint-plugin-sergeant-design/index.js
@@ -14,6 +14,17 @@
  *     what Web Interface Guidelines recommend for truncation cues
  *     ("Loading…", "Пошук…", etc.). Auto-fixable.
  *
+ *   - no-hex-in-classname: forbid arbitrary-value hex colors in
+ *     className (`bg-[#10b981]`, `text-[#fff]/50`, …). Every color must
+ *     come from the design-system token layer so dark-mode, palette
+ *     migration, and WCAG tiers apply uniformly.
+ *
+ *   - no-foreign-module-accent: inside `apps/[app]/src/modules/[X]/`
+ *     subtrees, only `[X]`'s accent utilities (`bg-[X]-surface`,
+ *     `text-[X]-strong`, `ring-[X]`, …) are allowed. Cross-module
+ *     shells (`core/`, `shared/`, `stories/`) remain free to reference
+ *     all four module accents.
+ *
  * Motion / reduced-motion (convention — not auto-enforced yet):
  *   - Prefer `motion-safe:` on `animate-*` and decorative transitions so
  *     `prefers-reduced-motion: reduce` users get calmer UI; pair with
@@ -1415,6 +1426,211 @@ const noStrictBypass = {
   },
 };
 
+// ─────────────────────────────────────────────────────────────────────────
+// `no-hex-in-classname` — forbid arbitrary hex colors in Tailwind className
+// ─────────────────────────────────────────────────────────────────────────
+//
+// Tailwind's arbitrary-value syntax (`bg-[#10b981]`, `text-[#fff]/50`,
+// `border-[#123]`) bypasses the design-system tokens entirely. A raw hex
+// in a className means: (a) dark-mode won't adapt, (b) the value doesn't
+// re-theme when the palette evolves, (c) it can't be grep'd from a single
+// place when we need to migrate. The Sergeant rule is simple: every color
+// in a className comes from the token scale (`bg-surface`, `text-muted`,
+// `border-border`, `bg-finyk-surface`, `text-brand-strong`, `bg-success-soft`,
+// …). If a colour is truly one-off (chart series, illustration fill), put
+// it in the token layer (CSS var + preset alias) — not inline.
+//
+// The rule only flags hex inside the arbitrary-value brackets of
+// Tailwind's color-aware utilities (`bg-`, `text-`, `border-`, `ring-`,
+// `fill-`, `stroke-`, `from-`, `to-`, `via-`, `shadow-`, `outline-`,
+// `divide-`, `placeholder-`, `caret-`, `decoration-`, `accent-`). Plain
+// hex literals outside className context (e.g. chart config passing a
+// hex to recharts) are NOT this rule's concern — those are a code review
+// issue for `shared/charts/chartPalette.ts`.
+
+const HEX_IN_CLASSNAME_MESSAGE =
+  "Raw hex `{{utility}}-[#{{hex}}]` bypasses the design-system tokens — use a semantic utility (e.g. `bg-surface`, `text-fg`, `bg-finyk-surface`, `text-brand-strong`, `bg-success-soft`) or extend the palette in `packages/design-tokens/tailwind-preset.js` if a new token is genuinely needed.";
+
+// Match `[variants:]<utility>-[#HEX]` with optional `/OPACITY` suffix.
+//   • utility ∈ TAILWIND_OPACITY_UTILITIES (the color-aware set reused from
+//     valid-tailwind-opacity so we keep one list).
+//   • `<HEX>` is 3, 4, 6, or 8 hex digits.
+//   • `\b` anchor lets variant prefixes (`dark:`, `hover:`, `lg:`) sit in
+//     front of the utility without tripping the regex.
+const RX_HEX_IN_CLASSNAME = new RegExp(
+  String.raw`\b(` +
+    TAILWIND_OPACITY_UTILITIES.join("|") +
+    String.raw`)-\[#([0-9a-fA-F]{3,8})\]`,
+  "g",
+);
+
+function findHexInClassName(value) {
+  if (typeof value !== "string" || value.length === 0) return [];
+  if (!value.includes("[#")) return [];
+  const hits = [];
+  let match;
+  RX_HEX_IN_CLASSNAME.lastIndex = 0;
+  while ((match = RX_HEX_IN_CLASSNAME.exec(value)) !== null) {
+    const [, utility, hex] = match;
+    // Validate hex length so `bg-[#12]` or `bg-[#1234567]` don't trigger.
+    if (![3, 4, 6, 8].includes(hex.length)) continue;
+    hits.push({ utility, hex });
+  }
+  return hits;
+}
+
+const noHexInClassname = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Forbid arbitrary `<utility>-[#hex]` colors in className — every color must come from the design-system token layer.",
+    },
+    schema: [],
+    messages: { hex: HEX_IN_CLASSNAME_MESSAGE },
+  },
+  create(context) {
+    function report(node, value) {
+      const hits = findHexInClassName(value);
+      for (const hit of hits) {
+        context.report({
+          node,
+          messageId: "hex",
+          data: { utility: hit.utility, hex: hit.hex },
+        });
+      }
+    }
+    return {
+      Literal(node) {
+        if (typeof node.value === "string") report(node, node.value);
+      },
+      TemplateElement(node) {
+        const cooked = node.value && node.value.cooked;
+        if (typeof cooked === "string") report(node, cooked);
+      },
+    };
+  },
+};
+
+// ─────────────────────────────────────────────────────────────────────────
+// `no-foreign-module-accent` — keep module colors within their module
+// ─────────────────────────────────────────────────────────────────────────
+//
+// Sergeant has 4 module brand colors: `finyk` (emerald), `fizruk` (teal),
+// `routine` (coral), `nutrition` (lime). They're tuned close in saturation,
+// so accidental cross-module use reads as a design bug — a fizruk button
+// rendering coral `ring-routine` says "Рутина" to the user. The rule:
+//
+//   Files under `apps/web/src/modules/<X>/**` may only use `<X>`'s accent
+//   utilities. Cross-module shells (`core/**`, `shared/**`, `stories/**`)
+//   are free to use all four, because that's their job.
+//
+// Accent utilities matched: `(bg|text|border|ring|from|to|via|fill|stroke|
+// shadow|outline|divide|placeholder|caret|decoration|accent)-<module>`
+// with optional `-<shade>` suffix (e.g. `-strong`, `-soft`, `-500`,
+// `-surface`) and optional `/<opacity>` suffix. Variant prefixes
+// (`dark:`, `hover:`, `lg:`) are allowed in front.
+
+const MODULE_ACCENTS = ["finyk", "fizruk", "routine", "nutrition"];
+
+const FOREIGN_MODULE_ACCENT_MESSAGE =
+  "`{{match}}` is a `{{foreign}}` accent inside a `{{home}}` module — modules must only use their own accent. Use `{{home}}` equivalents or move this to a cross-module surface (`core/**`, `shared/**`).";
+
+// Match `[variants:]<utility>-<module>[-<shade>][/<opacity>]`.
+const RX_MODULE_ACCENT = new RegExp(
+  String.raw`\b(` +
+    TAILWIND_OPACITY_UTILITIES.join("|") +
+    String.raw`)-(` +
+    MODULE_ACCENTS.join("|") +
+    String.raw`)(-[a-z0-9]+(?:-[a-z0-9]+)?)?(\/\d{1,3})?\b`,
+  "g",
+);
+
+// Derive the "home" module from an absolute or repo-relative file path.
+// Accepts web and mobile source trees; returns null for non-module paths
+// and for `modules/shared/` (a cross-module utility folder that hosts
+// primitives rendering any of the four accents — e.g.
+// `apps/mobile/src/modules/shared/ModuleErrorBoundary.tsx`).
+function homeModuleFromFilename(filename) {
+  if (typeof filename !== "string") return null;
+  // Normalize path separators for Windows; tests feed a unix-style mock.
+  const norm = filename.replace(/\\/g, "/");
+  const m = norm.match(
+    /\/(?:apps\/(?:web|mobile)\/src|apps\/mobile\/app)\/modules\/([a-z]+)\//,
+  );
+  if (!m) return null;
+  const home = m[1];
+  // Only the four canonical modules own their accent palette — any
+  // other folder under `modules/` is a cross-module utility and must
+  // stay free to render every accent.
+  return MODULE_ACCENTS.includes(home) ? home : null;
+}
+
+function findForeignModuleAccents(value, home) {
+  if (typeof value !== "string" || value.length === 0) return [];
+  if (!home) return [];
+  // Cheap prefilter so we don't regex every unrelated literal.
+  let maybe = false;
+  for (const m of MODULE_ACCENTS) {
+    if (m !== home && value.includes(`-${m}`)) {
+      maybe = true;
+      break;
+    }
+  }
+  if (!maybe) return [];
+  const hits = [];
+  let match;
+  RX_MODULE_ACCENT.lastIndex = 0;
+  while ((match = RX_MODULE_ACCENT.exec(value)) !== null) {
+    const [full, , mod] = match;
+    if (mod !== home) hits.push({ match: full, foreign: mod });
+  }
+  return hits;
+}
+
+const noForeignModuleAccent = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Forbid cross-module accent utilities inside `apps/*/src/modules/<X>/**` — a fizruk component must not render `ring-routine` etc.",
+    },
+    schema: [],
+    messages: { foreign: FOREIGN_MODULE_ACCENT_MESSAGE },
+  },
+  create(context) {
+    const filename =
+      (context.filename != null ? context.filename : context.getFilename()) ||
+      "";
+    const home = homeModuleFromFilename(filename);
+    if (!home) return {};
+    // Cross-module accent rule doesn't apply to the module-accent system
+    // itself (the map literals that declare every accent) or to module-
+    // scoped tests (they naturally reference all four for coverage).
+    if (/\.(test|spec)\.[jt]sx?$/.test(filename)) return {};
+
+    function report(node, value) {
+      const hits = findForeignModuleAccents(value, home);
+      for (const hit of hits) {
+        context.report({
+          node,
+          messageId: "foreign",
+          data: { match: hit.match, foreign: hit.foreign, home },
+        });
+      }
+    }
+    return {
+      Literal(node) {
+        if (typeof node.value === "string") report(node, node.value);
+      },
+      TemplateElement(node) {
+        const cooked = node.value && node.value.cooked;
+        if (typeof cooked === "string") report(node, cooked);
+      },
+    };
+  },
+};
+
 const plugin = {
   rules: {
     "no-eyebrow-drift": noEyebrowDrift,
@@ -1423,6 +1639,8 @@ const plugin = {
     "no-raw-local-storage": noRawLocalStorage,
     "ai-marker-syntax": aiMarkerSyntax,
     "valid-tailwind-opacity": validTailwindOpacity,
+    "no-hex-in-classname": noHexInClassname,
+    "no-foreign-module-accent": noForeignModuleAccent,
     "no-low-contrast-text-on-fill": noLowContrastTextOnFill,
     "no-bigint-string": noBigintString,
     "rq-keys-only-from-factory": rqKeysOnlyFromFactory,


### PR DESCRIPTION
## What changed

Wave **1a** of the design-system guardrail plan — two new ESLint rules plus the dark-mode audit report that will drive the later waves.

### New rule: `sergeant-design/no-hex-in-classname`

Forbids arbitrary `<utility>-[#hex]` colors in Tailwind classNames:

```tsx
// ❌ flagged
<div className="bg-[#10b981] text-[#fff]/50" />
// ✅ use semantic tokens
<div className="bg-brand-soft text-on-brand" />
```

Raw hex bypasses the token layer entirely: dark-mode adaptation, WCAG-AA `-strong` promotion, and future palette migration all stop working for those literals. The rule covers all color-aware utilities (`bg-`, `text-`, `border-`, `ring-`, `fill-`, `stroke-`, `from-`, `to-`, `via-`, `shadow-`, `outline-`, `divide-`, `placeholder-`, `caret-`, `decoration-`, `accent-`) and validates hex length (3 / 4 / 6 / 8 digits). Non-hex arbitrary values (`bg-[oklch(…)]`, `border-[var(--foo)]`, `bg-[rgb(…)]`) are left alone. **0 violations in the current tree — rule ships clean.**

### New rule: `sergeant-design/no-foreign-module-accent`

Inside `apps/<app>/src/modules/<X>/` subtrees only `<X>`'s accent utilities (`bg-<X>-surface`, `text-<X>-strong`, `ring-<X>`, …) may appear:

```tsx
// apps/web/src/modules/fizruk/pages/PlanCalendar.tsx
// ❌ flagged — coral ring-routine reads as "Рутина" to the user
<button className="focus-visible:ring-routine" />
// ✅ module-consistent focus ring
<button className="focus-visible:ring-fizruk" />
```

Sergeant's four module accents (`finyk`/emerald, `fizruk`/teal, `routine`/coral, `nutrition`/lime) are deliberately close in saturation — accidental cross-module use reads as a design bug, not a stylistic choice. Cross-module shells (`core/`, `shared/`, `modules/shared/`, `stories/`, test files) remain free to reference all four.

**1 violation fixed:** `apps/web/src/modules/fizruk/pages/PlanCalendar.tsx:34` (`ring-routine` → `ring-fizruk`).

### Dark-mode audit (`docs/design/DARK-MODE-AUDIT.md`)

Catalogues the **28 call-sites** that express dark mode as an explicit raw-palette `dark:` override — the exact anti-pattern class behind bug #814:

```tsx
// ❌ Two palette values encoded per theme
<div className="bg-amber-50 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300" />
// ✅ One semantic token; the preset owns both themes
<div className="bg-warning-soft text-warning" />
```

Grouped by target semantic token:

- `bg-{module}-surface` — 10 sites (Card, WeeklyDigestCard, routineConstants).
- `bg-brand-soft` — 6 sites (Badge, Segmented, Tabs, Button, AssistantAdviceCard).
- `bg-{status}-soft` — 5 sites (Badge, Banner).
- `<WorkoutStatTile>` primitive extraction — 4 sites (WorkoutFinishSheets).
- `chartTheme` coral pairs → CSS variables — 3 sites.

Totals: 306 `dark:` overrides repo-wide; 28 are the anti-pattern; Waves 1b / 1c will migrate them in small reviewable batches, targeting ~250 `dark:` overrides after refactor and eventually promoting a `no-raw-dark-palette` rule to `error`.

### Plugin-self overrides

`eslint.config.js` disables both new rules for `packages/eslint-plugin-sergeant-design/**` so the fixture literals in `__tests__` (`bg-[#10b981]`, `ring-routine`) don't self-flag — same pattern already used for `valid-tailwind-opacity` / `no-low-contrast-text-on-fill`.

## Why

Design-system drift prevention, enforced in CI instead of code review:

- **`no-hex-in-classname`** closes off the #1 lint-catchable way to smuggle an off-palette color into the app — you can't accidentally tint a card wrong if `bg-[#...]` fails CI.
- **`no-foreign-module-accent`** protects the muscle-memory contract between the four module colors and their modules. A fizruk screen with a coral focus ring is a bug; this rule makes it uncatchable outside CI.
- **Dark-mode audit** turns 28 ad-hoc `dark:` patches into a tracked, incremental migration plan — each batch reduces `dark:` count and moves logic into the preset.

Together they are Wave 1a of the broader Design / UI / UX improvement plan discussed in the session that spawned this PR.

## How to test

```bash
pnpm lint:plugins   # 200 / 200 plugin unit tests green
pnpm lint           # repo-wide lint passes; no new violations surfaced
pnpm format:check   # prettier clean
```

Sanity-check each new rule locally:

```bash
# no-hex-in-classname
echo 'const c = "bg-[#10b981]";' > /tmp/hex.tsx
pnpm --filter @sergeant/web exec eslint /tmp/hex.tsx
# expect: "bg-[#10b981] bypasses the design-system tokens…"

# no-foreign-module-accent
echo 'export const c = "ring-routine";' \
  > apps/web/src/modules/fizruk/pages/__sandbox.tsx
pnpm --filter @sergeant/web lint
# expect: "ring-routine is a routine accent inside a fizruk module…"
rm apps/web/src/modules/fizruk/pages/__sandbox.tsx
```

---

## How AI-tested this PR

- [x] `pnpm lint:plugins`: 200 / 200 tests pass (173 baseline + 12 no-hex + 15 no-foreign-module-accent).
- [x] `pnpm lint`: repo-wide clean after fixing `PlanCalendar.tsx:34` (`ring-routine` → `ring-fizruk`).
- [x] `pnpm format:check`: clean.
- [x] Typecheck delta vs `main` verified: pre-existing 816 TS errors unchanged — no new errors introduced by this PR.
- [x] No new `AI-DANGER` markers added.
- [x] Docs prose (`DARK-MODE-AUDIT.md`) in English for technical precision of the inventory; commit body / PR description bilingual per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules; the two ESLint rules are self-documenting via the rule description + error message, and the dark-mode audit document is the migration plan rather than a standing rule.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ESLint rules to enforce semantic token usage for colors and prevent cross-module accent class conflicts, improving design consistency.

* **Documentation**
  * Added dark mode design audit documentation outlining anti-patterns and a staged migration strategy for color implementation.

* **Style**
  * Updated focus ring styling on the scheduled routines action button.

* **Tests**
  * Added comprehensive test coverage for new design guardrail rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->