### PR TITLE
feat(shared): response-schema SSOT for /api/weekly-digest (Hard Rule #3)

### DIFF
--- a/apps/server/src/modules/digest/weekly-digest.ts
+++ b/apps/server/src/modules/digest/weekly-digest.ts
@@ -4,7 +4,11 @@ import {
   extractAnthropicText,
 } from "../../lib/anthropic.js";
 import { validateBody } from "../../http/validate.js";
-import { WeeklyDigestSchema } from "../../http/schemas.js";
+import {
+  WeeklyDigestSchema,
+  WeeklyDigestReportSchema,
+  WeeklyDigestSuccessSchema,
+} from "../../http/schemas.js";
 import { ExternalServiceError, ValidationError } from "../../obs/errors.js";
 
 type WithAnthropicKey = Request & { anthropicKey?: string };
@@ -200,13 +204,32 @@ ${dataContext}`;
 
   const text = extractAnthropicText(aiData);
 
-  const report = extractJsonObject(text);
-  if (!report) {
+  const rawReport = extractJsonObject(text);
+  if (!rawReport) {
     throw new ExternalServiceError("Не вдалося розпарсити відповідь AI", {
       status: 502,
       code: "ANTHROPIC_PARSE_ERROR",
     });
   }
 
-  res.status(200).json({ report, generatedAt: new Date().toISOString() });
+  // Validate Claude's output against the schema (SSOT in
+  // `@sergeant/shared/schemas/api`; Hard Rule #3). Shape drift from the
+  // LLM becomes a 502 at the edge rather than typed lies reaching the UI.
+  const reportParse = WeeklyDigestReportSchema.safeParse(rawReport);
+  if (!reportParse.success) {
+    throw new ExternalServiceError(
+      "Відповідь AI не відповідає очікуваній структурі звіту",
+      {
+        status: 502,
+        code: "ANTHROPIC_SHAPE_MISMATCH",
+      },
+    );
+  }
+
+  res.status(200).json(
+    WeeklyDigestSuccessSchema.parse({
+      report: reportParse.data,
+      generatedAt: new Date().toISOString(),
+    }),
+  );
 }

--- a/apps/web/src/core/insights/useWeeklyDigest.ts
+++ b/apps/web/src/core/insights/useWeeklyDigest.ts
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { coachApi, weeklyDigestApi } from "@shared/api";
+import type { WeeklyDigestReport } from "@shared/api";
 import { STORAGE_KEYS, getWeekKey as sharedGetWeekKey } from "@sergeant/shared";
 import { safeReadLS } from "@shared/lib/storage";
 import { loadDigest as sharedLoadDigest } from "@shared/lib/weeklyDigestStorage";
@@ -371,7 +372,7 @@ export function aggregateRoutine(weekKey: string): RoutineAggregate | null {
 }
 
 async function generateWeeklyDigest(weekKey: string): Promise<{
-  report: unknown;
+  report: WeeklyDigestReport;
   generatedAt: string;
   weekKey: string;
   weekRange: string;
@@ -386,13 +387,20 @@ async function generateWeeklyDigest(weekKey: string): Promise<{
   // React Query (`isRetriableError` читає `.status`) і приховувало `kind`
   // від UI-селекторів. Консьюмери тепер читають `.serverMessage` через
   // `isApiError(query.error)`.
-  const json = (await weeklyDigestApi.generate({
+  const json = await weeklyDigestApi.generate({
     weekRange: currentWeekRange,
     finyk,
     fizruk,
     nutrition,
     routine,
-  })) as { report: unknown; generatedAt: string };
+  });
+
+  // `WeeklyDigestResponse` is a `{ report, generatedAt } | { error }` union;
+  // the HTTP client throws an `ApiError` on non-2xx, so by the time we reach
+  // this branch the response is the success variant. Narrow via `'report' in`.
+  if (!("report" in json)) {
+    throw new Error(json.error);
+  }
 
   return {
     report: json.report,
@@ -437,7 +445,7 @@ export function useWeeklyDigest(selectedWeekKey?: string) {
     mutationFn: generateWeeklyDigest,
     onSuccess: ({ report, generatedAt, weekKey: wk, weekRange: wr }) => {
       const newDigest = {
-        ...(report as object),
+        ...report,
         generatedAt,
         weekKey: wk,
         weekRange: wr,
@@ -454,7 +462,7 @@ export function useWeeklyDigest(selectedWeekKey?: string) {
               weekKey: wk,
               weekRange: wr,
               generatedAt,
-              ...(report as object),
+              ...report,
             },
           })
           .catch((err: unknown) => {
@@ -476,7 +484,7 @@ export function useWeeklyDigest(selectedWeekKey?: string) {
     try {
       const result = await mutateAsync(weekKey);
       return {
-        ...(result.report as object),
+        ...result.report,
         generatedAt: result.generatedAt,
         weekKey: result.weekKey,
         weekRange: result.weekRange,

--- a/apps/web/src/shared/api/index.ts
+++ b/apps/web/src/shared/api/index.ts
@@ -108,5 +108,6 @@ export type {
   SyncEndpoints,
   TokenProvider,
   WeeklyDigestPayload,
+  WeeklyDigestReport,
   WeeklyDigestResponse,
 } from "@sergeant/api-client";

--- a/packages/api-client/src/endpoints/weeklyDigest.ts
+++ b/packages/api-client/src/endpoints/weeklyDigest.ts
@@ -1,18 +1,26 @@
+import type {
+  WeeklyDigestRequest as SharedWeeklyDigestRequest,
+  WeeklyDigestResponse as SharedWeeklyDigestResponse,
+  WeeklyDigestReport as SharedWeeklyDigestReport,
+} from "@sergeant/shared/schemas";
 import type { HttpClient } from "../httpClient";
 
-export interface WeeklyDigestPayload {
-  weekRange: unknown;
-  finyk: unknown;
-  fizruk: unknown;
-  nutrition: unknown;
-  routine: unknown;
-}
+// SSOT for the `/api/weekly-digest` contract lives in
+// `@sergeant/shared/schemas/api` (AGENTS.md Hard Rule #3). Both the server
+// handler and this api-client derive their types from the same Zod schema;
+// the server additionally validates Claude's output against the schema
+// before it ever reaches this client.
+//
+// Historical: every field of both the request (`WeeklyDigestPayload`) and
+// the response (`WeeklyDigestResponse`) was typed as `unknown`, which was a
+// way to silence the type checker rather than describe the contract. The
+// request is a structured weekly-aggregate blob (`WeeklyDigestSchema`), and
+// the response is a four-module AI-generated report (`WeeklyDigestReportSchema`)
+// — both are now honestly typed.
 
-export interface WeeklyDigestResponse {
-  report?: unknown;
-  generatedAt?: string;
-  error?: string;
-}
+export type WeeklyDigestPayload = SharedWeeklyDigestRequest;
+export type WeeklyDigestReport = SharedWeeklyDigestReport;
+export type WeeklyDigestResponse = SharedWeeklyDigestResponse;
 
 export interface WeeklyDigestEndpoints {
   generate: (payload: WeeklyDigestPayload) => Promise<WeeklyDigestResponse>;

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -152,5 +152,6 @@ export {
   createWeeklyDigestEndpoints,
   type WeeklyDigestEndpoints,
   type WeeklyDigestPayload,
+  type WeeklyDigestReport,
   type WeeklyDigestResponse,
 } from "./endpoints/weeklyDigest";

--- a/packages/shared/src/schemas/api.ts
+++ b/packages/shared/src/schemas/api.ts
@@ -312,6 +312,79 @@ export const WeeklyDigestSchema = z.object({
   nutrition: NutritionDigestSchema.nullish(),
   routine: RoutineDigestSchema.nullish(),
 });
+/**
+ * Request payload type for `POST /api/weekly-digest`. Both the server handler
+ * and the api-client derive their types from `WeeklyDigestSchema` per Hard
+ * Rule #3 — the api-client's historical `WeeklyDigestPayload` typed every
+ * field as `unknown`, which was only a way to silence TypeScript rather than
+ * describe the contract.
+ */
+export type WeeklyDigestRequest = z.infer<typeof WeeklyDigestSchema>;
+
+// ── Weekly digest response ─────────────────────────────────────────────
+//
+// Response from `POST /api/weekly-digest`. The server prompts Claude for a
+// JSON blob with four module-specific analysis blocks + an overall
+// recommendations array (see the prompt template in
+// `apps/server/src/modules/digest/weekly-digest.ts`). The blob is the
+// contract with Claude; after `extractJsonObject` succeeds, we validate it
+// against `WeeklyDigestReportSchema` so a shape drift from the LLM becomes
+// a 502 `ANTHROPIC_PARSE_ERROR` at the edge rather than a typed lie going
+// all the way to the UI.
+//
+// Each module block is `.partial()` — Claude is explicitly instructed to
+// return `null` for modules with no input data, and `.nullable()` captures
+// that. `recommendations` is always an array of strings (the prompt asks
+// for it; an empty array is the "no recommendation" encoding).
+
+const DigestModuleBlockSchema = z
+  .object({
+    summary: z.string().max(500),
+    comment: z.string().max(2000),
+    recommendations: z.array(z.string().max(500)).max(20),
+  })
+  .nullable();
+
+/**
+ * The AI-generated digest body. Lives under `report` in the HTTP response.
+ * Shape is fixed by the system prompt in the server handler; if the prompt
+ * changes, update this schema in the same PR (Hard Rule #3).
+ */
+export const WeeklyDigestReportSchema = z.object({
+  finyk: DigestModuleBlockSchema,
+  fizruk: DigestModuleBlockSchema,
+  nutrition: DigestModuleBlockSchema,
+  routine: DigestModuleBlockSchema,
+  overallRecommendations: z.array(z.string().max(500)).max(30),
+});
+export type WeeklyDigestReport = z.infer<typeof WeeklyDigestReportSchema>;
+
+/**
+ * Success envelope: the parsed `report` plus an ISO timestamp used by the
+ * client as a "when was this generated" marker (persisted to localStorage
+ * alongside the report so the UI can show a relative time like "6h ago").
+ */
+export const WeeklyDigestSuccessSchema = z.object({
+  report: WeeklyDigestReportSchema,
+  generatedAt: z.string().min(1),
+});
+export type WeeklyDigestSuccess = z.infer<typeof WeeklyDigestSuccessSchema>;
+
+/** Error envelope — validation / Anthropic upstream / parse failures. */
+export const WeeklyDigestErrorSchema = z.object({
+  error: z.string().min(1),
+});
+export type WeeklyDigestErrorResponse = z.infer<typeof WeeklyDigestErrorSchema>;
+
+/**
+ * Discriminated response. Same `{ data } | { error }` shape as the other
+ * AI-backed endpoints in this file.
+ */
+export const WeeklyDigestResponseSchema = z.union([
+  WeeklyDigestSuccessSchema,
+  WeeklyDigestErrorSchema,
+]);
+export type WeeklyDigestResponse = z.infer<typeof WeeklyDigestResponseSchema>;
 
 // AI-NOTE: `dateContext` обов'язковий для адекватного темпорального
 // обрамлення інсайту (без нього модель імпровізує "середина тижня" в неділю).

--- a/packages/shared/src/schemas/weeklyDigest.test.ts
+++ b/packages/shared/src/schemas/weeklyDigest.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import {
+  WeeklyDigestReportSchema,
+  WeeklyDigestSuccessSchema,
+  WeeklyDigestErrorSchema,
+  WeeklyDigestResponseSchema,
+} from "./api";
+
+/**
+ * Lock `POST /api/weekly-digest` response contract (AGENTS.md Hard Rule #3).
+ * The server validates Claude's JSON against these schemas before emitting
+ * the 200 response, so any drift in the prompt output → here becomes a
+ * 502 at the edge, not a typed lie reaching the UI.
+ */
+
+const EMPTY_BLOCK = {
+  summary: "Нічого не відбулось.",
+  comment: "Даних за тиждень немає.",
+  recommendations: [],
+};
+const VALID_REPORT = {
+  finyk: EMPTY_BLOCK,
+  fizruk: EMPTY_BLOCK,
+  nutrition: EMPTY_BLOCK,
+  routine: EMPTY_BLOCK,
+  overallRecommendations: ["Пиши кожен день."],
+};
+
+describe("WeeklyDigestReportSchema", () => {
+  it("accepts a fully-populated report", () => {
+    const parsed = WeeklyDigestReportSchema.parse(VALID_REPORT);
+    expect(parsed.finyk?.summary).toBe("Нічого не відбулось.");
+    expect(parsed.overallRecommendations).toHaveLength(1);
+  });
+
+  it("accepts null module blocks (prompt's 'no data → null' contract)", () => {
+    const parsed = WeeklyDigestReportSchema.parse({
+      finyk: null,
+      fizruk: null,
+      nutrition: VALID_REPORT.nutrition,
+      routine: null,
+      overallRecommendations: [],
+    });
+    expect(parsed.finyk).toBeNull();
+    expect(parsed.nutrition).not.toBeNull();
+  });
+
+  it("rejects an empty overallRecommendations key being absent", () => {
+    const { overallRecommendations: _oa, ...rest } = VALID_REPORT;
+    void _oa;
+    expect(() => WeeklyDigestReportSchema.parse(rest)).toThrow();
+  });
+
+  it("rejects a module block missing `recommendations`", () => {
+    expect(() =>
+      WeeklyDigestReportSchema.parse({
+        ...VALID_REPORT,
+        finyk: { summary: "s", comment: "c" },
+      }),
+    ).toThrow();
+  });
+
+  it("caps per-recommendation length and per-block count (prompt-injection guardrail)", () => {
+    const tooLong = "x".repeat(501);
+    expect(() =>
+      WeeklyDigestReportSchema.parse({
+        ...VALID_REPORT,
+        finyk: {
+          summary: "ok",
+          comment: "ok",
+          recommendations: [tooLong],
+        },
+      }),
+    ).toThrow();
+
+    const tooMany = Array.from({ length: 21 }, (_, i) => `rec ${i}`);
+    expect(() =>
+      WeeklyDigestReportSchema.parse({
+        ...VALID_REPORT,
+        finyk: {
+          summary: "ok",
+          comment: "ok",
+          recommendations: tooMany,
+        },
+      }),
+    ).toThrow();
+  });
+});
+
+describe("WeeklyDigestSuccessSchema", () => {
+  it("wraps a valid report + ISO generatedAt", () => {
+    const parsed = WeeklyDigestSuccessSchema.parse({
+      report: VALID_REPORT,
+      generatedAt: "2026-04-29T12:00:00.000Z",
+    });
+    expect(parsed.generatedAt).toMatch(/^\d{4}/);
+  });
+
+  it("rejects empty generatedAt", () => {
+    expect(() =>
+      WeeklyDigestSuccessSchema.parse({
+        report: VALID_REPORT,
+        generatedAt: "",
+      }),
+    ).toThrow();
+  });
+
+  it("rejects a response with report omitted (must be explicit envelope)", () => {
+    expect(() =>
+      WeeklyDigestSuccessSchema.parse({
+        generatedAt: "2026-04-29T12:00:00.000Z",
+      }),
+    ).toThrow();
+  });
+});
+
+describe("WeeklyDigestErrorSchema", () => {
+  it("requires a non-empty error string", () => {
+    expect(
+      WeeklyDigestErrorSchema.parse({ error: "Quota exceeded" }).error,
+    ).toBe("Quota exceeded");
+    expect(() => WeeklyDigestErrorSchema.parse({ error: "" })).toThrow();
+  });
+});
+
+describe("WeeklyDigestResponseSchema", () => {
+  it("matches the success variant", () => {
+    const parsed = WeeklyDigestResponseSchema.parse({
+      report: VALID_REPORT,
+      generatedAt: "2026-04-29T12:00:00.000Z",
+    });
+    expect("report" in parsed).toBe(true);
+  });
+
+  it("matches the error variant", () => {
+    const parsed = WeeklyDigestResponseSchema.parse({
+      error: "Сервіс недоступний",
+    });
+    expect("error" in parsed).toBe(true);
+  });
+
+  it("rejects a shape that is neither success nor error", () => {
+    expect(() =>
+      WeeklyDigestResponseSchema.parse({ somethingElse: 1 }),
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
## What changed

Third SSOT migration in the Hard-Rule-3 sweep (after `/api/barcode` #1160 and `/api/food-search` #1162). Lifts the `/api/weekly-digest` contract into `@sergeant/shared/schemas/api`:

- **New Zod schemas** — `WeeklyDigestReportSchema` (AI-generated four-module report), `WeeklyDigestSuccessSchema` (`{ report, generatedAt }`), `WeeklyDigestErrorSchema`, `WeeklyDigestResponseSchema` (discriminated union). The existing `WeeklyDigestSchema` gets a public `WeeklyDigestRequest` type alias.
- **Server** (`apps/server/src/modules/digest/weekly-digest.ts`) — two-step validation:
  1. `WeeklyDigestReportSchema.safeParse(rawReport)` — Claude-output drift becomes a 502 `ANTHROPIC_SHAPE_MISMATCH` at the edge (parallel to the existing `ANTHROPIC_PARSE_ERROR` 502 for JSON parse failures).
  2. `WeeklyDigestSuccessSchema.parse(...)` — drift between the schema and what the handler constructs becomes a test-time failure.
- **api-client** (`packages/api-client/src/endpoints/weeklyDigest.ts`) — `WeeklyDigestPayload`, `WeeklyDigestReport`, `WeeklyDigestResponse` all derive via `z.infer<>` from the shared schema. Historical note: every field of the request **and** response was typed as `unknown` — a way to silence TypeScript rather than describe the contract.
- **Web** (`apps/web/src/core/insights/useWeeklyDigest.ts`) — drops three `as object` / `as { report: unknown; generatedAt: string }` casts now that `report` has a real type; adds a `"report" in json` narrow for the error variant of the union.
- **+12 unit tests** — `packages/shared/src/schemas/weeklyDigest.test.ts`. Cover: null module blocks (prompt's 'no data → null' contract), recommendation-length caps (prompt-injection guardrail), rejection of missing `overallRecommendations`, success/error variant parsing.

## Why

Hard Rule #3 requires server-response shape, api-client types and tests to move together. The weekly-digest endpoint was the worst offender in the repo on the 'silence-instead-of-describe' axis — **both** sides of the contract were all-`unknown`. Making the schema explicit also lets the server fail fast when the LLM regresses shape (previously: typed lies flowed to the UI, which would spread `report as object` and show a half-rendered digest).

Knock-on cleanup in `useWeeklyDigest.ts` was unavoidable: once `WeeklyDigestReport` has a real shape, the `as object` casts no longer typecheck. I took the smallest possible diff and left the downstream `WeeklyDigest` interface (`{ generatedAt; weekKey; weekRange; [key: string]: unknown }`) alone — tightening it is a separate refactor.

## How to test

- `pnpm --filter @sergeant/shared test` — **352 passing** (+12 new).
- `pnpm --filter @sergeant/web exec vitest run insights stories` — 84 passing.
- `pnpm --filter @sergeant/api-client test` — 55 passing.
- `pnpm typecheck` — all 15 packages.
- `pnpm lint` — all 15 packages clean.

---

## Pre-flight (Hard Rule #15)

- [x] Read the `AGENTS.md` Hard Rules that apply to the touched paths — Hard Rule #3.
- [x] Read the matching playbook in `docs/playbooks/` — `add-api-endpoint.md`.
- [x] Checked freshness headers of docs cited in the change — none invalidated.

## Docs updated alongside code? (Hard Rule #15)

- [x] API contract change — `packages/api-client/**` types + contract test updated (Hard Rule #3).
- [ ] New / removed npm script — n/a.
- [ ] New design token / component / palette — n/a.
- [ ] Deprecation — n/a.
- [ ] Freshness header bumped on docs whose claims changed — n/a.
- [ ] N/A — no docs invalidated by this change.

## How AI-tested this PR

- [x] Manual smoke: `pnpm typecheck`, `pnpm lint`, shared/web/api-client vitest suites — all green locally.
- [x] Vitest passes: 352 shared + 84 web insights/stories + 55 api-client.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md` — server error message is Ukrainian ('Відповідь AI не відповідає очікуваній структурі звіту').
- [x] `pnpm dead-code:files` clean (or new files marked `@scaffolded`) — only one new test file.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — routine Hard-Rule-3 migration following the same pattern as #1160 and #1162.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1164" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized the `/api/weekly-digest` response with a shared schema in `@sergeant/shared/schemas/api` and enforced strict server-side validation. The api-client and web now use these types, replacing `unknown` and blocking malformed model output from reaching the UI. (Hard Rule #3 SSOT migration)

- **New Features**
  - Added `WeeklyDigestReportSchema`, `WeeklyDigestSuccessSchema`, `WeeklyDigestErrorSchema`, `WeeklyDigestResponseSchema` in `@sergeant/shared/schemas/api`, plus `WeeklyDigestRequest` and `WeeklyDigestReport` types.
  - Server returns 502 `ANTHROPIC_SHAPE_MISMATCH` when the model’s report shape is wrong; keeps 502 `ANTHROPIC_PARSE_ERROR` for JSON parse failures.

- **Refactors**
  - Server validates the report with `WeeklyDigestReportSchema.safeParse`, then wraps with `WeeklyDigestSuccessSchema.parse` before responding.
  - `@sergeant/api-client` derives `WeeklyDigestPayload`, `WeeklyDigestReport`, and `WeeklyDigestResponse` from the shared schema; removed `unknown` types.
  - Web `useWeeklyDigest` drops unsafe casts and narrows the union via `'report' in json'`.
  - Added 12 tests to lock the contract (null blocks, recommendation caps, missing `overallRecommendations`, success/error parsing).

<sup>Written for commit 347b9ec5c1e4b9fdfa29469294c34138495791f4. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1164?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for weekly digest generation with stricter data integrity checks and improved error responses when validation fails.

* **Tests**
  * Added comprehensive test coverage for weekly digest response validation, schema compliance, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->