### PR TITLE
fix(web): resolve axe-core a11y violations on hub surfaces

### DIFF
--- a/apps/web/src/core/app/HubMainContent.tsx
+++ b/apps/web/src/core/app/HubMainContent.tsx
@@ -174,7 +174,12 @@ export const HubMainContent = memo(function HubMainContent({
       >
         {hubView === "dashboard" && (
           <ErrorBoundary key="dashboard" fallback={HubSectionFallback}>
-            <div className="flex flex-col gap-5 pt-2">
+            <div
+              id="hub-panel-dashboard"
+              role="tabpanel"
+              aria-labelledby="hub-tab-dashboard"
+              className="flex flex-col gap-5 pt-2"
+            >
               <HubDashboard
                 onOpenModule={onOpenModule}
                 onOpenChat={onOpenChat}
@@ -187,7 +192,12 @@ export const HubMainContent = memo(function HubMainContent({
 
         {hubView === "reports" && (
           <ErrorBoundary key="reports" fallback={HubSectionFallback}>
-            <div className="pt-2">
+            <div
+              id="hub-panel-reports"
+              role="tabpanel"
+              aria-labelledby="hub-tab-reports"
+              className="pt-2"
+            >
               <HubReports />
             </div>
           </ErrorBoundary>
@@ -195,7 +205,12 @@ export const HubMainContent = memo(function HubMainContent({
 
         {hubView === "profile" && (
           <ErrorBoundary key="profile" fallback={HubSectionFallback}>
-            <div className="pt-2">
+            <div
+              id="hub-panel-profile"
+              role="tabpanel"
+              aria-labelledby="hub-tab-profile"
+              className="pt-2"
+            >
               <ProfilePage />
             </div>
           </ErrorBoundary>
@@ -203,12 +218,18 @@ export const HubMainContent = memo(function HubMainContent({
 
         {hubView === "settings" && (
           <ErrorBoundary key="settings" fallback={HubSectionFallback}>
-            <HubSettingsPage
-              syncing={syncing}
-              onSync={onSync}
-              onPull={onPull}
-              user={user}
-            />
+            <div
+              id="hub-panel-settings"
+              role="tabpanel"
+              aria-labelledby="hub-tab-settings"
+            >
+              <HubSettingsPage
+                syncing={syncing}
+                onSync={onSync}
+                onPull={onPull}
+                user={user}
+              />
+            </div>
           </ErrorBoundary>
         )}
       </main>

--- a/apps/web/src/core/onboarding/ModuleChecklist.tsx
+++ b/apps/web/src/core/onboarding/ModuleChecklist.tsx
@@ -259,38 +259,22 @@ export function ModuleChecklist({
           {def.steps.map((step, idx) => {
             const done = state.completedSteps.includes(step.id);
             return (
-              <div
+              <button
                 key={step.id}
-                role="button"
-                tabIndex={done ? -1 : 0}
-                aria-disabled={done}
-                onClick={(event) => {
-                  const target = event.target;
-                  if (
-                    done ||
-                    (target instanceof HTMLElement &&
-                      target.closest('[role="checkbox"]'))
-                  ) {
-                    return;
-                  }
-                  handleStepDone(step.id, step.action);
-                }}
-                onKeyDown={(event) => {
-                  if (
-                    done ||
-                    event.target !== event.currentTarget ||
-                    (event.key !== "Enter" && event.key !== " ")
-                  ) {
-                    return;
-                  }
-                  event.preventDefault();
+                type="button"
+                role="checkbox"
+                aria-checked={done}
+                aria-label={step.label}
+                disabled={done}
+                onClick={() => {
+                  if (done) return;
                   handleStepDone(step.id, step.action);
                 }}
                 className={cn(
                   "w-full flex items-center gap-3 px-3 py-2.5 rounded-xl text-left",
                   "transition-all duration-200",
                   done
-                    ? "bg-transparent"
+                    ? "bg-transparent cursor-default"
                     : "bg-panel/60 hover:bg-panel border border-line/50 hover:border-line cursor-pointer",
                   "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45",
                   "motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1",
@@ -298,12 +282,8 @@ export function ModuleChecklist({
                 style={{ animationDelay: `${idx * 50}ms` }}
               >
                 <AnimatedCheckbox
+                  decorative
                   checked={done}
-                  onChange={(checked) =>
-                    checked && handleStepDone(step.id, step.action)
-                  }
-                  disabled={done}
-                  aria-label={step.label}
                   size="sm"
                   className={cn(done && styles.checkBg)}
                 />
@@ -320,9 +300,10 @@ export function ModuleChecklist({
                     name="chevron-right"
                     size={14}
                     className="text-muted shrink-0"
+                    aria-hidden
                   />
                 )}
-              </div>
+              </button>
             );
           })}
 

--- a/apps/web/src/shared/components/ui/AnimatedCheckbox.tsx
+++ b/apps/web/src/shared/components/ui/AnimatedCheckbox.tsx
@@ -46,13 +46,21 @@ const sizeStyles: Record<CheckboxSize, { box: string; icon: number }> = {
 
 export interface AnimatedCheckboxProps {
   checked: boolean;
-  onChange: (checked: boolean) => void;
+  onChange?: (checked: boolean) => void;
   variant?: CheckboxVariant;
   size?: CheckboxSize;
   disabled?: boolean;
   showConfetti?: boolean;
   className?: string;
   "aria-label"?: string;
+  /**
+   * When `true`, renders a non-interactive visual indicator (no role,
+   * no focus, `aria-hidden`). Use when the checkbox is wrapped by an
+   * outer interactive element so axe's `nested-interactive` rule
+   * stays clean. Animation is then driven from the `checked` prop
+   * transitioning `false → true` instead of an internal click handler.
+   */
+  decorative?: boolean;
 }
 
 export const AnimatedCheckbox = memo(function AnimatedCheckbox({
@@ -64,12 +72,14 @@ export const AnimatedCheckbox = memo(function AnimatedCheckbox({
   showConfetti = false,
   className,
   "aria-label": ariaLabel,
+  decorative = false,
 }: AnimatedCheckboxProps) {
   const [isAnimating, setIsAnimating] = useState(false);
   const [confettiParticles, setConfettiParticles] = useState<
     Array<{ id: number; x: number; y: number; color: string; delay: number }>
   >([]);
   const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
+  const prevCheckedRef = useRef(checked);
 
   const prefersReducedMotion =
     typeof window !== "undefined" &&
@@ -79,7 +89,7 @@ export const AnimatedCheckbox = memo(function AnimatedCheckbox({
     if (disabled) return;
 
     const newValue = !checked;
-    onChange(newValue);
+    onChange?.(newValue);
 
     if (newValue) {
       hapticSuccess();
@@ -105,6 +115,20 @@ export const AnimatedCheckbox = memo(function AnimatedCheckbox({
     }
   }, [checked, onChange, disabled, showConfetti, prefersReducedMotion]);
 
+  // In decorative mode the parent owns the click — drive the bounce
+  // animation from the `checked` prop transitioning false → true.
+  useEffect(() => {
+    if (!decorative) {
+      prevCheckedRef.current = checked;
+      return;
+    }
+    if (!prevCheckedRef.current && checked && !prefersReducedMotion) {
+      setIsAnimating(true);
+      timeoutRef.current = setTimeout(() => setIsAnimating(false), 400);
+    }
+    prevCheckedRef.current = checked;
+  }, [checked, decorative, prefersReducedMotion]);
+
   useEffect(() => {
     return () => {
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
@@ -114,41 +138,54 @@ export const AnimatedCheckbox = memo(function AnimatedCheckbox({
   const styles = variantStyles[variant];
   const sizes = sizeStyles[size];
 
+  const indicator = (
+    <Icon
+      name="check"
+      size={sizes.icon}
+      strokeWidth={3}
+      className={cn(
+        "text-white",
+        !prefersReducedMotion && "motion-safe:animate-check-draw",
+      )}
+    />
+  );
+
+  const visualClass = cn(
+    "relative inline-flex items-center justify-center rounded-lg",
+    "border-2 transition-all duration-200",
+    sizes.box,
+    checked ? cn(styles.fill, "border-transparent") : "border-line bg-panel",
+    isAnimating && "motion-safe:animate-check-bounce",
+    disabled && "opacity-50",
+  );
+
   return (
-    <span className={cn("relative inline-flex", className)}>
-      <button
-        type="button"
-        role="checkbox"
-        aria-checked={checked}
-        aria-label={ariaLabel}
-        disabled={disabled}
-        onClick={handleToggle}
-        className={cn(
-          "relative inline-flex items-center justify-center rounded-lg",
-          "border-2 transition-all duration-200",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
-          styles.ring,
-          sizes.box,
-          checked
-            ? cn(styles.fill, "border-transparent")
-            : "border-line bg-panel hover:border-muted",
-          isAnimating && "motion-safe:animate-check-bounce",
-          disabled && "opacity-50 cursor-not-allowed",
-          !disabled && "cursor-pointer",
-        )}
-      >
-        {checked && (
-          <Icon
-            name="check"
-            size={sizes.icon}
-            strokeWidth={3}
-            className={cn(
-              "text-white",
-              !prefersReducedMotion && "motion-safe:animate-check-draw",
-            )}
-          />
-        )}
-      </button>
+    <span
+      className={cn("relative inline-flex", className)}
+      aria-hidden={decorative ? true : undefined}
+    >
+      {decorative ? (
+        <span className={visualClass}>{checked && indicator}</span>
+      ) : (
+        <button
+          type="button"
+          role="checkbox"
+          aria-checked={checked}
+          aria-label={ariaLabel}
+          disabled={disabled}
+          onClick={handleToggle}
+          className={cn(
+            visualClass,
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
+            styles.ring,
+            !checked && "hover:border-muted",
+            disabled && "cursor-not-allowed",
+            !disabled && "cursor-pointer",
+          )}
+        >
+          {checked && indicator}
+        </button>
+      )}
 
       {/* Confetti burst */}
       {confettiParticles.length > 0 && (


### PR DESCRIPTION
## What changed

Two real WCAG violations were blocking the `Accessibility (axe-core)` CI job on every PR (and on `main`). Both are fixed here.

1. **Hub bottom-nav `aria-controls` referenced a missing panel id (critical, 1 node).** `<button id="hub-tab-dashboard" role="tab" aria-controls="hub-panel-dashboard">` pointed at `hub-panel-dashboard`, but no element in the DOM carried that id (the `<main>` element was `id="main"` for the skip-link). axe flagged this as `aria-valid-attr-value`. The fix annotates each rendered hub view's wrapper `<div>` with the matching `id`, `role="tabpanel"`, and `aria-labelledby="hub-tab-{view}"`, so the active tab's `aria-controls` resolves while leaving `<main id="main">` intact for the skip-link.
2. **Pre-FTUX checklist had nested interactive controls (serious, 4 nodes).** Each `ModuleChecklist` step rendered as `<div role="button" tabIndex={0}>` containing an `AnimatedCheckbox` whose internal `<button role="checkbox">` was independently focusable — axe's `nested-interactive` rule. The fix promotes the row itself to `<button type="button" role="checkbox" aria-checked>` and adds a `decorative` mode to `AnimatedCheckbox` that renders a non-interactive, `aria-hidden` visual (no inner button, animation now driven from the `checked` prop transitioning false→true). One interactive element per row, same UX, identical test API (`getByRole("checkbox", …)` / `aria-checked`).

## Why

The `Accessibility (axe-core)` job has been red on every PR + on `main` because `a11y: hub-pre-ftux` (1 critical + 4 serious) and `a11y: hub-root` (1 critical) actually find serious/critical WCAG violations in the rendered DOM. These aren't infrastructure flakes — the proxy `ECONNREFUSED 127.0.0.1:3000` log lines around them are unrelated noise (the test ignores network errors via `waitForLoadState(...).catch`). Fixing the two violations turns the suite green and unblocks every future PR's CI.

## How to test

Local repro of the previous failure was identical to CI:

```sh
pnpm --filter @sergeant/web run test:a11y --reporter=list
```

Before this PR: `2 failed (hub-pre-ftux, hub-root) / 8 passed`.
After this PR: `10 passed (35.6s)` — all 9 hub surfaces clean + the `sw-smoke` spec.

Also passes:
- `pnpm --filter @sergeant/web run lint`
- `pnpm --filter @sergeant/web run typecheck`
- `pnpm --filter @sergeant/web exec vitest run src/core/onboarding/ModuleChecklist.test.tsx src/core/app/HubMainContent.test.tsx` → 4/4

## Pre-flight (Hard Rule #15)

- [x] Conventional Commits with allowed scope `web`
- [x] Branch follows `devin/{timestamp}-{slug}`
- [x] No `focus:` colour utilities introduced (only existing `focus-visible:` retained)
- [x] No new dependencies
- [x] No edits to generated files / lockfiles outside the scope
- [x] Lint, typecheck, unit, and a11y suites green locally

## Docs updated alongside code? (Hard Rule #15)

- [x] N/A — no docs invalidated by this change. The `decorative` prop on `AnimatedCheckbox` is documented inline in JSDoc on the prop itself.

## How AI-tested this PR

Reproduced the failing axe run locally with a temporary debug spec (deleted before commit) that printed each violation's `target`, `html`, and `failureSummary`. That isolated:
- `aria-valid-attr-value` → `#hub-tab-dashboard` referencing missing `hub-panel-dashboard` →  source: `HubBottomNav` + `HubMainContent`.
- `nested-interactive` → 4 `<div role="button">` rows in `ModuleChecklist` containing focusable `<AnimatedCheckbox>` inner buttons.

After applying the fixes, re-ran `pnpm test:a11y` (full suite) and confirmed `10 passed`.

## AGENTS.md updated?

No — no new conventions introduced.
