### PR TITLE
docs(docs): cross-reference no-hex + no-foreign-module-accent rules (AGENTS #11/#12)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,7 +220,7 @@ The rule deliberately does **not** fire on:
 - `bg-{family}-strong text-white` — the canonical fix.
 - `bg-{family}-{700,800,900}` — explicit dark steps already clear AA.
 - `bg-{family}/N` — opacity-tinted soft washes; the foreground is `text-{family}-strong`, not white.
-- `bg-[#hex] text-white` — arbitrary values; deliberate one-off opt-out.
+- `bg-[#hex] text-white` — arbitrary hex values, now separately forbidden by rule #11 (`sergeant-design/no-hex-in-classname`).
 - `dark:bg-{family} text-white` — on dark surfaces emerald-500 vs. white passes ~5.4 : 1; the strong tier would actually regress contrast.
 - `hover:bg-{family} text-white` — hover-only saturated bg if the base state is fine.
 
@@ -281,6 +281,46 @@ Right after the existing `> **Last validated:** YYYY-MM-DD …` line, add:
 - **Dead-code PRs** — agent/human MUST check for `@scaffolded`/`@deprecated` markers before deleting a "knip-says-unused" file. If a marker exists, leave the file. If knip flags an unmarked file, prefer to add `@scaffolded` (with owner + next step) rather than delete, unless `git log --follow` makes it obvious the file is truly orphaned (e.g. last touched > 12 months ago, no `feat(...)` commit). Document the reasoning in the PR description.
 - **Doc cleanup PRs** — `Archived` docs may be moved to `archive/`, but their content is not edited.
 - **AI agents** — when surfacing files for review, group by status. A file with `@scaffolded` is NOT a candidate for the "remove dead code" task type.
+
+### 11. No arbitrary hex colors in `className`
+
+Raw `<utility>-[#hex]` values in Tailwind `className` (`bg-[#10b981]`, `text-[#fff]/50`, `border-[#abc]`, `ring-[#1234ab]`) bypass the design-system token layer entirely. Dark-mode adaptation, the WCAG-AA `-strong` promotion from rule #9, the module-accent containment from rule #12, and future palette migrations all stop working for those literals — you get a hard-coded colour that no other system in the repo can reason about.
+
+```tsx
+// ❌ BAD — off-palette emerald that dark-mode cannot touch
+<div className="bg-[#10b981] text-[#fff]/50" />
+
+// ✅ GOOD — semantic token; `dark:` + `-strong` work automatically
+<div className="bg-brand-soft text-on-brand" />
+
+// ✅ GOOD — module accent; covered by the `-surface` / `-strong` pair
+<div className="bg-finyk-surface text-finyk-strong" />
+```
+
+The rule covers every colour-aware utility (`bg-`, `text-`, `border-`, `ring-`, `fill-`, `stroke-`, `from-`, `to-`, `via-`, `shadow-`, `outline-`, `divide-`, `placeholder-`, `caret-`, `decoration-`, `accent-`) and validates hex length (3 / 4 / 6 / 8 digits). Non-hex arbitrary values (`bg-[oklch(…)]`, `border-[var(--foo)]`, `bg-[rgb(…)]`) are **intentionally left alone** — they can reference CSS variables owned by the preset and are occasionally necessary for one-off interop.
+
+If you genuinely need a new shade, add it to `packages/design-tokens/tailwind-preset.js` (alongside a `-soft` / `-strong` companion per rule #9) instead of inlining hex at the call-site. Enforced by `sergeant-design/no-hex-in-classname` (`error`).
+
+### 12. Module-accent containment — no foreign accents inside a module subtree
+
+Sergeant's four module accents (`finyk`/emerald, `fizruk`/teal, `routine`/coral, `nutrition`/lime) are deliberately close in saturation. A fizruk screen that accidentally renders a coral `ring-routine` reads to the user as "Рутина" — it's a semantic design bug, not a stylistic choice. Inside the `apps/<app>/src/modules/<X>/` subtree, only `<X>`'s accent utilities (`bg-<X>-surface`, `text-<X>-strong`, `ring-<X>`, `bg-<X>-500/15`, …) may appear.
+
+```tsx
+// apps/web/src/modules/fizruk/pages/PlanCalendar.tsx
+// ❌ BAD — coral focus ring inside a Fizruk page
+<button className="focus-visible:ring-routine" />
+
+// ✅ GOOD — module-consistent focus ring
+<button className="focus-visible:ring-fizruk" />
+```
+
+The rule handles variant prefixes (`dark:`, `hover:`, `lg:`), shade suffixes (`-500`, `-soft`, `-strong`), and opacity suffixes (`/15`) transparently. Cross-module shells remain **exempt** so the Hub / HubChat / shared widgets can still reference every accent:
+
+- `apps/*/src/core/**`, `apps/*/src/shared/**`, `apps/*/src/stories/**`
+- `apps/*/src/modules/shared/**` (non-canonical module folder — a cross-module utility, not an accent owner)
+- `__tests__/*.{ts,tsx,mjs}` — test fixtures naturally reference all four for coverage.
+
+Enforced by `sergeant-design/no-foreign-module-accent` (`error`). See `docs/design/MODULE-ACCENT.md` for the "one accent = one module" design principle.
 
 ## AI markers
 

--- a/docs/design/MODULE-ACCENT.md
+++ b/docs/design/MODULE-ACCENT.md
@@ -136,12 +136,57 @@ const TINT = {
   <div className="bg-module-accent/10" />  {/* ← no ambient accent */}
 </HubDashboard>
 
+// ❌ BAD — foreign module accent inside another module's subtree
+// apps/web/src/modules/fizruk/pages/PlanCalendar.tsx
+<button className="focus-visible:ring-routine">…</button>
+// (coral focus ring reads to the user as "Рутина", not "Фізрук")
+// Enforced by `sergeant-design/no-foreign-module-accent` (error).
+
 // ✅ GOOD — ambient accent inside a module surface
 <ModuleShell module="routine">
   <Card className="bg-module-accent/8 border-module-accent/20" />
   <Button className="bg-module-accent-strong text-white">Зберегти</Button>
 </ModuleShell>
 ```
+
+### Module-accent containment (`sergeant-design/no-foreign-module-accent`)
+
+Inside `apps/<app>/src/modules/<X>/` only `<X>`'s accent utilities
+(`bg-<X>-surface`, `text-<X>-strong`, `ring-<X>`, `bg-<X>-500/15`, …)
+may appear. The rule handles variant prefixes (`dark:`, `hover:`,
+`lg:`), shade suffixes (`-500`, `-soft`, `-strong`), and opacity
+suffixes (`/15`) transparently.
+
+Exempt subtrees (free to reference every accent):
+
+- `apps/*/src/core/**`, `apps/*/src/shared/**`, `apps/*/src/stories/**`
+  — cross-module shell / Hub / HubChat.
+- `apps/*/src/modules/shared/**` — non-canonical module folder;
+  cross-module utility, not an accent owner.
+- `__tests__/*.{ts,tsx,mjs}` — test fixtures naturally reference all
+  four for coverage.
+
+`AGENTS.md` hard rule #12 is the full spec. The file-at-a-time
+anti-pattern above — a `fizruk` page reaching for `ring-routine` — is
+exactly what the rule catches:
+
+```tsx
+// ❌ BAD
+<button className="focus-visible:ring-routine" />
+// ✅ GOOD
+<button className="focus-visible:ring-fizruk" />
+```
+
+### No arbitrary hex colors (`sergeant-design/no-hex-in-classname`)
+
+Do not write `bg-[#10b981]` / `text-[#fff]/50` / `ring-[#1234ab]` inside
+`className`. A raw hex literal bypasses the whole three-layer system
+above — `--module-accent-rgb` cannot tint it, the `-strong` companion
+does not exist for it, and dark-mode cannot adapt it. If you genuinely
+need a new shade, add it to `packages/design-tokens/tailwind-preset.js`
+(alongside a `-soft` / `-strong` companion per `AGENTS.md` rule #9).
+Enforced by `sergeant-design/no-hex-in-classname` (error); see
+`AGENTS.md` hard rule #11.
 
 ## API
 
@@ -213,3 +258,8 @@ it("публікує --module-accent-rgb + strong для finyk", () => {
 - [`docs/design/brand-palette-wcag-aa-proposal.md`](./brand-palette-wcag-aa-proposal.md) — migration history (PRs #854 / #855 / #857).
 - `AGENTS.md` hard rule #8 — Tailwind opacity scale.
 - `AGENTS.md` hard rule #9 — `-strong` companion behind `text-white`.
+- `AGENTS.md` hard rule #11 — no arbitrary hex colors in `className`.
+- `AGENTS.md` hard rule #12 — module-accent containment.
+- [`docs/design/DARK-MODE-AUDIT.md`](./DARK-MODE-AUDIT.md) — pending
+  migration plan from 28 raw-palette `dark:` patches to semantic tokens
+  (bg-{module}-surface / bg-brand-soft / bg-{status}-soft / etc.).

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -17,13 +17,22 @@
 ## 1. Принципи
 
 1. **Семантичні токени → Tailwind-утиліти → примітиви.** Ніяких hex-кодів в
-   `className`. Якщо потрібен новий колір — додай CSS-змінну в
-   `src/index.css` і алиас у `tailwind.config.js`, не в компонент.
+   `className` (`bg-[#10b981]`, `text-[#fff]/50` — заборонено правилом
+   `sergeant-design/no-hex-in-classname` на рівні `error`; див.
+   `AGENTS.md` hard rule #11). Якщо потрібен новий колір — додай його
+   у `packages/design-tokens/tailwind-preset.js` разом із
+   `-soft` / `-strong` компаньйонами, не inline в компонент.
 2. **Темна тема — first-class.** Всі токени живуть у CSS-змінних
    `:root` та `.dark`; теми перемикаються класом без перезапису стилів.
+   Парні `dark:` override з сирою палітрою (`bg-teal-100 dark:bg-teal-900/30`)
+   — це міграційний борг: [`DARK-MODE-AUDIT.md`](./DARK-MODE-AUDIT.md)
+   ведe інвентар 28 таких сайтів і план переносу в семантичні токени.
 3. **Модулі діляться токенами, а не стилями.** `bg-finyk-surface`,
    `text-fizruk`, `border-routine/30` — це семантичні аксенти; вся базова
-   типографіка, spacing, радіуси одні для всіх.
+   типографіка, spacing, радіуси одні для всіх. Всередині
+   `apps/<app>/src/modules/<X>/` дозволені лише акценти модуля `<X>` —
+   див. `AGENTS.md` hard rule #12 + [`MODULE-ACCENT.md`](./MODULE-ACCENT.md),
+   enforced by `sergeant-design/no-foreign-module-accent` (`error`).
 4. **Accessibility не опція.** Клавіатурний фокус завжди видимий
    (`focus-visible:ring-2 ring-brand-500/45`), touch-targets ≥44×44 px,
    контраст ≥4.5:1 для тексту, ≥3:1 для UI-елементів (WCAG AA).

--- a/packages/eslint-plugin-sergeant-design/README.md
+++ b/packages/eslint-plugin-sergeant-design/README.md
@@ -28,6 +28,31 @@ Validates AI code-marker comments follow the canonical syntax (`// AI-NOTE:`, `/
 
 Flags Tailwind `<color>/<N>` opacity modifiers where `N` is not registered in `theme.opacity`. Unregistered steps are silently dropped by Tailwind, breaking `dark:` / `hover:` overrides. Severity: **error**.
 
+### `sergeant-design/no-hex-in-classname`
+
+Forbids arbitrary `<utility>-[#hex]` colors in Tailwind classNames (`bg-[#10b981]`, `text-[#fff]/50`, `border-[#abc]`). Raw hex bypasses the design-system token layer — dark-mode adaptation, WCAG-AA `-strong` promotion, and future palette migration all stop working for those literals. Covers every color-aware utility (`bg-`, `text-`, `border-`, `ring-`, `fill-`, `stroke-`, `from-`, `to-`, `via-`, `shadow-`, `outline-`, `divide-`, `placeholder-`, `caret-`, `decoration-`, `accent-`) and validates hex length (3 / 4 / 6 / 8 digits). Non-hex arbitrary values (`bg-[oklch(…)]`, `border-[var(--foo)]`, `bg-[rgb(…)]`) are intentionally left alone — extend the preset if a truly one-off color is needed. See [AGENTS.md rule #11](../../AGENTS.md). Severity: **error**.
+
+```tsx
+// ❌ BAD — hex bypasses the token layer
+<div className="bg-[#10b981] text-[#fff]/50" />
+
+// ✅ GOOD — semantic token
+<div className="bg-brand-soft text-on-brand" />
+```
+
+### `sergeant-design/no-foreign-module-accent`
+
+Inside `apps/<app>/src/modules/<X>/` subtrees only `<X>`'s accent utilities (`bg-<X>-surface`, `text-<X>-strong`, `ring-<X>`, `bg-<X>-500/15`, …) may appear. Sergeant's four module accents (`finyk`/emerald, `fizruk`/teal, `routine`/coral, `nutrition`/lime) are deliberately close in saturation — a fizruk screen accidentally rendering a coral `ring-routine` reads to the user as "Рутина" and is a design bug, not a stylistic choice. Cross-module shells (`core/`, `shared/`, `modules/shared/`, `stories/`, test files) remain free to reference all four. Variant prefixes (`dark:`, `hover:`, `lg:`), shade suffixes (`-500`, `-soft`, `-strong`), and opacity suffixes (`/15`) are handled transparently. See [AGENTS.md rule #12](../../AGENTS.md) and [`docs/design/MODULE-ACCENT.md`](../../docs/design/MODULE-ACCENT.md). Severity: **error**.
+
+```tsx
+// apps/web/src/modules/fizruk/pages/PlanCalendar.tsx
+// ❌ BAD — coral focus ring inside a Fizruk page
+<button className="focus-visible:ring-routine" />
+
+// ✅ GOOD — module-consistent focus ring
+<button className="focus-visible:ring-fizruk" />
+```
+
 ### `sergeant-design/no-low-contrast-text-on-fill`
 
 Forbids saturated brand `bg-*` utilities behind `text-white` — use the `-strong` companion (= 700/800 step) so the pairing clears WCAG AA 4.5 : 1. Severity: **error**.


### PR DESCRIPTION
## What changed

Follow-up documentation pass for #1145 (merged as `d73063e3`). Documents the two design-lint rules added in that PR so the hard-rule list, the plugin README, and the design-system references all agree.

**Rule numbering.** On the merged PR branch I planned these as hard rules `#10` / `#11`, but `main` meanwhile gained rule `#10` (Lifecycle markers, #1144). The two new design-lint rules are therefore `#11` (no-hex-in-classname) and `#12` (no-foreign-module-accent).

### `AGENTS.md`

- **New § 11 — No arbitrary hex colors in `className`.** Scope of covered utilities, hex-length check, kept-non-hex values (`oklch(…)`, `var(--…)`, `rgb(…)`), and the migration path (extend `tailwind-preset.js` instead of inlining hex).
- **New § 12 — Module-accent containment.** The `apps/<app>/src/modules/<X>/` boundary, exempt subtrees (`core/`, `shared/`, `modules/shared/`, `stories/`, `__tests__`), cross-reference to `docs/design/MODULE-ACCENT.md`.
- **§ 9 'not flagged' list updated.** `bg-[#hex] text-white` used to be described as a deliberate opt-out from the `-strong` rule. It no longer is — the bullet now points to rule #11 instead.

### `packages/eslint-plugin-sergeant-design/README.md`

Inserts `no-hex-in-classname` and `no-foreign-module-accent` sections with BAD / GOOD examples, immediately after `valid-tailwind-opacity` (grouped with the other colour-token guardrails).

### `docs/design/MODULE-ACCENT.md`

- New anti-pattern entry in the 'Anti-patterns' block: a foreign module accent inside another module's subtree (`ring-routine` in a `fizruk` page).
- Dedicated section explaining the containment rule, its handling of variant prefixes / shade suffixes / opacity, and the exempt cross-module subtrees.
- New 'No arbitrary hex colors' subsection pointing to rule #11.
- 'Related docs' now links `DARK-MODE-AUDIT.md` and AGENTS rules #11 / #12.

### `docs/design/design-system.md`

- Principle #1 — explicit reference to `sergeant-design/no-hex-in-classname` and AGENTS #11; guidance to extend the preset instead of inlining hex.
- Principle #2 — call out the `dark:`-override migration debt tracked in `DARK-MODE-AUDIT.md`.
- Principle #3 — reference AGENTS #12 + `MODULE-ACCENT.md` + `no-foreign-module-accent` for module-accent containment.

## Why

PR #1145 shipped the lint rules and their unit tests, but the repo's documentation (hard-rule catalogue, plugin README, design-system principles, module-accent guide) still described the pre-rule state. This closes that gap so a future contributor reading `AGENTS.md`, `MODULE-ACCENT.md`, or `design-system.md` sees the same rules that CI is already enforcing.

Docs-only PR — no code changes, no behaviour changes.

## How to test

```bash
pnpm format:check   # prettier clean (docs-only touch)
pnpm lint:plugins   # 200 / 200 plugin unit tests still green
```

Read-through checklist:

- `AGENTS.md` § Hard rules now enumerates 1 → 12 with no gaps.
- `AGENTS.md` rule #9 no longer lists `bg-[#hex] text-white` as a deliberate opt-out.
- `packages/eslint-plugin-sergeant-design/README.md` has 12 rule sections (was 10).
- `docs/design/MODULE-ACCENT.md` § Related docs links to `DARK-MODE-AUDIT.md` and AGENTS rules #11 / #12.
- `docs/design/design-system.md` § 1. Принципи references `no-hex-in-classname` / `no-foreign-module-accent` / `DARK-MODE-AUDIT.md`.

---

## How AI-tested this PR

- [x] `pnpm format:check`: clean.
- [x] `pnpm lint:plugins`: 200 / 200 tests pass.
- [x] No new `AI-DANGER` markers added.
- [x] Docs prose in Ukrainian where practical (`design-system.md` principle text remains in Ukrainian; new hard-rule bodies in `AGENTS.md` follow the existing English technical-reference style of rules #1 – #10).

## AGENTS.md updated?

- [x] Yes — added hard rules #11 and #12 (`AGENTS.md:285-323`).
- [ ] No — no new permanent rules.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update docs to reflect two new design-lint rules: `sergeant-design/no-hex-in-classname` (AGENTS #11) and `sergeant-design/no-foreign-module-accent` (AGENTS #12). Adds these to `AGENTS.md`, documents them with examples in `packages/eslint-plugin-sergeant-design/README.md`, and cross-links guidance in `docs/design/MODULE-ACCENT.md` and `docs/design/design-system.md`.

<sup>Written for commit c8e1f9aabf9c0c8e80b459ea8cabc6c45ce3ab9e. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1146?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Introduced design rule disallowing arbitrary hex color values in `className` literals; use design tokens instead.
* Added constraint restricting module accent utilities to their owning module subtree for improved scoping.
* Implemented automated ESLint enforcement for both design rules across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->