### PR TITLE
test(web): add BottomNav E2E coverage for all 6 module entry-points

### DIFF
--- a/apps/web/tests/smoke/bottom-nav.spec.ts
+++ b/apps/web/tests/smoke/bottom-nav.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * BottomNav coverage — smoke E2E for the six top-level entry points the
+ * user can land on:
+ *
+ *   1. Hub  · Головна  (default `/`)
+ *   2. Hub  · Налаштування (clicked tab inside the hub `<nav>`)
+ *   3. Module · ФІНІК      (`/?module=finyk`)
+ *   4. Module · ФІЗРУК     (`/?module=fizruk`)
+ *   5. Module · РУТИНА     (`/?module=routine`)
+ *   6. Module · ХАРЧУВАННЯ (`/?module=nutrition`)
+ *
+ * Each module is tested via the canonical URL (the only entry the app
+ * supports for direct linking) AND via the `ModuleHeaderBackButton`
+ * (aria-label: "До хабу") which returns to the hub. Combined, that
+ * exercises both the forward (route → mount module shell) and the
+ * reverse (click → unmount module, remount HubBottomNav) navigation
+ * legs without touching dashboard tile internals (which depend on
+ * vibe-pick state and are out of scope for this lane).
+ *
+ * Tagged `@critical` so it lives on the per-PR smoke lane —
+ * `playwright.smoke.config.ts` (`--grep @critical`) — and not the
+ * nightly extended one. Module entry-points are core regressions that
+ * shouldn't wait for a 02:00 cron run.
+ */
+
+const SEEDED_LS: Record<string, string> = {
+  hub_onboarding_done_v1: "1",
+  hub_first_action_done_v1: "1",
+  hub_vibe_picks_v1: JSON.stringify({
+    picks: ["finyk", "fizruk", "nutrition", "routine"],
+    firstActionPending: null,
+    firstActionStartedAt: null,
+    firstRealEntryAt: Date.now(),
+    updatedAt: Date.now(),
+  }),
+};
+
+async function seedLocalStorage(page: Page) {
+  await page.addInitScript((entries: Record<string, string>) => {
+    try {
+      for (const [k, v] of Object.entries(entries)) {
+        window.localStorage.setItem(k, v);
+      }
+    } catch {
+      /* ignore */
+    }
+  }, SEEDED_LS);
+}
+
+const MODULES = [
+  { id: "finyk", title: "ФІНІК" },
+  { id: "fizruk", title: "ФІЗРУК" },
+  { id: "routine", title: "РУТИНА" },
+  { id: "nutrition", title: "ХАРЧУВАННЯ" },
+] as const;
+
+test("@critical bottom-nav: hub root mounts HubBottomNav and tab switching works", async ({
+  page,
+}) => {
+  await seedLocalStorage(page);
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+
+  const hubNav = page.getByRole("navigation", { name: "Розділи хабу" });
+  await expect(hubNav).toBeVisible({ timeout: 10_000 });
+
+  const dashboardTab = hubNav.getByRole("tab", { name: "Головна" });
+  const settingsTab = hubNav.getByRole("tab", { name: "Налаштування" });
+
+  // Precondition: dashboard is the default selected tab.
+  await expect(dashboardTab).toHaveAttribute("aria-selected", "true");
+  await expect(settingsTab).toHaveAttribute("aria-selected", "false");
+
+  await settingsTab.click();
+  await expect(settingsTab).toHaveAttribute("aria-selected", "true");
+  await expect(dashboardTab).toHaveAttribute("aria-selected", "false");
+
+  // Round-trip back to dashboard so the regression covers both
+  // directions of the toggle, not just forward.
+  await dashboardTab.click();
+  await expect(dashboardTab).toHaveAttribute("aria-selected", "true");
+  await expect(settingsTab).toHaveAttribute("aria-selected", "false");
+});
+
+for (const mod of MODULES) {
+  test(`@critical bottom-nav: ${mod.id} module mounts shell and back-to-hub returns to dashboard`, async ({
+    page,
+  }) => {
+    await seedLocalStorage(page);
+    await page.goto(`/?module=${mod.id}`, { waitUntil: "domcontentloaded" });
+
+    // Module shell mounted: header title visible AND hub `<nav>` is gone.
+    await expect(page.getByText(mod.title, { exact: true })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(
+      page.getByRole("navigation", { name: "Розділи хабу" }),
+    ).toHaveCount(0);
+
+    // Click the canonical "До хабу" back button. All four modules use
+    // `ModuleHeaderBackButton` from `@shared/components/layout/ModuleHeader`,
+    // so this aria-label is the single contract under test.
+    const backButton = page.getByRole("button", { name: "До хабу" }).first();
+    await expect(backButton).toBeVisible();
+    await backButton.click();
+
+    // Returned to hub: BottomNav is back, dashboard tab is selected,
+    // and the URL no longer carries a `module=` param.
+    const hubNav = page.getByRole("navigation", { name: "Розділи хабу" });
+    await expect(hubNav).toBeVisible({ timeout: 10_000 });
+    await expect(hubNav.getByRole("tab", { name: "Головна" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    await expect(page).toHaveURL(/^[^?]*\/?(?:#.*)?$/);
+  });
+}


### PR DESCRIPTION
## What changed

Adds `apps/web/tests/smoke/bottom-nav.spec.ts` with five `@critical`
Playwright tests that cover the canonical six top-level entry points a
Sergeant user can land on:

1. **Hub · Головна** (default `/`)
2. **Hub · Налаштування** (clicked tab inside the hub `<nav>`)
3. **Module · ФІНІК** (`/?module=finyk`)
4. **Module · ФІЗРУК** (`/?module=fizruk`)
5. **Module · РУТИНА** (`/?module=routine`)
6. **Module · ХАРЧУВАННЯ** (`/?module=nutrition`)

Two test shapes:

- **Hub tab toggle** — one test asserts `HubBottomNav` mounts at `/`,
  Головна is selected by default, clicking Налаштування flips
  `aria-selected`, and clicking back to Головна restores state. Both
  directions are covered so a one-way regression is caught.
- **Module entry-point + back-to-hub** — four parametrised tests (one per
  module) navigate via `/?module=<id>`, assert the module-header title
  is visible, assert the hub `<nav aria-label="Розділи хабу">` is no
  longer mounted (proves the module shell — not the hub — owns the
  layout), then click the canonical `ModuleHeaderBackButton`
  (`aria-label="До хабу"`) to return. The reverse leg asserts the hub
  nav re-mounts, Головна is re-selected, and the URL drops the
  `module=` query param.

Tests reuse the `seedLocalStorage` helper pattern from the sibling
smoke specs (`auth.spec.ts` / `dashboard-health.spec.ts` /
`navigation-offline-sw.spec.ts`) to skip first-action onboarding so the
dashboard renders deterministically. No new fixtures, no DB seeds —
pure client-routing coverage.

## Why

The existing Playwright smoke suite (`apps/web/tests/smoke/`) covers
auth and dashboard health but no test exercises the canonical six
entry points or the back-to-hub return path. The only existing
module-route coverage is `navigation-offline-sw.spec.ts` which is
`@extended` (runs nightly only) and just calls `goto()` — it does not
exercise the click path or the reverse navigation. Module entry-point
regressions therefore would not surface on per-PR CI today, only at
02:00 UTC the next night.

Tagging the new tests `@critical` puts them on the per-PR smoke lane
(`playwright.smoke.config.ts` runs with `--grep @critical`) so a broken
module URL or a missing `ModuleHeaderBackButton` aria-label fails the
PR check, not the next morning's nightly run.

## How to test

```bash
# Local — Playwright smoke lane (boots DB + API + web preview):
pnpm --filter @sergeant/web exec playwright test \
  -c playwright.smoke.config.ts --grep "@critical bottom-nav"

# Or run all @critical smoke tests to confirm no regression in the
# auth / dashboard-health tests:
pnpm --filter @sergeant/web exec playwright test \
  -c playwright.smoke.config.ts --grep @critical
```

CI runs the same `--grep @critical` lane via `.github/workflows/ci.yml`
(`Critical-flow E2E (Playwright)` job).

---

## Pre-flight (Hard Rule #15)

- [x] Read the `AGENTS.md` Hard Rules that apply to the touched paths.
- [x] Read the matching playbook in `docs/playbooks/` (or noted that none exists). — none specifically for adding Playwright smoke specs; followed the conventions in the three sibling smoke files.
- [x] Checked freshness headers of docs cited in the change. — n/a, no docs cited.

## Docs updated alongside code? (Hard Rule #15)

- [x] N/A — no docs invalidated by this change.

## How AI-tested this PR

- [x] Manual smoke (which flow?): static analysis only locally — `pnpm prettier --write`, `pnpm exec eslint`, and `pnpm --filter @sergeant/web exec tsc --noEmit` all pass on the new file. Full Playwright run delegated to CI's `Critical-flow E2E (Playwright)` job, which provisions Postgres + API + web preview.
- [x] Vitest passes: n/a — this is a Playwright spec, not a Vitest unit test.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`. — file-level comment is English (matches sibling smoke specs); user-facing strings under test are Ukrainian, matching the app.
- [x] `pnpm dead-code:files` clean (or new files marked `@scaffolded`). — Playwright spec is auto-discovered via `testDir: "./tests/smoke"`; no orphan-import scenario.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1163" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Playwright E2E coverage for BottomNav across all six top-level entry points and the back-to-hub flow. Tagged `@critical` so failures surface on per-PR CI instead of the nightly lane.

- **New Tests**
  - `apps/web/tests/smoke/bottom-nav.spec.ts`: 5 `@critical` tests.
  - Hub root: BottomNav mounts; switching between Головна and Налаштування flips `aria-selected` in both directions.
  - Modules (`finyk`, `fizruk`, `routine`, `nutrition`): open via `/?module=<id>`, assert module title, hub nav absent; click "До хабу" to return, hub nav visible, Головна selected, URL drops `module=`.
  - Seeds `localStorage` to skip onboarding; no DB seeds or new fixtures.

<sup>Written for commit 555ae43fad129545b998d85a7105a57f32a61b4f. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1163?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added smoke tests for bottom navigation and module switching functionality to ensure core user workflows operate as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->