### PR TITLE
feat(web): оформлення згорнутих секцій + «Профіль» у нижньому навбарі

### DIFF
--- a/apps/web/src/core/App.tsx
+++ b/apps/web/src/core/App.tsx
@@ -214,6 +214,16 @@ function AppInner() {
     return () => clearTimeout(timer);
   }, []);
 
+  // If the user signs out while the «Профіль» tab is active, bounce the
+  // hub back to the dashboard — the tab itself disappears from the
+  // bottom nav (gated on `user`), and without this the main content
+  // area would render nothing for the `profile` view.
+  useEffect(() => {
+    if (!user && ui.hubView === "profile") {
+      ui.setHubView("dashboard");
+    }
+  }, [user, ui]);
+
   useEffect(() => {
     const onMessage = (event: MessageEvent) => {
       if (event.data?.type === "OPEN_MODULE") {
@@ -479,6 +489,11 @@ function AppInner() {
           // потім стер дані — повертаємо його на дашборд, щоб не
           // лишався на неіснуючому табі.
           showReports={hasAnyRealEntry()}
+          // «Профіль» tab is gated on being signed in — a guest tapping
+          // it would just bounce through `/sign-in`, which clutters the
+          // FTUX strip. The header still exposes a "Sign in" button
+          // for anonymous visitors.
+          showProfile={!!user}
         />
 
         {/* Thumb-reach entry to the AI assistant. Always visible so the

--- a/apps/web/src/core/app/HubBottomNav.test.tsx
+++ b/apps/web/src/core/app/HubBottomNav.test.tsx
@@ -6,10 +6,13 @@ import { ToastProvider } from "@shared/hooks/useToast";
 
 const STORAGE_KEY = "sergeant.hub.reportsTabRevealedAt";
 
+type TestHubView = "dashboard" | "reports" | "profile" | "settings";
+
 function renderNav(props: {
-  hubView?: "dashboard" | "reports" | "settings";
+  hubView?: TestHubView;
   showReports?: boolean;
-  onChange?: (v: "dashboard" | "reports" | "settings") => void;
+  showProfile?: boolean;
+  onChange?: (v: TestHubView) => void;
 }) {
   const onChange = props.onChange ?? vi.fn();
   return {
@@ -20,6 +23,7 @@ function renderNav(props: {
           hubView={props.hubView ?? "dashboard"}
           onChange={onChange}
           showReports={props.showReports ?? true}
+          showProfile={props.showProfile}
         />
       </ToastProvider>,
     ),
@@ -47,6 +51,22 @@ describe("HubBottomNav", () => {
   it("ховає «Звіти» коли showReports=false", () => {
     renderNav({ showReports: false });
     expect(screen.queryByRole("tab", { name: /Звіти/ })).toBeNull();
+  });
+
+  it("ховає «Профіль» за замовчуванням (гість)", () => {
+    renderNav({});
+    expect(screen.queryByRole("tab", { name: /Профіль/ })).toBeNull();
+  });
+
+  it("показує «Профіль» коли showProfile=true (залогінений)", () => {
+    renderNav({ showProfile: true });
+    expect(screen.getByRole("tab", { name: /Профіль/ })).toBeInTheDocument();
+  });
+
+  it("виклик onChange при кліку на «Профіль»", () => {
+    const { onChange } = renderNav({ showProfile: true });
+    fireEvent.click(screen.getByRole("tab", { name: /Профіль/ }));
+    expect(onChange).toHaveBeenCalledWith("profile");
   });
 
   it("активний таб має aria-selected=true", () => {

--- a/apps/web/src/core/app/HubBottomNav.tsx
+++ b/apps/web/src/core/app/HubBottomNav.tsx
@@ -134,12 +134,19 @@ export interface HubBottomNavProps {
    * лише коли `hasAnyRealEntry()` повертає `true` (див. `firstRealEntry.ts`).
    */
   showReports?: boolean;
+  /**
+   * «Профіль» tab is only rendered when the user is signed in. Guests
+   * reach auth via the header button — a profile tab that bounces
+   * anonymous visitors to sign-in would clutter the FTUX strip.
+   */
+  showProfile?: boolean;
 }
 
 export function HubBottomNav({
   hubView,
   onChange,
   showReports = true,
+  showProfile = false,
 }: HubBottomNavProps) {
   const toast = useToast();
   // Чи був перехід `showReports: false → true` в межах поточного маунту.
@@ -216,6 +223,17 @@ export function HubBottomNav({
             iconName="bar-chart"
             label="Звіти"
             className={animateReveal ? "animate-bounce-in" : undefined}
+          />
+        )}
+
+        {showProfile && (
+          <HubBottomNavTab
+            id="profile"
+            panelId="hub-panel-profile"
+            active={hubView === "profile"}
+            onClick={() => onChange("profile")}
+            iconName="user"
+            label="Профіль"
           />
         )}
 

--- a/apps/web/src/core/app/HubMainContent.tsx
+++ b/apps/web/src/core/app/HubMainContent.tsx
@@ -7,6 +7,7 @@ import { ErrorBoundary } from "../ErrorBoundary";
 import { HubDashboard } from "../hub/HubDashboard";
 import { HubReports } from "../hub/HubReports";
 import { HubSettingsPage } from "../hub/HubSettingsPage";
+import { ProfilePage } from "../profile/ProfilePage";
 import type { OpenModuleOptions } from "../hooks/useHubNavigation";
 import type { HubView } from "../hooks/useHubUIState";
 import { IOSInstallBanner } from "./IOSInstallBanner";
@@ -201,6 +202,14 @@ export const HubMainContent = memo(function HubMainContent({
           <ErrorBoundary key="reports" fallback={HubSectionFallback}>
             <div className="pt-2">
               <HubReports />
+            </div>
+          </ErrorBoundary>
+        )}
+
+        {hubView === "profile" && (
+          <ErrorBoundary key="profile" fallback={HubSectionFallback}>
+            <div className="pt-2">
+              <ProfilePage embedded />
             </div>
           </ErrorBoundary>
         )}

--- a/apps/web/src/core/hooks/useHubUIState.ts
+++ b/apps/web/src/core/hooks/useHubUIState.ts
@@ -1,8 +1,13 @@
 import { useCallback, useEffect, useState } from "react";
 
-export type HubView = "dashboard" | "reports" | "settings";
+export type HubView = "dashboard" | "reports" | "profile" | "settings";
 
-const VALID_VIEWS = new Set<string>(["dashboard", "reports", "settings"]);
+const VALID_VIEWS = new Set<string>([
+  "dashboard",
+  "reports",
+  "profile",
+  "settings",
+]);
 
 function readViewFromURL(): HubView {
   try {

--- a/apps/web/src/core/hub/HubDashboard.tsx
+++ b/apps/web/src/core/hub/HubDashboard.tsx
@@ -76,6 +76,18 @@ export {
   resetDashboardOrder,
 } from "./dashboard/dashboardStore";
 
+// Ukrainian 1 / 2-4 / 5+ plural. Inline because this file is the only
+// current consumer; `AssistantCataloguePage` has its own copy with a
+// slightly different (tuple-based) signature. Kept intentionally small;
+// if a third call-site appears, promote to `@shared/lib/pluralize`.
+function pluralize(n: number, one: string, few: string, many: string): string {
+  const mod10 = n % 10;
+  const mod100 = n % 100;
+  if (mod10 === 1 && mod100 !== 11) return one;
+  if (mod10 >= 2 && mod10 <= 4 && (mod100 < 10 || mod100 >= 20)) return few;
+  return many;
+}
+
 interface HubDashboardProps {
   onOpenModule: (module: string) => void;
   onOpenChat?: () => void;
@@ -361,6 +373,16 @@ export function HubDashboard({
             <CollapsibleSection
               storageKey="sergeant:hub.hints.open"
               title="Підказки"
+              collapsedIcon="lightbulb"
+              collapsedSubtitle={
+                coachLoading
+                  ? "Готую AI-пораду…"
+                  : coachError
+                    ? "Не вдалось отримати AI-пораду"
+                    : activeNudge && !reengagement.show
+                      ? "AI-порада + нагадування"
+                      : "AI-порада на день"
+              }
             >
               <AssistantAdviceCard
                 insight={coachInsightText}
@@ -457,6 +479,18 @@ export function HubDashboard({
           <CollapsibleSection
             storageKey="sergeant:hub.analytics.open"
             title="Аналітика"
+            collapsedIcon="bar-chart"
+            collapsedSubtitle={
+              rest.length > 0
+                ? `${rest.length} ${pluralize(rest.length, "інсайт", "інсайти", "інсайтів")}${
+                    digestFresh ? " · свіжий дайджест" : ""
+                  }`
+                : digestFresh
+                  ? "Свіжий щотижневий дайджест"
+                  : showDigestFooter
+                    ? "Щотижневий дайджест"
+                    : "Без нових інсайтів"
+            }
           >
             <HubInsightsPanel
               items={rest}

--- a/apps/web/src/core/profile/ProfilePage.tsx
+++ b/apps/web/src/core/profile/ProfilePage.tsx
@@ -9,13 +9,58 @@ import { MemoryBankSection } from "./MemoryBankSection";
 import { PersonalInfoSection } from "./PersonalInfoSection";
 import { SessionsSection } from "./SessionsSection";
 
-export function ProfilePage() {
+export interface ProfilePageProps {
+  /**
+   * Render the page without its own sticky top bar + page-level padding.
+   * Used when the profile is embedded inside the hub as a bottom-nav tab
+   * — the hub already owns the header + bottom-nav chrome, so an
+   * additional "Назад" button and "Профіль" label would stack two nav
+   * rows. The standalone `/profile` route keeps the default chrome so
+   * deep-links and back-button still behave as before.
+   */
+  embedded?: boolean;
+}
+
+export function ProfilePage({ embedded = false }: ProfilePageProps = {}) {
   const navigate = useNavigate();
   const { user, logout, refresh } = useAuth();
   const online = useOnlineStatus();
 
   if (!user) {
     return null;
+  }
+
+  const body = (
+    <div className="max-w-lg mx-auto px-5 pb-10 space-y-3 pt-6">
+      {!online && (
+        <div className="flex items-center gap-2 rounded-xl bg-warning/10 border border-warning/30 px-4 py-3">
+          <Icon name="wifi-off" size={16} className="text-warning shrink-0" />
+          <p className="text-sm text-warning font-medium">
+            Ви офлайн — редагування профілю тимчасово недоступне
+          </p>
+        </div>
+      )}
+
+      <PersonalInfoSection user={user} online={online} onRefresh={refresh} />
+
+      {/* Section label */}
+      <p className="text-eyebrow text-muted/60 px-1 pt-2">Пам&apos;ять</p>
+      <MemoryBankSection />
+
+      <p className="text-eyebrow text-muted/60 px-1 pt-2">Безпека</p>
+      <ChangePasswordSection online={online} />
+      <SessionsSection online={online} />
+
+      <p className="text-eyebrow text-muted/60 px-1 pt-2">Акаунт</p>
+      <DangerZoneSection online={online} onLogout={logout} />
+    </div>
+  );
+
+  if (embedded) {
+    // Embedded mode: no sticky back-bar, no page-level safe-area padding
+    // — the hub shell already owns the header + bottom-nav chrome and
+    // the main scroll container. The section just renders its body.
+    return body;
   }
 
   return (
@@ -42,29 +87,7 @@ export function ProfilePage() {
         </div>
       </div>
 
-      <div className="max-w-lg mx-auto px-5 pb-10 space-y-3 pt-6">
-        {!online && (
-          <div className="flex items-center gap-2 rounded-xl bg-warning/10 border border-warning/30 px-4 py-3">
-            <Icon name="wifi-off" size={16} className="text-warning shrink-0" />
-            <p className="text-sm text-warning font-medium">
-              Ви офлайн — редагування профілю тимчасово недоступне
-            </p>
-          </div>
-        )}
-
-        <PersonalInfoSection user={user} online={online} onRefresh={refresh} />
-
-        {/* Section label */}
-        <p className="text-eyebrow text-muted/60 px-1 pt-2">Пам&apos;ять</p>
-        <MemoryBankSection />
-
-        <p className="text-eyebrow text-muted/60 px-1 pt-2">Безпека</p>
-        <ChangePasswordSection online={online} />
-        <SessionsSection online={online} />
-
-        <p className="text-eyebrow text-muted/60 px-1 pt-2">Акаунт</p>
-        <DangerZoneSection online={online} onLogout={logout} />
-      </div>
+      {body}
     </div>
   );
 }

--- a/apps/web/src/shared/components/ui/CollapsibleSection.test.tsx
+++ b/apps/web/src/shared/components/ui/CollapsibleSection.test.tsx
@@ -1,0 +1,61 @@
+/** @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { CollapsibleSection } from "./CollapsibleSection";
+
+describe("CollapsibleSection", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders an expanded heading and its children by default", () => {
+    render(
+      <CollapsibleSection storageKey="sergeant.test.expanded" title="Підказки">
+        <p>payload</p>
+      </CollapsibleSection>,
+    );
+    const toggle = screen.getByRole("button", { name: /Підказки/ });
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("payload")).toBeInTheDocument();
+  });
+
+  it("shows a collapsed pill with icon, title, and subtitle when collapsed", () => {
+    render(
+      <CollapsibleSection
+        storageKey="sergeant.test.collapsed"
+        title="Аналітика"
+        defaultOpen={false}
+        collapsedIcon="bar-chart"
+        collapsedSubtitle="3 інсайти"
+      >
+        <p>payload</p>
+      </CollapsibleSection>,
+    );
+    const toggle = screen.getByRole("button", { name: /Аналітика/ });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    // Subtitle is rendered in the collapsed pill.
+    expect(screen.getByText("3 інсайти")).toBeInTheDocument();
+  });
+
+  it("toggles open/closed on click and persists the state", () => {
+    render(
+      <CollapsibleSection storageKey="sergeant.test.persist" title="Підказки">
+        <p>payload</p>
+      </CollapsibleSection>,
+    );
+    const toggle = screen.getByRole("button", { name: /Підказки/ });
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(localStorage.getItem("sergeant.test.persist")).toBe("false");
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(localStorage.getItem("sergeant.test.persist")).toBe("true");
+  });
+});

--- a/apps/web/src/shared/components/ui/CollapsibleSection.tsx
+++ b/apps/web/src/shared/components/ui/CollapsibleSection.tsx
@@ -13,6 +13,18 @@ export interface CollapsibleSectionProps {
   defaultOpen?: boolean;
   /** SectionHeading size — defaults to "xs". */
   headingSize?: SectionHeadingSize;
+  /**
+   * Icon name (from the shared `Icon` set) rendered on the left of the
+   * collapsed "pill" state. When omitted, the collapsed state renders
+   * title-only — useful for sections without an obvious glyph.
+   */
+  collapsedIcon?: string;
+  /**
+   * Short preview / summary line shown inside the collapsed pill, below
+   * the title. Typical content: a live count, freshness timestamp,
+   * or a one-line CTA ("AI-порада оновлена", "3 інсайти").
+   */
+  collapsedSubtitle?: ReactNode;
   children?: ReactNode;
   className?: string;
 }
@@ -22,7 +34,14 @@ export interface CollapsibleSectionProps {
  * state in localStorage. Used on HubDashboard to let users collapse
  * the "Підказки" and "Аналітика" sections to reduce scroll depth.
  *
- * The heading row doubles as the toggle button (chevron + heading).
+ * Two visual states:
+ * - **Expanded** — minimal eyebrow heading + rotating chevron, so the
+ *   section's own content dominates the viewport.
+ * - **Collapsed** — full-width "pill" card (panel bg + border, icon,
+ *   regular-case title, optional `collapsedSubtitle` preview, right
+ *   chevron). Makes the collapsed row read as a purposeful, tappable
+ *   entry point instead of a stray eyebrow with nothing under it.
+ *
  * Collapse animation uses CSS `grid-template-rows` for smooth height
  * transitions (no JavaScript measurement needed).
  */
@@ -31,6 +50,8 @@ export function CollapsibleSection({
   title,
   defaultOpen = true,
   headingSize = "xs",
+  collapsedIcon,
+  collapsedSubtitle,
   children,
   className,
 }: CollapsibleSectionProps) {
@@ -48,26 +69,67 @@ export function CollapsibleSection({
 
   return (
     <section className={cn("space-y-2", className)}>
-      <button
-        type="button"
-        onClick={toggle}
-        aria-expanded={open}
-        className="flex items-center gap-1.5 w-full text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 rounded-lg -ml-0.5 pl-0.5"
-      >
-        <Icon
-          name="chevron-right"
-          size={12}
-          strokeWidth={2.5}
+      {open ? (
+        <button
+          type="button"
+          onClick={toggle}
+          aria-expanded={open}
+          className="flex items-center gap-1.5 w-full text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 rounded-lg -ml-0.5 pl-0.5"
+        >
+          <Icon
+            name="chevron-down"
+            size={12}
+            strokeWidth={2.5}
+            className="text-subtle"
+            aria-hidden
+          />
+          <SectionHeading as="span" size={headingSize} className="!px-0">
+            {title}
+          </SectionHeading>
+        </button>
+      ) : (
+        <button
+          type="button"
+          onClick={toggle}
+          aria-expanded={open}
           className={cn(
-            "text-subtle transition-transform duration-200",
-            open && "rotate-90",
+            "flex items-center gap-3 w-full text-left",
+            "px-3.5 py-3 rounded-2xl",
+            "bg-panel/70 hover:bg-panelHi border border-line/70",
+            "transition-colors active:scale-[0.99]",
+            "focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60",
           )}
-          aria-hidden
-        />
-        <SectionHeading as="span" size={headingSize} className="!px-0">
-          {title}
-        </SectionHeading>
-      </button>
+        >
+          {collapsedIcon && (
+            <span
+              className={cn(
+                "shrink-0 w-9 h-9 rounded-xl flex items-center justify-center",
+                "bg-brand-500/10 text-brand-strong dark:text-brand",
+              )}
+              aria-hidden
+            >
+              <Icon name={collapsedIcon} size={18} strokeWidth={2} />
+            </span>
+          )}
+          <span className="flex-1 min-w-0">
+            <span className="block text-sm font-semibold text-text leading-tight">
+              {title}
+            </span>
+            {collapsedSubtitle && (
+              <span className="block text-2xs text-muted mt-0.5 truncate">
+                {collapsedSubtitle}
+              </span>
+            )}
+          </span>
+          <Icon
+            name="chevron-right"
+            size={16}
+            strokeWidth={2}
+            className="text-subtle shrink-0"
+            aria-hidden
+          />
+        </button>
+      )}
 
       {/* CSS grid row transition for smooth collapse */}
       <div


### PR DESCRIPTION
## What changed

**1. Collapsed-state «pill» для `CollapsibleSection`**

`apps/web/src/shared/components/ui/CollapsibleSection.tsx` тепер має два візуальні стани:

- **Розгорнута** (без змін) — мінімальний eyebrow heading з ротованим шевроном. Контент секції домінує на екрані.
- **Згорнута** — повнорядкова «pill-картка»: `panel` фон + бордер, іконка зліва, заголовок у звичайному регістрі, опційний `collapsedSubtitle` preview, шеврон справа. Рядок читається як свідома точка входу, а не як «сирий» eyebrow без контенту під ним.

Нові опційні пропси: `collapsedIcon` (назва з shared `Icon`) та `collapsedSubtitle` (ReactNode).

Використання в `HubDashboard`:

- **Підказки** → `lightbulb` + динамічний preview (`«Готую AI-пораду…»` / `«Не вдалось отримати AI-пораду»` / `«AI-порада + нагадування»` / `«AI-порада на день»`).
- **Аналітика** → `bar-chart` + preview з кількістю інсайтів (укр. plural: «1 інсайт» / «3 інсайти» / «5 інсайтів») та позначкою «свіжий дайджест», якщо є.

**2. «Профіль» у нижньому навбарі**

- `HubView` розширено: `"dashboard" | "reports" | "profile" | "settings"` (сумісне з `?tab=` URL-param-ом).
- `HubBottomNav` приймає новий прапор `showProfile` (guest-и не бачать таб — до sign-in ведуть через хедер).
- `HubMainContent` рендерить `<ProfilePage embedded />` коли `hubView === "profile"`.
- `ProfilePage` тепер приймає `embedded?: boolean`. У embedded-режимі без власного sticky top-bar і page-level safe-area padding (hub-shell уже володіє хедером + bottom-nav). Роут `/profile` без змін — стандалон-режим з «Назад» лишається для deep-links.
- У `App.tsx` — невеликий `useEffect`: при розлогіні з активним `profile` табом повертаємо на дашборд (таб зникає з нижнього навбара, щоб main-область не рендерила нічого).

## Why

Feedback із дашборда: згорнуті «Підказки» та «Аналітика» «виглядають як сире щось» — нічого крім тонкого eyebrow-заголовка з шевроном не видно. Pill-вигляд дає візуальний якір і короткий preview, тож юзер одразу бачить, що там є і чи варто розгортати.

Прохання перенести сторінку юзера в нижній навбар: аватар у хедері — не найочевидніша точка входу на телефоні, а bottom-nav уже — основний навігаційний паттерн у хабі.

## How to test

1. `pnpm dev:web` → дашборд.
2. У згорнутому стані «Підказки» та «Аналітика» мають виглядати як pill-картки з іконкою, заголовком і preview. Тап розгортає у звичайний вигляд (heading + діти).
3. Стан collapsed/expanded персистентний (`sergeant:hub.hints.open` / `sergeant:hub.analytics.open`).
4. Залогінений юзер бачить у нижньому навбарі 4 таби: «Головна», «Звіти» (якщо є реальні записи), «Профіль», «Налаштування». Тап на «Профіль» показує ProfilePage без власного «Назад»-бару.
5. Гість (або logout) → «Профіль» зникає з навбару. Якщо був активний — автоматично перекидає на «Головну».
6. Прямий deep-link на `/profile` — без змін, стандалон з «Назад» кнопкою.

---

## Pre-flight (Hard Rule #15)

- [x] Read the `AGENTS.md` Hard Rules that apply to the touched paths (web/core).
- [x] Read the matching playbook in `docs/playbooks/` — n/a (чисто UI-зміни в існуючих компонентах хаба).
- [x] Checked freshness headers of docs cited in the change — n/a.

## Docs updated alongside code? (Hard Rule #15)

- [x] N/A — no docs invalidated by this change. (Component API лишається сумісним, нові пропси опційні; `HubView` розширений, але це внутрішній тип.)
- [ ] API contract change — n/a
- [ ] New / removed npm script — n/a
- [ ] New design token / component / palette — n/a (новий режим уже існуючого компонента)
- [ ] Deprecation — n/a
- [ ] Freshness header bumped — n/a

## How AI-tested this PR

- [x] `pnpm --filter @sergeant/web typecheck` — clean (усі 4 tsconfig-и).
- [x] `pnpm --filter @sergeant/web lint` — clean.
- [x] `pnpm --filter @sergeant/web test` — 1473 tests passed (включно з 3 новими для `CollapsibleSection` + 3 новими для `HubBottomNav` profile-таб).
- [x] `pnpm format:check` — clean.
- [ ] Manual smoke — лишаю на ревіювача (або зроблю в наступному циклі сесії).
- [x] No new `AI-DANGER` markers added.
- [x] Docs prose uses Ukrainian where practical (коментарі + PR тіло).
- [x] `pnpm dead-code:files` — не застосовувалось: зміни лише в існуючих файлах + 1 новий test file поруч з компонентом.

## AGENTS.md updated?

- [ ] No — no new permanent rules.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Profile section now integrated into the hub with conditional visibility—appears when logged in and automatically hides upon sign out
  * Hub navigation displays profile tab alongside other sections for seamless access
  * Collapsible sections enhanced with preview icons and descriptive subtitles when collapsed, improving content discoverability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->