### PR TITLE
fix(shared,web): address CodeRabbit feedback from #1172

### DIFF
--- a/apps/web/src/core/observability/webVitals.test.ts
+++ b/apps/web/src/core/observability/webVitals.test.ts
@@ -118,6 +118,34 @@ describe("webVitals.flush", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  it("drops metrics without a recognized rating to avoid server-side batch loss", async () => {
+    // Server validates `WebVitalsPayloadSchema` де `rating` обов'язковий.
+    // Якщо відправити запис без рейтингу, ВЕСЬ батч буде відкинутий і
+    // решта валідних метрик мовчки втратиться. Тому drop саме на клієнті,
+    // ще до буфера.
+    enqueue({ name: "LCP", value: 100 } as { name: string; value: number });
+    enqueue({ name: "LCP", value: 100, rating: "" });
+    enqueue({ name: "LCP", value: 100, rating: "unknown" });
+    await waitMicrotasks();
+    expect(sendBeaconSpy).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    // Натомість запис із рейтингом потрапляє в батч одного хоста.
+    enqueue({ name: "LCP", value: 100, rating: "good" });
+    enqueue({ name: "INP", value: 100, rating: "needs-improvement" });
+    await waitMicrotasks();
+    expect(sendBeaconSpy).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(
+      await (sendBeaconSpy.mock.calls[0][1] as Blob).text(),
+    );
+    expect(payload.metrics).toHaveLength(2);
+    expect(payload.metrics[0]).toMatchObject({ name: "LCP", rating: "good" });
+    expect(payload.metrics[1]).toMatchObject({
+      name: "INP",
+      rating: "needs-improvement",
+    });
+  });
+
   it("rounds non-CLS metrics to integers and keeps CLS precision", async () => {
     enqueue(makeMetric("LCP", 123.6));
     enqueue(makeMetric("CLS", 0.123456));

--- a/apps/web/src/core/observability/webVitals.ts
+++ b/apps/web/src/core/observability/webVitals.ts
@@ -32,7 +32,7 @@ export const MAX_BATCH = 10;
 interface WebVitalReport {
   name: WebVitalsMetricName;
   value: number;
-  rating?: WebVitalsMetricRating;
+  rating: WebVitalsMetricRating;
 }
 
 const buffer: WebVitalReport[] = [];
@@ -148,14 +148,16 @@ export function enqueue(metric: MetricInput | null | undefined) {
     typeof metric.value !== "number" ||
     !Number.isFinite(metric.value) ||
     metric.value < 0 ||
-    !isSupportedName(metric.name)
+    !isSupportedName(metric.name) ||
+    !metric.rating ||
+    !isSupportedRating(metric.rating)
   ) {
+    // SSOT `WebVitalsPayloadSchema` робить `rating` обов'язковим. Якщо
+    // буферити запис без рейтингу, server safeParse відкине ВЕСЬ батч —
+    // і кілька валідних метрик мовчки втрачаються разом з невалідним.
+    // Тому метрики без розпізнаного рейтингу drop'аємо тут, до буфера.
     return;
   }
-  const rating =
-    metric.rating && isSupportedRating(metric.rating)
-      ? metric.rating
-      : undefined;
   buffer.push({
     name: metric.name,
     value:
@@ -163,7 +165,7 @@ export function enqueue(metric: MetricInput | null | undefined) {
       metric.name === "CLS"
         ? Number(metric.value.toFixed(4))
         : Math.round(metric.value),
-    rating,
+    rating: metric.rating,
   });
   if (buffer.length >= MAX_BATCH) {
     flush();

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -862,9 +862,30 @@
     "/api/nutrition/backup-download": {
       "post": {
         "summary": "Отримати останній зашифрований backup nutrition-blob",
-        "description": "Token-authenticated через header `x-token`. Повертає 404, якщо для наданого токена бекапів ще немає.",
+        "description": "Token-authenticated через header `x-token`. Повертає 404, якщо для наданого токена бекапів ще немає. Роут під `requireSession()` — потрібна активна сесія ЧИ Bearer-токен НА ДОДАЧУ до запитуваного `x-token`.",
         "tags": [
           "nutrition"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-token",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Опаковий токен, який хешується для формування імені файлу бекапу."
+            },
+            "required": true,
+            "description": "Опаковий токен, який хешується для формування імені файлу бекапу."
+          }
         ],
         "responses": {
           "200": {
@@ -875,6 +896,16 @@
                   "type": "object",
                   "properties": {},
                   "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized — потрібна активна сесія.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
                 }
               }
             }
@@ -2028,13 +2059,43 @@
                 "format": "binary"
               }
             },
+            "audio/m4a": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            },
             "audio/mpeg": {
               "schema": {
                 "type": "string",
                 "format": "binary"
               }
             },
+            "audio/mp3": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            },
             "audio/wav": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            },
+            "audio/x-wav": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            },
+            "audio/wave": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            },
+            "audio/flac": {
               "schema": {
                 "type": "string",
                 "format": "binary"
@@ -4273,36 +4334,68 @@
             "maxItems": 10,
             "type": "array",
             "items": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "enum": [
-                    "LCP",
-                    "INP",
-                    "FCP",
-                    "TTFB",
-                    "CLS"
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "const": "CLS"
+                    },
+                    "value": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 10
+                    },
+                    "rating": {
+                      "type": "string",
+                      "enum": [
+                        "good",
+                        "needs-improvement",
+                        "poor"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "value",
+                    "rating"
                   ]
                 },
-                "value": {
-                  "type": "number",
-                  "minimum": 0
-                },
-                "rating": {
-                  "type": "string",
-                  "enum": [
-                    "good",
-                    "needs-improvement",
-                    "poor"
+                {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "enum": [
+                        "LCP",
+                        "INP",
+                        "FCP",
+                        "TTFB"
+                      ]
+                    },
+                    "value": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 120000
+                    },
+                    "rating": {
+                      "type": "string",
+                      "enum": [
+                        "good",
+                        "needs-improvement",
+                        "poor"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "value",
+                    "rating"
                   ]
                 }
-              },
-              "required": [
-                "name",
-                "value",
-                "rating"
-              ]
+              ],
+              "type": "object"
             }
           }
         },

--- a/packages/shared/src/openapi/routes.ts
+++ b/packages/shared/src/openapi/routes.ts
@@ -304,10 +304,27 @@ export const paths: ZodOpenApiPathsObject = {
       summary: "Отримати останній зашифрований backup nutrition-blob",
       description:
         "Token-authenticated через header `x-token`. Повертає 404, якщо " +
-        "для наданого токена бекапів ще немає.",
+        "для наданого токена бекапів ще немає. Роут під `requireSession()` — " +
+        "потрібна активна сесія ЧИ Bearer-токен НА ДОДАЧУ до запитуваного `x-token`.",
       tags: ["nutrition"],
+      security: cookieOrBearer,
+      requestParams: {
+        // `x-token` формує ключ для пошуку бекап-файлу в файловій сховищі сервера
+        // (див. `apps/server/src/modules/nutrition/backup-download.ts:safeKeyFromToken`).
+        // Без цього хедера в контракті generated-клієнти і люди-читачі не можуть
+        // виявити який вхід потрібен для отримання бекапу.
+        header: z.object({
+          "x-token": z
+            .string()
+            .min(1)
+            .describe(
+              "Опаковий токен, який хешується для формування імені файлу бекапу.",
+            ),
+        }),
+      },
       responses: {
         "200": okEmpty,
+        "401": unauthorized,
         "404": {
           description: "Backup для наданого x-token не знайдено.",
           content: {
@@ -698,13 +715,22 @@ export const paths: ZodOpenApiPathsObject = {
       tags: ["transcribe"],
       security: cookieOrBearer,
       requestParams: { query: namedSchemas.TranscribeQuery },
+      // Медіа-типи синхронізовані зі списком `SUPPORTED_AUDIO_MIME` у
+      // `apps/server/src/modules/transcribe/transcribe.ts`. Будь-який inconsistency
+      // означає, що опублікований контракт бреше клієнтам про те, які формати
+      // приймаються — обїїхавши в 415 намість успіху.
       requestBody: {
         content: {
           "audio/webm": { schema: { type: "string", format: "binary" } },
           "audio/ogg": { schema: { type: "string", format: "binary" } },
           "audio/mp4": { schema: { type: "string", format: "binary" } },
+          "audio/m4a": { schema: { type: "string", format: "binary" } },
           "audio/mpeg": { schema: { type: "string", format: "binary" } },
+          "audio/mp3": { schema: { type: "string", format: "binary" } },
           "audio/wav": { schema: { type: "string", format: "binary" } },
+          "audio/x-wav": { schema: { type: "string", format: "binary" } },
+          "audio/wave": { schema: { type: "string", format: "binary" } },
+          "audio/flac": { schema: { type: "string", format: "binary" } },
         },
       },
       responses: {

--- a/packages/shared/src/schemas/api.ts
+++ b/packages/shared/src/schemas/api.ts
@@ -955,16 +955,27 @@ export type WebVitalsMetricRating = z.infer<typeof WebVitalsMetricRatingSchema>;
 // мс, upper-bound 120_000 (2 хв — будь-що більше це зламаний клієнтський
 // таймер). Окремий upper-bound для CLS не дає анонімному endpoint-у інфлейтити
 // `web_vitals_cls_sum`, що зробило б `avg = _sum / _count` беззмістовним.
-export const WebVitalsMetricSchema = z
-  .object({
-    name: WebVitalsMetricNameSchema,
-    value: z.number().finite().min(0),
-    rating: WebVitalsMetricRatingSchema,
-  })
-  .refine((m) => (m.name === "CLS" ? m.value <= 10 : m.value <= 120_000), {
-    message: "value out of range for metric",
-    path: ["value"],
-  });
+//
+// Розбито на дискримінований union по `name` замість `.refine()` так, щоб межі
+// `value` для CLS (≤10) і таймінгів (≤120_000) переживали серіалізацію в
+// OpenAPI: кастомні `.refine()`-предикати у `docs/api/openapi.json` не
+// потрапляють, і генерований контракт мовчки втрачав би верхні межі.
+const WebVitalsClsMetricSchema = z.object({
+  name: z.literal("CLS"),
+  value: z.number().finite().min(0).max(10),
+  rating: WebVitalsMetricRatingSchema,
+});
+
+const WebVitalsTimingMetricSchema = z.object({
+  name: z.enum(["LCP", "INP", "FCP", "TTFB"]),
+  value: z.number().finite().min(0).max(120_000),
+  rating: WebVitalsMetricRatingSchema,
+});
+
+export const WebVitalsMetricSchema = z.discriminatedUnion("name", [
+  WebVitalsClsMetricSchema,
+  WebVitalsTimingMetricSchema,
+]);
 export type WebVitalsMetric = z.infer<typeof WebVitalsMetricSchema>;
 
 export const WebVitalsPayloadSchema = z.object({


### PR DESCRIPTION
## What changed

Follow-up до #1172 — закриваю всі 4 «actionable» CodeRabbit-зауваження + дотичні коментарі від Cubic / Devin Review:

1. **`apps/web/src/core/observability/webVitals.ts`** — `enqueue()` тепер відкидає метрику ще до буфера, якщо `rating` відсутній або не з whitelist. Тип `WebVitalReport.rating` з `optional` став обов'язковим.
   - SSOT `WebVitalsPayloadSchema` робить `rating` required, тож одна метрика без рейтингу примушувала server `safeParse` відкинути ВЕСЬ батч (до 10 метрик), і решта валідних замірів мовчки втрачалася.
   - Доданий unit-тест на цей сценарій.

2. **`packages/shared/src/schemas/api.ts`** — `WebVitalsMetricSchema` переписано з `.refine()`-предиката на `z.discriminatedUnion("name", […])`:
   - `WebVitalsClsMetricSchema` → `name: "CLS"`, `value` з межами `[0, 10]`.
   - `WebVitalsTimingMetricSchema` → `name ∈ {LCP, INP, FCP, TTFB}`, `value` з межами `[0, 120_000]`.
   - Раніше OpenAPI-генератор не переносив `.refine()` у спеку, і опублікований контракт мовчки гарантував лише `value >= 0`. Тепер межі CLS / timing видно і в `docs/api/openapi.json`.

3. **`packages/shared/src/openapi/routes.ts` → `/api/nutrition/backup-download`**:
   - додано `security: cookieOrBearer` (роут під `requireSession()` через `r.use("/api/nutrition", requireSession())`),
   - додано `401` response,
   - додано `requestParams.header` з обов'язковим `x-token` хедером, який handler читає для формування файл-ключа бекапу.
   - Без цих полів generated-клієнти і люди-читачі не могли визначити, що endpoint потребує і сесії, і токена.

4. **`packages/shared/src/openapi/routes.ts` → `/api/transcribe`** — `requestBody.content` синхронізовано з `SUPPORTED_AUDIO_MIME` у `apps/server/src/modules/transcribe/transcribe.ts`. Додано: `audio/m4a`, `audio/mp3`, `audio/x-wav`, `audio/wave`, `audio/flac`. Раніше OpenAPI рекламував `audio/mpeg` + `audio/wav`, але мовчав про `audio/flac` тощо — клієнти, які покладалися на спеку, відловлювали 415 на форматах, які handler приймає.

5. **`docs/api/openapi.json`** — перегенеровано через `pnpm api:generate-openapi`, freshness-gate (`pnpm api:check-openapi`) у lint passes.

## Why

PR #1172 був замержений до того, як CodeRabbit + Cubic + Devin Review встигли пройтися повним проходом, тож зауваження не були враховані. Це безпекова та контрактна гігієна:

- `webVitals` enqueue без рейтингу — silent data-loss baseline-у `web_vitals_*`;
- non-discriminated union у Zod — silent contract-drift у згенерованій OpenAPI;
- відсутній `x-token` header у спеці — generated-клієнти будуть отримувати 404 без зрозумілої причини;
- неузгоджені audio MIME-типи — клієнти ловитимуть несподіваний 415.

Тримає Hard Rule #3 («API contract: server response shape ↔ api-client types ↔ test») чесною.

## How to test

```bash
pnpm typecheck
pnpm lint                 # включає pnpm api:check-openapi (freshness)
pnpm --filter @sergeant/shared exec vitest run
pnpm --filter @sergeant/server exec vitest run web-vitals
pnpm --filter @sergeant/web exec vitest run webVitals
```

Усі проходять локально (Node 20.20.2).

Перевірка OpenAPI вручну:

```bash
jq '.paths."/api/nutrition/backup-download".post.parameters' docs/api/openapi.json
jq '.paths."/api/nutrition/backup-download".post.security' docs/api/openapi.json
jq '.paths."/api/transcribe".post.requestBody.content | keys' docs/api/openapi.json
jq '.components.schemas.WebVitalsPayload.properties.metrics.items.oneOf' docs/api/openapi.json
```

---

## Pre-flight (Hard Rule #15)

- [x] Read the `AGENTS.md` Hard Rules that apply to the touched paths (Hard Rule #3 — server ↔ api-client ↔ test тримати в синхроні).
- [x] Read the matching playbook in `docs/playbooks/` (or noted that none exists). — n/a, contract-fix follow-up.
- [x] Checked freshness headers of docs cited in the change.

## Docs updated alongside code? (Hard Rule #15)

- [x] API contract change — OpenAPI спека (`docs/api/openapi.json`) перегенерована, схема `WebVitalsMetric` переписана з збереженням контракту (`name`, `value`, `rating` усе ще required).
- [x] N/A — no other docs invalidated by this change.

## How AI-tested this PR

- [x] Manual smoke: інспекція згенерованого `docs/api/openapi.json` — `oneOf` із межами CLS<=10 / timing<=120_000 + `parameters: x-token header` + усі audio MIME присутні.
- [x] Vitest passes (`@sergeant/shared`, `@sergeant/web` webVitals, `@sergeant/server` web-vitals — ✅; інші пакети без змін).
- [x] No new `AI-DANGER` markers added.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.
- [x] `pnpm api:check-openapi` (freshness gate) — `≡ generator output`.

## AGENTS.md updated?

- [x] No — no new permanent rules
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes silent Web Vitals batch drops and aligns OpenAPI with server behavior for nutrition backup and transcribe. Schemas now enforce correct metric bounds and accepted audio types in generated docs.

- **Bug Fixes**
  - Web Vitals: require `rating` and drop metrics with missing/unknown ratings in `enqueue()` to prevent batch loss; added unit test.
  - Schemas: switch to `z.discriminatedUnion("name", ...)` so CLS (≤10) and timing (≤120000 ms) limits show up in OpenAPI.
  - Nutrition backup-download: add `cookieOrBearer` security, 401, and required `x-token` header to the spec.
  - Transcribe: align requestBody media types with handler (`audio/m4a`, `audio/mp3`, `audio/x-wav`, `audio/wave`, `audio/flac`); regenerate `docs/api/openapi.json`.

<sup>Written for commit b25bf907955bd988b18e97dc8e517c01c3112cbf. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1178?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for m4a, mp3, wav, and flac audio formats in transcription.

* **Bug Fixes**
  * Improved web vitals metrics validation to filter out invalid entries before reporting.

* **Security**
  * Enhanced authentication enforcement for backup downloads with explicit session requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->