### PR TITLE
feat(web): add quick "Вийти" pill next to cloud sync in Settings › Загальні

### DIFF
--- a/apps/web/src/core/settings/GeneralSection.tsx
+++ b/apps/web/src/core/settings/GeneralSection.tsx
@@ -1,7 +1,11 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { Button } from "@shared/components/ui/Button";
+import { Icon } from "@shared/components/ui/Icon";
 import { useToast } from "@shared/hooks/useToast";
 import { webKVStore } from "@shared/lib/storage";
 import { resetOnboardingState, type User } from "@sergeant/shared";
+import { useAuth } from "../auth/AuthContext";
 import { SettingsGroup, SettingsSubGroup } from "./SettingsPrimitives";
 
 export interface GeneralSectionProps {
@@ -18,6 +22,23 @@ export function GeneralSection({
   user,
 }: GeneralSectionProps) {
   const toast = useToast();
+  const navigate = useNavigate();
+  const { logout } = useAuth();
+  const [loggingOut, setLoggingOut] = useState(false);
+
+  const handleLogout = async () => {
+    if (loggingOut) return;
+    setLoggingOut(true);
+    try {
+      await logout();
+      toast.success("Ви вийшли з акаунта");
+      navigate("/", { replace: true });
+    } catch {
+      toast.error("Не вдалося вийти, спробуйте ще раз");
+    } finally {
+      setLoggingOut(false);
+    }
+  };
 
   return (
     <SettingsGroup title="Загальні" emoji="⚙️">
@@ -72,6 +93,24 @@ export function GeneralSection({
               {syncing ? "Завантаження…" : "Завантажити з хмари"}
             </Button>
           </div>
+          {/* Quick logout: lives next to sync because both actions belong
+              to the "current cloud session" mental model and both are
+              gated on `user`. Previously logout was buried 4 taps deep
+              (Profile → Видалення акаунта → expand → onLogout from
+              `DangerZoneSection`'s post-delete handler). The destructive
+              `Account-deletion` path stays where it is — this only
+              surfaces a plain sign-out. */}
+          <Button
+            type="button"
+            variant="danger"
+            size="sm"
+            className="h-10 w-full justify-center gap-2"
+            disabled={loggingOut}
+            onClick={handleLogout}
+          >
+            <Icon name="log-out" size={16} />
+            {loggingOut ? "Виходимо…" : "Вийти"}
+          </Button>
         </SettingsSubGroup>
       )}
     </SettingsGroup>


### PR DESCRIPTION
## What changed

Додав кнопку **«Вийти»** у `GeneralSection` (`Settings › Загальні › Хмарна синхронізація`) — поряд із парою sync-кнопок «Зберегти в хмару» / «Завантажити з хмари».

- `variant="danger"` (soft destructive) + іконка `log-out`, ширина `w-full`.
- Stateful `loggingOut` дисейблить кнопку поки `auth.logout()` у польоті; success-toast і редірект на `/`. Помилка → error-toast.
- Кнопка рендериться тільки коли `user !== null` (як і блок sync) — анонімному відвідувачу не показуємо.

## Why

Logout deep-buried: раніше було 2 тапи (avatar → «Вийти»), після перенесення меню в hub bottom-nav — 4 тапи: **Профіль → Видалення акаунта → розгорнути секцію → onLogout** (і той викликається пост-фактум `DangerZoneSection`-ом тільки після успішного `deleteUser`). Тобто *чистого* sign-out flow з UI взагалі не було — лишилася тільки гілка через delete-account, що небезпечно і просто незручно.

Settings → Загальні — це місце, куди користувач і так заходить за «session-level» речами (онбординг, синхронізація). Сюсідство з sync-кнопками виправдано: обидві дії (sync push/pull і logout) gated на `user` і обидві стосуються «поточної хмарної сесії».

Account-deletion (необоротна) **залишається** у Profile › Danger Zone — це різні рівні ризику, об'єднувати їх не треба.

## How to test

1. Залогінитися. У хабі: bottom-nav → ⚙️ Settings → таб «Загальні» → блок «Хмарна синхронізація» (відкритий за замовч.) → кнопка **«Вийти»** під двома sync-кнопками.
2. Тап → toast «Ви вийшли з акаунта», редірект на `/` → unauth surface (welcome / sign-in).
3. Анонімний візитер: блок «Хмарна синхронізація» не рендериться, кнопки «Вийти» немає (правильно — нема з чого виходити).
4. Disable стан: під час in-flight logout кнопка disabled, лейбл «Виходимо…».
5. `pnpm --filter @sergeant/web exec eslint src/core/settings/GeneralSection.tsx` — чисто.
6. `pnpm --filter @sergeant/web exec vitest run src/core/settings` — passes (4/4 у `FinykSection.test.tsx`; для `GeneralSection` тестів немає, поведінка проста: один кнопковий handler, що дзвонить `auth.logout()`).

---

## Pre-flight (Hard Rule #15)

- [x] Read the `AGENTS.md` Hard Rules that apply to the touched paths.
- [x] Read the matching playbook in `docs/playbooks/` — n/a (UI affordance shuffle).
- [x] Checked freshness headers of docs cited in the change — n/a.

## Docs updated alongside code? (Hard Rule #15)

- [x] N/A — no docs invalidated by this change. Internal UI shuffle; route surface, API contracts, design tokens unchanged.

## How AI-tested this PR

- [x] Manual smoke (which flow?): clicked through Settings › Загальні стек локально (`pnpm dev:web`); logout flow → редірект на `/` (anon surface) ок.
- [x] Vitest passes: `pnpm --filter @sergeant/web exec vitest run src/core/settings` (4/4 у наявних тестах settings).
- [x] Lint clean: `pnpm exec eslint src/core/settings/GeneralSection.tsx`.
- [x] Format clean: `pnpm exec prettier --check src/core/settings/GeneralSection.tsx`.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.
- [x] No new files added → `dead-code:files` n/a.

## AGENTS.md updated?

- [x] No — no new permanent rules

Link to Devin session: https://app.devin.ai/sessions/1a6c855b7b154d598549dd35c605ac67
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1188" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a quick "Вийти" (Logout) button next to cloud sync in Settings › Загальні to surface a simple sign‑out flow and reduce taps.

- **New Features**
  - Renders in `GeneralSection` only when `user` is present; hidden for anonymous.
  - Calls `useAuth().logout()`, disables while in flight with label "Виходимо…".
  - Soft‑destructive `Button` with `log-out` icon; full‑width to align with sync buttons.
  - Shows success/error toasts; on success redirects to `/`.

<sup>Written for commit 6c772fc816b2670f6600c87da83a3f17d7e5c430. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1188?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

