### PR TITLE
refactor(web): migrate HubBottomNav DashboardIcon to shared Icon

### DIFF
--- a/apps/web/src/core/app/HubBottomNav.tsx
+++ b/apps/web/src/core/app/HubBottomNav.tsx
@@ -33,35 +33,11 @@ import type { HubView } from "../hooks/useHubUIState";
 
 const REPORTS_TAB_REVEALED_AT_KEY = "sergeant.hub.reportsTabRevealedAt";
 
-// "dashboard" icon is bespoke (2×2 grid of squares) so we render it
-// inline here rather than adding a one-off entry to the shared Icon map.
-function DashboardIcon({ size = 20 }: { size?: number }) {
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden
-    >
-      <rect x="3" y="3" width="7" height="7" rx="1" />
-      <rect x="14" y="3" width="7" height="7" rx="1" />
-      <rect x="3" y="14" width="7" height="7" rx="1" />
-      <rect x="14" y="14" width="7" height="7" rx="1" />
-    </svg>
-  );
-}
-
 interface HubBottomNavTabProps {
   active: boolean;
   onClick: () => void;
   label: string;
-  iconName?: string;
-  iconBody?: React.ReactNode;
+  iconName: string;
   className?: string;
   panelId: string;
   id: string;
@@ -72,7 +48,6 @@ function HubBottomNavTab({
   onClick,
   label,
   iconName,
-  iconBody,
   className,
   panelId,
   id,
@@ -113,11 +88,7 @@ function HubBottomNavTab({
         )}
         aria-hidden
       >
-        {iconName ? (
-          <Icon name={iconName} size={20} strokeWidth={2} />
-        ) : (
-          iconBody
-        )}
+        <Icon name={iconName} size={20} strokeWidth={2} />
       </span>
       <span className="text-2xs font-semibold leading-none">{label}</span>
     </button>
@@ -210,7 +181,7 @@ export function HubBottomNav({
           panelId="hub-panel-dashboard"
           active={hubView === "dashboard"}
           onClick={() => onChange("dashboard")}
-          iconBody={<DashboardIcon />}
+          iconName="grid"
           label="Головна"
         />
 

--- a/apps/web/src/shared/components/ui/Icon.tsx
+++ b/apps/web/src/shared/components/ui/Icon.tsx
@@ -551,6 +551,20 @@ const PATHS: Record<string, ReactNode> = {
       <line x1="12" y1="17" x2="12" y2="21" />
     </>
   ),
+  // 4-cell grid — Lucide `layout-grid`. Used by the hub bottom-nav
+  // "Дашборд" tab; previously a hand-rolled inline SVG component
+  // (`DashboardIcon`) inside `HubBottomNav.tsx`. Migrated here so all
+  // bottom-nav tabs render through the same `<Icon />` pipeline (same
+  // stroke-width, viewBox, focus-ring/aria-hidden conventions). Same
+  // pattern as `monitor` above (#1189).
+  grid: (
+    <>
+      <rect x="3" y="3" width="7" height="7" rx="1" />
+      <rect x="14" y="3" width="7" height="7" rx="1" />
+      <rect x="3" y="14" width="7" height="7" rx="1" />
+      <rect x="14" y="14" width="7" height="7" rx="1" />
+    </>
+  ),
 };
 
 export type IconName = keyof typeof PATHS;


### PR DESCRIPTION
## What changed

- Added a `grid` entry to `apps/web/src/shared/components/ui/Icon.tsx` PATHS — Lucide `layout-grid` (4-cell square grid). Same SVG body as the previous bespoke `DashboardIcon`, just centralized.
- Removed the hand-rolled `DashboardIcon` component from `apps/web/src/core/app/HubBottomNav.tsx:38-57`.
- Removed the now-unused `iconBody` escape hatch on `HubBottomNavTab` (only `iconName` remains; the prop is now required).
- Wired the dashboard tab via `iconName="grid"` like the other three tabs.

## Why

Audit follow-up. The hub bottom-nav had three tabs going through `<Icon name=… />` (Звіти / Профіль / Налаштування) and one tab rendering a bespoke inline SVG component. That asymmetry forced `HubBottomNavTab` to expose an `iconBody` escape hatch and meant the dashboard tab silently bypassed the shared icon's `aria-hidden` / focus-ring conventions. Same pattern that #1189 fixed for `SessionsSection` (the `monitor` icon was added there for the same reason).

Bit-for-bit identical SVG path data — the rendered icon is the same pixel result, but now lives in the shared map alongside `lock`, `monitor`, etc.

## How to test

1. Sign in to the hub.
2. Confirm the bottom-nav «Головна» tab renders the same 2×2 grid icon as before.
3. Confirm the active-state pill, brand-strong text colour, and focus ring still apply identically.
4. `pnpm --filter @sergeant/web exec vitest run src/core/app/HubBottomNav.test.tsx src/shared/components/ui/Icon.test.tsx` — 13/13 green.

---

## Pre-flight (Hard Rule #15)

- [x] Read the `AGENTS.md` Hard Rules that apply to the touched paths.
- [x] Read the matching playbook in `docs/playbooks/` (or noted that none exists). — n/a (icon-system housekeeping)
- [x] Checked freshness headers of docs cited in the change. — n/a

## Docs updated alongside code? (Hard Rule #15)

- [x] N/A — no docs invalidated by this change.

## How AI-tested this PR

- [x] Vitest passes: `HubBottomNav.test.tsx` (10/10) + `Icon.test.tsx` (3/3).
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.
- [x] `pnpm dead-code:files` clean (or new files marked `@scaffolded`). — n/a (no files added/removed; `DashboardIcon` was a private function inside `HubBottomNav.tsx`)

## AGENTS.md updated?

- [x] No — no new permanent rules

Link to Devin session: https://app.devin.ai/sessions/1a6c855b7b154d598549dd35c605ac67
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the hub bottom-nav dashboard icon to the shared `Icon` by adding a `grid` path and removing the bespoke inline SVG. No visual changes; rendering and accessibility are now consistent with other tabs.

- **Refactors**
  - Added `grid` to `apps/web/src/shared/components/ui/Icon.tsx` (Lucide 4-cell grid).
  - Removed the inline `DashboardIcon` and the `iconBody` prop from `HubBottomNavTab`; `iconName` is now required.
  - Updated the dashboard tab to use `iconName="grid"`.

<sup>Written for commit 82db01e7b2ef0c591cd8f6ac7b861e6763c1b705. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1191?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

