### PR TITLE
test(web): unbreak HubDashboard.test by seeding past-FTUX flag

### DIFF
--- a/apps/web/src/core/hub/HubDashboard.test.tsx
+++ b/apps/web/src/core/hub/HubDashboard.test.tsx
@@ -278,6 +278,11 @@ describe("HubDashboard", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-29T09:00:00+03:00"));
     localStorage.clear();
+    // Past the FTUX gate: render `TodaySummaryStrip`, `HubInsightsPanel`,
+    // and the «Аналітика» section (incl. `WeeklyDigestFooter`). Also
+    // suppresses `ModuleChecklist`, whose «Фінік: Перші кроки» heading
+    // would collide with the bento «Фінік» button under `getByRole`.
+    localStorage.setItem("hub_first_real_entry_done_v1", "1");
     mocks.dashboardFocus.focus = null;
     mocks.dashboardFocus.rest = [];
     mocks.dashboardFocus.dismiss.mockClear();


### PR DESCRIPTION
## What changed

Seed `hub_first_real_entry_done_v1 = "1"` in `HubDashboard.test.tsx`'s `beforeEach`, so all six tests run past the first-real-entry FTUX gate.

## Why

CI on `main` has been red because 4/6 tests in `apps/web/src/core/hub/HubDashboard.test.tsx` failed against the current component. Two unrelated dashboard refactors moved nodes behind the FTUX gate without the test being updated:

1. **`ModuleChecklist`** renders only while `!hasRealEntry && sessionDays <= 7`. Its heading is «Фінік: Перші кроки» — which collides with the bento «💸 Фінік» button under `getByRole("button", { name: /Фінік/ })`, breaking *"opens module cards and keeps quick-add actions scoped to active modules"*.
2. **`HubInsightsPanel`** and **`WeeklyDigestFooter`** are now nested inside the «Аналітика» `CollapsibleSection`, which is itself gated on `hasRealEntry`. Tests querying `[data-testid="insight-count"]` and `[data-testid="weekly-digest-footer"]` never found them because the section never rendered.

Seeding the FTUX-done flag in `beforeEach` puts every test in the post-FTUX state — which is what the existing assertions describe. Tests 1 and 3 (which only exercise the bento grid + hide-inactive toggle) keep passing because they only depend on their own keys.

## How to test

```bash
pnpm --filter @sergeant/web exec vitest run src/core/hub/HubDashboard.test.tsx
```

All 6 tests pass locally. Lint + typecheck on `@sergeant/web` are clean.

## Things to look at in review

- **Scope decision.** I chose to flip the FTUX flag globally in `beforeEach` rather than mocking `ModuleChecklist` or seeding non-demo entries via `FIRST_REAL_ENTRY_SOURCES.*`. Cheaper and isolates the test from `ModuleChecklist` internals, but it does mean **no test in this file now exercises the pre-FTUX path** (checklist + analytics-section gating). If we want a regression test for that gate, it should be a separate `describe("FTUX gate", …)`.
- **Hardcoded key string.** I inlined `"hub_first_real_entry_done_v1"` rather than importing `FIRST_REAL_ENTRY_KEY` from `@sergeant/shared`. Happy to switch to the symbol import if you prefer (it would require adding `FIRST_REAL_ENTRY_KEY` to the shared barrel — currently only `vibePicks.ts` re-exports it).
- **Stale-assertion vs runtime-bug.** I treated all four failures as stale tests, not runtime regressions. Worth a sanity check that the dashboard actually behaves correctly at runtime in the post-FTUX state — the `ModuleChecklist`/«Фінік: Перші кроки» heading is a real button users see before their first entry, and the test no longer covers that surface.

---

## Pre-flight (Hard Rule #15)

- [x] Read the `AGENTS.md` Hard Rules that apply to the touched paths.
- [x] Read the matching playbook in `docs/playbooks/` (or noted that none exists). — n/a, test-only change.
- [x] Checked freshness headers of docs cited in the change. — n/a.

## Docs updated alongside code? (Hard Rule #15)

- [x] N/A — test-only change, no public surface, no docs invalidated.

## How AI-tested this PR

- [x] Vitest: `pnpm --filter @sergeant/web exec vitest run src/core/hub/HubDashboard.test.tsx` → 6 passed.
- [x] `pnpm --filter @sergeant/web run lint` clean.
- [x] `pnpm --filter @sergeant/web run typecheck` clean (all four tsconfigs).
- [x] No new `AI-DANGER` markers added.
- [x] Docs prose uses Ukrainian where practical (test comment is English; matches surrounding test file conventions).
- [ ] `pnpm dead-code:files` — not run; no new files added.

## AGENTS.md updated?

- [x] No — no new permanent rules.

Link to Devin session: https://app.devin.ai/sessions/6cb21739ed1c4871b807a1a7f37704eb
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration to properly simulate the completed first-time user experience state, ensuring accurate rendering of dashboard features during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->