### PR TITLE
fix(server,web): fix Mono sync-state 500 and analytics per-month cache

### DIFF
--- a/apps/web/src/modules/finyk/hooks/useMonobankWebhook.ts
+++ b/apps/web/src/modules/finyk/hooks/useMonobankWebhook.ts
@@ -254,6 +254,13 @@ export function useMonobankWebhook({
           .map(webhookTxToNormalized)
           .sort((a, b) => (b.time ?? 0) - (a.time ?? 0));
         setHistoryTx(normalized);
+
+        // Persist per-month cache so Analytics (reads via
+        // `finyk_tx_cache_${year}_${month}`) sees the fetched data.
+        writeJSON(`finyk_tx_cache_${year}_${month}`, {
+          txs: normalized,
+          timestamp: Date.now(),
+        });
       } catch {
         // Partial failure — keep existing historyTx
       } finally {


### PR DESCRIPTION
## What changed

**Commit 1 — `fix(server)`: coerce TIMESTAMPTZ Date→ISO string in syncStateHandler**

Coerce `last_event_at` and `last_backfill_at` from pg `Date` objects to ISO strings before passing them to `MonoSyncStateSchema.parse()`. Fixed the TypeScript type annotation to `Date | string | null`. Added a test for Date-object coercion.

**Commit 2 — `fix(web)`: persist per-month tx cache in fetchMonth for Analytics**

`fetchMonth()` stored fetched historical transactions in React state (`historyTx`) but never wrote to the per-month localStorage cache (`finyk_tx_cache_${year}_${month}`). `Analytics.tsx` reads from that cache via `readTxCache()`, so it always got `[]` for non-current months — showing 0 or stale data instead of actual transactions.

## Why

### sync-state 500
`node-postgres` returns `TIMESTAMPTZ` columns as JavaScript `Date` objects, but `MonoSyncStateSchema` expects `z.string().nullable()`. When a user had an existing `mono_connection` row with non-null `last_event_at`, the Zod `.parse()` threw → 500 on every `GET /api/mono/sync-state` → UI could never read connection state → the connect button kept resetting.

The existing normalizer in `lib/normalizers/mono.ts` already handles `Date → string` with `instanceof Date ? .toISOString()`, but `syncStateHandler` was missed when the schema SSOT validation was added.

### Analytics empty for historical months
The Transactions page uses `historyTx` state directly from `fetchMonth`, so it works fine. But Analytics reads from the per-month localStorage cache that `fetchMonth` never wrote to — only deleted (in `finykActions.ts`). After the fix, `fetchMonth` writes the normalized transactions to `finyk_tx_cache_${year}_${month}` after fetching.

## How to test

1. **sync-state**: Ensure a user has an existing `mono_connection` row with non-null `last_event_at`. `GET /api/mono/sync-state` → 200 with ISO date strings.
2. **Analytics**: Open Фінік → Аналітика → navigate to a previous month. Should show correct totals matching the Операції page.
3. Tests: `pnpm --filter @sergeant/server exec vitest run src/modules/mono/connection.test.ts` — 16 pass.
4. Tests: `pnpm --filter @sergeant/web exec vitest run src/modules/finyk/hooks/useMonobankWebhook.test.tsx` — 6 pass.

---

## Pre-flight (Hard Rule #15)

- [x] Read the `AGENTS.md` Hard Rules that apply to the touched paths.
- [x] Read the matching playbook in `docs/playbooks/` (or noted that none exists).
- [x] Checked freshness headers of docs cited in the change.

## Docs updated alongside code? (Hard Rule #15)

- [x] N/A — no docs invalidated by this change.

## How AI-tested this PR

- [x] Vitest passes: 16 tests (connection.test.ts) + 6 tests (useMonobankWebhook.test.tsx).
- [x] TypeScript compiles cleanly (`tsc --noEmit` for both server and web).
- [x] ESLint passes on changed files.
- [x] No new `AI-DANGER` markers added without justification.

## AGENTS.md updated?

- [x] No — no new permanent rules

---

Link to Devin session: https://app.devin.ai/sessions/76362bee62424ee581f968162a7bdae1
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Mono sync-state 500s by coercing TIMESTAMPTZ dates to ISO strings. Persists per‑month transaction cache so Analytics shows correct data for past months.

- **Bug Fixes**
  - Server: Coerce `last_event_at` and `last_backfill_at` from `Date` to ISO before `MonoSyncStateSchema.parse()`; types set to `Date | string | null`.
  - Web: In `fetchMonth()` (`useMonobankWebhook`), write normalized txs to `localStorage` key `finyk_tx_cache_${year}_${month}` so `Analytics.tsx`/`readTxCache()` loads historical data.

<sup>Written for commit b7ca47e93e165eef341f8e2b92e2359ced26545e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved caching of monthly transaction history to ensure analytics and reporting features have reliable access to the most recent transaction data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->