### PR TITLE
Devin/1777592579 UI ux top10

### DIFF
--- a/apps/web/src/core/app/HubHeader.tsx
+++ b/apps/web/src/core/app/HubHeader.tsx
@@ -86,13 +86,18 @@ export function HubHeader({
         "transition-all duration-300 ease-out",
         // Progressive header states
         isHidden && "-translate-y-full",
-        isShrunk ? "pt-3 pb-2" : "pt-10 pb-3",
+        isShrunk ? "pt-2 pb-2" : "pt-6 pb-2.5",
         hasBlur && "bg-bg/80 backdrop-blur-md border-b border-line/50",
       )}
       style={{
+        // Prefer the OS-reported safe-area inset on devices that have one
+        // (notched/dynamic-island phones, PWA standalone with status-bar);
+        // fall back to a tighter 1.5rem (24px) baseline on the web instead
+        // of the previous 2.5rem (40px), which ate ~16px of dashboard
+        // real estate on every cold start without serving any system chrome.
         paddingTop: isShrunk
           ? undefined
-          : "max(2.5rem, env(safe-area-inset-top))",
+          : "max(1.5rem, env(safe-area-inset-top))",
       }}
     >
       {/* ── Row 1: Mark + Wordmark + Action icons ─────────────── */}
@@ -153,7 +158,7 @@ export function HubHeader({
       {/* брендовий шум, який забирав вертикальний простір. */}
       <p
         className={cn(
-          "mt-2 ml-[3px] text-[13px] leading-snug text-muted truncate",
+          "mt-1.5 ml-[3px] text-[13px] leading-snug text-muted truncate",
           "transition-all duration-300",
           isShrunk && "opacity-0 h-0 mt-0 overflow-hidden",
         )}

--- a/apps/web/src/core/app/HubHeader.tsx
+++ b/apps/web/src/core/app/HubHeader.tsx
@@ -120,7 +120,7 @@ export function HubHeader({
               aria-label="Пошук"
               className={ICON_BUTTON_CLS}
             >
-              <Icon name="search" size={20} />
+              <Icon name="search" size="lg" />
             </button>
           </Tooltip>
 
@@ -143,7 +143,7 @@ export function HubHeader({
                 aria-label="Увійти в акаунт"
                 className={ICON_BUTTON_CLS}
               >
-                <Icon name="user" size={20} />
+                <Icon name="user" size="lg" />
               </button>
             </Tooltip>
           )}

--- a/apps/web/src/core/hub/HubDashboard.tsx
+++ b/apps/web/src/core/hub/HubDashboard.tsx
@@ -420,59 +420,11 @@ export function HubDashboard({
         </StaggerChild>
       )}
 
-      {/* FTUX-гейт: до першого реального запису всі data-driven блоки
-       * приховуємо, бо вони порожні / сигнал «advice без даних».
-       * - TodaySummaryStrip — нулі по всіх модулях.
-       * - AssistantAdviceCard — coach працює на історії; нічого корисного.
-       * - DailyNudge — нудж за сценаріями, які ще не існують.
-       * Лишаємо: hero, checklist, module-bento (навігація), digest-fter.
-       * Після `hasRealEntry === true` блок з’являється цілісним пакетом. */}
-      {hasRealEntry && (
-        <>
-          {/* "Твій день" summary strip */}
-          <StaggerChild index={si++}>
-            <TodaySummaryStrip onOpenModule={onOpenModule} />
-          </StaggerChild>
-
-          {/* «Підказки» секція: AssistantAdvice + DailyNudge — обидві
-           * картки показували пораду на день, але рендерились як два
-           * незалежних блоки з різним візуальним chrome. Обʼєднання
-           * під одним SectionHeading знижує card-density (#1130).
-           * Collapsible so users with many modules can reduce scroll depth. */}
-          <StaggerChild index={si++}>
-            <CollapsibleSection
-              storageKey="sergeant:hub.hints.open"
-              title="Підказки"
-              collapsedIcon="lightbulb"
-              collapsedSubtitle={
-                coachLoading
-                  ? "Готую AI-пораду…"
-                  : coachError
-                    ? "Не вдалось отримати AI-пораду"
-                    : activeNudge && !reengagement.show
-                      ? "AI-порада + нагадування"
-                      : "AI-порада на день"
-              }
-            >
-              <AssistantAdviceCard
-                insight={coachInsightText}
-                loading={coachLoading}
-                error={coachError}
-                onRefresh={coachRefresh}
-              />
-              {activeNudge && !reengagement.show && (
-                <DailyNudge
-                  nudge={activeNudge}
-                  sessionDays={sessionDays}
-                  onDismiss={() => setNudgeDismissed(true)}
-                />
-              )}
-            </CollapsibleSection>
-          </StaggerChild>
-        </>
-      )}
-
-      {/* MODULE CARDS — 2×2 bento grid */}
+      {/* MODULE CARDS — 2×2 bento grid.
+       * Hoisted above the FTUX-gated Hints/Analytics block so the
+       * primary navigation surface is reachable above-the-fold on
+       * smaller viewports — secondary, data-dependent insights load
+       * underneath rather than burying the modules grid. */}
       <StaggerChild index={si++}>
         <section className="space-y-2">
           <div className="flex items-center justify-between gap-2 px-0.5">
@@ -541,6 +493,58 @@ export function HubDashboard({
           )}
         </section>
       </StaggerChild>
+
+      {/* FTUX-гейт: до першого реального запису всі data-driven блоки
+       * приховуємо, бо вони порожні / сигнал «advice без даних».
+       * - TodaySummaryStrip — нулі по всіх модулях.
+       * - AssistantAdviceCard — coach працює на історії; нічого корисного.
+       * - DailyNudge — нудж за сценаріями, які ще не існують.
+       * Лишаємо: hero, checklist, module-bento (навігація), digest-fter.
+       * Після `hasRealEntry === true` блок з’являється цілісним пакетом. */}
+      {hasRealEntry && (
+        <>
+          {/* "Твій день" summary strip */}
+          <StaggerChild index={si++}>
+            <TodaySummaryStrip onOpenModule={onOpenModule} />
+          </StaggerChild>
+
+          {/* «Підказки» секція: AssistantAdvice + DailyNudge — обидві
+           * картки показували пораду на день, але рендерились як два
+           * незалежних блоки з різним візуальним chrome. Обʼєднання
+           * під одним SectionHeading знижує card-density (#1130).
+           * Collapsible so users with many modules can reduce scroll depth. */}
+          <StaggerChild index={si++}>
+            <CollapsibleSection
+              storageKey="sergeant:hub.hints.open"
+              title="Підказки"
+              collapsedIcon="lightbulb"
+              collapsedSubtitle={
+                coachLoading
+                  ? "Готую AI-пораду…"
+                  : coachError
+                    ? "Не вдалось отримати AI-пораду"
+                    : activeNudge && !reengagement.show
+                      ? "AI-порада + нагадування"
+                      : "AI-порада на день"
+              }
+            >
+              <AssistantAdviceCard
+                insight={coachInsightText}
+                loading={coachLoading}
+                error={coachError}
+                onRefresh={coachRefresh}
+              />
+              {activeNudge && !reengagement.show && (
+                <DailyNudge
+                  nudge={activeNudge}
+                  sessionDays={sessionDays}
+                  onDismiss={() => setNudgeDismissed(true)}
+                />
+              )}
+            </CollapsibleSection>
+          </StaggerChild>
+        </>
+      )}
 
       {/* «Аналітика» секція (FTUX-гейт): insights-panel + weekly-digest —
        * обидва data-driven блоки на історії. До першого реального запису

--- a/apps/web/src/core/hub/HubDashboard.tsx
+++ b/apps/web/src/core/hub/HubDashboard.tsx
@@ -445,7 +445,7 @@ export function HubDashboard({
             >
               <Icon
                 name="grip-vertical"
-                size={12}
+                size="xs"
                 strokeWidth={2}
                 aria-hidden
               />

--- a/apps/web/src/core/hub/HubDashboard.tsx
+++ b/apps/web/src/core/hub/HubDashboard.tsx
@@ -462,7 +462,7 @@ export function HubDashboard({
               items={displayOrder}
               strategy={rectSortingStrategy}
             >
-              <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+              <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
                 {displayOrder.map((id) => (
                   <SortableCard
                     key={id}

--- a/apps/web/src/core/hub/HubSearch.tsx
+++ b/apps/web/src/core/hub/HubSearch.tsx
@@ -180,6 +180,7 @@ function searchFinyk(tokens: string[]): Hit[] {
           title: tx.description || tx.comment || "Транзакція",
           subtitle: `${sign}${Math.abs(amount).toLocaleString("uk-UA", { maximumFractionDigits: 2 })} ₴ · ${time > 1e10 ? localDateKey(new Date(time)) : localDateKey(new Date(time * 1000))}`,
           icon: "💳",
+          target: { kind: "module", moduleId: "finyk" },
         },
         tokens,
         20,
@@ -203,6 +204,7 @@ function searchFinyk(tokens: string[]): Hit[] {
           title: s.name || "Підписка",
           subtitle: `Підписка · ${amt ? (amt / 100).toFixed(0) + " ₴" : ""}`,
           icon: "🔄",
+          target: { kind: "module", moduleId: "finyk" },
         },
         tokens,
         25,
@@ -247,6 +249,7 @@ function searchFizruk(tokens: string[]): Hit[] {
             ? ` · ${itemsRaw.length} вправ · ${fullTokensText}`
             : ""),
         icon: "🏋️",
+        target: { kind: "module", moduleId: "fizruk" },
       },
       tokens,
       10,
@@ -270,6 +273,7 @@ function searchFizruk(tokens: string[]): Hit[] {
           (Array.isArray(e.muscles) ? e.muscles : []).join(", ") ||
           "Власна вправа",
         icon: "💪",
+        target: { kind: "module", moduleId: "fizruk" },
       },
       tokens,
       15,
@@ -310,6 +314,7 @@ function searchRoutine(tokens: string[]): Hit[] {
         title,
         subtitle: h.archived ? "Архівовано" : h.recurrence || "daily",
         icon: "✅",
+        target: { kind: "module", moduleId: "routine" },
       },
       tokens,
       10,
@@ -370,8 +375,7 @@ const SETTINGS_INDEX: ReadonlyArray<{
     id: "notifications",
     title: "Нагадування",
     description: "Push-нагадування і щоденні сповіщення",
-    keywords:
-      "сповіщення нагадування пуш push notifications reminders щоденні",
+    keywords: "сповіщення нагадування пуш push notifications reminders щоденні",
     icon: "bell",
   },
   {
@@ -541,6 +545,7 @@ function searchNutrition(tokens: string[]): Hit[] {
           title: m.name || "Прийом їжі",
           subtitle: `${date} · ${m.macros?.kcal ?? 0} ккал`,
           icon: "🥗",
+          target: { kind: "module", moduleId: "nutrition" },
         },
         tokens,
         10,
@@ -921,34 +926,34 @@ export function HubSearch({ onClose, onOpenModule }: HubSearchProps) {
             {group.items.length >= 10 &&
               moduleId !== "settings" &&
               moduleId !== "assistant" && (
-              <button
-                type="button"
-                onClick={() => {
-                  hapticTap();
-                  commitQuery(query);
-                  onOpenModule(moduleId);
-                  onClose();
-                }}
-                className="mt-1.5 w-full flex items-center justify-between px-3 py-2 rounded-xl text-xs font-medium text-muted hover:text-text hover:bg-panelHi transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45"
-              >
-                <span>
-                  Показано {group.items.length} — відкрити {group.label}
-                </span>
-                <svg
-                  width="12"
-                  height="12"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  aria-hidden
+                <button
+                  type="button"
+                  onClick={() => {
+                    hapticTap();
+                    commitQuery(query);
+                    onOpenModule(moduleId);
+                    onClose();
+                  }}
+                  className="mt-1.5 w-full flex items-center justify-between px-3 py-2 rounded-xl text-xs font-medium text-muted hover:text-text hover:bg-panelHi transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45"
                 >
-                  <path d="M9 18l6-6-6-6" />
-                </svg>
-              </button>
-            )}
+                  <span>
+                    Показано {group.items.length} — відкрити {group.label}
+                  </span>
+                  <svg
+                    width="12"
+                    height="12"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden
+                  >
+                    <path d="M9 18l6-6-6-6" />
+                  </svg>
+                </button>
+              )}
           </div>
         ))}
       </div>

--- a/apps/web/src/core/hub/HubSearch.tsx
+++ b/apps/web/src/core/hub/HubSearch.tsx
@@ -1,5 +1,11 @@
 import { useState, useEffect, useRef, useMemo, startTransition } from "react";
+import { useNavigate } from "react-router-dom";
 import type { ModuleAccent } from "@sergeant/design-tokens";
+import {
+  ASSISTANT_CAPABILITIES,
+  CAPABILITY_MODULE_META,
+  type AssistantCapability,
+} from "@sergeant/shared";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
 import { EmptyState } from "@shared/components/ui/EmptyState";
@@ -105,13 +111,26 @@ function localDateKey(d = new Date()) {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 }
 
+/**
+ * `module` is the visual grouping/colour key. Real modules use the
+ * `ModuleAccent` palette; the two pseudo-modules ("settings" and
+ * "assistant") render with their own neutral swatches and route to a
+ * different navigation target (`?tab=settings` / `/assistant`).
+ */
+type SearchSurface = ModuleAccent | "settings" | "assistant";
+
 type Hit = {
   id: string;
-  module: ModuleAccent;
+  module: SearchSurface;
   moduleLabel: string;
   title: string;
   subtitle: string;
   icon: string;
+  /** Where the hit dispatches when activated. */
+  target:
+    | { kind: "module"; moduleId: string }
+    | { kind: "settings"; sectionId?: string }
+    | { kind: "assistant"; capability?: AssistantCapability };
   _score: number;
 };
 
@@ -315,6 +334,190 @@ interface NutritionDayLog {
 
 type NutritionLog = Record<string, NutritionDayLog>;
 
+// Settings sections — mirrors the catalogue declared in HubSettingsPage.tsx
+// so a query like "експорт" surfaces "Експорт/імпорт JSON" directly from
+// the global ⌘K palette, instead of forcing the user to first open
+// Settings and then re-query inside its own search field.
+//
+// Keep `keywords` in sync with HubSettingsPage's `sections` table whenever
+// new sections are added there. We deliberately don't import that array —
+// it carries `render: () => <Section/>` closures that would drag a much
+// larger render-time graph into the search modal's chunk.
+const SETTINGS_INDEX: ReadonlyArray<{
+  id: string;
+  title: string;
+  description: string;
+  keywords: string;
+  icon: string;
+}> = [
+  {
+    id: "dashboard",
+    title: "Дашборд",
+    description: "Підказки, щільність, активні модулі",
+    keywords:
+      "дашборд dashboard підказки щільність density вигляд активні модулі порядок упорядкувати reorder hide inactive приховати",
+    icon: "layout-grid",
+  },
+  {
+    id: "general",
+    title: "Загальні",
+    description: "Онбординг, акаунт, синхронізація",
+    keywords:
+      "загальні онбординг onboarding welcome синхронізація акаунт sync cloud",
+    icon: "settings",
+  },
+  {
+    id: "notifications",
+    title: "Нагадування",
+    description: "Push-нагадування і щоденні сповіщення",
+    keywords:
+      "сповіщення нагадування пуш push notifications reminders щоденні",
+    icon: "bell",
+  },
+  {
+    id: "ai",
+    title: "AI-дайджести",
+    description: "Тижневий тренер, insights",
+    keywords:
+      "ai штучний інтелект дайджест digest тижневий тренер coach insights",
+    icon: "sparkles",
+  },
+  {
+    id: "assistant",
+    title: "Можливості асистента",
+    description: "Каталог інструментів, які може запустити AI",
+    keywords:
+      "асистент команди chat help допомога інструменти каталог можливості tools",
+    icon: "sparkles",
+  },
+  {
+    id: "routine",
+    title: "Рутина",
+    description: "Звички, цілі, reset",
+    keywords: "звички рутина habits streak ціль reset",
+    icon: "check-circle",
+  },
+  {
+    id: "fizruk",
+    title: "Фізрук",
+    description: "Тренування, кардіо, вага",
+    keywords: "фізрук тренування кардіо вага workouts gym fitness",
+    icon: "dumbbell",
+  },
+  {
+    id: "finyk",
+    title: "Фінік",
+    description: "Інтеграції банків, бюджет",
+    keywords:
+      "фінанси фінік finyk monobank privatbank token api transactions budget",
+    icon: "wallet",
+  },
+  {
+    id: "nutrition",
+    title: "Харчування",
+    description: "Калорії, макроси, комора",
+    keywords:
+      "харчування їжа nutrition meals food kбжу калорії kcal білки жири вуглеводи вода комора pantry скан штрихкод barcode",
+    icon: "utensils",
+  },
+  {
+    id: "pwa",
+    title: "PWA та офлайн",
+    description: "Service worker, кеш, діагностика",
+    keywords:
+      "pwa офлайн offline service worker sw кеш cache діагностика скинути reset",
+    icon: "wifi-off",
+  },
+  {
+    id: "dataExport",
+    title: "Експорт/імпорт JSON",
+    description: "Резервна копія Hub, перенос даних",
+    keywords:
+      "експорт імпорт export import json резервна копія backup hub дані data перенос",
+    icon: "download",
+  },
+  {
+    id: "experimental",
+    title: "Експериментальні",
+    description: "Lab, beta, debug",
+    keywords: "experimental lab beta debug розробка розробник developer",
+    icon: "flask-conical",
+  },
+];
+
+function searchSettings(tokens: string[]): Hit[] {
+  const results: Hit[] = [];
+  for (const section of SETTINGS_INDEX) {
+    pushScored(
+      results,
+      {
+        id: `settings_${section.id}`,
+        module: "settings",
+        moduleLabel: "Налаштування",
+        title: section.title,
+        // Включаємо keywords у subtitle, щоб scoreMatch могла "побачити"
+        // токен на кшталт `monobank` всередині Finyk-секції без появи
+        // самого слова в видимому описі.
+        subtitle: `${section.description} · ${section.keywords}`,
+        icon: section.icon,
+        target: { kind: "settings", sectionId: section.id },
+      },
+      tokens,
+      8,
+    );
+  }
+  // Прибираємо keywords з видимого subtitle після scoring — інакше
+  // картка перетворюється на заплутану мішанину тегів.
+  return results
+    .map((r) => ({
+      ...r,
+      subtitle:
+        SETTINGS_INDEX.find((s) => `settings_${s.id}` === r.id)?.description ||
+        r.subtitle,
+    }))
+    .sort((a, b) => b._score - a._score)
+    .slice(0, 5);
+}
+
+function searchAssistantTools(tokens: string[]): Hit[] {
+  const results: Hit[] = [];
+  for (const cap of ASSISTANT_CAPABILITIES) {
+    const moduleLabel = CAPABILITY_MODULE_META[cap.module]?.title ?? cap.module;
+    pushScored(
+      results,
+      {
+        id: `assistant_${cap.id}`,
+        module: "assistant",
+        moduleLabel: "AI-можливості",
+        title: cap.label,
+        // Subtitle містить опис + keywords + назву модуля — токени з
+        // `keywords` беруть участь у scoring, але після сортування ми
+        // показуємо тільки опис.
+        subtitle: `${cap.description} · ${moduleLabel} · ${(cap.keywords ?? []).join(" ")} ${cap.examples.join(" ")}`,
+        icon: cap.icon,
+        target: { kind: "assistant", capability: cap },
+      },
+      tokens,
+      8,
+    );
+  }
+  return results
+    .map((r) => {
+      const cap = ASSISTANT_CAPABILITIES.find(
+        (c) => `assistant_${c.id}` === r.id,
+      );
+      const moduleLabel = cap
+        ? (CAPABILITY_MODULE_META[cap.module]?.title ?? cap.module)
+        : "";
+      return {
+        ...r,
+        subtitle: cap ? `${cap.description} · ${moduleLabel}` : r.subtitle,
+      };
+    })
+    .sort((a, b) => b._score - a._score)
+    .slice(0, 5);
+}
+
 function searchNutrition(tokens: string[]): Hit[] {
   const results: Hit[] = [];
   const seen = new Set<string>();
@@ -352,11 +555,17 @@ function searchNutrition(tokens: string[]): Hit[] {
 function performSearch(query: string): Hit[] {
   const tokens = tokenize(query);
   if (tokens.length === 0) return [];
+  // Order matters for the rendered groups (see `flat`/`grouped` below).
+  // Module hits surface first because the user is far more likely to be
+  // chasing concrete data; settings + AI capabilities follow as the
+  // "what can I do?" surface.
   return [
     ...searchFinyk(tokens),
     ...searchFizruk(tokens),
     ...searchRoutine(tokens),
     ...searchNutrition(tokens),
+    ...searchSettings(tokens),
+    ...searchAssistantTools(tokens),
   ];
 }
 
@@ -366,11 +575,17 @@ function performSearch(query: string): Hit[] {
 // is the WCAG-AA companion at body sizes; `dark:text-{m}` falls back
 // to the saturated DEFAULT step on dark panels). Equivalent to the
 // Wave 1b token-swap recipe in `docs/design/DARK-MODE-AUDIT.md`.
+//
+// Settings + Assistant pseudo-modules share the neutral panel-tinted
+// swatch so they read as "system" surfaces rather than competing for
+// attention with module-coloured data.
 const MODULE_COLORS: Record<string, string> = {
   finyk: "bg-finyk-soft text-finyk-strong dark:text-finyk",
   fizruk: "bg-fizruk-soft text-fizruk-strong dark:text-fizruk",
   routine: "bg-routine-soft text-routine-strong dark:text-routine",
   nutrition: "bg-nutrition-soft text-nutrition-strong dark:text-nutrition",
+  settings: "bg-panelHi text-muted",
+  assistant: "bg-brand-500/10 text-brand-strong dark:text-brand",
 };
 
 interface HubSearchProps {
@@ -385,6 +600,10 @@ export function HubSearch({ onClose, onOpenModule }: HubSearchProps) {
   const [recents, setRecents] = useState<string[]>(() => getRecentQueries());
   const inputRef = useRef<HTMLInputElement | null>(null);
   const listRef = useRef<HTMLDivElement | null>(null);
+  // HubSearch is rendered inside the BrowserRouter (via HubModals → AppInner),
+  // so it can navigate to the URL-addressable Settings tab and the Assistant
+  // catalogue without plumbing extra callbacks through the modal stack.
+  const navigate = useNavigate();
 
   useEffect(() => {
     inputRef.current?.focus();
@@ -411,9 +630,17 @@ export function HubSearch({ onClose, onOpenModule }: HubSearchProps) {
   }, [query]);
 
   // Готуємо плоский список для keyboard-nav (↑/↓/Enter працюють по
-  // порядку рендеру, а не по groups-first).
+  // порядку рендеру, а не по groups-first). Settings + Assistant pseudo-
+  // groups render last so the hot-path module hits stay at the top.
   const flat = useMemo(() => {
-    const order = ["finyk", "fizruk", "routine", "nutrition"];
+    const order = [
+      "finyk",
+      "fizruk",
+      "routine",
+      "nutrition",
+      "settings",
+      "assistant",
+    ];
     return order.map((m) => results.filter((r) => r.module === m)).flat();
   }, [results]);
 
@@ -426,8 +653,35 @@ export function HubSearch({ onClose, onOpenModule }: HubSearchProps) {
   const openHit = (hit: Hit) => {
     hapticTap();
     commitQuery(query);
-    onOpenModule(hit.module);
     onClose();
+    // `target` carries the navigation intent so we don't have to re-derive
+    // it from `hit.module` (which is the visual grouping, not the route):
+    //   - module hits  → existing onOpenModule plumbing
+    //   - settings hit → URL-addressable settings tab (Settings page reads
+    //                    `?tab=settings` via useHubUIState); section deep-
+    //                    linking can be wired in a follow-up once the
+    //                    settings page exposes a section anchor API
+    //   - assistant hit→ the full /assistant catalogue route. We don't
+    //                    auto-fire the chat here (capability.requiresInput
+    //                    handling lives in the catalogue page) so the user
+    //                    keeps a chance to read the description first.
+    switch (hit.target.kind) {
+      case "module":
+        onOpenModule(hit.target.moduleId);
+        break;
+      case "settings": {
+        const url = new URL(window.location.href);
+        url.searchParams.set("tab", "settings");
+        navigate({
+          pathname: url.pathname || "/",
+          search: url.search,
+        });
+        break;
+      }
+      case "assistant":
+        navigate("/assistant");
+        break;
+    }
   };
 
   useEffect(() => {
@@ -660,8 +914,13 @@ export function HubSearch({ onClose, onOpenModule }: HubSearchProps) {
             </div>
             {/* When a module returns exactly 10 hits the list is saturated —
                 there may be more results. Show a link to open the module so
-                the user can browse/filter there instead of refining here. */}
-            {group.items.length >= 10 && (
+                the user can browse/filter there instead of refining here.
+                Settings + Assistant pseudo-modules cap at 5 hits and don't
+                expose a "browse all" entry point from this list, so we
+                only render the saturation footer for real modules. */}
+            {group.items.length >= 10 &&
+              moduleId !== "settings" &&
+              moduleId !== "assistant" && (
               <button
                 type="button"
                 onClick={() => {

--- a/apps/web/src/core/hub/dashboard/BentoCard.tsx
+++ b/apps/web/src/core/hub/dashboard/BentoCard.tsx
@@ -190,7 +190,7 @@ export const BentoCard = memo(function BentoCard({
               "opacity-80 group-hover:opacity-100 transition-opacity",
             )}
           >
-            <Icon name="plus" size={11} strokeWidth={2.5} aria-hidden />
+            <Icon name="plus" size="xs" strokeWidth={2.5} aria-hidden />
             {config.emptyLabel}
           </span>
         ) : (
@@ -231,7 +231,7 @@ export const BentoCard = memo(function BentoCard({
             "focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-1",
           )}
         >
-          <Icon name="plus" size={13} strokeWidth={2.5} />
+          <Icon name="plus" size="sm" strokeWidth={2.5} />
         </button>
       )}
 
@@ -251,7 +251,7 @@ export const BentoCard = memo(function BentoCard({
             "focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-1",
           )}
         >
-          <Icon name="grip-vertical" size={14} strokeWidth={2} />
+          <Icon name="grip-vertical" size="sm" strokeWidth={2} />
         </button>
       )}
     </div>

--- a/apps/web/src/core/hub/dashboard/BentoCard.tsx
+++ b/apps/web/src/core/hub/dashboard/BentoCard.tsx
@@ -153,14 +153,26 @@ export const BentoCard = memo(function BentoCard({
         {adaptiveReason && !inactive && (
           <span
             className={cn(
-              "mt-1 inline-flex items-center gap-1 self-start",
-              "rounded-full border border-line bg-panel/80 px-1.5 py-0.5",
+              "mt-1 inline-flex items-start gap-1 self-start",
+              "rounded-full border border-line bg-panel/80 px-2 py-0.5",
               "text-2xs font-medium text-muted",
+              // Soft entry animation so the lifted card visibly *animates*
+              // its reason chip in, instead of the previous instant-pop
+              // that made the adaptive reorder feel like layout jitter.
+              "motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-top-1 motion-safe:duration-300",
             )}
-            title={`Підняли в топ: ${adaptiveReason}`}
+            title={adaptiveReason}
           >
-            <span aria-hidden>✦</span>
-            <span className="truncate max-w-[12ch]">{adaptiveReason}</span>
+            <span aria-hidden className="leading-none mt-px">
+              ✦
+            </span>
+            {/* Render the full reason instead of a 12-char truncated tail —
+             * the reason is what makes the adaptive reorder explainable
+             * (e.g. "ранкова кава" / "вечірня вечеря"); chopping it to
+             * "ранкова кав…" gave the lift an air of mystery without
+             * actually saving meaningful horizontal space (cards already
+             * accommodate the chip on a second visual line). */}
+            <span className="leading-snug">{adaptiveReason}</span>
           </span>
         )}
 

--- a/apps/web/src/modules/finyk/components/TxListItem.tsx
+++ b/apps/web/src/modules/finyk/components/TxListItem.tsx
@@ -75,6 +75,15 @@ function TxListItemImpl({
           onSwipeRight={undefined}
           rightLabel="🙈 Приховати"
           rightColor="bg-warning/80"
+          // Surface the swipe-affordance peek on the first row of the list
+          // for first-time users only — `SwipeToAction` reads/writes a
+          // single localStorage flag (`sergeant:swipe_hint_shown`) so the
+          // hint is dismissed for good after the first successful swipe
+          // anywhere in the app.
+          showHint={canSwipeLeft && rowIndex === 0}
+          hintText={
+            isManual ? "Свайпни вліво — видалити" : "Свайпни вліво — приховати"
+          }
         >
           <TxRow
             tx={tx}

--- a/apps/web/src/modules/finyk/pages/Transactions.tsx
+++ b/apps/web/src/modules/finyk/pages/Transactions.tsx
@@ -106,7 +106,7 @@ export function Transactions({
   const [showHidden, setShowHidden] = useState(false);
   // Batch selection
   const [selectMode, setSelectMode] = useState(false);
-  const [selectedIds, setSelectedIds] = useState(new Set());
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [batchCatPicker, setBatchCatPicker] = useState(false);
 
   // useCallback — `toggleSelect` передається у кожен рядок вибору.

--- a/apps/web/src/modules/finyk/pages/Transactions.tsx
+++ b/apps/web/src/modules/finyk/pages/Transactions.tsx
@@ -26,6 +26,18 @@ import { TransactionsBatchToolbar } from "./TransactionsBatchToolbar";
 
 const now = new Date();
 
+// Ukrainian 1 / 2-4 / 5+ noun plural for "операція" (operation/transaction).
+// Inline because the only consumers are the batch-undo toasts below — if a
+// third caller appears, promote to `@shared/lib/pluralize`.
+function pluralizeOps(n: number): string {
+  const mod10 = n % 10;
+  const mod100 = n % 100;
+  if (mod10 === 1 && mod100 !== 11) return "операції";
+  if (mod10 >= 2 && mod10 <= 4 && (mod100 < 10 || mod100 >= 20))
+    return "операцій";
+  return "операцій";
+}
+
 export function Transactions({
   mono,
   storage,
@@ -156,25 +168,77 @@ export function Transactions({
   // дозволяє безпечно мемоїзувати toolbar у майбутньому.
   const applyBatchCategory = useCallback(
     (catId) => {
-      for (const id of selectedIds) overrideCategory(id, catId);
+      // Snapshot the previous override (or `null` for "default category")
+      // for every selected id so the undo can restore each row to whatever
+      // category it had before the batch — including rows that previously
+      // had no override.
+      const prev: Array<[string, string | null]> = [];
+      for (const id of selectedIds) {
+        prev.push([id, txCategories?.[id] ?? null]);
+      }
+      for (const [id] of prev) overrideCategory(id, catId);
       exitSelectMode();
+      if (prev.length > 0) {
+        showUndoToast(toast, {
+          msg: `Категорію змінено для ${prev.length} ${pluralizeOps(prev.length)}`,
+          onUndo: () => {
+            for (const [id, prevCat] of prev) overrideCategory(id, prevCat);
+          },
+        });
+      }
     },
-    [selectedIds, overrideCategory, exitSelectMode],
+    [selectedIds, overrideCategory, exitSelectMode, txCategories, toast],
   );
 
   const applyBatchHide = useCallback(() => {
+    // Capture which ids were *newly* hidden so the undo doesn't accidentally
+    // un-hide rows the user had already hidden manually before entering
+    // select-mode. `hideTx` is a toggle, so calling it again on the same id
+    // restores visibility.
+    const hiddenNow: string[] = [];
     for (const id of selectedIds) {
-      if (!hiddenTxIds.includes(id)) hideTx(id);
+      if (!hiddenTxIds.includes(id)) {
+        hideTx(id);
+        hiddenNow.push(id);
+      }
     }
     exitSelectMode();
-  }, [selectedIds, hiddenTxIds, hideTx, exitSelectMode]);
+    if (hiddenNow.length > 0) {
+      showUndoToast(toast, {
+        msg: `Приховано ${hiddenNow.length} ${pluralizeOps(hiddenNow.length)}`,
+        onUndo: () => {
+          for (const id of hiddenNow) hideTx(id);
+        },
+      });
+    }
+  }, [selectedIds, hiddenTxIds, hideTx, exitSelectMode, toast]);
 
   const applyBatchExclude = useCallback(() => {
+    // Same toggle/snapshot pattern as applyBatchHide — capture the ids that
+    // were newly excluded and call `toggleExcludeFromStats` again on undo.
+    const excludedNow: string[] = [];
     for (const id of selectedIds) {
-      if (!(excludedStatTxIds || []).includes(id)) toggleExcludeFromStats(id);
+      if (!(excludedStatTxIds || []).includes(id)) {
+        toggleExcludeFromStats(id);
+        excludedNow.push(id);
+      }
     }
     exitSelectMode();
-  }, [selectedIds, excludedStatTxIds, toggleExcludeFromStats, exitSelectMode]);
+    if (excludedNow.length > 0) {
+      showUndoToast(toast, {
+        msg: `Виключено зі статистики: ${excludedNow.length} ${pluralizeOps(excludedNow.length)}`,
+        onUndo: () => {
+          for (const id of excludedNow) toggleExcludeFromStats(id);
+        },
+      });
+    }
+  }, [
+    selectedIds,
+    excludedStatTxIds,
+    toggleExcludeFromStats,
+    exitSelectMode,
+    toast,
+  ]);
   const [selMonth, setSelMonth] = useState(() => ({
     year: now.getFullYear(),
     month: now.getMonth(),

--- a/apps/web/src/shared/components/ui/EmptyState.tsx
+++ b/apps/web/src/shared/components/ui/EmptyState.tsx
@@ -3,9 +3,19 @@ import type { ModuleAccent } from "@sergeant/design-tokens";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "./Icon";
 import { Button } from "./Button";
+import { ModuleEmptyIllustration } from "./EmptyStateIllustrations";
 
 export interface EmptyStateProps {
   icon?: ReactNode;
+  /**
+   * Larger module-shaped SVG illustration rendered above the title in place
+   * of the small icon-in-rounded-square container. When both `illustration`
+   * and `icon` are provided, `illustration` wins and the icon is dropped —
+   * the two leading visuals serve the same role and stacking them looks
+   * cluttered. Use `icon` for tiny, dense surfaces (compact, inline) and
+   * `illustration` for full-bleed empty states.
+   */
+  illustration?: ReactNode;
   title?: ReactNode;
   description?: ReactNode;
   action?: ReactNode;
@@ -47,6 +57,7 @@ const MODULE_ICON_TINT: Record<
 
 export function EmptyState({
   icon,
+  illustration,
   title,
   description,
   action,
@@ -69,19 +80,31 @@ export function EmptyState({
         className,
       )}
     >
-      {icon && (
+      {illustration ? (
         <div
           className={cn(
-            "flex items-center justify-center rounded-2xl border",
-            accent ? accent.container : "bg-panelHi border-line text-subtle",
-            compact ? "w-10 h-10" : "w-14 h-14",
-            // Staggered icon animation
+            "flex items-center justify-center",
             !disableAnimation &&
               "motion-safe:animate-in motion-safe:fade-in motion-safe:zoom-in-90 motion-safe:duration-300 motion-safe:delay-75",
           )}
         >
-          {icon}
+          {illustration}
         </div>
+      ) : (
+        icon && (
+          <div
+            className={cn(
+              "flex items-center justify-center rounded-2xl border",
+              accent ? accent.container : "bg-panelHi border-line text-subtle",
+              compact ? "w-10 h-10" : "w-14 h-14",
+              // Staggered icon animation
+              !disableAnimation &&
+                "motion-safe:animate-in motion-safe:fade-in motion-safe:zoom-in-90 motion-safe:duration-300 motion-safe:delay-75",
+            )}
+          >
+            {icon}
+          </div>
+        )
       )}
       <p
         className={cn(
@@ -248,12 +271,28 @@ export function ModuleEmptyState({
 
   return (
     <EmptyState
+      // Compact variant keeps the small icon-in-rounded-square so it fits
+      // dense surfaces (in-list placeholders, sidebar panels). The default
+      // (full-bleed) variant promotes to a module-shaped SVG illustration
+      // which carries far more personality and recognisability than the
+      // generic lucide glyph the empty state used to render.
       icon={
-        <Icon
-          name={config.icon}
-          size={compact ? 20 : 24}
-          className={config.accent.split(" ")[0]}
-        />
+        compact ? (
+          <Icon
+            name={config.icon}
+            size="lg"
+            className={config.accent.split(" ")[0]}
+          />
+        ) : undefined
+      }
+      illustration={
+        compact ? undefined : (
+          <ModuleEmptyIllustration
+            module={module}
+            size={120}
+            className="text-text"
+          />
+        )
       }
       title={config.title}
       description={config.description}
@@ -261,6 +300,7 @@ export function ModuleEmptyState({
       examplePreview={!compact ? examplePreview : undefined}
       compact={compact}
       className={className}
+      module={module}
       action={
         onAction && (
           <Button

--- a/apps/web/src/shared/components/ui/Icon.tsx
+++ b/apps/web/src/shared/components/ui/Icon.tsx
@@ -578,12 +578,38 @@ const PATHS: Record<string, ReactNode> = {
 
 export type IconName = keyof typeof PATHS;
 
+/**
+ * Tight 5-step scale (matches the Tailwind text-xs/sm/base/lg/xl ramp so an
+ * icon and its adjacent label visually align without ad-hoc numeric tweaks).
+ * Numeric `size` is still accepted for one-off cases (e.g. dense lists)
+ * and existing callers, but new code should prefer the tokens.
+ */
+export const ICON_SIZES = {
+  xs: 12,
+  sm: 14,
+  md: 16,
+  lg: 20,
+  xl: 24,
+} as const;
+
+export type IconSizeToken = keyof typeof ICON_SIZES;
+export type IconSize = IconSizeToken | number;
+
+function resolveIconSize(size: IconSize): number {
+  return typeof size === "number" ? size : ICON_SIZES[size];
+}
+
 export interface IconProps extends Omit<
   SVGAttributes<SVGSVGElement>,
   "name" | "title"
 > {
   name: IconName | (string & {});
-  size?: number;
+  /**
+   * Pixel size — accepts a numeric value (e.g. `18`) or a scale token
+   * (`xs`/`sm`/`md`/`lg`/`xl`). Defaults to `lg` (20px), which preserves
+   * the previous numeric default of `20`.
+   */
+  size?: IconSize;
   strokeWidth?: number;
   title?: string;
 }
@@ -594,7 +620,7 @@ export interface IconProps extends Omit<
  */
 export function Icon({
   name,
-  size = 20,
+  size = "lg",
   strokeWidth = 2,
   className,
   title,
@@ -607,13 +633,14 @@ export function Icon({
     }
     return null;
   }
+  const px = resolveIconSize(size);
   const labelProps: SVGAttributes<SVGSVGElement> = title
     ? { role: "img", "aria-label": title }
     : { "aria-hidden": true };
   return (
     <svg
-      width={size}
-      height={size}
+      width={px}
+      height={px}
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"

--- a/apps/web/src/shared/components/ui/VoiceMicButton.test.tsx
+++ b/apps/web/src/shared/components/ui/VoiceMicButton.test.tsx
@@ -107,7 +107,12 @@ describe("VoiceMicButton", () => {
     } as unknown as RecCtor;
 
     const onResult = vi.fn();
-    const { container } = render(<VoiceMicButton onResult={onResult} />);
+    // confirmBeforeCommit=false — тест перевіряє безпосередній transport
+    // транскрипту з Web Speech у callback. Шлях з підтвердженням
+    // (3-сек preview-чип, UX-3) перевіряється окремим тестом нижче.
+    const { container } = render(
+      <VoiceMicButton onResult={onResult} confirmBeforeCommit={false} />,
+    );
     const btn = container.querySelector("button")!;
 
     act(() => {
@@ -120,5 +125,155 @@ describe("VoiceMicButton", () => {
       });
     });
     expect(onResult).toHaveBeenCalledWith("купив каву");
+  });
+
+  it("показує preview-чип і відкладає commit до підтвердження (UX-3)", () => {
+    type RecCtor = new () => {
+      lang: string;
+      interimResults: boolean;
+      maxAlternatives: number;
+      continuous: boolean;
+      onstart: (() => void) | null;
+      onend: (() => void) | null;
+      onresult:
+        | ((e: {
+            results?: ArrayLike<ArrayLike<{ transcript?: string }>>;
+          }) => void)
+        | null;
+      onerror: ((e: { error: string }) => void) | null;
+      start: () => void;
+      stop: () => void;
+      abort: () => void;
+    };
+    let lastInstance: InstanceType<RecCtor> | null = null;
+    type W = typeof window & { webkitSpeechRecognition?: RecCtor };
+    (window as W).webkitSpeechRecognition = class {
+      lang = "";
+      interimResults = false;
+      maxAlternatives = 1;
+      continuous = false;
+      onstart: (() => void) | null = null;
+      onend: (() => void) | null = null;
+      onresult:
+        | ((e: {
+            results?: ArrayLike<ArrayLike<{ transcript?: string }>>;
+          }) => void)
+        | null = null;
+      onerror: ((e: { error: string }) => void) | null = null;
+      constructor() {
+        lastInstance = this as unknown as InstanceType<RecCtor>;
+      }
+      start() {
+        this.onstart?.();
+      }
+      stop() {
+        this.onend?.();
+      }
+      abort() {}
+    } as unknown as RecCtor;
+
+    const onResult = vi.fn();
+    const { container } = render(<VoiceMicButton onResult={onResult} />);
+    const btn = container.querySelector("button")!;
+
+    act(() => {
+      btn.click();
+    });
+    act(() => {
+      lastInstance!.onresult?.({
+        results: [[{ transcript: "тренування з гирею" }]],
+      });
+    });
+
+    // Поки чип висить — onResult мовчить.
+    expect(onResult).not.toHaveBeenCalled();
+
+    // Чип рендериться у portal на document.body, тому шукаємо там, а не
+    // в container, який тримає лише саму кнопку.
+    const chip = document.body.querySelector('[role="dialog"]');
+    expect(chip).not.toBeNull();
+    expect(chip!.textContent).toContain("тренування з гирею");
+
+    // Тап по тексту = "зберегти зараз".
+    const confirmBtn = chip!.querySelector(
+      'button[title="Зберегти зараз"]',
+    ) as HTMLButtonElement | null;
+    expect(confirmBtn).not.toBeNull();
+    act(() => {
+      confirmBtn!.click();
+    });
+    expect(onResult).toHaveBeenCalledWith("тренування з гирею");
+    expect(document.body.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it("скасовує preview без commit при натисканні ✕ (UX-3)", () => {
+    type RecCtor = new () => {
+      lang: string;
+      interimResults: boolean;
+      maxAlternatives: number;
+      continuous: boolean;
+      onstart: (() => void) | null;
+      onend: (() => void) | null;
+      onresult:
+        | ((e: {
+            results?: ArrayLike<ArrayLike<{ transcript?: string }>>;
+          }) => void)
+        | null;
+      onerror: ((e: { error: string }) => void) | null;
+      start: () => void;
+      stop: () => void;
+      abort: () => void;
+    };
+    let lastInstance: InstanceType<RecCtor> | null = null;
+    type W = typeof window & { webkitSpeechRecognition?: RecCtor };
+    (window as W).webkitSpeechRecognition = class {
+      lang = "";
+      interimResults = false;
+      maxAlternatives = 1;
+      continuous = false;
+      onstart: (() => void) | null = null;
+      onend: (() => void) | null = null;
+      onresult:
+        | ((e: {
+            results?: ArrayLike<ArrayLike<{ transcript?: string }>>;
+          }) => void)
+        | null = null;
+      onerror: ((e: { error: string }) => void) | null = null;
+      constructor() {
+        lastInstance = this as unknown as InstanceType<RecCtor>;
+      }
+      start() {
+        this.onstart?.();
+      }
+      stop() {
+        this.onend?.();
+      }
+      abort() {}
+    } as unknown as RecCtor;
+
+    const onResult = vi.fn();
+    const { container } = render(<VoiceMicButton onResult={onResult} />);
+    const btn = container.querySelector("button")!;
+
+    act(() => {
+      btn.click();
+    });
+    act(() => {
+      lastInstance!.onresult?.({
+        results: [[{ transcript: "купив 10 яйок" }]],
+      });
+    });
+
+    const chip = document.body.querySelector('[role="dialog"]');
+    expect(chip).not.toBeNull();
+    const cancelBtn = chip!.querySelector(
+      'button[aria-label="Скасувати"]',
+    ) as HTMLButtonElement | null;
+    expect(cancelBtn).not.toBeNull();
+    act(() => {
+      cancelBtn!.click();
+    });
+    expect(onResult).not.toHaveBeenCalled();
+    expect(document.body.querySelector('[role="dialog"]')).toBeNull();
   });
 });

--- a/apps/web/src/shared/components/ui/VoiceMicButton.tsx
+++ b/apps/web/src/shared/components/ui/VoiceMicButton.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { cn } from "@shared/lib/cn";
 import { hapticTap } from "@shared/lib/haptic";
 import { transcribeApi } from "@shared/api";
@@ -432,6 +433,205 @@ export interface VoiceMicButtonProps {
    * у Web Speech-fallback.
    */
   promptHint?: string;
+  /**
+   * Якщо `true` (за замовчуванням), після успішного розпізнавання
+   * показуємо preview-чипі з 3-секундним таймером авто-підтвердження
+   * (à la Gmail Undo Send). Користувач може:
+   *   - тапнути по тексту → застосувати миттєво,
+   *   - натиснути ✕ → скасувати без застосування,
+   *   - не робити нічого → авто-застосувати через 3 секунди.
+   * Це рятує від «голос почув не те» — найгірший сценарій, коли
+   * розпізнаний текст одразу зберігається у форму без шансу на правку.
+   *
+   * Передавайте `false` тільки коли upstream сам показує миттєвий
+   * preview (наприклад, чат, де voice-повідомлення спершу попадає у
+   * draft, а юзер бачить його і може правити).
+   */
+  confirmBeforeCommit?: boolean;
+}
+
+/* -------------------------------------------------------------------------- *
+ *  Confirm chip — 3-сек preview/undo після успішного STT.
+ * -------------------------------------------------------------------------- */
+
+const VOICE_CONFIRM_MS = 3000;
+const CHIP_WIDTH = 288;
+const CHIP_VIEWPORT_MARGIN = 8;
+// Висота чипа динамічна (1–2 рядки тексту), але для розрахунку «вгору vs
+// вниз» нам достатньо консервативної оцінки: один рядок ≈ 56px,
+// два рядки ≈ 72px. Беремо більшу — краще трохи зайнятого простору
+// зверху, ніж чип, який вилазить за нижній край в'юпорта.
+const CHIP_HEIGHT_ESTIMATE = 72;
+
+interface PendingVoiceChipProps {
+  text: string;
+  anchorRect: DOMRect;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+function PendingVoiceChip({
+  text,
+  anchorRect,
+  onConfirm,
+  onCancel,
+}: PendingVoiceChipProps) {
+  const [progress, setProgress] = useState(1);
+  const startedAtRef = useRef<number>(Date.now());
+  const onConfirmRef = useRef(onConfirm);
+  onConfirmRef.current = onConfirm;
+
+  useEffect(() => {
+    startedAtRef.current = Date.now();
+    let raf = 0;
+    const tick = () => {
+      const elapsed = Date.now() - startedAtRef.current;
+      const remaining = Math.max(0, VOICE_CONFIRM_MS - elapsed);
+      setProgress(remaining / VOICE_CONFIRM_MS);
+      if (remaining <= 0) {
+        onConfirmRef.current();
+        return;
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  // Escape — швидкий вихід без збереження. Особливо важливо на десктопі,
+  // де керування з клавіатури дешевше за тач-цілі.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onCancel();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onCancel]);
+
+  // Позиціонування фіксоване відносно в'юпорта: пробуємо знизу від
+  // кнопки; якщо не вліз — піднімаємо вгору. Горизонтально центруємо
+  // по кнопці, але клампимо у в'юпорт.
+  const vw = typeof window !== "undefined" ? window.innerWidth : 0;
+  const vh = typeof window !== "undefined" ? window.innerHeight : 0;
+  const spaceBelow = vh - anchorRect.bottom;
+  const placeAbove = spaceBelow < CHIP_HEIGHT_ESTIMATE + CHIP_VIEWPORT_MARGIN;
+  const top = placeAbove
+    ? Math.max(
+        CHIP_VIEWPORT_MARGIN,
+        anchorRect.top - CHIP_HEIGHT_ESTIMATE - CHIP_VIEWPORT_MARGIN,
+      )
+    : Math.min(
+        vh - CHIP_HEIGHT_ESTIMATE - CHIP_VIEWPORT_MARGIN,
+        anchorRect.bottom + CHIP_VIEWPORT_MARGIN,
+      );
+  const rawLeft = anchorRect.left + anchorRect.width / 2 - CHIP_WIDTH / 2;
+  const left = Math.max(
+    CHIP_VIEWPORT_MARGIN,
+    Math.min(vw - CHIP_WIDTH - CHIP_VIEWPORT_MARGIN, rawLeft),
+  );
+
+  const radius = 10;
+  const circumference = 2 * Math.PI * radius;
+  const secondsLeft = Math.ceil(progress * (VOICE_CONFIRM_MS / 1000));
+
+  if (typeof document === "undefined") return null;
+  return createPortal(
+    <div
+      role="dialog"
+      aria-live="polite"
+      aria-label="Підтвердження голосового вводу"
+      style={{
+        position: "fixed",
+        top,
+        left,
+        width: CHIP_WIDTH,
+        zIndex: 9999,
+      }}
+      className="rounded-2xl bg-panel/95 backdrop-blur-sm border border-line shadow-xl px-3 py-2 flex items-center gap-2 motion-safe:animate-fade-in"
+    >
+      {/* Countdown ring + remaining seconds.  Ring fills counter-clockwise
+          so the visual "drains" toward zero. */}
+      <div className="relative w-7 h-7 shrink-0" aria-hidden>
+        <svg viewBox="0 0 24 24" className="w-7 h-7 -rotate-90">
+          <circle
+            cx="12"
+            cy="12"
+            r={radius}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            className="text-line"
+          />
+          <circle
+            cx="12"
+            cy="12"
+            r={radius}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            className="text-brand"
+            style={{
+              strokeDasharray: circumference,
+              strokeDashoffset: circumference * (1 - progress),
+              transition: "stroke-dashoffset 80ms linear",
+            }}
+          />
+        </svg>
+        <span className="absolute inset-0 flex items-center justify-center text-[10px] font-semibold text-text tabular-nums">
+          {secondsLeft}
+        </span>
+      </div>
+
+      {/* Tapping the transcript = "save now". The button is the largest
+          touch target in the chip on purpose — the most likely action is
+          "looks right, just commit it without waiting". */}
+      <button
+        type="button"
+        onClick={() => {
+          hapticTap();
+          onConfirm();
+        }}
+        className="flex-1 min-w-0 text-left text-xs leading-tight text-text hover:text-brand-strong line-clamp-2"
+        title="Зберегти зараз"
+      >
+        <span className="block text-[10px] uppercase tracking-wide text-subtle">
+          Голос
+        </span>
+        <span className="block">{text}</span>
+      </button>
+
+      <button
+        type="button"
+        onClick={() => {
+          hapticTap();
+          onCancel();
+        }}
+        className="shrink-0 w-7 h-7 rounded-full bg-line/30 text-muted hover:text-error hover:bg-error/15 flex items-center justify-center [@media(pointer:coarse)]:min-h-[44px] [@media(pointer:coarse)]:min-w-[44px]"
+        aria-label="Скасувати"
+        title="Скасувати"
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden
+        >
+          <line x1="18" y1="6" x2="6" y2="18" />
+          <line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+      </button>
+    </div>,
+    document.body,
+  );
 }
 
 type Provider = "auto" | "groq" | "webspeech";
@@ -456,20 +656,65 @@ export function VoiceMicButton({
   label,
   disabled = false,
   promptHint,
+  confirmBeforeCommit = true,
 }: VoiceMicButtonProps) {
   // Sticky-fallback на Web Speech, якщо `/api/transcribe` повернув 503.
   // Тримаємо у state, щоб не спамити upstream і не плутати юзера між
   // двома провайдерами в межах однієї сесії.
   const [forceFallback, setForceFallback] = useState(false);
 
+  // `pending` — це останній transcript, що чекає на підтвердження.
+  // Anchor-rect знімаємо разом з ним, бо чип позиціонується ВІДНОСНО
+  // кнопки, але рендериться у portal (фіксоване розташування у в'юпорті
+  // живе своїм життям незалежно від overflow:hidden обгорток форм).
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const [pending, setPending] = useState<{
+    text: string;
+    anchorRect: DOMRect;
+  } | null>(null);
+  const onResultRef = useRef(onResult);
+  onResultRef.current = onResult;
+
+  // Інтерсептор: замість миттєвого commit показуємо preview-чипі.
+  // Якщо `confirmBeforeCommit=false` — поведінка стара (миттєвий
+  // commit, як до UX-3), щоб чат і подібні call-сайти лишались
+  // незмінні.
+  const handleTranscript = useCallback(
+    (text: string) => {
+      const trimmed = text.trim();
+      if (!trimmed) return;
+      if (!confirmBeforeCommit) {
+        onResultRef.current?.(trimmed);
+        return;
+      }
+      const rect =
+        buttonRef.current?.getBoundingClientRect() ??
+        // Fallback — кнопка ще не змонтована (теоретично неможливо тут,
+        // бо event прилетіти може лише після click). На всякий випадок —
+        // центр в'юпорта.
+        new DOMRect(
+          window.innerWidth / 2,
+          window.innerHeight / 2,
+          0,
+          0,
+        );
+      setPending({ text: trimmed, anchorRect: rect });
+    },
+    [confirmBeforeCommit],
+  );
+
   const groq = useGroqVoiceInput({
     lang,
     promptHint,
-    onResult,
+    onResult: handleTranscript,
     onError,
     onProviderUnavailable: () => setForceFallback(true),
   });
-  const webspeech = useVoiceInput({ lang, onResult, onError });
+  const webspeech = useVoiceInput({
+    lang,
+    onResult: handleTranscript,
+    onError,
+  });
 
   const configured = resolveConfiguredProvider();
   // Якщо явно вибрано webspeech — ігноруємо Groq повністю.
@@ -481,6 +726,26 @@ export function VoiceMicButton({
     groq.supported;
 
   const active = useGroq ? groq : webspeech;
+
+  const confirmPending = useCallback(() => {
+    setPending((curr) => {
+      if (curr) onResultRef.current?.(curr.text);
+      return null;
+    });
+  }, []);
+  const cancelPending = useCallback(() => {
+    setPending(null);
+  }, []);
+
+  // Якщо компонент анмаунтається з активним pending — мовчки скидаємо
+  // (НЕ комітимо). Інше було б сюрпризом: user закрив форму, а текст
+  // "доставився" по таймеру.
+  useEffect(() => {
+    return () => {
+      setPending(null);
+    };
+  }, []);
+
   if (!active.supported) return null;
 
   const isUploading = useGroq ? groq.uploading : false;
@@ -497,6 +762,13 @@ export function VoiceMicButton({
 
   const handleClick = () => {
     hapticTap();
+    // Натиснули кнопку, поки висить pending — це явний сигнал
+    // "перезапиши". Скасуємо чип і одразу почнемо новий цикл, бо інакше
+    // буде гонитва: timer auto-commit-не старий рядок а рекордер
+    // одночасно почне новий запис.
+    if (pending) {
+      setPending(null);
+    }
     active.toggle();
   };
 
@@ -507,67 +779,78 @@ export function VoiceMicButton({
       : label || "Голосовий ввід";
 
   return (
-    <button
-      type="button"
-      onClick={handleClick}
-      disabled={disabled || isUploading}
-      aria-label={ariaLabel}
-      title={ariaLabel}
-      className={cn(
-        "relative flex items-center justify-center rounded-2xl shrink-0 touch-manipulation",
-        "motion-safe:transition-all motion-reduce:transition-none",
-        sizeMap[size] || sizeMap.md,
-        busy
-          ? "bg-error/15 text-error border border-error/30 motion-safe:animate-pulse"
-          : "bg-panelHi text-muted hover:text-text hover:bg-line/40 border border-line",
-        (disabled || isUploading) && "opacity-40 pointer-events-none",
-        className,
+    <>
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={handleClick}
+        disabled={disabled || isUploading}
+        aria-label={ariaLabel}
+        title={ariaLabel}
+        className={cn(
+          "relative flex items-center justify-center rounded-2xl shrink-0 touch-manipulation",
+          "motion-safe:transition-all motion-reduce:transition-none",
+          sizeMap[size] || sizeMap.md,
+          busy
+            ? "bg-error/15 text-error border border-error/30 motion-safe:animate-pulse"
+            : "bg-panelHi text-muted hover:text-text hover:bg-line/40 border border-line",
+          (disabled || isUploading) && "opacity-40 pointer-events-none",
+          className,
+        )}
+      >
+        {listening ? (
+          <svg
+            width={iconSize}
+            height={iconSize}
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            aria-hidden
+          >
+            <rect x="6" y="4" width="4" height="16" rx="1" />
+            <rect x="14" y="4" width="4" height="16" rx="1" />
+          </svg>
+        ) : isUploading ? (
+          <svg
+            width={iconSize}
+            height={iconSize}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden
+            className="motion-safe:animate-spin"
+          >
+            <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+          </svg>
+        ) : (
+          <svg
+            width={iconSize}
+            height={iconSize}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden
+          >
+            <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z" />
+            <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+            <line x1="12" y1="19" x2="12" y2="23" />
+            <line x1="8" y1="23" x2="16" y2="23" />
+          </svg>
+        )}
+      </button>
+      {pending && (
+        <PendingVoiceChip
+          text={pending.text}
+          anchorRect={pending.anchorRect}
+          onConfirm={confirmPending}
+          onCancel={cancelPending}
+        />
       )}
-    >
-      {listening ? (
-        <svg
-          width={iconSize}
-          height={iconSize}
-          viewBox="0 0 24 24"
-          fill="currentColor"
-          aria-hidden
-        >
-          <rect x="6" y="4" width="4" height="16" rx="1" />
-          <rect x="14" y="4" width="4" height="16" rx="1" />
-        </svg>
-      ) : isUploading ? (
-        <svg
-          width={iconSize}
-          height={iconSize}
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden
-          className="motion-safe:animate-spin"
-        >
-          <path d="M21 12a9 9 0 1 1-6.219-8.56" />
-        </svg>
-      ) : (
-        <svg
-          width={iconSize}
-          height={iconSize}
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden
-        >
-          <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z" />
-          <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
-          <line x1="12" y1="19" x2="12" y2="23" />
-          <line x1="8" y1="23" x2="16" y2="23" />
-        </svg>
-      )}
-    </button>
+    </>
   );
 }

--- a/apps/web/src/shared/components/ui/VoiceMicButton.tsx
+++ b/apps/web/src/shared/components/ui/VoiceMicButton.tsx
@@ -598,6 +598,7 @@ function PendingVoiceChip({
         className="flex-1 min-w-0 text-left text-xs leading-tight text-text hover:text-brand-strong line-clamp-2"
         title="Зберегти зараз"
       >
+        {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift */}
         <span className="block text-[10px] uppercase tracking-wide text-subtle">
           Голос
         </span>
@@ -692,12 +693,7 @@ export function VoiceMicButton({
         // Fallback — кнопка ще не змонтована (теоретично неможливо тут,
         // бо event прилетіти може лише після click). На всякий випадок —
         // центр в'юпорта.
-        new DOMRect(
-          window.innerWidth / 2,
-          window.innerHeight / 2,
-          0,
-          0,
-        );
+        new DOMRect(window.innerWidth / 2, window.innerHeight / 2, 0, 0);
       setPending({ text: trimmed, anchorRect: rect });
     },
     [confirmBeforeCommit],


### PR DESCRIPTION
## What changed

<!-- Brief description of the changes. -->

## Why

<!-- Motivation, linked issue, or context. -->

## How to test

<!-- Steps for a reviewer to verify correctness. -->

---

## Pre-flight (Hard Rule #15)

<!--
Before opening this PR you should have read the relevant governance.
Tick what applies; if a box is N/A, write "n/a" inline.
-->

- [ ] Read the `AGENTS.md` Hard Rules that apply to the touched paths.
- [ ] Read the matching playbook in `docs/playbooks/` (or noted that none exists).
- [ ] Checked freshness headers of docs cited in the change.

## Docs updated alongside code? (Hard Rule #15)

<!--
Documentation is part of the change set, not a follow-up. Tick what applies.
-->

- [ ] API contract change — `packages/api-client/**` types + contract test updated (Hard Rule #3).
- [ ] New / removed npm script — `CONTRIBUTING.md § Everyday Commands` and `CLAUDE.md § Quick commands` updated.
- [ ] New design token / component / palette — `docs/design/design-system.md` (and `BRANDBOOK.md` if branded) updated.
- [ ] Deprecation — `@deprecated` JSDoc with `@removeBy` added; consuming docs marked `> **Status:** Deprecated`.
- [ ] Freshness header bumped on docs whose claims changed (`> Last validated: YYYY-MM-DD by @owner`).
- [ ] N/A — no docs invalidated by this change.

## How AI-tested this PR

<!-- If this PR was created by an AI agent, describe what was verified. -->

- [ ] Manual smoke (which flow?): ...
- [ ] Vitest passes: ...
- [ ] No new `AI-DANGER` markers added without justification.
- [ ] Docs prose uses Ukrainian where practical, per `AGENTS.md`.
- [ ] `pnpm dead-code:files` clean (or new files marked `@scaffolded`).

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [ ] No — no new permanent rules

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Search now includes Settings and Assistant results with intelligent routing
  * Voice input supports optional confirmation before saving transcripts with auto-confirm countdown

* **Improvements**
  * Enhanced undo functionality for batch transaction operations with proper plural labels
  * Added entrance animations and improved dashboard visual hierarchy
  * New swipe affordance hint guides first-time transaction users

* **UI/UX**
  * Optimized header and dashboard spacing to reduce clutter
  * Support for custom illustrations in empty states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->