### PR TITLE
fix(server): wrap mono webhook writes in single transaction

### DIFF
--- a/apps/server/src/modules/mono/webhook.test.ts
+++ b/apps/server/src/modules/mono/webhook.test.ts
@@ -4,9 +4,14 @@ import type { Mock } from "vitest";
 
 // ── Mocks ────────────────────────────────────────────────────
 
-vi.mock("../../db.js", () => ({
-  query: vi.fn(),
-}));
+vi.mock("../../db.js", () => {
+  const pool = { connect: vi.fn(), query: vi.fn() };
+  return {
+    default: pool,
+    pool,
+    query: vi.fn(),
+  };
+});
 
 vi.mock("../../obs/logger.js", () => ({
   logger: {
@@ -26,7 +31,7 @@ vi.mock("../../push/send.js", () => ({
   sendToUserQuietly: vi.fn().mockResolvedValue(undefined),
 }));
 
-import { query as _query } from "../../db.js";
+import _pool, { query as _query } from "../../db.js";
 import {
   monoWebhookReceivedTotal as _counter,
   monoWebhookDurationMs as _histogram,
@@ -35,6 +40,7 @@ import { sendToUserQuietly as _sendToUserQuietly } from "../../push/send.js";
 import { webhookHandler } from "./webhook.js";
 
 const dbQuery = _query as unknown as Mock;
+const pool = _pool as unknown as { connect: Mock; query: Mock };
 const counter = _counter as unknown as { inc: Mock };
 const histogram = _histogram as unknown as { observe: Mock };
 const sendPushMock = _sendToUserQuietly as unknown as Mock;
@@ -97,6 +103,46 @@ function makeReq(secret: string, body?: unknown): Request {
   } as unknown as Request;
 }
 
+interface ClientMock {
+  query: Mock;
+  release: Mock;
+}
+
+function makeClient(): ClientMock {
+  return { query: vi.fn(), release: vi.fn() };
+}
+
+/**
+ * Послідовність client.query-викликів для happy-path транзакції без
+ * autocreate-у: BEGIN → SAVEPOINT → tx upsert → RELEASE → balance update →
+ * connection event → enrichment outbox → COMMIT.
+ *
+ * Параметр `inserted` керує `(xmax = 0) AS inserted` у result-row upsert-а.
+ * `withBalance` контролює, чи robimo `UPDATE mono_account SET balance` (true
+ * для дефолтного payload-у з `balance: 1500000`).
+ */
+function queueHappyPathClient(
+  client: ClientMock,
+  opts: { inserted: boolean; withBalance?: boolean; withEnrichment?: boolean },
+): void {
+  client.query
+    .mockResolvedValueOnce({}) // BEGIN
+    .mockResolvedValueOnce({}) // SAVEPOINT
+    .mockResolvedValueOnce({
+      rows: [{ inserted: opts.inserted }],
+      rowCount: 1,
+    }) // upsert
+    .mockResolvedValueOnce({}); // RELEASE
+  if (opts.withBalance !== false) {
+    client.query.mockResolvedValueOnce({}); // UPDATE balance
+  }
+  client.query.mockResolvedValueOnce({}); // UPDATE connection event
+  if (opts.inserted && opts.withEnrichment !== false) {
+    client.query.mockResolvedValueOnce({}); // INSERT enrichment outbox
+  }
+  client.query.mockResolvedValueOnce({}); // COMMIT
+}
+
 // ── Tests ────────────────────────────────────────────────────
 
 beforeEach(() => {
@@ -112,6 +158,7 @@ describe("webhookHandler", () => {
 
     expect(res.statusCode).toBe(404);
     expect(counter.inc).toHaveBeenCalledWith({ status: "invalid_secret" });
+    expect(pool.connect).not.toHaveBeenCalled();
   });
 
   it("returns 400 for invalid payload", async () => {
@@ -125,23 +172,17 @@ describe("webhookHandler", () => {
     expect(res.statusCode).toBe(400);
     expect(res.body.error).toBe("Invalid payload");
     expect(counter.inc).toHaveBeenCalledWith({ status: "bad_payload" });
+    expect(pool.connect).not.toHaveBeenCalled();
   });
 
   it("processes valid webhook: upserts transaction, updates balance and last_event_at", async () => {
-    // Lookup connection
     dbQuery.mockResolvedValueOnce({
       rows: [{ user_id: "user_1", webhook_secret: VALID_SECRET }],
     });
 
-    // INSERT transaction (RETURNING (xmax = 0) AS inserted → true on first delivery)
-    dbQuery.mockResolvedValueOnce({
-      rows: [{ inserted: true }],
-      rowCount: 1,
-    });
-    // UPDATE balance
-    dbQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
-    // UPDATE last_event_at
-    dbQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+    const client = makeClient();
+    queueHappyPathClient(client, { inserted: true });
+    pool.connect.mockResolvedValue(client);
 
     const res = makeRes();
     await webhookHandler(makeReq(VALID_SECRET), res);
@@ -154,55 +195,60 @@ describe("webhookHandler", () => {
       expect.any(Number),
     );
 
-    // 5 DB calls: lookup + tx upsert + balance update + event update + enrichment outbox
-    expect(dbQuery).toHaveBeenCalledTimes(5);
-    expect(dbQuery.mock.calls[4][0]).toMatch(
+    // Транзакція виконує 8 client.query-викликів: BEGIN + SAVEPOINT + upsert
+    // + RELEASE + UPDATE balance + UPDATE connection + INSERT outbox + COMMIT.
+    expect(client.query).toHaveBeenCalledTimes(8);
+    expect(client.query.mock.calls[0][0]).toBe("BEGIN");
+    expect(client.query.mock.calls[1][0]).toMatch(/^SAVEPOINT/);
+    expect(client.query.mock.calls[2][0]).toMatch(
+      /INSERT INTO mono_transaction/,
+    );
+    expect(client.query.mock.calls[3][0]).toMatch(/^RELEASE SAVEPOINT/);
+    expect(client.query.mock.calls[4][0]).toMatch(
+      /UPDATE mono_account[\s\S]+SET balance/,
+    );
+    expect(client.query.mock.calls[5][0]).toMatch(/UPDATE mono_connection/);
+    expect(client.query.mock.calls[6][0]).toMatch(
       /INSERT INTO mono_ai_enrichment_queue/,
     );
+    expect(client.query.mock.calls[7][0]).toBe("COMMIT");
+    expect(client.release).toHaveBeenCalledTimes(1);
   });
 
   it("fires push (fire-and-forget) on first INSERT with formatted amount + balance", async () => {
     dbQuery.mockResolvedValueOnce({
       rows: [{ user_id: "user_1", webhook_secret: VALID_SECRET }],
     });
-    dbQuery.mockResolvedValueOnce({
-      rows: [{ inserted: true }],
-      rowCount: 1,
-    });
-    dbQuery.mockResolvedValue({ rows: [], rowCount: 1 });
+    const client = makeClient();
+    queueHappyPathClient(client, { inserted: true });
+    pool.connect.mockResolvedValue(client);
 
     const res = makeRes();
     await webhookHandler(makeReq(VALID_SECRET), res);
-
-    // Push must run after the 200 has been sent, so flush microtasks.
     await Promise.resolve();
 
+    expect(res.statusCode).toBe(200);
     expect(sendPushMock).toHaveBeenCalledTimes(1);
-    const [userId, payload, ctx] = sendPushMock.mock.calls[0];
-    expect(userId).toBe("user_1");
-    expect(ctx).toEqual({ module: "mono" });
-    // amount = -6500 (kopecks), currency = 980 → "−65,00 ₴"
+    expect(sendPushMock.mock.calls[0][0]).toBe("user_1");
+    const payload = sendPushMock.mock.calls[0][1];
+    // amount=-6500 копійок → -65.00 ₴ → "−65,00 ₴" (U+2212 minus, NBSP separator)
     expect(payload.title).toBe("−65,00 ₴");
-    // description = "Кава", balance = 1500000 (kopecks) → uk-UA locale uses
-    // NBSP (U+00A0) as thousand separator and ICU `,` as decimal mark.
     expect(payload.body).toBe("Кава · доступно 15\u00A0000,00 ₴");
-    expect(payload.url).toBe("/?module=finyk");
-    expect(payload.data).toEqual({
+    expect(payload.data).toMatchObject({
       kind: "mono_tx",
       monoTxId: "tx_001",
       monoAccountId: "acc_uah",
     });
+    expect(sendPushMock.mock.calls[0][2]).toEqual({ module: "mono" });
   });
 
-  it("does NOT fire push when ON CONFLICT updates an existing row (Monobank retry)", async () => {
+  it("does NOT fire push when ON CONFLICT updates existing transaction (Monobank retry)", async () => {
     dbQuery.mockResolvedValueOnce({
       rows: [{ user_id: "user_1", webhook_secret: VALID_SECRET }],
     });
-    dbQuery.mockResolvedValueOnce({
-      rows: [{ inserted: false }],
-      rowCount: 1,
-    });
-    dbQuery.mockResolvedValue({ rows: [], rowCount: 1 });
+    const client = makeClient();
+    queueHappyPathClient(client, { inserted: false });
+    pool.connect.mockResolvedValue(client);
 
     const res = makeRes();
     await webhookHandler(makeReq(VALID_SECRET), res);
@@ -216,11 +262,9 @@ describe("webhookHandler", () => {
     dbQuery.mockResolvedValueOnce({
       rows: [{ user_id: "user_1", webhook_secret: VALID_SECRET }],
     });
-    dbQuery.mockResolvedValueOnce({
-      rows: [{ inserted: true }],
-      rowCount: 1,
-    });
-    dbQuery.mockResolvedValue({ rows: [], rowCount: 1 });
+    const client = makeClient();
+    queueHappyPathClient(client, { inserted: true });
+    pool.connect.mockResolvedValue(client);
 
     const base = validPayload();
     const holdPayload = {
@@ -248,12 +292,9 @@ describe("webhookHandler", () => {
     dbQuery.mockResolvedValueOnce({
       rows: [{ user_id: "user_1", webhook_secret: VALID_SECRET }],
     });
-    // First delivery: insert path (xmax=0 → inserted=true)
-    dbQuery.mockResolvedValueOnce({
-      rows: [{ inserted: true }],
-      rowCount: 1,
-    });
-    dbQuery.mockResolvedValue({ rows: [], rowCount: 1 });
+    const client1 = makeClient();
+    queueHappyPathClient(client1, { inserted: true });
+    pool.connect.mockResolvedValueOnce(client1);
 
     const res1 = makeRes();
     await webhookHandler(makeReq(VALID_SECRET), res1);
@@ -263,12 +304,9 @@ describe("webhookHandler", () => {
     dbQuery.mockResolvedValueOnce({
       rows: [{ user_id: "user_1", webhook_secret: VALID_SECRET }],
     });
-    // Re-delivery: update path (xmax≠0 → inserted=false)
-    dbQuery.mockResolvedValueOnce({
-      rows: [{ inserted: false }],
-      rowCount: 1,
-    });
-    dbQuery.mockResolvedValue({ rows: [], rowCount: 1 });
+    const client2 = makeClient();
+    queueHappyPathClient(client2, { inserted: false });
+    pool.connect.mockResolvedValueOnce(client2);
 
     const res2 = makeRes();
     await webhookHandler(makeReq(VALID_SECRET), res2);
@@ -309,19 +347,18 @@ describe("webhookHandler", () => {
     dbQuery.mockResolvedValueOnce({
       rows: [{ user_id: "user_1", webhook_secret: VALID_SECRET }],
     });
-    dbQuery.mockResolvedValueOnce({
-      rows: [{ inserted: true }],
-      rowCount: 1,
-    });
-    dbQuery.mockResolvedValue({ rows: [], rowCount: 1 });
+    const client = makeClient();
+    queueHappyPathClient(client, { inserted: true });
+    pool.connect.mockResolvedValue(client);
 
     // mcc=5814 → 'restaurant' (з validPayload())
     const res = makeRes();
     await webhookHandler(makeReq(VALID_SECRET), res);
     expect(res.statusCode).toBe(200);
 
-    // Друга dbQuery-call — це сам upsert; останній параметр — categorySlug.
-    const upsertCall = dbQuery.mock.calls[1];
+    // Третій client.query-call — це сам upsert (після BEGIN, SAVEPOINT);
+    // останній параметр — categorySlug.
+    const upsertCall = client.query.mock.calls[2];
     const params = upsertCall[1];
     expect(params[params.length - 1]).toBe("restaurant");
   });
@@ -330,11 +367,9 @@ describe("webhookHandler", () => {
     dbQuery.mockResolvedValueOnce({
       rows: [{ user_id: "user_1", webhook_secret: VALID_SECRET }],
     });
-    dbQuery.mockResolvedValueOnce({
-      rows: [{ inserted: true }],
-      rowCount: 1,
-    });
-    dbQuery.mockResolvedValue({ rows: [], rowCount: 1 });
+    const client = makeClient();
+    queueHappyPathClient(client, { inserted: true });
+    pool.connect.mockResolvedValue(client);
 
     const base = validPayload();
     const unknownMccPayload = {
@@ -349,7 +384,7 @@ describe("webhookHandler", () => {
     await webhookHandler(makeReq(VALID_SECRET, unknownMccPayload), res);
     expect(res.statusCode).toBe(200);
 
-    const params = dbQuery.mock.calls[1][1];
+    const params = client.query.mock.calls[2][1];
     expect(params[params.length - 1]).toBeNull();
   });
 
@@ -357,26 +392,30 @@ describe("webhookHandler", () => {
     dbQuery.mockResolvedValueOnce({
       rows: [{ user_id: "user_1", webhook_secret: VALID_SECRET }],
     });
-    dbQuery.mockResolvedValueOnce({
-      rows: [{ inserted: false }],
-      rowCount: 1,
-    });
-    dbQuery.mockResolvedValue({ rows: [], rowCount: 1 });
+    const client = makeClient();
+    queueHappyPathClient(client, { inserted: false });
+    pool.connect.mockResolvedValue(client);
 
     const res = makeRes();
     await webhookHandler(makeReq(VALID_SECRET), res);
 
-    const sql = dbQuery.mock.calls[1][0];
+    const sql = client.query.mock.calls[2][0] as string;
     // Sanity-check, що SQL містить захист category_overridden.
     expect(sql).toMatch(/category_overridden/);
     expect(sql).toMatch(/category_slug = CASE/);
   });
 
-  it("re-throws DB errors and records error metric", async () => {
+  it("re-throws DB errors and records error metric (rollback runs)", async () => {
     dbQuery.mockResolvedValueOnce({
       rows: [{ user_id: "user_1", webhook_secret: VALID_SECRET }],
     });
-    dbQuery.mockRejectedValueOnce(new Error("DB gone"));
+    const client = makeClient();
+    client.query
+      .mockResolvedValueOnce({}) // BEGIN
+      .mockResolvedValueOnce({}) // SAVEPOINT
+      .mockRejectedValueOnce(new Error("DB gone")) // upsert fails
+      .mockResolvedValueOnce({}); // ROLLBACK (catch path)
+    pool.connect.mockResolvedValue(client);
 
     const res = makeRes();
     await expect(webhookHandler(makeReq(VALID_SECRET), res)).rejects.toThrow(
@@ -384,27 +423,34 @@ describe("webhookHandler", () => {
     );
 
     expect(counter.inc).toHaveBeenCalledWith({ status: "error" });
+    expect(counter.inc).not.toHaveBeenCalledWith({ status: "ok" });
+    // ROLLBACK був викликаний на catch-гілці.
+    expect(client.query.mock.calls.at(-1)?.[0]).toBe("ROLLBACK");
+    expect(client.release).toHaveBeenCalledTimes(1);
   });
 
-  it("FK violation (23503) on tx upsert → autocreates mono_account stub and retries", async () => {
-    // Lookup connection
+  it("FK violation (23503) on tx upsert → autocreates mono_account stub and retries inside same TX", async () => {
     dbQuery.mockResolvedValueOnce({
       rows: [{ user_id: "user_1", webhook_secret: VALID_SECRET }],
     });
-    // First tx upsert attempt fails with FK violation (unknown account)
+
     const fkErr = Object.assign(new Error("FK violation"), { code: "23503" });
-    dbQuery.mockRejectedValueOnce(fkErr);
-    // Stub-INSERT into mono_account
-    dbQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
-    // Retry tx upsert succeeds
-    dbQuery.mockResolvedValueOnce({
-      rows: [{ inserted: true }],
-      rowCount: 1,
-    });
-    // UPDATE balance
-    dbQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
-    // UPDATE last_event_at
-    dbQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+    const client = makeClient();
+    client.query
+      .mockResolvedValueOnce({}) // BEGIN
+      .mockResolvedValueOnce({}) // SAVEPOINT
+      .mockRejectedValueOnce(fkErr) // first upsert attempt
+      .mockResolvedValueOnce({}) // ROLLBACK TO SAVEPOINT
+      .mockResolvedValueOnce({}) // INSERT mono_account stub
+      .mockResolvedValueOnce({
+        rows: [{ inserted: true }],
+        rowCount: 1,
+      }) // retry upsert
+      .mockResolvedValueOnce({}) // UPDATE balance
+      .mockResolvedValueOnce({}) // UPDATE connection
+      .mockResolvedValueOnce({}) // INSERT enrichment outbox
+      .mockResolvedValueOnce({}); // COMMIT
+    pool.connect.mockResolvedValue(client);
 
     const res = makeRes();
     await webhookHandler(makeReq(VALID_SECRET), res);
@@ -414,38 +460,47 @@ describe("webhookHandler", () => {
     expect(counter.inc).toHaveBeenCalledWith({ status: "account_autocreated" });
     expect(counter.inc).toHaveBeenCalledWith({ status: "ok" });
 
-    // 7 DB calls: lookup + failed tx upsert + account stub + retry tx upsert
-    //           + balance update + event update + enrichment outbox
-    expect(dbQuery).toHaveBeenCalledTimes(7);
+    // Перевіряємо, що ROLLBACK TO SAVEPOINT справді викликаний перед stub-INSERT.
+    const calls = client.query.mock.calls.map((c) => c[0]);
+    const rollbackIdx = calls.findIndex((sql: string) =>
+      /^ROLLBACK TO SAVEPOINT/.test(sql),
+    );
+    expect(rollbackIdx).toBeGreaterThanOrEqual(0);
+    expect(calls[rollbackIdx + 1]).toMatch(/INSERT INTO mono_account/);
 
-    // Verify the stub uses StatementItem currency + balance fields.
-    const stubCall = dbQuery.mock.calls[2];
-    expect(stubCall[0]).toMatch(/INSERT INTO mono_account/);
-    expect(stubCall[0]).toMatch(/ON CONFLICT[\s\S]*DO NOTHING/);
+    // Stub використовує currency + balance з самого StatementItem.
+    const stubCall = client.query.mock.calls[rollbackIdx + 1];
     expect(stubCall[1]).toEqual(["user_1", "acc_uah", 980, 1500000]);
-    expect(stubCall[2]).toEqual({ op: "mono_account_autocreate" });
+
+    expect(client.release).toHaveBeenCalledTimes(1);
   });
 
   it("non-FK errors are NOT retried (only 23503 triggers autocreate)", async () => {
     dbQuery.mockResolvedValueOnce({
       rows: [{ user_id: "user_1", webhook_secret: VALID_SECRET }],
     });
-    // Some other DB error — must propagate without autocreate retry.
+
     const otherErr = Object.assign(new Error("connection lost"), {
       code: "08006",
     });
-    dbQuery.mockRejectedValueOnce(otherErr);
+    const client = makeClient();
+    client.query
+      .mockResolvedValueOnce({}) // BEGIN
+      .mockResolvedValueOnce({}) // SAVEPOINT
+      .mockRejectedValueOnce(otherErr) // upsert fails with non-FK code
+      .mockResolvedValueOnce({}); // ROLLBACK
+    pool.connect.mockResolvedValue(client);
 
     const res = makeRes();
     await expect(webhookHandler(makeReq(VALID_SECRET), res)).rejects.toThrow(
       "connection lost",
     );
 
-    // Only 2 DB calls: lookup + failed tx upsert. No autocreate, no retry.
-    expect(dbQuery).toHaveBeenCalledTimes(2);
     expect(counter.inc).toHaveBeenCalledWith({ status: "error" });
     expect(counter.inc).not.toHaveBeenCalledWith({
       status: "account_autocreated",
     });
+    // BEGIN, SAVEPOINT, fail, ROLLBACK — рівно 4 виклики, ніяких retry.
+    expect(client.query).toHaveBeenCalledTimes(4);
   });
 });

--- a/apps/server/src/modules/mono/webhook.ts
+++ b/apps/server/src/modules/mono/webhook.ts
@@ -1,6 +1,7 @@
 import type { Request, Response } from "express";
+import type { QueryResult } from "pg";
 import { z } from "zod";
-import { query } from "../../db.js";
+import { pool, query } from "../../db.js";
 import { logger } from "../../obs/logger.js";
 import {
   monoWebhookReceivedTotal,
@@ -189,75 +190,92 @@ export async function webhookHandler(
 
   const { account: monoAccountId, statementItem: item } = parsed.data.data;
 
+  // RETURNING (xmax = 0) AS inserted is a Postgres trick: on a fresh INSERT
+  // `xmax` is 0, on the UPDATE branch of ON CONFLICT it is the txid of the
+  // updating transaction (non-zero). We use this to fire push notifications
+  // only on first delivery and stay silent on retries — Monobank can re-send
+  // the same statement item if our 200 response is lost. See AI-DANGER below.
+  // Server-side MCC → category resolution. Returns NULL for MCC 0 / null /
+  // unknown — caller stays NULL and the user can override via UI.
+  // ON CONFLICT branch refreshes `category_slug` only when the user has not
+  // manually overridden it (`category_overridden = FALSE`); otherwise
+  // Monobank's refund-with-different-MCC events would silently undo a
+  // user's correction.
+  const categorySlug = categorizeMcc(item.mcc);
+
+  const txUpsertSql = `INSERT INTO mono_transaction
+       (user_id, mono_account_id, mono_tx_id, time, amount, operation_amount,
+        currency_code, mcc, original_mcc, hold, description, comment,
+        cashback_amount, commission_rate, balance, receipt_id, invoice_id,
+        counter_edrpou, counter_iban, counter_name, raw, source,
+        category_slug)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14,
+             $15, $16, $17, $18, $19, $20, $21, 'webhook',
+             $22)
+     ON CONFLICT (user_id, mono_tx_id) DO UPDATE SET
+       amount = EXCLUDED.amount,
+       operation_amount = EXCLUDED.operation_amount,
+       hold = EXCLUDED.hold,
+       balance = EXCLUDED.balance,
+       description = EXCLUDED.description,
+       comment = EXCLUDED.comment,
+       raw = EXCLUDED.raw,
+       category_slug = CASE
+         WHEN mono_transaction.category_overridden THEN mono_transaction.category_slug
+         ELSE EXCLUDED.category_slug
+       END,
+       received_at = NOW()
+     RETURNING (xmax = 0) AS inserted`;
+  const txUpsertParams = [
+    userId,
+    monoAccountId,
+    item.id,
+    new Date(item.time * 1000).toISOString(),
+    item.amount,
+    item.operationAmount,
+    item.currencyCode,
+    item.mcc ?? null,
+    item.originalMcc ?? null,
+    item.hold ?? null,
+    item.description ?? null,
+    item.comment ?? null,
+    item.cashbackAmount ?? null,
+    item.commissionRate ?? null,
+    item.balance ?? null,
+    item.receiptId ?? null,
+    item.invoiceId ?? null,
+    item.counterEdrpou ?? null,
+    item.counterIban ?? null,
+    item.counterName ?? null,
+    JSON.stringify(item),
+    categorySlug,
+  ];
+
+  // Усі мутації під одним `BEGIN…COMMIT` через виділеного клієнта. Раніше
+  // це були 4–5 послідовних `pool.query` без транзакції — partial failure
+  // (SIGTERM між upsert-ом і UPDATE balance, OOM під час enrichment-INSERT)
+  // лишав баланс/`last_event_at`/outbox у неузгодженому стані. Idempotency
+  // на `(user_id, mono_tx_id)` рятує retry, але не rollback. Pattern
+  // дзеркалить `modules/sync/sync.ts::syncPushAll`. Метрики `ok`/`error`/
+  // `account_autocreated` емітяться ЛИШЕ після успішного COMMIT.
+  const client = await pool.connect();
+  let inserted = false;
+  let autocreated = false;
   try {
-    // RETURNING (xmax = 0) AS inserted is a Postgres trick: on a fresh INSERT
-    // `xmax` is 0, on the UPDATE branch of ON CONFLICT it is the txid of the
-    // updating transaction (non-zero). We use this to fire push notifications
-    // only on first delivery and stay silent on retries — Monobank can re-send
-    // the same statement item if our 200 response is lost. See AI-DANGER below.
-    // Server-side MCC → category resolution. Returns NULL for MCC 0 / null /
-    // unknown — caller stays NULL and the user can override via UI.
-    // ON CONFLICT branch refreshes `category_slug` only when the user has not
-    // manually overridden it (`category_overridden = FALSE`); otherwise
-    // Monobank's refund-with-different-MCC events would silently undo a
-    // user's correction.
-    const categorySlug = categorizeMcc(item.mcc);
+    await client.query("BEGIN");
 
-    const txUpsertSql = `INSERT INTO mono_transaction
-         (user_id, mono_account_id, mono_tx_id, time, amount, operation_amount,
-          currency_code, mcc, original_mcc, hold, description, comment,
-          cashback_amount, commission_rate, balance, receipt_id, invoice_id,
-          counter_edrpou, counter_iban, counter_name, raw, source,
-          category_slug)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14,
-               $15, $16, $17, $18, $19, $20, $21, 'webhook',
-               $22)
-       ON CONFLICT (user_id, mono_tx_id) DO UPDATE SET
-         amount = EXCLUDED.amount,
-         operation_amount = EXCLUDED.operation_amount,
-         hold = EXCLUDED.hold,
-         balance = EXCLUDED.balance,
-         description = EXCLUDED.description,
-         comment = EXCLUDED.comment,
-         raw = EXCLUDED.raw,
-         category_slug = CASE
-           WHEN mono_transaction.category_overridden THEN mono_transaction.category_slug
-           ELSE EXCLUDED.category_slug
-         END,
-         received_at = NOW()
-       RETURNING (xmax = 0) AS inserted`;
-    const txUpsertParams = [
-      userId,
-      monoAccountId,
-      item.id,
-      new Date(item.time * 1000).toISOString(),
-      item.amount,
-      item.operationAmount,
-      item.currencyCode,
-      item.mcc ?? null,
-      item.originalMcc ?? null,
-      item.hold ?? null,
-      item.description ?? null,
-      item.comment ?? null,
-      item.cashbackAmount ?? null,
-      item.commissionRate ?? null,
-      item.balance ?? null,
-      item.receiptId ?? null,
-      item.invoiceId ?? null,
-      item.counterEdrpou ?? null,
-      item.counterIban ?? null,
-      item.counterName ?? null,
-      JSON.stringify(item),
-      categorySlug,
-    ];
-
-    let upsertResult: { rows: Array<{ inserted: boolean }> };
+    // SAVEPOINT навколо upsert-у: на 23503 (FK на `mono_account`) ми робимо
+    // ROLLBACK TO SAVEPOINT і ретраїмо upsert після autocreate-у. Без
+    // savepoint Postgres абортить усю транзакцію при першій помилці і
+    // подальші client.query() кидають "current transaction is aborted".
+    await client.query("SAVEPOINT mono_tx_upsert_attempt");
+    let upsertResult: QueryResult<{ inserted: boolean }>;
     try {
-      upsertResult = await query<{ inserted: boolean }>(
+      upsertResult = await client.query<{ inserted: boolean }>(
         txUpsertSql,
         txUpsertParams,
-        { op: "mono_tx_upsert" },
       );
+      await client.query("RELEASE SAVEPOINT mono_tx_upsert_attempt");
     } catch (err) {
       // Postgres SQLSTATE 23503 = foreign_key_violation. На цьому FK тільки
       // один зовнішній ключ — `(user_id, mono_account_id)` → `mono_account`.
@@ -274,6 +292,7 @@ export async function webhookHandler(
           ? (err as { code?: unknown }).code
           : undefined;
       if (code !== "23503") throw err;
+      await client.query("ROLLBACK TO SAVEPOINT mono_tx_upsert_attempt");
       logger.warn({
         msg: "mono_webhook_account_autocreate",
         userId,
@@ -281,83 +300,87 @@ export async function webhookHandler(
         currencyCode: item.currencyCode,
         monoTxId: item.id,
       });
-      await query(
+      await client.query(
         `INSERT INTO mono_account
            (user_id, mono_account_id, currency_code, balance, last_seen_at)
          VALUES ($1, $2, $3, $4, NOW())
          ON CONFLICT (user_id, mono_account_id) DO NOTHING`,
         [userId, monoAccountId, item.currencyCode, item.balance ?? null],
-        { op: "mono_account_autocreate" },
       );
-      monoWebhookReceivedTotal.inc({ status: "account_autocreated" });
-      upsertResult = await query<{ inserted: boolean }>(
+      upsertResult = await client.query<{ inserted: boolean }>(
         txUpsertSql,
         txUpsertParams,
-        { op: "mono_tx_upsert" },
       );
+      autocreated = true;
     }
 
     if (item.balance != null) {
-      await query(
+      await client.query(
         `UPDATE mono_account
          SET balance = $1, last_seen_at = NOW()
          WHERE user_id = $2 AND mono_account_id = $3`,
         [item.balance, userId, monoAccountId],
-        { op: "mono_account_balance" },
       );
     }
 
-    await query(
+    await client.query(
       `UPDATE mono_connection
        SET last_event_at = NOW(), updated_at = NOW()
        WHERE user_id = $1`,
       [userId],
-      { op: "mono_connection_event" },
     );
 
-    const inserted = upsertResult.rows[0]?.inserted === true;
+    inserted = upsertResult.rows[0]?.inserted === true;
 
     if (inserted) {
-      await query(
+      await client.query(
         `INSERT INTO mono_ai_enrichment_queue (user_id, mono_tx_id)
          VALUES ($1, $2)
          ON CONFLICT (user_id, mono_tx_id) DO NOTHING`,
         [userId, item.id],
-        { op: "mono_ai_enrichment_enqueue" },
       );
     }
 
-    const ms = Number(process.hrtime.bigint() - start) / 1e6;
-    monoWebhookReceivedTotal.inc({ status: "ok" });
-    monoWebhookDurationMs.observe({ status: "ok" }, ms);
-
-    logger.info({
-      msg: "mono_webhook_processed",
-      monoAccountId,
-      monoTxId: item.id,
-      inserted,
-    });
-
-    res.status(200).json({ ok: true });
-
-    // Fan-out push notification AFTER the 200 response — sendToUserQuietly
-    // never throws (logs internally on failure), but we still defer until
-    // after `res.json()` so a slow APNs/FCM round-trip can't extend the
-    // webhook latency window. Skip on duplicate deliveries (`inserted` is
-    // false on the UPDATE branch of ON CONFLICT) so Monobank's retries
-    // don't spam the user.
-    if (inserted) {
-      void sendToUserQuietly(
-        userId,
-        buildMonoPushPayload(item, monoAccountId),
-        { module: "mono" },
-      );
-    }
+    await client.query("COMMIT");
   } catch (err) {
+    try {
+      await client.query("ROLLBACK");
+    } catch {
+      /* ignore secondary rollback failure — original error matters more */
+    }
     const ms = Number(process.hrtime.bigint() - start) / 1e6;
     monoWebhookReceivedTotal.inc({ status: "error" });
     monoWebhookDurationMs.observe({ status: "error" }, ms);
     logger.error({ msg: "mono_webhook_error", err });
     throw err;
+  } finally {
+    client.release();
+  }
+
+  const ms = Number(process.hrtime.bigint() - start) / 1e6;
+  if (autocreated)
+    monoWebhookReceivedTotal.inc({ status: "account_autocreated" });
+  monoWebhookReceivedTotal.inc({ status: "ok" });
+  monoWebhookDurationMs.observe({ status: "ok" }, ms);
+
+  logger.info({
+    msg: "mono_webhook_processed",
+    monoAccountId,
+    monoTxId: item.id,
+    inserted,
+  });
+
+  res.status(200).json({ ok: true });
+
+  // Fan-out push notification AFTER the 200 response — sendToUserQuietly
+  // never throws (logs internally on failure), but we still defer until
+  // after `res.json()` so a slow APNs/FCM round-trip can't extend the
+  // webhook latency window. Skip on duplicate deliveries (`inserted` is
+  // false on the UPDATE branch of ON CONFLICT) so Monobank's retries
+  // don't spam the user.
+  if (inserted) {
+    void sendToUserQuietly(userId, buildMonoPushPayload(item, monoAccountId), {
+      module: "mono",
+    });
   }
 }


### PR DESCRIPTION
## What changed

`apps/server/src/modules/mono/webhook.ts` тепер виконує всі мутації під одним `BEGIN…COMMIT` через виділеного `pool.connect()`-клієнта (раніше було 4–5 послідовних `pool.query` без транзакції).

- Upsert у `mono_transaction`, `UPDATE mono_account`, `UPDATE mono_connection` та `INSERT INTO mono_ai_enrichment_queue` тепер в одній транзакції.
- Autocreate-гілка для FK-violation (23503) використовує `SAVEPOINT mono_tx_upsert_attempt` + `ROLLBACK TO SAVEPOINT`, тож stub-INSERT у `mono_account` і retry upsert-у виконуються у тій самій транзакції без аборту.
- Метрики `monoWebhookReceivedTotal{status=ok|error|account_autocreated}` емітяться **лише** після успішного COMMIT — раніше `account_autocreated` міг збільшитися навіть якщо потім падав інший крок.
- Lookup `mono_connection` (read-only, без RW-сайд-ефектів) залишається на `query()`-обгортці.
- Push fan-out (`sendToUserQuietly`) залишається ПІСЛЯ `res.json()`, щоб APNs/FCM round-trip не подовжував webhook-латенцію (це окремо адресуємо durable-чергою у наступному PR).

## Why

Partial-failure між кроками (SIGTERM під час deploy-у, OOM, network blip, deadlock у одному з UPDATE-ів) лишав одну з трьох таблиць у неузгодженому стані: баланс рахунку міг оновитися, а `last_event_at` сполучення — ні; outbox-INSERT міг проскочити без матеріалізованої транзакції; metric-success рахувався поверх записів, що відкотилися. Idempotency-PK на `(user_id, mono_tx_id)` рятує **повторні доставки** від Monobank, але не in-flight rollback одного DB-кроку посеред п'яти.

Patrn повторює `modules/sync/sync.ts::syncPushAll` — один `pool.connect()` + `BEGIN/COMMIT/ROLLBACK` + emit метрик ЛИШЕ після COMMIT, з `client.release()` у `finally`.

## How to test

```bash
pnpm --filter @sergeant/server exec vitest run src/modules/mono/webhook.test.ts
pnpm --filter @sergeant/server typecheck
pnpm --filter @sergeant/server lint
pnpm --filter @sergeant/server exec vitest run   # повний прогон серверних тестів
```

Локально:

- 15 тестів `webhook.test.ts` зелені (включно з оновленими сценаріями `re-throws DB errors and records error metric (rollback runs)` і `FK violation (23503) → autocreate inside same TX`).
- Повний прогон `vitest run` у `apps/server` — 655/655 passed.
- `pnpm lint` / `pnpm typecheck` без помилок.

Тести були переписані на pool-mock-патерн (`pool.connect` + `client.query`), що дзеркалить `sync.test.ts`. SQL-послідовність валідовується: `BEGIN → SAVEPOINT → upsert → RELEASE → UPDATE balance → UPDATE connection → INSERT outbox → COMMIT`. Для FK-гілки додатково перевіряється `ROLLBACK TO SAVEPOINT` перед stub-INSERT-ом.

---

## Pre-flight (Hard Rule #15)

- [x] Read the `AGENTS.md` Hard Rules that apply to the touched paths (#1 bigint coercion — без змін до серіалізаторів; #5 Conventional Commits — `fix(server)`).
- [x] Read the matching playbook in `docs/playbooks/` — n/a, це чистий refactor існуючого endpoint-а без зміни контракту.
- [x] Checked freshness headers of docs cited in the change — n/a.

## Docs updated alongside code? (Hard Rule #15)

- [ ] API contract change — n/a, response shape (`{ ok: true }`) і HTTP-коди не змінилися.
- [ ] New / removed npm script — n/a.
- [ ] New design token / component / palette — n/a.
- [ ] Deprecation — n/a.
- [ ] Freshness header bumped on docs whose claims changed — n/a.
- [x] N/A — no docs invalidated by this change.

## How AI-tested this PR

- [x] Vitest passes: `pnpm --filter @sergeant/server exec vitest run` → 655/655 (15/15 у `webhook.test.ts`).
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.
- [x] `pnpm dead-code:files` n/a (чистий refactor існуючого файлу, нових файлів не додано).

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

Link to Devin session: https://app.devin.ai/sessions/e53da53adee44a5cbf3f6b3d1aa45a68
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1246" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced webhook processing with improved transaction handling and error recovery mechanisms for increased reliability and consistency.

* **Tests**
  * Strengthened test coverage for transaction behavior and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->