### PR TITLE
Devin/1777650243 p0 UI ux fixes

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -2,9 +2,18 @@
 <html lang="uk">
   <head>
     <meta charset="UTF-8" />
+    <!--
+      `interactive-widget=resizes-content` — when iOS Safari (or any
+      browser that honours the proposed `interactive-widget` attr)
+      shows the soft keyboard, the layout viewport shrinks instead of
+      sliding under the keyboard. Without it, fixed-position sheets
+      like ManualExpenseSheet and HubChat have their inputs covered by
+      the keyboard. Pairs with `viewport-fit=cover` so the content
+      still reaches the safe-area edges when the keyboard is hidden.
+    -->
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content"
     />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/apps/web/src/core/hub/HubSearch.tsx
+++ b/apps/web/src/core/hub/HubSearch.tsx
@@ -4,12 +4,15 @@ import type { ModuleAccent } from "@sergeant/design-tokens";
 import {
   ASSISTANT_CAPABILITIES,
   CAPABILITY_MODULE_META,
+  formatMoney,
+  formatMoneyFromKopecks,
   type AssistantCapability,
 } from "@sergeant/shared";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
 import { EmptyState } from "@shared/components/ui/EmptyState";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
+import { emitHubBus } from "@shared/lib/hubBus";
 import { hapticTap } from "@shared/lib/haptic";
 import {
   scoreMatch,
@@ -169,7 +172,6 @@ function searchFinyk(tokens: string[]): Hit[] {
       if (!tx || typeof tx !== "object") continue;
       const amtRaw = Number(tx.amount);
       const amount = (Number.isFinite(amtRaw) ? amtRaw : 0) / 100;
-      const sign = amount < 0 ? "−" : "+";
       const time = tx.time ?? 0;
       const stop = pushScored(
         results,
@@ -178,7 +180,7 @@ function searchFinyk(tokens: string[]): Hit[] {
           module: "finyk",
           moduleLabel: "Фінік",
           title: tx.description || tx.comment || "Транзакція",
-          subtitle: `${sign}${Math.abs(amount).toLocaleString("uk-UA", { maximumFractionDigits: 2 })} ₴ · ${time > 1e10 ? localDateKey(new Date(time)) : localDateKey(new Date(time * 1000))}`,
+          subtitle: `${formatMoney(amount, { signed: true, maxFractionDigits: 2 })} · ${time > 1e10 ? localDateKey(new Date(time)) : localDateKey(new Date(time * 1000))}`,
           icon: "💳",
           target: { kind: "module", moduleId: "finyk" },
         },
@@ -202,7 +204,7 @@ function searchFinyk(tokens: string[]): Hit[] {
           module: "finyk",
           moduleLabel: "Фінік",
           title: s.name || "Підписка",
-          subtitle: `Підписка · ${amt ? (amt / 100).toFixed(0) + " ₴" : ""}`,
+          subtitle: `Підписка · ${amt ? formatMoneyFromKopecks(amt) : ""}`,
           icon: "🔄",
           target: { kind: "module", moduleId: "finyk" },
         },
@@ -666,10 +668,11 @@ export function HubSearch({ onClose, onOpenModule }: HubSearchProps) {
     //                    `?tab=settings` via useHubUIState); section deep-
     //                    linking can be wired in a follow-up once the
     //                    settings page exposes a section anchor API
-    //   - assistant hit→ the full /assistant catalogue route. We don't
-    //                    auto-fire the chat here (capability.requiresInput
-    //                    handling lives in the catalogue page) so the user
-    //                    keeps a chance to read the description first.
+    //   - assistant hit→ if the hit carries a capability, open the chat
+    //                    with its first example prefilled (the chat input
+    //                    receives focus so the user can edit before
+    //                    sending). Without a capability we fall back to
+    //                    the full /assistant catalogue route.
     switch (hit.target.kind) {
       case "module":
         onOpenModule(hit.target.moduleId);
@@ -683,9 +686,18 @@ export function HubSearch({ onClose, onOpenModule }: HubSearchProps) {
         });
         break;
       }
-      case "assistant":
-        navigate("/assistant");
+      case "assistant": {
+        const cap = hit.target.capability;
+        const example = cap?.examples?.[0];
+        if (example) {
+          // Match AssistantCataloguePage's "Try in chat" CTA: prefill
+          // without auto-sending so the user keeps full control.
+          emitHubBus("openChat", { message: example, autoSend: false });
+        } else {
+          navigate("/assistant");
+        }
         break;
+      }
     }
   };
 

--- a/apps/web/src/modules/finyk/components/TxRow.tsx
+++ b/apps/web/src/modules/finyk/components/TxRow.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, useMemo, useState } from "react";
+import { formatMoney } from "@sergeant/shared";
 import { getCategory, getIncomeCategory, fmtAmt, fmtDate } from "../utils";
 import {
   MCC_CATEGORIES,
@@ -360,9 +361,7 @@ function TxRowImpl({
       {splitEditor && onSplitChange && (
         <div className="pb-3 px-2 space-y-2">
           <div className="text-xs text-subtle font-medium">
-            Розподіл ·{" "}
-            {totalAmt.toLocaleString("uk-UA", { minimumFractionDigits: 2 })} ₴
-            всього
+            Розподіл · {formatMoney(totalAmt, { minFractionDigits: 2 })} всього
           </div>
           {draftSplits.map((sp, i) => (
             <div key={i} className="flex items-center gap-2">
@@ -418,7 +417,7 @@ function TxRowImpl({
           >
             {Math.abs(remaining) < 0.01
               ? "✓ Суми збігаються"
-              : `Залишок: ${remaining.toLocaleString("uk-UA", { minimumFractionDigits: 2 })} ₴`}
+              : `Залишок: ${formatMoney(remaining, { minFractionDigits: 2 })}`}
           </div>
           <button
             onClick={() =>

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -55,6 +55,12 @@ export * from "./lib/dashboardFocus";
 // Hub dashboard quick-stats preview selector (pure; callers own storage I/O).
 export * from "./lib/quickStats";
 
+// Centralized hryvnia / currency formatter — single source of truth for ₴
+// amounts across the web app and shared package. See `formatMoney.ts`
+// for conventions; `fmtAmt` (in `@sergeant/finyk-domain`) remains the
+// transaction-row formatter and is intentionally separate.
+export * from "./lib/formatMoney";
+
 // Hub weekly-digest helpers — week key / storage key / digest freshness.
 export * from "./lib/weeklyDigest";
 

--- a/packages/shared/src/lib/formatMoney.test.ts
+++ b/packages/shared/src/lib/formatMoney.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { formatMoney, formatMoneyFromKopecks } from "./formatMoney";
+
+describe("formatMoney", () => {
+  it("appends ₴ with a regular space and uses uk-UA grouping by default", () => {
+    const out = formatMoney(1250);
+    expect(out).toMatch(/₴$/);
+    // Allow for either NBSP or thin-space depending on the active Intl
+    // implementation — we only care that the digits and symbol survive.
+    expect(out).toContain("1");
+    expect(out).toContain("250");
+  });
+
+  it("respects minFractionDigits / maxFractionDigits", () => {
+    expect(formatMoney(1, { minFractionDigits: 2 })).toMatch(/^1[,.]00 ₴$/);
+    expect(formatMoney(1.234, { maxFractionDigits: 2 })).toMatch(/^1[,.]23 ₴$/);
+  });
+
+  it("emits a leading + only for signed positive values", () => {
+    expect(formatMoney(50, { signed: true })).toMatch(/^\+50 ₴$/);
+    expect(formatMoney(0, { signed: true })).toMatch(/^0 ₴$/);
+    // Negative values use the locale minus sign supplied by toLocaleString;
+    // we only assert it does NOT start with "+".
+    const neg = formatMoney(-50, { signed: true });
+    expect(neg.startsWith("+")).toBe(false);
+    expect(neg).toMatch(/50 ₴$/);
+  });
+
+  it("supports custom symbols", () => {
+    expect(formatMoney(100, { symbol: "$" })).toMatch(/^100 \$$/);
+  });
+
+  it("treats non-finite inputs as 0 instead of throwing", () => {
+    expect(formatMoney(Number.NaN)).toMatch(/^0 ₴$/);
+    expect(formatMoney(Number.POSITIVE_INFINITY)).toMatch(/^0 ₴$/);
+  });
+});
+
+describe("formatMoneyFromKopecks", () => {
+  it("divides by 100 and rounds away floating-point drift", () => {
+    expect(formatMoneyFromKopecks(199)).toMatch(/^2 ₴$/);
+    expect(formatMoneyFromKopecks(199, { minFractionDigits: 2 })).toMatch(
+      /^1[,.]99 ₴$/,
+    );
+  });
+
+  it("treats non-finite inputs as 0", () => {
+    expect(formatMoneyFromKopecks(Number.NaN)).toMatch(/^0 ₴$/);
+  });
+});

--- a/packages/shared/src/lib/formatMoney.ts
+++ b/packages/shared/src/lib/formatMoney.ts
@@ -1,0 +1,107 @@
+/**
+ * Centralized hryvnia / generic-currency formatter.
+ *
+ * Single source of truth for ₴ amounts across the web app and shared
+ * package — replaces the previous patchwork of `toFixed(0) + " ₴"`,
+ * `value.toLocaleString("uk-UA")`, ad-hoc `Intl.NumberFormat` calls,
+ * and bespoke "грн" suffixes that produced visibly different sums in
+ * neighbouring surfaces (TxRow vs BentoCard vs HubSearch).
+ *
+ * Conventions:
+ *  - Locale is `uk-UA` so thousand separators match the rest of the
+ *    Ukrainian-language UI (NBSP between groups, comma decimal).
+ *  - The currency symbol is appended with a regular space (`"1 250 ₴"`)
+ *    — this matches the TxRow/HubSearch convention and is the format
+ *    `Intl.NumberFormat("uk-UA", { style: "currency" })` produces too.
+ *  - Fraction digits default to `0` (whole hryvnia) — most surfaces
+ *    show round amounts. Pass `{ minFractionDigits: 2 }` for the
+ *    split-editor / debt subtitle where kopecks matter.
+ *  - Inputs are assumed to be in *hryvnia* (not kopecks). Helpers that
+ *    work in kopecks should divide by 100 before calling this. The
+ *    `formatMoneyFromKopecks` helper does that and rounds away tiny
+ *    floating-point drift introduced by the division.
+ *
+ * `fmtAmt` in `@sergeant/finyk-domain` is a parallel formatter that
+ * handles the transaction-row case (with leading "+" sign, no space
+ * before the symbol, currency-code dispatch). It is intentionally left
+ * alone here so existing transaction visuals don't shift; new sites
+ * should prefer `formatMoney` for non-transaction sums.
+ */
+
+export interface FormatMoneyOptions {
+  /**
+   * Currency symbol appended after the formatted number with a single
+   * space. Defaults to `"₴"`.
+   */
+  symbol?: string;
+  /**
+   * If `true`, positive non-zero amounts are prefixed with `"+"`.
+   * Negative amounts always render with the locale's minus sign — the
+   * caller does not need to pass an absolute value.
+   */
+  signed?: boolean;
+  /**
+   * Minimum fraction digits passed to `toLocaleString`. Defaults to
+   * `0`. When set without `maxFractionDigits`, the maximum is bumped
+   * to match so `1250` always renders as `"1 250,00"` (not
+   * `"1 250,00…"`).
+   */
+  minFractionDigits?: number;
+  /**
+   * Maximum fraction digits passed to `toLocaleString`. Defaults to
+   * the value of `minFractionDigits` (or `0` if neither is set).
+   */
+  maxFractionDigits?: number;
+}
+
+function formatNumberUkUA(value: number, min: number, max: number): string {
+  try {
+    return value.toLocaleString("uk-UA", {
+      minimumFractionDigits: min,
+      maximumFractionDigits: max,
+    });
+  } catch {
+    // Older runtimes without full Intl support — fall back to a plain
+    // `toFixed`, accepting the loss of thousand separators.
+    return value.toFixed(max);
+  }
+}
+
+/**
+ * Format a hryvnia amount. See module-level docstring for conventions.
+ */
+export function formatMoney(
+  amount: number,
+  opts: FormatMoneyOptions = {},
+): string {
+  const {
+    symbol = "₴",
+    signed = false,
+    minFractionDigits = 0,
+    maxFractionDigits = minFractionDigits,
+  } = opts;
+  const safe = Number.isFinite(amount) ? amount : 0;
+  const formatted = formatNumberUkUA(
+    safe,
+    minFractionDigits,
+    maxFractionDigits,
+  );
+  const sign = signed && safe > 0 ? "+" : "";
+  return `${sign}${formatted} ${symbol}`;
+}
+
+/**
+ * Convenience wrapper for kopecks-denominated amounts (Finyk stores
+ * transaction sums in kopecks). Performs the `/100` and clamps tiny
+ * floating-point residue (`1.0000000002 → 1`) before formatting.
+ */
+export function formatMoneyFromKopecks(
+  amountInKopecks: number,
+  opts: FormatMoneyOptions = {},
+): string {
+  const safe = Number.isFinite(amountInKopecks) ? amountInKopecks : 0;
+  // Round to the nearest kopeck before division so 199 / 100 stays at
+  // 1.99 (not 1.99000000…2) regardless of upstream arithmetic noise.
+  const hryvnia = Math.round(safe) / 100;
+  return formatMoney(hryvnia, opts);
+}

--- a/packages/shared/src/lib/quickStats.test.ts
+++ b/packages/shared/src/lib/quickStats.test.ts
@@ -41,13 +41,17 @@ describe("parseQuickStatsJson", () => {
 });
 
 describe("selectModulePreview — finyk", () => {
-  it("formats todaySpent as UAH and budgetLeft as plain number", () => {
+  it("formats todaySpent and budgetLeft via the centralized money formatter", () => {
     const raw = JSON.stringify({ todaySpent: 1250, budgetLeft: 7300 });
     const preview = selectModulePreview("finyk", raw);
-    expect(preview.main).toMatch(/грн$/);
+    // `formatMoney` emits "<number> ₴" — we assert the suffix and digits
+    // separately so the test stays robust against whichever NBSP-flavoured
+    // thousand separator the active Intl runtime picks for `uk-UA`.
+    expect(preview.main).toMatch(/₴$/);
     expect(preview.main).toContain("1");
     expect(preview.main).toContain("250");
     expect(preview.sub).toMatch(/Залишок:/);
+    expect(preview.sub).toMatch(/₴$/);
     expect(preview.sub).toContain("7");
     expect(preview.sub).toContain("300");
     expect(preview.progress).toBeUndefined();

--- a/packages/shared/src/lib/quickStats.ts
+++ b/packages/shared/src/lib/quickStats.ts
@@ -22,6 +22,8 @@
  * can render a dash without guarding every case inline.
  */
 
+import { formatMoney } from "./formatMoney";
+
 export const QUICK_STATS_MODULE_IDS = [
   "finyk",
   "fizruk",
@@ -73,18 +75,6 @@ function asFiniteNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
-function formatAmount(value: number): string {
-  // Using uk-UA keeps the dashboard visual identity consistent with
-  // the web, which relies on browser `toLocaleString()` for thousand
-  // separators. Hermes on RN 0.76 ships Intl so this works on mobile
-  // too (verified via jest-expo snapshot of the number output).
-  try {
-    return value.toLocaleString("uk-UA");
-  } catch {
-    return String(value);
-  }
-}
-
 /**
  * Select the preview shape for a given module from a raw JSON
  * payload. Implements the web truthiness rules 1:1 so no row on
@@ -114,8 +104,8 @@ export function selectModulePreview(
       const todaySpent = asFiniteNumber(stats.todaySpent);
       const budgetLeft = asFiniteNumber(stats.budgetLeft);
       return {
-        main: todaySpent ? `${formatAmount(todaySpent)} грн` : null,
-        sub: budgetLeft ? `Залишок: ${formatAmount(budgetLeft)}` : null,
+        main: todaySpent ? formatMoney(todaySpent) : null,
+        sub: budgetLeft ? `Залишок: ${formatMoney(budgetLeft)}` : null,
       };
     }
     case "fizruk": {


### PR DESCRIPTION
## What changed

<!-- Brief description of the changes. -->

## Why

<!-- Motivation, linked issue, or context. -->

## How to test

<!-- Steps for a reviewer to verify correctness. -->

---

## Pre-flight (Hard Rule #15)

<!--
Before opening this PR you should have read the relevant governance.
Tick what applies; if a box is N/A, write "n/a" inline.
-->

- [ ] Read the `AGENTS.md` Hard Rules that apply to the touched paths.
- [ ] Read the matching playbook in `docs/playbooks/` (or noted that none exists).
- [ ] Checked freshness headers of docs cited in the change.

## Docs updated alongside code? (Hard Rule #15)

<!--
Documentation is part of the change set, not a follow-up. Tick what applies.
-->

- [ ] API contract change — `packages/api-client/**` types + contract test updated (Hard Rule #3).
- [ ] New / removed npm script — `CONTRIBUTING.md § Everyday Commands` and `CLAUDE.md § Quick commands` updated.
- [ ] New design token / component / palette — `docs/design/design-system.md` (and `BRANDBOOK.md` if branded) updated.
- [ ] Deprecation — `@deprecated` JSDoc with `@removeBy` added; consuming docs marked `> **Status:** Deprecated`.
- [ ] Freshness header bumped on docs whose claims changed (`> Last validated: YYYY-MM-DD by @owner`).
- [ ] N/A — no docs invalidated by this change.

## How AI-tested this PR

<!-- If this PR was created by an AI agent, describe what was verified. -->

- [ ] Manual smoke (which flow?): ...
- [ ] Vitest passes: ...
- [ ] No new `AI-DANGER` markers added without justification.
- [ ] Docs prose uses Ukrainian where practical, per `AGENTS.md`.
- [ ] `pnpm dead-code:files` clean (or new files marked `@scaffolded`).

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [ ] No — no new permanent rules

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1262" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies money formatting across the app, fixes iOS keyboard overlap, and makes Cmd+K assistant hits open chat with a helpful prefill.

- **New Features**
  - Cmd+K assistant capability hits now open chat prefilled with the first example (no auto-send). Falls back to `/assistant` when no capability is present.

- **Bug Fixes**
  - Consistent ₴ formatting via `@sergeant/shared` `formatMoney` and `formatMoneyFromKopecks`; applied in HubSearch (transactions, subscriptions), Finyk split editor totals/remaining, and Quick Stats. Tests added.
  - iOS Safari keyboard no longer covers inputs by adding `interactive-widget=resizes-content` to the viewport meta.

<sup>Written for commit a4143f1844bec41925ae9f7b0b1690231ce9e5d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved assistant search experience - clicking relevant search results now pre-fills the chat with contextual examples instead of navigating to a separate page.

* **Bug Fixes & Improvements**
  * Enhanced mobile keyboard handling on iOS Safari for better viewport management when the soft keyboard appears.
  * Standardized currency formatting across the application for consistency and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->