### PR TITLE
feat(web): compact assistant chat header

### DIFF
--- a/apps/web/src/core/hub/HubChat.tsx
+++ b/apps/web/src/core/hub/HubChat.tsx
@@ -3,7 +3,11 @@ import { useQueryClient } from "@tanstack/react-query";
 import { ApiError, chatApi, isApiError } from "@shared/api";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
-import { Popover } from "@shared/components/ui/Popover";
+import {
+  Popover,
+  PopoverItem,
+  PopoverDivider,
+} from "@shared/components/ui/Popover";
 import { Tooltip } from "@shared/components/ui/Tooltip";
 import { perfMark, perfEnd } from "@shared/lib/perf";
 import { useOnlineStatus } from "@shared/hooks/useOnlineStatus";
@@ -110,6 +114,9 @@ function HubChat({
     () => initialSessionsRef.current!.activeId,
   );
   const [historyOpen, setHistoryOpen] = useState(false);
+  // Header "Деталі" popover — controlled so item actions (open
+  // history drawer, minimize) can dismiss it after the click.
+  const [detailsOpen, setDetailsOpen] = useState(false);
 
   const [messages, setMessages] = useState(() => {
     const initial = initialSessionsRef.current!;
@@ -720,141 +727,140 @@ function HubChat({
           <div className="w-10 h-1 bg-line rounded-full" />
         </div>
 
-        {/* Header — compact: avatar + title + 1-line subtitle.
-            Context status, history counters, and the privacy
-            disclaimer collapse into the "Деталі" popover so the header
-            stays single-row on narrow phones. */}
-        <div className="flex items-center justify-between gap-3 px-4 pb-3 shrink-0 border-b border-line">
-          <div className="flex items-center gap-3 min-w-0">
-            <div
-              className={cn(
-                "relative w-10 h-10 rounded-xl bg-brand-500/10 flex items-center justify-center shrink-0",
-                contextState.status === "building" &&
-                  "motion-safe:animate-pulse",
-              )}
-              aria-hidden
-            >
-              <Icon name="sparkle" size={18} className="text-brand-500" />
-              {/* Context-status dot anchored on the avatar — replaces the
-                  full pill that used to live below the title. */}
+        {/* Header — single-row, ChatGPT-style:
+            avatar + "Асистент ▾" trigger (popover with status, всі
+            бесіди, згорнути, privacy) | + Нова pill | ✕.
+            All secondary affordances (info, history list, minimize,
+            module subtitle, Mono warning) collapse into the "Деталі"
+            popover behind the title. */}
+        <div className="flex items-center justify-between gap-2 px-3 pb-3 shrink-0 border-b border-line">
+          <Popover
+            placement="bottom-start"
+            open={detailsOpen}
+            onOpenChange={setDetailsOpen}
+            wrapperClassName="min-w-0 flex-1"
+            className="!min-w-[280px] p-1.5"
+            trigger={
               <span
-                className={cn(
-                  "absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 rounded-full ring-2 ring-bg",
-                  contextState.status === "ready"
-                    ? "bg-brand-500"
-                    : contextState.status === "building"
-                      ? "bg-warning"
-                      : "bg-line",
-                )}
-                aria-hidden
-              />
-            </div>
-            <div className="min-w-0">
-              <div
-                id="hub-chat-title"
-                className="text-[15px] font-bold text-text leading-snug"
+                aria-label="Деталі асистента"
+                className="flex items-center gap-2.5 min-w-0 w-full px-1.5 py-1 -mx-1.5 rounded-xl hover:bg-panelHi transition-colors cursor-pointer select-none"
               >
-                Асистент
-              </div>
-              <div
-                className={cn(
-                  "text-2xs leading-snug truncate",
-                  hasData ? "text-subtle" : "text-warning",
-                )}
-              >
-                {hasData
-                  ? "Фінік · Фізрук · Рутина · Харчування"
-                  : "Mono не підключено"}
-              </div>
-            </div>
-          </div>
-          <div className="flex items-center gap-0.5 shrink-0">
-            <Popover
-              placement="bottom-end"
-              className="!min-w-[260px] p-3"
-              trigger={
-                <Tooltip content="Деталі контексту" placement="bottom-center">
-                  <button
-                    type="button"
-                    className="w-9 h-9 flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors"
-                    aria-label="Деталі контексту"
-                  >
-                    <Icon name="info" size={16} />
-                  </button>
-                </Tooltip>
-              }
-            >
-              <div
-                role="status"
-                className="space-y-2 text-left"
-                id="hub-chat-privacy"
-              >
-                <div className="flex items-center gap-2 text-xs text-text">
+                <span
+                  className={cn(
+                    "relative w-9 h-9 rounded-xl bg-brand-500/10 flex items-center justify-center shrink-0",
+                    contextState.status === "building" &&
+                      "motion-safe:animate-pulse",
+                  )}
+                  aria-hidden
+                >
+                  <Icon name="sparkle" size={16} className="text-brand-500" />
                   <span
                     className={cn(
-                      "inline-block w-2 h-2 rounded-full",
+                      "absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 rounded-full ring-2 ring-bg",
                       contextState.status === "ready"
                         ? "bg-brand-500"
                         : contextState.status === "building"
-                          ? "bg-warning motion-safe:animate-pulse"
-                          : "bg-line",
+                          ? "bg-warning"
+                          : !hasData
+                            ? "bg-warning"
+                            : "bg-line",
                     )}
                     aria-hidden
                   />
-                  <span className="font-semibold">
-                    {contextState.status === "building"
-                      ? "Готую контекст…"
-                      : contextState.status === "ready"
-                        ? "Контекст готовий"
-                        : "Очікую"}
+                </span>
+                <span className="flex items-center gap-1 min-w-0">
+                  <span
+                    id="hub-chat-title"
+                    className="text-[15px] font-bold text-text leading-snug truncate"
+                  >
+                    Асистент
                   </span>
-                </div>
-                <p className="text-2xs text-subtle leading-snug">
-                  В контексті: {sessionInfo.historyCount} з останніх 10
-                  повідомлень · ~{Math.round(sessionInfo.chars / 100) / 10}k
-                  символів.
-                </p>
-                <p className="text-2xs text-muted leading-snug">
-                  Контекст (фінанси, тренування, звички, харчування)
-                  відправляється до AI.
-                </p>
+                  <Icon
+                    name="chevron-down"
+                    size={14}
+                    className={cn(
+                      "text-muted shrink-0 transition-transform duration-150",
+                      detailsOpen && "rotate-180",
+                    )}
+                  />
+                </span>
+              </span>
+            }
+          >
+            <div
+              role="status"
+              id="hub-chat-privacy"
+              className="space-y-2 px-2 pt-2 pb-1"
+            >
+              <div className="flex items-center gap-2 text-xs text-text">
+                <span
+                  className={cn(
+                    "inline-block w-2 h-2 rounded-full",
+                    contextState.status === "ready"
+                      ? "bg-brand-500"
+                      : contextState.status === "building"
+                        ? "bg-warning motion-safe:animate-pulse"
+                        : "bg-line",
+                  )}
+                  aria-hidden
+                />
+                <span className="font-semibold">
+                  {contextState.status === "building"
+                    ? "Готую контекст…"
+                    : contextState.status === "ready"
+                      ? "Контекст готовий"
+                      : "Очікую"}
+                </span>
               </div>
-            </Popover>
-            <Tooltip content="Усі бесіди" placement="bottom-center">
-              <button
-                type="button"
-                onClick={() => setHistoryOpen(true)}
-                className="w-9 h-9 flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors"
-                aria-label={`Відкрити список бесід (${sessions.length})`}
-                aria-haspopup="dialog"
-                aria-expanded={historyOpen}
+              {!hasData && (
+                <div className="px-2.5 py-2 bg-warning/10 border border-warning/30 rounded-xl text-2xs text-warning leading-snug">
+                  Mono не підключено — фінансовий контекст обмежений.
+                </div>
+              )}
+              <p className="text-2xs text-subtle leading-snug">
+                В контексті: {sessionInfo.historyCount} з останніх 10
+                повідомлень · ~{Math.round(sessionInfo.chars / 100) / 10}k
+                символів.
+              </p>
+              <p className="text-2xs text-muted leading-snug">
+                Контекст (фінанси, тренування, звички, харчування)
+                відправляється до AI.
+              </p>
+            </div>
+            <PopoverDivider />
+            <PopoverItem
+              icon={<Icon name="list" size={14} />}
+              onClick={() => {
+                setDetailsOpen(false);
+                setHistoryOpen(true);
+              }}
+            >
+              Усі бесіди ({sessions.length})
+            </PopoverItem>
+            {onMinimize && (
+              <PopoverItem
+                icon={<Icon name="minus" size={14} />}
+                onClick={() => {
+                  setDetailsOpen(false);
+                  onMinimize();
+                }}
               >
-                <Icon name="list" size={15} />
-              </button>
-            </Tooltip>
+                Згорнути в FAB
+              </PopoverItem>
+            )}
+          </Popover>
+          <div className="flex items-center gap-1 shrink-0">
             <Tooltip content="Почати нову бесіду" placement="bottom-center">
               <button
                 type="button"
                 onClick={clearChat}
-                className="h-9 px-2.5 flex items-center gap-1.5 rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors text-2xs font-semibold"
+                className="h-9 px-3 flex items-center gap-1.5 rounded-xl bg-brand-soft text-brand-strong dark:text-brand border border-brand-soft-border/50 hover:bg-brand-soft-hover transition-colors text-xs font-semibold outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45"
                 aria-label="Нова бесіда"
               >
                 <Icon name="plus" size={14} />
                 Нова
               </button>
             </Tooltip>
-            {onMinimize && (
-              <Tooltip content="Згорнути в FAB" placement="bottom-center">
-                <button
-                  type="button"
-                  onClick={onMinimize}
-                  className="w-9 h-9 flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors"
-                  aria-label="Згорнути асистента"
-                >
-                  <Icon name="minus" size={16} />
-                </button>
-              </Tooltip>
-            )}
             <button
               type="button"
               onClick={onClose}

--- a/apps/web/src/shared/components/ui/Popover.tsx
+++ b/apps/web/src/shared/components/ui/Popover.tsx
@@ -46,6 +46,14 @@ export interface PopoverProps {
   className?: string;
   /** Additional className on the wrapper. */
   wrapperClassName?: string;
+  /**
+   * Controlled open state. When provided, the popover becomes a
+   * controlled component and `onOpenChange` must be wired up. Useful
+   * when the parent needs to close the popover after an item action
+   * (e.g. opening a sibling drawer).
+   */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 export function Popover({
@@ -54,13 +62,26 @@ export function Popover({
   placement = "bottom-start",
   className,
   wrapperClassName,
+  open: controlledOpen,
+  onOpenChange,
 }: PopoverProps) {
-  const [open, setOpen] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(false);
+  const isControlled = controlledOpen !== undefined;
+  const open = isControlled ? controlledOpen : internalOpen;
   const wrapperRef = useRef<HTMLDivElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
   const panelId = useId();
 
-  const close = useCallback(() => setOpen(false), []);
+  const setOpen = useCallback(
+    (next: boolean | ((prev: boolean) => boolean)) => {
+      const value = typeof next === "function" ? next(open) : next;
+      if (!isControlled) setInternalOpen(value);
+      onOpenChange?.(value);
+    },
+    [open, isControlled, onOpenChange],
+  );
+
+  const close = useCallback(() => setOpen(false), [setOpen]);
 
   // Close on outside click
   useEffect(() => {


### PR DESCRIPTION
## What changed

Хедер `HubChat` (bottom-sheet «Асистент» на телефоні) переходить з двохрядкового тулбара з 5 кнопками у one-row layout у стилі ChatGPT/Claude.

**Раніше**: `[avatar•] Асистент / Фінік · Фізрук · Рутина · Харчування` + `[(i) info] [≡ список] [+ Нова] [— згорнути] [✕ закрити]` (8 елементів, ~76px заввишки, на айфонах сабтайтл обрізався).

**Тепер**: `[avatar•] Асистент ▾` (trigger існуючого «Деталі»-попапу) + `[+ Нова]` + `[✕]` — 3 елементи, ~52px заввишки.

Зміни:

- Аватар + «Асистент ▾» стають єдиним trigger-ом попапу (chevron підказує клікабельність). Попап тепер містить:
  - статус контексту (`Готую…` / `Готовий` / `Очікую`) + лічильник історії та символів;
  - warning «Mono не підключено — фінансовий контекст обмежений» (раніше жив у червоному сабтайтлі);
  - `Усі бесіди (N)` — відкриває існуючий `HubChatHistoryDrawer`;
  - `Згорнути в FAB` (рендериться лише якщо `onMinimize` передано).
- Окремі кнопки `info`, `≡ список`, `— згорнути` прибрані з хедера.
- Сабтайтл «Фінік · Фізрук · Рутина · Харчування» прибраний — крапка-статус на аватарі вже передає готовність контексту, а warning-стан переїхав у попап (крапка стає `bg-warning` коли `!hasData`).
- `+ Нова` лишається primary-дією в хедері, перефарбована у `bg-brand-soft text-brand-strong` (Hard Rule #9 — використовуються `-strong`/`-soft` companions, не сирий `brand-500`).
- `Popover` отримав опціональні controlled props `open` / `onOpenChange`, щоб батьківський `HubChat` міг закривати попап після кліку по `PopoverItem` (інакше попап лишався б відкритим за списком бесід). Існуючий uncontrolled use-case не зачеплений.

## Why

Користувач у feedback назвав хедер «перевантаженим і шумним». На вузьких айфонах сабтайтл обрізався трикрапкою, а 5 однотипних icon-кнопок справа візуально конкурували за увагу з primary-дією «+ Нова». Перевели на патерн ChatGPT/Claude (заголовок-як-меню + одна primary дія + закрити), де секондарі-афордансі централізовані в попапі за назвою.

## How to test

1. `pnpm dev:web` → відкрити мобільний viewport (375×812 або iPhone Mini).
2. На головному екрані Hub відкрити Асистент (FAB або quick action).
3. **Хедер**: переконатися що бачите тільки `[avatar] Асистент ▾  [+ Нова] [✕]`, без сабтайтлу та без окремих info/list/minimize кнопок.
4. Тап по `Асистент ▾` → відкривається попап зі статусом + privacy-нотаткою + `Усі бесіди (N)` + `Згорнути в FAB` (якщо chat згортається у FAB).
5. Тап по `Усі бесіди (N)` → попап закривається, відкривається існуючий drawer зі списком бесід.
6. Тап по `Згорнути в FAB` → попап закривається, асистент мінімізується.
7. **Mono warning**: якщо акаунт без Mono-токена — крапка-статус на аватарі стає жовтою (`bg-warning`), у попапі нагорі з'являється warning-плашка «Mono не підключено».
8. **Контекст building**: при першому відкритті крапка коротко мигтить жовтим, у попапі — `Готую контекст…` з пульсуючою крапкою.
9. Esc / клік поза попапом / клік на trigger удруге — попап закривається.
10. Регресія: `+ Нова` створює нову бесіду; `✕` закриває асистент.

---

## Pre-flight (Hard Rule #15)

- [x] Read the `AGENTS.md` Hard Rules that apply to the touched paths (Hard Rule #2 RQ-keys n/a, #8 Tailwind opacity steps — використані тільки `/10`, `/30`, `/45`, `/50`; #9 brand-strong для `+ Нова`; #6 `--force-with-lease` n/a).
- [x] Read the matching playbook in `docs/playbooks/` — UI-tweak без додаткового playbook.
- [x] Checked freshness headers of docs cited in the change — n/a, ніяких docs-claims не змінено.

## Docs updated alongside code? (Hard Rule #15)

- [x] N/A — UI-only зміна, ніяких контрактів API, нових скриптів, токенів чи palette-змін.

## How AI-tested this PR

- [x] Vitest related: `pnpm --filter @sergeant/web exec vitest related --run src/core/hub/HubChat.tsx src/shared/components/ui/Popover.tsx` → no test files (header не покритий unit-тестами; жодних snapshot/RTL fixtures на ці aria-label не знайдено в репозиторії).
- [x] `pnpm --filter @sergeant/web exec eslint src/core/hub/HubChat.tsx src/shared/components/ui/Popover.tsx` → clean.
- [x] `pnpm --filter @sergeant/web typecheck` → clean (всі 4 tsconfig-вузли).
- [ ] Manual smoke у dev-сервері — після цього PR, окремим записом / скріншотами в коментарях.
- [x] No new `AI-DANGER` markers.
- [x] Docs prose Ukrainian.
- [x] `pnpm dead-code:files` n/a — нічого не видалено, тільки рефакторинг JSX.

## AGENTS.md updated?

- [x] No — no new permanent rules.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **UI/UX Improvements**
  * Reorganized chat header layout with consolidated controls in a "Details" popover.
  * Added visual indicator (rotating chevron) for popover state on the header.
  * Updated status messaging and disconnect warnings within the details panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->