### PR TITLE
ci(ci): add Trivy container image scan workflow

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -1,0 +1,105 @@
+name: Container image scan (Trivy)
+
+# Сканує зібраний Docker-образ Hub API (`Dockerfile.api`) на CVE через
+# Trivy. Це OS+бібліотечний шар поверх існуючого `pnpm audit` / OSV-Scanner
+# / Snyk pipeline (див. `.github/workflows/nightly-audit.yml`) — там
+# скануються лише lockfile-залежності, тут — реальний runtime-image
+# (alpine layers, transitive npm у рантайм-вузлі тощо).
+
+on:
+  pull_request:
+    paths:
+      - "Dockerfile.api"
+      - ".dockerignore"
+      - "pnpm-lock.yaml"
+      - "apps/server/**"
+      - "packages/shared/**"
+      - "packages/config/**"
+      - "packages/finyk-domain/**"
+      - "patches/**"
+      - ".github/workflows/container-scan.yml"
+  push:
+    branches: [main]
+  schedule:
+    # Daily 04:00 UTC — через годину після nightly-audit, щоб не шарити
+    # runner pool у пік (03:00 UTC).
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: container-scan-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  trivy-image:
+    name: Trivy image scan (Dockerfile.api)
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout v6.0.2 (SHA-pinned for supply-chain hardening)
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      # docker/setup-buildx-action v4.0.0 (SHA-pinned)
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+
+      # docker/build-push-action v7.1.0 (SHA-pinned)
+      - name: Build hub-api image (load into local Docker, no push)
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
+        with:
+          context: .
+          file: Dockerfile.api
+          load: true
+          push: false
+          tags: hub-api:scan
+          cache-from: type=gha,scope=container-scan
+          cache-to: type=gha,mode=max,scope=container-scan
+
+      # aquasecurity/trivy-action v0.36.0 (SHA-pinned)
+      # Один прогін генерує SARIF (для code-scanning + артефакту) і
+      # одночасно фейлить job на CRITICAL/HIGH через `exit-code: 1`.
+      # `ignore-unfixed: true` — типовий шум від CVE без патчу не
+      # блокує merge; такі випадки лишаються в SARIF-trend і
+      # розглядаються в nightly-audit triage.
+      - name: Trivy image scan (SARIF + fail on CRITICAL/HIGH)
+        id: trivy
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        with:
+          image-ref: hub-api:scan
+          format: sarif
+          output: trivy-image.sarif
+          severity: "CRITICAL,HIGH"
+          ignore-unfixed: true
+          vuln-type: "os,library"
+          exit-code: "1"
+
+      - name: Upload SARIF to code-scanning
+        if: ${{ !cancelled() }}
+        # github/codeql-action/upload-sarif v4.35.2 (SHA-pinned)
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225
+        with:
+          sarif_file: trivy-image.sarif
+          category: trivy-image
+
+      - name: Upload SARIF artifact
+        if: ${{ !cancelled() }}
+        # actions/upload-artifact v4.4.3 (SHA-pinned)
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: trivy-image-sarif
+          path: trivy-image.sarif
+          retention-days: 30
+
+      - name: Summary
+        if: ${{ !cancelled() }}
+        run: |
+          {
+            echo "### Trivy image scan summary"
+            echo
+            echo "- Image: \`hub-api:scan\` (built from \`Dockerfile.api\`)"
+            echo "- Severity gate: CRITICAL, HIGH (ignore-unfixed = true)"
+            echo "- SARIF artifact: \`trivy-image-sarif\`"
+            echo "- Code Scanning category: \`trivy-image\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,12 @@
 
 ## [Unreleased]
 
-_Нові зміни з'являться тут перед наступним релізом._
+### Added
+
+- **CI: container image scan (Trivy).** Новий workflow
+  `.github/workflows/container-scan.yml` збирає `Dockerfile.api` і
+  сканує отриманий образ на CVE рівнів CRITICAL/HIGH; SARIF
+  завантажується в GitHub Code Scanning (`category: trivy-image`) і
+  доступний як артефакт. Тригери: PR (на зміни Dockerfile / serverside
+  пакетів), push to main, schedule (04:00 UTC) і workflow_dispatch.
+  Триаж — див. [`docs/security/container-scan.md`](./docs/security/container-scan.md).

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -8,5 +8,6 @@
 | Документ                                         | Опис                                     |
 | ------------------------------------------------ | ---------------------------------------- |
 | [`audit-exceptions.md`](./audit-exceptions.md)   | Винятки із security audit (обґрунтовані) |
+| [`container-scan.md`](./container-scan.md)       | Trivy CVE-скан Docker-образу `hub-api`   |
 | [`nightly-audit.md`](./nightly-audit.md)         | Nightly audit: triage flow               |
 | [`vulnerability-sla.md`](./vulnerability-sla.md) | SLA на реакцію і усунення вразливостей   |

--- a/docs/security/container-scan.md
+++ b/docs/security/container-scan.md
@@ -1,0 +1,100 @@
+# Container image scan — Trivy
+
+> **Last validated:** 2026-04-29 by @devin-ai. **Next review:** 2026-07-29.
+> **Status:** Active
+
+## Огляд
+
+Workflow [`.github/workflows/container-scan.yml`](../../.github/workflows/container-scan.yml)
+збирає `hub-api` образ з [`Dockerfile.api`](../../Dockerfile.api) і сканує його
+[Trivy](https://aquasecurity.github.io/trivy/) на CVE рівнів **CRITICAL/HIGH**.
+
+Це окремий шар від [nightly-audit](./nightly-audit.md), який сканує лише
+**lockfile-залежності** (pnpm audit, OSV-Scanner, Snyk). Trivy дивиться на
+**рантайм-image**: alpine OS-пакети, файли в final-stage, потенційні misconfig.
+
+### Тригери
+
+| Подія               | Коли запускається                                                                                               |
+| ------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `pull_request`      | PR торкається `Dockerfile.api`, `.dockerignore`, `pnpm-lock.yaml`, серверних апов/пакетів, або самого workflow. |
+| `push` to `main`    | Кожен merge на main.                                                                                            |
+| `schedule`          | Щоденно о **04:00 UTC** (через годину після `nightly-audit`).                                                   |
+| `workflow_dispatch` | Ручний запуск через Actions UI.                                                                                 |
+|                     |                                                                                                                 |
+
+### Output
+
+- **GitHub Code Scanning** — SARIF завантажується з `category: trivy-image`,
+  тренди видно в `Security > Code Scanning > Trivy image`.
+- **Артефакт `trivy-image-sarif`** — `trivy-image.sarif` (retention 30 днів)
+  для офлайн-аналізу.
+- **Job summary** — короткий зведений блок у Actions UI.
+
+### Severity gate
+
+- Job **fail**-ить на `CRITICAL` або `HIGH` (`exit-code: 1`).
+- `ignore-unfixed: true` — CVE без доступного патчу не блокують merge; такі
+  випадки залишаються видимими в SARIF-trend і розглядаються разом
+  з nightly-audit triage (див. [`./nightly-audit.md`](./nightly-audit.md) і
+  [`./vulnerability-sla.md`](./vulnerability-sla.md)).
+
+## Що робити, коли job впав
+
+### 1. Подивись Trivy SARIF
+
+В Actions run-і скачай артефакт `trivy-image-sarif` або відкрий
+**Security > Code Scanning** і відфільтруй по category `trivy-image`.
+
+### 2. Triage за SLA
+
+Той самий SLA, що й для nightly-audit — див. таблицю у
+[`./vulnerability-sla.md`](./vulnerability-sla.md).
+
+| Severity     | SLA       |
+| ------------ | --------- |
+| **Critical** | 24 години |
+| **High**     | 14 днів   |
+
+### 3. Якщо фікс зараз неможливий
+
+1. Задокументуй виняток у [`./audit-exceptions.md`](./audit-exceptions.md)
+   з обґрунтуванням і `removeBy` датою.
+2. Якщо це CVE без патчу (наприклад, base-image поки немає виправленого
+   тегу) — додай у `.trivyignore` з коментарем + посиланням на upstream
+   issue. Ignore-and-revisit, не silent-suppress.
+3. Розглянь варіант оновити base image (`node:20.20.2-alpine` → новіший
+   minor) у Dockerfile.api.
+
+### 4. Перевір, що nightly-audit і container-scan не дублюють виняток
+
+Лежать вони в одному файлі `audit-exceptions.md` — просто не плодь
+дві окремі лінії для одного CVE.
+
+## Як локально відтворити
+
+```bash
+# 1. Build image
+docker build -f Dockerfile.api -t hub-api:scan .
+
+# 2. Install Trivy locally (один раз)
+brew install trivy   # або см. https://aquasecurity.github.io/trivy/
+
+# 3. Scan
+trivy image \
+  --severity CRITICAL,HIGH \
+  --ignore-unfixed \
+  --vuln-type os,library \
+  hub-api:scan
+```
+
+Якщо локально CVE є, а в CI немає (або навпаки) — найімовірніша причина
+розбіжна версія Trivy DB. Запусти `trivy image --download-db-only`
+перед сканом.
+
+## Зв'язані документи
+
+- [`./nightly-audit.md`](./nightly-audit.md) — dependency-only сканування.
+- [`./vulnerability-sla.md`](./vulnerability-sla.md) — SLA per severity.
+- [`./audit-exceptions.md`](./audit-exceptions.md) — задокументовані винятки.
+- [`Dockerfile.api`](../../Dockerfile.api) — образ, який сканується.


### PR DESCRIPTION
## What changed

Новий workflow `.github/workflows/container-scan.yml`, який:

- збирає `hub-api` образ з `Dockerfile.api` (через `docker/build-push-action`, з GHA-кешем);
- прогоняє його через Trivy на CVE рівнів **CRITICAL/HIGH** з `ignore-unfixed: true`;
- завантажує SARIF у GitHub Code Scanning з `category: trivy-image` і зберігає як 30-денний артефакт `trivy-image-sarif`;
- фейлить job (`exit-code: 1`), якщо знайдено непропатчені CRITICAL/HIGH.

**Тригери:** PR (на зміни `Dockerfile.api`, `.dockerignore`, `pnpm-lock.yaml`, `apps/server/**`, відповідних `packages/**`, `patches/**` і самого workflow), `push` на `main`, `schedule` (04:00 UTC, через годину після `nightly-audit`) і `workflow_dispatch`.

Усі actions SHA-pinned (відповідно до supply-chain-hardening практики решти workflow):

| Action                              | Версія    |
| ----------------------------------- | --------- |
| `actions/checkout`                  | v6.0.2    |
| `docker/setup-buildx-action`        | v4.0.0    |
| `docker/build-push-action`          | v7.1.0    |
| `aquasecurity/trivy-action`         | v0.36.0   |
| `github/codeql-action/upload-sarif` | v4.35.2   |
| `actions/upload-artifact`           | v4.4.3    |

Documentation:

- `docs/security/container-scan.md` — triage flow, severity gate, локальне відтворення.
- `docs/security/README.md` — індекс оновлено.
- `CHANGELOG.md` — `[Unreleased] / Added`.

## Why

Аудит репозиторію (high-priority #3): існуючий `nightly-audit` сканує **тільки залежності lockfile** (`pnpm audit`, OSV-Scanner, Snyk). Реальний рантайм-image (alpine OS-пакети, transitive npm у final-stage Dockerfile, патчі) не сканувався — це сліпа пляма для CVE рівня base-image. Trivy закриває цей шар окремою GitHub Action, як і пропонувалось в аудиті.

## How to test

1. **CI on this PR.** PR-тригер `paths` не зачіпає `apps/server/**` (зміни лише в `.github/`, `docs/`, `CHANGELOG.md`), тому `container-scan` сам по собі **не запускається на цей PR** — це by design (інакше будь-яка docs-зміна перезбирала б образ ~2-3 хв). Перевірити можна через **workflow_dispatch** після merge або через PR, що торкається `Dockerfile.api`/`apps/server/**`.

2. **Manual run after merge:**
   - Відкрий **Actions → Container image scan (Trivy) → Run workflow** на гілці `main`.
   - Очікуваний результат: образ збирається (~2-3 хв з cold cache), Trivy сканує, SARIF з'являється у **Security → Code Scanning** під фільтром `Tool: Trivy` / `Category: trivy-image`. Артефакт `trivy-image-sarif` доступний у Run summary.
   - Якщо у поточному base image (`node:20.20.2-alpine`) є відомі CRITICAL/HIGH CVE — job впаде; це очікувана поведінка, далі triage по `docs/security/container-scan.md`.

3. **Локально:**

   ```bash
   docker build -f Dockerfile.api -t hub-api:scan .
   trivy image --severity CRITICAL,HIGH --ignore-unfixed --vuln-type os,library hub-api:scan
   ```

---

## Pre-flight (Hard Rule #15)

- [x] Read the `AGENTS.md` Hard Rules that apply to the touched paths. (Rule #5: scope `ci`. Rule #6/#7: no force push, no `--no-verify`.)
- [x] Read the matching playbook in `docs/playbooks/` (or noted that none exists). — n/a (нема playbook для нових security-workflow; існуючий `docs/security/nightly-audit.md` слугував зразком).
- [x] Checked freshness headers of docs cited in the change.

## Docs updated alongside code? (Hard Rule #15)

- [ ] API contract change — n/a.
- [ ] New / removed npm script — n/a.
- [ ] New design token / component / palette — n/a.
- [ ] Deprecation — n/a.
- [x] Freshness header bumped on docs whose claims changed — `docs/security/container-scan.md` створено з валідним freshness; `docs/security/README.md` доповнено новим рядком.
- [ ] N/A — no docs invalidated by this change.

## How AI-tested this PR

- [x] Manual smoke: `pnpm format:check`, `pnpm docs:check-links`, `pnpm lint:governance-sync`, `pnpm lint:tech-debt-freshness` — pass. YAML парсинг workflow-у валідний (Python yaml.safe_load).
- [ ] Vitest passes: n/a (CI-only зміна; runtime-код не торкався).
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.
- [x] `pnpm dead-code:files` clean — лише `.yml` + `.md`, не сканується knip.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated container image vulnerability scanning now runs on pull requests, daily schedules, and pushes to main. Critical and high severity vulnerabilities are detected and enforced.

* **Documentation**
  * Added comprehensive documentation for the new container image scanning workflow, including operator procedures and troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->