### PR TITLE
ci(ci): fix AI-LEGACY workflow & document new pnpm scripts

### DIFF
--- a/.github/workflows/ai-legacy-scan.yml
+++ b/.github/workflows/ai-legacy-scan.yml
@@ -59,25 +59,33 @@ jobs:
           node-version: "20"
 
       - name: Check expired & malformed AI-LEGACY markers (PR gate)
-        # `--check` exits 1 on any expired/malformed marker. Runs on PRs so a
-        # regression cannot land. The scheduled run also re-checks main, in
-        # case a marker that was fresh at merge time has now expired.
+        # PR gate only — `--check` exits 1 on any expired/malformed marker.
+        # We deliberately do NOT run this on schedule/dispatch because expired
+        # markers are *expected* on those runs (that's the whole reason the
+        # weekly cron exists — to file issues for them). Running --check there
+        # would make GitHub Actions skip the issue/dashboard steps below.
+        if: github.event_name == 'pull_request'
         run: node scripts/check-ai-legacy.mjs --check
 
       - name: Open GitHub issues for expired markers
         # Issue creation is skipped on pull_request because forks cannot write.
-        if: github.event_name != 'pull_request'
+        # `if: always()` so a transient failure of the upstream check step does
+        # not silently swallow the weekly issue-bot.
+        if: always() && github.event_name != 'pull_request'
         run: node scripts/check-ai-legacy.mjs --issues
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build AI-LEGACY dashboard (HTML artifact)
-        # Always produced so engineers can download a single HTML file from
-        # any run instead of grepping the codebase or open-issue list.
+        # `if: always()` so the dashboard is produced even when the PR-gate
+        # `--check` step exited 1 — reviewers need the artifact most when
+        # there *are* expired markers.
+        if: always()
         run: node scripts/check-ai-legacy.mjs --dashboard dist/ai-legacy-dashboard.html
 
       - name: Upload AI-LEGACY dashboard
         # actions/upload-artifact v4.4.3 (SHA-pinned for supply-chain hardening)
+        if: always()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: ai-legacy-dashboard

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Sergeant — Claude Code context
 
-> **Last validated:** 2026-04-29 by @devin-ai. **Next review:** 2026-07-29.
+> **Last validated:** 2026-04-30 by @devin-ai-integration[bot]. **Next review:** 2026-07-29.
 > **Status:** Active
 
 > Full agent rules, hard rules, anti-patterns, and domain invariants are in **[`AGENTS.md`](./AGENTS.md)**.
@@ -30,6 +30,8 @@ pnpm docs:check-links    # Scan every .md for broken [text](target) links
 pnpm docs:gen-playbook-index       # Regenerate docs/playbooks/INDEX.md
 pnpm docs:check-playbook-index     # CI: fail if INDEX.md is stale
 pnpm docs:freshness-dashboard      # Build dist/freshness-dashboard.html
+pnpm lint:ai-legacy                # CI gate: fail on expired/malformed `// AI-LEGACY: expires …` markers
+pnpm ai-legacy:dashboard           # Build dist/ai-legacy-dashboard.html
 ```
 
 ## Before you write code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing у Sergeant
 
-> **Last validated:** 2026-04-29 by @devin-ai. **Next review:** 2026-07-29.
+> **Last validated:** 2026-04-30 by @devin-ai-integration[bot]. **Next review:** 2026-07-29.
 > **Status:** Active
 
 > **Ціль:** zero-to-running за ≤ 5 хвилин на будь-якій машині з Docker.
@@ -100,6 +100,8 @@ pnpm db:down                # зупинити й видалити Postgres-ко
 | `pnpm docs:gen-playbook-index`   | Перегенеровує `docs/playbooks/INDEX.md` з рядка `**Trigger:**` кожного playbook     |
 | `pnpm docs:check-playbook-index` | CI mode — fail якщо `INDEX.md` застарів (локально додавайте `--check`)              |
 | `pnpm docs:freshness-dashboard`  | Збирає звіт `dist/freshness-dashboard.html` (з кольорами, sortable)                 |
+| `pnpm lint:ai-legacy`            | CI gate: exit 1 якщо є прострочений / malformed `// AI-LEGACY: expires …` маркер    |
+| `pnpm ai-legacy:dashboard`       | Збирає звіт `dist/ai-legacy-dashboard.html` (по всіх `AI-LEGACY` маркерах у коді)   |
 | `pnpm ci:validate-pr-body`       | Валідовує `$PR_BODY` проти `.github/PULL_REQUEST_TEMPLATE.md`                       |
 
 ### Scoped команди


### PR DESCRIPTION
## What changed

Addresses both Devin Review findings on the merged PR [#1201](https://github.com/Skords-01/Sergeant/pull/1201).

**1. Workflow logic fix (`.github/workflows/ai-legacy-scan.yml`).**

The unconditional `--check` step exited 1 on expired markers, which caused GitHub Actions to skip the subsequent `--issues` and `--dashboard` steps (they had no `if: always()`). On the **weekly cron** that's the worst possible behaviour:

- Issue creation never ran — the cron's whole reason for existing was dead code.
- The dashboard artifact was only produced when there were no findings, the opposite of what reviewers need.

Fix:

- `--check` is now gated to `pull_request` events only — that's where it acts as a regression gate. On `schedule` / `workflow_dispatch` expired markers are *expected*.
- `--issues`, `--dashboard`, and `upload-artifact` steps gain `if: always()` so they are unaffected by upstream step status.

This matches the design of `docs-freshness.yml` (the stated reference): its `--check-coverage` gate fires on missing headers, never on stale dates, so the issue/dashboard pipeline always runs through.

**2. Hard Rule #15 docs sync (`CONTRIBUTING.md`, `CLAUDE.md`).**

The two new scripts added in #1201 (`lint:ai-legacy`, `ai-legacy:dashboard`) were missed in:

- `CONTRIBUTING.md` § Щоденні команди — added two rows alongside the existing `docs:` commands.
- `CLAUDE.md` § Quick commands — added two lines alongside `docs:freshness-dashboard`.

`AGENTS.md` was already updated in #1201; this PR just brings the other two governance docs in sync, as required by Hard Rule #15's must-update table ("New / removed npm script → CONTRIBUTING.md § Everyday Commands, CLAUDE.md § Quick commands").

## Why

Both findings are factual bugs in #1201 — the workflow one is a logic bug that disabled the weekly cron's purpose, and the docs one violates Hard Rule #15. Catching them in a fast follow-up keeps the original PR's history clean.

## How to test

```bash
# Workflow logic — verify the gating with `act` or just inspect the diff:
yq '.jobs.scan.steps[] | select(.name | test("AI-LEGACY")) | {name: .name, if: .if}' \
  .github/workflows/ai-legacy-scan.yml

# Docs sync:
pnpm docs:check-links --skip-external
pnpm docs:check-freshness-coverage
pnpm prettier --check CONTRIBUTING.md CLAUDE.md
```

The first scheduled run after merge (Mon 07:00 UTC) will be the real end-to-end test of the workflow fix — `--issues` / `--dashboard` should now both execute even when expired markers exist.

---

## Pre-flight (Hard Rule #15)

- [x] Read the `AGENTS.md` Hard Rules that apply — Hard Rule #5 (commit scopes), #10 (lifecycle markers), #15 (docs sync).
- [x] Read the matching playbook in `docs/playbooks/` — n/a, repo-tooling.
- [x] Checked freshness headers — `CLAUDE.md` and `CONTRIBUTING.md` are auto-bumped via the lint-staged hook from PR #1198.

## Docs updated alongside code? (Hard Rule #15)

- [ ] API contract change — n/a.
- [x] New / removed npm script — already added in #1201; **this PR closes the gap by mirroring them in `CONTRIBUTING.md` and `CLAUDE.md`** as Hard Rule #15 requires.
- [ ] New design token / component / palette — n/a.
- [ ] Deprecation — n/a.
- [x] Freshness header bumped on docs whose claims changed — handled by the lint-staged hook.
- [ ] N/A — no docs invalidated.

## How AI-tested this PR

- [x] `pnpm prettier --check` clean on all three changed files (after one auto-format pass on `CONTRIBUTING.md`).
- [x] `pnpm docs:check-links --skip-external` clean.
- [x] `pnpm docs:check-freshness-coverage` clean.
- [x] Manually re-read the workflow YAML to verify each step's `if:` condition matches the intent: PR → `--check` only; schedule/dispatch → `--issues` + `--dashboard` + upload, all guarded by `always()`.
- [x] No new `AI-DANGER` markers added.

## AGENTS.md updated?

- [x] No — `AGENTS.md` is already correct from #1201; the new scripts are documented there.

Link to Devin session: https://app.devin.ai/sessions/ffc16c80111b410cafaad19f640e0e16
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD validation workflows to improve marker validation handling and reporting
  * Enhanced automated dashboard generation for code quality tracking
  * Updated project documentation and validation records

<!-- end of auto-generated comment: release notes by coderabbit.ai -->