### PR TITLE
feat(web): UX/UI improvements — 5 UX + 3 UI changes

### DIFF
--- a/apps/web/src/core/ErrorBoundary.tsx
+++ b/apps/web/src/core/ErrorBoundary.tsx
@@ -71,7 +71,56 @@ export class ErrorBoundary extends Component<
       if (typeof Fallback === "function") {
         return <Fallback error={error} resetError={this.resetError} />;
       }
-      return Fallback || null;
+      if (Fallback) return Fallback;
+      // Default crash-recovery screen — shown when no custom fallback was
+      // provided. Gives the user a clear "something went wrong" message
+      // with a retry button instead of a blank white screen.
+      return (
+        <div className="min-h-dvh bg-bg flex flex-col items-center justify-center p-6 text-text safe-area-pt-pb">
+          <div className="w-14 h-14 rounded-2xl bg-danger/10 text-danger flex items-center justify-center mb-4">
+            <svg
+              width="28"
+              height="28"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden
+            >
+              <circle cx="12" cy="12" r="10" />
+              <line x1="12" y1="8" x2="12" y2="12" />
+              <line x1="12" y1="16" x2="12.01" y2="16" />
+            </svg>
+          </div>
+          <h1 className="text-lg font-bold text-text mb-1">
+            Щось пішло не так
+          </h1>
+          <p className="text-sm text-muted mb-4 text-center max-w-xs">
+            Виникла непередбачена помилка. Спробуй перезавантажити сторінку.
+          </p>
+          <pre className="text-xs text-danger/80 mb-6 max-w-lg w-full overflow-auto whitespace-pre-wrap break-words bg-panel rounded-xl p-3 border border-line">
+            {error.message}
+          </pre>
+          <div className="flex flex-col sm:flex-row gap-2 w-full max-w-xs">
+            <button
+              type="button"
+              onClick={this.resetError}
+              className="flex-1 px-5 py-2.5 rounded-2xl bg-primary text-bg text-sm font-semibold shadow-card hover:brightness-110 transition-[filter,box-shadow,opacity] focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+            >
+              Спробувати ще
+            </button>
+            <button
+              type="button"
+              onClick={() => window.location.reload()}
+              className="flex-1 px-5 py-2.5 rounded-2xl bg-panel border border-line text-text text-sm font-medium shadow-card hover:shadow-float transition-shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+            >
+              Перезавантажити
+            </button>
+          </div>
+        </div>
+      );
     }
     return children;
   }

--- a/apps/web/src/core/app/OfflineBanner.tsx
+++ b/apps/web/src/core/app/OfflineBanner.tsx
@@ -3,34 +3,34 @@ import { useSyncStatus } from "../cloudSync/useCloudSync";
 import { pluralUa } from "@sergeant/shared";
 
 /**
- * Офлайн-банер у шапці. Раніше показував лише статичне "Немає
- * підключення до інтернету". Тепер підтягує `useSyncStatus`, щоб
- * користувач одразу бачив, скільки дій стоїть у черзі — це закриває
- * головну тривогу ("чи збережеться витрата, якщо я без мережі?").
+ * Subtle offline indicator — a small floating pill in the top-right
+ * corner instead of a full-width warning banner. For a PWA designed to
+ * work offline, screaming "NO INTERNET!" felt like a critical error.
  *
- * Шрифт/кольори не змінюємо, щоб не зміщувати layout у залежності від
- * кількості елементів у черзі (висота банера константна).
+ * Shows a compact wifi-off icon + short label. When items are queued
+ * for sync, the pending count is displayed so the user knows their
+ * data is safe and waiting.
  */
 export function OfflineBanner() {
   const { queuedCount, dirtyCount } = useSyncStatus();
   const pending = Math.max(queuedCount, dirtyCount);
   const label =
     pending > 0
-      ? `Немає підключення · ${pending} ${pluralUa(pending, {
-          one: "дія чекає",
-          few: "дії чекають",
-          many: "дій чекають",
-        })} синхронізації`
-      : "Немає підключення до інтернету";
+      ? `Офлайн · ${pending} ${pluralUa(pending, {
+          one: "в черзі",
+          few: "в черзі",
+          many: "в черзі",
+        })}`
+      : "Офлайн";
 
   return (
     <div
       role="status"
       aria-live="polite"
-      className="fixed top-0 left-0 right-0 z-[300] flex items-center justify-center gap-2 px-4 py-2 bg-warning-strong text-white text-xs font-semibold safe-area-pt shadow-soft"
+      className="fixed top-3 right-3 z-[300] flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-panel/90 border border-line text-muted text-xs font-medium shadow-soft backdrop-blur-sm safe-area-pt motion-safe:animate-fade-in"
     >
-      <Icon name="wifi-off" size={14} strokeWidth={2.5} aria-hidden />
-      <span className="truncate max-w-[min(92vw,40rem)]">{label}</span>
+      <Icon name="wifi-off" size={12} strokeWidth={2.5} aria-hidden />
+      <span>{label}</span>
     </div>
   );
 }

--- a/apps/web/src/core/hub/HubDashboard.tsx
+++ b/apps/web/src/core/hub/HubDashboard.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
+import { CollapsibleSection } from "@shared/components/ui/CollapsibleSection";
 import { Icon } from "@shared/components/ui/Icon";
 import { cn } from "@shared/lib/cn";
 import {
@@ -354,12 +355,13 @@ export function HubDashboard({
           {/* «Підказки» секція: AssistantAdvice + DailyNudge — обидві
            * картки показували пораду на день, але рендерились як два
            * незалежних блоки з різним візуальним chrome. Обʼєднання
-           * під одним SectionHeading знижує card-density (#1130). */}
+           * під одним SectionHeading знижує card-density (#1130).
+           * Collapsible so users with many modules can reduce scroll depth. */}
           <StaggerChild index={si++}>
-            <section className="space-y-2">
-              <SectionHeading as="h2" size="xs" className="!px-0">
-                Підказки
-              </SectionHeading>
+            <CollapsibleSection
+              storageKey="sergeant:hub.hints.open"
+              title="Підказки"
+            >
               <AssistantAdviceCard
                 insight={coachInsightText}
                 loading={coachLoading}
@@ -373,7 +375,7 @@ export function HubDashboard({
                   onDismiss={() => setNudgeDismissed(true)}
                 />
               )}
-            </section>
+            </CollapsibleSection>
           </StaggerChild>
         </>
       )}
@@ -416,7 +418,7 @@ export function HubDashboard({
               items={visibleOrder}
               strategy={rectSortingStrategy}
             >
-              <div className="grid grid-cols-2 gap-3">
+              <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
                 {visibleOrder.map((id) => (
                   <SortableCard
                     key={id}
@@ -448,14 +450,14 @@ export function HubDashboard({
       {/* «Аналітика» секція (FTUX-гейт): insights-panel + weekly-digest —
        * обидва data-driven блоки на історії. До першого реального запису
        * insights пусті, а digest промовляє «нічого не було за тиждень».
-       * Гейтимо за hasRealEntry. SectionHeading з #1130 знижує
-       * card-density, а гейт — FTUX-noise. */}
+       * Гейтимо за hasRealEntry. Collapsible per UX audit — users who
+       * check analytics weekly can collapse the section to cut scroll depth. */}
       {hasRealEntry && (
         <StaggerChild index={si++}>
-          <section className="space-y-2">
-            <SectionHeading as="h2" size="xs" className="!px-0">
-              Аналітика
-            </SectionHeading>
+          <CollapsibleSection
+            storageKey="sergeant:hub.analytics.open"
+            title="Аналітика"
+          >
             <HubInsightsPanel
               items={rest}
               onOpenModule={openInsightTarget}
@@ -470,7 +472,7 @@ export function HubDashboard({
                 onExpand={() => setDigestExpanded(true)}
               />
             ) : null}
-          </section>
+          </CollapsibleSection>
         </StaggerChild>
       )}
 

--- a/apps/web/src/core/hub/HubSearch.tsx
+++ b/apps/web/src/core/hub/HubSearch.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo } from "react";
+import { useState, useEffect, useRef, useMemo, startTransition } from "react";
 import type { ModuleAccent } from "@sergeant/design-tokens";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
@@ -398,8 +398,14 @@ export function HubSearch({ onClose, onOpenModule }: HubSearchProps) {
     }
     const timer = setTimeout(() => {
       const next = performSearch(query);
-      setResults(next);
-      setActiveIdx(0);
+      // Wrap state updates in startTransition so the heavy localStorage
+      // parse + scoring work doesn't block the input from accepting the
+      // next keystroke. React can interrupt this low-priority update if
+      // new input arrives.
+      startTransition(() => {
+        setResults(next);
+        setActiveIdx(0);
+      });
     }, 120);
     return () => clearTimeout(timer);
   }, [query]);

--- a/apps/web/src/modules/nutrition/NutritionApp.tsx
+++ b/apps/web/src/modules/nutrition/NutritionApp.tsx
@@ -25,7 +25,11 @@ import { usePhotoAnalysis } from "./hooks/usePhotoAnalysis";
 import { useShoppingList } from "./hooks/useShoppingList";
 import { useNutritionUiState } from "./hooks/useNutritionUiState";
 import { useNutritionHashRoute } from "./hooks/useNutritionHashRoute";
-import type { NutritionPage } from "./lib/nutritionRouter";
+import type {
+  NutritionPage,
+  PantrySubTab,
+  MenuSubTab,
+} from "./lib/nutritionRouter";
 import { useNutritionReminders } from "./hooks/useNutritionReminders";
 import { usePantryBarcodeScan } from "./hooks/usePantryBarcodeScan";
 import { useNutritionCloudBackup } from "./hooks/useNutritionCloudBackup";
@@ -53,13 +57,14 @@ export default function NutritionApp({
   const [err, setErr] = useState("");
   const [statusText, setStatusText] = useState("");
 
-  const { activePage, setActivePageAndHash } = useNutritionHashRoute();
-
-  // Sub-tab state for merged pages (pantry = Склад + Покупки,
-  // menu = План + Рецепти). Lives in component state because deep-linking
-  // into sub-tabs wasn't part of the old router either.
-  const [pantrySubTab, setPantrySubTab] = useState("items");
-  const [menuSubTab, setMenuSubTab] = useState("plan");
+  const {
+    activePage,
+    setActivePageAndHash,
+    pantrySubTab,
+    menuSubTab,
+    setPantrySubTab,
+    setMenuSubTab,
+  } = useNutritionHashRoute();
 
   const pantry = useNutritionPantries({ setBusy, setErr, setStatusText });
   const log = useNutritionLog();
@@ -380,7 +385,6 @@ export default function NutritionApp({
                   prefs={prefs}
                   onGoToLog={() => setActivePageAndHash("log")}
                   onGoToDailyPlan={() => {
-                    setMenuSubTab("plan");
                     setActivePageAndHash("menu");
                   }}
                   onFetchDayHint={fetchDayHint}
@@ -437,7 +441,7 @@ export default function NutritionApp({
               <>
                 <SubTabs
                   value={pantrySubTab}
-                  onChange={setPantrySubTab}
+                  onChange={(id) => setPantrySubTab(id as PantrySubTab)}
                   tabs={[
                     { id: "items", label: "Склад" },
                     { id: "shopping", label: "Покупки" },
@@ -535,7 +539,7 @@ export default function NutritionApp({
               <>
                 <SubTabs
                   value={menuSubTab}
-                  onChange={setMenuSubTab}
+                  onChange={(id) => setMenuSubTab(id as MenuSubTab)}
                   tabs={[
                     { id: "plan", label: "План на день" },
                     { id: "recipes", label: "Рецепти" },

--- a/apps/web/src/modules/nutrition/hooks/useNutritionHashRoute.ts
+++ b/apps/web/src/modules/nutrition/hooks/useNutritionHashRoute.ts
@@ -3,17 +3,35 @@ import {
   parseNutritionHash,
   setNutritionHash,
   type NutritionPage,
+  type PantrySubTab,
+  type MenuSubTab,
 } from "../lib/nutritionRouter";
 
 export interface UseNutritionHashRouteResult {
   activePage: NutritionPage;
   setActivePage: (page: NutritionPage) => void;
-  setActivePageAndHash: (page: NutritionPage) => void;
+  setActivePageAndHash: (page: NutritionPage, subTab?: string) => void;
+  /** Current sub-tab parsed from hash (e.g. `#pantry/shopping`). */
+  pantrySubTab: PantrySubTab;
+  menuSubTab: MenuSubTab;
+  setPantrySubTab: (sub: PantrySubTab) => void;
+  setMenuSubTab: (sub: MenuSubTab) => void;
 }
 
 export function useNutritionHashRoute(): UseNutritionHashRouteResult {
+  const initial = parseNutritionHash();
   const [activePage, setActivePage] = useState<NutritionPage>(
-    () => parseNutritionHash().page,
+    () => initial.page,
+  );
+  const [pantrySubTab, setPantrySubTabState] = useState<PantrySubTab>(() =>
+    initial.page === "pantry" && initial.subTab
+      ? (initial.subTab as PantrySubTab)
+      : "items",
+  );
+  const [menuSubTab, setMenuSubTabState] = useState<MenuSubTab>(() =>
+    initial.page === "menu" && initial.subTab
+      ? (initial.subTab as MenuSubTab)
+      : "plan",
   );
 
   useEffect(() => {
@@ -21,22 +39,46 @@ export function useNutritionHashRoute(): UseNutritionHashRouteResult {
     // (`#products`, `#plan`, `#recipes`, `#shop`) by rewriting the URL in
     // place. The state already holds the correct page because
     // parseNutritionHash resolves the redirect.
-    const initial = parseNutritionHash();
-    if (initial.redirectFrom) setNutritionHash(initial.page);
+    const init = parseNutritionHash();
+    if (init.redirectFrom) setNutritionHash(init.page, init.subTab);
 
     const onHash = () => {
       const p = parseNutritionHash();
       setActivePage(p.page);
-      if (p.redirectFrom) setNutritionHash(p.page);
+      if (p.page === "pantry" && p.subTab) {
+        setPantrySubTabState(p.subTab as PantrySubTab);
+      }
+      if (p.page === "menu" && p.subTab) {
+        setMenuSubTabState(p.subTab as MenuSubTab);
+      }
+      if (p.redirectFrom) setNutritionHash(p.page, p.subTab);
     };
     window.addEventListener("hashchange", onHash);
     return () => window.removeEventListener("hashchange", onHash);
   }, []);
 
-  const setActivePageAndHash = (page: NutritionPage) => {
+  const setActivePageAndHash = (page: NutritionPage, subTab?: string) => {
     setActivePage(page);
-    setNutritionHash(page);
+    setNutritionHash(page, subTab);
   };
 
-  return { activePage, setActivePage, setActivePageAndHash };
+  const setPantrySubTab = (sub: PantrySubTab) => {
+    setPantrySubTabState(sub);
+    setNutritionHash("pantry", sub === "items" ? undefined : sub);
+  };
+
+  const setMenuSubTab = (sub: MenuSubTab) => {
+    setMenuSubTabState(sub);
+    setNutritionHash("menu", sub === "plan" ? undefined : sub);
+  };
+
+  return {
+    activePage,
+    setActivePage,
+    setActivePageAndHash,
+    pantrySubTab,
+    menuSubTab,
+    setPantrySubTab,
+    setMenuSubTab,
+  };
 }

--- a/apps/web/src/modules/nutrition/lib/nutritionRouter.ts
+++ b/apps/web/src/modules/nutrition/lib/nutritionRouter.ts
@@ -18,24 +18,45 @@ const LEGACY_REDIRECTS: Record<string, NutritionPage> = {
   shop: "pantry",
 };
 
+/** Valid sub-tab ids per page. Only pages that have sub-tabs are listed. */
+export type PantrySubTab = "items" | "shopping";
+export type MenuSubTab = "plan" | "recipes";
+
+const VALID_PANTRY_SUBS: readonly string[] = ["items", "shopping"];
+const VALID_MENU_SUBS: readonly string[] = ["plan", "recipes"];
+
 export interface ParsedNutritionHash {
   page: NutritionPage;
+  /** Sub-tab segment parsed from `#page/sub`. `undefined` when absent. */
+  subTab?: string;
   redirectFrom?: string;
 }
 
 export function parseNutritionHash(): ParsedNutritionHash {
   const raw = (window.location.hash || "").replace(/^#/, "").trim();
   if (!raw || raw.startsWith("/")) return { page: "start" };
-  const [page] = raw.split("/").filter(Boolean);
+  const [page, sub] = raw.split("/").filter(Boolean);
   const redirect = LEGACY_REDIRECTS[page];
   if (redirect) return { page: redirect, redirectFrom: page };
   if (!VALID_NUTRITION_PAGES.includes(page as NutritionPage))
     return { page: "start" };
-  return { page: page as NutritionPage };
+
+  // Validate sub-tab against the page's allowed set
+  let validSub: string | undefined;
+  if (page === "pantry" && sub && VALID_PANTRY_SUBS.includes(sub)) {
+    validSub = sub;
+  } else if (page === "menu" && sub && VALID_MENU_SUBS.includes(sub)) {
+    validSub = sub;
+  }
+  return { page: page as NutritionPage, subTab: validSub };
 }
 
-export function setNutritionHash(next: NutritionPage | null | undefined): void {
-  const h = next ? `#${next}` : "#start";
+export function setNutritionHash(
+  next: NutritionPage | null | undefined,
+  subTab?: string,
+): void {
+  const page = next || "start";
+  const h = subTab ? `#${page}/${subTab}` : `#${page}`;
   if (window.location.hash === h) return;
   window.location.hash = h;
 }

--- a/apps/web/src/modules/routine/RoutineApp.tsx
+++ b/apps/web/src/modules/routine/RoutineApp.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useTransition,
+} from "react";
 import { cn } from "@shared/lib/cn";
 import { Banner } from "@shared/components/ui/Banner";
 import {
@@ -160,6 +166,10 @@ export default function RoutineApp({
   onPwaActionConsumed,
 }: RoutineAppProps = {}) {
   const [routine, setRoutine] = useRoutineState();
+  // Low-priority transition for habit toggles: the checkbox haptic fires
+  // instantly while React defers the heavier re-render (full list + persist)
+  // so the animation never feels janky on slower devices.
+  const [, startHabitTransition] = useTransition();
   // Finyk calendar events depend on both the Finyk Monobank cache and the
   // subscription calendar. The former now flows through React Query
   // (`hubKeys.preview("finyk")`), the latter still uses a custom event
@@ -401,9 +411,14 @@ export default function RoutineApp({
       // око встигне відскакувати до heatmap-анімації. `hapticTap` —
       // noop на desktop/iOS Safari і під prefers-reduced-motion.
       hapticTap();
-      setRoutine((prev) => toggleHabitCompletion(prev, habitId, dateKey));
+      // Wrap in startTransition so React can commit the haptic + checkbox
+      // visual change at high priority while deferring the full list
+      // re-render + localStorage persist to a lower-priority lane.
+      startHabitTransition(() => {
+        setRoutine((prev) => toggleHabitCompletion(prev, habitId, dateKey));
+      });
     },
-    [setRoutine],
+    [setRoutine, startHabitTransition],
   );
 
   const onBulkMarkDay = useCallback(() => {

--- a/apps/web/src/shared/components/ui/CollapsibleSection.tsx
+++ b/apps/web/src/shared/components/ui/CollapsibleSection.tsx
@@ -1,0 +1,85 @@
+import { useState, useCallback, type ReactNode } from "react";
+import { cn } from "../../lib/cn";
+import { Icon } from "./Icon";
+import { SectionHeading, type SectionHeadingSize } from "./SectionHeading";
+import { safeReadLS, safeWriteLS } from "../../lib/storage";
+
+export interface CollapsibleSectionProps {
+  /** Unique key for persisting collapse state in localStorage. */
+  storageKey: string;
+  /** Section heading text. */
+  title: ReactNode;
+  /** Default state when no localStorage value exists. */
+  defaultOpen?: boolean;
+  /** SectionHeading size — defaults to "xs". */
+  headingSize?: SectionHeadingSize;
+  children?: ReactNode;
+  className?: string;
+}
+
+/**
+ * Section wrapper that collapses/expands its children and persists the
+ * state in localStorage. Used on HubDashboard to let users collapse
+ * the "Підказки" and "Аналітика" sections to reduce scroll depth.
+ *
+ * The heading row doubles as the toggle button (chevron + heading).
+ * Collapse animation uses CSS `grid-template-rows` for smooth height
+ * transitions (no JavaScript measurement needed).
+ */
+export function CollapsibleSection({
+  storageKey,
+  title,
+  defaultOpen = true,
+  headingSize = "xs",
+  children,
+  className,
+}: CollapsibleSectionProps) {
+  const [open, setOpen] = useState<boolean>(
+    () => safeReadLS<boolean>(storageKey, defaultOpen) ?? defaultOpen,
+  );
+
+  const toggle = useCallback(() => {
+    setOpen((prev) => {
+      const next = !prev;
+      safeWriteLS(storageKey, next);
+      return next;
+    });
+  }, [storageKey]);
+
+  return (
+    <section className={cn("space-y-2", className)}>
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={open}
+        className="flex items-center gap-1.5 w-full text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 rounded-lg -ml-0.5 pl-0.5"
+      >
+        <Icon
+          name="chevron-right"
+          size={12}
+          strokeWidth={2.5}
+          className={cn(
+            "text-subtle transition-transform duration-200",
+            open && "rotate-90",
+          )}
+          aria-hidden
+        />
+        <SectionHeading as="span" size={headingSize} className="!px-0">
+          {title}
+        </SectionHeading>
+      </button>
+
+      {/* CSS grid row transition for smooth collapse */}
+      <div
+        className={cn(
+          "grid transition-[grid-template-rows] duration-200 ease-out",
+          open ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+        )}
+      >
+        <div className="overflow-hidden">
+          <div className="space-y-2">{children}</div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/shared/components/ui/Toast.tsx
+++ b/apps/web/src/shared/components/ui/Toast.tsx
@@ -39,7 +39,9 @@ export function ToastContainer() {
           key={t.id}
           className={cn(
             "pointer-events-auto w-full px-4 py-3 rounded-2xl text-sm font-semibold shadow-float flex items-center gap-2.5",
-            "motion-safe:animate-toast-enter",
+            t.leaving
+              ? "motion-safe:animate-toast-exit"
+              : "motion-safe:animate-toast-enter",
             VARIANT[t.type] || VARIANT.info,
           )}
           role="alert"

--- a/apps/web/src/shared/hooks/useToast.tsx
+++ b/apps/web/src/shared/hooks/useToast.tsx
@@ -21,6 +21,8 @@ export interface ToastItem {
   msg: ReactNode;
   type: ToastType;
   action: ToastAction | null;
+  /** Set to true during the exit animation before actual removal. */
+  leaving?: boolean;
 }
 
 export interface ToastApi {
@@ -56,11 +58,23 @@ export function ToastProvider({ children }: { children: ReactNode }) {
     };
   }, []);
 
-  const dismiss = useCallback((id: number) => {
-    clearTimeout(timersRef.current[id]);
-    delete timersRef.current[id];
+  const remove = useCallback((id: number) => {
     setToasts((prev) => prev.filter((t) => t.id !== id));
   }, []);
+
+  const dismiss = useCallback(
+    (id: number) => {
+      clearTimeout(timersRef.current[id]);
+      delete timersRef.current[id];
+      // Mark as leaving → triggers exit animation in <ToastContainer>.
+      // After 200ms (matches the CSS exit transition), actually remove.
+      setToasts((prev) =>
+        prev.map((t) => (t.id === id ? { ...t, leaving: true } : t)),
+      );
+      setTimeout(() => remove(id), 200);
+    },
+    [remove],
+  );
 
   const show = useCallback<ToastApi["show"]>(
     (msg, type = "success", duration = 3500, action) => {


### PR DESCRIPTION
## What changed

8 UX/UI покращень для `apps/web`:

**UX:**
1. **ErrorBoundary crash-recovery screen** — дефолтний fallback з описом помилки та кнопками retry/reload замість білого екрана.
2. **Nutrition sub-tab hash routing** — `pantrySubTab` / `menuSubTab` синхронізуються з URL hash (`#pantry/shopping`, `#menu/recipes`), кнопка «Назад» працює між підвкладками.
3. **Collapsible dashboard sections** — секції «Підказки» та «Аналітика» згортаються/розгортаються з persistence в localStorage. Новий `CollapsibleSection` компонент.
4. **HubSearch startTransition** — результати пошуку обгорнуті в `startTransition` для responsive input.
5. **Routine habit toggle useTransition** — haptic fires instantly, full re-render deferred.

**UI:**
1. **Toast exit animation** — двофазний dismiss з `animate-toast-exit` (200ms fade-out + slide-up).
2. **Subtle offline indicator** — компактний pill у top-right замість full-width `bg-warning-strong` банера.
3. **Responsive bento grid** — `grid-cols-2` → `sm:grid-cols-3` → `lg:grid-cols-4`.

## Why

Аудит UX/UI виявив 8 точок покращення: crash recovery, back-button navigation, scroll depth, search jank, toggle responsiveness, animation continuity, offline indicator aggressiveness, tablet/desktop layout.

## How to test

1. **ErrorBoundary** — throw inside a module to see crash screen with retry buttons.
2. **Nutrition hash** — navigate to Pantry → Покупки, press back — should return to Склад, not exit module.
3. **Collapsible sections** — on dashboard, tap «Підказки» / «Аналітика» headings — should collapse/expand; reload page to verify persistence.
4. **HubSearch** — type quickly in search — input should stay responsive.
5. **Routine toggle** — tap habit checkmarks rapidly — should feel snappy.
6. **Toast exit** — trigger a toast (e.g. save something) — should fade out smoothly when dismissed.
7. **Offline indicator** — disable network — should see small pill in top-right, not full banner.
8. **Responsive grid** — widen viewport past sm/lg breakpoints — module grid grows to 3/4 columns.

---

## Pre-flight (Hard Rule #15)

- [x] Read the `AGENTS.md` Hard Rules that apply to the touched paths.
- [x] Read the matching playbook in `docs/playbooks/` (or noted that none exists).
- [x] Checked freshness headers of docs cited in the change.

## Docs updated alongside code? (Hard Rule #15)

- [x] N/A — no docs invalidated by this change.

## How AI-tested this PR

- [ ] Manual smoke (which flow?): visual inspection pending reviewer.
- [x] Vitest passes: 1449 tests, 129 files — all green.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.
- [ ] `pnpm dead-code:files` clean (or new files marked `@scaffolded`).

## AGENTS.md updated?

- [x] No — no new permanent rules
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves `apps/web` UX with a crash-recovery screen, URL-synced nutrition sub-tabs, and collapsible dashboard sections. Adds smoother interactions and cleaner UI with a subtle offline indicator, toast exit animation, and a responsive grid.

- **New Features**
  - Default crash-recovery screen in `ErrorBoundary` with retry/reload.
  - Nutrition sub-tabs sync to URL hash (`#pantry/shopping`, `#menu/recipes`); back/forward navigates between sub-tabs.
  - Dashboard “Підказки” and “Аналітика” are collapsible with `localStorage` persistence (`CollapsibleSection`).

- **UX/UI**
  - Hub search updates results in a `startTransition` to keep typing responsive.
  - Routine habit toggles use `useTransition` for instant haptic and deferred re-render.
  - Toasts fade out with a 200ms exit animation before removal.
  - Replaced full-width offline banner with a small top-right pill showing queued sync count.
  - Bento grid now scales 2 → 3 → 4 columns at `sm`/`lg`.

<sup>Written for commit 8b1c4fd69ff279146515d7b5a7e7a2197f028235. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1177?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Collapsible sections for hints and analytics in the hub dashboard, with persistent state.
  * Offline indicator redesigned as a compact top-right pill showing queue count.
  * Error recovery screen displays error messages with options to reset or reload the page.
  * Sub-tab navigation added for nutrition pantry (Items/Shopping) and menu (Plan/Recipes) sections.
  * Toast messages now include exit animation on dismissal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->