### PR TITLE
refactor(web): expand tsconfig.strict.json scope to 10 dirs (Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,16 @@
 
 ## [Unreleased]
 
-_Нові зміни з'являться тут перед наступним релізом._
+### Changed
+
+- **Web: strict TS rollout — Phase 2.** `apps/web/tsconfig.strict.json`
+  розширено з `src/shared/**` до 10 директорій
+  (`src/shared`, `src/test`, `src/core/{auth, cloudSync, components,
+hints, hooks, observability, pricing, profile}`). Cross-file
+  SpeechRecognition type-collision між `useSpeech.ts` та
+  `VoiceMicButton.tsx` виправлено зняттям глобальної
+  `declare global Window` augmentation на користь приватного
+  `WindowWithSpeech` cast у `useSpeech.ts`. Жодних змін у runtime-коді,
+  лише типи + один тестовий null-guard у
+  `useCloudSync.behavior.test.ts`. Деталі — у
+  [`docs/tech-debt/frontend.md`](./docs/tech-debt/frontend.md) §11.

--- a/apps/web/src/core/cloudSync/useCloudSync.behavior.test.ts
+++ b/apps/web/src/core/cloudSync/useCloudSync.behavior.test.ts
@@ -97,9 +97,9 @@ describe("notifySyncDirty", () => {
     localStorage.setItem(STORAGE_KEYS.SYNC_DIRTY_MODULES, "{}");
     localStorage.removeItem(STORAGE_KEYS.SYNC_MODULE_MODIFIED);
     notifySyncDirty(STORAGE_KEYS.FINYK_BUDGETS);
-    const parsed = JSON.parse(
-      localStorage.getItem(STORAGE_KEYS.SYNC_MODULE_MODIFIED),
-    );
+    const raw = localStorage.getItem(STORAGE_KEYS.SYNC_MODULE_MODIFIED);
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw as string);
     expect(parsed.finyk).toBeTruthy();
     expect(new Date(parsed.finyk).toISOString()).toBe(parsed.finyk);
   });

--- a/apps/web/src/core/hooks/useSpeech.ts
+++ b/apps/web/src/core/hooks/useSpeech.ts
@@ -27,12 +27,14 @@ interface SpeechRecognitionLike {
 
 type SpeechRecognitionCtor = new () => SpeechRecognitionLike;
 
-declare global {
-  interface Window {
-    SpeechRecognition?: SpeechRecognitionCtor;
-    webkitSpeechRecognition?: SpeechRecognitionCtor;
-  }
-}
+// Web Speech API не входить у lib.dom — типи держимо локально і
+// читаємо `window` через приватну window-shape без `declare global`,
+// щоб не нав'язувати єдину сигнатуру іншим call-сайтам (наприклад,
+// `VoiceMicButton.tsx` має власну сумісну форму, ширшу для тестів).
+type WindowWithSpeech = typeof window & {
+  SpeechRecognition?: SpeechRecognitionCtor;
+  webkitSpeechRecognition?: SpeechRecognitionCtor;
+};
 
 export interface UseSpeechResult {
   listening: boolean;
@@ -50,11 +52,15 @@ export function useSpeech(
 
   const supported =
     typeof window !== "undefined" &&
-    !!(window.SpeechRecognition || window.webkitSpeechRecognition);
+    !!(
+      (window as WindowWithSpeech).SpeechRecognition ||
+      (window as WindowWithSpeech).webkitSpeechRecognition
+    );
 
   const toggle = useCallback(() => {
-    if (!supported) return;
-    const SR = window.SpeechRecognition || window.webkitSpeechRecognition;
+    if (!supported || typeof window === "undefined") return;
+    const w = window as WindowWithSpeech;
+    const SR = w.SpeechRecognition || w.webkitSpeechRecognition;
     if (!SR) return;
     if (listening) {
       recRef.current?.abort();

--- a/apps/web/tsconfig.strict.json
+++ b/apps/web/tsconfig.strict.json
@@ -4,6 +4,17 @@
     "strictNullChecks": true,
     "noEmit": true
   },
-  "include": ["src/shared/**/*"],
+  "include": [
+    "src/shared/**/*",
+    "src/test/**/*",
+    "src/core/auth/**/*",
+    "src/core/cloudSync/**/*",
+    "src/core/components/**/*",
+    "src/core/hints/**/*",
+    "src/core/hooks/**/*",
+    "src/core/observability/**/*",
+    "src/core/pricing/**/*",
+    "src/core/profile/**/*"
+  ],
   "exclude": ["node_modules", "dist"]
 }

--- a/docs/tech-debt/frontend.md
+++ b/docs/tech-debt/frontend.md
@@ -1,13 +1,15 @@
 # Frontend Tech Debt — Sergeant Web
 
-> **Last validated:** 2026-04-27 by @Skords-01. **Next review:** 2026-06-26.
+> **Last validated:** 2026-04-29 by @devin-ai. **Next review:** 2026-06-28.
 > **Status:** Active
 
 Аналіз кодової бази `apps/web/src` (434 source файли, 87k рядків).
 
-> **Оновлено 2026-04-27.** Базові cifri (allowlist size, file
-> sizes, countи) переперевірені відносно поточного `eslint.config.js`
-> і вмісту `apps/web/src/`.
+> **Оновлено 2026-04-29.** Розділ 11 (Strict TS rollout) промарковано Phase 2:
+> `tsconfig.strict.json` розширено з `src/shared/**` до всього `src/test`,
+> `src/core/{auth,cloudSync,components,hints,hooks,observability,pricing,profile}`
+> (10 директорій всього). Окремо виправлено cross-file SpeechRecognition
+> type-collision (`useSpeech.ts` більше не augment-ить глобальний `Window`).
 
 > **Як читати:** позначки в стовпчику «Статус» оновлюються в момент злиття PR.
 > Це жива сторінка — не «звіт», а контроль міграцій. Кожен запис стандартизує:
@@ -248,13 +250,14 @@ Production код чистий. Тестові `any` — фабрики фікт
 
 **Триетапний план:**
 
-| Phase | Прапор                                      | Скоуп                          | Статус      |
-| ----- | ------------------------------------------- | ------------------------------ | ----------- |
-| 1     | `strictNullChecks`                          | `src/shared/**`                | ✅ Виконано |
-| 2     | `strictNullChecks`                          | `src/core/lib/**` + розширення | TODO        |
-| 3     | повний `strict: true` + видалення `allowJs` | всі файли                      | TODO        |
+| Phase | Прапор                                      | Скоуп                                                                                                         | Статус      |
+| ----- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ----------- |
+| 1     | `strictNullChecks`                          | `src/shared/**`                                                                                               | ✅ Виконано |
+| 2     | `strictNullChecks`                          | + `src/test/**`, `src/core/{auth,cloudSync,components,hints,hooks,observability,pricing,profile}/**` (10 дир) | ✅ Виконано |
+| 3     | `strictNullChecks`                          | + `src/modules/{routine,nutrition,finyk,fizruk}/**`, `src/core/{app,hub,insights,onboarding,settings,lib}/**` | TODO        |
+| 4     | повний `strict: true` + видалення `allowJs` | всі файли                                                                                                     | TODO        |
 
-**Phase 1 деталі (цей PR — PR-6.A):**
+**Phase 1 деталі (PR-6.A):**
 
 - Додано `apps/web/tsconfig.strict.json` — extends основний tsconfig,
   додає `strictNullChecks: true`, includes тільки `src/shared/**`.
@@ -262,16 +265,32 @@ Production код чистий. Тестові `any` — фабрики фікт
   до pipeline.
 - **Baseline error count (з `strictNullChecks` на весь `apps/web`):** 518 помилок.
   - `src/shared/**` — 7 помилок → виправлено (non-null assertions у тестах).
-  - `src/core/lib/**` — 16 помилок → TODO Phase 2.
-  - Інші модулі (`modules/`, `core/` без lib) — ~495 помилок → Phase 3.
+  - `src/core/lib/**` — 16 помилок → TODO Phase 3 (було Phase 2 у первісному плані).
+  - Інші модулі (`modules/`, `core/` без lib) — ~495 помилок → Phase 3+.
 - Жодних `@ts-expect-error` або runtime-змін не додано.
 
-**Phase 2 (наступний PR):** розширити `tsconfig.strict.json` include на
-`src/core/lib/**`. Виправити 16 помилок (4 у production-коді
-`hubChatContext.ts`, решта в тестах).
+**Phase 2 деталі (PR — audit high-priority #1 крок 1):**
 
-**Phase 3:** увімкнути `strict: true` у головному `tsconfig.json`, видалити
-`allowJs`, виправити всі залишкові помилки.
+- `tsconfig.strict.json` розширено до 10 директорій:
+  `src/shared`, `src/test`, `src/core/{auth, cloudSync, components, hints, hooks, observability, pricing, profile}`.
+- **Виправлено cross-file SpeechRecognition type-collision** між
+  `useSpeech.ts` (`declare global Window`) і `VoiceMicButton.tsx` (локальна
+  форма). Глобальну augmentation знято — `useSpeech.ts` читає `window`
+  через приватний cast (`WindowWithSpeech`), що не навʼязує єдиної
+  сигнатури іншим call-сайтам.
+- **1 null-check error виправлено** у `useCloudSync.behavior.test.ts`
+  (`localStorage.getItem(...)` → додано `expect(...).not.toBeNull()`
+  - `as string` перед `JSON.parse`).
+- Жодних змін у runtime-коді (лише типи + один тест assertion).
+
+**Phase 3 (наступний PR):** розширити `tsconfig.strict.json` на
+`src/modules/{routine,nutrition,finyk,fizruk}/**` (~25 strict-null помилок
+по поточному виміру) і `src/core/lib/**` (16 помилок). Можна
+паралелити як 4 під-PR-и (по одному на модуль).
+
+**Phase 4:** увімкнути `strict: true` у головному `tsconfig.json`, видалити
+`allowJs`, виправити всі залишкові помилки (основний ROI — на `noImplicitAny`,
+`strictPropertyInitialization`).
 
 ---
 


### PR DESCRIPTION
## What changed

Це наступний конкретний крок міграції `apps/web` на strict TypeScript (audit high-priority **#1**), продовження PR-6.A, який покривав тільки `src/shared/**`.

### `apps/web/tsconfig.strict.json`

`include` розширено з 1 → 10 директорій:

```diff
   "include": [
     "src/shared/**/*",
+    "src/test/**/*",
+    "src/core/auth/**/*",
+    "src/core/cloudSync/**/*",
+    "src/core/components/**/*",
+    "src/core/hints/**/*",
+    "src/core/hooks/**/*",
+    "src/core/observability/**/*",
+    "src/core/pricing/**/*",
+    "src/core/profile/**/*"
   ]
```

`pnpm typecheck` уже chain-ить `tsconfig.strict.json` після основного pass-у, тож будь-яка регресія `strictNullChecks` у цих директоріях тепер блокує merge.

### Дві супутні правки

1. **Cross-file SpeechRecognition type collision.**
   `useSpeech.ts` augment-ив глобальний `Window` через `declare global`, а `VoiceMicButton.tsx` мав свою сумісну, але структурно ширшу `SpeechRecognitionLike` (особливо `onresult` — `results?: ...` опційний). Коли обидва файли потрапили в один strict-program graph, `VoiceMicButton.test.tsx` перестав компілитись (`RecCtor` несумісний з augment-нутим типом).
   Fix: знято глобальну augmentation; `useSpeech.ts` тепер читає `window` через приватний cast `WindowWithSpeech`. Runtime — ідентичний.

2. **`useCloudSync.behavior.test.ts:101`** — `JSON.parse(localStorage.getItem(...))` де `getItem` повертає `string | null`. Додано `expect(raw).not.toBeNull()` + `as string` перед `JSON.parse`. Тест продовжує перевіряти реальний інваріант (модуль реально пише ключ).

### Документація

- `docs/tech-debt/frontend.md` §11 — таблицю фаз промарковано Phase 2 = ✅, додано план Phase 3/4. Freshness header bumped до 2026-04-29.
- `CHANGELOG.md` — `[Unreleased] / Changed`.

## Why

Аудит high-priority #1 — повна міграція web-app на `strict: true`. Аудит явно радив поступовий, директорія-за-директорією роллаут — і ось перший великий крок: 1 директорія → 10. Це покриває весь `src/core/*` крім `lib/`, `app/`, `hub/`, `insights/`, `onboarding/`, `settings/`, та `designShowcase/`, плюс весь `src/test/`.

Залишок Phase 3 (за поточним вимірюванням, після цього PR):

| Скоуп                              | strict-null помилок |
| ---------------------------------- | ------------------- |
| `src/modules/routine/**`           | ~9                  |
| `src/modules/nutrition/**`         | ~16                 |
| `src/core/lib/**`                  | ~16 (4 production)  |
| `src/modules/{finyk,fizruk}/**`    | (не виміряно)       |

Кожне з цих — кандидат на окремий focused PR. Phase 4 — увімкнути `strict: true` в головному `tsconfig.json` і прибрати `allowJs`.

## How to test

```bash
pnpm --filter @sergeant/web typecheck
# tsc -p tsconfig.json && tsconfig.sw.json && tsconfig.strict.json && tsconfig.noimplicitany.json
# Все 4 проходять.

pnpm --filter @sergeant/web lint        # OK
pnpm format:check                        # OK
pnpm docs:check-links                    # OK (нові посилання резолвляться)
pnpm lint:tech-debt-freshness            # OK (freshness header bumped)

# Тести зачеплених файлів:
pnpm --filter @sergeant/web exec vitest run \
  src/core/cloudSync/useCloudSync.behavior.test.ts \
  src/shared/components/ui/VoiceMicButton.test.tsx
# 19/19 passed (16 cloudSync + 3 VoiceMic).
```

Manual smoke: `useSpeech` використовується у `ChatInput.tsx` (HubChat кнопка мікрофона). У браузері без Web Speech API кнопка не з'являється — поведінка ідентична до pre-change.

---

## Pre-flight (Hard Rule #15)

- [x] Read the `AGENTS.md` Hard Rules that apply to the touched paths. (Module ownership: `apps/web/src/{shared,core,test}/**`. Rule #5: scope `web`. Rule #15: docs alongside code.)
- [x] Read the matching playbook in `docs/playbooks/` (or noted that none exists). — n/a (нема playbook для strict-rollout; жива сторінка §11 у `docs/tech-debt/frontend.md` слугує його замінником).
- [x] Checked freshness headers of docs cited in the change. — `docs/tech-debt/frontend.md` freshness bumped (`2026-04-27` → `2026-04-29`); `CHANGELOG.md` Active.

## Docs updated alongside code? (Hard Rule #15)

- [ ] API contract change — n/a.
- [ ] New / removed npm script — n/a.
- [ ] New design token / component / palette — n/a.
- [ ] Deprecation — n/a (зняття `declare global Window` для Web Speech не deprecation, бо тип ніколи не експортувався і використовувався тільки в одному файлі).
- [x] Freshness header bumped on docs whose claims changed — `docs/tech-debt/frontend.md` (нова Phase 2 інформація + перерахування фаз).
- [ ] N/A — no docs invalidated by this change.

## How AI-tested this PR

- [x] Manual smoke: ChatInput → mic кнопка все ще рендериться/прихована за тим самим правилом (presence of `window.SpeechRecognition` || `window.webkitSpeechRecognition`).
- [x] Vitest passes: 19/19 у дотичних файлах. Повний `pnpm --filter @sergeant/web typecheck` clean (chain з 4 tsconfig).
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.
- [x] `pnpm dead-code:files` — без нових файлів (тільки правки існуючих).

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded `apps/web` strict TypeScript scope to 10 more directories to enforce `strictNullChecks` and gate merges via the chained `pnpm typecheck`. No runtime behavior changes.

- **Refactors**
  - Updated `apps/web/tsconfig.strict.json` include to: `src/shared/**`, `src/test/**`, and `src/core/{auth,cloudSync,components,hints,hooks,observability,pricing,profile}/**`.

- **Bug Fixes**
  - Resolved SpeechRecognition type collision by removing global `Window` augmentation in `useSpeech.ts` and using a local `WindowWithSpeech` cast.
  - Added a null-guard in `useCloudSync.behavior.test.ts` before `JSON.parse(localStorage.getItem(...))`.

<sup>Written for commit 3f5abdfec0872f64fb950caceab420d101ad7dae. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1173?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

