### PR TITLE
fix(eslint-plugins): no-raw-dark-palette skips dark: when prefixed by another variant

### DIFF
--- a/packages/eslint-plugin-sergeant-design/__tests__/no-raw-dark-palette.test.mjs
+++ b/packages/eslint-plugin-sergeant-design/__tests__/no-raw-dark-palette.test.mjs
@@ -184,4 +184,49 @@ describe("no-raw-dark-palette", () => {
     );
     assert.equal(messages.length, 1);
   });
+
+  it("does NOT match `dark:` when prefixed by another variant (lg:dark:…)", () => {
+    // Regression test for cubic finding on PR #1155 — `lg:dark:bg-amber-500/15`
+    // tokens carry an extra breakpoint condition that the rule's
+    // pair-only contract does not model. Treating them as bare `dark:`
+    // matches produced false-positive pair reports against unrelated
+    // bare light utilities (`bg-amber-50`) elsewhere in the same
+    // className. The dark-side regex now uses the same `(?<![\w:-])`
+    // lookbehind as the light-side regex.
+    const messages = lint(`const c = "bg-amber-50 lg:dark:bg-amber-500/15";`);
+    assert.equal(
+      messages.length,
+      0,
+      "lg:dark: prefixed dark utility must not pair with bare bg-amber-50",
+    );
+  });
+
+  it("does NOT match `dark:` when prefixed by a hover state (hover:dark:…)", () => {
+    // Same family of false-positives: `hover:dark:text-coral-300` is
+    // a stateful + dark-mode override, not a bare dark pair.
+    const messages = lint(
+      `const c = "text-coral-700 hover:dark:text-coral-300 underline";`,
+    );
+    assert.equal(messages.length, 0);
+  });
+
+  it("does NOT match `dark:` when prefixed by a focus state (focus-visible:dark:…)", () => {
+    const messages = lint(
+      `const c = "border-teal-200 focus-visible:dark:border-teal-700";`,
+    );
+    assert.equal(messages.length, 0);
+  });
+
+  it("still flags a bare `dark:` pair even when the same className has a `lg:dark:` variant on a different family", () => {
+    // The bare `text-brand-600 dark:text-brand-400` pair must still
+    // fire even when an unrelated `lg:dark:bg-amber-500/15` token
+    // appears in the same className — the variant-prefix dark token
+    // is invisible to the rule, but the bare pair is unambiguous.
+    const messages = lint(
+      `const c = "text-brand-600 dark:text-brand-400 lg:dark:bg-amber-500/15";`,
+    );
+    assert.equal(messages.length, 1);
+    assert.match(messages[0].message, /text-brand-600/);
+    assert.match(messages[0].message, /dark:text-brand-400/);
+  });
 });

--- a/packages/eslint-plugin-sergeant-design/index.js
+++ b/packages/eslint-plugin-sergeant-design/index.js
@@ -1736,11 +1736,19 @@ const RX_LIGHT_RAW_PALETTE = new RegExp(
   "g",
 );
 
-// Match `dark:<utility>-<palette>-<step>[/<opacity>]`. We use a
-// negative-lookbehind on `:` to avoid matching `lg:dark:bg-…` weirdness
-// while still allowing the `dark:` prefix.
+// Match `dark:<utility>-<palette>-<step>[/<opacity>]`. The negative
+// lookbehind `(?<![\w:-])` excludes any token where `dark:` itself is
+// preceded by another variant (`lg:dark:bg-amber-500/15`,
+// `hover:dark:text-coral-300`, …) — those tokens carry an extra
+// breakpoint / state condition that the rule's pair-only contract does
+// not model, and treating them as bare `dark:` matches produced
+// false-positive pair reports against unrelated bare light utilities
+// elsewhere in the same className. The light-side regex already uses
+// the same lookbehind, so the pair logic stays symmetric: only
+// genuinely bare `<utility>-<palette>-<step>` and bare
+// `dark:<utility>-<palette>-<step>` tokens contribute to a match.
 const RX_DARK_RAW_PALETTE = new RegExp(
-  String.raw`\bdark:(` +
+  String.raw`(?<![\w:-])dark:(` +
     RAW_DARK_PALETTE_UTILITIES.join("|") +
     String.raw`)-(` +
     RAW_DARK_PALETTE_FAMILIES.join("|") +


### PR DESCRIPTION
## What changed

Follow-up to [#1155](https://github.com/Skords-01/Sergeant/pull/1155). Closes a false-positive in `sergeant-design/no-raw-dark-palette` where `lg:dark:bg-amber-500/15` (and similar variant-prefixed dark utilities) were treated as bare `dark:` matches and produced spurious pair reports against unrelated bare light utilities elsewhere in the same className.

The dark-side regex relied on a leading `\b` word-boundary. `\b` matches between `:` (non-word) and `d` (word), so `lg:dark:bg-amber-500/15`, `hover:dark:text-coral-300`, `focus-visible:dark:border-teal-700`, … all produced a dark hit. Combined with a bare light utility on the same className (e.g. `bg-amber-50 lg:dark:bg-amber-500/15`) the rule emitted a misleading pair report — the user is being told that `bg-amber-50` is paired with a `dark:` override that, in fact, only fires at the `lg` breakpoint.

The fix:

- Switch `RX_DARK_RAW_PALETTE` to the same `(?<![\w:-])` negative lookbehind the light-side regex already uses. Now both halves of the rule's pair contract require a genuinely bare match — i.e. the leading character (if any) is whitespace, line-start, string-start, or a JSX/JS delimiter, but never another Tailwind variant.
- Document why the rule deliberately does **not** model variant-prefixed pairs (`lg:bg-amber-50 lg:dark:bg-amber-500/15`). That's still an anti-pattern semantically, but catching it properly requires variant-aware tokenisation that would expand the rule's scope significantly — the audit doc treats it as a future Wave 2f item.

## Why

Cubic flagged this as a P2 finding on PR #1155:

> P2: `RX_DARK_RAW_PALETTE` is missing the `:` negative-lookbehind, so `lg:dark:*` tokens are still matched and can trigger false-positive pair reports.

I confirmed by hand-running the regex against `bg-amber-50 lg:dark:bg-amber-500/15` — the existing rule reports a pair, even though the dark side is gated by a breakpoint. A false-positive `error` from a Hard Rule lint would block legitimate work and is a regression worth fixing immediately rather than rolling into the next dark-mode PR.

## How to test

```bash
node --test packages/eslint-plugin-sergeant-design/__tests__/*.mjs
                       # 224 / 224 passing (220 → 224, +4 regression cases)
pnpm format            # exit 0
pnpm lint              # exit 0
pnpm typecheck         # exit 0 across 14 packages
```

The 4 new test cases cover:

1. `bg-amber-50 lg:dark:bg-amber-500/15` — bare light + breakpoint-prefixed dark → **0 reports** (was 1).
2. `text-coral-700 hover:dark:text-coral-300 underline` — bare light + state-prefixed dark → **0 reports**.
3. `border-teal-200 focus-visible:dark:border-teal-700` — bare light + focus-state-prefixed dark → **0 reports**.
4. `text-brand-600 dark:text-brand-400 lg:dark:bg-amber-500/15` — bare pair + unrelated variant-prefixed dark → **1 report** (the bare pair is still caught; the variant-prefixed token is invisible to the rule, which is the intended behaviour).

Manual verification: I grepped `apps/web` for `lg:dark:|md:dark:|sm:dark:|xl:dark:|hover:dark:|focus-visible:dark:` and confirmed the codebase has no current call-sites that exercised the false-positive path. The fix is therefore preventive against future regressions, not a behaviour change for any existing call-site.

---

## Pre-flight (Hard Rule #14)

- [x] Read `AGENTS.md` Hard Rule #13 (the rule being patched) and #14 (governance).
- [x] No matching playbook (the audit doc owns this rule's spec).
- [x] Freshness header on `docs/design/DARK-MODE-AUDIT.md` was bumped in PR #1155 yesterday and remains valid; this PR doesn't move the spec, it tightens the implementation.

## Docs updated alongside code? (Hard Rule #14)

- [ ] API contract change — n/a.
- [ ] New / removed npm script — n/a.
- [ ] New design token / component / palette — n/a.
- [ ] Deprecation — n/a.
- [ ] Freshness header bumped — n/a (no normative change to spec).
- [x] N/A — bug fix in implementation; the rule's documented behaviour (pair-only, bare halves) is unchanged. The in-source comment block above `RX_DARK_RAW_PALETTE` is updated to spell out the variant-prefix case.

## How AI-tested this PR

- [x] Plugin tests: 224 / 224 passing via `node --test __tests__/*.mjs`.
- [x] `pnpm lint` exit 0 (no new violations or false-positive cleanups needed in apps/web).
- [x] `pnpm typecheck` exit 0.
- [x] `pnpm format` clean.

## AGENTS.md updated?

- [ ] Yes
- [x] No — the rule and Hard Rule #13 are unchanged in scope; only the implementation tightens its match.


Link to Devin session: https://app.devin.ai/sessions/2617bca7346942c28c8596728e7294b8
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a false-positive in `sergeant-design/no-raw-dark-palette` by ignoring `dark:` tokens when they’re prefixed by another variant (e.g., `lg:dark:*`, `hover:dark:*`). This aligns the dark-side regex with the light side to only match bare pairs and prevents spurious reports.

- **Bug Fixes**
  - Switched `RX_DARK_RAW_PALETTE` to `(?<![\w:-])` negative lookbehind to exclude variant-prefixed `dark:` tokens.
  - Kept pair logic symmetric: only bare light vs bare `dark:` pairs are considered; existing bare pairs still reported.
  - Added four regression tests; all plugin tests pass.

<sup>Written for commit 09c95647a78afb8aaf344f4751744f9e2b5d066e. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1157?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

