### PR TITLE
fix(web): add lock + monitor icons; migrate SessionsSection inline SVG

### DIFF
--- a/apps/web/src/core/profile/SessionsSection.tsx
+++ b/apps/web/src/core/profile/SessionsSection.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { Button } from "@shared/components/ui/Button";
 import { Card } from "@shared/components/ui/Card";
+import { Icon } from "@shared/components/ui/Icon";
 import { useToast } from "@shared/hooks/useToast";
 import {
   listSessions,
@@ -69,22 +70,7 @@ export function SessionsSection({ online }: { online: boolean }) {
     <Card radius="lg" padding="none" className="overflow-hidden">
       <div className="px-4 py-3.5 flex items-center justify-between border-b border-line">
         <div className="flex items-center gap-2">
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            className="text-muted"
-            aria-hidden
-          >
-            <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
-            <line x1="8" y1="21" x2="16" y2="21" />
-            <line x1="12" y1="17" x2="12" y2="21" />
-          </svg>
+          <Icon name="monitor" size={16} className="text-muted" />
           <span className="text-sm font-semibold text-text">Активні сесії</span>
         </div>
         <Button

--- a/apps/web/src/shared/components/ui/Icon.tsx
+++ b/apps/web/src/shared/components/ui/Icon.tsx
@@ -530,6 +530,27 @@ const PATHS: Record<string, ReactNode> = {
       <line x1="9" y1="9" x2="15" y2="15" />
     </>
   ),
+  // Padlock — Lucide `lock`. Used by `ChangePasswordSection` (the
+  // "Зміна пароля" eyebrow icon) and `OnboardingWizard`'s privacy
+  // step. Without this entry `Icon` renders nothing (returns `null`)
+  // so the eyebrow looked broken in /profile.
+  lock: (
+    <>
+      <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+      <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+    </>
+  ),
+  // Desktop monitor — Lucide `monitor`. Used by `SessionsSection`
+  // ("Активні сесії") to mark the device row; previously hand-rolled
+  // inline SVG. Migrated to the shared icon so the bounding box and
+  // stroke width stay consistent with siblings.
+  monitor: (
+    <>
+      <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
+      <line x1="8" y1="21" x2="16" y2="21" />
+      <line x1="12" y1="17" x2="12" y2="21" />
+    </>
+  ),
 };
 
 export type IconName = keyof typeof PATHS;


### PR DESCRIPTION
## What changed

Додано дві відсутні іконки у `Icon`-реєстр (`apps/web/src/shared/components/ui/Icon.tsx`) та переведено хенд-роллед SVG у `SessionsSection` на спільний компонент.

- `lock` — Lucide-стиль padlock (24×24, fill=none, stroke=2).
- `monitor` — Lucide-стиль desktop monitor (24×24, fill=none, stroke=2).
- `SessionsSection.tsx`: `<svg …><rect/><line/></svg>` → `<Icon name="monitor" size={16} className="text-muted" />` (-15 рядків inline JSX, +1 import).

## Why

`Icon` повертає `null` (із DEV-only `console.warn`) коли name не зареєстрований у `PATHS`. У `/profile` саме так і ламались два eyebrow-glyph-и:

- **`lock`** — використовується в `ChangePasswordSection.tsx:46` (eyebrow біля «Зміна пароля») і `OnboardingWizard.tsx:238` (privacy-крок). Без запису у `PATHS` обидва місця показували порожнечу — користувач бачив зміщений flex-row без іконки.
- **`monitor`** — `SessionsSection.tsx` обходив відсутність іконки, заклавши власний inline SVG із зайвим бойлерплейтом (`width/height/viewBox/fill/stroke/strokeWidth/strokeLinecap/strokeLinejoin/aria-hidden`). Тепер ця конкретна сесія `Icon` доросла, тож переводимо хедер на канон.

Окрема перевага міграції: bounding box, stroke-width і a11y-семантика (`aria-hidden` за замовч., `role=img` + `<title>` коли передано `title`) тепер ідентичні до решти ~50 іконок у `PATHS`.

## How to test

1. `pnpm dev:web` → залогінитись → hub → bottom-nav «Профіль» →
   - Розгорнути «Пароль» → у заголовку має бути padlock-іконка перед «Зміна пароля». До фіксу: пусто, тільки текст.
   - Розгорнути «Активні сесії» → у заголовку має бути monitor-іконка перед «Активні сесії» (рендерилась і раніше через inline SVG; візуально без змін, але тепер з canonical `Icon`).
2. Onboarding (`/welcome` після reset) → privacy-крок: `<Icon name="lock" />` тепер видна.
3. `pnpm --filter @sergeant/web exec vitest run src/shared/components/ui/Icon src/core/profile` — 31/31 passes (Icon×3, SessionsSection×3, ProfilePage×25).
4. `pnpm --filter @sergeant/web exec eslint src/shared/components/ui/Icon.tsx src/core/profile/SessionsSection.tsx` — clean.
5. `pnpm --filter @sergeant/web exec prettier --check …` — clean.

---

## Pre-flight (Hard Rule #15)

- [x] Read the `AGENTS.md` Hard Rules that apply to the touched paths.
- [x] Read the matching playbook in `docs/playbooks/` — n/a (registry-додавання двох іконок).
- [x] Checked freshness headers of docs cited in the change — n/a.

## Docs updated alongside code? (Hard Rule #15)

- [x] N/A — no docs invalidated. Internal icon registry; немає публічного контракту, немає design-system entry per icon.

## How AI-tested this PR

- [x] Manual smoke (which flow?): clicked through Profile › Пароль / Активні сесії — eyebrow-іконки рендеряться як очікувано.
- [x] Vitest passes: `pnpm --filter @sergeant/web exec vitest run src/shared/components/ui/Icon src/core/profile` (31/31).
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.
- [x] `pnpm dead-code:files` n/a — no new files added; only registry entries + inline-SVG migration.

## AGENTS.md updated?

- [x] No — no new permanent rules

Link to Devin session: https://app.devin.ai/sessions/1a6c855b7b154d598549dd35c605ac67
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1189" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `lock` and `monitor` to the shared `Icon` registry and replaced the inline SVG in profile sessions with `<Icon name="monitor" />`. This fixes missing icons on `/profile` and standardizes size, stroke, and a11y across icons.

<sup>Written for commit 8b3e1a292f22fdcc776f065297363eedaf3deea6. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1189?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

