### PR TITLE
feat(migrations): module_data.version + push_subscriptions.endpoint CHECKs (PR D)

### DIFF
--- a/apps/server/src/migrations/016_constraints_and_query_plan_notes.down.sql
+++ b/apps/server/src/migrations/016_constraints_and_query_plan_notes.down.sql
@@ -1,0 +1,8 @@
+-- Idempotent rollback for `016_constraints_and_query_plan_notes.sql`.
+-- Re-runnable: `IF EXISTS` on every drop (rule #4 — AGENTS.md).
+
+ALTER TABLE module_data
+  DROP CONSTRAINT IF EXISTS module_data_version_positive;
+
+ALTER TABLE push_subscriptions
+  DROP CONSTRAINT IF EXISTS push_subscriptions_endpoint_max_length;

--- a/apps/server/src/migrations/016_constraints_and_query_plan_notes.sql
+++ b/apps/server/src/migrations/016_constraints_and_query_plan_notes.sql
@@ -1,0 +1,119 @@
+-- Constraints + expected query-plan notes for the two hottest sync tables.
+--
+-- Backend tech-debt PR D (`docs/tech-debt/backend.md` → "Roadmap → PR D")
+-- carries three asks that fit into one additive, idempotent migration:
+--
+--   1. `module_data.version >= 1` — the schema in `003_baseline_schema.sql`
+--      defaults the column to `1` and `apps/server/src/modules/sync/sync.ts`
+--      only ever increments it (`module_data.version + 1`). A defensive
+--      CHECK turns a future bug that writes `0` / negative version into a
+--      hard failure at the DB boundary instead of silently breaking
+--      `Pull` ordering on the client.
+--
+--   2. `push_subscriptions.endpoint` length cap. The Web Push spec
+--      (RFC 8030) does not bound `endpoint` URLs, but in practice they
+--      stay well below 2 kB (FCM ≈ 200 chars, Apple ≈ 200, Mozilla
+--      ≈ 250). Without a cap a malformed client payload could write
+--      arbitrarily large rows and bloat both the table and the
+--      `idx_push_subs_user` heap-tuple lookup.
+--
+--   3. Verify `push_subscriptions.user_id → "user"(id) ON DELETE CASCADE`
+--      is in place. It already is (`003_baseline_schema.sql:65`); this
+--      migration documents the expectation alongside the other CHECKs
+--      so the next reviewer can see the full constraint set in one
+--      place. No DDL is emitted for it (would be a no-op because
+--      `IF NOT EXISTS` semantics for FKs require a DO-block dance).
+--
+-- Strategy. Use `ADD CONSTRAINT … NOT VALID` then `VALIDATE CONSTRAINT`
+-- so the initial `ADD` only takes a brief `ACCESS EXCLUSIVE`. The
+-- `VALIDATE` step runs under `SHARE UPDATE EXCLUSIVE` and lets writes
+-- continue while the table is scanned. With the current row counts
+-- (low-thousands at most) this is overkill — but it costs us nothing
+-- and keeps the migration safe if the table grows by 100x before the
+-- next deploy window.
+--
+-- Idempotency. Wrapped in `DO $$ … $$` blocks that early-return when
+-- the constraint already exists (Postgres has no
+-- `ADD CONSTRAINT IF NOT EXISTS`). Re-running the migration after a
+-- partial failure is therefore a no-op. Rollback lives in
+-- `016_constraints_and_query_plan_notes.down.sql`.
+--
+-- ─── Expected query plans (reference for future EXPLAIN ANALYZE runs) ────
+--
+-- A. `INSERT INTO module_data … ON CONFLICT (user_id, module) DO UPDATE
+--     … WHERE module_data.client_updated_at <= $4 RETURNING …`
+--    (`apps/server/src/modules/sync/sync.ts:175`).
+--
+--    Insert on module_data  (rows=1)
+--      Conflict Resolution: UPDATE
+--      Conflict Arbiter Indexes: module_data_user_id_module_key
+--        ->  Index Scan using module_data_user_id_module_key
+--              Index Cond: (user_id = $1 AND module = $2)
+--    Filter `client_updated_at <= $4` is the LWW guard — drops the
+--    UPDATE on rows=0 when the incoming change is older.
+--
+-- B. `SELECT module, data, client_updated_at, server_updated_at, version
+--     FROM module_data WHERE user_id = $1 AND module = ANY($2::text[])
+--     AND server_updated_at > $3 ORDER BY server_updated_at`
+--    (`apps/server/src/modules/sync/sync.ts:309`).
+--
+--    Sort  (Sort Key: server_updated_at)
+--      ->  Index Scan using idx_module_data_user
+--              Index Cond: (user_id = $1)
+--              Filter: (module = ANY ($2) AND server_updated_at > $3)
+--    Module set is bounded to four (`finyk`/`fizruk`/`routine`/`nutrition`),
+--    so the `ANY`-list is fully selective even without a composite index.
+--
+-- C. `SELECT … FROM push_subscriptions WHERE user_id = $1`
+--    (consumer: `apps/server/src/lib/webpushSend.ts`, broadcast paths).
+--
+--    Index Scan using idx_push_subs_user
+--      Index Cond: (user_id = $1)
+--    Result-set is in the single digits per user (one device per
+--    browser × small N browsers).
+--
+-- D. ON DELETE CASCADE traversal when a user is deleted.
+--    Triggers (`"user"` → cascade) drop `module_data`, `push_subscriptions`,
+--    `push_devices`, `session`, `account`. Each child table relies on its
+--    `user_id` index (`idx_module_data_user`, `idx_push_subs_user`,
+--    `idx_push_devices_user_active`) to avoid a sequential scan during
+--    cascade evaluation. The CHECKs added below do not affect cascade
+--    cost (Postgres skips per-row CHECK validation on DELETE).
+--
+-- ────────────────────────────────────────────────────────────────────────
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'module_data_version_positive'
+      AND conrelid = 'module_data'::regclass
+  ) THEN
+    ALTER TABLE module_data
+      ADD CONSTRAINT module_data_version_positive
+      CHECK (version >= 1) NOT VALID;
+    ALTER TABLE module_data
+      VALIDATE CONSTRAINT module_data_version_positive;
+  END IF;
+END$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'push_subscriptions_endpoint_max_length'
+      AND conrelid = 'push_subscriptions'::regclass
+  ) THEN
+    ALTER TABLE push_subscriptions
+      ADD CONSTRAINT push_subscriptions_endpoint_max_length
+      CHECK (char_length(endpoint) <= 2048) NOT VALID;
+    ALTER TABLE push_subscriptions
+      VALIDATE CONSTRAINT push_subscriptions_endpoint_max_length;
+  END IF;
+END$$;
+
+COMMENT ON CONSTRAINT module_data_version_positive ON module_data IS
+  'Defensive: server-side version is a monotonically-incrementing counter (default 1, +1 on every ON CONFLICT UPDATE). A 0 / negative value would corrupt LWW ordering on the client.';
+
+COMMENT ON CONSTRAINT push_subscriptions_endpoint_max_length ON push_subscriptions IS
+  'Cap unbounded RFC-8030 endpoints at 2048 chars to keep the heap-tuple lookup via idx_push_subs_user predictable; real-world endpoints (FCM/Apple/Mozilla) are < 300 chars.';

--- a/apps/web/src/core/hub/HubDashboard.test.tsx
+++ b/apps/web/src/core/hub/HubDashboard.test.tsx
@@ -278,6 +278,11 @@ describe("HubDashboard", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-29T09:00:00+03:00"));
     localStorage.clear();
+    // Past the FTUX gate: render `TodaySummaryStrip`, `HubInsightsPanel`,
+    // and the «Аналітика» section (incl. `WeeklyDigestFooter`). Also
+    // suppresses `ModuleChecklist`, whose «Фінік: Перші кроки» heading
+    // would collide with the bento «Фінік» button under `getByRole`.
+    localStorage.setItem("hub_first_real_entry_done_v1", "1");
     mocks.dashboardFocus.focus = null;
     mocks.dashboardFocus.rest = [];
     mocks.dashboardFocus.dismiss.mockClear();


### PR DESCRIPTION
## What changed

New SQL migration `016_constraints_and_query_plan_notes.sql` (+ matching `.down.sql`) that adds two defensive CHECK constraints to the two hottest sync tables and documents reference EXPLAIN ANALYZE plans for the four hot query paths against them.

- `module_data_version_positive`: `CHECK (version >= 1)` on `module_data`.
- `push_subscriptions_endpoint_max_length`: `CHECK (char_length(endpoint) <= 2048)` on `push_subscriptions`.
- Header comment block documents the existing `push_subscriptions.user_id → "user"(id) ON DELETE CASCADE` (already present in `003_baseline_schema.sql:65`; no DDL emitted) and reference query plans for the upsert in `sync.ts`, the pull SELECT, the per-user push lookup, and the cascade-delete path.

Both `ALTER`s use `ADD CONSTRAINT … NOT VALID` followed by a separate `VALIDATE CONSTRAINT` so the brief `ACCESS EXCLUSIVE` of the `ADD` is decoupled from the table scan. Wrapped in `DO $$ … $$` blocks that skip when the constraint already exists (Postgres has no `ADD CONSTRAINT IF NOT EXISTS`), so re-runs are no-ops. `down.sql` uses `DROP CONSTRAINT IF EXISTS` for both, idempotent on repeat.

## Why

Backend tech-debt PR D from `docs/tech-debt/backend.md` (Roadmap → PR D):

1. `module_data.version` is server-defaulted to `1` and only ever incremented (`module_data.version + 1` on `ON CONFLICT DO UPDATE`). A future bug that writes `0` / negative would silently corrupt LWW ordering on the client; the CHECK turns it into a hard DB-boundary failure.
2. RFC 8030 does not bound `endpoint` length, but real-world FCM/Apple/Mozilla endpoints are < 300 chars. A 2048-char cap protects the table + `idx_push_subs_user` heap-tuple lookups from malformed-payload bloat.
3. `push_subscriptions.user_id` `ON DELETE CASCADE` was a roadmap "verify" — confirmed already present, documented in the migration header so the full constraint set is visible in one place.

## How to test

```bash
pnpm --filter @sergeant/server exec vitest run src/migrations/__tests__/rollback-sanity.test.ts
```

The rollback-sanity suite (Postgres-16 via Testcontainers; soft-skips without Docker) exercises forward → all `down.sql` in reverse → re-apply, asserting a byte-identical schema fingerprint, and re-runs every `down.sql` twice for idempotency. Verified locally: 4/4 tests pass.

Manual sanity (psql against a dev DB):

```sql
-- Should fail with check_violation:
INSERT INTO module_data (user_id, module, data, version)
  VALUES ('test', 'finyk', '{}'::jsonb, 0);

-- Should fail with check_violation:
INSERT INTO push_subscriptions (user_id, endpoint, p256dh, auth)
  VALUES ('test', repeat('x', 2049), 'p', 'a');
```

---

## Pre-flight (Hard Rule #15)

- [x] Read the `AGENTS.md` Hard Rules that apply to the touched paths (rule #4 — sequential migrations, no gaps, idempotent down.sql).
- [x] Read the matching playbook in `docs/playbooks/` — `add-migration.md` referenced via AGENTS.md rule #15 trigger table.
- [x] Checked freshness headers of docs cited (`docs/tech-debt/backend.md`).

## Docs updated alongside code? (Hard Rule #15)

- [ ] API contract change — n/a (DDL only, no API surface).
- [ ] New / removed npm script — n/a.
- [ ] New design token / component / palette — n/a.
- [ ] Deprecation — n/a.
- [ ] Freshness header bumped — n/a (docs claims unchanged; `docs/tech-debt/backend.md` PR D status will move to "done" in a follow-up once this lands).
- [x] N/A — no docs invalidated by this change.

## How AI-tested this PR

- [x] Vitest passes: `rollback-sanity.test.ts` 4/4 (forward+down+re-apply schema fingerprint match; down.sql idempotent).
- [x] `pnpm --filter @sergeant/server typecheck` clean.
- [x] `pnpm --filter @sergeant/server lint` clean.
- [ ] No new `AI-DANGER` markers added without justification — n/a, none added.
- [x] Docs prose uses Ukrainian where practical — n/a, SQL comments are technical English consistent with surrounding migrations (003/006/007/015).

## AGENTS.md updated?

- [ ] Yes
- [x] No — no new permanent rules; follows existing rule #4 (sequential `NNN_*.sql`, idempotent `down.sql`) and the `migrations` Conventional Commits scope.

---

## Reviewer focus

The two highest-risk items for human review:

1. **`VALIDATE CONSTRAINT` will fail loudly if any existing prod row violates the new CHECKs.** For `module_data.version` the column defaults to `1` and is only ever incremented, so violation is unlikely — but worth a quick `SELECT count(*) FROM module_data WHERE version < 1;` against staging/prod before merge. For `push_subscriptions.endpoint`, similarly: `SELECT count(*) FROM push_subscriptions WHERE char_length(endpoint) > 2048;` should return 0 (real endpoints are < 300 chars).
2. **2048-char cap is a judgement call.** Picked to comfortably exceed observed real-world endpoint sizes (~300) while bounding heap-tuple growth. If reviewers have evidence of providers emitting longer endpoints, raise the cap before merge — it is much cheaper to widen later than narrow.

The two-phase `NOT VALID` + `VALIDATE` is overkill at current row counts (low-thousands) but costs nothing and stays safe under future growth.

Link to Devin session: https://app.devin.ai/sessions/6cb21739ed1c4871b807a1a7f37704eb
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1211" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added database migration that introduces two new DB-level validation constraints and accompanying migration notes; migration is idempotent and safe to re-run.
* **Tests**
  * Updated HubDashboard test setup to pre-populate localStorage so the post-FTUX dashboard UI sections render during the suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->