### PR TITLE
feat(web): hubchat tool-call undo contract for 4 mutators

### DIFF
--- a/apps/web/src/core/hub/HubChat.tsx
+++ b/apps/web/src/core/hub/HubChat.tsx
@@ -433,6 +433,24 @@ function HubChat({
           content: handlerResults[idx]?.result ?? "",
         }));
 
+        // Mutator-handler-и (`create_transaction`, `mark_habit_done`,
+        // `log_meal`, `create_habit`, …) повертають `{ undo }` поряд з
+        // текстовим результатом. Показуємо стандартний 5-секундний
+        // undo-toast для кожного — `showUndoToast` сам повертає taimer
+        // (overlap-stack тут прийнятний: один tool-call на 99 % турнів,
+        // у дуже рідкісному випадку 2-3 одночасних змін юзер бачить
+        // окремий toast на кожну). Read-only handler-и (search,
+        // підрахунки, summaries) `undo` не мають — toast не показується.
+        for (const hr of handlerResults) {
+          if (hr.undo) {
+            const undoFn = hr.undo;
+            showUndoToast(toast, {
+              msg: hr.result,
+              onUndo: undoFn,
+            });
+          }
+        }
+
         const actionsText = toolResults
           .map((r) => `✅ ${r.content}`)
           .join("\n");

--- a/apps/web/src/core/lib/chatActions/crossActions.ts
+++ b/apps/web/src/core/lib/chatActions/crossActions.ts
@@ -39,6 +39,7 @@ import type {
   Workout,
   NutritionDay,
   ChatAction,
+  ChatActionResult,
 } from "./types";
 
 /**
@@ -103,7 +104,9 @@ function diffLine(label: string, a: number, b: number, unit: string): string {
   return `${label}: ${a}${unit} vs ${b}${unit} (${sign}${delta}${unit})`;
 }
 
-export function handleCrossAction(action: ChatAction): string | undefined {
+export function handleCrossAction(
+  action: ChatAction,
+): ChatActionResult | undefined {
   switch (action.name) {
     case "morning_briefing": {
       const now = new Date();

--- a/apps/web/src/core/lib/chatActions/finykActions.test.ts
+++ b/apps/web/src/core/lib/chatActions/finykActions.test.ts
@@ -15,10 +15,10 @@ afterEach(() => {
 
 function call(action: ChatAction): string {
   const out = handleFinykAction(action);
-  if (typeof out !== "string") {
-    throw new Error(`handler returned ${typeof out}, expected string`);
+  if (out == null) {
+    throw new Error(`handler returned ${typeof out}, expected string|object`);
   }
-  return out;
+  return typeof out === "string" ? out : out.result;
 }
 
 // ---------------------------------------------------------------------------
@@ -710,5 +710,79 @@ describe("export_report", () => {
     expect(typeof out).toBe("string");
     expect(out).toContain("Дохід");
     expect(out).toContain("Витрати");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// create_transaction · undo
+// ---------------------------------------------------------------------------
+describe("create_transaction · undo", () => {
+  it("повертає {undo} який видаляє щойно створену транзакцію", () => {
+    const out = handleFinykAction({
+      name: "create_transaction",
+      input: { amount: 250, description: "кава" },
+    });
+    if (typeof out === "string" || out == null) {
+      throw new Error(`expected undoable result, got ${typeof out}`);
+    }
+    expect(out.result).toContain("250");
+    const before = JSON.parse(
+      localStorage.getItem("finyk_manual_expenses_v1") || "[]",
+    );
+    expect(before).toHaveLength(1);
+
+    out.undo();
+
+    const after = JSON.parse(
+      localStorage.getItem("finyk_manual_expenses_v1") || "[]",
+    );
+    expect(after).toHaveLength(0);
+  });
+
+  it("undo не зачіпає інші транзакції що з'явились пізніше", () => {
+    const first = handleFinykAction({
+      name: "create_transaction",
+      input: { amount: 50, description: "перша" },
+    });
+    if (typeof first === "string" || first == null)
+      throw new Error("expected object");
+
+    // Емулюємо додавання другої транзакції після першої
+    handleFinykAction({
+      name: "create_transaction",
+      input: { amount: 100, description: "друга" },
+    });
+
+    first.undo();
+
+    const after = JSON.parse(
+      localStorage.getItem("finyk_manual_expenses_v1") || "[]",
+    );
+    expect(after).toHaveLength(1);
+    expect(after[0].description).toBe("друга");
+  });
+
+  it("undo ідемпотентний — другий виклик нічого не ламає", () => {
+    const out = handleFinykAction({
+      name: "create_transaction",
+      input: { amount: 250 },
+    });
+    if (typeof out === "string" || out == null)
+      throw new Error("expected object");
+
+    out.undo();
+    expect(() => out.undo()).not.toThrow();
+    const after = JSON.parse(
+      localStorage.getItem("finyk_manual_expenses_v1") || "[]",
+    );
+    expect(after).toHaveLength(0);
+  });
+
+  it("error path (некоректна сума) повертає string без undo", () => {
+    const out = handleFinykAction({
+      name: "create_transaction",
+      input: { amount: 0 },
+    });
+    expect(typeof out).toBe("string");
   });
 });

--- a/apps/web/src/core/lib/chatActions/finykActions.ts
+++ b/apps/web/src/core/lib/chatActions/finykActions.ts
@@ -28,6 +28,7 @@ import type {
   BudgetGoal,
   MonthlyPlan,
   ChatAction,
+  ChatActionResult,
 } from "./types";
 
 type FinykSearchTx = {
@@ -182,7 +183,9 @@ function formatTxList(items: FinykSearchTx[]): string {
     .join("; ");
 }
 
-export function handleFinykAction(action: ChatAction): string | undefined {
+export function handleFinykAction(
+  action: ChatAction,
+): ChatActionResult | undefined {
   switch (action.name) {
     case "change_category": {
       const { tx_id, category_id } = (action as ChangeCategoryAction).input;
@@ -386,7 +389,24 @@ export function handleFinykAction(action: ChatAction): string | undefined {
       lsSet("finyk_manual_expenses_v1", manualExpenses);
       const label = categoryLabel ? ` (${categoryLabel})` : "";
       const human = txType === "income" ? "Дохід" : "Витрату";
-      return `${human} ${amt} грн${description ? ` "${description.trim()}"` : ""}${label} записано (id:${manualId})`;
+      const result = `${human} ${amt} грн${description ? ` "${description.trim()}"` : ""}${label} записано (id:${manualId})`;
+      // Undo видаляє щойно додану транзакцію за `manualId`. Якщо юзер
+      // паралельно встиг видалити її іншим шляхом — ідемпотентно
+      // нічого не робимо (а не throw): двічі натиснений undo не має
+      // дати "не вдалось повернути".
+      return {
+        result,
+        undo: () => {
+          const current = ls<Array<{ id: string }>>(
+            "finyk_manual_expenses_v1",
+            [],
+          );
+          const next = current.filter((tx) => tx.id !== manualId);
+          if (next.length !== current.length) {
+            lsSet("finyk_manual_expenses_v1", next);
+          }
+        },
+      };
     }
     case "delete_transaction": {
       const { tx_id } = (action as DeleteTransactionAction).input;

--- a/apps/web/src/core/lib/chatActions/fizrukActions.test.ts
+++ b/apps/web/src/core/lib/chatActions/fizrukActions.test.ts
@@ -15,10 +15,10 @@ afterEach(() => {
 
 function call(action: ChatAction): string {
   const out = handleFizrukAction(action);
-  if (typeof out !== "string") {
-    throw new Error(`handler returned ${typeof out}, expected string`);
+  if (out == null) {
+    throw new Error(`handler returned ${typeof out}, expected string|object`);
   }
-  return out;
+  return typeof out === "string" ? out : out.result;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/core/lib/chatActions/fizrukActions.ts
+++ b/apps/web/src/core/lib/chatActions/fizrukActions.ts
@@ -17,6 +17,7 @@ import type {
   WorkoutItem,
   Workout,
   ChatAction,
+  ChatActionResult,
 } from "./types";
 
 function readWorkouts(): Workout[] {
@@ -33,7 +34,9 @@ function readWorkouts(): Workout[] {
   return [];
 }
 
-export function handleFizrukAction(action: ChatAction): string | undefined {
+export function handleFizrukAction(
+  action: ChatAction,
+): ChatActionResult | undefined {
   switch (action.name) {
     case "plan_workout": {
       const { date, time, note, exercises } =

--- a/apps/web/src/core/lib/chatActions/nutritionActions.test.ts
+++ b/apps/web/src/core/lib/chatActions/nutritionActions.test.ts
@@ -15,10 +15,10 @@ afterEach(() => {
 
 function call(action: ChatAction): string {
   const out = handleNutritionAction(action);
-  if (typeof out !== "string") {
-    throw new Error(`handler returned ${typeof out}, expected string`);
+  if (out == null) {
+    throw new Error(`handler returned ${typeof out}, expected string|object`);
   }
-  return out;
+  return typeof out === "string" ? out : out.result;
 }
 
 // ---------------------------------------------------------------------------
@@ -441,5 +441,63 @@ describe("plan_meals_for_day", () => {
     expect(typeof out).toBe("string");
     expect(out).toContain("вегетаріанська");
     expect(out).toContain("Рекомендацію");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// log_meal · undo
+// ---------------------------------------------------------------------------
+describe("log_meal · undo", () => {
+  it("повертає {undo} що видаляє щойно доданий прийом", () => {
+    const out = handleNutritionAction({
+      name: "log_meal",
+      input: { name: "Сніданок", kcal: 450 },
+    });
+    if (typeof out === "string" || out == null) {
+      throw new Error(`expected undoable result, got ${typeof out}`);
+    }
+    expect(out.result).toContain("Сніданок");
+    const before = JSON.parse(localStorage.getItem("nutrition_log_v1") || "{}");
+    expect(before["2026-04-22"].meals).toHaveLength(1);
+
+    out.undo();
+
+    const after = JSON.parse(localStorage.getItem("nutrition_log_v1") || "{}");
+    // Day is removed entirely коли meals = 0 (cleanup empty days).
+    expect(after["2026-04-22"]).toBeUndefined();
+  });
+
+  it("undo прибирає тільки свій прийом, інші лишаються", () => {
+    const first = handleNutritionAction({
+      name: "log_meal",
+      input: { name: "Перший", kcal: 100 },
+    });
+    if (typeof first === "string" || first == null)
+      throw new Error("expected object");
+
+    // Просуваємо час щоб другий meal отримав інший id
+    vi.advanceTimersByTime(1000);
+    handleNutritionAction({
+      name: "log_meal",
+      input: { name: "Другий", kcal: 200 },
+    });
+
+    first.undo();
+
+    const after = JSON.parse(localStorage.getItem("nutrition_log_v1") || "{}");
+    expect(after["2026-04-22"].meals).toHaveLength(1);
+    expect(after["2026-04-22"].meals[0].name).toBe("Другий");
+  });
+
+  it("undo ідемпотентний — повторний виклик не кидає", () => {
+    const out = handleNutritionAction({
+      name: "log_meal",
+      input: { name: "Обід", kcal: 600 },
+    });
+    if (typeof out === "string" || out == null)
+      throw new Error("expected object");
+
+    out.undo();
+    expect(() => out.undo()).not.toThrow();
   });
 });

--- a/apps/web/src/core/lib/chatActions/nutritionActions.ts
+++ b/apps/web/src/core/lib/chatActions/nutritionActions.ts
@@ -14,9 +14,12 @@ import type {
   NutritionMeal,
   NutritionDay,
   ChatAction,
+  ChatActionResult,
 } from "./types";
 
-export function handleNutritionAction(action: ChatAction): string | undefined {
+export function handleNutritionAction(
+  action: ChatAction,
+): ChatActionResult | undefined {
   switch (action.name) {
     case "log_meal": {
       const { name, kcal, protein_g, fat_g, carbs_g } = (
@@ -38,8 +41,9 @@ export function handleNutritionAction(action: ChatAction): string | undefined {
       const meals: NutritionMeal[] = Array.isArray(dayData.meals)
         ? dayData.meals.slice()
         : [];
+      const mealId = `m_${Date.now()}`;
       meals.push({
-        id: `m_${Date.now()}`,
+        id: mealId,
         name: name || "Без назви",
         macros: {
           kcal: Number(kcal) || 0,
@@ -51,7 +55,27 @@ export function handleNutritionAction(action: ChatAction): string | undefined {
       });
       nutritionLog[todayKey] = { ...dayData, meals };
       lsSet("nutrition_log_v1", nutritionLog);
-      return `Прийом їжі "${name || "Без назви"}" записано: ${Math.round(Number(kcal) || 0)} ккал`;
+      const result = `Прийом їжі "${name || "Без назви"}" записано: ${Math.round(Number(kcal) || 0)} ккал`;
+      return {
+        result,
+        undo: () => {
+          const cur = ls<Record<string, NutritionDay>>("nutrition_log_v1", {});
+          const day = cur[todayKey];
+          if (!day || !Array.isArray(day.meals)) return;
+          const next = day.meals.filter((m) => m.id !== mealId);
+          if (next.length === day.meals.length) return;
+          if (next.length === 0) {
+            const { [todayKey]: _removed, ...rest } = cur;
+            void _removed;
+            lsSet("nutrition_log_v1", rest);
+          } else {
+            lsSet("nutrition_log_v1", {
+              ...cur,
+              [todayKey]: { ...day, meals: next },
+            });
+          }
+        },
+      };
     }
     case "log_water": {
       const { amount_ml, date: waterDate } = (action as LogWaterAction).input;

--- a/apps/web/src/core/lib/chatActions/routineActions.test.ts
+++ b/apps/web/src/core/lib/chatActions/routineActions.test.ts
@@ -15,10 +15,10 @@ afterEach(() => {
 
 function call(action: ChatAction): string {
   const out = handleRoutineAction(action);
-  if (typeof out !== "string") {
-    throw new Error(`handler returned ${typeof out}, expected string`);
+  if (out == null) {
+    throw new Error(`handler returned ${typeof out}, expected string|object`);
   }
-  return out;
+  return typeof out === "string" ? out : out.result;
 }
 
 function seedHabit(id: string, name: string, extra?: Record<string, unknown>) {
@@ -560,5 +560,122 @@ describe("habit_trend", () => {
     const out = call({ name: "habit_trend", input: { period_days: 14 } });
     expect(typeof out).toBe("string");
     expect(out.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// create_habit · undo
+// ---------------------------------------------------------------------------
+describe("create_habit · undo", () => {
+  it("повертає {undo} що видаляє створену звичку", () => {
+    const out = handleRoutineAction({
+      name: "create_habit",
+      input: { name: "Біг" },
+    });
+    if (typeof out === "string" || out == null) {
+      throw new Error(`expected undoable result, got ${typeof out}`);
+    }
+    expect(out.result).toContain("Біг");
+    const before = JSON.parse(localStorage.getItem("hub_routine_v1") || "{}");
+    expect(before.habits).toHaveLength(1);
+    const createdId = before.habits[0].id;
+
+    out.undo();
+
+    const after = JSON.parse(localStorage.getItem("hub_routine_v1") || "{}");
+    expect(
+      after.habits.find((h: { id: string }) => h.id === createdId),
+    ).toBeUndefined();
+  });
+
+  it("undo прибирає completions для видаленої звички (cleanup)", () => {
+    const out = handleRoutineAction({
+      name: "create_habit",
+      input: { name: "Йога" },
+    });
+    if (typeof out === "string" || out == null)
+      throw new Error("expected object");
+
+    // Додаємо completion вручну, щоб перевірити що undo чистить його теж.
+    const state = JSON.parse(localStorage.getItem("hub_routine_v1")!);
+    const createdId = state.habits[0].id;
+    state.completions = {
+      ...(state.completions || {}),
+      [createdId]: ["2024-06-15"],
+    };
+    localStorage.setItem("hub_routine_v1", JSON.stringify(state));
+
+    out.undo();
+
+    const after = JSON.parse(localStorage.getItem("hub_routine_v1") || "{}");
+    expect(after.completions[createdId]).toBeUndefined();
+  });
+
+  it("error path (порожня назва) повертає string без undo", () => {
+    const out = handleRoutineAction({
+      name: "create_habit",
+      input: { name: "   " },
+    });
+    expect(typeof out).toBe("string");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mark_habit_done · undo
+// ---------------------------------------------------------------------------
+describe("mark_habit_done · undo", () => {
+  it("повертає {undo} що прибирає completion для дати", () => {
+    seedHabit("h1", "Вода");
+    const out = handleRoutineAction({
+      name: "mark_habit_done",
+      input: { habit_id: "h1", date: "2024-06-15" },
+    });
+    if (typeof out === "string" || out == null) {
+      throw new Error(`expected undoable result, got ${typeof out}`);
+    }
+    const before = JSON.parse(localStorage.getItem("hub_routine_v1")!);
+    expect(before.completions.h1).toContain("2024-06-15");
+
+    out.undo();
+
+    const after = JSON.parse(localStorage.getItem("hub_routine_v1")!);
+    expect(after.completions.h1 ?? []).not.toContain("2024-06-15");
+  });
+
+  it("якщо дата вже була виконана — повертає string без undo (no-op)", () => {
+    seedHabit("h1", "Вода");
+    // Перший виклик — вставляємо completion
+    const first = handleRoutineAction({
+      name: "mark_habit_done",
+      input: { habit_id: "h1", date: "2024-06-15" },
+    });
+    expect(typeof first).toBe("object");
+
+    // Другий виклик з тією ж датою — completion вже є, undo не потрібен
+    const second = handleRoutineAction({
+      name: "mark_habit_done",
+      input: { habit_id: "h1", date: "2024-06-15" },
+    });
+    expect(typeof second).toBe("string");
+  });
+
+  it("undo не зачіпає інші дати того ж habit-а", () => {
+    seedHabit("h1", "Вода");
+    handleRoutineAction({
+      name: "mark_habit_done",
+      input: { habit_id: "h1", date: "2024-06-13" },
+    });
+    const out = handleRoutineAction({
+      name: "mark_habit_done",
+      input: { habit_id: "h1", date: "2024-06-15" },
+    });
+    if (typeof out === "string" || out == null)
+      throw new Error("expected object");
+
+    out.undo();
+
+    const after = JSON.parse(localStorage.getItem("hub_routine_v1")!);
+    expect(after.completions.h1).toContain("2024-06-13");
+    expect(after.completions.h1).not.toContain("2024-06-15");
   });
 });

--- a/apps/web/src/core/lib/chatActions/routineActions.ts
+++ b/apps/web/src/core/lib/chatActions/routineActions.ts
@@ -18,6 +18,7 @@ import type {
   PauseHabitAction,
   HabitState,
   ChatAction,
+  ChatActionResult,
 } from "./types";
 
 // Mon-first 0..6 — matches `@sergeant/routine-domain` `isoWeekdayFromDateKey`
@@ -58,7 +59,9 @@ function normalizeDayToken(token: unknown): number | null {
   return typeof idx === "number" ? idx : null;
 }
 
-export function handleRoutineAction(action: ChatAction): string | undefined {
+export function handleRoutineAction(
+  action: ChatAction,
+): ChatActionResult | undefined {
   switch (action.name) {
     case "mark_habit_done": {
       const { habit_id, date: habitDate } = (action as MarkHabitDoneAction)
@@ -78,14 +81,39 @@ export function handleRoutineAction(action: ChatAction): string | undefined {
           String(now.getMonth() + 1).padStart(2, "0"),
           String(now.getDate()).padStart(2, "0"),
         ].join("-");
-      const arr = Array.isArray(completions[habit_id])
+      const prevArr = Array.isArray(completions[habit_id])
         ? completions[habit_id].slice()
         : [];
-      if (!arr.includes(targetDate)) arr.push(targetDate);
+      const alreadyDone = prevArr.includes(targetDate);
+      const arr = alreadyDone ? prevArr : [...prevArr, targetDate];
       completions[habit_id] = arr;
       lsSet("hub_routine_v1", { ...routineState, completions });
       const habit = (routineState.habits || []).find((h) => h.id === habit_id);
-      return `Звичку "${habit?.name || habit_id}" відмічено як виконану (${targetDate})`;
+      const result = `Звичку "${habit?.name || habit_id}" відмічено як виконану (${targetDate})`;
+      // Якщо звичка вже була в completions до виклику — undo нічого не
+      // робить (no-op); інакше прибираємо `targetDate` зі списку.
+      if (alreadyDone) {
+        return result;
+      }
+      return {
+        result,
+        undo: () => {
+          const cur = ls<HabitState>("hub_routine_v1", {
+            habits: [],
+            completions: {},
+          });
+          const curCompletions = { ...(cur.completions || {}) };
+          const list = Array.isArray(curCompletions[habit_id])
+            ? curCompletions[habit_id].filter((d) => d !== targetDate)
+            : [];
+          if (list.length > 0) {
+            curCompletions[habit_id] = list;
+          } else {
+            delete curCompletions[habit_id];
+          }
+          lsSet("hub_routine_v1", { ...cur, completions: curCompletions });
+        },
+      };
     }
     case "create_habit": {
       const {
@@ -115,8 +143,8 @@ export function handleRoutineAction(action: ChatAction): string | undefined {
         timeOfDay && /^\d{1,2}:\d{2}$/.test(String(timeOfDay).trim())
           ? String(timeOfDay).trim().padStart(5, "0")
           : "";
-      const state = loadRoutineState();
-      const nextState = routineCreateHabit(state, {
+      const stateBefore = loadRoutineState();
+      const nextState = routineCreateHabit(stateBefore, {
         name: trimmed,
         emoji: emoji || "✓",
         recurrence: rec,
@@ -124,6 +152,7 @@ export function handleRoutineAction(action: ChatAction): string | undefined {
         timeOfDay: tod,
       });
       const created = nextState.habits[nextState.habits.length - 1];
+      const createdId = created?.id;
       const recLabelMap: Record<string, string> = {
         daily: "щодня",
         weekdays: "по буднях",
@@ -131,7 +160,28 @@ export function handleRoutineAction(action: ChatAction): string | undefined {
         monthly: "щомісяця",
         once: "разово",
       };
-      return `Звичку "${trimmed}" створено (${recLabelMap[rec] || rec}, id:${created?.id || "?"})`;
+      const result = `Звичку "${trimmed}" створено (${recLabelMap[rec] || rec}, id:${createdId || "?"})`;
+      if (!createdId) return result;
+      // Undo тримає id (а не повний snapshot), щоб не переписувати
+      // інші зміни, які можуть статися між створенням і undo
+      // (інша звичка створена, completions додані, etc.).
+      return {
+        result,
+        undo: () => {
+          const cur = loadRoutineState();
+          const habits = Array.isArray(cur.habits)
+            ? cur.habits.filter((h) => h.id !== createdId)
+            : [];
+          if (habits.length === (cur.habits?.length ?? 0)) return;
+          const curCompletions = { ...(cur.completions || {}) };
+          delete curCompletions[createdId];
+          lsSet("hub_routine_v1", {
+            ...cur,
+            habits,
+            completions: curCompletions,
+          });
+        },
+      };
     }
     case "create_reminder": {
       const { habit_id, time } = (action as CreateReminderAction).input;

--- a/apps/web/src/core/lib/chatActions/types.ts
+++ b/apps/web/src/core/lib/chatActions/types.ts
@@ -1,5 +1,32 @@
 import type { ModuleAccent } from "@sergeant/design-tokens";
 
+/**
+ * Виконані mutator-handler-и можуть опційно повернути об'єкт з полем
+ * `undo`, яке HubChat сам пропустить через `showUndoToast`. Read-only
+ * tools (`find_transaction`, `weekly_summary`, …) залишаються
+ * `string` — там нема що реверсити. Це навмисно дискриміноване
+ * об'єднання, а не загальне `unknown`-розширення: тип дозволяє
+ * перевіряти `typeof out === "string"` як «не було undo» без додаткових
+ * runtime-перевірок.
+ */
+export interface ChatActionUndoableResult {
+  /** Текст для `tool_result` (та чату). Identical до того, що раніше було сам по собі `string`. */
+  result: string;
+  /**
+   * Реверсує мутацію handler-а. Викликається з обробника `showUndoToast`
+   * у HubChat, тож має бути ідемпотентним і не кидати на повторний клік
+   * (показ undo-toast гарантує максимум одне натискання, але safer is safer).
+   */
+  undo: () => void;
+}
+
+/**
+ * Уніфікований результат handler-а. Старі handler-и далі повертають
+ * `string` без жодних змін; нові mutator-и повертають
+ * `ChatActionUndoableResult` коли мають reverse-snapshot.
+ */
+export type ChatActionResult = string | ChatActionUndoableResult;
+
 export interface ChangeCategoryAction {
   name: "change_category";
   input: { tx_id: string; category_id: string };

--- a/apps/web/src/core/lib/hubChatActions.ts
+++ b/apps/web/src/core/lib/hubChatActions.ts
@@ -3,31 +3,64 @@ import { handleFizrukAction } from "./chatActions/fizrukActions";
 import { handleRoutineAction } from "./chatActions/routineActions";
 import { handleNutritionAction } from "./chatActions/nutritionActions";
 import { handleCrossAction } from "./chatActions/crossActions";
+import type { ChatActionResult } from "./chatActions/types";
 
-export type { ChatAction } from "./chatActions/types";
+export type { ChatAction, ChatActionResult } from "./chatActions/types";
 
 type ChatAction = import("./chatActions/types").ChatAction;
 
-export function executeAction(action: ChatAction): string {
+/**
+ * Внутрішній уніфікований результат: завжди є `result` (текст для
+ * Anthropic-`tool_result`), опційно є `undo` (reverse-snapshot, який
+ * `HubChat` пропускає у `showUndoToast`).
+ */
+interface ExecutedAction {
+  result: string;
+  undo?: () => void;
+}
+
+function normalize(out: ChatActionResult | undefined): ExecutedAction | null {
+  if (out == null) return null;
+  if (typeof out === "string") return { result: out };
+  return { result: out.result, undo: out.undo };
+}
+
+function dispatch(action: ChatAction): ExecutedAction {
   try {
     return (
-      handleFinykAction(action) ??
-      handleFizrukAction(action) ??
-      handleRoutineAction(action) ??
-      handleNutritionAction(action) ??
-      handleCrossAction(action) ??
-      `Невідома дія: ${action.name}`
+      normalize(handleFinykAction(action)) ??
+      normalize(handleFizrukAction(action)) ??
+      normalize(handleRoutineAction(action)) ??
+      normalize(handleNutritionAction(action)) ??
+      normalize(handleCrossAction(action)) ?? {
+        result: `Невідома дія: ${action.name}`,
+      }
     );
   } catch (e) {
-    return `Помилка виконання: ${e instanceof Error ? e.message : String(e)}`;
+    return {
+      result: `Помилка виконання: ${e instanceof Error ? e.message : String(e)}`,
+    };
   }
+}
+
+/**
+ * Виконати один tool-call. Повертає лише текстовий результат для
+ * сумісності з існуючими тестами та `tool_result`-протоколом.
+ *
+ * AI-CONTEXT: для отримання `undo`-функції використовуй `executeActions`
+ * (множина), яка прокидає її далі у `HubChat.tsx → showUndoToast`. Тут
+ * undo навмисно "проковтується" — single-tool path-у в продакшні нема,
+ * а контракт `string` критичний для ~30+ існуючих юніт-тестів.
+ */
+export function executeAction(action: ChatAction): string {
+  return dispatch(action).result;
 }
 
 /**
  * Execute multiple tool calls and return their results in the same order.
  *
  * Today every handler is synchronous (writes go to localStorage) so this is
- * effectively the same as `actions.map(executeAction)` — the value is in
+ * effectively the same as `actions.map(dispatch)` — the value is in
  * pinning the API shape now. As soon as a handler needs to hit the network
  * (e.g. `compare_weeks` aggregating from `/api/...` snapshots), we can flip
  * its `handle*Action` signature to `Promise<string>` and `Promise.all` here
@@ -41,11 +74,11 @@ export function executeAction(action: ChatAction): string {
  */
 export async function executeActions(
   actions: ReadonlyArray<ChatAction>,
-): Promise<Array<{ name: string; result: string }>> {
+): Promise<Array<{ name: string; result: string; undo?: () => void }>> {
   return Promise.all(
-    actions.map(async (action) => ({
-      name: action.name,
-      result: await Promise.resolve(executeAction(action)),
-    })),
+    actions.map(async (action) => {
+      const out = await Promise.resolve(dispatch(action));
+      return { name: action.name, ...out };
+    }),
   );
 }

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -664,8 +664,36 @@ CloudSync помилки — `useSyncErrorToast(syncErrorDetail, toast, pushAll)
 ### Інші toast-патерни
 
 - **`showUndoToast`** (`@shared/lib/undoToast`) — деструктивні дії
-  (видалення звички / транзакції): 5 c, кнопка «Повернути». Не плутати з
-  retry-toast: `undo` повертає минулий стан, `retry` повторює невдалу дію.
+  (видалення звички / транзакції) АБО **mutator-tool-call у HubChat**: 5 c,
+  кнопка «Повернути». Не плутати з retry-toast: `undo` повертає минулий
+  стан, `retry` повторює невдалу дію.
+
+#### HubChat tool-call undo
+
+Mutator-handler-и в `apps/web/src/core/lib/chatActions/` повертають
+`{ result: string; undo: () => void }` замість простого `string`. Контракт
+у `types.ts → ChatActionResult`. `HubChat.tsx` після `executeActions` ітерує
+по результатам і для кожного, який має `undo`, кидає
+`showUndoToast(toast, { msg: result, onUndo: undo })`. Read-only handler-и
+(`find_transaction`, `weekly_summary`, …) залишаються `string` — нема що
+реверсити.
+
+Правила для нових mutator-handler-ів:
+
+1. **`undo` має бути ідемпотентним.** Користувач не повторить дію — але
+   паралельні UI-зміни (видалення з іншого екрану) можуть зробити стан
+   таким, що скасовувати нема чого. У такому разі — `return` без throw.
+2. **Тримай у замиканні `id` створеної сутності, а не повний snapshot
+   стану.** Snapshot переписує паралельні правки; `id`-філтр прибирає
+   тільки свою мутацію.
+3. **Якщо мутація — no-op** (напр., `mark_habit_done` для дати, де галочка
+   вже стоїть) — повертай простий `string`, не `{ undo }`. Toast «Повернути
+   на нічого» збиває з пантелику.
+4. **Зміни тестів:** хелпер `call()` у `*.test.ts` приймає обидві форми
+   (`typeof out === "string" ? out : out.result`). Додай окремий
+   `describe("<tool> · undo")`-блок з тестами на видалення, ідемпотентність
+   та no-op гілку.
+
 - **`tryShowCrossModulePrompt`** (`@shared/lib/crossModulePrompt`) — нудж із
   модуля в модуль («витрата в ресторані → запиши прийом їжі?»). Має
   fatigue-suppression на дисмиси.


### PR DESCRIPTION
## What changed

Розширює HubChat tool-handler контракт із `string | undefined` до
`ChatActionResult | undefined`, де
`ChatActionResult = string | { result: string; undo: () => void }`.

Підключає 4 перших mutator-и з undo-функціями:
- `finyk.create_transaction` — видаляє щойно створену транзакцію за
  `manualId`.
- `routine.create_habit` — видаляє звичку + її completions cleanup.
- `routine.mark_habit_done` — прибирає completion для дати; no-op
  гілка (галочка вже стоїть) повертає `string` без `undo`.
- `nutrition.log_meal` — видаляє meal по id; чистить порожній день.

`HubChat.tsx` після `executeActions` ітерує по результатам і для
кожного, який має `undo`, кидає `showUndoToast(toast, { msg, onUndo })`
— той самий 5-секундний контракт, який вже використовується для
видалення чат-сесій (`@shared/lib/undoToast`).

Read-only handler-и (`find_transaction`, `weekly_summary`,
`spending_trend`, …) лишаються `string` — нема що реверсити.

## Why

Сьогодні юзер не може скасувати дії, які HubChat виконав через
`tool_calls`. Це порушує дизайн-принцип «дія повинна мати undo, поки це
дешево», який ми вже декларуємо в §15 design-system. Вертикальний
зріз: контракт + 4 hot-path mutator-и + UI-toast → dovedeno end-to-end.
Решта ~30 mutator-ів отримають `undo` у follow-up PR-ах **без зміни
контракту**.

Backward-compatibility критична — `executeAction` (singular) лишається
`string`-only, бо ~30 юніт-тестів `executeAction(...)` стрінгують
результат напряму. Undo доступний лише через `executeActions` (plural),
який і так використовується тільки в `HubChat.tsx`.

## How to test

```bash
pnpm --filter @sergeant/web exec vitest run \
  src/core/lib/hubChatActions.test.ts \
  src/core/lib/chatActions/

pnpm --filter @sergeant/web exec tsc --noEmit
pnpm exec eslint apps/web/src/core/lib/chatActions \
  apps/web/src/core/lib/hubChatActions.ts \
  apps/web/src/core/hub/HubChat.tsx
```

Очікувано: **276 / 276 тестів проходять** (+ 13 нових undo-тестів
поверх 263 існуючих).

Smoke-flow в живому HubChat:

1. Спитати асистента «додай витрату 250 грн на каву» → у відповіді
   побачити «✅ Витрату 250 грн "кава" записано» І нижче 5 c toast із
   кнопкою «Повернути».
2. Натиснути «Повернути» → toast зникає, у `Finyk` транзакція пропадає
   з історії.
3. Аналогічно для `mark_habit_done`, `create_habit`, `log_meal`.

---

## Pre-flight (Hard Rule #15)

- [x] Read the `AGENTS.md` Hard Rules that apply to the touched paths.
- [x] Read the matching playbook in `docs/playbooks/` (or noted that none exists). — `add-hubchat-tool.md` стосується додавання нових tool-ів; цей PR — інфраструктурне розширення контракту, що буде задокументоване для майбутніх tool-ів через `docs/design/design-system.md` §15. Не дублюю в `add-hubchat-tool.md` бо інструкція там — про серверну сторону.
- [x] Checked freshness headers of docs cited in the change. — `docs/design/design-system.md` бамплено в PR #1161, на 2026-04-29.

## Docs updated alongside code? (Hard Rule #15)

- [x] New design token / component / palette — `docs/design/design-system.md` §15 → "Інші toast-патерни" розширено новим підрозділом "HubChat tool-call undo" з 4 правилами для майбутніх mutator-ів.
- [x] Freshness header bumped on docs whose claims changed — n/a, `Last validated: 2026-04-29` уже сьогоднішній.

## How AI-tested this PR

- [x] Manual smoke (which flow?): локальні `vitest` + `tsc --noEmit` + `eslint` на всіх торкнутих файлах. Реального HubChat-стріму локально не запускав — потребує `ANTHROPIC_API_KEY` і API-сервера; делегую ручному QA.
- [x] Vitest passes: 276 / 276 у `apps/web/src/core/lib/hubChatActions.test.ts` + `chatActions/`.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`. — design-system.md, нові test-blocks і коментарі — всі українською.
- [x] `pnpm dead-code:files` clean (or new files marked `@scaffolded`). — нових файлів не додано, лише змінені існуючі.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds undo to HubChat tool-calls by extending handler results to support `{ result, undo }` and showing a 5‑second undo toast for undoable actions. Implements undo for four mutators while keeping read‑only tools and existing APIs backward compatible.

- **New Features**
  - Extend `handle*Action` return type to `ChatActionResult` (`string` or `{ result, undo }`).
  - `executeActions` now returns `undo`; `HubChat.tsx` calls `showUndoToast` for each undoable result.
  - Undo added for: `finyk.create_transaction` (delete by `manualId`), `routine.create_habit` (delete habit + clean completions), `routine.mark_habit_done` (remove completion; no‑op returns `string` if already done), `nutrition.log_meal` (delete meal by id; remove empty day). All undos are idempotent.
  - `executeAction` stays `string`‑only for backward compatibility; read‑only handlers still return `string`.
  - Tests: +13 undo tests, 276/276 passing. Docs: design‑system §15 updated with “HubChat tool‑call undo”.

<sup>Written for commit 4b1c7ce2e135df6f3188e7777ee749845691adb4. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1165?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

