### PR TITLE
docs(root): restore governance Hard Rule #13, sync CONTRIBUTING, fix ADR format

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,30 @@
 
 ---
 
+## Pre-flight (Hard Rule #13)
+
+<!--
+Before opening this PR you should have read the relevant governance.
+Tick what applies; if a box is N/A, write "n/a" inline.
+-->
+
+- [ ] Read the `AGENTS.md` Hard Rules that apply to the touched paths.
+- [ ] Read the matching playbook in `docs/playbooks/` (or noted that none exists).
+- [ ] Checked freshness headers of docs cited in the change.
+
+## Docs updated alongside code? (Hard Rule #13)
+
+<!--
+Documentation is part of the change set, not a follow-up. Tick what applies.
+-->
+
+- [ ] API contract change — `packages/api-client/**` types + contract test updated (Hard Rule #3).
+- [ ] New / removed npm script — `CONTRIBUTING.md § Everyday Commands` and `CLAUDE.md § Quick commands` updated.
+- [ ] New design token / component / palette — `docs/design/design-system.md` (and `BRANDBOOK.md` if branded) updated.
+- [ ] Deprecation — `@deprecated` JSDoc with `@removeBy` added; consuming docs marked `> **Status:** Deprecated`.
+- [ ] Freshness header bumped on docs whose claims changed (`> Last validated: YYYY-MM-DD by @owner`).
+- [ ] N/A — no docs invalidated by this change.
+
 ## How AI-tested this PR
 
 <!-- If this PR was created by an AI agent, describe what was verified. -->
@@ -20,6 +44,7 @@
 - [ ] Vitest passes: ...
 - [ ] No new `AI-DANGER` markers added without justification.
 - [ ] Docs prose uses Ukrainian where practical, per `AGENTS.md`.
+- [ ] `pnpm dead-code:files` clean (or new files marked `@scaffolded`).
 
 ## AGENTS.md updated?
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # Agents in Sergeant
 
-> **Last validated:** 2026-04-27 by @Skords-01. **Next review:** 2026-07-26.
+> **Last validated:** 2026-04-29 by @devin-ai. **Next review:** 2026-07-29.
+> **Status:** Active
 
 ## Repo overview
 
@@ -322,6 +323,63 @@ The rule handles variant prefixes (`dark:`, `hover:`, `lg:`), shade suffixes (`-
 - `__tests__/*.{ts,tsx,mjs}` — test fixtures naturally reference all four for coverage.
 
 Enforced by `sergeant-design/no-foreign-module-accent` (`error`). See `docs/design/MODULE-ACCENT.md` for the "one accent = one module" design principle.
+
+### 13. Read governance before coding; update docs alongside code
+
+> Why a hard rule? Because rules are useless if no one reads them, and docs are dangerous if they describe behaviour the code no longer has. Both failure modes have shipped here ([#1143](https://github.com/Skords-01/Sergeant/pull/1143) deleted scaffolded code partly because the AI agent skipped the playbook; multiple Tailwind-opacity bugs survived because the design-system doc still listed deprecated tokens). This rule closes both gaps.
+
+#### Before writing any code
+
+Both AI agents and human contributors **must** read the relevant governance up front, in this order:
+
+1. **`AGENTS.md`** — Hard Rules (#1–#13), Module ownership map for the path you're touching, AI-marker conventions, Domain invariants.
+2. **`CONTRIBUTING.md`** — branch/commit conventions, pre-commit hooks, PR checklist.
+3. **`CLAUDE.md`** — Claude/AI-specific commands and guardrails (sister file to AGENTS.md).
+4. **The matching playbook** in `docs/playbooks/` — pick by trigger phrase. New API endpoint → `add-api-endpoint.md`. New HubChat tool → `add-hubchat-tool.md`. Removing code → `cleanup-dead-code.md`. Migrations → `add-migration.md`.
+5. **The freshness header** of every doc you cite or change (`> Last validated: YYYY-MM-DD by @owner`). If the doc is stale (`Next review` date passed), flag it in the PR — don't blindly trust it, but don't silently ignore it either.
+
+If you're an AI agent, treat steps 1–4 as a **pre-flight checklist**: do not begin implementation until you can name (a) the Hard Rules that apply, (b) the playbook(s) you'll follow, (c) the owner of the path. If no playbook exists for the task type, write a one-paragraph mini-plan and link it in the PR.
+
+#### During the work
+
+- Do not work around a rule because it's inconvenient. If you genuinely believe a rule is wrong, raise it in the PR description (or open an `AGENTS.md` PR first) — don't ship code that violates it.
+- If you discover the rule is unclear or contradictory, fix it in the same PR (one paragraph in `AGENTS.md` is cheaper than the next confused agent).
+- Honour `@scaffolded` / `@deprecated` / `@experimental` markers (Hard Rule #10).
+
+#### Before opening the PR — update docs alongside code
+
+Documentation is part of the change set, not a follow-up. Treat any of the following as **must-update** when the underlying code/contract moves:
+
+| Code change                                       | Docs that must move with it                                                                                                                                            |
+| ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| New / changed JSON response shape                 | `packages/api-client/**` types **+** the matching contract test (Hard Rule #3). If the response is documented in `docs/api/*.md`, update there too.                    |
+| New SQL migration                                 | `apps/server/src/migrations/README.md` (if present), and any ER-diagram in `docs/architecture/`.                                                                       |
+| New / removed npm script                          | `CONTRIBUTING.md § Everyday Commands`, `CLAUDE.md § Quick commands`.                                                                                                   |
+| New Hard Rule, lint rule, or convention           | `AGENTS.md` § Hard Rules (the canonical entry) **+** mirror summary in `CONTRIBUTING.md § Hard rules`. PR template's "AGENTS.md updated?" checkbox **must** be ticked. |
+| New design token, palette, or component           | `docs/design/design-system.md`, `docs/design/BRANDBOOK.md`, and the relevant audit (`docs/audits/*-audit-*.md`) if it changes status.                                  |
+| Deprecating a behaviour                           | Add `@deprecated` JSDoc with `@removeBy YYYY-MM-DD` (Hard Rule #10) **+** update the consuming doc to mark the section `> **Status:** Deprecated`.                     |
+| New playbook trigger or HubChat tool              | `docs/playbooks/<name>.md` (or update the existing playbook). Cross-link from `CLAUDE.md § Before you write code` if it's a frequent trigger.                          |
+| Anything that invalidates an existing doc's claim | Update the doc in the same PR, or move it to `docs/<area>/archive/` with a `> **Status:** Archived` badge if the claim is no longer relevant.                          |
+
+In every doc you touch, also bump the freshness header:
+
+```md
+> **Last validated:** 2026-04-29 by @your-handle. **Next review:** 2026-07-29.
+> **Status:** Active
+```
+
+If you genuinely change nothing in the doc but its claims still hold, leave the header alone — _do not_ touch the date just to silence freshness warnings. The freshness checker (`scripts/check-tech-debt-freshness.mjs`) accepts unchanged dates.
+
+#### What this rule blocks
+
+- Silent contract drift (server changed, `api-client` didn't).
+- Stale design-system docs that still document deprecated tokens / removed components.
+- AI agents shipping code that violates a Hard Rule because they didn't read AGENTS.md.
+- "Just a one-line change" PRs that quietly remove behaviour the docs still promise.
+
+#### Verification
+
+The PR template includes the relevant boxes (`AGENTS.md updated?`, "Docs updated alongside code?"). CI doesn't fail on missing doc updates today (it's hard to detect mechanically), so this is reviewer- and self-discipline-enforced. If a reviewer spots an unchecked-but-required doc update, that's a request-changes signal — not a "follow-up issue".
 
 ## AI markers
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,10 +26,14 @@ pnpm gen                 # Plop code generators (migration, rq-hook, hubchat-too
 
 ## Before you write code
 
-1. Read the relevant playbook in `docs/playbooks/` — pick by trigger phrase (e.g. "нова API-функціональність" → `add-api-endpoint.md`).
-2. Check `AGENTS.md` § Hard rules — especially bigint coercion (#1), RQ keys (#2), migration numbering (#4).
-3. New HubChat tool? Needs **3 coordinated edits** — see `docs/playbooks/add-hubchat-tool.md`.
-4. New migration? Use `pnpm gen migration --name <desc>` — auto-numbers from last migration (`015`).
+> Hard Rule #13 in `AGENTS.md` applies to AI agents: complete this pre-flight before implementing.
+
+1. Read the relevant playbook in `docs/playbooks/` — pick by trigger phrase (e.g. "нова API-функціональність" → `add-api-endpoint.md`; "remove dead code" → `cleanup-dead-code.md`).
+2. Check `AGENTS.md` § Hard rules — especially bigint coercion (#1), RQ keys (#2), migration numbering (#4), lifecycle markers (#10), governance + docs discipline (#13).
+3. Before deleting any file, run `pnpm dead-code:files` (which honours `@scaffolded` markers — Hard Rule #10). Never delete a scaffolded file just because it has zero importers.
+4. New HubChat tool? Needs **3 coordinated edits** — see `docs/playbooks/add-hubchat-tool.md`.
+5. New migration? Use `pnpm gen migration --name <desc>` — auto-numbers from last migration (`015`).
+6. Before opening the PR, update docs alongside code (Hard Rule #13): api-client types, design-system docs, playbooks, freshness headers — see the must-update table in `AGENTS.md` § Hard Rule #13.
 
 ## Verification before PR
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributing to Sergeant
 
-> **Last validated:** 2026-04-27 by @Skords-01. **Next review:** 2026-07-26.
+> **Last validated:** 2026-04-29 by @devin-ai. **Next review:** 2026-07-29.
+> **Status:** Active
 
 > **Ціль:** zero-to-running за ≤ 5 хвилин на будь-якій машині з Docker.
 
@@ -297,6 +298,9 @@ These are non-negotiable. Read `AGENTS.md` for full context.
 8. **Tailwind opacity steps** must be on the registered scale (`0,5,8,10,15,…,100`). Off-scale values silently drop.
 9. **Saturated brand fills behind `text-white`** must use the `-strong` companion for WCAG AA compliance.
 10. **Lifecycle markers** — every file declares its status. New components/hooks committed ahead of integration MUST carry a `@scaffolded` JSDoc block with `@owner` + `@nextStep`. Docs add `> **Status:** Active | Scaffolded | Deprecated | Archived`. Dead-code cleanup PRs MUST run `pnpm dead-code:files` (which honours markers) — never delete a `@scaffolded` file just because it has no importers.
+11. **No arbitrary hex colors in `className`** — raw `<utility>-[#hex]` values bypass the design-system token layer. Use semantic tokens (`bg-success-soft`, `text-fg`, etc.) instead. Add new shades to the preset, not inline at call-site. Enforced by `sergeant-design/no-hex-in-classname` (`error`).
+12. **Module-accent containment** — inside `apps/<app>/src/modules/<X>/`, only `<X>`'s accent utilities may appear. Cross-module shells (`core/`, `shared/`, `stories/`) are exempt. Enforced by `sergeant-design/no-foreign-module-accent` (`error`).
+13. **Read governance before coding; update docs alongside code** — read `AGENTS.md`, `CONTRIBUTING.md`, `CLAUDE.md`, and the matching playbook before writing code. Documentation is part of the change set: when code/contracts move, update the corresponding docs in the same PR (api-client types, design-system, playbooks, freshness headers). See `AGENTS.md` § Hard Rule #13 for the full must-update table.
 
 ---
 

--- a/docs/adr/0026-n8n-workflow-source-of-truth.md
+++ b/docs/adr/0026-n8n-workflow-source-of-truth.md
@@ -1,8 +1,12 @@
-# ADR 0026: n8n Workflow Source of Truth
+# ADR-0026: n8n Workflow Source of Truth
 
-## Status
+- **Status:** accepted
+- **Date:** 2026-04-27
+- **Reviewers:** @Skords-01
+- **Supersedes:** —
+- **Related:** —
 
-Accepted
+---
 
 ## Context
 

--- a/docs/adr/0027-openclaw-console-mcp-policy.md
+++ b/docs/adr/0027-openclaw-console-mcp-policy.md
@@ -1,8 +1,12 @@
-# ADR 0027: OpenClaw, Console, and MCP Policy
+# ADR-0027: OpenClaw, Console, and MCP Policy
 
-## Status
+- **Status:** accepted
+- **Date:** 2026-04-27
+- **Reviewers:** @Skords-01
+- **Supersedes:** —
+- **Related:** —
 
-Accepted
+---
 
 ## Context
 

--- a/docs/playbooks/cleanup-dead-code.md
+++ b/docs/playbooks/cleanup-dead-code.md
@@ -10,6 +10,7 @@
 ## Step 0. Verify the file isn't scaffolding
 
 > Added 2026-04-29 in response to PR [#1143](https://github.com/Skords-01/Sergeant/pull/1143). See AGENTS.md → Hard Rule #10.
+> Also see Hard Rule #13 — read governance before coding; update docs alongside code.
 
 Before deleting **anything** flagged by `pnpm knip`, check whether it carries a lifecycle marker:
 


### PR DESCRIPTION
## What changed

**PR A (must-have, recovery)** from the docs-maturity audit of 2026-04-29.

1. **Hard Rule #13 restored** — "Read governance before coding; update docs alongside code." Content adapted from orphaned commit `0bb42e68` (lost during PR #1144 merge race). Renumbered from #11 → #13 since slots #11/#12 are now taken by `no-hex-in-classname` and `module-accent-containment`.
2. **CONTRIBUTING.md synced** — mirrors for rules #11, #12, and #13 added to the Hard rules quick-reference section (was missing #11 and #12 after PR #1146).
3. **ADR-0026 and ADR-0027 harmonized** — converted from heading-based format to the front-matter list format used by ADR-0001…0025.
4. **CLAUDE.md pre-flight updated** — numbered steps now reference Rules #10 and #13; added step for `pnpm dead-code:files` and doc-update discipline.
5. **PR template expanded** — two new sections: "Pre-flight (Hard Rule #13)" and "Docs updated alongside code? (Hard Rule #13)" with per-change-type checkboxes.
6. **cleanup-dead-code playbook** — cross-link to Rule #13.
7. **Freshness headers bumped** + `Status: Active` badges added to AGENTS.md and CONTRIBUTING.md.

## Why

Docs-maturity audit findings:
- **#1 (critical):** governance discipline rule was lost during merge race — agents continue to skip reading governance and forget to update docs.
- **#2 (critical):** CONTRIBUTING.md was out of sync with AGENTS.md (rules #11, #12 missing).
- **#6 (minor):** ADR-0026/0027 format inconsistency.

## How to test

1. `grep -n '### 13.' AGENTS.md` — rule #13 exists with full content.
2. `grep -c 'Hard rules' CONTRIBUTING.md` — rules #11, #12, #13 present.
3. `head -8 docs/adr/0026-n8n-workflow-source-of-truth.md` — front-matter list format.
4. `head -8 docs/adr/0027-openclaw-console-mcp-policy.md` — front-matter list format.

---

## Pre-flight (Hard Rule #13)

- [x] Read the `AGENTS.md` Hard Rules that apply to the touched paths.
- [x] Read the matching playbook in `docs/playbooks/` (or noted that none exists).
- [x] Checked freshness headers of docs cited in the change.

## Docs updated alongside code? (Hard Rule #13)

- [x] Freshness header bumped on docs whose claims changed.
- [x] N/A — no code changes, docs-only PR.

## How AI-tested this PR

- [x] Manual smoke: verified all 7 files changed match audit requirements.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [x] Yes — Hard Rule #13 added, freshness header bumped.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores governance Hard Rule #13 (“read governance before coding; update docs alongside code”) and syncs contributor docs. Also standardizes ADR-0026/0027 and expands the PR template with pre-flight and docs-update checks.

- **Refactors**
  - Restored Hard Rule #13 in `AGENTS.md` with pre-flight steps and a must‑update table; set as rule #13.
  - Synced `CONTRIBUTING.md` to include rules #11, #12, and #13; added Status badge and refreshed headers.
  - Updated `CLAUDE.md` pre-flight to reference Rules #10 and #13; added `pnpm dead-code:files`.
  - Expanded `.github/PULL_REQUEST_TEMPLATE.md` with “Pre-flight” and “Docs updated alongside code?” sections and a dead‑code check.
  - Converted `docs/adr/0026-*.md` and `docs/adr/0027-*.md` to the front‑matter list format.
  - Cross-linked `docs/playbooks/cleanup-dead-code.md` to Rule #13.

<sup>Written for commit 7e2ad5249a9e6029dc9155ba83afb87dae8869f5. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1150?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced Hard Rule #13 requiring governance reading and synchronized documentation updates with code changes.
  * Updated PR template checklists for enhanced pre-flight verification.
  * Reformatted ADR document headers with structured metadata.
  * Added new hard rules for design token enforcement and module utility constraints.
  * Enhanced cleanup dead-code playbook with governance reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->