### PR TITLE
feat(shared): sync OpenAPI SSOT + wrap transcribe/webVitals in api-client

### DIFF
--- a/apps/server/src/modules/observability/web-vitals.ts
+++ b/apps/server/src/modules/observability/web-vitals.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from "express";
-import { z } from "zod";
+import { WebVitalsPayloadSchema } from "@sergeant/shared";
 import { logger } from "../../obs/logger.js";
 import { webVitalsCls, webVitalsDurationMs } from "../../obs/metrics.js";
 
@@ -28,31 +28,14 @@ const TIMING_METRICS = new Set<"LCP" | "INP" | "FCP" | "TTFB">([
   "TTFB",
 ]);
 
-// CLS — безрозмірний, в реальних умовах 0..1+ (0.25 вже "poor"). Таймінги
-// (LCP/INP/FCP/TTFB) — мс, з приватним upper-bound 120_000 (2 хв — будь-що
-// більше означає зламаний client-side таймер). Окремий upper-bound для CLS
-// важливий: без нього анонімний endpoint приймає value=100000 і інфлейтить
-// `web_vitals_cls_sum` на порядки, роблячи `avg = _sum / _count` безглуздим.
-const MetricSchema = z
-  .object({
-    name: z.enum(["LCP", "INP", "FCP", "TTFB", "CLS"]),
-    value: z.number().finite().min(0),
-    rating: z.enum(["good", "needs-improvement", "poor"]),
-  })
-  .refine((m) => (m.name === "CLS" ? m.value <= 10 : m.value <= 120_000), {
-    message: "value out of range for metric",
-    path: ["value"],
-  });
-
-const PayloadSchema = z.object({
-  metrics: z.array(MetricSchema).min(1).max(10),
-});
+// Schema SSOT у `@sergeant/shared/schemas/api.ts#WebVitalsPayloadSchema`.
+// Upper-bound для CLS (<=10) і для таймінгів (<=120_000 мс) живуть там.
 
 export default function webVitalsHandler(req: Request, res: Response): void {
   // sendBeacon з `type: "application/json"` приходить як Buffer/string залежно
   // від middleware-а — Express `express.json()` уже парсить у req.body, але
   // якщо клієнт помилиться з content-type, body може бути undefined.
-  const parsed = PayloadSchema.safeParse(req.body);
+  const parsed = WebVitalsPayloadSchema.safeParse(req.body);
   if (!parsed.success) {
     if (Math.random() < 0.01) {
       logger.warn({

--- a/apps/server/src/modules/transcribe/transcribe.ts
+++ b/apps/server/src/modules/transcribe/transcribe.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from "express";
-import { z } from "zod";
+import { TranscribeQuerySchema } from "@sergeant/shared";
 import { validateQuery } from "../../http/validate.js";
 import { transcribeAudio, GroqTranscribeError } from "../../lib/groq.js";
 import { logger } from "../../obs/logger.js";
@@ -20,23 +20,8 @@ const SUPPORTED_AUDIO_MIME = [
 ];
 
 const MAX_AUDIO_BYTES = 10 * 1024 * 1024; // 10 MB
-const MAX_PROMPT_LENGTH = 1024;
 
-export const TranscribeQuerySchema = z.object({
-  language: z
-    .string()
-    .trim()
-    .min(2)
-    .max(8)
-    .optional()
-    .describe("ISO-код мови, напр. uk або en. Якщо порожньо — auto-detect."),
-  prompt: z
-    .string()
-    .trim()
-    .max(MAX_PROMPT_LENGTH)
-    .optional()
-    .describe("Доменна підказка (списки вправ, продуктів тощо)."),
-});
+export { TranscribeQuerySchema };
 
 function pickMimeType(req: Request): string | null {
   const raw = req.headers["content-type"];

--- a/apps/web/src/core/observability/webVitals.ts
+++ b/apps/web/src/core/observability/webVitals.ts
@@ -1,5 +1,9 @@
 import { apiUrl } from "@shared/lib/apiUrl";
-import { isCapacitor } from "@sergeant/shared";
+import {
+  isCapacitor,
+  type WebVitalsMetricName,
+  type WebVitalsMetricRating,
+} from "@sergeant/shared";
 
 /**
  * Збір Core Web Vitals (LCP / INP / CLS / FCP / TTFB) і відправка батчем
@@ -22,10 +26,13 @@ import { isCapacitor } from "@sergeant/shared";
 const ENDPOINT_PATH = "/api/metrics/web-vitals";
 export const MAX_BATCH = 10;
 
+// Shape локальних буферних записів похідна від SSOT-схеми
+// `WebVitalsPayloadSchema` у `@sergeant/shared`. Якщо додати нову метрику
+// у шарі schemas, TS одразу підсвітить необхідні зміни тут.
 interface WebVitalReport {
-  name: string;
+  name: WebVitalsMetricName;
   value: number;
-  rating?: string;
+  rating?: WebVitalsMetricRating;
 }
 
 const buffer: WebVitalReport[] = [];
@@ -113,15 +120,42 @@ interface MetricInput {
   rating?: string;
 }
 
+const SUPPORTED_METRIC_NAMES = new Set<WebVitalsMetricName>([
+  "LCP",
+  "INP",
+  "FCP",
+  "TTFB",
+  "CLS",
+]);
+
+const SUPPORTED_RATINGS = new Set<WebVitalsMetricRating>([
+  "good",
+  "needs-improvement",
+  "poor",
+]);
+
+function isSupportedName(value: string): value is WebVitalsMetricName {
+  return SUPPORTED_METRIC_NAMES.has(value as WebVitalsMetricName);
+}
+
+function isSupportedRating(value: string): value is WebVitalsMetricRating {
+  return SUPPORTED_RATINGS.has(value as WebVitalsMetricRating);
+}
+
 export function enqueue(metric: MetricInput | null | undefined) {
   if (
     !metric ||
     typeof metric.value !== "number" ||
     !Number.isFinite(metric.value) ||
-    metric.value < 0
+    metric.value < 0 ||
+    !isSupportedName(metric.name)
   ) {
     return;
   }
+  const rating =
+    metric.rating && isSupportedRating(metric.rating)
+      ? metric.rating
+      : undefined;
   buffer.push({
     name: metric.name,
     value:
@@ -129,7 +163,7 @@ export function enqueue(metric: MetricInput | null | undefined) {
       metric.name === "CLS"
         ? Number(metric.value.toFixed(4))
         : Math.round(metric.value),
-    rating: metric.rating,
+    rating,
   });
   if (buffer.length >= MAX_BATCH) {
     flush();

--- a/apps/web/src/shared/api/index.ts
+++ b/apps/web/src/shared/api/index.ts
@@ -40,6 +40,8 @@ export const monoWebhookApi = apiClient.monoWebhook;
 export const privatApi = apiClient.privat;
 export const waitlistApi = apiClient.waitlist;
 export const weeklyDigestApi = apiClient.weeklyDigest;
+export const transcribeApi = apiClient.transcribe;
+export const webVitalsApi = apiClient.webVitals;
 
 // Errors, types, HTTP primitives
 export { ApiError, isApiError, createHttpClient } from "@sergeant/api-client";

--- a/apps/web/src/shared/components/ui/VoiceMicButton.tsx
+++ b/apps/web/src/shared/components/ui/VoiceMicButton.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { cn } from "@shared/lib/cn";
 import { hapticTap } from "@shared/lib/haptic";
-import { apiUrl } from "@shared/lib/apiUrl";
+import { transcribeApi } from "@shared/api";
 
 /* -------------------------------------------------------------------------- *
  *  Web Speech API (browser-native) — fallback path.
@@ -246,50 +246,54 @@ function useGroqVoiceInput({
       abortRef.current = controller;
       setUploading(true);
       try {
-        const params = new URLSearchParams();
         // Whisper бере 2-літерний ISO-код (`uk-UA` → `uk`).
         const isoLang = lang.split("-")[0]?.trim();
-        if (isoLang) params.set("language", isoLang);
+        const query: { language?: string; prompt?: string } = {};
+        if (isoLang) query.language = isoLang;
         if (promptHint && promptHint.trim()) {
-          params.set("prompt", promptHint.trim().slice(0, 1024));
+          query.prompt = promptHint.trim().slice(0, 1024);
         }
-        const url = `${apiUrl("/api/transcribe")}${
-          params.toString() ? `?${params.toString()}` : ""
-        }`;
-        const res = await fetch(url, {
-          method: "POST",
-          headers: { "Content-Type": mimeType },
-          body: blob,
-          credentials: "include",
-          signal: controller.signal,
-        });
-        if (res.status === 503) {
-          onProviderUnavailable?.();
-          onError?.(
-            "Голосовий сервер тимчасово недоступний — перемикаюсь на браузерне розпізнавання.",
-          );
-          return;
+        const result = await transcribeApi.send(
+          { audio: blob, mimeType },
+          query,
+          { signal: controller.signal },
+        );
+        switch (result.outcome) {
+          case "ok": {
+            const text = result.data.text.trim();
+            if (text) onResult?.(text);
+            else onError?.("Не вдалося розпізнати мову. Спробуй ще раз.");
+            return;
+          }
+          case "provider_unavailable":
+            onProviderUnavailable?.();
+            onError?.(
+              "Голосовий сервер тимчасово недоступний — перемикаюсь на браузерне розпізнавання.",
+            );
+            return;
+          case "unauthorized":
+            onError?.(
+              "Сесія завершилась. Увійди знову, щоб користуватись голосом.",
+            );
+            return;
+          case "rate_limited":
+            onError?.("Забагато голосових запитів — спробуйте за хвилину.");
+            return;
+          case "payload_too_large":
+            onError?.("Запис задовгий. Зроби коротшим і повтори.");
+            return;
+          case "unsupported_media_type":
+            onError?.("Браузер записав невідомий формат. Оновись і повтори.");
+            return;
+          case "error":
+            onError?.(
+              `Помилка розпізнавання (${result.status}). Спробуй ще раз.`,
+            );
+            return;
         }
-        if (res.status === 401) {
-          onError?.(
-            "Сесія завершилась. Увійди знову, щоб користуватись голосом.",
-          );
-          return;
-        }
-        if (res.status === 429) {
-          onError?.("Забагато голосових запитів — спробуйте за хвилину.");
-          return;
-        }
-        if (!res.ok) {
-          onError?.(`Помилка розпізнавання (${res.status}). Спробуй ще раз.`);
-          return;
-        }
-        const data = (await res.json()) as { text?: string };
-        const text = (data.text || "").trim();
-        if (text) onResult?.(text);
-        else onError?.("Не вдалося розпізнати мову. Спробуй ще раз.");
       } catch (err) {
         if ((err as { name?: string })?.name === "AbortError") return;
+        if ((err as { kind?: string })?.kind === "aborted") return;
         onError?.("Не вдалося надіслати аудіо. Перевір інтернет.");
       } finally {
         setUploading(false);

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -269,7 +269,7 @@
         }
       }
     },
-    "/api/digest/weekly": {
+    "/api/weekly-digest": {
       "post": {
         "summary": "Згенерувати тижневий digest по агрегатах модулів",
         "tags": [
@@ -848,6 +848,39 @@
           },
           "401": {
             "description": "Unauthorized — потрібна активна сесія.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/nutrition/backup-download": {
+      "post": {
+        "summary": "Отримати останній зашифрований backup nutrition-blob",
+        "description": "Token-authenticated через header `x-token`. Повертає 404, якщо для наданого токена бекапів ще немає.",
+        "tags": [
+          "nutrition"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Backup для наданого x-token не знайдено.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1839,7 +1872,7 @@
         }
       }
     },
-    "/api/v1/waitlist": {
+    "/api/waitlist": {
       "post": {
         "summary": "Sign-up на waitlist для майбутнього Pro-тіру (анонімний)",
         "tags": [
@@ -1884,6 +1917,214 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/api/v1/waitlist": {
+      "post": {
+        "summary": "Sign-up на waitlist для майбутнього Pro-тіру (v1 alias для /api/waitlist)",
+        "tags": [
+          "monetization"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WaitlistSubmit"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Submitted (created=true) або уже був у списку (created=false)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WaitlistSubmitResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — payload не пройшов zod-валідацію.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests — rate-limit перевищено.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/transcribe": {
+      "post": {
+        "summary": "Голосова транскрипція через Groq Whisper (audio/* → текст)",
+        "description": "Body — сирий аудіо-блоб (`Content-Type: audio/webm | audio/ogg | audio/mp4 | …`), ліміт 10 MB. Query визначає мову (auto-detect якщо порожньо) та prompt для доменних термінів. Потребує активну сесію + сконфігурований GROQ_API_KEY (503 інакше).",
+        "tags": [
+          "transcribe"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "language",
+            "schema": {
+              "description": "ISO-код мови, напр. uk або en. Якщо порожньо — auto-detect.",
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 8
+            },
+            "description": "ISO-код мови, напр. uk або en. Якщо порожньо — auto-detect."
+          },
+          {
+            "in": "query",
+            "name": "prompt",
+            "schema": {
+              "description": "Доменна підказка (списки вправ, продуктів тощо).",
+              "type": "string",
+              "maxLength": 1024
+            },
+            "description": "Доменна підказка (списки вправ, продуктів тощо)."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "audio/webm": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            },
+            "audio/ogg": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            },
+            "audio/mp4": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            },
+            "audio/mpeg": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            },
+            "audio/wav": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Транскрипція успішна.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TranscribeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — payload не пройшов zod-валідацію.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized — потрібна активна сесія.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Payload завеликий (>10 MB).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "Непідтримуваний Content-Type (очікуємо audio/*).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "GROQ_API_KEY не сконфігурований на сервері.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/metrics/web-vitals": {
+      "post": {
+        "summary": "Ingest Core Web Vitals (LCP / INP / FCP / TTFB / CLS)",
+        "description": "Анонімний beacon-endpoint для `navigator.sendBeacon` при pagehide / visibilitychange=hidden. Завжди відповідає 204 No Content — навіть на malformed payload (sendBeacon ігнорує відповідь, не даємо feedback-у зондам).",
+        "tags": [
+          "observability"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WebVitalsPayload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Accepted (завжди 204, незалежно від валідності payload)."
           }
         }
       }
@@ -4024,6 +4265,52 @@
         ],
         "description": "POST /api/v1/waitlist — sign-up на майбутній Pro-тір (Phase 0 monetization)."
       },
+      "WebVitalsPayload": {
+        "type": "object",
+        "properties": {
+          "metrics": {
+            "minItems": 1,
+            "maxItems": 10,
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "enum": [
+                    "LCP",
+                    "INP",
+                    "FCP",
+                    "TTFB",
+                    "CLS"
+                  ]
+                },
+                "value": {
+                  "type": "number",
+                  "minimum": 0
+                },
+                "rating": {
+                  "type": "string",
+                  "enum": [
+                    "good",
+                    "needs-improvement",
+                    "poor"
+                  ]
+                }
+              },
+              "required": [
+                "name",
+                "value",
+                "rating"
+              ]
+            }
+          }
+        },
+        "required": [
+          "metrics"
+        ],
+        "description": "POST /api/metrics/web-vitals — батч Core Web Vitals (LCP/INP/FCP/TTFB/CLS)."
+      },
       "MeResponse": {
         "type": "object",
         "properties": {
@@ -4735,6 +5022,28 @@
         ],
         "additionalProperties": false,
         "description": "Відповідь на POST /api/v1/waitlist — `created` розрізняє новий запис vs duplicate."
+      },
+      "TranscribeResponse": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": "string"
+          },
+          "durationSec": {
+            "type": "number",
+            "minimum": 0
+          },
+          "model": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "text",
+          "durationSec",
+          "model"
+        ],
+        "additionalProperties": false,
+        "description": "Відповідь на POST /api/transcribe — розпізнаний текст + тривалість аудіо."
       }
     },
     "securitySchemes": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build:analyze": "pnpm --filter @sergeant/web build:analyze",
     "build:check-size": "node scripts/check-bundle-size.mjs",
     "preview": "pnpm --filter @sergeant/web preview",
-    "lint": "turbo run lint && node scripts/check-imports.mjs && node scripts/check-tsconfig-strict.mjs && pnpm lint:plugins && pnpm lint:tech-debt-freshness",
+    "lint": "turbo run lint && node scripts/check-imports.mjs && node scripts/check-tsconfig-strict.mjs && pnpm lint:plugins && pnpm lint:tech-debt-freshness && pnpm api:check-openapi",
     "lint:imports": "node scripts/check-imports.mjs",
     "lint:migrations": "node scripts/lint-migrations.mjs",
     "ops:n8n:validate": "node scripts/ops/validate-n8n-workflows.mjs",

--- a/packages/api-client/src/createApiClient.ts
+++ b/packages/api-client/src/createApiClient.ts
@@ -36,6 +36,14 @@ import {
   createWeeklyDigestEndpoints,
   type WeeklyDigestEndpoints,
 } from "./endpoints/weeklyDigest";
+import {
+  createTranscribeEndpoints,
+  type TranscribeEndpoints,
+} from "./endpoints/transcribe";
+import {
+  createWebVitalsEndpoints,
+  type WebVitalsEndpoints,
+} from "./endpoints/webVitals";
 
 export type ApiClientConfig = HttpClientConfig;
 
@@ -43,7 +51,7 @@ export type ApiClientConfig = HttpClientConfig;
  * Типізований API-клієнт для всіх публічних ендпоінтів Sergeant. Повертає
  * об'єкт з `http` (низькорівневі методи) та набором модульних ендпоінтів
  * (`sync`, `coach`, `chat`, `push`, `nutrition`, `barcode`, `foodSearch`,
- * `monoWebhook`, `privat`, `weeklyDigest`).
+ * `monoWebhook`, `privat`, `weeklyDigest`, `transcribe`, `webVitals`).
  *
  * Веб-додаток створює один інстанс на старті (див.
  * `apps/web/src/shared/api/client.ts`). RN-додаток зможе створити свій
@@ -63,6 +71,8 @@ export interface ApiClient {
   privat: PrivatEndpoints;
   waitlist: WaitlistEndpoints;
   weeklyDigest: WeeklyDigestEndpoints;
+  transcribe: TranscribeEndpoints;
+  webVitals: WebVitalsEndpoints;
 }
 
 export function createApiClient(config: ApiClientConfig = {}): ApiClient {
@@ -81,5 +91,7 @@ export function createApiClient(config: ApiClientConfig = {}): ApiClient {
     privat: createPrivatEndpoints(http),
     waitlist: createWaitlistEndpoints(http),
     weeklyDigest: createWeeklyDigestEndpoints(http),
+    transcribe: createTranscribeEndpoints(http),
+    webVitals: createWebVitalsEndpoints(http),
   };
 }

--- a/packages/api-client/src/endpoints/transcribe.ts
+++ b/packages/api-client/src/endpoints/transcribe.ts
@@ -1,0 +1,107 @@
+import {
+  TranscribeQuerySchema as SharedTranscribeQuerySchema,
+  TranscribeResponseSchema as SharedTranscribeResponseSchema,
+  z,
+} from "@sergeant/shared";
+import { ApiError, isApiError } from "../ApiError";
+import type { HttpClient } from "../httpClient";
+import type { RequestOptions } from "../types";
+
+/**
+ * `POST /api/transcribe` — проксі на Groq Whisper STT.
+ *
+ * Body — сирий аудіо-блоб (`Blob`/`ArrayBuffer`) із `Content-Type: audio/*`.
+ * `HttpClient.post` пропускає `Blob` як `BodyInit` без JSON-серіалізації
+ * (див. `isBodylessInit`), а query-string формує зі `opts.query`.
+ *
+ * Схема валідації та типи — SSOT у `@sergeant/shared/schemas/api.ts`.
+ * Реекспортуємо тут лише щоб callsite-и могли імпортувати з того самого
+ * пакета, що й інші endpoint-и.
+ */
+
+export const TranscribeQuerySchema = SharedTranscribeQuerySchema;
+export const TranscribeResponseSchema = SharedTranscribeResponseSchema;
+
+export type TranscribeQuery = z.infer<typeof TranscribeQuerySchema>;
+export type TranscribeResponse = z.infer<typeof TranscribeResponseSchema>;
+
+/**
+ * Outcome-дискримінована відповідь на transcribe-запит.
+ *
+ * Для `/api/transcribe` помилки — це нормальна частина flow (503 коли
+ * GROQ_KEY_MISSING → UI переходить на Web Speech, 401/429 → показати
+ * toast). Замість того, щоб залишати виклики з `try/catch` у UI і
+ * руками порівнювати `isApiError(err).status === 503`, повертаємо
+ * discriminated union, і колсайт звужує тип через `result.outcome`.
+ */
+export type TranscribeOutcome =
+  | { outcome: "ok"; data: TranscribeResponse }
+  | { outcome: "provider_unavailable"; status: 503 }
+  | { outcome: "unauthorized"; status: 401 }
+  | { outcome: "rate_limited"; status: 429 }
+  | { outcome: "payload_too_large"; status: 413 }
+  | { outcome: "unsupported_media_type"; status: 415 }
+  | { outcome: "error"; status: number; message: string };
+
+export interface TranscribeBody {
+  /** Бінарне аудіо. Сервер очікує `audio/*` Content-Type. */
+  audio: Blob | ArrayBuffer;
+  /** MIME-тип для `Content-Type` заголовка (наприклад, `audio/webm`). */
+  mimeType: string;
+}
+
+export interface TranscribeEndpoints {
+  /**
+   * Надіслати аудіо у Groq Whisper. Повертає `TranscribeOutcome`, щоб
+   * UI міг чисто переключатися на Web Speech при 503 без exception-driven
+   * flow.
+   */
+  send: (
+    body: TranscribeBody,
+    query?: TranscribeQuery,
+    opts?: Pick<RequestOptions, "signal">,
+  ) => Promise<TranscribeOutcome>;
+}
+
+export function createTranscribeEndpoints(
+  http: HttpClient,
+): TranscribeEndpoints {
+  return {
+    send: async ({ audio, mimeType }, query, { signal } = {}) => {
+      const parsedQuery = query ? TranscribeQuerySchema.parse(query) : {};
+      try {
+        const raw = await http.post<unknown>("/api/transcribe", audio, {
+          signal,
+          headers: { "Content-Type": mimeType },
+          query: parsedQuery,
+        });
+        const data = TranscribeResponseSchema.parse(raw);
+        return { outcome: "ok", data };
+      } catch (err) {
+        if (!isApiError(err)) throw err;
+        const apiErr = err as ApiError;
+        if (apiErr.kind !== "http" || typeof apiErr.status !== "number") {
+          throw err;
+        }
+        switch (apiErr.status) {
+          case 503:
+            return { outcome: "provider_unavailable", status: 503 };
+          case 401:
+            return { outcome: "unauthorized", status: 401 };
+          case 429:
+            return { outcome: "rate_limited", status: 429 };
+          case 413:
+            return { outcome: "payload_too_large", status: 413 };
+          case 415:
+            return { outcome: "unsupported_media_type", status: 415 };
+          default:
+            return {
+              outcome: "error",
+              status: apiErr.status,
+              message: apiErr.message,
+            };
+        }
+      }
+    },
+  };
+}

--- a/packages/api-client/src/endpoints/webVitals.ts
+++ b/packages/api-client/src/endpoints/webVitals.ts
@@ -1,0 +1,39 @@
+import {
+  WebVitalsPayloadSchema as SharedWebVitalsPayloadSchema,
+  z,
+} from "@sergeant/shared";
+import type { HttpClient } from "../httpClient";
+import type { RequestOptions } from "../types";
+
+/**
+ * `POST /api/metrics/web-vitals` — анонімний beacon-endpoint для Core Web
+ * Vitals. Сервер завжди відповідає `204 No Content`; payload валідується
+ * через `WebVitalsPayloadSchema` (SSOT у `@sergeant/shared`).
+ *
+ * Реальний транспорт у браузері — `navigator.sendBeacon`, а не `fetch`
+ * (див. `apps/web/src/core/observability/webVitals.ts`). Цей endpoint
+ * існує як SSR-/mobile-safe fallback і як явна точка для інструментальних
+ * тестів.
+ */
+
+export const WebVitalsPayloadSchema = SharedWebVitalsPayloadSchema;
+export type WebVitalsPayload = z.infer<typeof WebVitalsPayloadSchema>;
+
+export interface WebVitalsEndpoints {
+  send: (
+    payload: WebVitalsPayload,
+    opts?: Pick<RequestOptions, "signal">,
+  ) => Promise<void>;
+}
+
+export function createWebVitalsEndpoints(http: HttpClient): WebVitalsEndpoints {
+  return {
+    send: async (payload, { signal } = {}) => {
+      const parsed = WebVitalsPayloadSchema.parse(payload);
+      await http.post<unknown>("/api/metrics/web-vitals", parsed, {
+        signal,
+        parse: "text",
+      });
+    },
+  };
+}

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -158,3 +158,21 @@ export {
   type WeeklyDigestReport,
   type WeeklyDigestResponse,
 } from "./endpoints/weeklyDigest";
+
+export {
+  createTranscribeEndpoints,
+  TranscribeQuerySchema,
+  TranscribeResponseSchema,
+  type TranscribeBody,
+  type TranscribeEndpoints,
+  type TranscribeOutcome,
+  type TranscribeQuery,
+  type TranscribeResponse,
+} from "./endpoints/transcribe";
+
+export {
+  createWebVitalsEndpoints,
+  WebVitalsPayloadSchema,
+  type WebVitalsEndpoints,
+  type WebVitalsPayload,
+} from "./endpoints/webVitals";

--- a/packages/shared/src/openapi/registry.ts
+++ b/packages/shared/src/openapi/registry.ts
@@ -194,6 +194,21 @@ const WaitlistSubmitResponse = schemas.WaitlistSubmitResponseSchema.meta({
   description:
     "Відповідь на POST /api/v1/waitlist — `created` розрізняє новий запис vs duplicate.",
 });
+const TranscribeQuery = schemas.TranscribeQuerySchema.meta({
+  id: "TranscribeQuery",
+  description:
+    "Query для POST /api/transcribe (Groq Whisper proxy): мова + prompt.",
+});
+const TranscribeResponse = schemas.TranscribeResponseSchema.meta({
+  id: "TranscribeResponse",
+  description:
+    "Відповідь на POST /api/transcribe — розпізнаний текст + тривалість аудіо.",
+});
+const WebVitalsPayload = schemas.WebVitalsPayloadSchema.meta({
+  id: "WebVitalsPayload",
+  description:
+    "POST /api/metrics/web-vitals — батч Core Web Vitals (LCP/INP/FCP/TTFB/CLS).",
+});
 
 /** Стандартна 400-помилка для validateBody. */
 const ApiError = z
@@ -256,6 +271,9 @@ export const namedSchemas = {
   Pagination,
   WaitlistSubmit,
   WaitlistSubmitResponse,
+  TranscribeQuery,
+  TranscribeResponse,
+  WebVitalsPayload,
   ApiError,
 } as const;
 

--- a/packages/shared/src/openapi/routes.ts
+++ b/packages/shared/src/openapi/routes.ts
@@ -132,8 +132,8 @@ export const paths: ZodOpenApiPathsObject = {
     },
   },
 
-  // ────────────────────── /api/digest/weekly ──────────────────────
-  "/api/digest/weekly": {
+  // ────────────────────── /api/weekly-digest ──────────────────────
+  "/api/weekly-digest": {
     post: {
       summary: "Згенерувати тижневий digest по агрегатах модулів",
       tags: ["digest"],
@@ -296,6 +296,24 @@ export const paths: ZodOpenApiPathsObject = {
         "200": okEmpty,
         "400": validationError,
         "401": unauthorized,
+      },
+    },
+  },
+  "/api/nutrition/backup-download": {
+    post: {
+      summary: "Отримати останній зашифрований backup nutrition-blob",
+      description:
+        "Token-authenticated через header `x-token`. Повертає 404, якщо " +
+        "для наданого токена бекапів ще немає.",
+      tags: ["nutrition"],
+      responses: {
+        "200": okEmpty,
+        "404": {
+          description: "Backup для наданого x-token не знайдено.",
+          content: {
+            "application/json": { schema: namedSchemas.ApiError },
+          },
+        },
       },
     },
   },
@@ -609,7 +627,11 @@ export const paths: ZodOpenApiPathsObject = {
   },
 
   // ────────────────────── Waitlist (Phase 0 monetization) ───────────────────
-  "/api/v1/waitlist": {
+  // Сервер монтує обидва префікси (`/api/waitlist` + `/api/v1/waitlist`), щоб
+  // pricing-page CTA працював незалежно від стадії API-versioning shim-у.
+  // Обидва шляхи документуємо однаково — щоб консюмери бачили спеку що б вони
+  // не кликнули.
+  "/api/waitlist": {
     post: {
       summary: "Sign-up на waitlist для майбутнього Pro-тіру (анонімний)",
       tags: ["monetization"],
@@ -632,6 +654,106 @@ export const paths: ZodOpenApiPathsObject = {
           content: {
             "application/json": { schema: namedSchemas.ApiError },
           },
+        },
+      },
+    },
+  },
+  "/api/v1/waitlist": {
+    post: {
+      summary:
+        "Sign-up на waitlist для майбутнього Pro-тіру (v1 alias для /api/waitlist)",
+      tags: ["monetization"],
+      requestBody: {
+        content: {
+          "application/json": { schema: namedSchemas.WaitlistSubmit },
+        },
+      },
+      responses: {
+        "200": {
+          description:
+            "Submitted (created=true) або уже був у списку (created=false)",
+          content: {
+            "application/json": { schema: namedSchemas.WaitlistSubmitResponse },
+          },
+        },
+        "400": validationError,
+        "429": {
+          description: "Too many requests — rate-limit перевищено.",
+          content: {
+            "application/json": { schema: namedSchemas.ApiError },
+          },
+        },
+      },
+    },
+  },
+
+  // ────────────────────── Transcribe / Observability ────────────────────────
+  "/api/transcribe": {
+    post: {
+      summary: "Голосова транскрипція через Groq Whisper (audio/* → текст)",
+      description:
+        "Body — сирий аудіо-блоб (`Content-Type: audio/webm | audio/ogg | audio/mp4 | …`), " +
+        "ліміт 10 MB. Query визначає мову (auto-detect якщо порожньо) та prompt для " +
+        "доменних термінів. Потребує активну сесію + сконфігурований GROQ_API_KEY (503 інакше).",
+      tags: ["transcribe"],
+      security: cookieOrBearer,
+      requestParams: { query: namedSchemas.TranscribeQuery },
+      requestBody: {
+        content: {
+          "audio/webm": { schema: { type: "string", format: "binary" } },
+          "audio/ogg": { schema: { type: "string", format: "binary" } },
+          "audio/mp4": { schema: { type: "string", format: "binary" } },
+          "audio/mpeg": { schema: { type: "string", format: "binary" } },
+          "audio/wav": { schema: { type: "string", format: "binary" } },
+        },
+      },
+      responses: {
+        "200": {
+          description: "Транскрипція успішна.",
+          content: {
+            "application/json": { schema: namedSchemas.TranscribeResponse },
+          },
+        },
+        "400": validationError,
+        "401": unauthorized,
+        "413": {
+          description: "Payload завеликий (>10 MB).",
+          content: {
+            "application/json": { schema: namedSchemas.ApiError },
+          },
+        },
+        "415": {
+          description: "Непідтримуваний Content-Type (очікуємо audio/*).",
+          content: {
+            "application/json": { schema: namedSchemas.ApiError },
+          },
+        },
+        "503": {
+          description: "GROQ_API_KEY не сконфігурований на сервері.",
+          content: {
+            "application/json": { schema: namedSchemas.ApiError },
+          },
+        },
+      },
+    },
+  },
+  "/api/metrics/web-vitals": {
+    post: {
+      summary: "Ingest Core Web Vitals (LCP / INP / FCP / TTFB / CLS)",
+      description:
+        "Анонімний beacon-endpoint для `navigator.sendBeacon` при pagehide / " +
+        "visibilitychange=hidden. Завжди відповідає 204 No Content — навіть на " +
+        "malformed payload (sendBeacon ігнорує відповідь, не даємо feedback-у зондам).",
+      tags: ["observability"],
+      requestBody: {
+        content: {
+          "application/json": { schema: namedSchemas.WebVitalsPayload },
+        },
+      },
+      responses: {
+        "204": {
+          description:
+            "Accepted (завжди 204, незалежно від валідності payload).",
         },
       },
     },

--- a/packages/shared/src/schemas/api.ts
+++ b/packages/shared/src/schemas/api.ts
@@ -900,4 +900,76 @@ export type WaitlistSubmitResponse = z.infer<
   typeof WaitlistSubmitResponseSchema
 >;
 
+// ────────────────────── Transcribe (Groq Whisper proxy) ─────────────────────
+// `POST /api/transcribe` приймає сире audio-тіло (Content-Type: `audio/*`),
+// query визначає мову/prompt. Schema тут — SSOT і для server-side
+// `validateQuery`, і для `@sergeant/api-client` (типізує query + response).
+
+const TRANSCRIBE_MAX_PROMPT_LENGTH = 1024;
+
+export const TranscribeQuerySchema = z.object({
+  language: z
+    .string()
+    .trim()
+    .min(2)
+    .max(8)
+    .optional()
+    .describe("ISO-код мови, напр. uk або en. Якщо порожньо — auto-detect."),
+  prompt: z
+    .string()
+    .trim()
+    .max(TRANSCRIBE_MAX_PROMPT_LENGTH)
+    .optional()
+    .describe("Доменна підказка (списки вправ, продуктів тощо)."),
+});
+export type TranscribeQuery = z.infer<typeof TranscribeQuerySchema>;
+
+export const TranscribeResponseSchema = z.object({
+  text: z.string(),
+  durationSec: z.number().nonnegative(),
+  model: z.string(),
+});
+export type TranscribeResponse = z.infer<typeof TranscribeResponseSchema>;
+
+// ────────────────────── Web Vitals ingestion ────────────────────────────────
+// `POST /api/metrics/web-vitals` — анонімний beacon-endpoint, приймає батч
+// Core Web Vitals замірів. Server завжди відповідає 204 No Content.
+
+export const WebVitalsMetricNameSchema = z.enum([
+  "LCP",
+  "INP",
+  "FCP",
+  "TTFB",
+  "CLS",
+]);
+export type WebVitalsMetricName = z.infer<typeof WebVitalsMetricNameSchema>;
+
+export const WebVitalsMetricRatingSchema = z.enum([
+  "good",
+  "needs-improvement",
+  "poor",
+]);
+export type WebVitalsMetricRating = z.infer<typeof WebVitalsMetricRatingSchema>;
+
+// CLS — безрозмірний (0..1+, 0.25 = "poor"). Таймінги (LCP/INP/FCP/TTFB) —
+// мс, upper-bound 120_000 (2 хв — будь-що більше це зламаний клієнтський
+// таймер). Окремий upper-bound для CLS не дає анонімному endpoint-у інфлейтити
+// `web_vitals_cls_sum`, що зробило б `avg = _sum / _count` беззмістовним.
+export const WebVitalsMetricSchema = z
+  .object({
+    name: WebVitalsMetricNameSchema,
+    value: z.number().finite().min(0),
+    rating: WebVitalsMetricRatingSchema,
+  })
+  .refine((m) => (m.name === "CLS" ? m.value <= 10 : m.value <= 120_000), {
+    message: "value out of range for metric",
+    path: ["value"],
+  });
+export type WebVitalsMetric = z.infer<typeof WebVitalsMetricSchema>;
+
+export const WebVitalsPayloadSchema = z.object({
+  metrics: z.array(WebVitalsMetricSchema).min(1).max(10),
+});
+export type WebVitalsPayload = z.infer<typeof WebVitalsPayloadSchema>;
+
 export { z };


### PR DESCRIPTION
## What changed

**SSOT alignment після аудиту — PR 1 з 3 (P0+P1).**

### OpenAPI spec (`docs/api/openapi.json` + `packages/shared/src/openapi/*`)

- Виправлено шлях `/api/digest/weekly` → `/api/weekly-digest` (OpenAPI був stale, сервер уже давно на `/api/weekly-digest`; api-client теж туди ходить).
- Прибрано legacy `/api/mono` GET-proxy — його видалили зі сервера, але у спеці він залишався.
- Додано відсутні Mono-ендпоінти: `POST /api/mono/disconnect`, `GET /api/mono/sync-state`, `GET /api/mono/transactions`.
- Додано `POST /api/nutrition/backup-download` (token-auth через `x-token`).
- Додано `POST /api/transcribe` (Groq Whisper proxy, `audio/*` body + `TranscribeQuery` query + `TranscribeResponse` body).
- Додано `POST /api/metrics/web-vitals` (анонімний beacon, завжди `204 No Content`).
- Задокументовано обидва шляхи `/api/waitlist` та `/api/v1/waitlist` (сервер монтує обидва).
- До всіх Mono-endpoint-ів підключено реальні response-схеми замість `okEmpty`-плейсхолдерів.

### Zod-схеми консолідовано у `@sergeant/shared`

Раніше дублювалися локально в серверних модулях; тепер SSOT:

- `TranscribeQuerySchema`, `TranscribeResponseSchema` (перенесено з `apps/server/src/modules/transcribe/transcribe.ts`).
- `WebVitalsMetricNameSchema`, `WebVitalsMetricRatingSchema`, `WebVitalsMetricSchema`, `WebVitalsPayloadSchema` (перенесено з `apps/server/src/modules/observability/web-vitals.ts`).

Серверні модулі тепер імпортують ці схеми з shared — без зміни runtime-поведінки.

### `@sergeant/api-client` покриває всі шляхи

- `createTranscribeEndpoints(http)` → `transcribe.send({ audio, mimeType }, query, opts)`. Повертає `TranscribeOutcome` — discriminated union з гілками `ok | provider_unavailable | unauthorized | rate_limited | payload_too_large | unsupported_media_type | error`. UI тепер звужує `result.outcome`, а не ловить `ApiError` і вручну перевіряє `.status`.
- `createWebVitalsEndpoints(http)` → `webVitals.send(payload, opts)`. SSR-/mobile-safe fallback; браузер продовжує слати через `navigator.sendBeacon` на pagehide/visibilitychange=hidden (свідома decision — єдиний надійний транспорт на unload).

Обидва підключені у `ApiClient` і реекспортнуті з `@shared/api` як `transcribeApi`/`webVitalsApi`.

### Consumer-рефактори (webapp)

- `apps/web/src/shared/components/ui/VoiceMicButton.tsx` — прибрано прямий `fetch('/api/transcribe')`, переведено на `transcribeApi.send()`. Додано обробку `413`/`415` outcome-ів (раніше падали в generic "Помилка розпізнавання").
- `apps/web/src/core/observability/webVitals.ts` — shape буферу тепер похідна від SSOT-схеми (`WebVitalsMetricName`, `WebVitalsMetricRating`), runtime-фільтрація невалідних `name`/`rating` перед enqueue. `sendBeacon`-path залишено.

### CI-gate

`pnpm api:check-openapi` додано у root `lint` скрипт — тепер spec drift провалить `pnpm lint` (і PR-CI).

> ⚠️ **Окремо від цього PR:** треба додати вручну `.github/workflows/openapi-freshness.yml` як окремий гейт PR-checks (ADR-0025 його згадує, але файл у репо відсутній). OAuth scope Devin не дозволяє редагувати `.github/workflows/` — це на людський PR.

## Why

Аудит стандартизації виявив розсинхронізацію `docs/api/openapi.json` зі станом сервера (36 шляхів, частина stale). `pnpm api:check-openapi` падав на main. Два endpoint-и (`/api/transcribe`, `/api/metrics/web-vitals`) обминали `@sergeant/api-client`, тому ні типізації, ні покриття в OpenAPI не мали.

Цей PR закриває **P0 (OpenAPI drift)** + **P1 (api-client coverage gaps)** зі звіту аудиту. Наступні PR-и:

- **PR 2 (P2):** tsconfig/lint coverage для console + mobile-shell + пакетів без `lint` скриптa; злиття tsconfig-guard-ів.
- **PR 3 (P3+P4):** вирівнювання версій `react`, уніфікація push-схем, snapshot-test реєстрації роутерів.

## How to test

```bash
pnpm install
pnpm api:check-openapi     # spec тепер freshness-clean
pnpm lint                  # включно з api:check-openapi
pnpm typecheck
pnpm --filter @sergeant/api-client exec vitest run
pnpm --filter @sergeant/shared exec vitest run
pnpm --filter @sergeant/server exec vitest run src/modules/transcribe src/modules/observability
pnpm --filter @sergeant/web exec vitest run src/core/observability
```

Ручний smoke у web:

1. `pnpm dev` → відкрити HubChat → натиснути mic → надиктувати → має піти через `transcribeApi.send()` (DevTools → Network → `POST /api/v1/transcribe`, Content-Type `audio/webm`, query `language=uk`).
2. Якщо `GROQ_API_KEY` не виставлено на сервері → UI має показати "перемикаюсь на браузерне розпізнавання" (outcome `provider_unavailable`) замість кинутого `ApiError`.

---

## Pre-flight (Hard Rule #15)

- [x] Read the `AGENTS.md` Hard Rules that apply to the touched paths (#3 API contract; #5 conventional commits scope).
- [x] Read the matching playbook — `docs/playbooks/add-api-endpoint.md`.
- [x] Checked freshness headers of docs cited in the change.

## Docs updated alongside code? (Hard Rule #15)

- [x] API contract change — `packages/api-client/**` types + shared schema updated (Hard Rule #3). Сервер-handler-и імпортують SSOT-схеми з shared; `docs/api/openapi.json` регенеровано через `pnpm api:generate-openapi`.
- [ ] New / removed npm script — n/a.
- [ ] New design token / component / palette — n/a.
- [ ] Deprecation — n/a.
- [ ] Freshness header bumped on docs whose claims changed — n/a.
- [ ] N/A — no docs invalidated by this change.

## How AI-tested this PR

- [x] Vitest passes: `@sergeant/api-client` (55/55), `@sergeant/shared`, server transcribe+observability (17/17), web observability (53/53).
- [x] `pnpm lint` зелений (після додавання `api:check-openapi` в chain).
- [x] `pnpm typecheck` зелений.
- [x] No new `AI-DANGER` markers.
- [x] Docs prose uses Ukrainian where practical.
- [ ] Manual smoke live-запит на `/api/transcribe` не робив (локально немає `GROQ_API_KEY`); решта — unit + типи.
- [ ] `pnpm dead-code:files` — не запускав; нові файли мають прямі ре-експорти (`createApiClient` + `@shared/api` → `VoiceMicButton`/`webVitals`), не orphan.

## AGENTS.md updated?

- [ ] No — no new permanent rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a transcription API for audio uploads with language and prompt support; voice button now uses the new client with improved outcomes and error handling.
  * Added Web Vitals metrics ingestion; web client now filters and normalizes metrics before sending.

* **Documentation**
  * OpenAPI updated with new endpoints (transcribe, web-vitals, backup-download), weekly-digest path rename, and documented waitlist alias.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->