### PR TITLE
feat(shared): response-schema SSOT for /api/barcode (Hard Rule #3)

### DIFF
--- a/apps/mobile/src/modules/nutrition/lib/__tests__/applyBarcodeProduct.test.ts
+++ b/apps/mobile/src/modules/nutrition/lib/__tests__/applyBarcodeProduct.test.ts
@@ -6,11 +6,13 @@ describe("mealFormStateFromBarcodeProduct", () => {
     const p: BarcodeProduct = {
       name: "Milk",
       brand: "Test",
+      servingSize: null,
       servingGrams: 250,
       kcal_100g: 100,
       protein_100g: 3,
       fat_100g: 3.5,
       carbs_100g: 5,
+      source: "off",
     };
     const f = mealFormStateFromBarcodeProduct(p, "12345678");
     expect(f.name).toBe("Milk Test");

--- a/apps/server/src/modules/nutrition/barcode.ts
+++ b/apps/server/src/modules/nutrition/barcode.ts
@@ -1,4 +1,8 @@
 import type { Request, Response } from "express";
+import {
+  BarcodeLookupSuccessSchema,
+  type BarcodeProduct,
+} from "@sergeant/shared/schemas";
 import { recordExternalHttp } from "../../lib/externalHttp.js";
 import { elapsedMs } from "../../lib/timing.js";
 import { BarcodeQuerySchema } from "../../http/schemas.js";
@@ -13,18 +17,11 @@ import {
   type USDAFood,
 } from "../../lib/normalizers/index.js";
 
-interface NormalizedProduct {
-  name: string;
-  brand: string | null;
-  kcal_100g: number | null;
-  protein_100g: number | null;
-  fat_100g: number | null;
-  carbs_100g: number | null;
-  servingSize: string | null;
-  servingGrams: number | null;
-  source: "off" | "usda" | "upcitemdb";
-  partial?: boolean;
-}
+// SSOT for the barcode response shape lives in `@sergeant/shared/schemas`
+// (AGENTS.md Hard Rule #3). The server derives its internal type via
+// `z.infer<>` and asserts the outgoing payload against the schema before
+// `res.json()` so drift from the api-client types becomes a test failure.
+type NormalizedProduct = BarcodeProduct;
 
 // ──────────────────────────────────────────────────────────────────────────────
 // In-memory TTL cache for cascade results.
@@ -321,7 +318,9 @@ export default async function handler(
   const cached = cacheGet(barcode);
   if (cached) {
     if (cached.product) {
-      res.status(200).json({ product: cached.product });
+      res
+        .status(200)
+        .json(BarcodeLookupSuccessSchema.parse({ product: cached.product }));
     } else {
       res.status(404).json({ error: "Продукт не знайдено" });
     }
@@ -363,7 +362,7 @@ export default async function handler(
     }
 
     cacheSet(barcode, product);
-    res.status(200).json({ product });
+    res.status(200).json(BarcodeLookupSuccessSchema.parse({ product }));
   } catch (e: unknown) {
     if (hasErrorName(e, "TimeoutError") || hasErrorName(e, "AbortError")) {
       res

--- a/packages/api-client/src/endpoints/barcode.ts
+++ b/packages/api-client/src/endpoints/barcode.ts
@@ -1,20 +1,26 @@
+import type {
+  BarcodeProduct as SharedBarcodeProduct,
+  BarcodeLookupSuccess,
+  BarcodeLookupError,
+} from "@sergeant/shared/schemas";
 import type { HttpClient } from "../httpClient";
 
-export interface BarcodeProduct {
-  name?: string;
-  brand?: string;
-  servingGrams?: number;
-  kcal_100g?: number;
-  protein_100g?: number;
-  fat_100g?: number;
-  carbs_100g?: number;
-  partial?: boolean;
-}
+// Response shapes come from `@sergeant/shared/schemas` (AGENTS.md Hard
+// Rule #3 — single source of truth for API contracts). The server handler
+// in `apps/server/src/modules/nutrition/barcode.ts` validates its outgoing
+// payload against the same schema, so drift between these types and what
+// the server actually sends is caught at test time instead of silently in
+// production.
+//
+// Historical note: `BarcodeProduct` used to be declared here by hand with
+// every field marked optional (`name?: string`) even though the server
+// always returned `name: string`. That mismatch let consumers write code
+// guarding against an impossible `undefined`. The schema now locks down
+// which fields are truly nullable (brand, macros, serving, …) vs required.
+export type BarcodeProduct = SharedBarcodeProduct;
 
-export interface BarcodeLookupResponse {
-  product?: BarcodeProduct | null;
-  error?: string;
-}
+export type BarcodeLookupResponse = Partial<BarcodeLookupSuccess> &
+  Partial<BarcodeLookupError>;
 
 export interface BarcodeEndpoints {
   lookup: (barcode: string) => Promise<BarcodeLookupResponse>;

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -1,2 +1,3 @@
 export * from "./api";
 export * from "./finyk";
+export * from "./nutrition";

--- a/packages/shared/src/schemas/nutrition.test.ts
+++ b/packages/shared/src/schemas/nutrition.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import {
+  BarcodeProductSchema,
+  BarcodeLookupSuccessSchema,
+  BarcodeLookupErrorSchema,
+} from "./nutrition";
+
+describe("BarcodeProductSchema", () => {
+  it("accepts a fully-populated OFF product", () => {
+    const parsed = BarcodeProductSchema.parse({
+      name: "Milk 2%",
+      brand: "Yagotynske",
+      kcal_100g: 52,
+      protein_100g: 3.4,
+      fat_100g: 2,
+      carbs_100g: 4.8,
+      servingSize: "250 ml",
+      servingGrams: 250,
+      source: "off",
+    });
+    expect(parsed.brand).toBe("Yagotynske");
+    expect(parsed.partial).toBeUndefined();
+  });
+
+  it("accepts null for every nullable field except enum", () => {
+    const parsed = BarcodeProductSchema.parse({
+      name: "Unknown",
+      brand: null,
+      kcal_100g: null,
+      protein_100g: null,
+      fat_100g: null,
+      carbs_100g: null,
+      servingSize: null,
+      servingGrams: null,
+      source: "upcitemdb",
+      partial: true,
+    });
+    expect(parsed.brand).toBeNull();
+    expect(parsed.partial).toBe(true);
+  });
+
+  it("rejects an empty name", () => {
+    expect(() =>
+      BarcodeProductSchema.parse({
+        name: "",
+        brand: null,
+        kcal_100g: null,
+        protein_100g: null,
+        fat_100g: null,
+        carbs_100g: null,
+        servingSize: null,
+        servingGrams: null,
+        source: "off",
+      }),
+    ).toThrow();
+  });
+
+  it("rejects an unknown source value", () => {
+    expect(() =>
+      BarcodeProductSchema.parse({
+        name: "Milk",
+        brand: null,
+        kcal_100g: null,
+        protein_100g: null,
+        fat_100g: null,
+        carbs_100g: null,
+        servingSize: null,
+        servingGrams: null,
+        source: "barcoo",
+      }),
+    ).toThrow();
+  });
+
+  it("rejects undefined for a nullable field (guards against implicit absent)", () => {
+    expect(() =>
+      BarcodeProductSchema.parse({
+        name: "Milk",
+        // brand intentionally omitted
+        kcal_100g: null,
+        protein_100g: null,
+        fat_100g: null,
+        carbs_100g: null,
+        servingSize: null,
+        servingGrams: null,
+        source: "off",
+      }),
+    ).toThrow();
+  });
+});
+
+describe("BarcodeLookupSuccessSchema", () => {
+  it("wraps a valid product in `product`", () => {
+    const parsed = BarcodeLookupSuccessSchema.parse({
+      product: {
+        name: "Milk",
+        brand: null,
+        kcal_100g: 50,
+        protein_100g: 3,
+        fat_100g: 2,
+        carbs_100g: 5,
+        servingSize: null,
+        servingGrams: null,
+        source: "usda",
+      },
+    });
+    expect(parsed.product.name).toBe("Milk");
+  });
+
+  it("rejects a missing product envelope (server must never send just a bare product)", () => {
+    expect(() =>
+      BarcodeLookupSuccessSchema.parse({
+        name: "Milk",
+      }),
+    ).toThrow();
+  });
+});
+
+describe("BarcodeLookupErrorSchema", () => {
+  it("requires a non-empty error string", () => {
+    expect(
+      BarcodeLookupErrorSchema.parse({ error: "Продукт не знайдено" }).error,
+    ).toBe("Продукт не знайдено");
+    expect(() => BarcodeLookupErrorSchema.parse({ error: "" })).toThrow();
+  });
+});

--- a/packages/shared/src/schemas/nutrition.ts
+++ b/packages/shared/src/schemas/nutrition.ts
@@ -1,0 +1,69 @@
+import { z } from "zod";
+
+/**
+ * Response schemas for `apps/server/src/modules/nutrition/*`.
+ *
+ * SSOT pattern for AGENTS.md Hard Rule #3 — "API contract: server response
+ * shape ↔ api-client types ↔ test". Previously, the server handler
+ * declared a local `interface NormalizedProduct`, and `@sergeant/api-client`
+ * declared a separate `interface BarcodeProduct` by copy-paste. The two
+ * drifted (optional vs nullable fields, missing `source` / `servingSize`
+ * on the client). These schemas are the single source of truth; both
+ * sides now derive their types via `z.infer<>`.
+ *
+ * Pattern:
+ *   - Server handler imports the schema and calls `Schema.parse(payload)`
+ *     immediately before `res.json(payload)`. Shape mismatch throws at
+ *     runtime in tests, not silently in production.
+ *   - `@sergeant/api-client` re-exports `z.infer<typeof Schema>` instead of
+ *     hand-authoring a mirror interface.
+ *   - Any new response field moves through this file first, then both
+ *     ends compile-error until they use the new field.
+ */
+
+/**
+ * A single normalised product row returned by any of the three barcode
+ * upstreams (Open Food Facts / USDA Branded Foods / UPCitemdb). Every
+ * non-enum field is explicitly nullable — normalisers must not leave
+ * `undefined` lurking (consumers rely on `null` as the "absent" sentinel).
+ */
+export const BarcodeProductSchema = z.object({
+  name: z.string().min(1),
+  brand: z.string().nullable(),
+  kcal_100g: z.number().nullable(),
+  protein_100g: z.number().nullable(),
+  fat_100g: z.number().nullable(),
+  carbs_100g: z.number().nullable(),
+  servingSize: z.string().nullable(),
+  servingGrams: z.number().nullable(),
+  source: z.enum(["off", "usda", "upcitemdb"]),
+  // `partial` is only set by UPCitemdb today (macros missing, serving
+  // present); keep optional (not nullable) to avoid forcing other sources
+  // to emit it explicitly.
+  partial: z.boolean().optional(),
+});
+export type BarcodeProduct = z.infer<typeof BarcodeProductSchema>;
+
+/** Success envelope for `GET /api/barcode?barcode=…` (HTTP 200). */
+export const BarcodeLookupSuccessSchema = z.object({
+  product: BarcodeProductSchema,
+});
+export type BarcodeLookupSuccess = z.infer<typeof BarcodeLookupSuccessSchema>;
+
+/** Error envelope for `/api/barcode` (HTTP 400 / 404 / 500 / 504). */
+export const BarcodeLookupErrorSchema = z.object({
+  error: z.string().min(1),
+});
+export type BarcodeLookupError = z.infer<typeof BarcodeLookupErrorSchema>;
+
+/**
+ * Discriminated response — what the client actually observes across all
+ * status codes. Either `{ product }` on 200 or `{ error }` otherwise.
+ * `product` is optional at the type level (so the 404 branch is a valid
+ * value), matching the existing `BarcodeLookupResponse` semantics.
+ */
+export const BarcodeLookupResponseSchema = z.union([
+  BarcodeLookupSuccessSchema,
+  BarcodeLookupErrorSchema,
+]);
+export type BarcodeLookupResponse = z.infer<typeof BarcodeLookupResponseSchema>;


### PR DESCRIPTION
## What changed

Introduces `packages/shared/src/schemas/nutrition.ts` with Zod schemas for the `/api/barcode` response (`BarcodeProductSchema`, `BarcodeLookupSuccessSchema`, `BarcodeLookupErrorSchema`). Both the server handler and the api-client now derive their types from the same schema, and the server asserts the outgoing payload against it immediately before `res.json(...)`.

**Files touched (6):**
- `packages/shared/src/schemas/nutrition.ts` (new) — Zod SSOT for the barcode response.
- `packages/shared/src/schemas/nutrition.test.ts` (new) — 8 unit tests locking schema behaviour.
- `packages/shared/src/schemas/index.ts` — re-export.
- `apps/server/src/modules/nutrition/barcode.ts` — `import { BarcodeLookupSuccessSchema }` + `.parse()` before both `res.status(200).json(...)` call sites; internal `NormalizedProduct` is now `type = z.infer<>`.
- `packages/api-client/src/endpoints/barcode.ts` — `BarcodeProduct` / `BarcodeLookupResponse` are now `z.infer<>` of the shared schema; the drifted local interface is gone.
- `apps/mobile/src/modules/nutrition/lib/__tests__/applyBarcodeProduct.test.ts` — fixture updated to satisfy the stricter `source` + `servingSize` requirement.

## Why

AGENTS.md Hard Rule #3 says that for any response-shape change, three artifacts move together: server serializer, `@sergeant/api-client` type, and the test snapshot. Today this is enforced by code review only. `BarcodeProduct` is a real example of how that discipline silently fails:

| Field          | Server (actual)                  | api-client (before this PR) |
| -------------- | -------------------------------- | --------------------------- |
| `name`         | `string` (always non-empty)      | `string \| undefined`       |
| `brand`        | `string \| null`                 | `string \| undefined`       |
| `kcal_100g`    | `number \| null`                 | `number \| undefined`       |
| `servingSize`  | `string \| null`                 | field missing               |
| `source`       | `"off" \| "usda" \| "upcitemdb"`   | field missing               |

Consumers (`useBarcodeLookup`, `applyBarcodeProduct`, …) wrote `p.name ?? fallback` to guard against an impossible `undefined`, and missed the `source` discriminant entirely — so they couldn't distinguish "OFF found nothing, UPCitemdb partial" from "OFF complete", which is exactly why `partial` exists but only UPCitemdb sets it.

After this PR, the shape lives in exactly one place. A future field rename / addition becomes a compile error on both sides simultaneously.

This is the first in a series of per-endpoint SSOT migrations. Follow-ups will move `nutrition/analyze-photo`, `nutrition/refine-photo`, `coach/*`, `me`, `weekly-digest` to the same pattern. An ESLint rule that bans `res.json(...)` in `apps/server/src/modules/**` without a nearby `.parse()` call is the endgame — I'd rather build it after 3–5 endpoints exist so the rule has a real corpus to test against.

## How to test

```bash
# Schema itself (8 new tests)
pnpm --filter @sergeant/shared test

# Server handler still passes (21 tests)
pnpm --filter @sergeant/server exec vitest run src/modules/nutrition/barcode

# api-client still builds and typechecks
pnpm --filter @sergeant/api-client test

# Mobile fixture
pnpm --filter @sergeant/mobile exec jest applyBarcodeProduct

# Full repo
pnpm lint && pnpm typecheck
```

All green locally.

To verify the guard bites: flip one field in the Zod schema (e.g. `brand: z.string()` — drop `.nullable()`) and re-run the server test. It should fail with a Zod parse error on the "OFF product with null brand" case, not silently pass.

---

## Pre-flight (Hard Rule #13)

- [x] Read the `AGENTS.md` Hard Rules that apply to the touched paths — Rule #3 is the whole point of this PR; also noted #5 (scope `shared` chosen because the SSOT lives there) and #2 (no RQ-key changes).
- [x] Read the matching playbook in `docs/playbooks/` — `add-api-endpoint.md` describes the 3-way coordinated edit this PR implements as a typed pattern.
- [x] Checked freshness headers of docs cited in the change — none invalidated (AGENTS.md still current 2026-04-29).

## Docs updated alongside code? (Hard Rule #13)

- [x] API contract change — `packages/api-client/**` types + contract-equivalent schema tests updated (Hard Rule #3).
- [ ] New / removed npm script — n/a.
- [ ] New design token / component / palette — n/a.
- [ ] Deprecation — n/a (old inline interface is simply replaced; public export names are unchanged).
- [ ] Freshness header bumped on docs whose claims changed — n/a (no prose changed).
- [ ] N/A — no docs invalidated by this change.

## How AI-tested this PR

- [x] Manual smoke: none (pure-function refactor; runtime path exercised by existing 21 barcode handler tests).
- [x] Vitest passes: `@sergeant/shared` (340), `@sergeant/server` (barcode 21/21), `@sergeant/api-client` (55), mobile jest (applyBarcodeProduct 1/1).
- [x] No new `AI-DANGER` markers added.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md` — schema docstrings explain the SSOT pattern in English (matches existing `schemas/api.ts` style); no prose changes.
- [x] `pnpm dead-code:files` clean (no new files that wouldn't have importers).

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules. This PR operationalises an existing rule (#3) without changing what the rule says.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized the `/api/barcode` response in a shared Zod schema in `@sergeant/shared` and validated server responses against it. Server and `@sergeant/api-client` now share types from one source, fixing drift (e.g., `name` required, `brand` nullable, `servingSize`/`source` present).

- **Refactors**
  - Added `BarcodeProductSchema` and response envelopes in `packages/shared/src/schemas/nutrition.ts` with tests; re-exported from `schemas/index.ts`.
  - Server derives types from the schema and parses payloads before `res.json(...)` to catch shape mismatches in tests.
  - `@sergeant/api-client` now uses `z.infer` types from the shared schema; removed the hand-written `BarcodeProduct`/response interfaces.
  - Updated one mobile test fixture to satisfy the stricter shape (explicit nullables and `source`).

<sup>Written for commit 1041dbfd7033b15734678d52a6f9387cf029d14b. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1160?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

