### PR TITLE
ci(docs): ADR graph integrity check (statuses + supersede + README index)

### DIFF
--- a/.github/workflows/docs-automation.yml
+++ b/.github/workflows/docs-automation.yml
@@ -43,6 +43,21 @@ jobs:
       - name: Check docs/playbooks/INDEX.md is up to date
         run: node scripts/docs/generate-playbook-index.mjs --check
 
+  adr-graph:
+    name: ADR graph (statuses, supersede, README index)
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout v6.0.2 (SHA-pinned for supply-chain hardening)
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      # actions/setup-node v6.4.0 (SHA-pinned for supply-chain hardening)
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "20"
+
+      - name: Validate docs/adr/ graph integrity
+        run: node scripts/docs/check-adr-graph.mjs
+
   markdown-links:
     name: Markdown link checker
     runs-on: ubuntu-latest
@@ -111,4 +126,5 @@ jobs:
             scripts/docs/__tests__/generate-playbook-index.test.mjs \
             scripts/docs/__tests__/generate-freshness-dashboard.test.mjs \
             scripts/docs/__tests__/check-markdown-links.test.mjs \
+            scripts/docs/__tests__/check-adr-graph.test.mjs \
             scripts/ci/__tests__/validate-pr-body.test.mjs

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,6 +1,6 @@
 # Architecture Decision Records (ADR) — реєстр рішень
 
-> **Last validated:** 2026-04-29 by @devin-ai. **Next review:** 2026-07-29.
+> **Last validated:** 2026-04-30 by @devin-ai. **Next review:** 2026-07-29.
 > **Status:** Active
 
 > Архітектурні рішення Sergeant. Кожен ADR фіксує **рішення з контекстом і альтернативами**, щоб через рік не довелось гадати «чому ми тут зробили так, а не інакше».
@@ -94,5 +94,9 @@ pnpm gen:adr
 | 0023 | Turborepo as monorepo task runner               | accepted | 2026-04-27 | `turbo@2` поверх pnpm-workspace; task-граф у `turbo.json`; remote-cache opt-in через `TURBO_TOKEN`.      |
 | 0024 | Monorepo split — `apps/*` + `packages/*`        | accepted | 2026-04-27 | Деплоюються `apps/*`, перевикористовуються `packages/*`; `packages/*` ніколи не імпортує з `apps/*`.     |
 | 0025 | OpenAPI 3.1 spec — generated from zod-схем      | accepted | 2026-04-27 | `docs/api/openapi.json` згенеровано з canonical zod-схем; freshness-скрипт ловить drift у rule #3.       |
+| 0026 | n8n — джерело істини для воркфлоу               | accepted | 2026-04-27 | Git — джерело істини для n8n; JSON у `ops/n8n-workflows/` + manifest з owner / risk / secrets.           |
+| 0027 | Політика OpenClaw, Console та MCP               | accepted | 2026-04-27 | `apps/console` як internal admin; allowlist по Telegram user-id; вивід агента — untrusted.               |
 
-> **Note on numbering 0016–0022 jump:** ADRs `0016`–`0022` — це retroactive batch, що був написаний паралельно з `0006`–`0012`. Через паралельне виконання Devin-сесій виникли колізії номерів `0003`–`0012`. Розв'язано через PR `docs(adr): resolve numbering collisions` — same-topic дублі (refund, anthropic, PII) видалено, late-comers перенумеровано в `0016`+. ADRs нумеруються **sequentially without gaps** надалі — наступний номер `0026`.
+> **Note on numbering 0016–0022 jump:** ADRs `0016`–`0022` — це retroactive batch, що був написаний паралельно з `0006`–`0012`. Через паралельне виконання Devin-сесій виникли колізії номерів `0003`–`0012`. Розв'язано через PR `docs(adr): resolve numbering collisions` — same-topic дублі (refund, anthropic, PII) видалено, late-comers перенумеровано в `0016`+. ADRs нумеруються **sequentially without gaps** надалі — наступний номер `0028`.
+
+> **Graph integrity:** Парсинг метаданих ADR (`Status:` / `Supersedes:`, з підтримкою англо- та україномовних назв полів — див. ADR-0026/0027) і перевірка індексу + бідіректіонального supersede-зв'язку автоматизовані: `node scripts/docs/check-adr-graph.mjs` (CI gate в `docs-automation.yml`).

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "docs:gen-playbook-index": "node scripts/docs/generate-playbook-index.mjs",
     "docs:check-playbook-index": "node scripts/docs/generate-playbook-index.mjs --check",
     "docs:check-freshness-coverage": "node scripts/docs/check-freshness.mjs --check-coverage",
+    "docs:check-adr-graph": "node scripts/docs/check-adr-graph.mjs",
     "docs:freshness-dashboard": "node scripts/docs/generate-freshness-dashboard.mjs",
     "ci:validate-pr-body": "node scripts/ci/validate-pr-body.mjs"
   },

--- a/scripts/docs/__tests__/check-adr-graph.test.mjs
+++ b/scripts/docs/__tests__/check-adr-graph.test.mjs
@@ -1,0 +1,306 @@
+// scripts/docs/__tests__/check-adr-graph.test.mjs
+//
+// Unit + integration tests for the ADR graph validator.
+// Pure helpers (`extractField`, `parseAdr`, `listIndexedNumbers`,
+// `validateGraph`) are tested with synthetic fixtures; one integration
+// test runs against the real on-disk ADR set so the script catches
+// drift between code and docs.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  extractField,
+  parseAdr,
+  listIndexedNumbers,
+  validateGraph,
+  listAdrFiles,
+} from "../check-adr-graph.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "../../..");
+const ADR_DIR = resolve(REPO_ROOT, "docs/adr");
+const README_PATH = resolve(ADR_DIR, "README.md");
+
+const sample = ({ status, supersedes, lang = "en" }) => {
+  const statusKey = lang === "uk" ? "Статус" : "Status";
+  const supKey = lang === "uk" ? "Замінює" : "Supersedes";
+  return [
+    "# ADR-0042: Sample",
+    "",
+    `- **${statusKey}:** ${status}`,
+    "- **Date:** 2026-04-30",
+    "- **Reviewers:** @Skords-01",
+    `- **${supKey}:** ${supersedes}`,
+    "- **Related:** —",
+    "",
+    "## Context",
+    "Body.",
+  ].join("\n");
+};
+
+// ── extractField ─────────────────────────────────────────────────────────────
+
+test("extractField: pulls the English value", () => {
+  const c = sample({ status: "accepted", supersedes: "—" });
+  assert.equal(extractField(c, ["Status"]), "accepted");
+});
+
+test("extractField: pulls the Ukrainian value when given alias", () => {
+  const c = sample({ status: "accepted", supersedes: "—", lang: "uk" });
+  assert.equal(extractField(c, ["Status", "Статус"]), "accepted");
+});
+
+test("extractField: returns null if absent", () => {
+  assert.equal(extractField("# Foo\n\n- **Other:** x", ["Status"]), null);
+});
+
+// ── parseAdr ─────────────────────────────────────────────────────────────────
+
+test("parseAdr: accepts an `accepted` ADR with no supersedes", () => {
+  const r = parseAdr(
+    "/x/0042-foo.md",
+    sample({ status: "accepted", supersedes: "—" }),
+  );
+  assert.equal(r.number, "0042");
+  assert.equal(r.status, "accepted");
+  assert.deepEqual(r.supersedeTargets, []);
+  assert.equal(r.supersededBy, null);
+  assert.deepEqual(r.errors, []);
+});
+
+test("parseAdr: parses 'Superseded by ADR-0010'", () => {
+  const r = parseAdr(
+    "/x/0042-foo.md",
+    sample({ status: "Superseded by ADR-0010", supersedes: "—" }),
+  );
+  assert.equal(r.status, "superseded");
+  assert.equal(r.supersededBy, "0010");
+  assert.deepEqual(r.errors, []);
+});
+
+test("parseAdr: parses 'Supersedes: ADR-0005'", () => {
+  const r = parseAdr(
+    "/x/0042-foo.md",
+    sample({ status: "accepted", supersedes: "ADR-0005" }),
+  );
+  assert.deepEqual(r.supersedeTargets, ["0005"]);
+});
+
+test("parseAdr: parses multiple supersede targets", () => {
+  const r = parseAdr(
+    "/x/0042-foo.md",
+    sample({ status: "accepted", supersedes: "ADR-0005, ADR-0006" }),
+  );
+  assert.deepEqual(r.supersedeTargets, ["0005", "0006"]);
+});
+
+test("parseAdr: tolerates Ukrainian field names", () => {
+  const r = parseAdr(
+    "/x/0042-foo.md",
+    sample({ status: "accepted", supersedes: "—", lang: "uk" }),
+  );
+  assert.equal(r.status, "accepted");
+  assert.deepEqual(r.errors, []);
+});
+
+test("parseAdr: tolerates HTML-comment placeholder in Status", () => {
+  const r = parseAdr(
+    "/x/0042-foo.md",
+    sample({
+      status:
+        "accepted <!-- Proposed | Accepted | Deprecated | Superseded by ADR-NNNN -->",
+      supersedes: "—",
+    }),
+  );
+  assert.equal(r.status, "accepted");
+  assert.deepEqual(r.errors, []);
+});
+
+test("parseAdr: rejects unknown status", () => {
+  const r = parseAdr(
+    "/x/0042-foo.md",
+    sample({ status: "bogus", supersedes: "—" }),
+  );
+  assert.equal(r.errors.length, 1);
+  assert.match(r.errors[0], /unknown status/);
+});
+
+test("parseAdr: rejects bad filename", () => {
+  const r = parseAdr(
+    "/x/foo.md",
+    sample({ status: "accepted", supersedes: "—" }),
+  );
+  assert.equal(r.number, null);
+  assert.match(r.errors[0], /filename does not match/);
+});
+
+test("parseAdr: rejects superseded with no ADR-NNNN reference", () => {
+  const r = parseAdr(
+    "/x/0042-foo.md",
+    sample({ status: "Superseded by something", supersedes: "—" }),
+  );
+  assert.match(r.errors[0], /no single ADR-NNNN reference/);
+});
+
+// ── listIndexedNumbers ───────────────────────────────────────────────────────
+
+test("listIndexedNumbers: extracts from a markdown table column", () => {
+  const md = `
+| #    | Назва         |
+| ---- | ------------- |
+| 0001 | First         |
+| 0002 | Second        |
+| 0099 | Last          |
+`;
+  const set = listIndexedNumbers(md);
+  assert.deepEqual([...set].sort(), ["0001", "0002", "0099"]);
+});
+
+test("listIndexedNumbers: ignores 4-digit numbers in body prose", () => {
+  const md = `Body text mentions 1234 in passing.\n\n| 0001 | x |\n`;
+  const set = listIndexedNumbers(md);
+  assert.deepEqual([...set], ["0001"]);
+});
+
+// ── validateGraph ────────────────────────────────────────────────────────────
+
+test("validateGraph: green for two unrelated `accepted` ADRs both indexed", () => {
+  const a = parseAdr(
+    "/x/0001-a.md",
+    sample({ status: "accepted", supersedes: "—" }),
+  );
+  const b = parseAdr(
+    "/x/0002-b.md",
+    sample({ status: "accepted", supersedes: "—" }),
+  );
+  const errors = validateGraph([a, b], new Set(["0001", "0002"]));
+  assert.deepEqual(errors, []);
+});
+
+test("validateGraph: complains when an ADR is missing from the README index", () => {
+  const a = parseAdr(
+    "/x/0001-a.md",
+    sample({ status: "accepted", supersedes: "—" }),
+  );
+  const errors = validateGraph([a], new Set([]));
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /not listed in docs\/adr\/README\.md/);
+});
+
+test("validateGraph: enforces bidirectional supersede (forward direction missing)", () => {
+  // ADR-0002 says it supersedes 0001, but ADR-0001's status is still "accepted".
+  const a = parseAdr(
+    "/x/0001-a.md",
+    sample({ status: "accepted", supersedes: "—" }),
+  );
+  const b = parseAdr(
+    "/x/0002-b.md",
+    sample({ status: "accepted", supersedes: "ADR-0001" }),
+  );
+  const errors = validateGraph([a, b], new Set(["0001", "0002"]));
+  assert.equal(errors.length, 1);
+  assert.match(
+    errors[0],
+    /claims to supersede ADR-0001.*expected "Superseded by ADR-0002"/s,
+  );
+});
+
+test("validateGraph: enforces bidirectional supersede (reverse direction missing)", () => {
+  // ADR-0001 says superseded by 0002, but 0002 doesn't list 0001 in Supersedes.
+  const a = parseAdr(
+    "/x/0001-a.md",
+    sample({ status: "Superseded by ADR-0002", supersedes: "—" }),
+  );
+  const b = parseAdr(
+    "/x/0002-b.md",
+    sample({ status: "accepted", supersedes: "—" }),
+  );
+  const errors = validateGraph([a, b], new Set(["0001", "0002"]));
+  assert.ok(
+    errors.some((e) => /Supersedes field does not list ADR-0001/.test(e)),
+    `expected reverse-direction error, got: ${JSON.stringify(errors)}`,
+  );
+});
+
+test("validateGraph: green for a valid supersede pair", () => {
+  const a = parseAdr(
+    "/x/0001-a.md",
+    sample({ status: "Superseded by ADR-0002", supersedes: "—" }),
+  );
+  const b = parseAdr(
+    "/x/0002-b.md",
+    sample({ status: "accepted", supersedes: "ADR-0001" }),
+  );
+  const errors = validateGraph([a, b], new Set(["0001", "0002"]));
+  assert.deepEqual(errors, []);
+});
+
+test("validateGraph: complains when supersede target doesn't exist", () => {
+  const a = parseAdr(
+    "/x/0042-a.md",
+    sample({ status: "accepted", supersedes: "ADR-9999" }),
+  );
+  const errors = validateGraph([a], new Set(["0042"]));
+  assert.ok(errors.some((e) => /Supersedes ADR-9999 but no such ADR/.test(e)));
+});
+
+test("validateGraph: complains when supersede target points to wrong ADR (mismatch)", () => {
+  // 0001 says it's superseded by 0002, but 0003 also claims to supersede 0001.
+  const a = parseAdr(
+    "/x/0001-a.md",
+    sample({ status: "Superseded by ADR-0002", supersedes: "—" }),
+  );
+  const b = parseAdr(
+    "/x/0002-b.md",
+    sample({ status: "accepted", supersedes: "ADR-0001" }),
+  );
+  const c = parseAdr(
+    "/x/0003-c.md",
+    sample({ status: "accepted", supersedes: "ADR-0001" }),
+  );
+  const errors = validateGraph([a, b, c], new Set(["0001", "0002", "0003"]));
+  // 0003 claims to supersede 0001 but 0001 points to 0002 → mismatch.
+  assert.ok(
+    errors.some((e) => /points to ADR-0002 \(mismatch\)/.test(e)),
+    `expected mismatch error, got: ${JSON.stringify(errors)}`,
+  );
+});
+
+// ── On-disk integration ──────────────────────────────────────────────────────
+
+test("on-disk: every ADR file in docs/adr/ parses cleanly", () => {
+  const files = listAdrFiles(ADR_DIR);
+  assert.ok(files.length >= 27, `expected ≥27 ADRs, got ${files.length}`);
+  for (const f of files) {
+    const r = parseAdr(f, readFileSync(f, "utf8"));
+    assert.deepEqual(
+      r.errors,
+      [],
+      `${f} has parse errors: ${JSON.stringify(r.errors)}`,
+    );
+  }
+});
+
+test("on-disk: validateGraph passes against the real docs/adr tree", () => {
+  const files = listAdrFiles(ADR_DIR);
+  const adrs = files.map((f) => parseAdr(f, readFileSync(f, "utf8")));
+  const indexed = listIndexedNumbers(readFileSync(README_PATH, "utf8"));
+  const errors = validateGraph(adrs, indexed);
+  assert.deepEqual(
+    errors,
+    [],
+    `unexpected graph errors:\n${errors.join("\n")}`,
+  );
+});
+
+test("on-disk: README.md ↔ ADR file count parity", () => {
+  // every indexed number must have a matching ADR file and vice versa.
+  const files = readdirSync(ADR_DIR).filter((f) => /^\d{4}-/.test(f));
+  const fileNumbers = new Set(files.map((f) => f.slice(0, 4)));
+  const indexed = listIndexedNumbers(readFileSync(README_PATH, "utf8"));
+  assert.deepEqual([...fileNumbers].sort(), [...indexed].sort());
+});

--- a/scripts/docs/check-adr-graph.mjs
+++ b/scripts/docs/check-adr-graph.mjs
@@ -1,0 +1,292 @@
+#!/usr/bin/env node
+// scripts/docs/check-adr-graph.mjs
+//
+// Validate the integrity of the ADR collection in `docs/adr/`:
+//
+//   1. Every ADR file (NNNN-*.md) has a recognised `Status:` value.
+//   2. Every ADR file has a `Supersedes:` field (`—` for none, or a list
+//      of `ADR-NNNN` references that must resolve).
+//   3. The supersede graph is **bidirectional**: if A says it supersedes
+//      B, then B's status must be `superseded by ADR-A`. The reverse
+//      direction is also enforced — superseded ADRs must declare which
+//      ADR replaced them.
+//   4. Every ADR file is listed in `docs/adr/README.md` (the «Поточні
+//      ADR» table) under its number.
+//   5. No "dangling" ADRs: every file has a numeric prefix and its
+//      status is one of accepted / proposed / deprecated / superseded.
+//
+// Both English and Ukrainian field names are accepted in metadata
+// (`Status:` / `Статус:`, `Supersedes:` / `Замінює:`) — ADR-0026 and
+// ADR-0027 use the Ukrainian form and would otherwise be rejected.
+//
+// Usage:
+//   node scripts/docs/check-adr-graph.mjs            # CI gate
+//   node scripts/docs/check-adr-graph.mjs --json     # machine-readable report
+//
+// Exits 0 if the graph is valid; 1 if any rule is violated.
+
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve, dirname, basename } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolve(__dirname, "../..");
+const ADR_DIR = resolve(REPO_ROOT, "docs/adr");
+const README_PATH = resolve(ADR_DIR, "README.md");
+
+const ADR_FILE_RE = /^(\d{4})-[a-z0-9-]+\.md$/;
+const ADR_REF_RE = /\bADR-(\d{4})\b/gi;
+
+const VALID_STATUSES = new Set([
+  "accepted",
+  "proposed",
+  "deprecated",
+  "superseded",
+]);
+
+// ── Pure helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Extract the metadata bullet at the top of an ADR. Returns null if the
+ * field is absent. Tolerates leading whitespace, varying dash styles, and
+ * either English or Ukrainian field names from `aliases`.
+ */
+export function extractField(content, aliases) {
+  const escaped = aliases.map((a) => a.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+  const re = new RegExp(
+    `^\\s*-\\s+\\*\\*(?:${escaped.join("|")}):\\*\\*\\s*(.+?)\\s*$`,
+    "m",
+  );
+  const m = content.match(re);
+  return m ? m[1].trim() : null;
+}
+
+/**
+ * Parse an ADR's metadata + supersede graph data. Returns:
+ *   { number, file, statusRaw, status, supersedeTargets, supersededBy, errors }
+ * Errors here are field-level only (missing Status, malformed Supersedes);
+ * cross-file consistency is checked in `validateGraph`.
+ */
+export function parseAdr(file, content) {
+  const m = basename(file).match(ADR_FILE_RE);
+  if (!m) {
+    return {
+      file,
+      number: null,
+      errors: [`filename does not match NNNN-kebab-case-title.md`],
+    };
+  }
+  const number = m[1];
+
+  const statusRaw = extractField(content, ["Status", "Статус"]) ?? null;
+  const supersedesRaw =
+    extractField(content, ["Supersedes", "Замінює"]) ?? null;
+
+  const errors = [];
+
+  // Normalise status. Strip trailing HTML comments / extra commentary.
+  const cleaned = (statusRaw ?? "")
+    .replace(/<!--[\s\S]*?-->/g, "")
+    .trim()
+    .toLowerCase();
+  let status = null;
+  let supersededBy = null;
+  if (!cleaned) {
+    errors.push("missing `Status:` field");
+  } else if (cleaned.startsWith("superseded by")) {
+    status = "superseded";
+    const refs = [...cleaned.matchAll(ADR_REF_RE)];
+    if (refs.length !== 1) {
+      errors.push(
+        `Status says superseded but no single ADR-NNNN reference found in: "${statusRaw}"`,
+      );
+    } else {
+      supersededBy = refs[0][1];
+    }
+  } else if (VALID_STATUSES.has(cleaned)) {
+    status = cleaned;
+  } else {
+    errors.push(
+      `unknown status "${statusRaw}" — expected one of: ${[...VALID_STATUSES].join(", ")} or "superseded by ADR-NNNN"`,
+    );
+  }
+
+  // Parse supersedes: `—` means "supersedes nothing", otherwise comma /
+  // space separated list of ADR-NNNN refs.
+  const supersedeTargets = [];
+  if (supersedesRaw === null) {
+    errors.push("missing `Supersedes:` field");
+  } else {
+    const cleanedSup = supersedesRaw.replace(/<!--[\s\S]*?-->/g, "").trim();
+    if (cleanedSup && cleanedSup !== "—" && cleanedSup !== "-") {
+      const matches = [...cleanedSup.matchAll(ADR_REF_RE)];
+      if (matches.length === 0) {
+        errors.push(
+          `Supersedes field is non-empty but contains no ADR-NNNN references: "${supersedesRaw}"`,
+        );
+      }
+      for (const ref of matches) supersedeTargets.push(ref[1]);
+    }
+  }
+
+  return {
+    file,
+    number,
+    statusRaw,
+    status,
+    supersedeTargets,
+    supersededBy,
+    errors,
+  };
+}
+
+/**
+ * Collect all numeric ADR-NNNN entries in the README's table column.
+ * Returns a Set of zero-padded 4-digit strings.
+ */
+export function listIndexedNumbers(readmeContent) {
+  const indexed = new Set();
+  // Match lines like:
+  //   | 0001 | Monetization architecture | proposed | …
+  // The leading `|` and the column for the number make matching robust to
+  // surrounding columns moving around.
+  const re = /^\s*\|\s*(\d{4})\s*\|/gm;
+  for (const m of readmeContent.matchAll(re)) {
+    indexed.add(m[1]);
+  }
+  return indexed;
+}
+
+/**
+ * Validate the cross-file invariants given the parsed ADRs and the README
+ * index. Returns an array of human-readable error strings.
+ */
+export function validateGraph(adrs, readmeIndexed) {
+  const errors = [];
+  const byNumber = new Map();
+  for (const a of adrs) {
+    if (a.number) byNumber.set(a.number, a);
+  }
+
+  for (const a of adrs) {
+    // 1. Per-file errors are bubbled up directly.
+    for (const e of a.errors) {
+      errors.push(`${basename(a.file)}: ${e}`);
+    }
+    if (!a.number) continue;
+
+    // 2. README-index check.
+    if (!readmeIndexed.has(a.number)) {
+      errors.push(
+        `${basename(a.file)}: ADR-${a.number} is not listed in docs/adr/README.md`,
+      );
+    }
+
+    // 3. Supersedes references must resolve to existing ADR files.
+    for (const target of a.supersedeTargets) {
+      const targetAdr = byNumber.get(target);
+      if (!targetAdr) {
+        errors.push(
+          `${basename(a.file)}: Supersedes ADR-${target} but no such ADR exists`,
+        );
+        continue;
+      }
+      if (targetAdr.status !== "superseded") {
+        errors.push(
+          `${basename(a.file)}: claims to supersede ADR-${target}, but ADR-${target}'s Status is "${targetAdr.statusRaw}" (expected "Superseded by ADR-${a.number}")`,
+        );
+      } else if (targetAdr.supersededBy !== a.number) {
+        errors.push(
+          `${basename(a.file)}: claims to supersede ADR-${target}, but ADR-${target}'s Status points to ADR-${targetAdr.supersededBy} (mismatch)`,
+        );
+      }
+    }
+
+    // 4. Reverse direction: if this ADR is superseded, the replacement
+    //    must declare it in its Supersedes list.
+    if (a.status === "superseded" && a.supersededBy) {
+      const target = byNumber.get(a.supersededBy);
+      if (!target) {
+        errors.push(
+          `${basename(a.file)}: Status says superseded by ADR-${a.supersededBy} but no such ADR exists`,
+        );
+      } else if (!target.supersedeTargets.includes(a.number)) {
+        errors.push(
+          `${basename(a.file)}: marked as superseded by ADR-${a.supersededBy}, but ADR-${a.supersededBy}'s Supersedes field does not list ADR-${a.number}`,
+        );
+      }
+    }
+  }
+
+  return errors;
+}
+
+// ── I/O ──────────────────────────────────────────────────────────────────────
+
+/**
+ * List candidate ADR files in `dir`. Skips `README.md`, `TEMPLATE.md`, and
+ * anything that doesn't match the NNNN-kebab-case naming convention.
+ */
+export function listAdrFiles(dir) {
+  return readdirSync(dir)
+    .filter((f) => ADR_FILE_RE.test(f))
+    .sort()
+    .map((f) => resolve(dir, f));
+}
+
+function loadAll() {
+  const files = listAdrFiles(ADR_DIR);
+  const adrs = files.map((f) => parseAdr(f, readFileSync(f, "utf8")));
+  const indexed = listIndexedNumbers(readFileSync(README_PATH, "utf8"));
+  return { adrs, indexed, files };
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────────────
+
+const isMain =
+  process.argv[1] &&
+  resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+
+if (isMain) {
+  const args = process.argv.slice(2);
+  const { adrs, indexed } = loadAll();
+  const errors = validateGraph(adrs, indexed);
+
+  if (args.includes("--json")) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          adrs: adrs.map((a) => ({
+            number: a.number,
+            file: basename(a.file),
+            status: a.status,
+            supersedeTargets: a.supersedeTargets,
+            supersededBy: a.supersededBy,
+          })),
+          indexed: [...indexed],
+          errors,
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    process.exit(errors.length > 0 ? 1 : 0);
+  }
+
+  if (errors.length > 0) {
+    console.error(
+      `[check-adr-graph] ${errors.length} problem(s) found in docs/adr/:`,
+    );
+    for (const e of errors) console.error(`  ✘ ${e}`);
+    console.error(
+      `\nFix the metadata in the offending ADR files (Status, Supersedes) or update docs/adr/README.md to list missing entries.`,
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `[check-adr-graph] OK — ${adrs.length} ADR(s) checked, graph is consistent.`,
+  );
+  process.exit(0);
+}


### PR DESCRIPTION
## What changed

Додав CI-валідатор графа ADR-ів. Sprint 2 / план оптимізації документації, пункт **#8**.

[`scripts/docs/check-adr-graph.mjs`](../../scripts/docs/check-adr-graph.mjs) парсить метадані всіх ADR у `docs/adr/` і валідує:

1. **Статуси** — кожен ADR має recognised `Status:`: `accepted`, `proposed`, `deprecated` або `Superseded by ADR-NNNN`.
2. **Supersedes** — кожен ADR має `Supersedes:` (`—` для none, або список `ADR-NNNN`).
3. **Бідіректіональний supersede-зв'язок** — якщо A каже, що supersedes B, то B's Status має бути `Superseded by ADR-A` (і навпаки). Обидва напрямки enforce-яться, тому split-brain ADR-пари ловляться.
4. **README index** — кожен ADR-файл має бути в таблиці «Поточні ADR» у `docs/adr/README.md`.
5. **No dangling ADRs** — кожен файл має numeric prefix і recognised status.

Парсер приймає **і англійські, і українські** назви полів метаданих (`Status:` / `Статус:`, `Supersedes:` / `Замінює:`) — `ADR-0026` (n8n) і `ADR-0027` (OpenClaw / Console / MCP) використовують українську форму і інакше були б відхилені.

## Drift, який скрипт виявив прямо в процесі написання

`ADR-0026` і `ADR-0027` лежали як `accepted` файли у дереві, але **не були в індексі** `docs/adr/README.md`. Це класичний drift, який скрипт ловить за дизайном. Додав обидва записи в таблицю «Поточні ADR» — частина цього PR-а.

## Why

- **Нульова вартість, висока ROI.** ADR-граф — один із найдрейфуваніших артефактів (хто пам'ятає оновити інший ADR при `Superseded by`?). Скрипт його тримає.
- **Розблоковано наступні автоматизації.** `--json` режим дає дамп графа, з якого монтуватиметься monthly-governance-review (PR #5 sprint 3).
- **CI-gate.** Новий job `adr-graph` у `docs-automation.yml` падає, якщо граф не консистентний.

## Що в коробці

| Файл                                                       | Призначення                                                                                                                                                                                                          |
| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `scripts/docs/check-adr-graph.mjs`                         | Pure helpers (`extractField`, `parseAdr`, `listIndexedNumbers`, `validateGraph`, `listAdrFiles`) + CLI (`--json`).                                                                                                  |
| `scripts/docs/__tests__/check-adr-graph.test.mjs`          | 24 тести: alias-extraction (3), parseAdr (8 — accepted / superseded / multi-supersede / Ukrainian / placeholder / unknown-status / bad-filename / no-ref), listIndexedNumbers (2), validateGraph (8), on-disk (3). |
| `package.json`                                             | Новий npm-script: `pnpm docs:check-adr-graph` для локальних прогонів.                                                                                                                                              |
| `.github/workflows/docs-automation.yml`                    | Новий job `adr-graph`; тест додано в `docs-scripts-tests`.                                                                                                                                                          |
| `docs/adr/README.md`                                       | Додано записи 0026, 0027 у таблицю «Поточні ADR» (drift-fix). Додано «Graph integrity»-callout із посиланням на скрипт.                                                                                              |

## How to test

```bash
# 1. Юніт-тести
node --test scripts/docs/__tests__/check-adr-graph.test.mjs
# → 24/24 pass

# 2. Локальний прогон
pnpm docs:check-adr-graph
# → "[check-adr-graph] OK — 27 ADR(s) checked, graph is consistent."

# 3. Machine-readable дамп графа
node scripts/docs/check-adr-graph.mjs --json | jq '.adrs | map(select(.status == "superseded"))'
# → [] (поки що жоден ADR не superseded)
```

Перевірив локально: 138 тестів у `scripts/docs/__tests__/` проходять, `pnpm format:check` чистий, `pnpm lint` чистий.

---

## Pre-flight (Hard Rule #15)

- [x] Прочитав `AGENTS.md` Hard Rules — особливо #5 (commit scope), #15 (governance + docs discipline).
- [x] Перевірив freshness headers на тих доках, які торкаюся.

## Docs updated alongside code? (Hard Rule #15)

- [x] N/A — API contract change.
- [x] Новий npm-script задокументований у README.md (Graph integrity callout).
- [x] Design tokens / palette docs — n/a.
- [x] Deprecation — n/a.
- [x] Freshness headers: `docs/adr/README.md` — buml `Last validated` у тому ж комміті (pre-commit hook).
- [x] No other docs invalidated.

## How AI-tested this PR

- [x] `node --test scripts/docs/__tests__/check-adr-graph.test.mjs` — 24/24 pass.
- [x] `node --test scripts/docs/__tests__/*.test.mjs` — 138/138 pass.
- [x] `pnpm docs:check-adr-graph` — green.
- [x] `pnpm format:check`, `pnpm lint` — clean.
- [x] Перевірив, що скрипт відмовляє коли:
  - ADR файл не в README index (виявив drift на 0026/0027 — реальний живий приклад).
  - `Supersedes:` посилається на неіснуючий ADR.
  - Forward direction OK, але reverse не задекларований.
  - Mismatch (A says superseded by B; C also claims to supersede A).

## AGENTS.md updated?

- [x] Yes — нічого не змінює в Hard Rules; це новий tooling під existing governance.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1200" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated validation of Architecture Decision Record (ADR) integrity now enforced via CI, ensuring metadata consistency and cross-reference validity.

* **Documentation**
  * ADR registry updated with two new records documenting workflow governance and policy decisions.

* **Tests**
  * Comprehensive test suite added for ADR validation logic.

* **Chores**
  * CI workflow enhanced with dedicated ADR graph integrity check step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->