### PR TITLE
docs(docs): correct non-existent token refs in rule #11 examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -290,11 +290,12 @@ Raw `<utility>-[#hex]` values in Tailwind `className` (`bg-[#10b981]`, `text-[#f
 // ❌ BAD — off-palette emerald that dark-mode cannot touch
 <div className="bg-[#10b981] text-[#fff]/50" />
 
-// ✅ GOOD — semantic token; `dark:` + `-strong` work automatically
-<div className="bg-brand-soft text-on-brand" />
+// ✅ GOOD — status soft token; both `bg-` and `text-` adapt per theme
+// via CSS variables owned by the preset.
+<div className="bg-success-soft text-success-strong" />
 
-// ✅ GOOD — module accent; covered by the `-surface` / `-strong` pair
-<div className="bg-finyk-surface text-finyk-strong" />
+// ✅ GOOD — page-level surface + foreground; semantic and theme-aware.
+<div className="bg-surface text-fg" />
 ```
 
 The rule covers every colour-aware utility (`bg-`, `text-`, `border-`, `ring-`, `fill-`, `stroke-`, `from-`, `to-`, `via-`, `shadow-`, `outline-`, `divide-`, `placeholder-`, `caret-`, `decoration-`, `accent-`) and validates hex length (3 / 4 / 6 / 8 digits). Non-hex arbitrary values (`bg-[oklch(…)]`, `border-[var(--foo)]`, `bg-[rgb(…)]`) are **intentionally left alone** — they can reference CSS variables owned by the preset and are occasionally necessary for one-off interop.

--- a/docs/design/DARK-MODE-AUDIT.md
+++ b/docs/design/DARK-MODE-AUDIT.md
@@ -42,9 +42,18 @@ end up using once migrated.
 
 ### → `bg-{module}-surface` (module-tinted hero / list surfaces)
 
-Existing token: `bg-{finyk,fizruk,routine,nutrition}-surface` already
-adapts per theme via the preset. Each of these rows is hand-rolling
-an ad-hoc equivalent.
+**Target tokens (Wave 1b will add the dark-mode auto-adapt):** today
+`bg-{finyk,fizruk,routine,nutrition}-surface` resolves to a fixed
+light color (`moduleColors.{module}.surface`) and its dark-mode
+counterpart lives in a separate `{module}-surface-dark` token that
+callers must pair with an explicit `dark:` variant. Wave 1b will
+either (a) back each `{module}-surface` utility with a CSS variable
+that flips per-theme (`--c-{module}-surface-light` / `-dark`), or
+(b) ship a single `{module}-surface-soft` alias that already bundles
+the `dark:` override — tracked in
+[`docs/planning/dev-stack-roadmap.md`](../planning/dev-stack-roadmap.md).
+The rows below are hand-rolling the light/dark pair at the call-site
+— they become one-token lines after the preset change.
 
 | File                                                   | Line | Current                                                                                                 | Target                                         |
 | ------------------------------------------------------ | ---- | ------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
@@ -61,9 +70,13 @@ an ad-hoc equivalent.
 
 ### → `bg-brand-soft` (brand accent background)
 
-Existing token: `bg-brand-soft` (light 8 % / dark 15 % wash) ships in
-the preset and is what `Segmented`, `Tabs`, `Button`, `Badge` variants
-should all reuse.
+**Target token (Wave 1b will add it):** `bg-brand-soft` (light 8 % /
+dark 15 % wash) is **not yet in the preset** — today the call-sites
+below hand-roll `bg-brand-50 dark:bg-brand-500/15`. Wave 1b will add
+`--c-brand-soft`, `--c-brand-soft-border`, `--c-brand-soft-hover` to
+`apps/web/src/index.css` and register matching Tailwind utilities in
+`packages/design-tokens/tailwind-preset.js` so `Segmented`, `Tabs`,
+`Button`, `Badge` variants can all reuse them.
 
 | File                                                 | Line | Current                                                                                                                                        | Target                                                                               |
 | ---------------------------------------------------- | ---- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |

--- a/docs/design/MODULE-ACCENT.md
+++ b/docs/design/MODULE-ACCENT.md
@@ -262,4 +262,6 @@ it("публікує --module-accent-rgb + strong для finyk", () => {
 - `AGENTS.md` hard rule #12 — module-accent containment.
 - [`docs/design/DARK-MODE-AUDIT.md`](./DARK-MODE-AUDIT.md) — pending
   migration plan from 28 raw-palette `dark:` patches to semantic tokens
-  (bg-{module}-surface / bg-brand-soft / bg-{status}-soft / etc.).
+  (`bg-{module}-surface`, `bg-{status}-soft`, and the Wave-1b target
+  tokens `bg-brand-soft` / `border-brand-soft-border` / `-soft-hover`
+  which will ship in the preset at the same time as the migration).

--- a/packages/eslint-plugin-sergeant-design/README.md
+++ b/packages/eslint-plugin-sergeant-design/README.md
@@ -36,8 +36,8 @@ Forbids arbitrary `<utility>-[#hex]` colors in Tailwind classNames (`bg-[#10b981
 // ❌ BAD — hex bypasses the token layer
 <div className="bg-[#10b981] text-[#fff]/50" />
 
-// ✅ GOOD — semantic token
-<div className="bg-brand-soft text-on-brand" />
+// ✅ GOOD — semantic token; both `bg-` and `text-` adapt per theme
+<div className="bg-success-soft text-success-strong" />
 ```
 
 ### `sergeant-design/no-foreign-module-accent`


### PR DESCRIPTION
## What changed

The previous docs pass (#1146, merged as `c8e1f9aa`) introduced `bg-brand-soft text-on-brand` as a GOOD example under `AGENTS.md` hard rule #11 and in the plugin README. While writing it I copied the example from `docs/design/DARK-MODE-AUDIT.md`, which itself described `bg-brand-soft` as an 'existing token'. **Neither token exists in the preset today**:

- `bg-brand-soft` is a Wave-1b **target** token — `--c-brand-soft` is not yet declared in `apps/web/src/index.css` and `tailwind-preset.js` has no matching utility.
- `text-on-brand` has never existed. The real WCAG-AA companion for brand-fill foregrounds is `text-brand-strong` (rule #9).

This PR fixes the examples so every token we cite actually resolves, and flags the Wave-1b scope in `DARK-MODE-AUDIT.md` so contributors reading the migration plan don't think the tokens are already there.

### `AGENTS.md` rule #11

GOOD examples now use:

- `bg-success-soft text-success-strong` — both tokens exist, both adapt per theme via `--c-success-soft` / the `-strong` companion defined in the preset.
- `bg-surface text-fg` — page-level semantic pair, always available and theme-aware.

### `packages/eslint-plugin-sergeant-design/README.md`

`no-hex-in-classname` GOOD example aligned with `AGENTS.md` (`bg-success-soft text-success-strong`).

### `docs/design/DARK-MODE-AUDIT.md`

- `bg-{module}-surface` section reframed: today `bg-{module}-surface` is a fixed light color; Wave 1b will add the per-theme auto-swap (either by backing the utility with a CSS variable that flips, or by shipping a `-soft` alias that bundles the `dark:` override). Callers currently need an explicit `dark:bg-{module}-surface-dark/N` pair.
- `bg-brand-soft` section reframed as **Target token (Wave 1b will add it)** with the list of CSS vars that need to ship (`--c-brand-soft`, `--c-brand-soft-border`, `--c-brand-soft-hover`).

### `docs/design/MODULE-ACCENT.md`

'Related docs' note on `DARK-MODE-AUDIT.md` now describes `bg-brand-soft` / `border-brand-soft-border` / `-soft-hover` as Wave-1b target tokens (not existing ones).

## Why

Broken examples in `AGENTS.md` hard rules are a confidence drag. A reader who copies `bg-brand-soft text-on-brand` into their component hits a silent fail (Tailwind emits no class, the element falls back to the browser default) and concludes the rule itself is wrong. Better to cite tokens that actually work today and call out the Wave-1b extension as a separate, planned piece of work.

## How to test

```bash
pnpm format:check   # prettier clean
pnpm lint:plugins   # 200 / 200 still green
```

Read-through checklist:

- `AGENTS.md` rule #11 GOOD examples resolve to real utilities (grep the preset for `success-soft` → line 123; `success-strong` → line 129; `surface` → line 64; `fg-` aliases → § 'TEXT / FOREGROUND').
- `packages/eslint-plugin-sergeant-design/README.md` no-hex-in-classname example uses the same pair.
- `docs/design/DARK-MODE-AUDIT.md` no longer claims `bg-brand-soft` or `bg-{module}-surface` auto-adapt — both are framed as Wave-1b work.
- `docs/design/MODULE-ACCENT.md` 'Related docs' note is consistent with the audit.

---

## How AI-tested this PR

- [x] `pnpm format:check`: clean.
- [x] `pnpm lint:plugins`: 200 / 200.
- [x] Grepped `bg-brand-soft|text-on-brand` across the repo after the edits — only remaining matches are the audit rows (`bg-brand-soft` as the *target* column in the migration table) and the now-corrected 'Target token (Wave 1b)' header.
- [x] No code changes.

## AGENTS.md updated?

- [x] Yes — rule #11 GOOD-example snippet corrected (`AGENTS.md:289-299`).
- [ ] No — no new permanent rules.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected token examples so all cited utilities exist and are theme-aware. Clarified that `bg-brand-soft` and related tokens are Wave‑1b targets, not in the preset yet.

- **Bug Fixes**
  - AGENTS.md rule #11: replaced `bg-brand-soft text-on-brand` with `bg-success-soft text-success-strong`, and added `bg-surface text-fg` as a page-level example.
  - `packages/eslint-plugin-sergeant-design/README.md`: aligned the GOOD example to `bg-success-soft text-success-strong`.
  - `docs/design/DARK-MODE-AUDIT.md`: marked `bg-brand-soft` as a Wave‑1b target and listed required CSS vars; clarified `bg-{module}-surface` does not auto-adapt yet and needs explicit `dark:` pairing until the preset update.
  - `docs/design/MODULE-ACCENT.md`: updated related-docs note to label `bg-brand-soft`/`-soft-border`/`-soft-hover` as Wave‑1b target tokens.

<sup>Written for commit 501ec17427e1994f1299fc9f66ae17f40128972f. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1147?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined Tailwind design token examples to showcase updated semantic token patterns across documentation
  * Clarified dark-mode semantic token pairing mechanics and documented upcoming CSS variable support for automatic theme adaptation
  * Updated semantic token target specifications for the design system migration roadmap
  * Enhanced eslint-plugin documentation with revised semantic token usage examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->