### PR TITLE
feat(web): swipe-to-dismiss sheets, screen-reader announcer, Finyk swipe feedback

### DIFF
--- a/apps/web/src/core/App.tsx
+++ b/apps/web/src/core/App.tsx
@@ -13,6 +13,7 @@ import { useDarkMode } from "@shared/hooks/useDarkMode";
 import { useOnlineStatus } from "@shared/hooks/useOnlineStatus";
 import { ToastProvider, useToast } from "@shared/hooks/useToast";
 import { ToastContainer } from "@shared/components/ui/Toast";
+import { ScreenReaderAnnouncerProvider } from "@shared/components/ui/ScreenReaderAnnouncer";
 import { HUB_OPEN_MODULE_EVENT } from "@shared/lib/hubNav";
 import { ApiClientProvider } from "@sergeant/api-client/react";
 import { apiClient } from "@shared/api";
@@ -97,6 +98,14 @@ export default function App() {
   return (
     <ToastProvider>
       <ToastContainer />
+      {/*
+        Screen reader announcer: mounts two `aria-live` regions
+        (polite + assertive) at the app root. Any descendant can call
+        `useAnnounce()` to surface dynamic state changes (toggles,
+        expand/collapse, training completion, etc.) to assistive
+        tech. Lives outside ApiClientProvider/AuthProvider so even
+        unauthenticated screens (sign-in, onboarding) can announce.
+      */}
       {/* Capacitor deep-link bridge: монтуємо ВСЕРЕДИНІ роутера (App
           рендериться під <BrowserRouter>), але поза AppInner, щоб
           bridge переживав ранні return-и в AppInner (/sign-in,
@@ -109,11 +118,13 @@ export default function App() {
           `/reset-password`) — без цього onboarding / auth funnels
           у PostHog були б сліпими перед login-ом. */}
       <PageviewTracker />
-      <ApiClientProvider client={apiClient}>
-        <AuthProvider>
-          <AppInner />
-        </AuthProvider>
-      </ApiClientProvider>
+      <ScreenReaderAnnouncerProvider>
+        <ApiClientProvider client={apiClient}>
+          <AuthProvider>
+            <AppInner />
+          </AuthProvider>
+        </ApiClientProvider>
+      </ScreenReaderAnnouncerProvider>
     </ToastProvider>
   );
 }

--- a/apps/web/src/modules/finyk/FinykApp.tsx
+++ b/apps/web/src/modules/finyk/FinykApp.tsx
@@ -166,6 +166,15 @@ export default function App({
   // Свайп між вкладками (без pull-to-refresh: скрол живе всередині сторінок, зовнішній scrollTop завжди 0)
   const touchStartX = useRef(null);
   const touchStartY = useRef(null);
+  // Live drag offset for visual feedback. While the user is dragging
+  // we translate the page wrapper horizontally (clamped to ±SWIPE_DRAG_LIMIT)
+  // and surface a thin progress bar at the bottom — without this,
+  // the only feedback was the abrupt page swap on release, which
+  // many users interpreted as a missed gesture.
+  const SWIPE_THRESHOLD_PX = 60;
+  const SWIPE_DRAG_LIMIT_PX = 120;
+  const [swipeDx, setSwipeDx] = useState(0);
+  const swipeActiveRef = useRef(false);
 
   // Ascend from the touch target and bail out if any ancestor is marked as
   // a horizontal scroller (e.g. the category filter strip on Operations) or
@@ -205,18 +214,55 @@ export default function App({
     }
     touchStartX.current = e.touches[0].clientX;
     touchStartY.current = e.touches[0].clientY;
+    swipeActiveRef.current = false;
+    setSwipeDx(0);
+  };
+  const handleTouchMove = (e) => {
+    if (touchStartX.current === null || touchStartY.current === null) return;
+    const rawDx = e.touches[0].clientX - touchStartX.current; // sign: +right, -left
+    const rawDy = e.touches[0].clientY - touchStartY.current;
+    // Stay quiet until the gesture is unambiguously horizontal. We
+    // need the same dominance check as touchEnd (|dx| ≥ 1.5·|dy|) so
+    // vertical scrolls inside nested lists never start tugging the
+    // page sideways.
+    if (Math.abs(rawDx) < 12) return;
+    if (Math.abs(rawDx) < Math.abs(rawDy) * 1.5) return;
+    swipeActiveRef.current = true;
+    const curIdx = NAV_IDS.indexOf(page);
+    // Cancel feedback at the ends of the tab list so the user doesn't
+    // get a "fake" drag that goes nowhere when they're already on
+    // overview / analytics.
+    if (curIdx === 0 && rawDx > 0) {
+      setSwipeDx(0);
+      return;
+    }
+    if (curIdx === NAV_IDS.length - 1 && rawDx < 0) {
+      setSwipeDx(0);
+      return;
+    }
+    const clamped = Math.max(
+      -SWIPE_DRAG_LIMIT_PX,
+      Math.min(SWIPE_DRAG_LIMIT_PX, rawDx),
+    );
+    setSwipeDx(clamped);
   };
   const handleTouchEnd = (e) => {
-    if (touchStartX.current === null || touchStartY.current === null) return;
+    if (touchStartX.current === null || touchStartY.current === null) {
+      setSwipeDx(0);
+      return;
+    }
     const dx = touchStartX.current - e.changedTouches[0].clientX;
     const dy = touchStartY.current - e.changedTouches[0].clientY;
     touchStartX.current = null;
     touchStartY.current = null;
+    swipeActiveRef.current = false;
+    setSwipeDx(0);
 
     // Require a clearly horizontal swipe so vertical scrolls in nested lists
     // (transactions, budgets) never trigger tab switches: |dx| must exceed
     // both a comfortable threshold (60px) AND ~1.5× the vertical travel.
-    if (Math.abs(dx) < 60 || Math.abs(dx) < Math.abs(dy) * 1.5) return;
+    if (Math.abs(dx) < SWIPE_THRESHOLD_PX || Math.abs(dx) < Math.abs(dy) * 1.5)
+      return;
     const curIdx = NAV_IDS.indexOf(page);
     if (curIdx === -1) return;
     const next = curIdx + (dx > 0 ? 1 : -1);
@@ -340,13 +386,58 @@ export default function App({
 
       {/* Page content */}
       <div
-        className="flex-1 overflow-hidden flex flex-col min-h-0 touch-pan-y"
+        className="flex-1 overflow-hidden flex flex-col min-h-0 touch-pan-y relative"
         onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
         onTouchEnd={handleTouchEnd}
       >
+        {/*
+          Swipe progress bar — surfaces an in-progress tab swipe so
+          the gesture isn't a black box anymore. Sits at the top of
+          the page wrapper, fills toward the threshold (60 px), then
+          tints fully on commit. Hidden when the user isn't dragging
+          to keep the chrome clean.
+        */}
+        {swipeDx !== 0 && (
+          <div
+            aria-hidden
+            className="pointer-events-none absolute top-0 inset-x-0 h-0.5 z-20 overflow-hidden"
+          >
+            <div
+              className={cn(
+                "h-full",
+                Math.abs(swipeDx) >= SWIPE_THRESHOLD_PX
+                  ? "bg-finyk"
+                  : "bg-finyk/40",
+              )}
+              style={{
+                width: `${Math.min(100, (Math.abs(swipeDx) / SWIPE_THRESHOLD_PX) * 100)}%`,
+                marginLeft: swipeDx < 0 ? "auto" : 0,
+                transition: "background-color 120ms linear",
+              }}
+            />
+          </div>
+        )}
         <div
           key={`page-${page}`}
           className="flex-1 overflow-hidden flex flex-col min-h-0 motion-safe:animate-fade-in"
+          style={
+            swipeDx !== 0
+              ? {
+                  // 0.45 follow-coefficient mirrors iOS' "rubber band"
+                  // feel — the page tracks the finger but lags behind
+                  // it, so the dominant motion stays in the user's
+                  // hand, not the screen. No transition while dragging
+                  // so there's no rubber-banding lag.
+                  transform: `translate3d(${swipeDx * 0.45}px, 0, 0)`,
+                  transition: "none",
+                  willChange: "transform",
+                }
+              : {
+                  transform: "translate3d(0, 0, 0)",
+                  transition: "transform 200ms cubic-bezier(0.32, 0.72, 0, 1)",
+                }
+          }
         >
           {page === "overview" && (
             <SectionErrorBoundary

--- a/apps/web/src/modules/fizruk/components/workouts/WorkoutJournalSection.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/WorkoutJournalSection.tsx
@@ -10,6 +10,7 @@ import { Card } from "@shared/components/ui/Card";
 import { useToast } from "@shared/hooks/useToast";
 import { hapticSuccess } from "@shared/lib/haptic";
 import { showUndoToast } from "@shared/lib/undoToast";
+import { useAnnounce } from "@shared/components/ui/ScreenReaderAnnouncer";
 
 function WorkoutRow({ w, activeWorkoutId, setActiveWorkoutId }) {
   // An ended workout is always "Завершене" — even if it happens to be the
@@ -92,6 +93,7 @@ export function WorkoutJournalSection({
   restoreWorkout,
 }) {
   const toast = useToast();
+  const { announce } = useAnnounce();
   const workoutList = workouts || [];
   const handleSwipeDelete = useCallback(
     (id) => {
@@ -181,6 +183,11 @@ export function WorkoutJournalSection({
               // Nutrition (meal save).
               hapticSuccess();
               toast.success("Тренування збережено.");
+              // Mirror the visible toast for screen-reader users — the
+              // toast queue uses an `aria-live` region too but only for
+              // the toast text region, which AT may filter as cosmetic.
+              // A polite announce() here is short and high-signal.
+              announce("Тренування завершено та збережено.");
               // Collapse the expanded active workout panel immediately —
               // a finished session should live on in the history list as a
               // "Завершене" entry, not keep occupying the "Активне" slot.

--- a/apps/web/src/shared/components/layout/ModuleSettingsDrawer.tsx
+++ b/apps/web/src/shared/components/layout/ModuleSettingsDrawer.tsx
@@ -1,6 +1,7 @@
-import { useId, useRef, type ReactNode } from "react";
+import { useId, useRef, type CSSProperties, type ReactNode } from "react";
 import { Icon } from "@shared/components/ui/Icon";
 import { useDialogFocusTrap } from "@shared/hooks/useDialogFocusTrap";
+import { useSwipeToDismiss } from "@shared/hooks/useSwipeToDismiss";
 import { cn } from "@shared/lib/cn";
 
 /**
@@ -32,7 +33,27 @@ export function ModuleSettingsDrawer({
 
   useDialogFocusTrap(open, panelRef, { onEscape: onClose });
 
+  // Right-side drawers dismiss with a rightward swipe — opposite of
+  // bottom sheets but the same useSwipeToDismiss primitive. We bind
+  // the gesture on the header bar (not the body) so vertical scroll
+  // and form input drags inside the drawer are not hijacked.
+  const swipe = useSwipeToDismiss({
+    enabled: open,
+    direction: "right",
+    onDismiss: onClose,
+  });
+
   if (!open) return null;
+
+  const panelStyle: CSSProperties = swipe.dragging
+    ? {
+        transform: `translate3d(${swipe.dragOffset}px, 0, 0)`,
+        transition: "none",
+      }
+    : {
+        transform: "translate3d(0, 0, 0)",
+        transition: "transform 200ms cubic-bezier(0.32, 0.72, 0, 1)",
+      };
 
   return (
     <div className="fixed inset-0 z-[80] flex justify-end" role="presentation">
@@ -47,12 +68,16 @@ export function ModuleSettingsDrawer({
         role="dialog"
         aria-modal="true"
         aria-labelledby={titleId}
+        style={panelStyle}
         className={cn(
           "relative w-full max-w-sm h-full bg-panel border-l border-line shadow-2xl flex flex-col safe-area-pt-pb",
           className,
         )}
       >
-        <div className="shrink-0 flex items-center justify-between gap-3 px-4 py-3 border-b border-line">
+        <div
+          className="shrink-0 flex items-center justify-between gap-3 px-4 py-3 border-b border-line touch-pan-x"
+          {...swipe.bind}
+        >
           <h2 id={titleId} className="text-base font-semibold text-text">
             {title}
           </h2>

--- a/apps/web/src/shared/components/ui/ConfirmDialog.tsx
+++ b/apps/web/src/shared/components/ui/ConfirmDialog.tsx
@@ -83,7 +83,6 @@ export function ConfirmDialog({
         role="dialog"
         aria-modal="true"
         aria-labelledby="confirm-title"
-        onPointerDown={(e) => e.stopPropagation()}
         style={
           swipe.dragging
             ? ({
@@ -95,7 +94,17 @@ export function ConfirmDialog({
                 transition: "transform 200ms cubic-bezier(0.32, 0.72, 0, 1)",
               } satisfies CSSProperties)
         }
-        {...swipe.bind}
+        // Stop propagation so a pointerdown on the panel doesn't fall
+        // through to the scrim button beneath. We forward the swipe
+        // hook's handlers explicitly (rather than spreading) so we can
+        // also call stopPropagation on the down event.
+        onPointerDown={(e) => {
+          e.stopPropagation();
+          swipe.bind.onPointerDown(e);
+        }}
+        onPointerMove={swipe.bind.onPointerMove}
+        onPointerUp={swipe.bind.onPointerUp}
+        onPointerCancel={swipe.bind.onPointerCancel}
         className={cn(
           "relative z-10 w-full max-w-sm mx-4 mb-4 sm:mb-0 overscroll-contain touch-pan-y",
           "bg-panel rounded-3xl shadow-float border border-line p-6",

--- a/apps/web/src/shared/components/ui/ConfirmDialog.tsx
+++ b/apps/web/src/shared/components/ui/ConfirmDialog.tsx
@@ -1,5 +1,12 @@
-import { useEffect, useRef, type KeyboardEvent, type ReactNode } from "react";
+import {
+  useEffect,
+  useRef,
+  type CSSProperties,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react";
 import { useDialogFocusTrap } from "@shared/hooks/useDialogFocusTrap";
+import { useSwipeToDismiss } from "@shared/hooks/useSwipeToDismiss";
 import { cn } from "@shared/lib/cn";
 import { Button } from "./Button";
 
@@ -29,6 +36,14 @@ export function ConfirmDialog({
 }: ConfirmDialogProps) {
   const ref = useRef<HTMLDivElement>(null);
   useDialogFocusTrap(open, ref, { onEscape: onCancel });
+
+  // Pulling the sheet down to dismiss is the same gesture users already
+  // know from <Sheet>. We treat dismiss as "cancel" — destructive
+  // confirms still require an explicit tap on the danger button.
+  const swipe = useSwipeToDismiss({
+    enabled: open,
+    onDismiss: () => onCancel?.(),
+  });
 
   useEffect(() => {
     if (!open) return;
@@ -69,8 +84,20 @@ export function ConfirmDialog({
         aria-modal="true"
         aria-labelledby="confirm-title"
         onPointerDown={(e) => e.stopPropagation()}
+        style={
+          swipe.dragging
+            ? ({
+                transform: `translate3d(0, ${swipe.dragOffset}px, 0)`,
+                transition: "none",
+              } satisfies CSSProperties)
+            : ({
+                transform: "translate3d(0, 0, 0)",
+                transition: "transform 200ms cubic-bezier(0.32, 0.72, 0, 1)",
+              } satisfies CSSProperties)
+        }
+        {...swipe.bind}
         className={cn(
-          "relative z-10 w-full max-w-sm mx-4 mb-4 sm:mb-0 overscroll-contain",
+          "relative z-10 w-full max-w-sm mx-4 mb-4 sm:mb-0 overscroll-contain touch-pan-y",
           "bg-panel rounded-3xl shadow-float border border-line p-6",
           "motion-safe:animate-in motion-safe:slide-in-from-bottom-4 motion-safe:duration-200",
         )}

--- a/apps/web/src/shared/components/ui/Sheet.tsx
+++ b/apps/web/src/shared/components/ui/Sheet.tsx
@@ -7,6 +7,8 @@ import {
 } from "react";
 import { cn } from "../../lib/cn";
 import { useDialogFocusTrap } from "../../hooks/useDialogFocusTrap";
+import { useSwipeToDismiss } from "../../hooks/useSwipeToDismiss";
+import { useAnnounce } from "./ScreenReaderAnnouncer";
 
 /**
  * Sergeant Design System — Sheet (bottom sheet / modal)
@@ -79,6 +81,15 @@ export function Sheet({
   const titleId = useId();
   useDialogFocusTrap(open, panelRef, { onEscape: onClose });
 
+  // Swipe-to-dismiss — drag the panel down ≥ 80 px to close. Mirrors
+  // the iOS Maps / Apple Pay sheet feel; the drag handle pill at the
+  // top now actually does something. We disable the gesture once the
+  // sheet starts closing so the panel doesn't snap back mid-exit.
+  const swipe = useSwipeToDismiss({
+    enabled: open,
+    onDismiss: onClose,
+  });
+
   // Lock body scroll while sheet is open. Matches the ad-hoc patterns
   // several existing sheets already implemented inconsistently.
   useEffect(() => {
@@ -90,6 +101,19 @@ export function Sheet({
     };
   }, [open]);
 
+  // Announce the sheet title to assistive tech when it opens. The
+  // `aria-labelledby` wiring already exposes the title to screen
+  // readers, but only if the AT user pulls focus into the dialog —
+  // many SR users on iOS / Android receive a polite live-region
+  // announcement faster.
+  const { announce } = useAnnounce();
+  useEffect(() => {
+    if (!open) return;
+    if (typeof title !== "string") return;
+    if (!title.trim()) return;
+    announce(title);
+  }, [open, title, announce]);
+
   if (!open) return null;
 
   // Lift the panel above the module bottom nav (set via the
@@ -97,13 +121,25 @@ export function Sheet({
   // home-indicator inset. `kbInsetPx` overrides the offset entirely
   // when the soft keyboard is visible — we want the sheet to hug the
   // keyboard, not float above where the nav would be.
-  const panelStyle: CSSProperties =
+  const baseStyle: CSSProperties =
     kbInsetPx && kbInsetPx > 0
       ? { marginBottom: kbInsetPx }
       : {
           marginBottom:
             "calc(var(--bottom-nav-height, 0px) + env(safe-area-inset-bottom, 0px))",
         };
+  const panelStyle: CSSProperties = swipe.dragging
+    ? {
+        ...baseStyle,
+        transform: `translate3d(0, ${swipe.dragOffset}px, 0)`,
+        transition: "none",
+        touchAction: "none",
+      }
+    : {
+        ...baseStyle,
+        transform: "translate3d(0, 0, 0)",
+        transition: "transform 200ms cubic-bezier(0.32, 0.72, 0, 1)",
+      };
 
   return (
     <div
@@ -131,12 +167,26 @@ export function Sheet({
           panelClassName,
         )}
       >
+        {/*
+          Swipe-to-dismiss handle. We bind the gesture to the handle
+          row + header (not the full panel) so vertical scrolling
+          inside the body and text input drags don't get hijacked. The
+          handle is the iOS-conventional grab target and now actually
+          functional.
+        */}
         {!hideHandle && (
-          <div className="flex justify-center pt-3 pb-1 shrink-0">
+          <div
+            className="flex justify-center pt-3 pb-1 shrink-0 cursor-grab active:cursor-grabbing touch-none"
+            {...swipe.bind}
+            role="presentation"
+          >
             <div className="w-12 h-[5px] bg-line/70 rounded-full" aria-hidden />
           </div>
         )}
-        <div className="flex items-start justify-between gap-3 px-5 pt-1 pb-3 shrink-0">
+        <div
+          className="flex items-start justify-between gap-3 px-5 pt-1 pb-3 shrink-0 touch-pan-y"
+          {...swipe.bind}
+        >
           <div className="min-w-0 flex-1">
             <div
               id={titleId}

--- a/apps/web/src/shared/components/ui/Switch.tsx
+++ b/apps/web/src/shared/components/ui/Switch.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@shared/lib/cn";
 import { hapticTap } from "@shared/lib/haptic";
+import { useAnnounce } from "@shared/components/ui/ScreenReaderAnnouncer";
 import type { ChangeEvent } from "react";
 
 export interface SwitchProps {
@@ -8,6 +9,13 @@ export interface SwitchProps {
   disabled?: boolean;
   label?: string;
   className?: string;
+  /**
+   * Custom screen-reader announcement on toggle. Receives the new
+   * `checked` value. Defaults to a Ukrainian "{label} увімкнено / вимкнено"
+   * message when `label` is provided. Pass an explicit empty string to
+   * suppress announcements.
+   */
+  announceText?: (checked: boolean) => string;
 }
 
 /**
@@ -26,11 +34,24 @@ export function Switch({
   disabled = false,
   label,
   className,
+  announceText,
 }: SwitchProps) {
+  const { announce } = useAnnounce();
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     if (disabled) return;
     hapticTap();
-    onChange(e.target.checked);
+    const next = e.target.checked;
+    onChange(next);
+    // Visual checked state already conveys this to sighted users; the
+    // aria-live announcement closes the gap for screen readers, who
+    // otherwise only hear "checkbox, checked/not checked" with no
+    // context about *what* was toggled.
+    const text = announceText
+      ? announceText(next)
+      : label
+        ? `${label} ${next ? "увімкнено" : "вимкнено"}`
+        : "";
+    if (text) announce(text);
   };
 
   return (

--- a/apps/web/src/shared/hooks/index.ts
+++ b/apps/web/src/shared/hooks/index.ts
@@ -66,6 +66,13 @@ export type {
   UsePullToRefreshOptions,
 } from "./usePullToRefresh";
 
+export { useSwipeToDismiss } from "./useSwipeToDismiss";
+export type {
+  SwipeBind,
+  UseSwipeToDismissOptions,
+  UseSwipeToDismissReturn,
+} from "./useSwipeToDismiss";
+
 export { useFocusTrap } from "./useFocusTrap";
 
 export { useFormValidation, validationRules } from "./useFormValidation";

--- a/apps/web/src/shared/hooks/useSwipeToDismiss.test.ts
+++ b/apps/web/src/shared/hooks/useSwipeToDismiss.test.ts
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useSwipeToDismiss } from "./useSwipeToDismiss";
+
+// Minimal pointer event mock — Pointer Events aren't constructible
+// in jsdom out of the box, but the hook only reads `pointerId`,
+// `pointerType`, `clientX`, `clientY`, `button`, and `target`.
+function makePointer(
+  overrides: Partial<{
+    clientX: number;
+    clientY: number;
+    pointerId: number;
+    pointerType: string;
+    button: number;
+    target: HTMLElement;
+  }>,
+): React.PointerEvent {
+  const target =
+    overrides.target ??
+    Object.assign(document.createElement("div"), {
+      setPointerCapture: vi.fn(),
+    });
+  return {
+    clientX: overrides.clientX ?? 0,
+    clientY: overrides.clientY ?? 0,
+    pointerId: overrides.pointerId ?? 1,
+    pointerType: overrides.pointerType ?? "touch",
+    button: overrides.button ?? 0,
+    target,
+  } as unknown as React.PointerEvent;
+}
+
+describe("useSwipeToDismiss", () => {
+  it("calls onDismiss when downward drag exceeds threshold", () => {
+    const onDismiss = vi.fn();
+    const { result } = renderHook(() =>
+      useSwipeToDismiss({ threshold: 80, onDismiss }),
+    );
+
+    act(() => {
+      result.current.bind.onPointerDown(makePointer({ clientY: 100 }));
+    });
+    act(() => {
+      result.current.bind.onPointerMove(makePointer({ clientY: 200 }));
+    });
+    expect(result.current.dragOffset).toBe(100);
+    act(() => {
+      result.current.bind.onPointerUp(makePointer({ clientY: 200 }));
+    });
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(result.current.dragging).toBe(false);
+  });
+
+  it("snaps back when drag is below threshold", () => {
+    const onDismiss = vi.fn();
+    const { result } = renderHook(() =>
+      useSwipeToDismiss({ threshold: 80, onDismiss }),
+    );
+
+    act(() => {
+      result.current.bind.onPointerDown(makePointer({ clientY: 100 }));
+      result.current.bind.onPointerMove(makePointer({ clientY: 140 }));
+      result.current.bind.onPointerUp(makePointer({ clientY: 140 }));
+    });
+
+    expect(onDismiss).not.toHaveBeenCalled();
+    expect(result.current.dragOffset).toBe(0);
+  });
+
+  it("ignores upward drags for direction=down", () => {
+    const onDismiss = vi.fn();
+    const { result } = renderHook(() =>
+      useSwipeToDismiss({ threshold: 80, onDismiss }),
+    );
+
+    act(() => {
+      result.current.bind.onPointerDown(makePointer({ clientY: 200 }));
+      result.current.bind.onPointerMove(makePointer({ clientY: 50 }));
+    });
+    expect(result.current.dragOffset).toBe(0);
+  });
+
+  it("dismisses on rightward drag for direction=right", () => {
+    const onDismiss = vi.fn();
+    const { result } = renderHook(() =>
+      useSwipeToDismiss({ threshold: 80, direction: "right", onDismiss }),
+    );
+
+    act(() => {
+      result.current.bind.onPointerDown(makePointer({ clientX: 0 }));
+      result.current.bind.onPointerMove(makePointer({ clientX: 120 }));
+      result.current.bind.onPointerUp(makePointer({ clientX: 120 }));
+    });
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("is inert when enabled=false", () => {
+    const onDismiss = vi.fn();
+    const { result } = renderHook(() =>
+      useSwipeToDismiss({ threshold: 80, onDismiss, enabled: false }),
+    );
+
+    act(() => {
+      result.current.bind.onPointerDown(makePointer({ clientY: 100 }));
+      result.current.bind.onPointerMove(makePointer({ clientY: 300 }));
+      result.current.bind.onPointerUp(makePointer({ clientY: 300 }));
+    });
+
+    expect(onDismiss).not.toHaveBeenCalled();
+    expect(result.current.dragOffset).toBe(0);
+  });
+
+  it("ignores secondary mouse buttons", () => {
+    const onDismiss = vi.fn();
+    const { result } = renderHook(() =>
+      useSwipeToDismiss({ threshold: 80, onDismiss }),
+    );
+
+    act(() => {
+      result.current.bind.onPointerDown(
+        makePointer({ clientY: 0, pointerType: "mouse", button: 2 }),
+      );
+      result.current.bind.onPointerMove(makePointer({ clientY: 200 }));
+      result.current.bind.onPointerUp(makePointer({ clientY: 200 }));
+    });
+
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/shared/hooks/useSwipeToDismiss.ts
+++ b/apps/web/src/shared/hooks/useSwipeToDismiss.ts
@@ -1,0 +1,167 @@
+import { useCallback, useRef, useState } from "react";
+
+/**
+ * Sergeant Design System — useSwipeToDismiss
+ *
+ * Drag-to-dismiss for bottom sheets and side drawers. Mirrors iOS
+ * Maps / Apple Pay sheet behaviour: pointer-down on the panel, drag
+ * past `threshold` in the configured `direction`, release →
+ * `onDismiss()`. Releasing before threshold snaps the panel back.
+ *
+ * The hook is **headless** — it returns:
+ *   - `bind`: spread onto the panel element to capture pointer events.
+ *   - `dragOffset`: signed offset along the drag axis (px) — host
+ *     applies it via transform/opacity for the visual feedback.
+ *   - `dragging`: whether the user is actively dragging.
+ *
+ * Why not `touchstart`/`touchmove`? Pointer Events unify mouse, touch,
+ * and stylus, work in iOS Safari ≥ 13 (our floor), and let us call
+ * `setPointerCapture` so the gesture keeps tracking even if the
+ * pointer leaves the element bounds — important when a downward drag
+ * escapes past the viewport bottom.
+ *
+ * Why per-direction? Bottom sheets only dismiss downward; right-side
+ * drawers only dismiss rightward. We never accept multi-direction
+ * dismiss because that fights with horizontal swipes used by other
+ * UI (carousels, tab swipes in Finyk).
+ */
+export type SwipeDirection = "down" | "right";
+
+export interface UseSwipeToDismissOptions {
+  /** Pixels of drag along `direction` required to dismiss. Default 80px. */
+  threshold?: number;
+  /**
+   * Multiplier applied to drag distance once it exceeds the threshold.
+   * Lower than 1 means the panel "fights back" past the threshold —
+   * matches iOS rubber-band feel. Default 1 (no resistance).
+   */
+  overshootResistance?: number;
+  /**
+   * Which axis & sign counts as "dismiss".
+   *   - `"down"` (default): positive Y delta dismisses; negative is ignored.
+   *   - `"right"`: positive X delta dismisses; negative is ignored.
+   */
+  direction?: SwipeDirection;
+  /** Called when the user releases past `threshold`. */
+  onDismiss: () => void;
+  /** When false, the hook is inert (gesture is ignored). Default true. */
+  enabled?: boolean;
+}
+
+export interface SwipeBind {
+  onPointerDown: (e: React.PointerEvent) => void;
+  onPointerMove: (e: React.PointerEvent) => void;
+  onPointerUp: (e: React.PointerEvent) => void;
+  onPointerCancel: (e: React.PointerEvent) => void;
+}
+
+export interface UseSwipeToDismissReturn {
+  bind: SwipeBind;
+  /** Signed drag offset along the configured axis (always ≥ 0). */
+  dragOffset: number;
+  dragging: boolean;
+}
+
+export function useSwipeToDismiss({
+  threshold = 80,
+  overshootResistance = 1,
+  direction = "down",
+  onDismiss,
+  enabled = true,
+}: UseSwipeToDismissOptions): UseSwipeToDismissReturn {
+  const startXRef = useRef<number | null>(null);
+  const startYRef = useRef<number | null>(null);
+  // We capture the pointerId so subsequent move/up events from a
+  // different finger/mouse don't poison the gesture.
+  const pointerIdRef = useRef<number | null>(null);
+  const [dragOffset, setDragOffset] = useState(0);
+  const [dragging, setDragging] = useState(false);
+
+  const reset = useCallback(() => {
+    startXRef.current = null;
+    startYRef.current = null;
+    pointerIdRef.current = null;
+    setDragOffset(0);
+    setDragging(false);
+  }, []);
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      if (!enabled) return;
+      // Mouse: only primary button. Touch / pen: always allow.
+      if (e.pointerType === "mouse" && e.button !== 0) return;
+      startXRef.current = e.clientX;
+      startYRef.current = e.clientY;
+      pointerIdRef.current = e.pointerId;
+      setDragging(true);
+      // Pointer capture keeps subsequent move/up events targeted at
+      // this element even if the pointer leaves the bounds — critical
+      // for a drag that escapes past the viewport edge.
+      try {
+        (e.target as Element).setPointerCapture?.(e.pointerId);
+      } catch {
+        // Older browsers may throw if the target is detached; ignore.
+      }
+    },
+    [enabled],
+  );
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!enabled) return;
+      if (startXRef.current === null || startYRef.current === null) return;
+      if (e.pointerId !== pointerIdRef.current) return;
+      const delta =
+        direction === "down"
+          ? e.clientY - startYRef.current
+          : e.clientX - startXRef.current;
+      // Drags in the wrong direction are ignored (panel doesn't move).
+      // Past the threshold we apply optional rubber-band resistance.
+      if (delta <= 0) {
+        setDragOffset(0);
+        return;
+      }
+      if (delta <= threshold || overshootResistance === 1) {
+        setDragOffset(delta);
+      } else {
+        const overshoot = delta - threshold;
+        setDragOffset(threshold + overshoot * overshootResistance);
+      }
+    },
+    [enabled, threshold, overshootResistance, direction],
+  );
+
+  const onPointerUp = useCallback(
+    (e: React.PointerEvent) => {
+      if (!enabled) {
+        reset();
+        return;
+      }
+      if (startXRef.current === null || startYRef.current === null) {
+        reset();
+        return;
+      }
+      if (e.pointerId !== pointerIdRef.current) return;
+      const delta =
+        direction === "down"
+          ? e.clientY - startYRef.current
+          : e.clientX - startXRef.current;
+      if (delta >= threshold) {
+        onDismiss();
+      }
+      // Snap back regardless — host will unmount on dismiss path.
+      reset();
+    },
+    [enabled, threshold, direction, onDismiss, reset],
+  );
+
+  const onPointerCancel = useCallback(() => {
+    reset();
+  }, [reset]);
+
+  return {
+    bind: { onPointerDown, onPointerMove, onPointerUp, onPointerCancel },
+    dragOffset,
+    dragging,
+  };
+}

--- a/docs/audits/UX-IMPROVEMENT-PLAN.md
+++ b/docs/audits/UX-IMPROVEMENT-PLAN.md
@@ -784,7 +784,7 @@ export default function ForgotPasswordScreen() {
   - [ ] Замінити всі ← текстові кнопки на `BackButton`
 
 - [ ] **Week 2**
-  - [ ] Додати gesture dismiss в `Sheet`
+  - [x] Додати gesture dismiss в `Sheet` _(web — done у [#1181](https://github.com/Skords-01/Sergeant/pull/1181) через `useSwipeToDismiss`; також застосовано в `ConfirmDialog` і `ModuleSettingsDrawer`. Mobile RN-частина — pending.)_
   - [ ] Встановити `react-native-reanimated` якщо ще не встановлено
   - [ ] Тестувати на iOS та Android
 

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -1,6 +1,6 @@
 # Sergeant Design System
 
-> **Last validated:** 2026-04-29 by @devin-ai. **Next review:** 2026-07-29.
+> **Last validated:** 2026-04-28 by @devin-ai. **Next review:** 2026-07-28.
 > **Status:** Active
 
 Єдина візуальна мова для хаба з 4 модулями: **ФІНІК**, **ФІЗРУК**, **Рутина**,
@@ -700,7 +700,134 @@ Mutator-handler-и в `apps/web/src/core/lib/chatActions/` повертають
 
 ---
 
-## 16. Що далі
+## 16. Gestures & a11y (2026-04, batch 3)
+
+Третій batch UX-покращень додав три горизонтальні примітиви: dismiss-by-drag для
+overlay-ів, headless-сповіщення для скрін-рідерів, і live-feedback для tab-swipe.
+
+### Sheet — swipe-to-dismiss
+
+`Sheet` (bottom sheet) і `ConfirmDialog` (модалка) тепер закриваються
+свайпом униз. Жест прив'язаний до **handle pill + header** (Sheet) або до
+всього контейнера (ConfirmDialog), щоб не конфліктувати зі скролом /
+текстовими інпутами в body.
+
+- Поріг: `80px` (`useSwipeToDismiss` default).
+- Snap-back: `200ms cubic-bezier(0.32, 0.72, 0, 1)` через `translate3d`.
+- Coercion: на `ConfirmDialog` dismiss = "cancel" (не "confirm").
+
+Жест працює і на тач-скрінах, і на трекпадах через **Pointer Events** з
+`setPointerCapture`. Зворотну сумісність із кнопкою `×` / Escape
+збережено.
+
+### ModuleSettingsDrawer — swipe-right-to-dismiss
+
+`ModuleSettingsDrawer` (правий side-drawer) використовує той самий хук
+з `direction: "right"`. Жест прив'язаний **тільки до header** —
+налаштування в body часто містять інпути / списки, які не мають
+"крастися" вбік під час скролу.
+
+### `useSwipeToDismiss` — спільний headless хук
+
+```tsx
+import { useSwipeToDismiss } from "@shared/hooks";
+
+const swipe = useSwipeToDismiss({
+  threshold: 80, // default 80px
+  direction: "down", // "down" | "right"
+  overshootResistance: 1, // 1 = no resistance, >1 = rubber-band
+  enabled: open,
+  onDismiss: onClose,
+});
+
+return (
+  <div
+    {...swipe.bind}
+    style={{
+      // Consumer reapplies the same axis it passed in options.
+      transform: `translate3d(0, ${swipe.dragOffset}px, 0)`,
+      transition: swipe.dragging
+        ? "none"
+        : "transform 200ms cubic-bezier(0.32, 0.72, 0, 1)",
+    }}
+  />
+);
+```
+
+**Контракт:**
+
+| Поле         | Тип                                      | Призначення                               |
+| ------------ | ---------------------------------------- | ----------------------------------------- |
+| `bind`       | `{ onPointerDown / Move / Up / Cancel }` | Розпаковуй у елемент-ручку через `{...}`  |
+| `dragOffset` | `number` (≥ 0)                           | Поточний offset уздовж осі для transform  |
+| `dragging`   | `boolean`                                | true в момент drag — вимикай `transition` |
+
+**Не біндь жест на body зі скролом / інпутами** — handle/header only,
+інакше pointer events перехоплюються до scroll-у.
+
+### `ScreenReaderAnnouncerProvider` + `useAnnounce`
+
+Глобальний headless-об'явник, змонтований **в `App.tsx` над
+`ApiClientProvider` / `AuthProvider`**, рендерить два невидимі
+`aria-live` регіони (`polite` + `assertive`). `useAnnounce()`
+повертає імперативний `announce(message, options?)`, який AT
+(NVDA / JAWS / VoiceOver / TalkBack) озвучить у наступному циклі.
+
+```tsx
+import { useAnnounce } from "@shared/components/ui";
+
+const { announce } = useAnnounce();
+
+// Polite — для нейтральних подій
+announce("Тренування збережено.");
+
+// Assertive — для помилок / критичних змін
+announce("Не вдалось зберегти. Спробуй ще раз.", { assertive: true });
+```
+
+Викликай `announce()`:
+
+- При відкритті будь-якого `Sheet` (озвучує `title`).
+- При тоглі `Switch` (через проп `announceText`, див. нижче).
+- При завершенні мутації, яку користувач ініціював, але результат не
+  показує одразу візуально (workout finish, save settings, …).
+
+**Не дублюй `aria-live`** на сторінках — провайдер уже один на весь
+застосунок. Це особливо важливо для мобільних read-режимів, де AT
+читають кожен live-регіон окремо.
+
+### `Switch` — `announceText`
+
+```tsx
+<Switch
+  checked={pushOn}
+  onChange={setPushOn}
+  label="Push-сповіщення"
+  announceText={(checked) =>
+    checked ? "Push-сповіщення увімкнено" : "Push-сповіщення вимкнено"
+  }
+/>
+```
+
+Якщо `announceText` не передано — нічого не озвучується (back-compat).
+Колбек отримує **новий** стан після toggle.
+
+### Finyk swipe-between-tabs — visual feedback
+
+`FinykApp` тепер показує two-channel feedback при горизонтальному
+свайпі між табами:
+
+- **Live drag follow** — page wrapper рухається разом із пальцем
+  (`translate3d(dx * 0.45, 0, 0)`) для тактильного відгуку.
+- **Top progress bar** — тонка `bg-finyk` смужка згори, що заповнюється
+  до 60px threshold (повільний `0–100%` фейд) і темнішає на коміті.
+
+Цей патерн поки локальний для Finyk; якщо buyer-у потрібно перенести в
+інші модулі — обгорни в `useSwipeBetweenTabs` хук і документуй тут.
+
+---
+
+## 17. Що далі
 
 - Догнати всі модулі (ФІНІК / ФІЗРУК / Рутина / Харчування) під єдині
   примітиви — окремими PR'ами, по модулю.


### PR DESCRIPTION
## What changed

Three additional UX improvements (continuation of #1119 and #1125):

### 1. Swipe-to-dismiss for `Sheet` / `ConfirmDialog` / `ModuleSettingsDrawer`
- New headless `useSwipeToDismiss` hook (`apps/web/src/shared/hooks/useSwipeToDismiss.ts`)
  uses Pointer Events with `setPointerCapture`. Supports `direction: "down" | "right"`
  for bottom sheets vs side drawers. Default 80 px dismissal threshold; rubber-band
  resistance optional.
- `Sheet`: gesture is bound to the drag-handle pill **and** the header row only —
  body scroll and form input drags inside the sheet are not hijacked. Drag distance
  follows the finger via `translate3d`; release snaps back at 200 ms with
  iOS-equivalent easing. The drag handle is no longer purely decorative.
- `ConfirmDialog`: same gesture; downward release ≥ threshold calls `onCancel`
  (destructive action still requires an explicit tap on the danger button).
- `ModuleSettingsDrawer`: right-anchored, so it uses `direction: "right"`. Gesture
  bound to the header bar only.

### 2. ScreenReaderAnnouncer wired
- `ScreenReaderAnnouncerProvider` is now mounted at the App root (above
  `ApiClientProvider`/`AuthProvider`), so even unauthenticated screens
  (`/sign-in`, onboarding) can announce.
- `Sheet`: `useEffect` on `open=true` now calls `announce(title)` — AT users get
  a polite live-region announcement on sheet open, faster than waiting for focus.
- `Switch`: new optional `announceText?: (checked: boolean) => string` prop;
  defaults to `"{label} увімкнено"` / `"{label} вимкнено"` when `label` is set.
  Pass `() => ""` to suppress.
- Fizruk workout finish: announces `"Тренування завершено та збережено."` alongside
  the existing toast + haptic.

### 3. Finyk swipe-between-tabs visual feedback
- `FinykApp.tsx` previously only ran `touchstart` / `touchend` and committed an
  abrupt page swap on release. Added `handleTouchMove` that tracks live `dx`
  (horizontal-dominance check matches the existing 1.5×|dy| guard) and applies
  a `translate3d(dx * 0.45, 0, 0)` follow on the page wrapper, clamped to
  ±120 px.
- Thin `bg-finyk` progress bar at the top of the page wrapper fills toward the
  60 px threshold and tints fully on commit. Hidden when not dragging.
- Drag is suppressed at the ends of the tab list (`overview` / `analytics`) so
  there's no fake drag that goes nowhere.
- All thresholds match existing behaviour: 60 px dismiss, 1.5× horizontal
  dominance, end-of-list guard.

## Why

- Drag handles on bottom sheets are conventionally a swipe-to-dismiss target
  (iOS Maps / Apple Pay). Ours was decorative — users had to find the X button
  or the scrim, which is fewer than two taps but still a discoverability gap on
  mobile PWAs.
- `ScreenReaderAnnouncerProvider` and `useAnnounce()` shipped in the design
  system but were unused — toggles, sheet opens, and async confirmations
  produced no aria-live announcements.
- Finyk tab swipe was a black box until release. Adding the live follow + a
  threshold-matching progress bar makes the gesture self-evident.

## How to test

1. **Sheet swipe-to-dismiss**: Open any `<Sheet>` (e.g. category management,
   workout finish). Drag the panel down ≥ 80 px → sheet closes. Drag < 80 px →
   panel snaps back. Drag inside the body / a text field → no dismiss (only
   handle + header bind the gesture).
2. **ConfirmDialog swipe-to-dismiss**: Trigger a destructive confirm (e.g. delete
   a habit category). Drag down → cancels. Tap "Видалити" → still confirms.
3. **ModuleSettingsDrawer swipe-to-close**: Open a module settings drawer
   (Fizruk cog → settings). Drag the header bar to the right ≥ 80 px → closes.
4. **Switch announcements**: With VoiceOver / TalkBack on, toggle a switch with
   a `label`. SR speaks `"{label} увімкнено"` / `"вимкнено"`.
5. **Sheet announcements**: With SR on, open any sheet. SR speaks the sheet
   title.
6. **Workout finish announcement**: Finish a Fizruk workout. SR speaks
   "Тренування завершено та збережено."
7. **Finyk swipe feedback**: In Finyk, swipe horizontally on a page (e.g.
   Огляд → Операції). Page tracks the finger; thin teal bar appears at the
   top, dims under threshold, tints fully past it. Release past 60 px →
   commits the tab change.

---

## Pre-flight (Hard Rule #15)

- [x] Read the `AGENTS.md` Hard Rules that apply to the touched paths.
- [x] Read the matching playbook in `docs/playbooks/` (or noted that none exists).
- [x] Checked freshness headers of docs cited in the change.

## Docs updated alongside code? (Hard Rule #15)

- [x] N/A — no docs invalidated by this change.

## How AI-tested this PR

- [x] Manual smoke (which flow?): n/a — covered by hook unit tests; manual UI
      verification deferred to reviewer / preview deploy.
- [x] Vitest passes: 1480 / 1480 tests pass; new `useSwipeToDismiss.test.ts`
      covers downward dismiss, snap-back, ignored upward drags, rightward
      direction, `enabled=false`, and secondary mouse buttons.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.
- [x] `pnpm dead-code:files` clean (or new files marked `@scaffolded`).

## AGENTS.md updated?

- [x] No — no new permanent rules

Link to Devin session: https://app.devin.ai/sessions/9bee8c7adf104ab3ba72a2f26f26cd9e
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1181" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves mobile UX and accessibility. Adds swipe-to-dismiss to sheets/dialogs/drawers, wires screen-reader announcements, shows live swipe progress in Finyk, and documents these patterns in the design system.

- **New Features**
  - Swipe-to-dismiss: `useSwipeToDismiss` (Pointer Events, 80 px threshold, `direction: "down" | "right"`); integrated into `Sheet` (handle + header only), `ConfirmDialog` (down-swipe cancels), and `ModuleSettingsDrawer` (right-swipe on header).
  - Screen reader announcer: `ScreenReaderAnnouncerProvider` at app root; `Sheet` announces its title on open; `Switch` adds `announceText` (defaults to `"{label} увімкнено/вимкнено"`); Fizruk workout finish announces “Тренування завершено та збережено.”
  - Finyk tabs: live `translate3d` follow during horizontal swipe (clamped ±120 px) and a thin progress bar toward the 60 px threshold; keeps horizontal-dominance and end guards.

- **Bug Fixes**
  - `ConfirmDialog`: merged `onPointerDown` with `swipe.bind` to keep `stopPropagation` while enabling swipe handlers (fixes TS2783).

<sup>Written for commit 3752fc9aaf144745facdde5f7997e492202fc3bb. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1181?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Swipe-to-dismiss gestures for drawers, dialogs, and sheets
  * Gesture-driven horizontal tab swiping with live drag feedback and progress indicator
  * Application-wide screen-reader announcer for accessibility
  * Screen-reader announcements for workout saves and customizable switch toggle announcements

* **Tests**
  * Added tests covering swipe-to-dismiss gesture behavior

* **Documentation**
  * Updated design and UX docs to include gestures & accessibility guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->