### PR TITLE
docs(docs): fix design-system Switch announceText default + bump freshness

### DIFF
--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -1,6 +1,6 @@
 # Sergeant Design System
 
-> **Last validated:** 2026-04-28 by @devin-ai. **Next review:** 2026-07-28.
+> **Last validated:** 2026-04-30 by @devin-ai. **Next review:** 2026-07-30.
 > **Status:** Active
 
 Єдина візуальна мова для хаба з 4 модулями: **ФІНІК**, **ФІЗРУК**, **Рутина**,
@@ -809,8 +809,10 @@ announce("Не вдалось зберегти. Спробуй ще раз.", { 
 />
 ```
 
-Якщо `announceText` не передано — нічого не озвучується (back-compat).
-Колбек отримує **новий** стан після toggle.
+Якщо `announceText` не передано і `label` задано — `Switch` все одно
+озвучить дефолтне `"{label} увімкнено / вимкнено"`. Без `label` — нічого
+не озвучується. Щоб явно придушити озвучення при заданому `label`,
+передай `() => ""`. Колбек отримує **новий** стан після toggle.
 
 ### Finyk swipe-between-tabs — visual feedback
 


### PR DESCRIPTION
## What changed

Follow-up to merged PR #1181 — addresses two Devin Review comments on `docs/design/design-system.md`.

- **Freshness header**: bumped from `2026-04-28` → `2026-04-30`. The previous PR inadvertently moved the date *backwards* (was `2026-04-29` on `main`). Hard Rule #15 requires the header to track forward to the most recent validation.
- **§16 `Switch` — `announceText`**: corrected the default-behaviour wording. The doc said "якщо `announceText` не передано — нічого не озвучується (back-compat)", but `Switch.tsx:49-53` falls through to the default `"{label} увімкнено / вимкнено"` whenever `label` is provided. New wording matches `Switch.tsx` JSDoc, and documents the explicit opt-out (`announceText={() => ""}`).

No code changes.

## Why

Hard Rule #15: docs must accurately reflect code, and freshness headers should be bumped (not regressed) on every doc that's touched. Devin Review flagged both issues on the merged PR — this PR closes the loop.

## How to test

- `git diff main..devin/1777532053-docs-review-fixes -- docs/design/design-system.md` — should show only two hunks (header date + Switch announceText paragraph).
- `pnpm docs:check-links` — passes (no link changes).

---

## Pre-flight (Hard Rule #15)

- [x] Read the `AGENTS.md` Hard Rules that apply to the touched paths.
- [x] Read the matching playbook in `docs/playbooks/` (n/a — docs-only fix).
- [x] Checked freshness headers of docs cited in the change.

## Docs updated alongside code? (Hard Rule #15)

- [ ] API contract change — `packages/api-client/**` types + contract test updated (Hard Rule #3).
- [ ] New / removed npm script — `CONTRIBUTING.md § Everyday Commands` and `CLAUDE.md § Quick commands` updated.
- [ ] New design token / component / palette — `docs/design/design-system.md` (and `BRANDBOOK.md` if branded) updated.
- [ ] Deprecation — `@deprecated` JSDoc with `@removeBy` added; consuming docs marked `> **Status:** Deprecated`.
- [x] Freshness header bumped on docs whose claims changed (`> Last validated: YYYY-MM-DD by @owner`).
- [x] N/A — no code changes; this PR *is* the doc fix.

## How AI-tested this PR

- [x] Manual smoke: re-read `Switch.tsx:31-55` to confirm the default-announcement behaviour matches the new wording.
- [x] Vitest passes: n/a — no source changes.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.
- [x] `pnpm dead-code:files` clean (or new files marked `@scaffolded`).

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

Link to Devin session: https://app.devin.ai/sessions/9bee8c7adf104ab3ba72a2f26f26cd9e
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed design-system docs: bumped "Last validated" to 2026-04-30 and corrected `Switch` `announceText` default to match code. When `announceText` is omitted and `label` is set, it announces `"{label} увімкнено / вимкнено"`; no announcement without `label`; documented opt-out via `announceText={() => ""}`.

<sup>Written for commit 7ff94e9e50d30d71e0d677fd84d3a0ab0d9c802b. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1184?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Switch component accessibility announcement behavior, including how labels affect default announcements and options for suppressing them entirely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->