### PR TITLE
ci(root): add governance-sync CI check for Hard Rules, Status badges, dangling refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,9 @@ jobs:
       - name: Validate n8n workflow definitions
         run: pnpm ops:n8n:validate
 
+      - name: Governance sync (Hard Rules + Status badges + dangling refs)
+        run: pnpm lint:governance-sync
+
       - name: Format, lint, test, build
         run: pnpm check
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "n8n:import": "node scripts/ops/n8n-workflows.mjs import",
     "n8n:export": "node scripts/ops/n8n-workflows.mjs export",
     "lint:tech-debt-freshness": "node scripts/check-tech-debt-freshness.mjs",
+    "lint:governance-sync": "node scripts/check-governance-sync.mjs",
     "api:generate-openapi": "node scripts/api/generate-openapi.mjs",
     "api:check-openapi": "node scripts/api/check-openapi-fresh.mjs",
     "lint:plugins": "node --test packages/eslint-plugin-sergeant-design/__tests__/*.test.mjs",

--- a/scripts/check-governance-sync.mjs
+++ b/scripts/check-governance-sync.mjs
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+// scripts/check-governance-sync.mjs
+//
+// CI script that validates governance document consistency:
+//
+// 1. Hard Rules sync: every "### N." heading in AGENTS.md § Hard rules
+//    must have a matching "N. **..." entry in CONTRIBUTING.md § Hard rules.
+//
+// 2. Status badge coverage: every doc with a "Last validated:" freshness
+//    header must also have a "> **Status:** ..." line (Hard Rule #10).
+//
+// 3. Dangling source refs: inline code refs like `apps/.../*.ts` or
+//    `packages/.../*.ts` in docs are checked against the filesystem.
+//    Files in ADRs with Status: proposed are exempt (future refs OK).
+//
+// Usage:
+//   node scripts/check-governance-sync.mjs
+//
+// Exit code 1 on any failure.
+
+import { readFileSync, existsSync, readdirSync } from "node:fs";
+import { resolve, dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const ROOT = resolve(__dirname, "..");
+
+let errors = 0;
+let warnings = 0;
+
+function error(msg) {
+  console.error(`❌ ${msg}`);
+  errors++;
+}
+
+function warn(msg) {
+  console.warn(`⚠️  ${msg}`);
+  warnings++;
+}
+
+function ok(msg) {
+  console.log(`✅ ${msg}`);
+}
+
+// ── Check 1: Hard Rules sync ─────────────────────────────────────────────────
+
+function checkHardRulesSync() {
+  console.log(
+    "\n── Check 1: Hard Rules sync (AGENTS.md ↔ CONTRIBUTING.md) ──\n",
+  );
+
+  const agentsContent = readFileSync(resolve(ROOT, "AGENTS.md"), "utf-8");
+  const contribContent = readFileSync(
+    resolve(ROOT, "CONTRIBUTING.md"),
+    "utf-8",
+  );
+
+  // Extract rule numbers from AGENTS.md (### N. ...)
+  const agentsRuleRe = /^### (\d+)\.\s+(.+)$/gm;
+  const agentsRules = new Map();
+  let match;
+  while ((match = agentsRuleRe.exec(agentsContent)) !== null) {
+    agentsRules.set(parseInt(match[1], 10), match[2].trim());
+  }
+
+  // Extract rule numbers from CONTRIBUTING.md (N. **...**)
+  const contribRuleRe = /^(\d+)\.\s+\*\*(.+?)\*\*/gm;
+  const contribRules = new Set();
+  while ((match = contribRuleRe.exec(contribContent)) !== null) {
+    contribRules.add(parseInt(match[1], 10));
+  }
+
+  let synced = 0;
+  for (const [num, title] of agentsRules) {
+    if (contribRules.has(num)) {
+      synced++;
+    } else {
+      error(
+        `Hard Rule #${num} ("${title}") exists in AGENTS.md but is missing from CONTRIBUTING.md § Hard rules.`,
+      );
+    }
+  }
+
+  if (synced === agentsRules.size && agentsRules.size > 0) {
+    ok(`All ${agentsRules.size} Hard Rules are mirrored in CONTRIBUTING.md.`);
+  }
+}
+
+// ── Check 2: Status badge coverage ───────────────────────────────────────────
+
+function checkStatusBadges() {
+  console.log("\n── Check 2: Status badge coverage (freshness → Status:) ──\n");
+
+  const mdFiles = findMdFiles(ROOT);
+  let hasFreshness = 0;
+  let hasStatus = 0;
+  let missing = 0;
+
+  for (const file of mdFiles) {
+    const relPath = relative(ROOT, file);
+
+    // Skip ADRs — they use their own Status format
+    if (relPath.startsWith("docs/adr/") && !relPath.endsWith("README.md")) {
+      continue;
+    }
+    // Skip templates
+    if (relPath.includes("TEMPLATE")) continue;
+    // Skip node_modules, .git, etc.
+    if (
+      relPath.startsWith("node_modules") ||
+      relPath.startsWith(".git/") ||
+      relPath.startsWith("apps/") ||
+      relPath.startsWith("packages/")
+    ) {
+      continue;
+    }
+
+    const content = readFileSync(file, "utf-8");
+    const lines = content.split("\n").slice(0, 15);
+    const headerBlock = lines.join("\n");
+
+    const hasFreshnessMarker =
+      /\*\*Last validated:\*\*/.test(headerBlock) ||
+      /Last reviewed:/.test(headerBlock);
+
+    if (!hasFreshnessMarker) continue;
+    hasFreshness++;
+
+    const hasStatusBadge = />\s*\*\*Status:\*\*/.test(headerBlock);
+    if (hasStatusBadge) {
+      hasStatus++;
+    } else {
+      error(`${relPath}: has freshness marker but no "> **Status:** …" badge.`);
+      missing++;
+    }
+  }
+
+  if (missing === 0 && hasFreshness > 0) {
+    ok(`All ${hasFreshness} docs with freshness markers have Status: badges.`);
+  } else {
+    console.log(
+      `   ${hasStatus}/${hasFreshness} docs with freshness have Status badges (${missing} missing).`,
+    );
+  }
+}
+
+// ── Check 3: Dangling source refs ────────────────────────────────────────────
+
+function checkDanglingRefs() {
+  console.log("\n── Check 3: Dangling source refs in docs ──\n");
+
+  const mdFiles = findMdFiles(ROOT);
+  // Only check docs/ folder and root .md files
+  const docsFiles = mdFiles.filter((f) => {
+    const rel = relative(ROOT, f);
+    return (
+      rel.startsWith("docs/") ||
+      [
+        "AGENTS.md",
+        "CONTRIBUTING.md",
+        "CLAUDE.md",
+        "DEVIN.md",
+        "README.md",
+      ].includes(rel)
+    );
+  });
+
+  // Regex to find inline code refs like `apps/...` or `packages/...` or `scripts/...`
+  const refRe =
+    /`((?:apps|packages|scripts)\/[^`\s]+\.(?:ts|tsx|js|jsx|mjs|cjs|sql|json))`/g;
+
+  let totalRefs = 0;
+  let danglingRefs = 0;
+  const danglingByFile = new Map();
+
+  for (const file of docsFiles) {
+    const relPath = relative(ROOT, file);
+    const content = readFileSync(file, "utf-8");
+
+    // Check if this is a "proposed" ADR (future refs are OK)
+    if (
+      relPath.startsWith("docs/adr/") &&
+      /Status:\*?\*?\s*proposed/i.test(content)
+    ) {
+      continue;
+    }
+
+    // Check if this is the RN migration tracker (target-state refs are OK)
+    if (relPath.includes("react-native-migration")) continue;
+
+    let refMatch;
+    while ((refMatch = refRe.exec(content)) !== null) {
+      totalRefs++;
+      const refPath = refMatch[1];
+      const absRef = resolve(ROOT, refPath);
+      if (!existsSync(absRef)) {
+        danglingRefs++;
+        if (!danglingByFile.has(relPath)) {
+          danglingByFile.set(relPath, []);
+        }
+        danglingByFile.get(relPath).push(refPath);
+      }
+    }
+  }
+
+  if (danglingRefs === 0) {
+    ok(`All ${totalRefs} source refs in docs resolve to existing files.`);
+  } else {
+    warn(
+      `${danglingRefs} of ${totalRefs} source refs in docs point to non-existent files:`,
+    );
+    for (const [doc, refs] of danglingByFile) {
+      for (const ref of refs) {
+        warn(`  ${doc} → ${ref}`);
+      }
+    }
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function findMdFiles(dir) {
+  const results = [];
+  const entries = readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.name === "node_modules" || entry.name === ".git") continue;
+    if (entry.isDirectory()) {
+      results.push(...findMdFiles(fullPath));
+    } else if (entry.name.endsWith(".md")) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+checkHardRulesSync();
+checkStatusBadges();
+checkDanglingRefs();
+
+console.log("\n── Summary ──\n");
+console.log(`Errors: ${errors}`);
+console.log(`Warnings: ${warnings}`);
+
+if (errors > 0) {
+  console.error("\n💥 Governance sync check FAILED.\n");
+  process.exit(1);
+} else if (warnings > 0) {
+  console.log("\n⚠️  Governance sync check passed with warnings.\n");
+} else {
+  console.log("\n✅ Governance sync check passed.\n");
+}


### PR DESCRIPTION
## What changed

**PR C (automation)** from the docs-maturity audit of 2026-04-29.

New CI script `scripts/check-governance-sync.mjs` that runs three checks:

### 1. Hard Rules sync
Every `### N.` heading in `AGENTS.md` § Hard rules must have a matching `N. **...**` entry in `CONTRIBUTING.md`. Catches the exact drift that caused audit finding #2.

### 2. Status badge coverage
Every doc with a `Last validated:` freshness header must also have a `> **Status:** ...` line. Enforces Hard Rule #10 rollout.

### 3. Dangling source refs
Inline code refs (`` `apps/.../*.ts` ``, `` `packages/...` ``) in docs are checked against the filesystem. ADRs with `Status: proposed` are exempt (future refs OK).

Also:
- Added `lint:governance-sync` npm script to `package.json`.
- Added "Governance sync" step to `.github/workflows/ci.yml` (before main check suite).

## Why

Docs-maturity audit finding #8: no CI safety net to prevent governance drift. Manual review catches some issues, but the merge-race that lost Hard Rule #11 (now #13) proves we need automation.

> **Note:** This check will fail on `main` until PR A (#1150) and PR B (#1151) are merged — those PRs add the missing Status badges and sync the Hard Rules that this script validates. That's by design: the check gates future regressions.

## How to test

```bash
# Run locally (will show current drift on main)
node scripts/check-governance-sync.mjs

# After merging PR A + PR B, should pass clean
node scripts/check-governance-sync.mjs
```

---

## Pre-flight (Hard Rule #13)

- [x] Read the `AGENTS.md` Hard Rules that apply to the touched paths.
- [x] Read the matching playbook in `docs/playbooks/` (or noted that none exists).
- [x] Checked freshness headers of docs cited in the change.

## Docs updated alongside code? (Hard Rule #13)

- [x] N/A — CI script + config, no docs invalidated.

## How AI-tested this PR

- [x] Manual smoke: ran `node scripts/check-governance-sync.mjs` locally — correctly detects missing Status badges and unsynchronized rules on current `main`.
- [x] No new `AI-DANGER` markers added without justification.

## AGENTS.md updated?

- [ ] No — no new permanent rules (this PR adds tooling to enforce existing rules).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1152" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a governance-sync CI step to enforce Hard Rules parity, require status badges on fresh docs, and catch dangling source refs. This prevents governance drift and broken references across docs.

- **New Features**
  - Adds `scripts/check-governance-sync.mjs` and `lint:governance-sync`; wired into CI in `.github/workflows/ci.yml` before the main suite.
  - Validates: every "### N." in `AGENTS.md` has a matching "N. **...**" in `CONTRIBUTING.md`; docs with a freshness header must include `> **Status:** ...`; inline code refs to `apps/`, `packages/`, `scripts/` resolve (ADRs with `Status: proposed` are exempt).

<sup>Written for commit 221f499bd55e6687436be3c0491326e9cfc25054. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1152?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

