### PR TITLE
feat(web): adaptive bento dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 - **Щотижневий дайджест** (`WeeklyDigestCard`, `useWeeklyDigest`) — AI-зведення тижня по всіх модулях
 - **AI-порада дня** (`AssistantAdviceCard`, `useCoachInsight`, `/api/coach`) — короткі персональні поради на основі даних модулів
 - **Рекомендаційний рушій** (`TodayFocusCard`, `recommendationEngine`) — крос-модульні підказки без AI API
+- **Адаптивний bento** (`adaptiveSort`, `HubDashboard`) — м'яко піднімає в топ 1 модуль за контекстом (час доби × активний сигнал); ручний порядок зберігається, можна вимкнути в Налаштуваннях → Дашборд → «Адаптивний порядок»
 - **Голосовий ввід** (`VoiceMicButton`, `speechParsers`, `useSpeech`) — Web Speech API в Харчуванні, Фізруку та Фінікові
 - **AI-чат** (`HubChat`) — модульний чат з контекстом усіх даних, розбитий на `hubChatContext` / `hubChatActions` / `hubChatUtils` / `hubChatSpeech`
 - **PWA shortcuts** — 3 ярлики на головному екрані (нова витрата, почати тренування, додати їжу)

--- a/apps/web/src/core/hub/HubDashboard.tsx
+++ b/apps/web/src/core/hub/HubDashboard.tsx
@@ -61,6 +61,12 @@ import {
 import { type ModuleId } from "./dashboard/moduleConfigs";
 import { SortableCard } from "./dashboard/BentoCard";
 import {
+  applyAdaptiveLift,
+  pickAdaptiveLift,
+  pickStrongestSeverity,
+} from "./dashboard/adaptiveSort";
+import { useHubPref } from "../settings/hubPrefs";
+import {
   MotivationalFooter,
   StaggerChild,
   StreakIndicator,
@@ -212,6 +218,70 @@ export function HubDashboard({
     }
     return set;
   }, [focus, rest]);
+
+  // Adaptive bento — soft re-ordering of the 2x2 grid based on context
+  // (active rec signals × time of day). Off in editMode and when the
+  // user has flipped the `adaptiveBento` pref off (default ON).
+  const [adaptivePref] = useHubPref<boolean>("adaptiveBento", true);
+
+  const severityByModule = useMemo(() => {
+    const all = focus ? [focus, ...rest] : rest;
+    const map: Partial<Record<ModuleId, "danger" | "warning" | undefined>> = {};
+    for (const r of all) {
+      if (!r.module || r.module === "hub") continue;
+      const id = r.module as ModuleId;
+      const sev =
+        r.severity === "danger" || r.severity === "warning"
+          ? r.severity
+          : undefined;
+      map[id] = pickStrongestSeverity([map[id], sev]);
+    }
+    return map;
+  }, [focus, rest]);
+
+  // Re-evaluate every minute so time-of-day windows (breakfast / lunch /
+  // evening close-out) flip on the right side of their boundaries without
+  // a manual reload.
+  const [adaptiveNow, setAdaptiveNow] = useState(() => new Date());
+  useEffect(() => {
+    const id = setInterval(() => setAdaptiveNow(new Date()), 60_000);
+    return () => clearInterval(id);
+  }, []);
+
+  const activeSet = useMemo(
+    () => new Set<string>(activeModules),
+    [activeModules],
+  );
+
+  const adaptive = useMemo(() => {
+    if (!adaptivePref || editMode) {
+      return {
+        liftedId: null as ModuleId | null,
+        reason: null as string | null,
+      };
+    }
+    const result = pickAdaptiveLift({
+      order: visibleOrder as ModuleId[],
+      modulesWithSignal,
+      severityByModule,
+      activeModules: activeSet,
+      now: adaptiveNow,
+    });
+    return { liftedId: result.liftedId, reason: result.reason };
+  }, [
+    adaptivePref,
+    editMode,
+    visibleOrder,
+    modulesWithSignal,
+    severityByModule,
+    activeSet,
+    adaptiveNow,
+  ]);
+
+  const displayOrder = useMemo(
+    () => applyAdaptiveLift(visibleOrder as ModuleId[], adaptive.liftedId),
+    [visibleOrder, adaptive.liftedId],
+  );
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
@@ -437,11 +507,11 @@ export function HubDashboard({
             onDragEnd={handleDragEnd}
           >
             <SortableContext
-              items={visibleOrder}
+              items={displayOrder}
               strategy={rectSortingStrategy}
             >
               <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
-                {visibleOrder.map((id) => (
+                {displayOrder.map((id) => (
                   <SortableCard
                     key={id}
                     id={id as ModuleId}
@@ -449,6 +519,9 @@ export function HubDashboard({
                     quickAdd={quickAddByModule[id] || null}
                     inactive={!isActiveModule(activeModules, id)}
                     editMode={editMode}
+                    adaptiveReason={
+                      id === adaptive.liftedId ? adaptive.reason : null
+                    }
                   />
                 ))}
               </div>

--- a/apps/web/src/core/hub/dashboard/BentoCard.tsx
+++ b/apps/web/src/core/hub/dashboard/BentoCard.tsx
@@ -41,6 +41,13 @@ export interface BentoCardProps {
   editMode?: boolean;
   handleRef?: (node: HTMLButtonElement | null) => void;
   handleProps?: Record<string, unknown>;
+  /**
+   * Set on the single card the adaptive-bento engine has lifted to the top
+   * for the current context (signal × time of day). Renders a small
+   * "Зараз" pill with the reason so the reorder is explainable, not magic.
+   * `null`/`undefined` = not lifted.
+   */
+  adaptiveReason?: string | null;
 }
 
 /**
@@ -63,6 +70,7 @@ export const BentoCard = memo(function BentoCard({
   editMode,
   handleRef,
   handleProps,
+  adaptiveReason,
 }: BentoCardProps) {
   const preview = config.getPreview();
   const showProgress =
@@ -141,6 +149,20 @@ export const BentoCard = memo(function BentoCard({
         >
           {config.emoji} {config.label}
         </span>
+
+        {adaptiveReason && !inactive && (
+          <span
+            className={cn(
+              "mt-1 inline-flex items-center gap-1 self-start",
+              "rounded-full border border-line bg-panel/80 px-1.5 py-0.5",
+              "text-2xs font-medium text-muted",
+            )}
+            title={`Підняли в топ: ${adaptiveReason}`}
+          >
+            <span aria-hidden>✦</span>
+            <span className="truncate max-w-[12ch]">{adaptiveReason}</span>
+          </span>
+        )}
 
         {inactive ? (
           <span className="text-2xs text-muted mt-1 leading-snug">
@@ -235,6 +257,10 @@ export interface SortableCardProps {
    * to the module, while drag is gated to the explicit grip affordance.
    */
   editMode?: boolean;
+  /**
+   * Forwarded to `BentoCard` — adaptive-bento "lifted" reason chip.
+   */
+  adaptiveReason?: string | null;
 }
 
 /**
@@ -248,6 +274,7 @@ export const SortableCard = memo(function SortableCard({
   quickAdd,
   inactive,
   editMode,
+  adaptiveReason,
 }: SortableCardProps) {
   const {
     attributes,
@@ -297,6 +324,7 @@ export const SortableCard = memo(function SortableCard({
         isDragging={isDragging}
         inactive={inactive}
         editMode={editMode}
+        adaptiveReason={adaptiveReason}
       />
     </div>
   );

--- a/apps/web/src/core/hub/dashboard/adaptiveSort.test.ts
+++ b/apps/web/src/core/hub/dashboard/adaptiveSort.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import {
+  ADAPTIVE_LIFT_THRESHOLD,
+  applyAdaptiveLift,
+  pickAdaptiveLift,
+  pickStrongestSeverity,
+} from "./adaptiveSort";
+import type { ModuleId } from "./moduleConfigs";
+
+const ALL_ACTIVE = new Set<string>(["finyk", "fizruk", "routine", "nutrition"]);
+const NO_SIGNAL = new Set<string>();
+
+function at(hour: number): Date {
+  const d = new Date(2026, 3, 29, hour, 0, 0); // April 29 2026, local
+  return d;
+}
+
+const DEFAULT_ORDER: ModuleId[] = ["finyk", "fizruk", "routine", "nutrition"];
+
+describe("pickAdaptiveLift", () => {
+  it("does not lift when there's no signal and no time match", () => {
+    const result = pickAdaptiveLift({
+      order: DEFAULT_ORDER,
+      modulesWithSignal: NO_SIGNAL,
+      activeModules: ALL_ACTIVE,
+      now: at(15), // mid-afternoon, no peak window for any module
+    });
+    expect(result.liftedId).toBeNull();
+  });
+
+  it("lifts nutrition at breakfast time even without an active signal", () => {
+    const result = pickAdaptiveLift({
+      order: DEFAULT_ORDER,
+      modulesWithSignal: NO_SIGNAL,
+      activeModules: ALL_ACTIVE,
+      now: at(8),
+    });
+    expect(result.liftedId).toBe("nutrition");
+    expect(result.reason).toBe("час сніданку");
+    expect(result.score).toBeGreaterThanOrEqual(ADAPTIVE_LIFT_THRESHOLD);
+  });
+
+  it("lifts routine in the late evening (close-the-day window)", () => {
+    const result = pickAdaptiveLift({
+      order: DEFAULT_ORDER,
+      modulesWithSignal: NO_SIGNAL,
+      activeModules: ALL_ACTIVE,
+      now: at(21),
+    });
+    expect(result.liftedId).toBe("routine");
+    expect(result.reason).toBe("час закрити день");
+  });
+
+  it("prefers a danger-severity signal over a peak time match", () => {
+    // 8 AM = nutrition peak (50). finyk has a danger signal (60+30=90)
+    // and is NOT already first, so it should win and lift.
+    const order: ModuleId[] = ["nutrition", "fizruk", "routine", "finyk"];
+    const result = pickAdaptiveLift({
+      order,
+      modulesWithSignal: new Set(["finyk"]),
+      severityByModule: { finyk: "danger" },
+      activeModules: ALL_ACTIVE,
+      now: at(8),
+    });
+    expect(result.liftedId).toBe("finyk");
+    expect(result.reason).toBe("терміновий сигнал");
+  });
+
+  it("does not lift the module that's already in position 0", () => {
+    // Routine is first AND has the strongest evening signal — we should
+    // still no-op so the UI doesn't show a "Зараз" badge for the leader.
+    const order: ModuleId[] = ["routine", "finyk", "fizruk", "nutrition"];
+    const result = pickAdaptiveLift({
+      order,
+      modulesWithSignal: NO_SIGNAL,
+      activeModules: ALL_ACTIVE,
+      now: at(21),
+    });
+    expect(result.liftedId).toBeNull();
+  });
+
+  it("ignores inactive modules", () => {
+    // 8 AM normally lifts nutrition, but here nutrition is inactive.
+    // The next candidate is routine (morning habits, score 30) which is
+    // below threshold → nothing lifts.
+    const onlyFinyk = new Set<string>(["finyk", "fizruk"]);
+    const result = pickAdaptiveLift({
+      order: DEFAULT_ORDER,
+      modulesWithSignal: NO_SIGNAL,
+      activeModules: onlyFinyk,
+      now: at(8),
+    });
+    expect(result.liftedId).toBeNull();
+  });
+
+  it("returns liftedId=null for empty order", () => {
+    const result = pickAdaptiveLift({
+      order: [],
+      modulesWithSignal: NO_SIGNAL,
+      activeModules: ALL_ACTIVE,
+      now: at(12),
+    });
+    expect(result.liftedId).toBeNull();
+  });
+
+  it("breaks ties by preferring the module already higher in the order", () => {
+    // Two modules with identical scores: prefer the one already closer
+    // to the top so we minimise reorder churn. We construct this by
+    // giving both `finyk` and `nutrition` the same warning signal at a
+    // neutral hour (no time-of-day bonus).
+    const order: ModuleId[] = ["finyk", "nutrition", "fizruk", "routine"];
+    const result = pickAdaptiveLift({
+      order,
+      modulesWithSignal: new Set(["finyk", "nutrition"]),
+      severityByModule: { finyk: "warning", nutrition: "warning" },
+      activeModules: ALL_ACTIVE,
+      now: at(15), // outside every peak window
+    });
+    // finyk is already first, so the result should no-op
+    // (tie-breaker picks finyk, which is in slot 0 → null).
+    expect(result.liftedId).toBeNull();
+  });
+});
+
+describe("applyAdaptiveLift", () => {
+  it("returns a copy of the order when liftedId is null", () => {
+    const out = applyAdaptiveLift(DEFAULT_ORDER, null);
+    expect(out).toEqual(DEFAULT_ORDER);
+    expect(out).not.toBe(DEFAULT_ORDER);
+  });
+
+  it("moves the lifted id to position 0 preserving the rest", () => {
+    const out = applyAdaptiveLift(DEFAULT_ORDER, "nutrition");
+    expect(out).toEqual(["nutrition", "finyk", "fizruk", "routine"]);
+  });
+
+  it("is a no-op when liftedId is already first", () => {
+    const out = applyAdaptiveLift(DEFAULT_ORDER, "finyk");
+    expect(out).toEqual(DEFAULT_ORDER);
+  });
+
+  it("is a no-op when liftedId is not in the order", () => {
+    const out = applyAdaptiveLift(
+      DEFAULT_ORDER,
+      "ghost" as unknown as ModuleId,
+    );
+    expect(out).toEqual(DEFAULT_ORDER);
+  });
+});
+
+describe("pickStrongestSeverity", () => {
+  it("returns danger when present", () => {
+    expect(pickStrongestSeverity(["warning", "danger", undefined])).toBe(
+      "danger",
+    );
+  });
+  it("returns warning when no danger present", () => {
+    expect(pickStrongestSeverity([undefined, "warning"])).toBe("warning");
+  });
+  it("returns undefined when nothing meaningful", () => {
+    expect(pickStrongestSeverity([undefined, undefined])).toBeUndefined();
+  });
+});

--- a/apps/web/src/core/hub/dashboard/adaptiveSort.ts
+++ b/apps/web/src/core/hub/dashboard/adaptiveSort.ts
@@ -1,0 +1,241 @@
+/**
+ * Soft-adaptive bento ordering for the Hub dashboard.
+ *
+ * Goal: lift ONE module to the top of the bento grid based on the current
+ * context (active recommendation signals × time of day) without disturbing
+ * the rest of the manually-saved order. The rest of the cards stay in the
+ * order the user picked via DnD or `DashboardSection`.
+ *
+ * Off by default for `editMode` (so DnD-reorder is never fought) and
+ * controlled by the `adaptiveBento` Hub pref so users can opt out.
+ *
+ * Pure functions only — UI integration lives in `HubDashboard.tsx`.
+ */
+
+import type { ModuleId } from "./moduleConfigs";
+
+/**
+ * Subset of `Recommendations.RecSeverity` we actually use for ranking.
+ * The full alias is `StatusColor = "success" | "warning" | "danger" | "info"`,
+ * but only the warning / danger tones contribute negative weight here —
+ * `success` / `info` are informational and shouldn't lift cards.
+ */
+type RecSeverity = "warning" | "danger";
+
+/**
+ * Min total score required for a module to be "lifted". Picked so a single
+ * peak time-of-day match (50) is enough on its own, but a weak time match
+ * (25) is not unless paired with a signal.
+ */
+export const ADAPTIVE_LIFT_THRESHOLD = 40;
+
+const SIGNAL_BASE = 60;
+const SIGNAL_DANGER_BONUS = 30;
+const SIGNAL_WARNING_BONUS = 15;
+
+interface TimeMatch {
+  score: number;
+  reason: string;
+}
+
+/**
+ * Per-module time-of-day relevance. Returns the *best* matching window for
+ * the given hour, or `null` when no window is active.
+ *
+ * Windows are intentionally narrow: the goal is "right tool at the right
+ * moment", not "modules I might like in the morning".
+ */
+function timeOfDayMatch(module: ModuleId, hour: number): TimeMatch | null {
+  switch (module) {
+    case "nutrition": {
+      // Meal windows: breakfast / lunch / dinner.
+      if (hour >= 7 && hour <= 9) {
+        return { score: 50, reason: "час сніданку" };
+      }
+      if (hour >= 12 && hour <= 13) {
+        return { score: 50, reason: "час обіду" };
+      }
+      if (hour >= 18 && hour <= 20) {
+        return { score: 45, reason: "час вечері" };
+      }
+      return null;
+    }
+    case "fizruk": {
+      // Most users train late afternoon → evening.
+      if (hour >= 17 && hour <= 20) {
+        return { score: 40, reason: "час тренування" };
+      }
+      if (hour >= 6 && hour <= 8) {
+        return { score: 25, reason: "ранкова активність" };
+      }
+      return null;
+    }
+    case "routine": {
+      // Morning planning + evening close-out.
+      if (hour >= 6 && hour <= 9) {
+        return { score: 30, reason: "ранкові звички" };
+      }
+      if (hour >= 19 && hour <= 23) {
+        return { score: 45, reason: "час закрити день" };
+      }
+      return null;
+    }
+    case "finyk": {
+      // Mono webhooks land overnight; review next morning. End-of-day
+      // budget check covers the late-evening "did I overspend?" itch.
+      if (hour >= 8 && hour <= 10) {
+        return { score: 25, reason: "ранковий огляд транзакцій" };
+      }
+      if (hour >= 20 && hour <= 22) {
+        return { score: 25, reason: "підбити день" };
+      }
+      return null;
+    }
+    default:
+      return null;
+  }
+}
+
+/**
+ * The strongest severity wins when a module has multiple recommendations.
+ * `danger` > `warning` > anything else (treated as "no extra weight").
+ */
+export function pickStrongestSeverity(
+  severities: ReadonlyArray<RecSeverity | undefined>,
+): RecSeverity | undefined {
+  let best: RecSeverity | undefined;
+  for (const s of severities) {
+    if (s === "danger") return "danger";
+    if (s === "warning") best = "warning";
+  }
+  return best;
+}
+
+interface SignalMatch {
+  score: number;
+  reason: string;
+}
+
+function signalScore(severity: RecSeverity | undefined): SignalMatch {
+  let score = SIGNAL_BASE;
+  let reason = "активний сигнал";
+  if (severity === "danger") {
+    score += SIGNAL_DANGER_BONUS;
+    reason = "терміновий сигнал";
+  } else if (severity === "warning") {
+    score += SIGNAL_WARNING_BONUS;
+    reason = "увага: сигнал";
+  }
+  return { score, reason };
+}
+
+export interface AdaptiveLiftInput {
+  /** Current visible (already inactive-filtered) order. */
+  order: ReadonlyArray<ModuleId>;
+  /** Set of module ids that have at least one visible recommendation. */
+  modulesWithSignal: ReadonlySet<string>;
+  /** Strongest rec severity per module. Missing entry = no severity. */
+  severityByModule?: Partial<Record<ModuleId, RecSeverity | undefined>>;
+  /** Set of modules the user marked as active during onboarding. */
+  activeModules: ReadonlySet<string>;
+  /** Reference time. Tests pass a fixed Date; runtime uses `new Date()`. */
+  now: Date;
+}
+
+export interface AdaptiveLift {
+  /** Module to lift to position 0; `null` when no module qualifies. */
+  liftedId: ModuleId | null;
+  /** Short UA label explaining why this card was lifted (for the badge). */
+  reason: string | null;
+  /** Total score the lifted module reached. Useful for tests / telemetry. */
+  score: number;
+}
+
+/**
+ * Pick at most one module to surface at the top of the bento. Returns
+ * `{ liftedId: null }` when nothing crosses the threshold or the highest
+ * scorer is already first.
+ *
+ * Selection rules:
+ *  - Inactive modules never lift.
+ *  - The already-first card never lifts (no-op when it's the winner).
+ *  - Ties are broken by the module's current position (closer to top wins).
+ */
+export function pickAdaptiveLift({
+  order,
+  modulesWithSignal,
+  severityByModule = {},
+  activeModules,
+  now,
+}: AdaptiveLiftInput): AdaptiveLift {
+  if (order.length === 0) {
+    return { liftedId: null, reason: null, score: 0 };
+  }
+
+  const hour = now.getHours();
+  let best: {
+    id: ModuleId;
+    score: number;
+    reason: string;
+    index: number;
+  } | null = null;
+
+  for (let i = 0; i < order.length; i++) {
+    const id = order[i];
+    if (!activeModules.has(id)) continue;
+
+    let score = 0;
+    let reason = "";
+
+    if (modulesWithSignal.has(id)) {
+      const s = signalScore(severityByModule[id]);
+      score += s.score;
+      reason = s.reason;
+    }
+
+    const timeMatch = timeOfDayMatch(id, hour);
+    if (timeMatch) {
+      score += timeMatch.score;
+      // Prefer the time-of-day reason when it's the dominant component —
+      // it's more actionable ("час обіду") than "активний сигнал".
+      if (!reason || timeMatch.score >= SIGNAL_BASE) {
+        reason = timeMatch.reason;
+      }
+    }
+
+    if (score < ADAPTIVE_LIFT_THRESHOLD) continue;
+
+    if (
+      !best ||
+      score > best.score ||
+      (score === best.score && i < best.index)
+    ) {
+      best = { id, score, reason, index: i };
+    }
+  }
+
+  if (!best) return { liftedId: null, reason: null, score: 0 };
+  // Already in position 0 → don't pretend we lifted anything.
+  if (best.index === 0) {
+    return { liftedId: null, reason: null, score: best.score };
+  }
+
+  return { liftedId: best.id, reason: best.reason, score: best.score };
+}
+
+/**
+ * Move `liftedId` to position 0 in `order`, preserving the relative order
+ * of the remaining ids. No-op when `liftedId` is `null` or already first.
+ */
+export function applyAdaptiveLift<T extends string>(
+  order: ReadonlyArray<T>,
+  liftedId: T | null,
+): T[] {
+  if (!liftedId) return [...order];
+  const idx = order.indexOf(liftedId);
+  if (idx <= 0) return [...order];
+  const next = [...order];
+  next.splice(idx, 1);
+  next.unshift(liftedId);
+  return next;
+}

--- a/apps/web/src/core/settings/DashboardSection.tsx
+++ b/apps/web/src/core/settings/DashboardSection.tsx
@@ -90,6 +90,10 @@ function ModuleReorderList({ order, onMove }: ModuleReorderListProps) {
 export function DashboardSection() {
   const [orderReset, setOrderReset] = useState(false);
   const [showHints, setShowHints] = useHubPref<boolean>("showHints", true);
+  const [adaptiveBento, setAdaptiveBento] = useHubPref<boolean>(
+    "adaptiveBento",
+    true,
+  );
   const [density, setDensityState] = useState<DashboardDensity>(() => {
     const raw = safeReadStringLS(STORAGE_KEYS.DASHBOARD_DENSITY);
     return raw === null
@@ -159,6 +163,12 @@ export function DashboardSection() {
           description="Короткі підказки в моменті (без спаму)."
           checked={showHints !== false}
           onChange={setShowHints}
+        />
+        <ToggleRow
+          label="Адаптивний порядок"
+          description="Піднімає в топ модуль, актуальний зараз — за часом дня та сигналами. Ваш порядок зберігається."
+          checked={adaptiveBento !== false}
+          onChange={setAdaptiveBento}
         />
         <div className="space-y-2">
           <p className="text-xs text-subtle leading-snug">


### PR DESCRIPTION
## What changed

Hub-дашборд тепер «м'яко» піднімає в топ 1 модуль за контекстом — ручний порядок зберігається.

- New `apps/web/src/core/hub/dashboard/adaptiveSort.ts` — pure scoring (signal × severity × time-of-day) + `applyAdaptiveLift()` helper.
- `HubDashboard.tsx` обчислює `liftedId/reason` поза `editMode` (DnD не воюємо) і коли pref `adaptiveBento === false`. `setInterval(60s)` оновлює межі вікон (час сніданку / обіду / вечері).
- `BentoCard` отримав `adaptiveReason` — невелика «✦ {reason}» pill з `title` для підняттої картки. Видно тільки на 1 картці й тільки коли вона ще не в позиції 0.
- `DashboardSection` (Settings → Дашборд → Вигляд) — новий toggle «Адаптивний порядок» (default ON).
- 15 unit-тестів у `adaptiveSort.test.ts`: пік-час без сигналу, danger > час, ігнор inactive, no-op-якщо-вже-перший, tie-breaking.

Скоринг (поріг lift = 40):

- Сигнал у `modulesWithSignal`: +60, danger +30, warning +15
- Time-of-day:
  - `nutrition`: 7-9 / 12-13 → +50, 18-20 → +45
  - `fizruk`: 17-20 → +40, 6-8 → +25
  - `routine`: 19-23 → +45, 6-9 → +30
  - `finyk`: 8-10 → +25, 20-22 → +25

## Why

Ручний порядок Bento — статичний. Контекст дня — динамічний (ранок ≠ вечір; danger-сигнал ≠ neutral). Adaptive Bento — soft-mode over-layer над ручним порядком: піднімає 1 картку, не псуючи решту, з пояснювальним chip («час сніданку» / «терміновий сигнал»). `editMode` повністю вимикає adaptive, плюс toggle для опт-ауту.

## How to test

1. Hub Dashboard, не в edit-mode.
2. Між 7-9 / 12-13 / 18-20 → `nutrition` з ✦ chip «час сніданку/обіду/вечері» (якщо не вже #1).
3. `localStorage.setItem('finyk_budgets', …)` з перевитратою → `finyk` піднімається з «терміновий сигнал».
4. Settings → Дашборд → «Адаптивний порядок» off → chip зникає, повертається manual order.
5. «Налаштувати» (edit-mode) → adaptive вимкнений, DnD працює нормально.

---

## Pre-flight (Hard Rule #15)

- [x] `AGENTS.md` Hard Rules: #5 commit scope `web`, #7 husky kept, #8 Tailwind opacity (chip `/80`).
- [x] No matching playbook (UX feature). Mini-plan: pure `adaptiveSort.ts` → wire in `HubDashboard` → toggle → tests.
- [x] Freshness headers checked (`AGENTS.md` 2026-04-29).

## Docs updated alongside code? (Hard Rule #15)

- [x] N/A — no API/migration/script/token/playbook touched.
- [x] README.md «Hub-ядро» updated to mention `adaptiveSort` + Settings location.

## How AI-tested this PR

- [x] `pnpm --filter @sergeant/web exec vitest run src/core/hub src/core/settings` → 80 passed (incl. 15 нових).
- [x] `pnpm --filter @sergeant/web typecheck` → clean (4 tsconfigs).
- [x] `pnpm lint` (full) → clean.
- [x] `pnpm format:check` → clean.

## AGENTS.md updated?

- [x] No — no new permanent rules.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds adaptive bento ordering that softly lifts one module to the top based on time of day and active signals, without changing the user’s manual order. Disabled in edit mode; can be toggled in Settings.

- **New Features**
  - Added `adaptiveSort.ts` with pure scoring (signal × severity × time-of-day), `pickAdaptiveLift`, `applyAdaptiveLift`, and `pickStrongestSeverity` (lift threshold 40).
  - Wired into `HubDashboard.tsx`: computes `liftedId`/reason when not in edit mode and pref is on; updates every 60s; ignores inactive modules; no-op if the winner is already first.
  - `BentoCard` shows a small “✦ {reason}” pill on the lifted card when it’s not already in position 0.
  - New toggle in `DashboardSection` — “Адаптивний порядок” (default ON).
  - 15 unit tests in `adaptiveSort.test.ts`; README mentions the feature.

<sup>Written for commit c852cdce7e4dfa03ed24282a8cb66b26ecd1081a. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1182?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

