### PR TITLE
perf(web): idle-aware module prefetch + intent-prefetch on dashboard cards

### DIFF
--- a/apps/web/src/core/App.tsx
+++ b/apps/web/src/core/App.tsx
@@ -213,12 +213,24 @@ function AppInner() {
   const toast = useToast();
   useSyncErrorToast(sync.syncErrorDetail, toast, sync.pushAll);
 
-  // Prefetch critical module chunks on idle after initial render
+  // Prefetch critical module chunks once the main thread is free.
+  // Previously hard-coded to `setTimeout(2000)`, which over-paid on fast
+  // devices (idle by 200 ms) and under-paid on slow ones (still hydrating
+  // at 2 s). `requestIdleCallback` lets the browser fire whenever the
+  // initial-render burst is genuinely done; the 4 s `timeout` cap stops
+  // a permanently-busy main thread from starving the prefetch entirely.
+  // Safari ≤ 16 has no `requestIdleCallback`, so we keep the original
+  // 2 s fallback for it.
   useEffect(() => {
-    // Wait for initial paint, then prefetch modules
+    if ("requestIdleCallback" in window) {
+      const id = requestIdleCallback(() => prefetchCriticalModules(), {
+        timeout: 4000,
+      });
+      return () => cancelIdleCallback(id);
+    }
     const timer = setTimeout(() => {
       prefetchCriticalModules();
-    }, 2000); // 2s delay to prioritize initial render
+    }, 2000);
     return () => clearTimeout(timer);
   }, []);
 

--- a/apps/web/src/core/hub/dashboard/BentoCard.tsx
+++ b/apps/web/src/core/hub/dashboard/BentoCard.tsx
@@ -3,6 +3,7 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
+import { getModulePrefetchProps } from "../../lib/intentPrefetch";
 import {
   MODULE_CONFIGS,
   type ModuleConfig,
@@ -313,9 +314,24 @@ export const SortableCard = memo(function SortableCard({
   // primary `<button>` — both fail axe a11y rules.
   // In edit mode the same listeners move to the visible grip handle so
   // accidental drags from the card body don't fight the explicit handle.
+  // We also fold in `getModulePrefetchProps(id)` (intent-prefetch on hover/
+  // focus) when not editing — the same primary button is the user's "I'm
+  // about to open this module" affordance, so warming its chunk on hover
+  // shaves the next dynamic-import RTT off the click handler. Suppressed
+  // in edit mode because hovers there are about reordering, not opening.
   const dndProps = useMemo(
     () => ({ ...attributes, ...listeners }),
     [attributes, listeners],
+  );
+
+  const intentProps = useMemo(
+    () => (editMode ? null : getModulePrefetchProps(id)),
+    [editMode, id],
+  );
+
+  const primaryProps = useMemo(
+    () => (editMode ? undefined : { ...dndProps, ...intentProps }),
+    [editMode, dndProps, intentProps],
   );
 
   const handleClick = useCallback(() => onOpenModule(id), [onOpenModule, id]);
@@ -330,7 +346,7 @@ export const SortableCard = memo(function SortableCard({
         onClick={handleClick}
         onQuickAdd={quickAdd}
         primaryRef={editMode ? undefined : setActivatorNodeRef}
-        primaryProps={editMode ? undefined : dndProps}
+        primaryProps={primaryProps}
         handleRef={editMode ? setActivatorNodeRef : undefined}
         handleProps={editMode ? dndProps : undefined}
         isDragging={isDragging}

--- a/apps/web/src/core/lib/intentPrefetch.ts
+++ b/apps/web/src/core/lib/intentPrefetch.ts
@@ -1,0 +1,51 @@
+/**
+ * Intent-prefetch handlers (decoupled).
+ *
+ * `useRoutePrefetch.ts` owns the static `import("../../modules/...")`
+ * factories. Importing it from a strict-scope file (e.g. anything under
+ * `src/core/hub/**`) drags the entire module subgraph — including
+ * `Workouts.tsx` and `FizrukHeader.tsx` — into `tsconfig.strict.json`'s
+ * type-check program, surfacing pre-existing strict-null errors that
+ * the per-module `include` whitelist deliberately keeps out of scope.
+ *
+ * To add intent-prefetch on dashboard cards without dragging fizruk
+ * types into hub's strict program, this file:
+ *
+ *  1. Holds a runtime registry of the actual prefetch function.
+ *  2. Exposes `getModulePrefetchProps(id)` returning hover/focus
+ *     handlers that consult the registry at event time.
+ *
+ * `useRoutePrefetch.ts` is the only registrar (called once at module
+ * init); it is loaded synchronously by `App.tsx`, so the registry is
+ * populated before any dashboard card mounts. If for any reason the
+ * registrar hasn't run yet, the handlers no-op silently — intent-
+ * prefetch is best-effort, not a correctness guarantee.
+ */
+
+export type IntentPrefetchModuleId =
+  | "finyk"
+  | "fizruk"
+  | "routine"
+  | "nutrition";
+
+type Prefetcher = (id: IntentPrefetchModuleId) => void;
+
+let registered: Prefetcher | null = null;
+
+export function setModulePrefetcher(fn: Prefetcher): void {
+  registered = fn;
+}
+
+export interface ModuleIntentProps {
+  onMouseEnter: () => void;
+  onFocus: () => void;
+}
+
+export function getModulePrefetchProps(
+  id: IntentPrefetchModuleId,
+): ModuleIntentProps {
+  return {
+    onMouseEnter: () => registered?.(id),
+    onFocus: () => registered?.(id),
+  };
+}

--- a/apps/web/src/core/lib/useRoutePrefetch.ts
+++ b/apps/web/src/core/lib/useRoutePrefetch.ts
@@ -8,7 +8,15 @@
  *
  * Uses dynamic imports matching lazy() definitions in App.tsx to ensure
  * the same chunks are loaded.
+ *
+ * Hover/focus handlers for dashboard cards live in
+ * `intentPrefetch.ts` — that file holds a runtime registry which we
+ * populate below. The split exists so that strict-scope hub files
+ * can call `getModulePrefetchProps` without transitively pulling
+ * `import("../../modules/fizruk/...")` into their type-check program.
  */
+
+import { setModulePrefetcher } from "./intentPrefetch";
 
 type ModuleKey = "finyk" | "fizruk" | "routine" | "nutrition";
 type PageKey =
@@ -102,26 +110,47 @@ export function prefetchPage(page: PageKey): void {
 
 /**
  * Prefetch all primary modules on idle
+ *
+ * Schedules each module on its own idle callback rather than wall-clock
+ * `setTimeout(index * 500)` slots. Wall-clock staggering hides network
+ * congestion at the cost of always-blocking 2 s of bandwidth on every
+ * load — even on a snappy main thread. Idle scheduling lets the browser
+ * pace the prefetches against real CPU/network pressure: on fast
+ * devices the four modules land back-to-back, on slow ones the
+ * scheduler defers the tail of the queue until the user actually has
+ * spare time. The internal `prefetchModule` already wraps each import
+ * in its own `requestIdleCallback`, so this is staggering of
+ * staggering — the priority order is preserved by the order of calls,
+ * but no module starves on a busy main thread.
+ *
+ * Falls back to a single `setTimeout(0)` chain on Safari (no
+ * `requestIdleCallback`); a 100 ms tail keeps total wall-clock cost
+ * under the previous 2 s envelope while still draining the queue
+ * eagerly when nothing else is happening.
  */
 export function prefetchCriticalModules(): void {
   // Order by usage probability
   const priority: ModuleKey[] = ["finyk", "routine", "fizruk", "nutrition"];
 
+  if ("requestIdleCallback" in window) {
+    priority.forEach((module) => {
+      requestIdleCallback(() => prefetchModule(module), { timeout: 3000 });
+    });
+    return;
+  }
   priority.forEach((module, index) => {
-    // Stagger prefetches to avoid network congestion
-    setTimeout(() => prefetchModule(module), index * 500);
+    setTimeout(() => prefetchModule(module), index * 100);
   });
 }
 
 /**
- * Hook props for hover/focus prefetch
+ * Register the intent-prefetch dispatcher so hover/focus handlers in
+ * `intentPrefetch.ts` can reach `prefetchModule` without taking a
+ * direct import on this file. Runs once at module init — `App.tsx`
+ * imports this module synchronously at startup, well before any
+ * dashboard card mounts.
  */
-export function getModulePrefetchProps(module: ModuleKey) {
-  return {
-    onMouseEnter: () => prefetchModule(module),
-    onFocus: () => prefetchModule(module),
-  };
-}
+setModulePrefetcher((module) => prefetchModule(module));
 
 export function getPagePrefetchProps(page: PageKey) {
   return {


### PR DESCRIPTION
## What

PR 4 of 5 from the front-end top-5 review.

- Replace `setTimeout(2000)` for `prefetchCriticalModules()` with `requestIdleCallback` (4 s timeout cap, Safari ≤ 16 keeps the 2 s setTimeout fallback).
- Schedule each module on its own idle callback instead of wall-clock 500 ms slots — fast devices land all four back-to-back, slow ones defer the tail until the user actually has spare time.
- Add hover/focus intent-prefetch on dashboard cards (`SortableCard.primaryProps`) so the next dynamic-import RTT is paid before the click handler fires. Suppressed in edit mode (hovers there are about reordering, not opening).

## How

Why the new file `core/lib/intentPrefetch.ts`:

`useRoutePrefetch.ts` owns the static `import("../../modules/...")` factories. Importing it from a strict-scope file under `src/core/hub/**` drags the whole module subgraph (Workouts.tsx, FizrukHeader.tsx, …) into `tsconfig.strict.json`, surfacing pre-existing `strictNullChecks` errors that the per-module `include` whitelist deliberately keeps out of scope. To stay out of that subgraph, `intentPrefetch.ts` holds a runtime registry, `useRoutePrefetch.ts` registers `prefetchModule` once at module init, and `BentoCard` consults the registry via hover/focus handlers — zero static dynamic imports on the consumer side.

## Files

- `apps/web/src/core/App.tsx` — `useEffect` swapped from `setTimeout(2000)` to `requestIdleCallback({ timeout: 4000 })` with cleanup, fallback preserved.
- `apps/web/src/core/lib/useRoutePrefetch.ts` — `prefetchCriticalModules()` schedules each module via `requestIdleCallback({ timeout: 3000 })`; registers `prefetchModule` with `intentPrefetch.ts`.
- `apps/web/src/core/lib/intentPrefetch.ts` — new file, ~50 LOC, owns the registry + `getModulePrefetchProps(id)`.
- `apps/web/src/core/hub/dashboard/BentoCard.tsx` — `SortableCard` merges dnd-kit listeners with hover/focus intent props on the primary button (suppressed in edit mode).

## Tests

- `pnpm --filter @sergeant/web typecheck` — clean (all four tsconfigs).
- `pnpm --filter @sergeant/web lint` — clean.
- `pnpm --filter @sergeant/web test` — touched files green; the wider test run flaked once on `HubBottomNav` timeout under concurrent load but passes deterministically when run alone.

## Notes

Original plan also included a Cyrillic woff2 preload, but DM Sans (the app font) ships no Cyrillic glyphs at all (Google Fonts serves only `latin`, `latin-ext`, and `cyrillic-ext` — no Cyrillic), so that item was dropped from this PR rather than implemented as a no-op preload.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Modules now load significantly faster through intelligent background prefetching that runs when your browser is idle, reducing impact on responsiveness
  * Added proactive prefetching on hover and focus interactions, ensuring modules load faster right when you need them
  * Improved overall application performance with enhanced compatibility across all supported browsers and devices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->