### PR TITLE
fix(root): activate 15, 18, 19 — schedule rule wrapper + errorWorkflow=98 + 19 sequential restructure

### DIFF
--- a/ops/n8n-workflows/15-railway-deployment-notify.json
+++ b/ops/n8n-workflows/15-railway-deployment-notify.json
@@ -70,7 +70,8 @@
   },
   "settings": {
     "executionOrder": "v1",
-    "timezone": "Europe/Kyiv"
+    "timezone": "Europe/Kyiv",
+    "errorWorkflow": "iC82EFJzqBny9kxI"
   },
   "tags": [
     {

--- a/ops/n8n-workflows/18-nightly-security-audit.json
+++ b/ops/n8n-workflows/18-nightly-security-audit.json
@@ -3,12 +3,14 @@
   "nodes": [
     {
       "parameters": {
-        "interval": [
-          {
-            "field": "cronExpression",
-            "expression": "0 4 * * *"
-          }
-        ]
+        "rule": {
+          "interval": [
+            {
+              "field": "cronExpression",
+              "expression": "0 4 * * *"
+            }
+          ]
+        }
       },
       "id": "cron-4am-utc",
       "name": "Cron 04:00 UTC",
@@ -160,7 +162,8 @@
   },
   "settings": {
     "executionOrder": "v1",
-    "timezone": "UTC"
+    "timezone": "UTC",
+    "errorWorkflow": "iC82EFJzqBny9kxI"
   },
   "tags": [
     {

--- a/ops/n8n-workflows/19-db-health-report.json
+++ b/ops/n8n-workflows/19-db-health-report.json
@@ -3,12 +3,14 @@
   "nodes": [
     {
       "parameters": {
-        "interval": [
-          {
-            "field": "cronExpression",
-            "expression": "0 7 * * 1"
-          }
-        ]
+        "rule": {
+          "interval": [
+            {
+              "field": "cronExpression",
+              "expression": "0 7 * * 1"
+            }
+          ]
+        }
       },
       "id": "cron-monday",
       "name": "Cron Mon 07:00 Kyiv",
@@ -45,6 +47,7 @@
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2.5,
       "position": [460, 380],
+      "executeOnce": true,
       "credentials": {
         "postgres": {
           "id": "pwwVNTLBw43PJgey",
@@ -65,6 +68,8 @@
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2.5,
       "position": [460, 560],
+      "executeOnce": true,
+      "continueOnFail": true,
       "credentials": {
         "postgres": {
           "id": "pwwVNTLBw43PJgey",
@@ -80,7 +85,8 @@
       "name": "Format DB report",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [680, 380]
+      "position": [680, 380],
+      "executeOnce": true
     },
     {
       "parameters": {
@@ -111,16 +117,6 @@
             "node": "DB size & counts",
             "type": "main",
             "index": 0
-          },
-          {
-            "node": "Top 5 tables by size",
-            "type": "main",
-            "index": 0
-          },
-          {
-            "node": "Slow queries (pg_stat_statements)",
-            "type": "main",
-            "index": 0
           }
         ]
       ]
@@ -129,7 +125,7 @@
       "main": [
         [
           {
-            "node": "Format DB report",
+            "node": "Top 5 tables by size",
             "type": "main",
             "index": 0
           }
@@ -140,7 +136,7 @@
       "main": [
         [
           {
-            "node": "Format DB report",
+            "node": "Slow queries (pg_stat_statements)",
             "type": "main",
             "index": 0
           }
@@ -172,7 +168,8 @@
   },
   "settings": {
     "executionOrder": "v1",
-    "timezone": "Europe/Kyiv"
+    "timezone": "Europe/Kyiv",
+    "errorWorkflow": "iC82EFJzqBny9kxI"
   },
   "tags": [
     {

--- a/ops/n8n-workflows/manifest.json
+++ b/ops/n8n-workflows/manifest.json
@@ -113,11 +113,11 @@
     },
     "15-railway-deployment-notify.json": {
       "owner": "ops",
-      "status": "experimental",
+      "status": "prod-ready",
       "riskTier": "P2",
       "requiredEnv": ["TELEGRAM_ALERT_CHAT_ID"],
       "requiredCredentials": ["Telegram (Sergeant_alert_bot)"],
-      "notes": "Railway webhook notifications. Add signature/shared-secret if Railway supports it."
+      "notes": "Railway webhook notifications. Active; webhook path /webhook/railway-deploy. Configure Railway project webhook to POST deploy events here. Add signature/shared-secret if Railway supports it."
     },
     "16-posthog-daily-metrics.json": {
       "owner": "growth",
@@ -141,22 +141,22 @@
     },
     "18-nightly-security-audit.json": {
       "owner": "security",
-      "status": "experimental",
+      "status": "prod-ready",
       "riskTier": "P1",
       "requiredEnv": ["GITHUB_PAT", "TELEGRAM_ALERT_CHAT_ID"],
       "requiredCredentials": ["Telegram (Sergeant_alert_bot)"],
-      "notes": "Nightly security audit status report."
+      "notes": "Nightly security audit status report. Active; cron fires daily 04:00 UTC against the .github/workflows/nightly-audit.yml run history; alerts only if latest conclusion is failure/cancelled."
     },
     "19-db-health-report.json": {
       "owner": "ops",
-      "status": "experimental",
+      "status": "prod-ready",
       "riskTier": "P1",
       "requiredEnv": ["TELEGRAM_ALERT_CHAT_ID"],
       "requiredCredentials": [
         "Sergeant Postgres (sergeant-db)",
         "Telegram (Sergeant_alert_bot)"
       ],
-      "notes": "DB health report. pg_stat_statements may be absent and is tolerated."
+      "notes": "DB health report. Active; cron fires Mon 07:00 Kyiv. Sequential chain (DB size → Top tables → Slow queries → Format → Telegram) with executeOnce=true on chained postgres+code nodes. pg_stat_statements may be absent and is tolerated via continueOnFail."
     },
     "98-error-handler.json": {
       "owner": "ops",


### PR DESCRIPTION
## What changed

Activates three previously inactive n8n workflows (`15`, `18`, `19`) and brings them in line with the prod-ready conventions used by `01–06`/`17`/`99`.

| File | Change |
|---|---|
| `15-railway-deployment-notify.json` | + `settings.errorWorkflow = 98` (webhook trigger, no schedule). |
| `18-nightly-security-audit.json` | wrap cron `interval[]` in `parameters.rule` (n8n `scheduleTrigger` v1.2 requires the `rule` wrapper; without it the schedule never registers and the cron never fires) + `settings.errorWorkflow = 98`. |
| `19-db-health-report.json` | same `rule` wrapper fix + `settings.errorWorkflow = 98` + **restructure connections** from fan-out (Cron → 3 parallel Postgres → all converging on `Format DB report`) to a **sequential chain** (Cron → DB size → Top tables → Slow queries → Format → Telegram) with `executeOnce: true` on the chained Postgres + Code nodes. |
| `manifest.json` | 15, 18, 19 status `experimental` → `prod-ready`, with notes describing trigger and operational state. |

## Why

A live test of `19` exposed a latent wiring bug: when 3 nodes converge on a single Code node at the same input index, n8n fires `Format DB report` once per source instead of waiting for all three upstream nodes to finish. The first invocation called `$('Top 5 tables by size').all()` before that node had executed and threw `Cannot assign to read only property 'name' of object 'Error: Node 'Top 5 tables by size' hasn't been executed'`. Sequential chain + `executeOnce` on the post-fanout nodes guarantees Format sees full data from all upstream nodes exactly once and prevents N-row input multiplication on the chained Postgres nodes.

`15` and `18` had the same `rule`-wrapper schedule bug already discovered + fixed for `17` in #1250.

## How to test

These changes mirror state already deployed live to the n8n instance via API calls during the session. To verify locally:

1. `node scripts/ops/validate-n8n-workflows.mjs` should report 17 workflows OK.
2. JSON shape for the schedule trigger should match `99-heartbeat.json` and `04-daily-backup-verification.json` (both `parameters.rule.interval[]`).
3. For runtime behavior, see live exec records on the n8n instance:
   - `15` — exec `#38` (synthetic Railway payload POST → Telegram).
   - `18` — exec `#43` (Cron → GitHub Actions API → IF correctly silent because no failed `nightly-audit.yml` runs).
   - `19` — exec `#41` (sequential chain delivers a full DB report to Telegram: 11 MB / 12 users / 293 `mono_transaction` rows; `pg_stat_statements` absent, tolerated by `continueOnFail`).

## Things to scrutinize

- **`19` connection restructure** is a behavior change, not a pure formatting fix — please confirm the sequential ordering matches intent.
- **`executeOnce: true`** is added at node level (alongside `parameters`/`position`/`credentials`), matching typical n8n JSON exports. Worth confirming the schema validator accepts that location.
- **`continueOnFail: true`** on the Slow queries node is now present **both** at node level (new) and inside `parameters.options` (pre-existing). Redundant but not harmful; n8n exports normally only carry the node-level form. Happy to drop the inner `options.continueOnFail` if reviewers prefer.
- **`15`** is "active" only in the sense that the webhook listener is registered; Railway-side webhook config (target URL = `<n8n>/webhook/railway-deploy`) is out-of-band and noted in the manifest.

---

## Pre-flight (Hard Rule #15)

- [x] Read the `AGENTS.md` Hard Rules that apply to the touched paths.
- [x] Read the matching playbook in `docs/playbooks/` (or noted that none exists). — n/a (n8n playbook removed in main; manifest is source-of-truth)
- [x] Checked freshness headers of docs cited in the change.

## Docs updated alongside code? (Hard Rule #15)

- [ ] API contract change — n/a
- [ ] New / removed npm script — n/a
- [ ] New design token / component / palette — n/a
- [ ] Deprecation — n/a
- [x] Freshness header bumped on docs whose claims changed — manifest `notes` updated for 15, 18, 19.
- [x] N/A — no docs invalidated by this change beyond the manifest itself.

## How AI-tested this PR

- [x] Manual smoke: 15 (synthetic webhook POST), 18 (cron bumped to `* * * * *` temporarily, reverted), 19 (cron bumped temporarily, reverted) — all execs success against live n8n, Telegram delivery confirmed for 15 and 19; 18 IF-silent as expected (no failed audit runs).
- [x] Vitest passes: n/a (JSON-only change)
- [x] No new `AI-DANGER` markers added.
- [x] Docs prose uses Ukrainian where practical.
- [x] `pnpm dead-code:files` clean — n/a (no source files added).

## AGENTS.md updated?

- [x] No — no new permanent rules.

Link to Devin session: https://app.devin.ai/sessions/9782701fe5814639b7e7814f8cb1933a
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Activate and harden n8n workflows 15, 18, and 19 by fixing cron schedules, adding centralized error handling, and restructuring 19 to run sequentially. Marked all three as prod-ready in `manifest.json` with notes.

- **Bug Fixes**
  - Wrap cron config in `parameters.rule.interval[]` for `scheduleTrigger` v1.2 (18, 19) so schedules register and fire.
  - Add `settings.errorWorkflow = 98` to 15/18/19 for consistent failure routing.

- **Refactors**
  - 19: Replace parallel fan‑out with a sequential chain (Cron → DB size → Top tables → Slow queries → Format → Telegram); set `executeOnce: true` on chained Postgres/Code nodes and `continueOnFail` on slow queries to ensure one run with complete data and avoid input multiplication.

<sup>Written for commit 1f946207db1ded8d403e05663f5f6eff4a842a96. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Promoted three automation workflows from experimental to production-ready: Railway deployment notifications, nightly security audits, and database health reports.
  * Enhanced error handling and operational documentation for automated workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->