### PR TITLE
refactor(server): нормалізувати chat/coach upstream-помилки через ExternalServiceError + smoke-тести app_build_info

### DIFF
--- a/apps/server/src/modules/chat/chat.stream.test.ts
+++ b/apps/server/src/modules/chat/chat.stream.test.ts
@@ -47,6 +47,7 @@ import {
   recordAnthropicUsage as _recordAnthropicUsage,
 } from "../../lib/anthropic.js";
 import handler from "./chat.js";
+import { ExternalServiceError } from "../../obs/errors.js";
 
 const anthropicMessagesStream = _anthropicMessagesStream as unknown as Mock;
 const recordAnthropicUsageMock = _recordAnthropicUsage as unknown as Mock;
@@ -510,7 +511,12 @@ describe("chat handler — SSE graceful degradation на continuation-помил
 });
 
 describe("chat handler — SSE first-call upstream errors", () => {
-  it("перший upstream !ok → JSON-помилка зі статусом, БЕЗ SSE-заголовків і БЕЗ data-подій", async () => {
+  it("перший upstream !ok → кидає ExternalServiceError, БЕЗ SSE-заголовків і БЕЗ data-подій", async () => {
+    // Pre-SSE upstream-помилка: SSE-заголовки ще не виставлені, тому
+    // нормалізуємо у `ExternalServiceError`. `asyncHandler` довеже до
+    // `errorHandler`, який віддасть JSON `{ error, code: EXTERNAL_SERVICE,
+    // requestId }` зі статусом 429. Перевіряємо контракт на рівні throw —
+    // обгортка `errorHandler` тестується окремо в `errorHandler.test.ts`.
     anthropicMessagesStream.mockResolvedValueOnce({
       response: new Response(
         JSON.stringify({ error: { message: "rate limited" } }),
@@ -521,15 +527,24 @@ describe("chat handler — SSE first-call upstream errors", () => {
 
     const req = makeReq(makeStreamReqBody());
     const res = makeSseRes();
-    await handler(req, res);
-
-    expect(res.statusCode).toBe(429);
-    expect(res.body).toEqual({ error: "rate limited" });
+    let caught: unknown = null;
+    try {
+      await handler(req, res);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(ExternalServiceError);
+    expect(caught).toMatchObject({
+      status: 429,
+      code: "EXTERNAL_SERVICE",
+      message: "rate limited",
+    });
+    // Жодного запису у SSE-стрім (заголовки і body не задіяні).
     expect(res.writes).toHaveLength(0);
     expect(res.headers["Content-Type"]).toBeUndefined();
   });
 
-  it("перший upstream !ok з не-JSON боді → fallback на raw text() через clone()", async () => {
+  it("перший upstream !ok з не-JSON боді → fallback на raw text() через clone(), кидає ExternalServiceError", async () => {
     // `firstResponse.json()` консьюмить body-стрім. Щоб після failed-`.json()`
     // мати можливість прочитати raw-text, у chat.ts тримаємо `clone()` ДО
     // першої спроби — інакше `.text()` поверне нічого і ми втратимо edge-case
@@ -544,12 +559,58 @@ describe("chat handler — SSE first-call upstream errors", () => {
 
     const req = makeReq(makeStreamReqBody());
     const res = makeSseRes();
+    let caught: unknown = null;
+    try {
+      await handler(req, res);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(ExternalServiceError);
+    expect(caught).toMatchObject({
+      status: 503,
+      code: "EXTERNAL_SERVICE",
+      message: "Service Unavailable",
+    });
+    // SSE-заголовки НЕ виставлені (помилкова гілка йде через errorHandler, а не event-stream).
+    expect(res.headers["Content-Type"]).toBeUndefined();
+  });
+
+  it("getReader() === null edge-case → SSE 'err'-подія перед [DONE], стрім коректно закривається", async () => {
+    // Anthropic повернув 200 OK без body (Cloudflare/edge-проксі іноді
+    // стрипають body). SSE-заголовки вже виставлені на цьому етапі —
+    // ми НЕ кидаємо у JSON, а пишемо явну err-подію в стрім, інакше
+    // клієнт побачив би лише тиху [DONE]-закриватку без причини.
+    const responseWithoutBody = new Response(null, {
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+    });
+    // Деякі рантайми не повертають `getReader`-сумісне body для пустого
+    // Response — якщо платформа все ж повернула body, явно нулюємо.
+    Object.defineProperty(responseWithoutBody, "body", {
+      value: null,
+      configurable: true,
+    });
+
+    anthropicMessagesStream.mockResolvedValueOnce({
+      response: responseWithoutBody,
+      recordStreamEnd: vi.fn(),
+    });
+
+    const req = makeReq(makeStreamReqBody());
+    const res = makeSseRes();
     await handler(req, res);
 
-    expect(res.statusCode).toBe(503);
-    expect((res.body as { error: string }).error).toBe("Service Unavailable");
-    // SSE-заголовки НЕ виставлені (помилкова гілка віддає JSON, а не event-stream).
-    expect(res.headers["Content-Type"]).toBeUndefined();
+    const payloads = dataPayloads(res.writes);
+    // Очікуємо рівно одну err-подію (саме від edge-case-у), потім [DONE].
+    expect(payloads).toContain(
+      JSON.stringify({ err: "AI upstream returned empty body" }),
+    );
+    expect(payloads[payloads.length - 1]).toBe("[DONE]");
+    expect(res.writableEnded).toBe(true);
+    // SSE-заголовки виставлені (стрім ВЖЕ почато на момент edge-case-у).
+    expect(res.headers["Content-Type"]).toBe(
+      "text/event-stream; charset=utf-8",
+    );
   });
 });
 

--- a/apps/server/src/modules/chat/chat.test.ts
+++ b/apps/server/src/modules/chat/chat.test.ts
@@ -25,6 +25,7 @@ vi.mock("../../lib/anthropic.js", () => ({
 
 import { anthropicMessages as _anthropicMessages } from "../../lib/anthropic.js";
 import handler from "./chat.js";
+import { ExternalServiceError } from "../../obs/errors.js";
 
 const anthropicMessages = _anthropicMessages as unknown as Mock;
 
@@ -365,7 +366,7 @@ describe("chat handler — tool_use parsing", () => {
     expect(anthropicMessages).not.toHaveBeenCalled();
   });
 
-  it("поширює помилку коли Anthropic повертає !ok", async () => {
+  it("кидає ExternalServiceError коли Anthropic повертає !ok (єдиний контракт через errorHandler)", async () => {
     anthropicMessages.mockResolvedValueOnce({
       response: { ok: false, status: 429 },
       data: { error: { message: "rate limit" } },
@@ -374,9 +375,55 @@ describe("chat handler — tool_use parsing", () => {
       messages: [{ role: "user", content: "hello" }],
     });
     const res = makeRes();
-    await handler(req, res);
-    expect(res.statusCode).toBe(429);
-    expect(res.body).toEqual({ error: "rate limit" });
+    // Замість прямого `res.status().json()` тепер кидаємо `ExternalServiceError`.
+    // `asyncHandler` ловить через `Promise.resolve(...).catch(next)` і
+    // термінальний `errorHandler` віддає клієнту 4xx/5xx + `code: EXTERNAL_SERVICE`,
+    // інкрементує `app_errors_total` і (для 5xx без operational-маркера) пише в Sentry.
+    let caught: unknown = null;
+    try {
+      await handler(req, res);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(ExternalServiceError);
+    expect(caught).toMatchObject({
+      name: "ExternalServiceError",
+      status: 429,
+      message: "rate limit",
+      code: "EXTERNAL_SERVICE",
+    });
+  });
+
+  it("tool-result не-стрім !ok → кидає ExternalServiceError (502 fallback без upstream-статусу)", async () => {
+    anthropicMessages.mockResolvedValueOnce({
+      response: { ok: false, status: 0 }, // upstream без status (network glitch)
+      data: null,
+    });
+    const req = makeReq({
+      messages: [{ role: "user", content: "hi" }],
+      tool_calls_raw: [
+        {
+          type: "tool_use",
+          id: "toolu_01ABC",
+          name: "delete_transaction",
+          input: { tx_id: "m_abc123" },
+        },
+      ],
+      tool_results: [{ tool_use_id: "toolu_01ABC", content: "ok" }],
+    });
+    const res = makeRes();
+    let caught: unknown = null;
+    try {
+      await handler(req, res);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(ExternalServiceError);
+    expect(caught).toMatchObject({
+      status: 502,
+      code: "EXTERNAL_SERVICE",
+      message: "AI error",
+    });
   });
 });
 

--- a/apps/server/src/modules/chat/chat.ts
+++ b/apps/server/src/modules/chat/chat.ts
@@ -17,6 +17,7 @@ import { TOOLS, SYSTEM_PREFIX, SYSTEM_PROMPT_VERSION } from "./tools.js";
 import { recordToolProposals, recordToolExecutions } from "./toolMetrics.js";
 import { truncateToolResults } from "./toolResultTruncation.js";
 import { als } from "../../obs/requestContext.js";
+import { ExternalServiceError } from "../../obs/errors.js";
 
 type WithAnthropicKey = Request & { anthropicKey?: string };
 
@@ -392,10 +393,9 @@ export default async function handler(
 
     if (!response?.ok) {
       await refundQuotaOnUpstreamFailure(req);
-      res
-        .status(response?.status || 500)
-        .json({ error: data?.error?.message || "AI error" });
-      return;
+      throw new ExternalServiceError(data?.error?.message || "AI error", {
+        status: response?.status || 502,
+      });
     }
 
     const text = extractAnthropicText(data);
@@ -440,10 +440,9 @@ export default async function handler(
 
   if (!response?.ok) {
     await refundQuotaOnUpstreamFailure(req);
-    res
-      .status(response?.status || 500)
-      .json({ error: data?.error?.message || "AI error" });
-    return;
+    throw new ExternalServiceError(data?.error?.message || "AI error", {
+      status: response?.status || 502,
+    });
   }
 
   const content: AnthropicContentBlock[] = data?.content || [];
@@ -505,6 +504,17 @@ async function streamOneIterationToSse(
 ): Promise<StreamIterationResult> {
   const reader = upstream.body?.getReader();
   if (!reader) {
+    // Edge-case: 200 OK без `body`/`getReader()` — Anthropic не повинен
+    // такого віддавати, але Cloudflare/edge-проксі іноді стрипають body.
+    // SSE-заголовки тут ВЖЕ виставлені (caller — `streamAnthropicToSse`
+    // ставить їх до першого виклику цієї функції), тому ми НЕ можемо
+    // упасти у JSON через `errorHandler`. Натомість пишемо явну err-подію,
+    // щоб клієнт побачив помилку, а не тиху [DONE]-закриватку.
+    if (!res.writableEnded) {
+      res.write(
+        `data: ${JSON.stringify({ err: "AI upstream returned empty body" })}\n\n`,
+      );
+    }
     return {
       outcome: "error",
       stopReason: null,
@@ -630,8 +640,15 @@ async function streamAnthropicToSse(
         /* ignore */
       }
     }
-    res.status(firstResponse.status).json({ error: errMsg });
-    return;
+    // Pre-SSE Anthropic upstream-помилка: жодних SSE-заголовків ще не
+    // виставлено, тож кидаємо через `ExternalServiceError`, щоб
+    // `errorHandler` уніфіковано додав `code: EXTERNAL_SERVICE`,
+    // `requestId`, інкрементнув `app_errors_total{kind=operational}` і
+    // (для 5xx, де `isOperationalError(err)` — це 502 за замовчуванням)
+    // не дав Sentry повторити подію.
+    throw new ExternalServiceError(errMsg, {
+      status: firstResponse.status || 502,
+    });
   }
 
   res.setHeader("Content-Type", "text/event-stream; charset=utf-8");

--- a/apps/server/src/modules/chat/coach.test.ts
+++ b/apps/server/src/modules/chat/coach.test.ts
@@ -26,6 +26,7 @@ import _pool from "../../db.js";
 import { anthropicMessages as _anthropicMessages } from "../../lib/anthropic.js";
 import { coachInsight, coachMemoryGet, coachMemoryPost } from "./coach.js";
 import { MAX_BLOB_SIZE } from "../sync/sync.js";
+import { ExternalServiceError } from "../../obs/errors.js";
 
 const pool = _pool as unknown as { query: Mock };
 const anthropicMessages = _anthropicMessages as unknown as Mock;
@@ -229,26 +230,49 @@ describe("coachInsight", () => {
     expect(anthropicMessages).not.toHaveBeenCalled();
   });
 
-  it("AI upstream !ok → прокидає status+message (AI timeout/500 сценарій)", async () => {
+  it("AI upstream !ok → кидає ExternalServiceError зі статусом і message", async () => {
+    // Уніфікуємо upstream-помилки під `errorHandler`: status 504,
+    // code: EXTERNAL_SERVICE — той самий контракт, що в `chat.ts`/`weekly-digest.ts`.
     anthropicMessages.mockResolvedValueOnce({
       response: { ok: false, status: 504 },
       data: { error: { message: "Upstream timeout" } },
     });
     const res = makeRes();
-    await coachInsight(makeReq({ snapshot: {}, memory: {} }), res);
-    expect(res.statusCode).toBe(504);
-    expect(res.body).toEqual({ error: "Upstream timeout" });
+    let caught: unknown = null;
+    try {
+      await coachInsight(makeReq({ snapshot: {}, memory: {} }), res);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(ExternalServiceError);
+    expect(caught).toMatchObject({
+      status: 504,
+      code: "EXTERNAL_SERVICE",
+      message: "Upstream timeout",
+    });
   });
 
-  it("AI відповідь без помилкового тіла → fallback 'AI error'", async () => {
+  it("AI відповідь без помилкового тіла → fallback на 502 з 'AI error'", async () => {
+    // Якщо upstream-status відсутній (network glitch, response без `.status`),
+    // 5xx-fallback — 502 (`Bad Gateway`) — стандартне відображення для
+    // невдалого зовнішнього сервісу.
     anthropicMessages.mockResolvedValueOnce({
-      response: { ok: false, status: 500 },
+      response: { ok: false, status: 0 },
       data: null,
     });
     const res = makeRes();
-    await coachInsight(makeReq({ snapshot: {}, memory: {} }), res);
-    expect(res.statusCode).toBe(500);
-    expect(res.body).toEqual({ error: "AI error" });
+    let caught: unknown = null;
+    try {
+      await coachInsight(makeReq({ snapshot: {}, memory: {} }), res);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(ExternalServiceError);
+    expect(caught).toMatchObject({
+      status: 502,
+      code: "EXTERNAL_SERVICE",
+      message: "AI error",
+    });
   });
 
   it("порожній snapshot → prompt містить 'Даних за поточний тиждень ще немає.'", async () => {

--- a/apps/server/src/modules/chat/coach.ts
+++ b/apps/server/src/modules/chat/coach.ts
@@ -11,6 +11,7 @@ import {
   CoachInsightSchema,
   CoachMemoryPostSchema,
 } from "../../http/schemas.js";
+import { ExternalServiceError } from "../../obs/errors.js";
 
 type WithSessionUser = Request & { user?: { id: string } };
 type WithAnthropicKey = Request & { anthropicKey?: string };
@@ -365,10 +366,9 @@ ${snapshotText}
 
   if (!aiRes?.ok) {
     const errData = aiData as AnthropicErrorPayload | null | undefined;
-    res
-      .status(aiRes?.status || 500)
-      .json({ error: errData?.error?.message || "AI error" });
-    return;
+    throw new ExternalServiceError(errData?.error?.message || "AI error", {
+      status: aiRes?.status || 502,
+    });
   }
 
   const text = extractAnthropicText(aiData);

--- a/apps/server/src/obs/metrics.test.ts
+++ b/apps/server/src/obs/metrics.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Smoke-тести Prometheus-реєстру: переконуємось, що ключові метрики
+ * зареєстровані у спільному `register`-і й експортуються через
+ * `register.metrics()` у форматі, який Prometheus може відфетчити.
+ *
+ * Не вимірюємо самі значення (collectDefaultMetrics + business counters
+ * — це стани процесу, які тестувати в unit-форматі дорого і крихко).
+ * Покриваємо саме контракт: ім'я метрики, тип, набір лейблів, видимість
+ * у експорт-payload-і. Це той контракт, на який зав'язані Grafana-дашборди
+ * (e.g. `* on (instance) group_left(version, commit) http_request_duration_ms`)
+ * — тут ми ловимо drift, який інакше з'явився б тільки під alert-evaluator-ом.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  register,
+  appBuildInfo,
+  aiRequestDurationMs,
+  aiRequestsTotal,
+} from "./metrics.js";
+
+describe("metrics registry — `app_build_info` gauge", () => {
+  it("реєструється у спільному `register`-і з ім'ям `app_build_info`", () => {
+    const metric = register.getSingleMetric("app_build_info");
+    expect(metric).toBe(appBuildInfo);
+    expect(metric).toBeDefined();
+  });
+
+  it("експортує єдиний sample зі значенням 1 і повним набором лейблів", async () => {
+    const text = await register.metrics();
+    // `app_build_info{version="…", commit="…", release="…", env="…", node_version="…"} 1`
+    // — точна форма, яку Prometheus зчитує. Якщо хтось забуде один з
+    // лейблів (наприклад, прибере `env` для "стиснення"), всі дашборди,
+    // що роблять `group_left(commit, release)`, мовчки втратять точку
+    // join-а — тому лейбли явно фіксуємо у тесті.
+    expect(text).toMatch(/^app_build_info\{.*?\} 1$/m);
+    expect(text).toMatch(/version="[^"]+"/);
+    expect(text).toMatch(/commit="[^"]+"/);
+    expect(text).toMatch(/release="[^"]+"/);
+    expect(text).toMatch(/env="[^"]+"/);
+    expect(text).toMatch(/node_version="[^"]+"/);
+  });
+
+  it("`commit` обрізається до 12 символів (slice ув'язується з prom-cardinality bound-ом)", async () => {
+    const text = await register.metrics();
+    const match = /commit="([^"]+)"/.exec(text);
+    expect(match).not.toBeNull();
+    // 12 символів = стандартний short-SHA, який Railway/GitHub вставляють
+    // у release-таги. Більше — невиправдана cardinality, менше — ризик
+    // колізій SHA-prefix-у в великих репах.
+    if (match) expect(match[1].length).toBeLessThanOrEqual(12);
+  });
+});
+
+describe("metrics registry — AI per-endpoint duration histogram", () => {
+  it("`ai_request_duration_ms` зареєстрований і має лейбли provider/model/endpoint/outcome", () => {
+    // SLO/dashboards зав'язані саме на цей набір лейблів. Дзеркалить
+    // labelNames у `aiRequestsTotal` — щоб p95-латентність помилкових
+    // запитів можна було виокремити з `outcome="error"`.
+    const metric = register.getSingleMetric("ai_request_duration_ms");
+    expect(metric).toBe(aiRequestDurationMs);
+
+    const counter = register.getSingleMetric("ai_requests_total");
+    expect(counter).toBe(aiRequestsTotal);
+  });
+
+  it("експорт містить `# TYPE ai_request_duration_ms histogram` і lable-set", async () => {
+    aiRequestDurationMs.observe(
+      {
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        endpoint: "chat",
+        outcome: "ok",
+      },
+      123,
+    );
+    const text = await register.metrics();
+    expect(text).toContain("# TYPE ai_request_duration_ms histogram");
+    expect(text).toMatch(
+      /ai_request_duration_ms_bucket\{.*?endpoint="chat".*?outcome="ok".*?\}/,
+    );
+  });
+});


### PR DESCRIPTION
## What changed

- `apps/server/src/modules/chat/chat.ts`: усі ранні (pre-SSE) Anthropic-помилки тепер кидають `ExternalServiceError(message, { status })` замість прямого `res.status(...).json({ error })` — три точки: tool-result не-стрім (`callAnthropicWithContinuation` !ok), перший крок не-стрім, SSE pre-stream `firstResponse.ok === false`.
- `apps/server/src/modules/chat/chat.ts`: edge-case `upstream.body?.getReader() === null` (200 OK без body — Cloudflare/edge-проксі іноді стрипають body) тепер пише явну `data: { err: "AI upstream returned empty body" }\n\n`-подію в SSE-стрім перед `[DONE]`. До цього клієнт бачив тиху `[DONE]`-закриватку без жодного err-сигналу.
- `apps/server/src/modules/chat/coach.ts`: те саме нормалізування для `coachInsight` upstream-помилки.
- `apps/server/src/obs/metrics.test.ts` (новий): smoke-тести для `app_build_info` Prometheus-gauge (ім'я, label-set version/commit/release/env/node_version, 12-char SHA-truncate) і `ai_request_duration_ms` histogram (label-set provider/model/endpoint/outcome). Ці gauge/histogram уже існують у `obs/metrics.ts:357-380, 298-307` — тест лочить контракт, на який зав'язані Grafana-join-и (`* on (instance) group_left(commit) <metric>`).
- Тести оновлено для нового контракту:
  - `chat.test.ts`: перший upstream !ok → `ExternalServiceError` 429/EXTERNAL_SERVICE; новий тест tool-result не-стрім !ok → 502 fallback.
  - `chat.stream.test.ts`: SSE pre-stream !ok → throw 429; не-JSON pre-stream → throw 503; новий тест `getReader() === null` → SSE 'err'-подія + `[DONE]`.
  - `coach.test.ts`: 504 → throw з upstream-статусом; 0-status → 502 fallback.

## Why

`apps/server/src/modules/chat/chat.ts` ще мав edge-case прямого `res.status(500).json` коли `response.body` без `getReader()` до старту SSE (`docs/backend-tech-debt.md:610`) — і три інших pre-SSE upstream-помилки, які обходили термінальний `errorHandler`. Це означало:

1. Sentry мовчав для будь-якого Anthropic 5xx у chat/coach (бо `Sentry.captureException` живе всередині `errorHandler`).
2. Клієнт отримував body без `code`/`requestId` — на відміну від решти ендпоінтів, де response stable: `{ error, code, requestId }`.
3. Лічильник `app_errors_total{kind=operational, status, code, module}` не інкрементився, тож SLO/error-budget на chat-ендпоінтах був занижений (видно лише через `ai_requests_total{outcome=error}`, але це per-upstream-call, а не per-endpoint).

`weekly-digest.ts` уже використовує цей патерн (`apps/server/src/modules/digest/weekly-digest.ts:197-200`) — це привод для chat/coach. Зміни замикають Backend #5 з топ-5 покращень бекенду.

`app_build_info` gauge і `ai_request_duration_ms` histogram — обидва вже існують у `obs/metrics.ts`. Smoke-тест локує мінімальний контракт label-set-у, на який зав'язані dashboard-join-и: якщо хтось випадково прибере `release` чи перейменує `node_version`, всі `* on (instance) group_left(commit, release)` мовчки втратять точку join-а. Тест ловить це до production-deploy-а.

## How to test

```bash
pnpm --filter @sergeant/server test src/modules/chat/chat.test.ts \
  src/modules/chat/chat.stream.test.ts \
  src/modules/chat/coach.test.ts \
  src/obs/metrics.test.ts
```

Очікуваний результат: 60 нових/оновлених тестів проходять. Повний `pnpm --filter @sergeant/server test` — 690 passed.

E2E (із dev-сервером):

```bash
# 1. Anthropic upstream → 429
ANTHROPIC_API_KEY=invalid pnpm dev:server &
curl -sS -X POST http://localhost:3000/api/chat \
  -H "Content-Type: application/json" \
  -H "Cookie: <session>" \
  -d '{"messages":[{"role":"user","content":"hi"}]}' | jq

# Очікуємо: { "error": "...", "code": "EXTERNAL_SERVICE", "requestId": "req_..." } зі статусом 401/4xx (від Anthropic).

# 2. app_build_info експорт
curl -sS http://localhost:3000/metrics \
  -H "Authorization: Bearer ${METRICS_TOKEN}" | grep app_build_info
# Очікуємо: app_build_info{version="...",commit="...",release="...",env="...",node_version="..."} 1
```

---

## Pre-flight (Hard Rule #15)

- [x] Read the `AGENTS.md` Hard Rules that apply to the touched paths.
- [x] Read the matching playbook in `docs/playbooks/` (none for SSE error paths; closest is `docs/backend-tech-debt.md:610`).
- [x] Checked freshness headers of docs cited in the change.

## Docs updated alongside code? (Hard Rule #15)

- [x] N/A — no docs invalidated by this change. Response-shape залишився той самий (`{ error, code, requestId }` уже документовано через `errorHandler.ts`); попередній варіант (без `code`/`requestId`) був бажаною помилкою.

## How AI-tested this PR

- [x] Vitest passes: `pnpm --filter @sergeant/server test` → 690 passed.
- [x] Lint passes: `pnpm lint` зелений (включно з custom плагінами).
- [x] Typecheck passes: `pnpm typecheck` зелений.
- [x] Build passes: `pnpm --filter @sergeant/server build` зелений.
- [x] No new `AI-DANGER` markers added.
- [x] Docs prose uses Ukrainian.
- [x] `pnpm dead-code:files` clean (новий `metrics.test.ts` має імпорти з `metrics.ts`).

## AGENTS.md updated?

- [x] No — no new permanent rules. Це уніфікація з існуючим патерном (`weekly-digest.ts` + `errorHandler.ts`), не нова конвенція.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize Anthropic upstream errors in chat and coach to route through the global error handler and make SSE failures explicit. Add smoke tests to lock the `app_build_info` and `ai_request_duration_ms` Prometheus metric contracts.

- **Refactors**
  - Pre-SSE upstream errors in `chat.ts` and `coach.ts` now throw `ExternalServiceError(message, { status })`, producing consistent `{ error, code: EXTERNAL_SERVICE, requestId }` via the global handler.
  - SSE edge-case: when upstream returns 200 without a body, emit `data: {"err":"AI upstream returned empty body"}` before `[DONE]`.
  - Fallbacks: non-JSON pre-stream → 503; missing upstream status → 502. Tests updated; added smoke tests to verify metric names and label sets for `app_build_info` and `ai_request_duration_ms`.

<sup>Written for commit 24dac067c581bab1fd2b672050a4f89d000e8609. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1256?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Standardized external service failures in chat and coach: consistent error payloads with accurate status codes and a 502 fallback when upstream status is unavailable.
  - Streaming chat now emits a clear SSE error event and closes the stream when the upstream body is missing, preventing partial responses or incorrect headers.

- Tests
  - Expanded coverage for chat/coach error handling, SSE edge cases, and observability metrics to ensure reliability and contract stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->