### PR TITLE
feat(web,design-tokens,docs): wave 2a+2b — close dark-mode audit to zero

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -165,6 +165,14 @@
     --c-fizruk-soft-border: 153 246 228; /* teal-200 */
     --c-fizruk-soft-hover: 204 251 241; /* teal-100 */
 
+    /* `tile` + `tile-border` — subtle stat-tile wash on the fizruk hero
+       gradient (`bg-hero-teal`). Used by `<WorkoutStatTile>` and the
+       fizruk summary-sheet close button. Light=teal-800 (so a 10% wash
+       reads as a slightly darker tile on the bright teal gradient);
+       dark=white (10% wash on dark panel reads as a subtle bright tile). */
+    --c-fizruk-tile: 17 94 89; /* teal-800 */
+    --c-fizruk-tile-border: 17 94 89; /* teal-800 */
+
     --c-routine-soft: 255 245 243; /* coral-50 — parity with `brandColors.coral[50]` */
     --c-routine-soft-border: 255 210 200; /* coral-200 */
     --c-routine-soft-hover: 255 232 227; /* coral-100 */
@@ -286,6 +294,12 @@
     --c-fizruk-soft: 19 78 74; /* teal-900 */
     --c-fizruk-soft-border: 17 94 89; /* teal-800 */
     --c-fizruk-soft-hover: 17 94 89; /* teal-800 */
+
+    /* Dark-mode flip of the stat-tile token: white wash reads as a
+       subtle bright tile on dark panel (matches the legacy
+       `dark:bg-white/10 dark:border-white/15` hand-rolling). */
+    --c-fizruk-tile: 255 255 255; /* white */
+    --c-fizruk-tile-border: 255 255 255; /* white */
 
     --c-routine-soft: 159 36 30; /* coral-900 (≈ red-900 tuned) */
     --c-routine-soft-border: 185 54 48; /* coral-800 */

--- a/apps/web/src/modules/fizruk/components/workouts/WorkoutFinishSheets.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/WorkoutFinishSheets.tsx
@@ -9,6 +9,7 @@ import {
   recordCrossModulePromptAccepted,
 } from "@shared/lib/crossModulePrompt";
 import { formatDurShort } from "@sergeant/fizruk-domain";
+import { WorkoutStatTile } from "./WorkoutStatTile";
 
 export function WorkoutFinishSheets({
   finishFlash,
@@ -171,7 +172,7 @@ export function WorkoutFinishSheets({
                 </div>
                 <button
                   type="button"
-                  className="w-9 h-9 min-w-[44px] min-h-[44px] flex items-center justify-center rounded-full bg-teal-800/10 dark:bg-white/10 text-teal-700 dark:text-white/70 hover:text-teal-900 dark:hover:text-white text-lg"
+                  className="w-9 h-9 min-w-[44px] min-h-[44px] flex items-center justify-center rounded-full bg-fizruk-tile/10 text-teal-700 dark:text-white/70 hover:text-teal-900 dark:hover:text-white text-lg"
                   aria-label="Закрити"
                   onClick={() => setFinishFlash(null)}
                 >
@@ -179,39 +180,23 @@ export function WorkoutFinishSheets({
                 </button>
               </div>
               <div className="grid grid-cols-3 gap-2 mt-3">
-                <div className="rounded-xl bg-teal-800/10 dark:bg-white/10 border border-teal-800/15 dark:border-white/15 p-2.5 text-center">
-                  {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift --
-                      Summary-sheet stat caption on hero background —
-                      `text-white/60` isn't expressed by SectionHeading tones. */}
-                  <div className="text-2xs uppercase tracking-wide text-teal-600 dark:text-white/60">
-                    Час
-                  </div>
-                  <div className="text-sm font-black text-teal-900 dark:text-white tabular-nums mt-0.5">
-                    {formatDurShort(finishFlash.durationSec)}
-                  </div>
-                </div>
-                <div className="rounded-xl bg-teal-800/10 dark:bg-white/10 border border-teal-800/15 dark:border-white/15 p-2.5 text-center">
-                  {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift --
-                      Sibling caption; same rationale as above. */}
-                  <div className="text-2xs uppercase tracking-wide text-teal-600 dark:text-white/60">
-                    Вправ
-                  </div>
-                  <div className="text-lg font-black text-teal-900 dark:text-white tabular-nums">
-                    {finishFlash.items}
-                  </div>
-                </div>
-                <div className="rounded-xl bg-teal-800/10 dark:bg-white/10 border border-teal-800/15 dark:border-white/15 p-2.5 text-center">
-                  {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift --
-                      Sibling caption; same rationale as above. */}
-                  <div className="text-2xs uppercase tracking-wide text-teal-600 dark:text-white/60">
-                    Обʼєм
-                  </div>
-                  <div className="text-sm font-black text-teal-900 dark:text-white tabular-nums mt-0.5">
-                    {finishFlash.tonnageKg > 0
+                <WorkoutStatTile
+                  label="Час"
+                  value={formatDurShort(finishFlash.durationSec)}
+                />
+                <WorkoutStatTile
+                  label="Вправ"
+                  value={finishFlash.items}
+                  size="lg"
+                />
+                <WorkoutStatTile
+                  label="Обʼєм"
+                  value={
+                    finishFlash.tonnageKg > 0
                       ? `${Math.round(finishFlash.tonnageKg)} кг`
-                      : "—"}
-                  </div>
-                </div>
+                      : "—"
+                  }
+                />
               </div>
             </div>
             {finishFlash.savedWellbeing &&

--- a/apps/web/src/modules/fizruk/components/workouts/WorkoutStatTile.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/WorkoutStatTile.tsx
@@ -1,0 +1,58 @@
+/**
+ * `<WorkoutStatTile>` — stat tile for the fizruk workout-summary sheet.
+ *
+ * Renders an uppercase eyebrow caption above a tabular-numbered value on
+ * a subtle wash that adapts per theme via the `--c-fizruk-tile` /
+ * `--c-fizruk-tile-border` CSS variables (light = teal-800 wash on the
+ * `bg-hero-teal` summary header; dark = white wash on the dark panel
+ * gradient). Replaces the `bg-teal-800/10 dark:bg-white/10 …` className
+ * soup that used to be hand-rolled at three sibling call-sites in
+ * `WorkoutFinishSheets`. See `docs/design/DARK-MODE-AUDIT.md` →
+ * "→ new `WorkoutStatTile` primitive (WorkoutFinishSheets)".
+ */
+import { type ReactNode } from "react";
+import { cn } from "@shared/lib/cn";
+
+export interface WorkoutStatTileProps {
+  label: ReactNode;
+  value: ReactNode;
+  /**
+   * Tile sizing. Use `lg` for hero numbers (e.g. exercise count) and
+   * the default `sm` for shorter values that need a touch of breathing
+   * room above them (durations, tonnages). Defaults to `sm`.
+   */
+  size?: "sm" | "lg";
+  className?: string;
+}
+
+export function WorkoutStatTile({
+  label,
+  value,
+  size = "sm",
+  className,
+}: WorkoutStatTileProps) {
+  return (
+    <div
+      className={cn(
+        "rounded-xl bg-fizruk-tile/10 border border-fizruk-tile-border/15 p-2.5 text-center",
+        className,
+      )}
+    >
+      {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift --
+          Summary-sheet stat caption on the fizruk hero gradient —
+          `text-teal-600 dark:text-white/60` isn't expressed by the
+          SectionHeading tone scale (which targets neutral surfaces). */}
+      <div className="text-2xs uppercase tracking-wide text-teal-600 dark:text-white/60">
+        {label}
+      </div>
+      <div
+        className={cn(
+          "font-black text-teal-900 dark:text-white tabular-nums",
+          size === "lg" ? "text-lg" : "text-sm mt-0.5",
+        )}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/shared/charts/chartTheme.ts
+++ b/apps/web/src/shared/charts/chartTheme.ts
@@ -109,11 +109,18 @@ export const chartHeatmap = {
   routine: {
     empty: "bg-panelHi dark:bg-line/25",
     future: "bg-line/15 dark:bg-line/10",
+    /**
+     * Level scale (0 → 3). Levels 1–3 reference theme-aware CSS classes
+     * defined in `apps/web/src/styles/module-surfaces.css` so this module
+     * does not carry `dark:` overrides for chart palette pairs (Wave 2b
+     * of the dark-mode audit; see `docs/design/DARK-MODE-AUDIT.md` →
+     * "→ chart-palette refactor (chartTheme)").
+     */
     levels: [
       "bg-panelHi dark:bg-line/25",
-      "bg-coral-200/80 dark:bg-coral-900/55",
-      "bg-coral-400/75 dark:bg-coral-600/70",
-      "bg-coral-500/90 dark:bg-coral-500/80",
+      "bg-routine-heat-l1",
+      "bg-routine-heat-l2",
+      "bg-routine-heat-l3",
     ] as const,
     ring: "ring-coral-400/80 dark:ring-coral-300/70",
     outline: "outline-coral-400",

--- a/apps/web/src/styles/module-surfaces.css
+++ b/apps/web/src/styles/module-surfaces.css
@@ -97,6 +97,42 @@
   );
 }
 
+/* ── Routine heatmap cells ───────────────────────────────────────────────
+   Wave 2b: chart-side palette tokens for the routine activity heatmap.
+   The CSS layer owns the per-theme (light, dark) pair so consumers in
+   `apps/web/src/shared/charts/chartTheme.ts` reference one class per
+   level and the JS module stops carrying `dark:` overrides.
+
+   Level scale (0 → 3):
+     0 → no activity (uses semantic `bg-panelHi dark:bg-line/25` directly)
+     1 → coral-200 light, coral-900 dark
+     2 → coral-400 light, coral-600 dark
+     3 → coral-500 light, coral-500 dark
+
+   Opacity is baked into each declaration (light/dark differ slightly so
+   the heatmap reads as warm in both themes without hand-tuning at the
+   call-site). */
+.bg-routine-heat-l1 {
+  background-color: rgb(255 212 203 / 0.8); /* coral-200 @ 80% */
+}
+.dark .bg-routine-heat-l1 {
+  background-color: rgb(134 46 46 / 0.55); /* coral-900 @ 55% */
+}
+
+.bg-routine-heat-l2 {
+  background-color: rgb(255 140 120 / 0.75); /* coral-400 @ 75% */
+}
+.dark .bg-routine-heat-l2 {
+  background-color: rgb(230 77 77 / 0.7); /* coral-600 @ 70% */
+}
+
+.bg-routine-heat-l3 {
+  background-color: rgb(249 112 102 / 0.9); /* coral-500 @ 90% */
+}
+.dark .bg-routine-heat-l3 {
+  background-color: rgb(249 112 102 / 0.8); /* coral-500 @ 80% */
+}
+
 /* ── Nutrition (lime) ────────────────────────────────────────────────── */
 
 .module-card-nutrition {

--- a/docs/design/DARK-MODE-AUDIT.md
+++ b/docs/design/DARK-MODE-AUDIT.md
@@ -22,14 +22,14 @@
   `hover:bg-*-soft-hover`). The `--c-{brand,module,status}-soft*`
   CSS variables in `apps/web/src/index.css` now carry the light/dark
   swap, so the call-sites need no `dark:` override at all.
-- **7** sites are intentionally **deferred** to Wave 2 because they
-  need a _primitive_ rather than a token swap:
-  - 4 × `WorkoutFinishSheets.tsx` rows → become a
-    `<WorkoutStatTile>` primitive (same `bg-teal-800/10 dark:bg-white/10`
-    soup every stat card reuses).
-  - 3 × `chartTheme.ts` coral gradient rows → move into a
-    `chartGradients` CSS-variable layer so the JS module stops owning
-    light/dark pairs.
+- **Wave 2a + 2b** migrated the remaining **7 / 28** via two
+  refactor moves: the `WorkoutFinishSheets.tsx` four-row pattern
+  collapsed into a `<WorkoutStatTile>` primitive backed by the new
+  `--c-fizruk-tile{,-border}` token (light = teal-800 wash,
+  dark = white wash), and the `chartTheme.ts` coral heatmap rows
+  moved into `bg-routine-heat-l{1,2,3}` CSS classes whose
+  `.dark .X` override owns the per-theme colour. **Audit count
+  hits 0.**
 - Every remaining anti-pattern is one `dark:` override away from
   silently falling through on the next palette migration — exactly
   the class of bug [#814](https://github.com/Skords-01/Sergeant/pull/814)
@@ -156,12 +156,19 @@ stops owning them.
    `apps/web/src/index.css` that flip between light and dark themes
    automatically. 21 / 28 call-sites migrated; each drops ≥ 1
    `dark:` override, net reduction ≈ 40 `dark:` occurrences.
-2. **Wave 2**: the `WorkoutFinishSheets` four-row pattern becomes a
-   real `<WorkoutStatTile>` primitive; the `chartTheme` coral pairs
-   move into `chartGradients` CSS variables. After those two moves
-   land, the audit's anti-pattern count hits zero and total `dark:`
-   occurrences in `apps/web` drop under `250`.
-3. **Final step**: promote a lint rule in
+2. **Wave 2a — DONE.** The four `WorkoutFinishSheets.tsx` rows now
+   resolve through a `<WorkoutStatTile>` primitive in
+   `apps/web/src/modules/fizruk/components/workouts/WorkoutStatTile.tsx`,
+   backed by the new `--c-fizruk-tile{,-border}` CSS variables (light =
+   teal-800 wash, dark = white wash). The summary-sheet close button
+   reuses the same token (`bg-fizruk-tile/10`) so its raw-palette
+   `dark:bg-white/10` override is also gone.
+3. **Wave 2b — DONE.** The three `chartTheme.ts` heatmap rows now
+   resolve through `bg-routine-heat-l{1,2,3}` CSS classes defined in
+   `apps/web/src/styles/module-surfaces.css`. The `.dark .X` override
+   owns the per-theme RGB+opacity pair; the JS module references one
+   class name per level. Audit count = 0.
+4. **Final step (Wave 2c)**: promote a lint rule in
    `packages/eslint-plugin-sergeant-design` that forbids any
    `dark:bg-<palette>-<N>` / `dark:text-<palette>-<N>` pattern — the
    anti-pattern is then zero, so the rule promotes to `error` without

--- a/packages/design-tokens/tailwind-preset.js
+++ b/packages/design-tokens/tailwind-preset.js
@@ -179,6 +179,13 @@ const preset = {
           soft: "rgb(var(--c-fizruk-soft) / <alpha-value>)",
           "soft-border": "rgb(var(--c-fizruk-soft-border) / <alpha-value>)",
           "soft-hover": "rgb(var(--c-fizruk-soft-hover) / <alpha-value>)",
+          // `tile` + `tile-border` — subtle stat-tile wash on the
+          // fizruk hero gradient (Wave 2a). Light=teal-800,
+          // dark=white. Apply with the registered opacity scale,
+          // typically `bg-fizruk-tile/10` and
+          // `border-fizruk-tile-border/15`.
+          tile: "rgb(var(--c-fizruk-tile) / <alpha-value>)",
+          "tile-border": "rgb(var(--c-fizruk-tile-border) / <alpha-value>)",
         },
 
         /** Рутина — Soft coral habit tracker */


### PR DESCRIPTION
## What changed

Closes the final **7 / 28** anti-patterns from `docs/design/DARK-MODE-AUDIT.md` so the audit count hits **0**. Wave 1b ([#1149](https://github.com/Skords-01/Sergeant/pull/1149)) had already migrated the 21 token-swap call-sites; the remaining 7 needed primitive extraction / CSS-vars layer rather than a token rename. This PR ships both.

### Wave 2a — `<WorkoutStatTile>` primitive (4 sites)

`WorkoutFinishSheets.tsx` had a repeating "subtle teal/white-on-teal" wash pattern across 3 stat tiles + the close button — every site hand-rolled `bg-teal-800/10 dark:bg-white/10 …`.

- **New CSS variables** in `apps/web/src/index.css`:
  - `--c-fizruk-tile` (light = teal-800 `17 94 89`, dark = white `255 255 255`)
  - `--c-fizruk-tile-border` (same RGB; differentiated for future tuning)
- **Registered Tailwind utilities** in `packages/design-tokens/tailwind-preset.js`:
  - `bg-fizruk-tile` / `border-fizruk-tile-border` (use with `/10` and `/15` opacity steps).
- **New primitive** `apps/web/src/modules/fizruk/components/workouts/WorkoutStatTile.tsx`:
  - Props: `label`, `value`, `size?: "sm" | "lg"`, `className?`. Default `sm`.
  - Wraps the rounded-tile + uppercase eyebrow + tabular-nums value pattern.
- **Three stat tiles** (Час / Вправ / Обʼєм) collapse to `<WorkoutStatTile … />`.
- **Close button** keeps its inline structure (different shape, hover semantics) but its bg becomes `bg-fizruk-tile/10` — the `dark:bg-white/10` override is gone.

Net: **−4** raw-palette `dark:bg-…` / `dark:border-…` overrides, **−≈30** lines of repeated className soup.

### Wave 2b — chart heatmap CSS-vars layer (3 sites)

`chartHeatmap.routine.levels` in `chartTheme.ts` shipped three light/dark coral pairs as Tailwind className strings — the JS module owned both halves of the pair, so any palette retune required hand-editing all six entries.

- **New CSS classes** in `apps/web/src/styles/module-surfaces.css`:
  - `.bg-routine-heat-l1` / `.dark .bg-routine-heat-l1` (coral-200 @ 80% / coral-900 @ 55%)
  - `.bg-routine-heat-l2` / `.dark .bg-routine-heat-l2` (coral-400 @ 75% / coral-600 @ 70%)
  - `.bg-routine-heat-l3` / `.dark .bg-routine-heat-l3` (coral-500 @ 90% / coral-500 @ 80%)
- **`chartHeatmap.routine.levels`** now references one class name per level — the JS module no longer carries `dark:` overrides for chart palette pairs. The CSS layer owns the per-theme RGB+opacity pair.

Net: **−3** raw-palette `dark:bg-coral-{900,600,500}` overrides.

### Docs

- `docs/design/DARK-MODE-AUDIT.md` TL;DR updated: **28 / 28** migrated, audit count = 0.
- "What happens next" rewritten to mark Wave 2a + 2b as DONE and frame Wave 2c (lint-rule promotion to `error`) as the only remaining step. The reasoning still holds: with 0 anti-patterns, `no-raw-dark-palette` can promote to `error` without breaking anything.

## Why

Every anti-pattern is one `dark:` override away from silently falling through on the next palette migration — exactly the class of bug [#814](https://github.com/Skords-01/Sergeant/pull/814) fixed. Wave 1b proved the token-swap pattern works for 21 / 28 sites. The remaining 7 are structural — they need either a primitive (so the soup is centralised) or a CSS-vars layer (so the JS file stops owning the pair). Both moves are net reductions in line count and cognitive load, not just a rename.

Closing the audit to 0 unblocks Wave 2c (the `no-raw-dark-palette` lint rule promotion) — that's a separate PR on the heels of this one.

## How to test

```bash
pnpm format:check   # prettier clean
pnpm lint           # ESLint + plugin tests
pnpm typecheck      # TS clean (incl. tsconfig.strict + tsconfig.noimplicitany)
pnpm --filter @sergeant/web exec vitest run \
  src/modules/fizruk/components/workouts/WorkoutJournalSection.finish
```

Manual visual checks (light + dark):

1. Start a workout in **Фізрук → Тренування**, complete it, watch the wellbeing-then-summary sheet.
2. Confirm the 3 stat tiles (Час / Вправ / Обʼєм) and the close `✕` button have the same subtle teal-on-teal-gradient wash in light, white-on-dark-panel wash in dark, identical to the pre-PR appearance.
3. Open **Рутина → дашборд звичок**, scroll to the 7-day heatmap. Confirm each level (l1 / l2 / l3) renders the same warm coral in light, the same darker coral in dark.

---

## How AI-tested this PR

- [x] `pnpm format:check`: clean.
- [x] `pnpm lint`: clean (200/200 plugin tests pass; tech-debt freshness clean).
- [x] `pnpm typecheck`: 14 / 14 tasks successful — no new errors in `tsconfig.strict.json` / `tsconfig.noimplicitany.json` (816-error pre-existing baseline on `main` — see [#1148](https://github.com/Skords-01/Sergeant/pull/1148)).
- [x] `pnpm --filter @sergeant/web exec vitest run WorkoutJournalSection.finish`: 3 / 3 pass.
- [x] Grepped `dark:bg-(teal|coral|white)-` in `apps/web/src/**` after the edits — only legitimate matches remain (`dark:bg-white/{5,10,15}` — the documented "barely-there glass wash on dark" pattern from `design-system.md` § 2.1) and the audit doc itself.
- [x] No code changes outside the audit scope; no new `AI-DANGER` markers.
- [x] Docs prose updated in Ukrainian where the surrounding paragraph was Ukrainian; English where the surrounding paragraph was English (audit doc is English by convention).

## AGENTS.md updated?

- [ ] Yes
- [x] No — no new permanent rules. The new tokens (`bg-fizruk-tile`, `bg-routine-heat-l*`) are documented in `DARK-MODE-AUDIT.md` and inline JSDoc on the primitive; promotion of the `no-raw-dark-palette` rule (Wave 2c) will land as a follow-up PR with the matching AGENTS.md row.

Link to Devin session: https://app.devin.ai/sessions/2617bca7346942c28c8596728e7294b8
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes the final 7 dark‑mode audit anti‑patterns. The audit now reads 0. Adds a `WorkoutStatTile` primitive and theme-aware heatmap classes to remove raw `dark:` palette overrides.

- **New Features**
  - `WorkoutStatTile` for summary tiles (`label`, `value`, `size?`).
  - Fizruk tile tokens: `--c-fizruk-tile{,-border}` with Tailwind `bg-fizruk-tile` / `border-fizruk-tile-border`.
  - Heatmap classes: `.bg-routine-heat-l{1,2,3}` with `.dark` variants.

- **Refactors**
  - Replaced three tiles in `WorkoutFinishSheets` with `WorkoutStatTile`.
  - Close button uses `bg-fizruk-tile/10` (no `dark:` override).
  - `chartHeatmap.routine.levels` now references `bg-routine-heat-l{1,2,3}` (no inline `dark:`).
  - Updated `docs/design/DARK-MODE-AUDIT.md` to 28/28 migrated; Wave 2c (lint promotion) is next.

<sup>Written for commit 323a2d74049563c72abba20d3885e7f6cbbee087. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1153?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dark mode theming and visual consistency for workout summary displays
  * Enhanced routine heatmap chart styling with better dark mode support

* **Refactor**
  * Optimized component architecture for workout summary tiles to reduce code duplication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->