### PR TITLE
Polish backend timing and sync validation

### DIFF
--- a/apps/server/src/http/health.ts
+++ b/apps/server/src/http/health.ts
@@ -4,6 +4,7 @@ import { getRedisStats, pingRedis } from "../lib/redis.js";
 import { getPoolStats } from "../db.js";
 import { backgroundQueue } from "../lib/backgroundQueue.js";
 import { anthropicCircuitBreaker } from "../lib/circuitBreaker.js";
+import { elapsedMs } from "../lib/timing.js";
 
 interface DbPool {
   query(sql: string): Promise<unknown>;
@@ -50,9 +51,9 @@ export function createHealthzHandler(pool: DbPool): RequestHandler {
 
     // Database check
     try {
-      const start = Date.now();
+      const start = process.hrtime.bigint();
       await pool.query("SELECT 1");
-      const latencyMs = Date.now() - start;
+      const latencyMs = elapsedMs(start);
       checks.database = {
         status: "healthy",
         details: { latencyMs, ...getPoolStats() },

--- a/apps/server/src/lib/backgroundQueue.test.ts
+++ b/apps/server/src/lib/backgroundQueue.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Mock } from "vitest";
+
+vi.mock("../obs/logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+import { logger as _logger } from "../obs/logger.js";
+import { BackgroundQueue } from "./backgroundQueue.js";
+
+const logger = _logger as unknown as {
+  debug: Mock;
+  error: Mock;
+  info: Mock;
+  warn: Mock;
+};
+
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+}
+
+describe("BackgroundQueue", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("clears the timeout timer after a successful job", async () => {
+    const queue = new BackgroundQueue({ concurrency: 1, jobTimeoutMs: 1_000 });
+
+    expect(queue.enqueue("fast", async () => undefined)).toBe("job_1");
+    await flushMicrotasks();
+
+    expect(queue.getStats().running).toBe(0);
+    expect(vi.getTimerCount()).toBe(0);
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.objectContaining({ msg: "bg_job_completed", jobName: "fast" }),
+    );
+  });
+
+  it("logs timed-out jobs and releases the worker slot", async () => {
+    const queue = new BackgroundQueue({ concurrency: 1, jobTimeoutMs: 50 });
+
+    queue.enqueue("slow", () => new Promise(() => undefined));
+    expect(queue.getStats().running).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(50);
+    await flushMicrotasks();
+
+    expect(queue.getStats().running).toBe(0);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        msg: "bg_job_failed",
+        jobName: "slow",
+        error: "Job slow timed out after 50ms",
+      }),
+    );
+  });
+});

--- a/apps/server/src/lib/backgroundQueue.ts
+++ b/apps/server/src/lib/backgroundQueue.ts
@@ -1,4 +1,5 @@
 import { logger } from "../obs/logger.js";
+import { elapsedMs } from "./timing.js";
 
 /**
  * Simple in-memory background job queue for non-critical tasks.
@@ -42,7 +43,7 @@ interface QueueOptions {
   jobTimeoutMs?: number;
 }
 
-class BackgroundQueue {
+export class BackgroundQueue {
   private queue: Job[] = [];
   private running = 0;
   private jobIdCounter = 0;
@@ -115,37 +116,37 @@ class BackgroundQueue {
    * Run a single job with timeout and error handling.
    */
   private async runJob(job: Job): Promise<void> {
-    const startTime = Date.now();
+    const startTime = process.hrtime.bigint();
+    let timeoutTimer: NodeJS.Timeout | undefined;
 
     try {
-      // Create timeout promise
       const timeoutPromise = new Promise<never>((_, reject) => {
-        setTimeout(() => {
+        timeoutTimer = setTimeout(() => {
           reject(
             new Error(`Job ${job.name} timed out after ${this.jobTimeoutMs}ms`),
           );
         }, this.jobTimeoutMs);
+        if (typeof timeoutTimer.unref === "function") timeoutTimer.unref();
       });
 
-      // Race job against timeout
       await Promise.race([job.fn(), timeoutPromise]);
 
-      const durationMs = Date.now() - startTime;
       logger.debug({
         msg: "bg_job_completed",
         jobId: job.id,
         jobName: job.name,
-        durationMs,
+        durationMs: elapsedMs(startTime),
       });
     } catch (error) {
-      const durationMs = Date.now() - startTime;
       logger.error({
         msg: "bg_job_failed",
         jobId: job.id,
         jobName: job.name,
-        durationMs,
+        durationMs: elapsedMs(startTime),
         error: error instanceof Error ? error.message : String(error),
       });
+    } finally {
+      clearTimeout(timeoutTimer);
     }
   }
 

--- a/apps/server/src/lib/groq.ts
+++ b/apps/server/src/lib/groq.ts
@@ -1,4 +1,5 @@
 import { recordExternalHttp } from "./externalHttp.js";
+import { elapsedMs, isAbortError } from "./timing.js";
 
 const GROQ_TRANSCRIBE_URL =
   "https://api.groq.com/openai/v1/audio/transcriptions";
@@ -112,7 +113,7 @@ export async function transcribeAudio(
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   const signal = composeSignal(controller, opts.signal);
-  const startedAt = Date.now();
+  const startedAt = process.hrtime.bigint();
 
   let response: Response | null = null;
   try {
@@ -123,8 +124,8 @@ export async function transcribeAudio(
       signal,
     });
   } catch (err) {
-    const ms = Date.now() - startedAt;
-    const aborted = (err as { name?: string })?.name === "AbortError";
+    const ms = elapsedMs(startedAt);
+    const aborted = isAbortError(err);
     const outcome = aborted ? "timeout" : "error";
     recordExternalHttp("groq", outcome, ms);
     throw new GroqTranscribeError(
@@ -136,7 +137,7 @@ export async function transcribeAudio(
     clearTimeout(timer);
   }
 
-  const ms = Date.now() - startedAt;
+  const ms = elapsedMs(startedAt);
 
   if (!response.ok) {
     let detail = "";

--- a/apps/server/src/modules/sync/sync.test.ts
+++ b/apps/server/src/modules/sync/sync.test.ts
@@ -276,6 +276,31 @@ describe("syncPushAll metric correctness around transaction boundary", () => {
       module: "nutrition",
     });
   });
+
+  it("missing clientUpdatedAt in push_all → 400 before transaction", async () => {
+    const res = makeRes();
+
+    await syncPushAll(
+      makeReq({
+        modules: {
+          finyk: { data: { x: 1 } },
+        },
+      }),
+      res,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toMatchObject({ error: "Некоректні дані запиту" });
+    expect(res.body.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: "modules.finyk.clientUpdatedAt" }),
+      ]),
+    );
+    expect(pool.connect).not.toHaveBeenCalled();
+    expect(syncOperationsTotal.inc.mock.calls.map(([l]) => l)).toContainEqual(
+      expect.objectContaining({ op: "push_all", outcome: "invalid" }),
+    );
+  });
 });
 
 describe("syncPullAll module filtering", () => {

--- a/apps/server/src/modules/sync/sync.ts
+++ b/apps/server/src/modules/sync/sync.ts
@@ -49,8 +49,8 @@ interface ModuleDataUpsertRow {
 }
 
 interface PushAllPayloadEntry {
-  data?: unknown;
-  clientUpdatedAt?: string | number | Date;
+  data: unknown;
+  clientUpdatedAt: string | number | Date;
 }
 
 interface PushAllResult {
@@ -374,7 +374,7 @@ export async function syncPushAll(req: Request, res: Response): Promise<void> {
     await client.query("BEGIN");
     for (const [mod, payload] of Object.entries(modules)) {
       if (!VALID_MODULES.has(mod)) continue;
-      const { data, clientUpdatedAt } = payload || {};
+      const { data, clientUpdatedAt } = payload;
       if (data === undefined || data === null) continue;
       const blob = JSON.stringify(data);
       if (blob.length > MAX_BLOB_SIZE) {
@@ -384,7 +384,7 @@ export async function syncPushAll(req: Request, res: Response): Promise<void> {
       }
       // `clientUpdatedAt` — required у `SyncPushAllSchema`; fallback на
       // `new Date()` прибрано з тієї ж причини, що й у `syncPush` вище.
-      const clientTs = new Date(clientUpdatedAt ?? Date.now());
+      const clientTs = new Date(clientUpdatedAt);
       const r = await client.query<ModuleDataUpsertRow>(
         `INSERT INTO module_data (user_id, module, data, client_updated_at, version)
          VALUES ($1, $2, $3, $4, 1)


### PR DESCRIPTION
## What changed

- Reused the shared `elapsedMs()` / `isAbortError()` timing utilities in backend health checks, background jobs, and Groq transcription.
- Switched affected duration measurements from `Date.now()` deltas to `process.hrtime.bigint()` + `elapsedMs()`.
- Made `BackgroundQueue` exportable for focused unit coverage.
- Ensured background job timeout timers are cleared in `finally` and `unref()`ed so completed jobs do not leave timers behind.
- Tightened `syncPushAll` typing/handling so `clientUpdatedAt` is treated as required after schema validation instead of falling back to `Date.now()`.
- Added tests for background queue timeout cleanup/failure handling and `push_all` missing `clientUpdatedAt` validation.

## Why

This is backend polish: reduce duplicated timing logic, make duration measurements more consistent, improve queue cleanup behavior, and align `syncPushAll` runtime behavior with the shared API schema requiring `clientUpdatedAt`.

Review focus:
- Confirm fractional millisecond durations are acceptable for health/external HTTP/background job metrics.
- Confirm removing the `Date.now()` fallback in `syncPushAll` is compatible with expected clients.
- Confirm exporting `BackgroundQueue` for tests is acceptable as a small API-surface expansion.

## How to test

```bash
pnpm --filter @sergeant/server lint
pnpm --filter @sergeant/server typecheck
pnpm --filter @sergeant/server test
pnpm --filter @sergeant/server build
```

---

## Pre-flight (Hard Rule #15)

- [x] Read the `AGENTS.md` Hard Rules that apply to the touched paths.
- [x] Read the matching playbook in `docs/playbooks/` (or noted that none exists).
- [x] Checked freshness headers of docs cited in the change.

## Docs updated alongside code? (Hard Rule #15)

- [ ] API contract change — `packages/api-client/**` types + contract test updated (Hard Rule #3). n/a — existing shared schema already required `clientUpdatedAt`; this PR aligns server runtime handling.
- [ ] New / removed npm script — `CONTRIBUTING.md § Everyday Commands` and `CLAUDE.md § Quick commands` updated. n/a
- [ ] New design token / component / palette — `docs/design/design-system.md` (and `BRANDBOOK.md` if branded) updated. n/a
- [ ] Deprecation — `@deprecated` JSDoc with `@removeBy` added; consuming docs marked `> **Status:** Deprecated`. n/a
- [ ] Freshness header bumped on docs whose claims changed (`> Last validated: YYYY-MM-DD by @owner`). n/a
- [x] N/A — no docs invalidated by this change.

## How AI-tested this PR

- [ ] Manual smoke (which flow?): n/a — backend library/handler polish only.
- [x] Vitest passes: `pnpm --filter @sergeant/server test` — 52 files / 607 tests.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.
- [ ] `pnpm dead-code:files` clean (or new files marked `@scaffolded`). Not run; server lint/typecheck/test/build passed.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

Link to Devin session: https://app.devin.ai/sessions/c1e4d97c44304b789eb0848dacf57ebd
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout handling for background jobs to prevent lingering timers
  * Strengthened validation for sync operations to ensure complete data integrity

* **Tests**
  * Added comprehensive test coverage for background job queue behavior and sync payload validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->