### PR TITLE
ci(web): raise JS bundle budget 615->630 kB after #1239 merge

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,7 +23,7 @@
       "name": "JS (усього)",
       "path": "../server/dist/assets/*.js",
       "brotli": true,
-      "limit": "615 kB"
+      "limit": "630 kB"
     },
     {
       "name": "CSS",


### PR DESCRIPTION
## What changed

`apps/web/package.json` → `size-limit[0].limit`: **615 kB → 630 kB** (brotli).
CSS budget unchanged at 22 kB.

## Why

After #1239 (idle-prefetch + intent-prefetch on dashboard cards) merged, the
apps/web brotli JS bundle measures **624.42 kB** — 9.42 kB over the 615 kB
ceiling. The `size-limit` check now fails on every PR until either the budget
is raised or a chunk is shrunk.

`CONTRIBUTING.md` ("Performance Budgets" section) explicitly allows raising
the limit in the same PR that needs the headroom. This PR carries only the
budget bump so the source of the regression and the budget change are
independently revertable.

5 kB of headroom (630 − 624.42) keeps the gate tight enough to surface the
next ~5 kB of accidental growth.

## How to test

```bash
pnpm install
pnpm --filter @sergeant/web run build
pnpm --filter @sergeant/web run size
```

Expected:

```
JS (усього)
Size limit: 630 kB
Size:       624.42 kB brotlied
```

(Both lines green — no `Package size limit has exceeded` warning.)

---

## Pre-flight (Hard Rule #15)

- [x] Read `CONTRIBUTING.md § Performance Budgets` — explicitly permits raising
      the limit in the same PR that needs the headroom.
- [x] Read the matching `AGENTS.md` Hard Rules for `apps/web/**` — no
      governance rule pinned the 615 kB number specifically.
- [x] Checked freshness headers of docs cited in the change — n/a, only
      `package.json` touched.

## Docs updated alongside code? (Hard Rule #15)

- [ ] API contract change — n/a.
- [ ] New / removed npm script — n/a.
- [ ] New design token / component / palette — n/a.
- [ ] Deprecation — n/a.
- [ ] Freshness header bumped on docs whose claims changed — n/a.
- [x] N/A — no docs invalidated by this change. The 615 kB number was an
      implementation-side budget, not documented in any markdown freshness
      doc.

## How AI-tested this PR

- [x] Manual smoke (which flow?): ran `pnpm --filter @sergeant/web run build`
      then `pnpm --filter @sergeant/web run size` locally on the rebased
      branch. Output: `Size: 624.42 kB / Size limit: 630 kB` — pass.
- [ ] Vitest passes: n/a — no test code touched. Would still run under CI
      via the existing turbo pipeline.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md` — n/a, only
      a numeric budget changed.
- [x] `pnpm dead-code:files` clean — n/a, no source files added.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules. The budget value is intentionally kept
      out of the governance text so it can drift with reality without doc
      churn.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1245" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to reflect current bundle size parameters.

---

**Note:** This release contains no user-facing changes or new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->