### PR TITLE
fix(web): keep checklist checkbox selections

### DIFF
--- a/apps/web/src/core/onboarding/ModuleChecklist.test.tsx
+++ b/apps/web/src/core/onboarding/ModuleChecklist.test.tsx
@@ -1,0 +1,44 @@
+/** @vitest-environment jsdom */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ModuleChecklist } from "./ModuleChecklist";
+
+vi.mock("@shared/lib/haptic", () => ({
+  hapticTap: vi.fn(),
+  hapticSuccess: vi.fn(),
+}));
+
+describe("ModuleChecklist", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps earlier checklist steps checked when another checkbox is selected", () => {
+    render(<ModuleChecklist moduleId="finyk" />);
+
+    const addExpense = screen.getByRole("checkbox", {
+      name: "Додати першу витрату",
+    });
+    const setBudget = screen.getByRole("checkbox", {
+      name: "Встановити бюджет",
+    });
+
+    fireEvent.click(addExpense);
+    fireEvent.click(setBudget);
+
+    expect(addExpense).toHaveAttribute("aria-checked", "true");
+    expect(setBudget).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByText("2/4 виконано")).toBeInTheDocument();
+    expect(
+      JSON.parse(localStorage.getItem("finyk_checklist_v1") ?? "{}"),
+    ).toMatchObject({
+      completedSteps: ["add_expense", "set_budget"],
+    });
+  });
+});

--- a/apps/web/src/core/onboarding/ModuleChecklist.tsx
+++ b/apps/web/src/core/onboarding/ModuleChecklist.tsx
@@ -15,10 +15,10 @@ import { safeReadLS, safeWriteLS } from "@shared/lib/storage";
 import {
   MODULE_CHECKLISTS,
   getChecklistState,
-  markChecklistStepDone,
   markChecklistSeen,
   dismissChecklist,
   isChecklistVisible,
+  saveChecklistState,
   type DashboardModuleId,
   type KVStore,
 } from "@sergeant/shared";
@@ -111,21 +111,38 @@ export function ModuleChecklist({
   const handleStepDone = useCallback(
     (stepId: string, action?: string) => {
       hapticTap();
-      const next = markChecklistStepDone(localStorageStore, moduleId, stepId);
-      setState(next);
+      setState((previousState) => {
+        const persistedState = getChecklistState(localStorageStore, moduleId);
+        const completedSteps = Array.from(
+          new Set([
+            ...persistedState.completedSteps,
+            ...previousState.completedSteps,
+            stepId,
+          ]),
+        );
+        const next = {
+          completedSteps,
+          dismissed: persistedState.dismissed || previousState.dismissed,
+          firstSeenAt: previousState.firstSeenAt ?? persistedState.firstSeenAt,
+        };
+        saveChecklistState(localStorageStore, moduleId, next);
+        return next;
+      });
 
-      // Trigger action if provided
       if (action) {
         onAction?.(action);
       }
-
-      // Auto-hide when all steps completed
-      if (next.completedSteps.length >= def.steps.length) {
-        setTimeout(() => setVisible(false), 600);
-      }
     },
-    [moduleId, def.steps.length, onAction],
+    [moduleId, onAction],
   );
+
+  useEffect(() => {
+    if (visible && completed >= total) {
+      const timeout = setTimeout(() => setVisible(false), 600);
+      return () => clearTimeout(timeout);
+    }
+    return undefined;
+  }, [completed, total, visible]);
 
   const handleDismiss = useCallback(() => {
     hapticTap();
@@ -227,17 +244,39 @@ export function ModuleChecklist({
           {def.steps.map((step, idx) => {
             const done = state.completedSteps.includes(step.id);
             return (
-              <button
+              <div
                 key={step.id}
-                type="button"
-                onClick={() => !done && handleStepDone(step.id, step.action)}
-                disabled={done}
+                role="button"
+                tabIndex={done ? -1 : 0}
+                aria-disabled={done}
+                onClick={(event) => {
+                  const target = event.target;
+                  if (
+                    done ||
+                    (target instanceof HTMLElement &&
+                      target.closest('[role="checkbox"]'))
+                  ) {
+                    return;
+                  }
+                  handleStepDone(step.id, step.action);
+                }}
+                onKeyDown={(event) => {
+                  if (
+                    done ||
+                    event.target !== event.currentTarget ||
+                    (event.key !== "Enter" && event.key !== " ")
+                  ) {
+                    return;
+                  }
+                  event.preventDefault();
+                  handleStepDone(step.id, step.action);
+                }}
                 className={cn(
                   "w-full flex items-center gap-3 px-3 py-2.5 rounded-xl text-left",
                   "transition-all duration-200",
                   done
                     ? "bg-transparent"
-                    : "bg-panel/60 hover:bg-panel border border-line/50 hover:border-line",
+                    : "bg-panel/60 hover:bg-panel border border-line/50 hover:border-line cursor-pointer",
                   "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45",
                   "motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1",
                 )}
@@ -245,7 +284,11 @@ export function ModuleChecklist({
               >
                 <AnimatedCheckbox
                   checked={done}
-                  onChange={() => !done && handleStepDone(step.id, step.action)}
+                  onChange={(checked) =>
+                    checked && handleStepDone(step.id, step.action)
+                  }
+                  disabled={done}
+                  aria-label={step.label}
                   size="sm"
                   className={cn(done && styles.checkBg)}
                 />
@@ -264,7 +307,7 @@ export function ModuleChecklist({
                     className="text-muted shrink-0"
                   />
                 )}
-              </button>
+              </div>
             );
           })}
 


### PR DESCRIPTION
## What changed

<!-- Brief description of the changes. -->

## Why

<!-- Motivation, linked issue, or context. -->

## How to test

<!-- Steps for a reviewer to verify correctness. -->

---

## Pre-flight (Hard Rule #15)

<!--
Before opening this PR you should have read the relevant governance.
Tick what applies; if a box is N/A, write "n/a" inline.
-->

- [ ] Read the `AGENTS.md` Hard Rules that apply to the touched paths.
- [ ] Read the matching playbook in `docs/playbooks/` (or noted that none exists).
- [ ] Checked freshness headers of docs cited in the change.

## Docs updated alongside code? (Hard Rule #15)

<!--
Documentation is part of the change set, not a follow-up. Tick what applies.
-->

- [ ] API contract change — `packages/api-client/**` types + contract test updated (Hard Rule #3).
- [ ] New / removed npm script — `CONTRIBUTING.md § Everyday Commands` and `CLAUDE.md § Quick commands` updated.
- [ ] New design token / component / palette — `docs/design/design-system.md` (and `BRANDBOOK.md` if branded) updated.
- [ ] Deprecation — `@deprecated` JSDoc with `@removeBy` added; consuming docs marked `> **Status:** Deprecated`.
- [ ] Freshness header bumped on docs whose claims changed (`> Last validated: YYYY-MM-DD by @owner`).
- [ ] N/A — no docs invalidated by this change.

## How AI-tested this PR

<!-- If this PR was created by an AI agent, describe what was verified. -->

- [ ] Manual smoke (which flow?): ...
- [ ] Vitest passes: ...
- [ ] No new `AI-DANGER` markers added without justification.
- [ ] Docs prose uses Ukrainian where practical, per `AGENTS.md`.
- [ ] `pnpm dead-code:files` clean (or new files marked `@scaffolded`).

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [ ] No — no new permanent rules

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1213" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
