### PR TITLE
docs+fix: renumber stale Hard Rule #13 -> #15 + dedup prefer-focus-visible reports (#1158 follow-up)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
 
 ---
 
-## Pre-flight (Hard Rule #13)
+## Pre-flight (Hard Rule #15)
 
 <!--
 Before opening this PR you should have read the relevant governance.
@@ -23,7 +23,7 @@ Tick what applies; if a box is N/A, write "n/a" inline.
 - [ ] Read the matching playbook in `docs/playbooks/` (or noted that none exists).
 - [ ] Checked freshness headers of docs cited in the change.
 
-## Docs updated alongside code? (Hard Rule #13)
+## Docs updated alongside code? (Hard Rule #15)
 
 <!--
 Documentation is part of the change set, not a follow-up. Tick what applies.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,14 +34,14 @@ pnpm docs:freshness-dashboard      # Build dist/freshness-dashboard.html
 
 ## Before you write code
 
-> Hard Rule #13 in `AGENTS.md` applies to AI agents: complete this pre-flight before implementing.
+> Hard Rule #15 in `AGENTS.md` applies to AI agents: complete this pre-flight before implementing.
 
 1. Read the relevant playbook in `docs/playbooks/` — pick by trigger phrase (e.g. "нова API-функціональність" → `add-api-endpoint.md`; "remove dead code" → `cleanup-dead-code.md`).
-2. Check `AGENTS.md` § Hard rules — especially bigint coercion (#1), RQ keys (#2), migration numbering (#4), lifecycle markers (#10), governance + docs discipline (#13).
+2. Check `AGENTS.md` § Hard rules — especially bigint coercion (#1), RQ keys (#2), migration numbering (#4), lifecycle markers (#10), governance + docs discipline (#15).
 3. Before deleting any file, run `pnpm dead-code:files` (which honours `@scaffolded` markers — Hard Rule #10). Never delete a scaffolded file just because it has zero importers.
 4. New HubChat tool? Needs **3 coordinated edits** — see `docs/playbooks/add-hubchat-tool.md`.
 5. New migration? Use `pnpm gen migration --name <desc>` — auto-numbers from last migration (`015`).
-6. Before opening the PR, update docs alongside code (Hard Rule #13): api-client types, design-system docs, playbooks, freshness headers — see the must-update table in `AGENTS.md` § Hard Rule #13.
+6. Before opening the PR, update docs alongside code (Hard Rule #15): api-client types, design-system docs, playbooks, freshness headers — see the must-update table in `AGENTS.md` § Hard Rule #15.
 
 ## Verification before PR
 

--- a/docs/playbooks/cleanup-dead-code.md
+++ b/docs/playbooks/cleanup-dead-code.md
@@ -10,7 +10,7 @@
 ## Step 0. Verify the file isn't scaffolding
 
 > Added 2026-04-29 in response to PR [#1143](https://github.com/Skords-01/Sergeant/pull/1143). See AGENTS.md → Hard Rule #10.
-> Also see Hard Rule #13 — read governance before coding; update docs alongside code.
+> Also see Hard Rule #15 — read governance before coding; update docs alongside code.
 
 Before deleting **anything** flagged by `pnpm knip`, check whether it carries a lifecycle marker:
 

--- a/packages/eslint-plugin-sergeant-design/__tests__/prefer-focus-visible.test.mjs
+++ b/packages/eslint-plugin-sergeant-design/__tests__/prefer-focus-visible.test.mjs
@@ -84,6 +84,22 @@ describe("prefer-focus-visible", () => {
     assert.equal(messages.length, 1);
   });
 
+  it("flags `focus:outline-offset-2` once, not twice", () => {
+    // `outline-offset` is in `FOCUS_COLOR_UTILITIES`, so the colour-utility
+    // regex matches `focus:outline-offset-2` as `util="outline-offset"`,
+    // `rest="2"`. The separate `focus:outline-…` arm also matches the same
+    // token (`tail="offset-2"`, not in `FOCUS_OUTLINE_ALLOWED_TAILS`).
+    // The rule must dedup so only one report is emitted per token.
+    const messages = lint(`const c = "focus:outline-offset-2";`);
+    assert.equal(messages.length, 1);
+    assert.match(messages[0].message, /focus:outline-offset-2/);
+  });
+
+  it("flags `focus:outline-offset-4` once, not twice", () => {
+    const messages = lint(`const c = "rounded focus:outline-offset-4 mt-1";`);
+    assert.equal(messages.length, 1);
+  });
+
   it("flags inside a template literal", () => {
     const messages = lint(
       "const c = `flex items-center focus:bg-panelHi rounded-xl ${extra}`;",

--- a/packages/eslint-plugin-sergeant-design/index.js
+++ b/packages/eslint-plugin-sergeant-design/index.js
@@ -1975,6 +1975,11 @@ function findPreferFocusVisibleHits(value) {
   while ((m = RX_PREFER_FOCUS_VISIBLE_OUTLINE.exec(value)) !== null) {
     const [full, tail] = m;
     if (FOCUS_OUTLINE_ALLOWED_TAILS.has(tail)) continue;
+    // The colour-utility arm above already covers `focus:outline-offset-N`
+    // (because `outline-offset` is in `FOCUS_COLOR_UTILITIES`); the outline
+    // arm's broader regex also matches the same token. Dedup by `match`
+    // so each token produces a single report.
+    if (hits.some((h) => h.match === full)) continue;
     hits.push({ match: full, tail: `outline-${tail}` });
   }
   return hits;

--- a/scripts/ci/__tests__/validate-pr-body.test.mjs
+++ b/scripts/ci/__tests__/validate-pr-body.test.mjs
@@ -29,12 +29,12 @@ Fixes #123 — users saw 500s on /api/foo.
 pnpm test --filter foo
 \`\`\`
 
-## Pre-flight (Hard Rule #13)
+## Pre-flight (Hard Rule #15)
 
 - [x] Read AGENTS.md Hard Rules for the touched paths.
 - [ ] Checked freshness headers.
 
-## Docs updated alongside code? (Hard Rule #13)
+## Docs updated alongside code? (Hard Rule #15)
 
 - [x] N/A — no docs invalidated by this change.
 `;

--- a/scripts/ci/validate-pr-body.mjs
+++ b/scripts/ci/validate-pr-body.mjs
@@ -30,15 +30,15 @@ export const REQUIRED_SECTIONS = [
   "What changed",
   "Why",
   "How to test",
-  "Pre-flight (Hard Rule #13)",
-  "Docs updated alongside code? (Hard Rule #13)",
+  "Pre-flight (Hard Rule #15)",
+  "Docs updated alongside code? (Hard Rule #15)",
 ];
 
 // Sections where at least one checkbox must be ticked. Each entry is the
 // heading text; the validator scans checkboxes until the next H2.
 export const SECTIONS_REQUIRING_TICK = [
-  "Pre-flight (Hard Rule #13)",
-  "Docs updated alongside code? (Hard Rule #13)",
+  "Pre-flight (Hard Rule #15)",
+  "Docs updated alongside code? (Hard Rule #15)",
 ];
 
 // ── Pure helpers (exported for tests) ────────────────────────────────────────


### PR DESCRIPTION
## What changed

Two follow-ups to merged PR #1158 (Wave 2e — `prefer-focus-visible`), both surfaced by Devin Review after the merge:

**A. Governance rule references renumbered `#13` → `#15`** (docs scope)

#1158 inserted a new `AGENTS.md` Hard Rule #14 (`prefer-focus-visible`) and renumbered the old "Read governance before coding; update docs alongside code" rule from #14 to #15. The PR updated `AGENTS.md` itself but missed five sibling files that still referenced the old `#13` number (which was already stale before #1158, and is now further off):

- `CLAUDE.md` (3 places — primary AI-agent governance file)
- `docs/playbooks/cleanup-dead-code.md` (1 place)
- `.github/PULL_REQUEST_TEMPLATE.md` (2 H2 headings)
- `scripts/ci/validate-pr-body.mjs` (`REQUIRED_SECTIONS` + `SECTIONS_REQUIRING_TICK` arrays)
- `scripts/ci/__tests__/validate-pr-body.test.mjs` (template fixture)

The PR template + validator + test are a tight coupling — they're updated in lock-step in commit 3 so the validator keeps matching the live template.

**B. `prefer-focus-visible` no longer double-reports `focus:outline-offset-*`** (eslint-plugins scope)

`focus:outline-offset-N` was matched by both regex arms in `findPreferFocusVisibleHits()`:
- The colour-utility arm (`RX_PREFER_FOCUS_VISIBLE`), because `"outline-offset"` is in `FOCUS_COLOR_UTILITIES`.
- The broader outline arm (`RX_PREFER_FOCUS_VISIBLE_OUTLINE`), because `tail = "offset-2"` is not in `FOCUS_OUTLINE_ALLOWED_TAILS`.

Each token produced two identical error messages. Fix: dedup the second arm by full match. Adds two unit tests (`flags focus:outline-offset-2 once, not twice`, `flags focus:outline-offset-4 once, not twice`).

## Why

Both issues were filed by Devin Review on #1158 ([review link](https://app.devin.ai/review/skords-01/sergeant/pull/1158)) after merge:

- BUG_…_0001 (🔴) — CLAUDE.md governance rule references not updated after renumbering.
- BUG_…_0002 (🟡) — ESLint rule double-reports `focus:outline-offset-*` tokens.

Per `AGENTS.md` Hard Rule #15's must-update table: *"Anything that invalidates an existing doc's claim → Update the doc in the same PR."* #1158 missed this for these files; this PR closes the gap. Bundling A + B keeps the audit-line follow-up to a single small PR (per handoff plan).

The scope-A files I added beyond the original Devin Review report (PR template + validator + test) were caught by `grep -rn "Hard Rule #13"` across the repo — they're the same governance-renumber issue and must move together with the validator to stay coherent.

## How to test

```bash
# Plugin tests — verifies B + dedup
pnpm lint:plugins

# PR-body validator tests — verifies A's coupled validator/test/template trio
node --test scripts/ci/__tests__/validate-pr-body.test.mjs

# Confirm zero stale references remain in the repo
grep -rn "Hard Rule #13" .   # → no matches
```

Manual sanity check on B (paste in a test fixture):
```js
// Before fix: 2 ESLint reports for one token; after fix: 1 report.
const c = "focus:outline-offset-2";
```

---

## Pre-flight (Hard Rule #15)

- [x] Read the `AGENTS.md` Hard Rules that apply to the touched paths (#15 governance + #14 focus-visible — same surface as #1158).
- [x] Read the matching playbook in `docs/playbooks/` (n/a — this is a docs-correction follow-up, no new code path).
- [x] Checked freshness headers of docs cited in the change (CLAUDE.md and cleanup-dead-code.md headers already current at 2026-04-29; small references-only edits don't invalidate the validation date).

## Docs updated alongside code? (Hard Rule #15)

- [ ] API contract change — `packages/api-client/**` types + contract test updated (Hard Rule #3).
- [ ] New / removed npm script — `CONTRIBUTING.md § Everyday Commands` and `CLAUDE.md § Quick commands` updated.
- [ ] New design token / component / palette — `docs/design/design-system.md` (and `BRANDBOOK.md` if branded) updated.
- [ ] Deprecation — `@deprecated` JSDoc with `@removeBy` added; consuming docs marked `> **Status:** Deprecated`.
- [ ] Freshness header bumped on docs whose claims changed (`> Last validated: YYYY-MM-DD by @owner`).
- [x] N/A — no docs invalidated by this change. **This PR _is_ the doc update** (closing the gap left by #1158).

## How AI-tested this PR

- [x] Manual smoke (which flow?): ran `pnpm lint:plugins` (250 tests pass, including the two new outline-offset cases) and `node --test scripts/ci/__tests__/validate-pr-body.test.mjs` (8 tests pass with the renumbered fixture).
- [x] Vitest passes: plugin suite via `node --test` (its native runner). No vitest-tracked code touched.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md` (commit messages stay English per Conventional Commits scope-list; the diff itself is verbatim rule-number swaps).
- [x] `pnpm dead-code:files` clean (or new files marked `@scaffolded`) — no new files added.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules. AGENTS.md was already correct; this PR brings sibling files into sync with it.

---

[Devin run](https://app.devin.ai/sessions/3249fc1db99e4aa3bde8c345ae45688d) · Requested by Лупа (zlupa005@gmail.com)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renumbered governance references from Hard Rule #13 to #15 across docs and CI, and fixed `prefer-focus-visible` to stop duplicate reports for `focus:outline-offset-*`. Keeps docs aligned with `AGENTS.md` and reduces noisy ESLint output.

- **Bug Fixes**
  - In `packages/eslint-plugin-sergeant-design`, dedup `focus:outline-offset-N` matches in `findPreferFocusVisibleHits()` so each token reports once; added two tests.

- **Docs/CI**
  - Updated Hard Rule references to #15 in `CLAUDE.md`, `docs/playbooks/cleanup-dead-code.md`, `.github/PULL_REQUEST_TEMPLATE.md`, `scripts/ci/validate-pr-body.mjs`, and `scripts/ci/__tests__/validate-pr-body.test.mjs` (template, validator, and fixture updated together).

<sup>Written for commit 1e945016fb13ece797f36ebae545211268cc35f8. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1159?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate error reporting in the `prefer-focus-visible` ESLint rule for certain utility class patterns.

* **Documentation**
  * Updated governance rule references in PR templates and workflow documentation.

* **Tests**
  * Added test coverage for deduplication behavior; updated PR body validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->