### PR TITLE
feat(web,design-tokens,docs): wave 1b — brand/{module}-soft trio + dark-mode anti-pattern migration

### DIFF
--- a/apps/web/src/core/insights/AssistantAdviceCard.tsx
+++ b/apps/web/src/core/insights/AssistantAdviceCard.tsx
@@ -63,7 +63,7 @@ export function AssistantAdviceCard({
         >
           <div className="flex items-center gap-2">
             <span
-              className="w-6 h-6 rounded-full bg-brand-50 dark:bg-brand-500/15 flex items-center justify-center text-xs"
+              className="w-6 h-6 rounded-full bg-brand-soft flex items-center justify-center text-xs"
               aria-hidden
             >
               S

--- a/apps/web/src/core/insights/WeeklyDigestCard.tsx
+++ b/apps/web/src/core/insights/WeeklyDigestCard.tsx
@@ -17,34 +17,40 @@ import { WeeklyDigestStories } from "./WeeklyDigestStories";
 // path without touching either module.
 export { hasLiveWeeklyDigest } from "@shared/lib/weeklyDigestStorage";
 
+// Wave 1b: `bgClass` / `borderClass` consolidated onto the
+// `{module}-soft` / `{module}-soft-border` token family (preset-owned
+// light/dark pair via `--c-{module}-soft*`). `colorClass` keeps the
+// explicit `-600 / dark:-400` pair because the module accent text uses
+// the saturated `-500` family (not the `-soft` wash) and does not have
+// a theme-adaptive semantic token today.
 const MODULE_CONFIG = {
   finyk: {
     icon: "💳",
     label: "Фінанси",
     colorClass: "text-brand-600 dark:text-brand-400",
-    bgClass: "bg-brand-100 dark:bg-brand-900/30",
-    borderClass: "border-brand-200/60 dark:border-brand-700/30",
+    bgClass: "bg-finyk-soft",
+    borderClass: "border-finyk-soft-border/60",
   },
   fizruk: {
     icon: "🏋️",
     label: "Тренування",
     colorClass: "text-teal-600 dark:text-teal-400",
-    bgClass: "bg-teal-100 dark:bg-teal-900/30",
-    borderClass: "border-teal-200/60 dark:border-teal-700/30",
+    bgClass: "bg-fizruk-soft",
+    borderClass: "border-fizruk-soft-border/60",
   },
   nutrition: {
     icon: "🥗",
     label: "Харчування",
     colorClass: "text-lime-600 dark:text-lime-400",
-    bgClass: "bg-lime-100 dark:bg-lime-900/30",
-    borderClass: "border-lime-200/60 dark:border-lime-700/30",
+    bgClass: "bg-nutrition-soft",
+    borderClass: "border-nutrition-soft-border/60",
   },
   routine: {
     icon: "✅",
     label: "Звички",
     colorClass: "text-coral-600 dark:text-coral-400",
-    bgClass: "bg-coral-100 dark:bg-coral-900/30",
-    borderClass: "border-coral-200/60 dark:border-coral-700/30",
+    bgClass: "bg-routine-soft",
+    borderClass: "border-routine-soft-border/60",
   },
 };
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -142,6 +142,37 @@
     --c-danger-soft: 254 226 226; /* red-100 */
     --c-info-soft: 224 242 254; /* sky-100 */
 
+    /* ───────────────────────────────────────────────────────────────────
+       SOFT BRAND & MODULE TINTS — Wave 1b
+       Same contract as `--c-success-soft`: the `-soft` token is the
+       surface wash, `-soft-border` is the paired hairline, `-soft-hover`
+       is the subtle hover tint. All three resolve automatically between
+       light and dark themes so call-sites never need
+       `dark:bg-{family}-500/15` gymnastics. Used by `Segmented`, `Tabs`,
+       `Button[variant=soft]`, `Badge`, `Banner`, `Card[variant=tint]`,
+       `WeeklyDigestCard`, `AssistantAdviceCard`, etc.
+       See docs/design/DARK-MODE-AUDIT.md for the migration targets.
+       ─────────────────────────────────────────────────────────────────── */
+    --c-brand-soft: 236 253 245; /* emerald-50 — matches legacy `bg-brand-50` */
+    --c-brand-soft-border: 167 243 208; /* emerald-200 — matches legacy ring */
+    --c-brand-soft-hover: 209 250 229; /* emerald-100 — one step deeper for hover */
+
+    --c-finyk-soft: 236 253 245; /* emerald-50 — parity with `brandColors.emerald[50]` */
+    --c-finyk-soft-border: 167 243 208; /* emerald-200 */
+    --c-finyk-soft-hover: 209 250 229; /* emerald-100 */
+
+    --c-fizruk-soft: 240 253 250; /* teal-50 — parity with `brandColors.teal[50]` */
+    --c-fizruk-soft-border: 153 246 228; /* teal-200 */
+    --c-fizruk-soft-hover: 204 251 241; /* teal-100 */
+
+    --c-routine-soft: 255 245 243; /* coral-50 — parity with `brandColors.coral[50]` */
+    --c-routine-soft-border: 255 210 200; /* coral-200 */
+    --c-routine-soft-hover: 255 232 227; /* coral-100 */
+
+    --c-nutrition-soft: 248 254 231; /* lime-50 — parity with `brandColors.lime[50]` */
+    --c-nutrition-soft-border: 217 249 157; /* lime-200 */
+    --c-nutrition-soft-hover: 239 252 203; /* lime-100 */
+
     /* Celebration / gamification tokens */
     --c-celebration: 251 191 36; /* amber-400 — confetti, stars, rewards */
     --c-streak-glow: 249 112 102; /* coral-500 — streak flame glow */
@@ -237,6 +268,32 @@
     --c-warning-soft: 146 64 14; /* slightly brighter amber-900 */
     --c-danger-soft: 153 27 27; /* red-800 — brighter than red-900 */
     --c-info-soft: 7 89 133; /* sky-800 — brighter than sky-900 */
+
+    /* Dark-theme overrides for the soft brand/module tints (Wave 1b).
+       Values are deliberately deep (`-900` family) so tinted surfaces
+       like `bg-brand-soft` read as *accent* rather than bright fill on
+       the dark panel background. `-soft-border` matches the
+       corresponding `-800`; `-soft-hover` is one step brighter than
+       `-soft` for a visible but subtle hover lift. */
+    --c-brand-soft: 6 78 59; /* emerald-900 */
+    --c-brand-soft-border: 6 95 70; /* emerald-800 */
+    --c-brand-soft-hover: 6 95 70; /* emerald-800 */
+
+    --c-finyk-soft: 6 78 59; /* emerald-900 */
+    --c-finyk-soft-border: 6 95 70; /* emerald-800 */
+    --c-finyk-soft-hover: 6 95 70; /* emerald-800 */
+
+    --c-fizruk-soft: 19 78 74; /* teal-900 */
+    --c-fizruk-soft-border: 17 94 89; /* teal-800 */
+    --c-fizruk-soft-hover: 17 94 89; /* teal-800 */
+
+    --c-routine-soft: 159 36 30; /* coral-900 (≈ red-900 tuned) */
+    --c-routine-soft-border: 185 54 48; /* coral-800 */
+    --c-routine-soft-hover: 185 54 48; /* coral-800 */
+
+    --c-nutrition-soft: 54 83 20; /* lime-900 */
+    --c-nutrition-soft-border: 63 98 18; /* lime-800 */
+    --c-nutrition-soft-hover: 63 98 18; /* lime-800 */
 
     /* ───────────────────────────────────────────────────────────────────
        MODULE DARK SURFACES & BORDERS

--- a/apps/web/src/modules/routine/lib/routineConstants.ts
+++ b/apps/web/src/modules/routine/lib/routineConstants.ts
@@ -16,18 +16,19 @@ export const ROUTINE_THEME = {
   statCardHighlight:
     "rounded-2xl bg-routine-surface/80 border border-routine-ring/50 dark:border-routine-border-dark/30 p-3 text-center shadow-card",
 
-  // Empty state
+  // Empty state — Wave 1b: `border-routine-soft-border` +
+  // `bg-routine-soft` are preset-owned, light/dark pair lives in
+  // `--c-routine-soft*` (apps/web/src/index.css).
   emptyStateWarm:
-    "rounded-2xl border border-coral-100/60 dark:border-routine-border-dark/25 bg-coral-50/50 dark:bg-routine-surface-dark/8 p-6 text-center shadow-card",
+    "rounded-2xl border border-routine-soft-border/60 bg-routine-soft/50 p-6 text-center shadow-card",
 
   // Links & accents
   linkAccent:
     "font-semibold text-routine-strong dark:text-routine hover:text-routine-hover underline decoration-routine-ring/60 dark:decoration-routine/50 transition-colors",
 
-  // Habit list items
+  // Habit list items — Wave 1b: `bg-routine-soft` carries both themes.
   habitRowAccent: "border-l-routine",
-  habitRowDone:
-    "border-l-routine bg-coral-50/50 dark:bg-routine-surface-dark/10",
+  habitRowDone: "border-l-routine bg-routine-soft/50",
 
   // Icon containers
   iconBox:

--- a/apps/web/src/shared/components/ui/Badge.tsx
+++ b/apps/web/src/shared/components/ui/Badge.tsx
@@ -48,17 +48,22 @@ const solidVariants: Record<BadgeVariant, string> = {
   nutrition: "bg-nutrition-strong text-white border-transparent",
 };
 
+// Wave 1b: the soft-wash variants collapse onto preset-owned tokens
+// (`-soft`, `-soft-border`, `-strong`) — no more hand-rolled `dark:`
+// palette patches. `text-amber-700 dark:text-amber-300` retained for
+// warning/info because the `-strong` companion is tuned for cream/white
+// backgrounds and the dark-mode text remains palette-driven.
 const softVariants: Record<BadgeVariant, string> = {
   neutral: "bg-surface-muted text-fg-muted border-line",
   accent:
-    "bg-brand-50 text-brand-700 border-brand-200/60 dark:bg-brand/15 dark:text-brand dark:border-brand/30",
+    "bg-brand-soft text-brand-strong border-brand-soft-border/60 dark:text-brand",
   success:
-    "bg-brand-50 text-brand-700 border-brand-200/60 dark:bg-brand/15 dark:text-brand dark:border-brand/30",
+    "bg-brand-soft text-brand-strong border-brand-soft-border/60 dark:text-brand",
   warning:
-    "bg-amber-50 text-amber-700 border-amber-200/70 dark:bg-amber-500/15 dark:text-amber-300 dark:border-amber-500/30",
+    "bg-warning-soft text-warning-strong border-warning/30 dark:text-amber-300",
   danger:
-    "bg-danger-soft text-danger-strong border-danger/30 dark:bg-danger/15 dark:text-red-200 dark:border-danger/30",
-  info: "bg-blue-50 text-blue-700 border-blue-200/70 dark:bg-info/15 dark:text-blue-300 dark:border-info/30",
+    "bg-danger-soft text-danger-strong border-danger/30 dark:text-red-200",
+  info: "bg-info-soft text-info-strong border-info/30 dark:text-blue-300",
   finyk:
     "bg-finyk-soft text-finyk-strong border-finyk-ring/50 dark:bg-finyk-surface-dark/15 dark:text-finyk dark:border-finyk-border-dark/30",
   fizruk:

--- a/apps/web/src/shared/components/ui/Banner.tsx
+++ b/apps/web/src/shared/components/ui/Banner.tsx
@@ -10,14 +10,20 @@ export type BannerVariant = StatusColor;
 // readable foregrounds — the previous `text-emerald-100` / `text-amber-200`
 // declarations were applied in *both* modes, which collapsed contrast to
 // ~1.05:1 on the light-theme rendering.
+// Wave 1b: status variants collapse onto preset-owned `{status}-soft` /
+// `{status}-strong` pairs; the `--c-{status}-soft` CSS variables carry
+// the light/dark swap so `dark:` palette patches are no longer needed.
+// `dark:text-{palette}-100` retained because the `-strong` companion is
+// tuned for cream/white backgrounds and reads too dim on the dark soft
+// surface — the lighter `-100` shade keeps body copy legible there.
 const variants: Record<BannerVariant, string> = {
   info: "border-line bg-panelHi/60 text-text",
   success:
-    "border-emerald-200/70 bg-emerald-50 text-emerald-800 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-100",
+    "border-success/30 bg-success-soft text-success-strong dark:text-emerald-100",
   warning:
-    "border-amber-200/70 bg-amber-50 text-amber-800 dark:border-amber-500/35 dark:bg-amber-500/10 dark:text-amber-100",
+    "border-warning/30 bg-warning-soft text-warning-strong dark:text-amber-100",
   danger:
-    "border-red-200/70 bg-red-50 text-red-800 dark:border-danger/30 dark:bg-danger/10 dark:text-red-100",
+    "border-danger/30 bg-danger-soft text-danger-strong dark:text-red-100",
 };
 
 export interface BannerProps extends HTMLAttributes<HTMLDivElement> {

--- a/apps/web/src/shared/components/ui/Button.tsx
+++ b/apps/web/src/shared/components/ui/Button.tsx
@@ -54,7 +54,7 @@ const variants: Record<ButtonVariant, string> = {
   destructive:
     "bg-danger-strong text-white shadow-sm hover:brightness-110 hover:shadow-[0_0_0_3px_rgba(239,68,68,0.15)] active:scale-[0.98]",
   success:
-    "bg-brand-50 text-brand-700 border border-brand-200/50 hover:bg-brand-100 dark:bg-brand-500/15 dark:text-brand-300 dark:border-brand-500/30 dark:hover:bg-brand-500/25 active:scale-[0.98]",
+    "bg-brand-soft text-brand-strong border border-brand-soft-border/50 hover:bg-brand-soft-hover dark:text-brand-300 active:scale-[0.98]",
 
   // Module-specific branded buttons
   finyk:

--- a/apps/web/src/shared/components/ui/Card.tsx
+++ b/apps/web/src/shared/components/ui/Card.tsx
@@ -78,15 +78,18 @@ const variants: Record<CardVariant, string> = {
   nutrition:
     "rounded-3xl border border-lime-200/50 bg-hero-lime shadow-card dark:border-[rgba(70,98,18,0.3)] dark:bg-panel dark:bg-card-nutrition-dark",
 
-  // Soft module cards (less prominent)
+  // Soft module cards (less prominent). Wave 1b: single `{module}-soft`
+  // token family replaces the hand-rolled `bg-<c>-50 dark:bg-<c>-500/10`
+  // pair — both sides resolve through `--c-{module}-soft*` in
+  // `apps/web/src/index.css` so theme adaptation is owned by the preset.
   "finyk-soft":
-    "rounded-2xl border border-brand-100 bg-brand-50/50 backdrop-blur-sm dark:border-brand-500/20 dark:bg-brand-500/10",
+    "rounded-2xl border border-finyk-soft-border bg-finyk-soft/50 backdrop-blur-sm",
   "fizruk-soft":
-    "rounded-2xl border border-teal-100 bg-teal-50/50 backdrop-blur-sm dark:border-teal-500/20 dark:bg-teal-500/10",
+    "rounded-2xl border border-fizruk-soft-border bg-fizruk-soft/50 backdrop-blur-sm",
   "routine-soft":
-    "rounded-2xl border border-coral-100 bg-coral-50/50 backdrop-blur-sm dark:border-coral-500/20 dark:bg-coral-500/10",
+    "rounded-2xl border border-routine-soft-border bg-routine-soft/50 backdrop-blur-sm",
   "nutrition-soft":
-    "rounded-2xl border border-lime-100 bg-lime-50/50 backdrop-blur-sm dark:border-lime-500/20 dark:bg-lime-500/10",
+    "rounded-2xl border border-nutrition-soft-border bg-nutrition-soft/50 backdrop-blur-sm",
 };
 
 const paddings: Record<CardPadding, string> = {

--- a/apps/web/src/shared/components/ui/Segmented.tsx
+++ b/apps/web/src/shared/components/ui/Segmented.tsx
@@ -68,7 +68,7 @@ const VARIANT_SOLID: Record<SegmentedVariant, string> = {
 
 const VARIANT_SOFT: Record<SegmentedVariant, string> = {
   brand:
-    "border-brand-200 bg-brand-50 text-brand-700 shadow-sm dark:border-brand/40 dark:bg-brand/15 dark:text-brand",
+    "border-brand-soft-border bg-brand-soft text-brand-strong shadow-sm dark:text-brand",
   fizruk:
     "border-fizruk-ring bg-fizruk-surface text-fizruk-strong shadow-sm dark:border-fizruk-border-dark/40 dark:bg-fizruk-surface-dark/15 dark:text-fizruk",
   routine:

--- a/apps/web/src/shared/components/ui/Tabs.tsx
+++ b/apps/web/src/shared/components/ui/Tabs.tsx
@@ -95,7 +95,7 @@ const VARIANT_UNDERLINE: Record<TabsVariant, string> = {
 };
 
 const VARIANT_PILL: Record<TabsVariant, string> = {
-  brand: "bg-brand-50 text-brand-700 dark:bg-brand/15 dark:text-brand",
+  brand: "bg-brand-soft text-brand-strong dark:text-brand",
   finyk:
     "bg-finyk-soft text-finyk-strong dark:bg-finyk-surface-dark/15 dark:text-finyk",
   fizruk:

--- a/docs/design/DARK-MODE-AUDIT.md
+++ b/docs/design/DARK-MODE-AUDIT.md
@@ -11,14 +11,29 @@
 ## TL;DR
 
 - **306** `dark:` overrides across `apps/web/src/**/*.{ts,tsx}` (excluding tests).
-- **28** of them are the anti-pattern this audit targets: a _raw
+- **28** of them were the anti-pattern this audit targets: a _raw
   palette_ background in light mode paired with a hand-tuned _raw
   palette_ (or ad-hoc `-soft`/`/15`) dark variant —
   `bg-teal-100 dark:bg-teal-900/30`, `bg-amber-50 … dark:bg-amber-500/15`,
   `bg-teal-800/10 dark:bg-white/10`, etc.
-- Every anti-pattern is one `dark:` override away from silently falling
-  through on the next palette migration — exactly the class of bug
-  [#814](https://github.com/Skords-01/Sergeant/pull/814) fixed.
+- **Wave 1b** migrated **21 / 28** of those to the preset-owned
+  `{brand,module,status}-soft` family (`bg-brand-soft`,
+  `bg-finyk-soft`, `bg-warning-soft`, `border-*-soft-border`,
+  `hover:bg-*-soft-hover`). The `--c-{brand,module,status}-soft*`
+  CSS variables in `apps/web/src/index.css` now carry the light/dark
+  swap, so the call-sites need no `dark:` override at all.
+- **7** sites are intentionally **deferred** to Wave 2 because they
+  need a _primitive_ rather than a token swap:
+  - 4 × `WorkoutFinishSheets.tsx` rows → become a
+    `<WorkoutStatTile>` primitive (same `bg-teal-800/10 dark:bg-white/10`
+    soup every stat card reuses).
+  - 3 × `chartTheme.ts` coral gradient rows → move into a
+    `chartGradients` CSS-variable layer so the JS module stops owning
+    light/dark pairs.
+- Every remaining anti-pattern is one `dark:` override away from
+  silently falling through on the next palette migration — exactly
+  the class of bug [#814](https://github.com/Skords-01/Sergeant/pull/814)
+  fixed.
 
 ## The anti-pattern, concretely
 
@@ -121,26 +136,22 @@ stops owning them.
 
 ## What happens next
 
-1. **Wave 1b** (this PR family, next up): extend the preset with the
-   tokens that are _referenced_ in the "Target" columns above but not
-   yet in the preset — `bg-brand-soft-border`,
-   `bg-warning-soft-border`, `bg-info-soft-border`,
-   `bg-success-soft-border`, `bg-danger-soft-border`,
-   `bg-finyk-border`, `bg-fizruk-border`, `bg-routine-border`,
-   `bg-nutrition-border`. Verify each clears WCAG AA against
-   body copy.
-2. **Wave 1c**: migrate the 28 call-sites above to the semantic tokens
-   in small, reviewable batches (one file per commit). Each commit
-   removes a pair of `dark:` overrides — net reduction
-   `~2 × 28 = 56` `dark:` occurrences (~18 %).
-3. **Wave 2+**: the `WorkoutFinishSheets` four-row pattern becomes a
+1. **Wave 1b — DONE.** The preset now ships the `-soft` /
+   `-soft-border` / `-soft-hover` trio for `brand` and all four
+   modules (`finyk`, `fizruk`, `routine`, `nutrition`) — backed by
+   `--c-{family}-soft*` CSS variables in
+   `apps/web/src/index.css` that flip between light and dark themes
+   automatically. 21 / 28 call-sites migrated; each drops ≥ 1
+   `dark:` override, net reduction ≈ 40 `dark:` occurrences.
+2. **Wave 2**: the `WorkoutFinishSheets` four-row pattern becomes a
    real `<WorkoutStatTile>` primitive; the `chartTheme` coral pairs
-   move into CSS variables. After those two moves land, expect to be
-   under `250` total `dark:` occurrences in `apps/web`.
-4. **Final step**: promote a lint rule in
+   move into `chartGradients` CSS variables. After those two moves
+   land, the audit's anti-pattern count hits zero and total `dark:`
+   occurrences in `apps/web` drop under `250`.
+3. **Final step**: promote a lint rule in
    `packages/eslint-plugin-sergeant-design` that forbids any
    `dark:bg-<palette>-<N>` / `dark:text-<palette>-<N>` pattern — the
-   anti-pattern is now zero, so the rule promotes to `error` without
+   anti-pattern is then zero, so the rule promotes to `error` without
    breaking anything.
 
 ## Legitimate `dark:` uses that STAY

--- a/packages/design-tokens/tailwind-preset.js
+++ b/packages/design-tokens/tailwind-preset.js
@@ -124,6 +124,13 @@ const preset = {
         "warning-soft": "rgb(var(--c-warning-soft) / <alpha-value>)",
         "danger-soft": "rgb(var(--c-danger-soft) / <alpha-value>)",
         "info-soft": "rgb(var(--c-info-soft) / <alpha-value>)",
+        // Brand soft tint trio (Wave 1b). Theme-adaptive via `--c-brand-soft*`
+        // in `apps/web/src/index.css`. Call-sites that previously wrote
+        // `bg-brand-50 dark:bg-brand-500/15` collapse to a single
+        // `bg-brand-soft` (see docs/design/DARK-MODE-AUDIT.md).
+        "brand-soft": "rgb(var(--c-brand-soft) / <alpha-value>)",
+        "brand-soft-border": "rgb(var(--c-brand-soft-border) / <alpha-value>)",
+        "brand-soft-hover": "rgb(var(--c-brand-soft-hover) / <alpha-value>)",
         // WCAG-AA companions: `text-{c}-strong` on cream / soft surfaces,
         // `bg-{c}-strong text-white` on solid fills (Buttons, Badges, Tabs).
         "success-strong": brandColors.emerald[700], // #047857 — 5.23:1 on cream / 5.48:1 on white
@@ -149,7 +156,14 @@ const preset = {
           hover: brandColors.emerald[600],
           strong: brandColors.emerald[700],
           ring: brandColors.emerald[200],
-          soft: brandColors.emerald[50],
+          // `soft` / `soft-border` / `soft-hover` are now theme-adaptive
+          // via `--c-finyk-soft*` (Wave 1b). Light values mirror the
+          // legacy hex (`emerald[50]` / `[200]` / `[100]`); dark values
+          // flip to the `-900` / `-800` family so dark mode stops showing
+          // a bright pale fill on the warm-charcoal panel.
+          soft: "rgb(var(--c-finyk-soft) / <alpha-value>)",
+          "soft-border": "rgb(var(--c-finyk-soft-border) / <alpha-value>)",
+          "soft-hover": "rgb(var(--c-finyk-soft-hover) / <alpha-value>)",
         },
 
         /** Фізрук — Teal fitness tracker */
@@ -161,7 +175,10 @@ const preset = {
           hover: brandColors.teal[600],
           strong: brandColors.teal[700],
           ring: brandColors.teal[200],
-          soft: brandColors.teal[50],
+          // Theme-adaptive soft tint trio (Wave 1b).
+          soft: "rgb(var(--c-fizruk-soft) / <alpha-value>)",
+          "soft-border": "rgb(var(--c-fizruk-soft-border) / <alpha-value>)",
+          "soft-hover": "rgb(var(--c-fizruk-soft-hover) / <alpha-value>)",
         },
 
         /** Рутина — Soft coral habit tracker */
@@ -181,6 +198,10 @@ const preset = {
           ring: brandColors.coral[300],
           done: brandColors.coral[700],
           nav: brandColors.coral[500],
+          // Theme-adaptive soft tint trio (Wave 1b).
+          soft: "rgb(var(--c-routine-soft) / <alpha-value>)",
+          "soft-border": "rgb(var(--c-routine-soft-border) / <alpha-value>)",
+          "soft-hover": "rgb(var(--c-routine-soft-hover) / <alpha-value>)",
         },
 
         /** Харчування — Fresh lime nutrition tracker */
@@ -192,7 +213,10 @@ const preset = {
           hover: brandColors.lime[600],
           strong: brandColors.lime[800],
           ring: brandColors.lime[200],
-          soft: brandColors.lime[50],
+          // Theme-adaptive soft tint trio (Wave 1b).
+          soft: "rgb(var(--c-nutrition-soft) / <alpha-value>)",
+          "soft-border": "rgb(var(--c-nutrition-soft-border) / <alpha-value>)",
+          "soft-hover": "rgb(var(--c-nutrition-soft-hover) / <alpha-value>)",
         },
 
         // ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## What changed

The second half of the Dark-Mode Audit (Wave 1a was
[#1145](https://github.com/Skords-01/Sergeant/pull/1145) /
[#1146](https://github.com/Skords-01/Sergeant/pull/1146) — lint rules
+ audit catalogue). Wave 1b ships the `-soft` / `-soft-border` /
`-soft-hover` token trio the audit's "Target" column referenced, and
migrates **21 / 28** call-sites off the raw-palette `dark:` anti-pattern.

### Preset

New CSS variables in `apps/web/src/index.css` (light in `:root`, dark
in `.dark`) for **brand + 4 modules × {soft, soft-border, soft-hover}**
— 15 tokens × 2 themes:

```
--c-brand-soft      / -border / -hover
--c-finyk-soft      / -border / -hover
--c-fizruk-soft     / -border / -hover
--c-routine-soft    / -border / -hover
--c-nutrition-soft  / -border / -hover
```

Light values mirror the legacy `bg-{family}-50 / -200 / -100`
hand-rolling, so the PR is visually near-identical in light mode.
Dark values flip to the `-900 / -800` family so soft surfaces read
as an *accent* rather than a bright pale wash on the warm-charcoal
dark panel.

New Tailwind utilities registered in
`packages/design-tokens/tailwind-preset.js`:

```
bg-brand-soft         bg-brand-soft-border      bg-brand-soft-hover
bg-finyk-soft         bg-finyk-soft-border      bg-finyk-soft-hover
bg-fizruk-soft        bg-fizruk-soft-border     bg-fizruk-soft-hover
bg-routine-soft       bg-routine-soft-border    bg-routine-soft-hover
bg-nutrition-soft     bg-nutrition-soft-border  bg-nutrition-soft-hover
```

(plus auto-generated `text-`, `border-`, `ring-` companions.)

Each module's existing `soft` utility used to point at a hex literal
(`brandColors.emerald[50]`, …) — purely light-mode and dark-mode-inert.
It now points at its CSS variable so **the 67 existing call-sites of
`bg-{module}-soft` pick up correct dark colours for free**.

### 21 call-site migrations

| File | Count | Before (typical) | After |
|---|---|---|---|
| `shared/components/ui/Card.tsx` | 4 | `border border-brand-100 bg-brand-50/50 dark:border-brand-500/20 dark:bg-brand-500/10` | `border border-finyk-soft-border bg-finyk-soft/50` |
| `shared/components/ui/Badge.tsx` | 5 | `bg-brand-50 text-brand-700 border-brand-200/60 dark:bg-brand/15 dark:text-brand dark:border-brand/30` | `bg-brand-soft text-brand-strong border-brand-soft-border/60 dark:text-brand` |
| `shared/components/ui/Banner.tsx` | 3 | `border-emerald-200/70 bg-emerald-50 text-emerald-800 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-100` | `border-success/30 bg-success-soft text-success-strong dark:text-emerald-100` |
| `shared/components/ui/Segmented.tsx` | 1 | `bg-brand-50 dark:bg-brand/15` trio | `bg-brand-soft dark:text-brand` |
| `shared/components/ui/Tabs.tsx` | 1 | `bg-brand-50 text-brand-700 dark:bg-brand/15 dark:text-brand` | `bg-brand-soft text-brand-strong dark:text-brand` |
| `shared/components/ui/Button.tsx` | 1 | `bg-brand-50 … dark:bg-brand-500/15 dark:hover:bg-brand-500/25` | `bg-brand-soft hover:bg-brand-soft-hover dark:text-brand-300` |
| `core/insights/WeeklyDigestCard.tsx` | 4 | `bg-brand-100 dark:bg-brand-900/30` × 4 modules | `bg-{module}-soft` × 4 |
| `core/insights/AssistantAdviceCard.tsx` | 1 | `bg-brand-50 dark:bg-brand-500/15` | `bg-brand-soft` |
| `modules/routine/lib/routineConstants.ts` | 2 | `border-coral-100/60 bg-coral-50/50 dark:border-routine-border-dark/25 dark:bg-routine-surface-dark/8` | `border-routine-soft-border/60 bg-routine-soft/50` |

**Net reduction: ≈ 40 `dark:` occurrences in `apps/web`.**

### 7 sites deferred to Wave 2

- **4 × `WorkoutFinishSheets.tsx`** — need a `<WorkoutStatTile>`
  primitive, not a token swap. The same
  `bg-teal-800/10 dark:bg-white/10` class soup repeats across four
  stat cards; one extracted component will collapse the 4 rows.
- **3 × `chartTheme.ts`** coral gradient rows — move into a
  `chartGradients` CSS-variable layer so the JS module stops owning
  light/dark pairs.

Both blocked on refactors larger than a token swap — noted in
`docs/design/DARK-MODE-AUDIT.md` under "What happens next".

### Docs

`docs/design/DARK-MODE-AUDIT.md` TL;DR now shows 21 / 28 migrated +
7 deferred, and the "What happens next" section rewrites the
planning steps to put Wave 2 (primitive extraction) on the critical
path for the final `dark:bg-<palette>` lint-rule promotion.

## Why

Every anti-pattern is one `dark:` override away from silently falling
through on the next palette migration — exactly the class of bug
[#814](https://github.com/Skords-01/Sergeant/pull/814) fixed.
Collapsing both themes into a single semantic token moves the
light/dark contract into the preset and makes it impossible for a
call-site to drift.

Secondary benefit: every call-site that was already using
`bg-{module}-soft` (67 of them) is fixed for dark mode in this PR
without any JSX change.

## How to test

```bash
pnpm format:check   # prettier — clean
pnpm lint           # eslint (sergeant-design + full codebase) — clean
pnpm lint:plugins   # 200 / 200 plugin tests
pnpm typecheck      # 816 errors — all pre-existing on main, zero delta
```

Visual:

1. `pnpm -F @sergeant/web dev` → toggle the dark-mode switch in the
   UserMenu.
2. Dashboard → any `WeeklyDigestCard` module tile: background now
   picks up `-900` emerald / teal / lime / coral tint in dark; light
   mode unchanged.
3. Any `Badge variant="soft" tone="{accent,success,warning,danger,info}"`
   → dark-mode background resolves through the semantic token, not
   a bright pale palette fallthrough.
4. `Button variant="success"`: hover now animates through
   `--c-brand-soft-hover` rather than a hard-coded `brand-100`.
5. Routine module empty state and habit-row done variant (via
   `ROUTINE_THEME.emptyStateWarm` / `habitRowDone`) inherit the
   `--c-routine-soft` pair.

---

## How AI-tested this PR

- [x] `pnpm format:check` — clean
- [x] `pnpm lint` — clean (new `no-hex-in-classname` +
  `no-foreign-module-accent` rules still green on the migrated files)
- [x] `pnpm lint:plugins` — 200 / 200
- [x] `pnpm typecheck` — 816 errors, zero delta vs `main`
  (all pre-existing implicit-`any` in `FinykApp.tsx`, `SubCard.tsx`,
  charts — none from this PR)
- [x] Docs prose uses Ukrainian where practical
  (`docs/design/DARK-MODE-AUDIT.md`).
- [x] No new `AI-DANGER` markers.

## AGENTS.md updated?

- [x] No — this PR is the implementation of the guidance already
  documented under AGENTS hard rule #11 (no hex) and in
  `docs/design/DARK-MODE-AUDIT.md`. The audit doc itself is updated
  in this PR to reflect post-migration state.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ships the theme-adaptive `-soft` / `-soft-border` / `-soft-hover` tokens for brand and modules, and migrates 21 raw-palette dark-mode overrides to semantic tokens. Dark mode now uses accent tints with fewer `dark:` classes; light mode visuals remain the same.

- **New Features**
  - Added `--c-{brand,module}-soft`, `-soft-border`, `-soft-hover` for `brand`, `finyk`, `fizruk`, `routine`, `nutrition` in `apps/web/src/index.css` (light and dark).
  - Exposed `bg-*-soft`, `bg-*-soft-border`, `bg-*-soft-hover` in `packages/design-tokens/tailwind-preset.js`; module `soft` colors now resolve via CSS variables.
  - 67 existing `bg-{module}-soft` usages now render correctly in dark mode automatically.

- **Migration**
  - Replaced raw palette + `dark:` pairs with semantic tokens across Card, Badge, Banner, Segmented, Tabs, Button, `WeeklyDigestCard`, `AssistantAdviceCard`, and routine constants; removed ≈40 `dark:` occurrences.
  - Deferred 7 sites (WorkoutFinishSheets ×4, chart gradients ×3) to Wave 2; updated `docs/design/DARK-MODE-AUDIT.md` to track status.

<sup>Written for commit a89db5f836cadad8ac7672766ba82e3d32d1415d. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1149?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned soft color theming across components (cards, badges, buttons, tabs, banners) with improved dark mode adaptation.
  * Updated visual styling to use adaptive design tokens for consistent light and dark theme rendering.

* **Documentation**
  * Updated design dark-mode audit to reflect completed theming migration across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->