### PR TITLE
fix(server): coerce TIMESTAMPTZ Date objects to ISO strings in syncStateHandler

### DIFF
--- a/apps/server/src/modules/mono/connection.test.ts
+++ b/apps/server/src/modules/mono/connection.test.ts
@@ -355,4 +355,29 @@ describe("syncStateHandler", () => {
     expect(res.body.lastEventAt).toBe("2026-04-25T12:00:00Z");
     expect(res.body.accountsCount).toBe(3);
   });
+
+  it("coerces pg Date objects to ISO strings (TIMESTAMPTZ columns)", async () => {
+    dbQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          status: "active",
+          webhook_registered_at: new Date("2026-04-25T10:00:00Z"),
+          last_event_at: new Date("2026-04-25T12:00:00Z"),
+          last_backfill_at: new Date("2026-04-26T08:30:00Z"),
+        },
+      ],
+    });
+    dbQuery.mockResolvedValueOnce({ rows: [{ count: "5" }] });
+
+    const req = { method: "GET", user: { id: "user_1" } } as unknown as Request;
+    const res = makeRes();
+    await syncStateHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.status).toBe("active");
+    expect(res.body.webhookActive).toBe(true);
+    expect(res.body.lastEventAt).toBe("2026-04-25T12:00:00.000Z");
+    expect(res.body.lastBackfillAt).toBe("2026-04-26T08:30:00.000Z");
+    expect(res.body.accountsCount).toBe(5);
+  });
 });

--- a/apps/server/src/modules/mono/connection.ts
+++ b/apps/server/src/modules/mono/connection.ts
@@ -317,9 +317,9 @@ export async function syncStateHandler(
 
   const connResult = await query<{
     status: string;
-    webhook_registered_at: string | null;
-    last_event_at: string | null;
-    last_backfill_at: string | null;
+    webhook_registered_at: Date | string | null;
+    last_event_at: Date | string | null;
+    last_backfill_at: Date | string | null;
   }>(
     `SELECT status, webhook_registered_at, last_event_at, last_backfill_at
      FROM mono_connection WHERE user_id = $1`,
@@ -353,8 +353,14 @@ export async function syncStateHandler(
       status: conn.status,
       webhookActive:
         conn.status === "active" && conn.webhook_registered_at != null,
-      lastEventAt: conn.last_event_at,
-      lastBackfillAt: conn.last_backfill_at,
+      lastEventAt:
+        conn.last_event_at instanceof Date
+          ? conn.last_event_at.toISOString()
+          : conn.last_event_at,
+      lastBackfillAt:
+        conn.last_backfill_at instanceof Date
+          ? conn.last_backfill_at.toISOString()
+          : conn.last_backfill_at,
       accountsCount: Number(countResult.rows[0]?.count ?? 0),
     }),
   );


### PR DESCRIPTION
## What changed

Coerce `last_event_at` and `last_backfill_at` from pg `Date` objects to ISO strings before passing them to `MonoSyncStateSchema.parse()` in `syncStateHandler`. Also fixed the TypeScript type annotation for the query result to reflect the actual runtime type (`Date | string | null` instead of `string | null`).

Added a new test case that verifies the handler works correctly when pg returns `Date` objects (the real runtime behavior for TIMESTAMPTZ columns).

## Why

`node-postgres` returns `TIMESTAMPTZ` columns as JavaScript `Date` objects, but `MonoSyncStateSchema` expects `z.string().nullable()` for `lastEventAt` and `lastBackfillAt`. When a user already had a `mono_connection` row with non-null event/backfill timestamps, the Zod `.parse()` threw a validation error, causing **500 on every `GET /api/mono/sync-state`** call. This blocked the entire Monobank reconnection flow — the UI could never read the connection state, so the connect button kept resetting to its initial state.

The existing normalizer in `lib/normalizers/mono.ts` already handles `Date → string` conversion with `instanceof Date ? .toISOString()`, but `syncStateHandler` was missed when the schema SSOT validation was added in `a8b5b940`.

The 404s on `/api/mono/webhook/:secret` in the Railway logs are expected (Monobank verifying old/stale webhook URLs) and unrelated to this bug.

## How to test

1. Ensure a user has an existing `mono_connection` row with non-null `last_event_at` (i.e., they previously received webhook events).
2. Call `GET /api/mono/sync-state` — should return 200 with ISO-formatted date strings instead of 500.
3. Run `pnpm --filter @sergeant/server exec vitest run src/modules/mono/connection.test.ts` — all 16 tests pass, including the new `coerces pg Date objects to ISO strings` test.

---

## Pre-flight (Hard Rule #15)

- [x] Read the `AGENTS.md` Hard Rules that apply to the touched paths.
- [x] Read the matching playbook in `docs/playbooks/` (or noted that none exists).
- [x] Checked freshness headers of docs cited in the change.

## Docs updated alongside code? (Hard Rule #15)

- [x] N/A — no docs invalidated by this change.

## How AI-tested this PR

- [x] Vitest passes: all 16 tests in `connection.test.ts` pass (including new Date-coercion test).
- [x] TypeScript compiles cleanly (`tsc --noEmit`).
- [x] ESLint passes on changed files.
- [x] No new `AI-DANGER` markers added without justification.

## AGENTS.md updated?

- [x] No — no new permanent rules

---

Link to Devin session: https://app.devin.ai/sessions/76362bee62424ee581f968162a7bdae1
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1257" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 500s on `GET /api/mono/sync-state` by converting `TIMESTAMPTZ` dates from `node-postgres` to ISO strings in `syncStateHandler`. This returns schema-valid timestamps and unblocks the Monobank reconnection flow.

- **Bug Fixes**
  - Coerce `last_event_at` and `last_backfill_at` `Date` values to `.toISOString()` before schema parse.
  - Correct query result types to `Date | string | null` to match runtime.
  - Add test covering `TIMESTAMPTZ` behavior to prevent regressions.

<sup>Written for commit e91dab9dac535b0724bb1d685aefed0ddac1f313. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1257?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved timestamp handling to ensure consistent ISO 8601 string formatting in sync state responses, regardless of database driver format.

* **Tests**
  * Added test coverage for timestamp data type handling in sync state operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->