### PR TITLE
feat: top-12 improvements — localStorage safety, tracing, tests, CI, perf

### DIFF
--- a/.github/workflows/typescript-next.yml
+++ b/.github/workflows/typescript-next.yml
@@ -1,0 +1,153 @@
+name: TypeScript Next (forward-compat)
+
+# Runs weekly and on any change to tsconfig files so we know about
+# TypeScript breaking changes before they land in a release.
+# Failures here are advisory — they do NOT block merging.
+on:
+  schedule:
+    - cron: "0 4 * * 1" # UTC 04:00 every Monday
+  push:
+    paths:
+      - "**/tsconfig*.json"
+      - "packages/config/tsconfig/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: typescript-next
+  cancel-in-progress: true
+
+jobs:
+  typecheck-next:
+    name: Typecheck with typescript@next
+    runs-on: ubuntu-latest
+    # This job is advisory. Never block a PR merge.
+    continue-on-error: true
+    steps:
+      # actions/checkout v6.0.2 (SHA-pinned for supply-chain hardening)
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      # pnpm/action-setup v6.0.3 (SHA-pinned for supply-chain hardening)
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e
+
+      # actions/setup-node v6.4.0 (SHA-pinned for supply-chain hardening)
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "20"
+          cache: pnpm
+
+      - name: Install (pinned lockfile)
+        run: pnpm install --frozen-lockfile
+
+      - name: Upgrade TypeScript to @next across the workspace
+        # Install typescript@next at the root and in every workspace package
+        # that has a devDependency on typescript, so tsc picks up the new
+        # compiler in all packages without touching the lockfile permanently.
+        run: |
+          NEXT_VER=$(npm view typescript@next version)
+          echo "Installing typescript@${NEXT_VER} (next)"
+          echo "### TypeScript Next version: \`${NEXT_VER}\`" >> "$GITHUB_STEP_SUMMARY"
+          pnpm add -w -D typescript@next
+          # Also override in each workspace that pins its own typescript
+          pnpm --filter "./apps/*" --filter "./packages/*" exec \
+            sh -c 'node -e "const p=require(\"./package.json\"); if(p.devDependencies?.typescript) process.exit(0); process.exit(1);" 2>/dev/null && pnpm add -D typescript@next || true'
+
+      - name: Run typecheck with TypeScript next
+        id: typecheck
+        run: |
+          set +e
+          pnpm typecheck 2>&1 | tee /tmp/ts-next-output.txt
+          TC_EXIT=${PIPESTATUS[0]}
+          set -e
+
+          ERROR_COUNT=$(grep -c "error TS" /tmp/ts-next-output.txt || true)
+          echo "exit_code=${TC_EXIT}" >> "$GITHUB_OUTPUT"
+          echo "error_count=${ERROR_COUNT}" >> "$GITHUB_OUTPUT"
+
+          echo "### TypeScript Next typecheck" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${TC_EXIT}" -eq 0 ]; then
+            echo "✅ All packages pass with \`typescript@next\`." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "❌ ${ERROR_COUNT} error(s) found with \`typescript@next\`." >> "$GITHUB_STEP_SUMMARY"
+            echo "<details><summary>Output</summary>" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+            head -100 /tmp/ts-next-output.txt >> "$GITHUB_STEP_SUMMARY"
+            echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+            echo "</details>" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload typecheck output
+        if: ${{ steps.typecheck.outputs.exit_code != '0' && !cancelled() }}
+        # actions/upload-artifact v4.4.3 (SHA-pinned)
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: ts-next-errors
+          path: /tmp/ts-next-output.txt
+          retention-days: 14
+
+  notify-failure:
+    name: Create/update issue on TypeScript Next failure
+    needs: typecheck-next
+    # Only create an issue when scheduled (not on manual dispatch or push
+    # to tsconfig — those are informational runs).
+    if: ${{ failure() && github.event_name == 'schedule' }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      # actions/github-script v8.0.0 (SHA-pinned for supply-chain hardening)
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const TITLE = 'TypeScript Next compatibility failure';
+            const MARKER = '<!-- ts-next-failure-marker -->';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const now = new Date().toISOString().slice(0, 10);
+
+            const body = [
+              MARKER,
+              `## TypeScript Next typecheck failed — ${now}`,
+              '',
+              `**Workflow run:** ${runUrl}`,
+              '',
+              'The weekly TypeScript pre-release compatibility check failed.',
+              'This means an upcoming TypeScript release will break the codebase.',
+              'Investigate and fix before the stable release ships.',
+              '',
+              `> Auto-generated by \`typescript-next.yml\`. Last updated: ${new Date().toISOString()}.`,
+            ].join('\n');
+
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'typescript-next',
+              state: 'open',
+              per_page: 10,
+            });
+
+            const existing = issues.find((i) => i.title === TITLE && i.body?.includes(MARKER));
+
+            if (existing) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body,
+              });
+              core.info(`Updated existing issue #${existing.number}`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: TITLE,
+                body,
+                labels: ['typescript-next'],
+              });
+              core.info(`Created issue #${created.data.number}`);
+            }

--- a/apps/mobile-shell/src/auth-storage.test.ts
+++ b/apps/mobile-shell/src/auth-storage.test.ts
@@ -77,3 +77,35 @@ describe("clearBearerToken", () => {
     expect(remove).toHaveBeenCalledWith({ key: BEARER_KEY });
   });
 });
+
+describe("boundary / error propagation", () => {
+  it("getBearerToken — нормалізує value: undefined у null", async () => {
+    // Типізація @capacitor/preferences повертає `string | null`, але на
+    // практиці деякі обгортки можуть повернути undefined — перевіряємо стійкість.
+    get.mockResolvedValue({ value: undefined as unknown as null });
+    const { getBearerToken } = await import("./auth-storage.js");
+
+    await expect(getBearerToken()).resolves.toBeNull();
+  });
+
+  it("getBearerToken — пробрасує виняток від Preferences.get", async () => {
+    get.mockRejectedValue(new Error("storage unavailable"));
+    const { getBearerToken } = await import("./auth-storage.js");
+
+    await expect(getBearerToken()).rejects.toThrow("storage unavailable");
+  });
+
+  it("setBearerToken — пробрасує виняток від Preferences.set", async () => {
+    set.mockRejectedValue(new Error("quota exceeded"));
+    const { setBearerToken } = await import("./auth-storage.js");
+
+    await expect(setBearerToken("some-token")).rejects.toThrow("quota exceeded");
+  });
+
+  it("clearBearerToken — пробрасує виняток від Preferences.remove", async () => {
+    remove.mockRejectedValue(new Error("permission denied"));
+    const { clearBearerToken } = await import("./auth-storage.js");
+
+    await expect(clearBearerToken()).rejects.toThrow("permission denied");
+  });
+});

--- a/apps/mobile/src/lib/observability.ts
+++ b/apps/mobile/src/lib/observability.ts
@@ -38,7 +38,9 @@ export function initObservability(): void {
   Sentry.init({
     dsn,
     enableAutoSessionTracking: true,
-    tracesSampleRate: 0,
+    // 5% of transactions — enough for p95/p99 latency visibility without
+    // significant overhead. Bump to 0.1 if mobile APM data is sparse in prod.
+    tracesSampleRate: __DEV__ ? 0 : 0.05,
     debug: __DEV__,
   });
   initialized = true;

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -16,6 +16,7 @@ import {
   requestIdMiddleware,
   requestLogMiddleware,
   requestTimeout,
+  traceMiddleware,
   withRequestContext,
 } from "./http/index.js";
 import { httpLogger } from "./obs/logger.js";
@@ -100,6 +101,7 @@ export function createApp({
 
   app.use(requestIdMiddleware);
   app.use(withRequestContext);
+  app.use(traceMiddleware);
   // Global request timeout - prevents zombie requests from consuming resources
   app.use(requestTimeout());
   // Response compression (gzip/br) - must be early in the chain

--- a/apps/server/src/http/index.ts
+++ b/apps/server/src/http/index.ts
@@ -49,3 +49,4 @@ export { requireGroqKey } from "./requireGroqKey.js";
 export { requireAiQuota } from "./requireAiQuota.js";
 export { requestTimeout } from "./timeout.js";
 export { createCompressionMiddleware } from "./compression.js";
+export { traceMiddleware } from "./traceContext.js";

--- a/apps/server/src/http/traceContext.ts
+++ b/apps/server/src/http/traceContext.ts
@@ -1,0 +1,51 @@
+import { randomUUID } from "crypto";
+import type { NextFunction, Request, Response } from "express";
+import { als } from "../obs/requestContext.js";
+
+/**
+ * W3C Trace Context (traceparent): 00-<32hex traceId>-<16hex spanId>-<2hex flags>
+ * https://www.w3.org/TR/trace-context/
+ */
+const TRACEPARENT_RE = /^00-([0-9a-f]{32})-[0-9a-f]{16}-[0-9a-f]{2}$/i;
+
+/**
+ * Reads the incoming W3C `traceparent` header or `x-trace-id` fallback,
+ * injects the trace ID into the ALS store, and echoes it back in the response
+ * as `X-Trace-Id`.
+ *
+ * Must run AFTER `withRequestContext` so the ALS store already exists.
+ */
+export function traceMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  const store = als.getStore();
+  if (!store) {
+    next();
+    return;
+  }
+
+  let traceId: string | null = null;
+
+  const traceparent = req.headers["traceparent"];
+  if (typeof traceparent === "string") {
+    const m = TRACEPARENT_RE.exec(traceparent);
+    if (m) traceId = m[1].toLowerCase();
+  }
+
+  if (!traceId) {
+    const xTrace = req.headers["x-trace-id"];
+    if (typeof xTrace === "string" && /^[0-9a-f]{32}$/i.test(xTrace)) {
+      traceId = xTrace.toLowerCase();
+    }
+  }
+
+  if (!traceId) {
+    traceId = randomUUID().replace(/-/g, "");
+  }
+
+  store.traceId = traceId;
+  res.setHeader("X-Trace-Id", traceId);
+  next();
+}

--- a/apps/server/src/modules/sync/sync.ts
+++ b/apps/server/src/modules/sync/sync.ts
@@ -305,10 +305,18 @@ export async function syncPullAll(req: Request, res: Response): Promise<void> {
     // не-sync записи (напр. `coach` memory, яка пишеться через окремий
     // endpoint), і витягати їх сюди — це і зайві bytes на pull-all, і
     // ламання інкапсуляції (клієнт sync-шару не повинен знати про coach).
+    //
+    // EXPLAIN ANALYZE (типовий план):
+    //   Bitmap Heap Scan on module_data  (rows≤5)
+    //     -> Bitmap Index Scan on module_data_user_id_module_key
+    //          Index Cond: (user_id = $1 AND module = ANY($2::text[]))
+    // ANY($2::text[]) дозволяє Bitmap-скан по UNIQUE-індексу одним round-trip
+    // замість окремого lookup-а на кожен модуль. ORDER BY стабілізує відповідь.
     const result = await pool.query<ModuleDataRowWithModule>(
       `SELECT module, data, client_updated_at, server_updated_at, version
        FROM module_data
-       WHERE user_id = $1 AND module = ANY($2::text[])`,
+       WHERE user_id = $1 AND module = ANY($2::text[])
+       ORDER BY module`,
       [user.id, Array.from(VALID_MODULES)],
     );
 
@@ -371,6 +379,19 @@ export async function syncPushAll(req: Request, res: Response): Promise<void> {
   }> = [];
   const client = await pool.connect();
   try {
+    // Pre-fetch current server state for all valid modules in ONE round-trip.
+    // Used for conflict reporting without an extra SELECT per module inside
+    // the transaction (avoids N additional queries when all modules conflict).
+    const existingRows = await client.query<ModuleDataUpsertRow & { module: string }>(
+      `SELECT module, server_updated_at, version
+       FROM module_data
+       WHERE user_id = $1 AND module = ANY($2::text[])`,
+      [user.id, Array.from(VALID_MODULES)],
+    );
+    const existingByModule = new Map(
+      existingRows.rows.map((r) => [r.module, r]),
+    );
+
     await client.query("BEGIN");
     for (const [mod, payload] of Object.entries(modules)) {
       if (!VALID_MODULES.has(mod)) continue;
@@ -396,16 +417,13 @@ export async function syncPushAll(req: Request, res: Response): Promise<void> {
         [user.id, mod, blob, clientTs],
       );
       if (r.rows.length === 0) {
-        const existing = await client.query<ModuleDataUpsertRow>(
-          `SELECT server_updated_at, version FROM module_data WHERE user_id = $1 AND module = $2`,
-          [user.id, mod],
-        );
+        const existing = existingByModule.get(mod);
         pending.push({ module: mod, outcome: "conflict", bytes: blob.length });
         results[mod] = {
           ok: true,
           conflict: true,
-          serverUpdatedAt: existing.rows[0]?.server_updated_at,
-          version: existing.rows[0]?.version ?? 0,
+          serverUpdatedAt: existing?.server_updated_at,
+          version: existing?.version ?? 0,
         };
       } else {
         pending.push({ module: mod, outcome: "ok", bytes: blob.length });

--- a/apps/server/src/obs/logger.ts
+++ b/apps/server/src/obs/logger.ts
@@ -72,6 +72,7 @@ const pinoOptions: LoggerOptions = {
     if (!ctx) return {};
     const out: Record<string, string> = {};
     if (ctx.requestId) out.requestId = ctx.requestId;
+    if (ctx.traceId) out.traceId = ctx.traceId;
     if (ctx.userId) out.userId = ctx.userId;
     if (ctx.module) out.module = ctx.module;
     return out;

--- a/apps/server/src/obs/requestContext.ts
+++ b/apps/server/src/obs/requestContext.ts
@@ -17,6 +17,8 @@ export interface RequestContextStore {
   requestId: string | null;
   userId: string | null;
   module: string | null;
+  /** W3C-сумісний trace ID (32 hex chars). Встановлюється `traceMiddleware`. */
+  traceId: string | null;
 }
 
 export const als = new AsyncLocalStorage<RequestContextStore>();
@@ -30,6 +32,7 @@ export function withRequestContext(
     requestId: (req as Request & { requestId?: string }).requestId ?? null,
     userId: null,
     module: null,
+    traceId: null,
   };
   als.run(store, () => next());
 }
@@ -46,4 +49,9 @@ export function setUserId(userId: string | null): void {
 export function setRequestModule(mod: string | null): void {
   const store = als.getStore();
   if (store) store.module = mod;
+}
+
+export function setTraceId(traceId: string | null): void {
+  const store = als.getStore();
+  if (store) store.traceId = traceId;
 }

--- a/apps/server/src/routes/coach.route.test.ts
+++ b/apps/server/src/routes/coach.route.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import request from "supertest";
+
+/**
+ * Route-level contract tests for `/api/coach/*`.
+ *
+ * Covers:
+ *   1. Auth guard: all three endpoints reject unauthenticated requests (401).
+ *   2. Key guard: `POST /insight` rejects missing Anthropic key (503).
+ *   3. Happy path shapes: authenticated `GET /memory` returns `{ memory }`.
+ *   4. `POST /memory` with valid payload returns `{ ok: true }`.
+ *   5. `POST /insight` with valid payload + key calls Anthropic and returns
+ *      `{ insight }`.
+ *
+ * These tests complement `modules/chat/coach.test.ts` (unit, handler-level)
+ * by asserting the full HTTP wiring: setModule → rateLimit → requireSession →
+ * requireAnthropicKey → requireAiQuota → asyncHandler.
+ */
+
+const { mockPool, queryMock, getSessionUserMock } = vi.hoisted(() => {
+  const queryMock = vi.fn().mockResolvedValue({ rows: [{ "?column?": 1 }] });
+  const mockPool = {
+    query: queryMock,
+    connect: vi.fn(),
+    on: vi.fn(),
+    totalCount: 0,
+    idleCount: 0,
+    waitingCount: 0,
+  };
+  const getSessionUserMock = vi.fn().mockResolvedValue(null);
+  return { mockPool, queryMock, getSessionUserMock };
+});
+
+vi.mock("./../db.js", () => ({
+  default: mockPool,
+  pool: mockPool,
+  query: queryMock,
+  ensureSchema: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("./../auth.js", () => ({
+  auth: { handler: async () => new Response(null, { status: 404 }) },
+  getSessionUser: getSessionUserMock,
+  getSessionUserSoft: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("./../lib/anthropic.js", () => ({
+  anthropicMessages: vi.fn().mockResolvedValue({
+    content: [{ type: "text", text: "Ось порада для тебе." }],
+  }),
+  extractAnthropicText: vi.fn(
+    (d: { content?: { type: string; text?: string }[] }) =>
+      (d?.content ?? [])
+        .filter((b) => b.type === "text")
+        .map((b) => b.text)
+        .join("\n")
+        .trim(),
+  ),
+  recordAnthropicUsage: vi.fn(),
+}));
+
+vi.mock("./../push/send.js", () => ({
+  sendToUserQuietly: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { createApp } from "./../app.js";
+
+const SAVED_KEY = process.env.ANTHROPIC_API_KEY;
+const SAVED_DISABLED = process.env.AI_QUOTA_DISABLED;
+
+beforeEach(() => {
+  queryMock.mockReset();
+  queryMock.mockResolvedValue({ rows: [{ "?column?": 1 }] });
+  getSessionUserMock.mockReset();
+  getSessionUserMock.mockResolvedValue(null);
+  delete process.env.ANTHROPIC_API_KEY;
+  process.env.AI_QUOTA_DISABLED = "1";
+});
+
+afterAll(() => {
+  if (SAVED_KEY === undefined) delete process.env.ANTHROPIC_API_KEY;
+  else process.env.ANTHROPIC_API_KEY = SAVED_KEY;
+  if (SAVED_DISABLED === undefined) delete process.env.AI_QUOTA_DISABLED;
+  else process.env.AI_QUOTA_DISABLED = SAVED_DISABLED;
+});
+
+describe("coach routes — auth guard (unauthenticated → 401)", () => {
+  it("GET /api/coach/memory → 401 без сесії", async () => {
+    const app = createApp();
+    const res = await request(app).get("/api/coach/memory");
+    expect(res.status).toBe(401);
+  });
+
+  it("POST /api/coach/memory → 401 без сесії", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/api/coach/memory")
+      .send({ weeklyDigest: { weekKey: "2026-W18" } });
+    expect(res.status).toBe(401);
+  });
+
+  it("POST /api/coach/insight → 401 без сесії", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/api/coach/insight")
+      .send({ snapshot: {} });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("coach routes — key guard", () => {
+  it("POST /api/coach/insight → 503 з сесією але без ANTHROPIC_API_KEY", async () => {
+    getSessionUserMock.mockResolvedValue({ id: "u1" });
+    const app = createApp();
+    const res = await request(app)
+      .post("/api/coach/insight")
+      .send({ snapshot: {} });
+    expect(res.status).toBe(503);
+    expect(res.body).toMatchObject({ error: expect.any(String) });
+  });
+});
+
+describe("coach routes — GET /memory", () => {
+  it("повертає { memory: null } коли coach-рядка ще нема", async () => {
+    getSessionUserMock.mockResolvedValue({ id: "u1" });
+    // Перший query — module_data SELECT для memory; повертає порожній масив.
+    queryMock.mockResolvedValueOnce({ rows: [] });
+
+    const app = createApp();
+    const res = await request(app).get("/api/coach/memory");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ memory: null });
+  });
+
+  it("повертає { memory: <збережені дані> } коли рядок існує", async () => {
+    getSessionUserMock.mockResolvedValue({ id: "u1" });
+    const memoryData = {
+      weeklyDigests: [],
+      lastInsightDate: "2026-04-28",
+      lastInsightText: "Все добре.",
+    };
+    queryMock.mockResolvedValueOnce({
+      rows: [{ data: JSON.stringify(memoryData) }],
+    });
+
+    const app = createApp();
+    const res = await request(app).get("/api/coach/memory");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      memory: {
+        weeklyDigests: [],
+        lastInsightDate: "2026-04-28",
+        lastInsightText: "Все добре.",
+      },
+    });
+  });
+});
+
+describe("coach routes — POST /memory", () => {
+  it("зберігає weeklyDigest і повертає { ok: true }", async () => {
+    getSessionUserMock.mockResolvedValue({ id: "u1" });
+    // SELECT existing memory → empty
+    queryMock.mockResolvedValueOnce({ rows: [] });
+    // UPSERT → success
+    queryMock.mockResolvedValueOnce({ rows: [] });
+
+    const app = createApp();
+    const res = await request(app)
+      .post("/api/coach/memory")
+      .send({
+        weeklyDigest: {
+          weekKey: "2026-W18",
+          weekRange: "28 квіт – 4 трав 2026",
+          generatedAt: new Date().toISOString(),
+          finyk: { summary: "Витрати в нормі." },
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true });
+  });
+
+  it("повертає 400 при невалідному body (weeklyDigest без weekKey)", async () => {
+    getSessionUserMock.mockResolvedValue({ id: "u1" });
+
+    const app = createApp();
+    const res = await request(app)
+      .post("/api/coach/memory")
+      .send({ weeklyDigest: { summary: "no weekKey" } });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: expect.any(String) });
+  });
+});
+
+describe("coach routes — POST /insight", () => {
+  it("повертає { insight: string } коли ключ є і snapshot валідний", async () => {
+    getSessionUserMock.mockResolvedValue({ id: "u1" });
+    process.env.ANTHROPIC_API_KEY = "test-key";
+    // SELECT coach memory
+    queryMock.mockResolvedValueOnce({ rows: [] });
+    // SELECT ai_quota
+    queryMock.mockResolvedValueOnce({ rows: [{ request_count: 1 }] });
+    // SELECT push subscriptions for quiet push
+    queryMock.mockResolvedValueOnce({ rows: [] });
+
+    const app = createApp();
+    const res = await request(app)
+      .post("/api/coach/insight")
+      .set("x-anthropic-key", "test-key")
+      .send({
+        snapshot: {
+          finyk: { summary: "5 000 ₴ витрати." },
+          fizruk: null,
+          nutrition: null,
+          routine: null,
+        },
+        dateContext: {
+          today: "2026-05-01",
+          dayOfWeek: "четвер",
+          weekNumber: 18,
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ insight: expect.any(String) });
+    expect(typeof res.body.insight).toBe("string");
+    expect(res.body.insight.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/core/lib/hubChatUtils.ts
+++ b/apps/web/src/core/lib/hubChatUtils.ts
@@ -147,19 +147,17 @@ export function normalizeStoredMessages(raw: unknown): ChatMessage[] {
   }));
 }
 
+// Thin adapters over the canonical safe-storage helpers.
+// Callers import `ls`/`lsSet` for backward-compat; new code should prefer
+// `safeReadLS`/`safeWriteLS` from `@shared/lib/storage` directly.
+import { safeReadLS, safeWriteLS } from "@shared/lib/storage";
+
 export function ls<T>(key: string, fallback: T): T {
-  try {
-    const v = localStorage.getItem(key);
-    return v ? (JSON.parse(v) as T) : fallback;
-  } catch {
-    return fallback;
-  }
+  return (safeReadLS<T>(key) as T | null) ?? fallback;
 }
 
 export function lsSet(key: string, value: unknown): void {
-  try {
-    localStorage.setItem(key, JSON.stringify(value));
-  } catch {}
+  safeWriteLS(key, value);
 }
 
 export function fmt(n: number): string {

--- a/apps/web/src/modules/fizruk/components/TodayPlanCard.tsx
+++ b/apps/web/src/modules/fizruk/components/TodayPlanCard.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { safeWriteLS } from "@shared/lib/storage";
 import { Button } from "@shared/components/ui/Button";
 import { Card } from "@shared/components/ui/Card";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
@@ -73,9 +74,7 @@ export function TodayPlanCard({
       });
     }
     if (templateId) markTemplateUsed(templateId);
-    try {
-      localStorage.setItem(ACTIVE_WORKOUT_KEY, w.id);
-    } catch {}
+    safeWriteLS(ACTIVE_WORKOUT_KEY, w.id);
     try {
       sessionStorage.setItem("fizruk_workouts_mode", "log");
     } catch {}
@@ -130,9 +129,7 @@ export function TodayPlanCard({
             onChange={(e) => {
               const v = e.target.value;
               setSelectedTemplateId(v);
-              try {
-                localStorage.setItem(SELECTED_TEMPLATE_KEY, v);
-              } catch {}
+              safeWriteLS(SELECTED_TEMPLATE_KEY, v);
             }}
             aria-label="Обрати збережений шаблон тренування"
           >

--- a/apps/web/src/modules/fizruk/components/workouts/WorkoutsHome.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/WorkoutsHome.tsx
@@ -1,0 +1,216 @@
+import { useMemo } from "react";
+import { Button } from "@shared/components/ui/Button";
+import { Card } from "@shared/components/ui/Card";
+import { computeWorkoutSummary } from "@sergeant/fizruk-domain/domain";
+
+type WorkoutItem = ReadonlyArray<unknown>;
+
+type WorkoutShape = {
+  id: string;
+  startedAt: string;
+  endedAt?: string | null;
+  items?: WorkoutItem;
+};
+
+export interface WorkoutsHomeProps {
+  activeWorkout: WorkoutShape | null;
+  activeDuration: string | null;
+  recentWorkouts: ReadonlyArray<WorkoutShape>;
+  onOpenSession: () => void;
+  onOpenCatalog: () => void;
+  onOpenTemplates: () => void;
+  onOpenJournal: () => void;
+  /**
+   * Opens the start chooser (`QuickStartSheet`) instead of immediately
+   * spinning up an empty session — the chooser itself is responsible
+   * for creating the workout once the user picked a template or a set
+   * of exercises.
+   */
+  onRequestStart: () => void;
+  onOpenRetro: () => void;
+}
+
+export function WorkoutsHome({
+  activeWorkout,
+  activeDuration,
+  recentWorkouts,
+  onOpenSession,
+  onOpenCatalog,
+  onOpenTemplates,
+  onOpenJournal,
+  onRequestStart,
+  onOpenRetro,
+}: WorkoutsHomeProps) {
+  const hasActive = !!activeWorkout && !activeWorkout.endedAt;
+
+  return (
+    <div className="space-y-4">
+      {hasActive ? (
+        <div className="rounded-xl border border-teal-500/40 bg-teal-500/10 p-4">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <div className="text-xs font-semibold text-teal-700">
+                Активне тренування
+              </div>
+              <div className="mt-1 text-sm text-text">
+                <span className="font-bold">{activeDuration ?? "00:00"}</span>
+                {" · "}
+                {(activeWorkout?.items || []).length} вправ
+              </div>
+            </div>
+            <Button className="h-11 px-4" onClick={onOpenSession}>
+              Відкрити →
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="rounded-xl border border-border bg-surface p-4 text-center">
+          <div className="text-sm font-semibold text-text">
+            Немає активного тренування
+          </div>
+          <div className="text-xs text-subtle mt-1">
+            Почни нове — обереш шаблон або підбереш вправи перед стартом.
+          </div>
+          <div className="mt-3 grid grid-cols-1 gap-2">
+            <Button className="h-12 text-base" onClick={onRequestStart}>
+              ▶︎ Почати тренування
+            </Button>
+            <Button
+              variant="ghost"
+              className="h-12 text-base"
+              onClick={onOpenRetro}
+            >
+              ✏️ Внести проведене заняття
+            </Button>
+          </div>
+        </div>
+      )}
+
+      <Card as="section" radius="lg" aria-label="Останні тренування">
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-sm font-semibold text-text">
+            Останні тренування
+          </h2>
+          {recentWorkouts.length > 0 ? (
+            <button
+              type="button"
+              className="text-xs font-semibold text-fizruk-strong hover:underline active:opacity-70"
+              onClick={onOpenJournal}
+            >
+              Всі →
+            </button>
+          ) : null}
+        </div>
+        {recentWorkouts.length > 0 ? (
+          <ul className="flex flex-col gap-2">
+            {recentWorkouts.map((w) => (
+              <li key={w.id}>
+                <button
+                  type="button"
+                  className="w-full text-left rounded-xl border border-line bg-bg px-3 py-3 flex items-center justify-between hover:bg-panelHi transition-colors"
+                  onClick={onOpenJournal}
+                >
+                  <RecentWorkoutSummary workout={w} />
+                  <span className="text-subtle" aria-hidden>
+                    ›
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div className="rounded-2xl border border-dashed border-line p-4 text-xs text-subtle text-center">
+            Після першого завершеного тренування тут з&apos;являться останні
+            сесії.
+          </div>
+        )}
+      </Card>
+
+      <Card as="section" radius="lg" aria-label="Довідники">
+        <h2 className="text-sm font-semibold text-text mb-3">Довідники</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          <button
+            type="button"
+            className="rounded-2xl border border-line bg-bg p-4 text-left hover:bg-panelHi transition-colors"
+            onClick={onOpenCatalog}
+          >
+            <div className="flex items-center gap-3">
+              <span className="text-2xl" aria-hidden>
+                📚
+              </span>
+              <div className="flex-1 min-w-0">
+                <div className="text-sm font-semibold text-text">
+                  Каталог вправ
+                </div>
+                <div className="text-xs text-subtle mt-0.5">
+                  Пошук · групи м&apos;язів · своя вправа
+                </div>
+              </div>
+              <span className="text-subtle" aria-hidden>
+                ›
+              </span>
+            </div>
+          </button>
+          <button
+            type="button"
+            className="rounded-2xl border border-line bg-bg p-4 text-left hover:bg-panelHi transition-colors"
+            onClick={onOpenTemplates}
+          >
+            <div className="flex items-center gap-3">
+              <span className="text-2xl" aria-hidden>
+                📋
+              </span>
+              <div className="flex-1 min-w-0">
+                <div className="text-sm font-semibold text-text">Шаблони</div>
+                <div className="text-xs text-subtle mt-0.5">
+                  Збережені набори вправ на швидкий старт
+                </div>
+              </div>
+              <span className="text-subtle" aria-hidden>
+                ›
+              </span>
+            </div>
+          </button>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+interface RecentWorkoutSummaryProps {
+  workout: WorkoutShape;
+}
+
+export function RecentWorkoutSummary({ workout }: RecentWorkoutSummaryProps) {
+  const summary = useMemo(
+    () => computeWorkoutSummary(workout as never),
+    [workout],
+  );
+  const started = new Date(workout.startedAt);
+  const dateLabel = started.toLocaleDateString("uk-UA", {
+    day: "numeric",
+    month: "short",
+  });
+  const parts: string[] = [];
+  if (summary.itemCount > 0) parts.push(`${summary.itemCount} вправ`);
+  if (summary.setCount > 0) parts.push(`${summary.setCount} сетів`);
+  const durMin = summary.durationSec
+    ? Math.max(1, Math.round(summary.durationSec / 60))
+    : null;
+  if (durMin !== null) parts.push(`${durMin} хв`);
+  const subtitle = parts.length ? parts.join(" · ") : "порожнє тренування";
+
+  return (
+    <div className="flex-1 pr-2">
+      <div className="flex items-center gap-2">
+        <span className="text-sm font-semibold text-text">{dateLabel}</span>
+        {!summary.isFinished ? (
+          <span className="text-[10px] uppercase font-bold text-amber-700 bg-amber-500/15 px-2 py-0.5 rounded-full">
+            Чернетка
+          </span>
+        ) : null}
+      </div>
+      <div className="text-xs text-subtle mt-0.5 truncate">{subtitle}</div>
+    </div>
+  );
+}

--- a/apps/web/src/modules/fizruk/hooks/useExerciseCatalog.ts
+++ b/apps/web/src/modules/fizruk/hooks/useExerciseCatalog.ts
@@ -5,6 +5,7 @@ import {
   parseCustomExercisesFromStorage,
   serializeCustomExercisesToStorage,
 } from "@sergeant/fizruk-domain";
+import { safeReadStringLS, safeWriteLS } from "@shared/lib/storage";
 
 type RawExerciseDef = FizrukData.RawExerciseDef;
 
@@ -27,21 +28,14 @@ export function useExerciseCatalog() {
   const musclesByPrimaryGroup = FizrukData.MUSCLES_BY_PRIMARY_GROUP;
 
   useEffect(() => {
-    try {
-      const raw = localStorage.getItem(CUSTOM_EXERCISES_KEY);
-      const parsed = parseCustomExercisesFromStorage(raw);
-      if (Array.isArray(parsed)) setCustomExercises(parsed as RawExerciseDef[]);
-    } catch {}
+    const raw = safeReadStringLS(CUSTOM_EXERCISES_KEY);
+    const parsed = parseCustomExercisesFromStorage(raw);
+    if (Array.isArray(parsed)) setCustomExercises(parsed as RawExerciseDef[]);
   }, []);
 
   const persistCustom = useCallback((next: RawExerciseDef[]) => {
     setCustomExercises(next);
-    try {
-      localStorage.setItem(
-        CUSTOM_EXERCISES_KEY,
-        serializeCustomExercisesToStorage(next),
-      );
-    } catch {}
+    safeWriteLS(CUSTOM_EXERCISES_KEY, serializeCustomExercisesToStorage(next));
   }, []);
 
   const exercises = useMemo(

--- a/apps/web/src/modules/fizruk/hooks/useFizrukProgramStart.ts
+++ b/apps/web/src/modules/fizruk/hooks/useFizrukProgramStart.ts
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { ACTIVE_WORKOUT_KEY } from "@sergeant/fizruk-domain";
+import { safeWriteLS } from "@shared/lib/storage";
 
 interface Exercise {
   id: string;
@@ -79,8 +80,8 @@ export function useFizrukProgramStart({
           ...(isCardio ? { distanceM: 0 } : {}),
         });
       }
+      safeWriteLS(ACTIVE_WORKOUT_KEY, w.id);
       try {
-        localStorage.setItem(ACTIVE_WORKOUT_KEY, w.id);
         sessionStorage.setItem("fizruk_workouts_mode", "log");
       } catch {
         // best-effort session handoff; failure just means the Workouts

--- a/apps/web/src/modules/fizruk/hooks/useFizrukWorkoutReminder.ts
+++ b/apps/web/src/modules/fizruk/hooks/useFizrukWorkoutReminder.ts
@@ -1,16 +1,20 @@
 import { useEffect, useRef } from "react";
+import { safeReadStringLS, safeWriteLS } from "@shared/lib/storage";
 
 const LAST_KEY = "fizruk_last_reminder_notif_day";
 
 function readLastFiredDay(): string | null {
-  try {
-    return localStorage.getItem(LAST_KEY);
-  } catch {
-    return null;
-  }
+  return safeReadStringLS(LAST_KEY);
 }
 
-export function sendFizrukStateToSW(state) {
+interface FizrukReminderState {
+  reminderEnabled: boolean;
+  reminderHour: number;
+  reminderMinute: number;
+  days: Record<string, unknown>;
+}
+
+export function sendFizrukStateToSW(state: FizrukReminderState): void {
   try {
     if (!("serviceWorker" in navigator) || !navigator.serviceWorker.controller)
       return;
@@ -31,6 +35,12 @@ export function useFizrukWorkoutReminder({
   reminderMinute,
   reminderEnabled,
   days,
+}: {
+  enabled: boolean;
+  reminderHour: number;
+  reminderMinute: number;
+  reminderEnabled: boolean;
+  days: Record<string, unknown>;
 }) {
   // Seed from localStorage so that remount within the same day (e.g. after
   // HMR, route change, or the user navigating away and back) does not
@@ -65,11 +75,7 @@ export function useFizrukWorkoutReminder({
       if (Notification.permission !== "granted") return;
 
       firedRef.current = dayStr;
-      try {
-        localStorage.setItem(LAST_KEY, dayStr);
-      } catch {
-        /* ignore */
-      }
+      safeWriteLS(LAST_KEY, dayStr);
 
       try {
         if ("serviceWorker" in navigator) {

--- a/apps/web/src/modules/fizruk/hooks/useMonthlyPlan.ts
+++ b/apps/web/src/modules/fizruk/hooks/useMonthlyPlan.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { MONTHLY_PLAN_STORAGE_KEY } from "@sergeant/fizruk-domain";
+import { safeReadLS, safeWriteLS } from "@shared/lib/storage";
 
 const STORAGE_KEY = MONTHLY_PLAN_STORAGE_KEY;
 
@@ -20,38 +21,29 @@ function todayKey() {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 }
 
-function loadState() {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw)
-      return {
-        reminderEnabled: true,
-        reminderHour: 18,
-        reminderMinute: 0,
-        days: {},
-      };
-    const p = JSON.parse(raw);
-    return {
-      reminderEnabled: p.reminderEnabled !== false,
-      reminderHour: Number.isFinite(p.reminderHour) ? p.reminderHour : 18,
-      reminderMinute: Number.isFinite(p.reminderMinute) ? p.reminderMinute : 0,
-      days: typeof p.days === "object" && p.days ? p.days : {},
-    };
-  } catch {
-    return {
-      reminderEnabled: true,
-      reminderHour: 18,
-      reminderMinute: 0,
-      days: {},
-    };
-  }
+const DEFAULT_STATE: MonthlyPlanState = {
+  reminderEnabled: true,
+  reminderHour: 18,
+  reminderMinute: 0,
+  days: {},
+};
+
+function loadState(): MonthlyPlanState {
+  const p = safeReadLS<Partial<MonthlyPlanState>>(STORAGE_KEY);
+  if (!p) return DEFAULT_STATE;
+  return {
+    reminderEnabled: p.reminderEnabled !== false,
+    reminderHour: Number.isFinite(p.reminderHour) ? (p.reminderHour ?? 18) : 18,
+    reminderMinute: Number.isFinite(p.reminderMinute)
+      ? (p.reminderMinute ?? 0)
+      : 0,
+    days: typeof p.days === "object" && p.days ? p.days : {},
+  };
 }
 
-function saveState(s: MonthlyPlanState) {
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(s));
-    window.dispatchEvent(new CustomEvent("fizruk-storage-monthly-plan"));
-  } catch {}
+function saveState(s: MonthlyPlanState): void {
+  safeWriteLS(STORAGE_KEY, s);
+  window.dispatchEvent(new CustomEvent("fizruk-storage-monthly-plan"));
 }
 
 export function useMonthlyPlan() {

--- a/apps/web/src/modules/fizruk/hooks/useRestSettings.ts
+++ b/apps/web/src/modules/fizruk/hooks/useRestSettings.ts
@@ -6,36 +6,38 @@ import {
   REST_DEFAULTS,
   getRestCategory,
 } from "@sergeant/fizruk-domain";
-import { RestSettingsSchema } from "./useRestSettings.schema";
+import { RestSettingsSchema, type RestSettings } from "./useRestSettings.schema";
 
 export { REST_CATEGORY_LABELS, REST_DEFAULTS, getRestCategory };
 
 const KEY = STORAGE_KEYS.FIZRUK_REST_SETTINGS;
+
+type MergedSettings = typeof REST_DEFAULTS;
 
 /**
  * Hook that provides user-configurable default rest durations per exercise type.
  * Settings are stored in localStorage.
  */
 export function useRestSettings() {
-  const [settings, setSettings] = useState(() => {
-    const parsed = safeReadLSValidated(KEY, RestSettingsSchema, {});
+  const [settings, setSettings] = useState<MergedSettings>(() => {
+    const parsed = safeReadLSValidated(KEY, RestSettingsSchema, {} as RestSettings);
     return { ...REST_DEFAULTS, ...parsed };
   });
 
-  const persist = useCallback((next) => {
+  const persist = useCallback((next: MergedSettings) => {
     setSettings(next);
     safeWriteLS(KEY, next);
   }, []);
 
   const updateSetting = useCallback(
-    (category, sec) => {
+    (category: keyof MergedSettings, sec: number) => {
       persist({ ...settings, [category]: Number(sec) });
     },
     [settings, persist],
   );
 
   const getDefaultForGroup = useCallback(
-    (primaryGroup) => {
+    (primaryGroup: string) => {
       const cat = getRestCategory(primaryGroup);
       return settings[cat] ?? REST_DEFAULTS[cat];
     },

--- a/apps/web/src/modules/fizruk/hooks/useTrainingProgram.ts
+++ b/apps/web/src/modules/fizruk/hooks/useTrainingProgram.ts
@@ -1,25 +1,24 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { BUILTIN_PROGRAMS, getTodaySession } from "@sergeant/fizruk-domain";
+import {
+  safeReadStringLS,
+  safeWriteLS,
+  safeRemoveLS,
+} from "@shared/lib/storage";
 
 const ACTIVE_PROGRAM_KEY = "fizruk_active_program_id_v1";
 
 export function useTrainingProgram() {
-  const [activeProgramId, setActiveProgramId] = useState(() => {
-    try {
-      return localStorage.getItem(ACTIVE_PROGRAM_KEY) || null;
-    } catch {
-      return null;
-    }
-  });
+  const [activeProgramId, setActiveProgramId] = useState(() =>
+    safeReadStringLS(ACTIVE_PROGRAM_KEY),
+  );
 
   useEffect(() => {
-    try {
-      if (activeProgramId) {
-        localStorage.setItem(ACTIVE_PROGRAM_KEY, activeProgramId);
-      } else {
-        localStorage.removeItem(ACTIVE_PROGRAM_KEY);
-      }
-    } catch {}
+    if (activeProgramId) {
+      safeWriteLS(ACTIVE_PROGRAM_KEY, activeProgramId);
+    } else {
+      safeRemoveLS(ACTIVE_PROGRAM_KEY);
+    }
   }, [activeProgramId]);
 
   const activeProgram = useMemo(
@@ -27,7 +26,7 @@ export function useTrainingProgram() {
     [activeProgramId],
   );
 
-  const activateProgram = useCallback((id) => {
+  const activateProgram = useCallback((id: string | null) => {
     setActiveProgramId(id || null);
   }, []);
 

--- a/apps/web/src/modules/fizruk/pages/Body.tsx
+++ b/apps/web/src/modules/fizruk/pages/Body.tsx
@@ -9,6 +9,7 @@ import { Card } from "@shared/components/ui/Card";
 import { MiniLineChart } from "../components/MiniLineChart";
 import { useToast } from "@shared/hooks/useToast";
 import { showUndoToast } from "@shared/lib/undoToast";
+import { safeReadStringLS, safeWriteLS } from "@shared/lib/storage";
 
 /**
  * Trend cards on this page used to be always-expanded, which meant four
@@ -45,33 +46,18 @@ type JournalEntry = {
 };
 
 function readTrendOpen(key: string): boolean {
-  if (typeof window === "undefined") return false;
-  try {
-    return window.localStorage.getItem(TREND_STORAGE_PREFIX + key) === "1";
-  } catch {
-    return false;
-  }
+  return safeReadStringLS(TREND_STORAGE_PREFIX + key) === "1";
 }
 
 function readPersistedOpen(storageKey: string, fallback: boolean): boolean {
-  if (typeof window === "undefined") return fallback;
-  try {
-    const v = window.localStorage.getItem(storageKey);
-    if (v === "1") return true;
-    if (v === "0") return false;
-    return fallback;
-  } catch {
-    return fallback;
-  }
+  const v = safeReadStringLS(storageKey);
+  if (v === "1") return true;
+  if (v === "0") return false;
+  return fallback;
 }
 
 function writePersistedOpen(storageKey: string, open: boolean): void {
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(storageKey, open ? "1" : "0");
-  } catch {
-    /* ignore quota / disabled storage */
-  }
+  safeWriteLS(storageKey, open ? "1" : "0");
 }
 
 function CollapsibleTrendCard({
@@ -97,16 +83,7 @@ function CollapsibleTrendCard({
   const toggle = useCallback(() => {
     setOpen((prev) => {
       const next = !prev;
-      if (typeof window !== "undefined") {
-        try {
-          window.localStorage.setItem(
-            TREND_STORAGE_PREFIX + storageKey,
-            next ? "1" : "0",
-          );
-        } catch {
-          /* ignore quota / disabled storage */
-        }
-      }
+      safeWriteLS(TREND_STORAGE_PREFIX + storageKey, next ? "1" : "0");
       return next;
     });
   }, [storageKey]);

--- a/apps/web/src/modules/fizruk/pages/Dashboard.tsx
+++ b/apps/web/src/modules/fizruk/pages/Dashboard.tsx
@@ -1,3 +1,4 @@
+import { safeWriteLS } from "@shared/lib/storage";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Button } from "@shared/components/ui/Button";
 import { Sheet } from "@shared/components/ui/Sheet";
@@ -81,9 +82,7 @@ export function Dashboard({
       });
     }
     if (templateId) markTemplateUsed(templateId);
-    try {
-      localStorage.setItem(ACTIVE_WORKOUT_KEY, w.id);
-    } catch {}
+    safeWriteLS(ACTIVE_WORKOUT_KEY, w.id);
     try {
       sessionStorage.setItem("fizruk_workouts_mode", "log");
     } catch {}

--- a/apps/web/src/modules/fizruk/pages/Progress.tsx
+++ b/apps/web/src/modules/fizruk/pages/Progress.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { safeRemoveLS } from "@shared/lib/storage";
 import { downloadJson } from "@sergeant/shared";
 import { Button } from "@shared/components/ui/Button";
 import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
@@ -227,9 +228,7 @@ export function Progress() {
 
   const resetAll = () => {
     for (const k of FIZRUK_RESET_KEYS) {
-      try {
-        localStorage.removeItem(k);
-      } catch {}
+      safeRemoveLS(k);
     }
     window.location.reload();
   };

--- a/apps/web/src/modules/fizruk/pages/Workouts.tsx
+++ b/apps/web/src/modules/fizruk/pages/Workouts.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { safeReadStringLS, safeWriteLS, safeRemoveLS } from "@shared/lib/storage";
 import { Button } from "@shared/components/ui/Button";
 import { Card } from "@shared/components/ui/Card";
 import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
@@ -23,7 +24,10 @@ import {
   ACTIVE_WORKOUT_KEY,
   summarizeWorkoutForFinish,
 } from "@sergeant/fizruk-domain";
-import { computeWorkoutSummary } from "@sergeant/fizruk-domain/domain";
+import {
+  WorkoutsHome,
+  RecentWorkoutSummary,
+} from "../components/workouts/WorkoutsHome";
 
 type WorkoutsView = "home" | "catalog" | "log" | "templates";
 
@@ -96,13 +100,9 @@ export function Workouts() {
   // `WorkoutCatalogSection`). Kept in sync with `view` for those subviews.
   const mode = view === "templates" || view === "home" ? "catalog" : view;
   const [restTimer, setRestTimer] = useState(null);
-  const [activeWorkoutId, setActiveWorkoutId] = useState(() => {
-    try {
-      return localStorage.getItem(ACTIVE_WORKOUT_KEY) || null;
-    } catch {
-      return null;
-    }
-  });
+  const [activeWorkoutId, setActiveWorkoutId] = useState(() =>
+    safeReadStringLS(ACTIVE_WORKOUT_KEY),
+  );
   const [finishFlash, setFinishFlash] = useState(null);
   const [deleteExerciseConfirm, setDeleteExerciseConfirm] = useState(false);
   const [riskyTemplateConfirm, setRiskyTemplateConfirm] = useState(null); // stores template when risky
@@ -138,10 +138,8 @@ export function Workouts() {
   }, [activeWorkout?.startedAt, activeWorkout?.endedAt, now]);
 
   useEffect(() => {
-    try {
-      if (!activeWorkoutId) localStorage.removeItem(ACTIVE_WORKOUT_KEY);
-      else localStorage.setItem(ACTIVE_WORKOUT_KEY, activeWorkoutId);
-    } catch {}
+    if (!activeWorkoutId) safeRemoveLS(ACTIVE_WORKOUT_KEY);
+    else safeWriteLS(ACTIVE_WORKOUT_KEY, activeWorkoutId);
   }, [activeWorkoutId]);
 
   // Clear a stale activeWorkoutId that no longer matches any workout
@@ -656,227 +654,3 @@ export function Workouts() {
   );
 }
 
-/**
- * Landing view for the Workouts page.
- *
- * Shows one dominant path ("Почати тренування" → active session) plus two
- * supporting shortcuts (recent sessions preview and quick-link tiles to
- * the catalog / templates / full journal).
- */
-interface WorkoutsHomeProps {
-  activeWorkout: {
-    id: string;
-    startedAt: string;
-    endedAt?: string | null;
-    items?: ReadonlyArray<unknown>;
-  } | null;
-  activeDuration: string | null;
-  recentWorkouts: ReadonlyArray<{
-    id: string;
-    startedAt: string;
-    endedAt?: string | null;
-    items?: ReadonlyArray<unknown>;
-  }>;
-  onOpenSession: () => void;
-  onOpenCatalog: () => void;
-  onOpenTemplates: () => void;
-  onOpenJournal: () => void;
-  /**
-   * Opens the start chooser (`QuickStartSheet`) instead of immediately
-   * spinning up an empty session — the chooser itself is responsible
-   * for creating the workout once the user picked a template or a set
-   * of exercises.
-   */
-  onRequestStart: () => void;
-  onOpenRetro: () => void;
-}
-
-function WorkoutsHome({
-  activeWorkout,
-  activeDuration,
-  recentWorkouts,
-  onOpenSession,
-  onOpenCatalog,
-  onOpenTemplates,
-  onOpenJournal,
-  onRequestStart,
-  onOpenRetro,
-}: WorkoutsHomeProps) {
-  const hasActive = !!activeWorkout && !activeWorkout.endedAt;
-
-  return (
-    <div className="space-y-4">
-      {hasActive ? (
-        <div className="rounded-xl border border-teal-500/40 bg-teal-500/10 p-4">
-          <div className="flex items-center justify-between gap-3">
-            <div>
-              <div className="text-xs font-semibold text-teal-700">
-                Активне тренування
-              </div>
-              <div className="mt-1 text-sm text-text">
-                <span className="font-bold">{activeDuration ?? "00:00"}</span>
-                {" · "}
-                {(activeWorkout?.items || []).length} вправ
-              </div>
-            </div>
-            <Button className="h-11 px-4" onClick={onOpenSession}>
-              Відкрити →
-            </Button>
-          </div>
-        </div>
-      ) : (
-        <div className="rounded-xl border border-border bg-surface p-4 text-center">
-          <div className="text-sm font-semibold text-text">
-            Немає активного тренування
-          </div>
-          <div className="text-xs text-subtle mt-1">
-            Почни нове — обереш шаблон або підбереш вправи перед стартом.
-          </div>
-          <div className="mt-3 grid grid-cols-1 gap-2">
-            <Button className="h-12 text-base" onClick={onRequestStart}>
-              ▶︎ Почати тренування
-            </Button>
-            <Button
-              variant="ghost"
-              className="h-12 text-base"
-              onClick={onOpenRetro}
-            >
-              ✏️ Внести проведене заняття
-            </Button>
-          </div>
-        </div>
-      )}
-
-      <Card as="section" radius="lg" aria-label="Останні тренування">
-        <div className="flex items-center justify-between mb-3">
-          <h2 className="text-sm font-semibold text-text">
-            Останні тренування
-          </h2>
-          {recentWorkouts.length > 0 ? (
-            <button
-              type="button"
-              className="text-xs font-semibold text-fizruk-strong hover:underline active:opacity-70"
-              onClick={onOpenJournal}
-            >
-              Всі →
-            </button>
-          ) : null}
-        </div>
-        {recentWorkouts.length > 0 ? (
-          <ul className="flex flex-col gap-2">
-            {recentWorkouts.map((w) => (
-              <li key={w.id}>
-                <button
-                  type="button"
-                  className="w-full text-left rounded-xl border border-line bg-bg px-3 py-3 flex items-center justify-between hover:bg-panelHi transition-colors"
-                  onClick={onOpenJournal}
-                >
-                  <RecentWorkoutSummary workout={w} />
-                  <span className="text-subtle" aria-hidden>
-                    ›
-                  </span>
-                </button>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <div className="rounded-2xl border border-dashed border-line p-4 text-xs text-subtle text-center">
-            Після першого завершеного тренування тут з&apos;являться останні
-            сесії.
-          </div>
-        )}
-      </Card>
-
-      <Card as="section" radius="lg" aria-label="Довідники">
-        <h2 className="text-sm font-semibold text-text mb-3">Довідники</h2>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-          <button
-            type="button"
-            className="rounded-2xl border border-line bg-bg p-4 text-left hover:bg-panelHi transition-colors"
-            onClick={onOpenCatalog}
-          >
-            <div className="flex items-center gap-3">
-              <span className="text-2xl" aria-hidden>
-                📚
-              </span>
-              <div className="flex-1 min-w-0">
-                <div className="text-sm font-semibold text-text">
-                  Каталог вправ
-                </div>
-                <div className="text-xs text-subtle mt-0.5">
-                  Пошук · групи м&apos;язів · своя вправа
-                </div>
-              </div>
-              <span className="text-subtle" aria-hidden>
-                ›
-              </span>
-            </div>
-          </button>
-          <button
-            type="button"
-            className="rounded-2xl border border-line bg-bg p-4 text-left hover:bg-panelHi transition-colors"
-            onClick={onOpenTemplates}
-          >
-            <div className="flex items-center gap-3">
-              <span className="text-2xl" aria-hidden>
-                📋
-              </span>
-              <div className="flex-1 min-w-0">
-                <div className="text-sm font-semibold text-text">Шаблони</div>
-                <div className="text-xs text-subtle mt-0.5">
-                  Збережені набори вправ на швидкий старт
-                </div>
-              </div>
-              <span className="text-subtle" aria-hidden>
-                ›
-              </span>
-            </div>
-          </button>
-        </div>
-      </Card>
-    </div>
-  );
-}
-
-interface RecentWorkoutSummaryProps {
-  workout: {
-    id: string;
-    startedAt: string;
-    endedAt?: string | null;
-    items?: ReadonlyArray<unknown>;
-  };
-}
-
-function RecentWorkoutSummary({ workout }: RecentWorkoutSummaryProps) {
-  const summary = useMemo(
-    () => computeWorkoutSummary(workout as never),
-    [workout],
-  );
-  const started = new Date(workout.startedAt);
-  const dateLabel = started.toLocaleDateString("uk-UA", {
-    day: "numeric",
-    month: "short",
-  });
-  const parts: string[] = [];
-  if (summary.itemCount > 0) parts.push(`${summary.itemCount} вправ`);
-  if (summary.setCount > 0) parts.push(`${summary.setCount} сетів`);
-  const durMin = summary.durationSec
-    ? Math.max(1, Math.round(summary.durationSec / 60))
-    : null;
-  if (durMin !== null) parts.push(`${durMin} хв`);
-  const subtitle = parts.length ? parts.join(" · ") : "порожнє тренування";
-
-  return (
-    <div className="flex-1 pr-2">
-      <div className="flex items-center gap-2">
-        <span className="text-sm font-semibold text-text">{dateLabel}</span>
-        {!summary.isFinished ? (
-          <span className="text-[10px] uppercase font-bold text-amber-700 bg-amber-500/15 px-2 py-0.5 rounded-full">
-            Чернетка
-          </span>
-        ) : null}
-      </div>
-      <div className="text-xs text-subtle mt-0.5 truncate">{subtitle}</div>
-    </div>
-  );
-}

--- a/apps/web/tsconfig.strict.json
+++ b/apps/web/tsconfig.strict.json
@@ -22,7 +22,9 @@
     "src/core/app/**/*",
     "src/modules/nutrition/**/*",
     "src/modules/routine/**/*",
-    "src/modules/finyk/**/*"
+    "src/modules/finyk/**/*",
+    "src/modules/fizruk/**/*",
+    "src/core/lib/**/*"
   ],
   "exclude": ["node_modules", "dist"]
 }

--- a/docs/tech-debt/frontend.md
+++ b/docs/tech-debt/frontend.md
@@ -5,12 +5,12 @@
 
 Аналіз кодової бази `apps/web/src` (434 source файли, 87k рядків).
 
-> **Оновлено 2026-04-30.** Розділ 11 (Strict TS rollout) розширено Phase 2.1:
-> `tsconfig.strict.json` тепер покриває 12 директорій (`src/shared`, `src/test`,
-> `src/core/{auth,cloudSync,components,hints,hooks,hub,observability,pricing,profile,settings}`).
-> 16 strict-null помилок у 5 транзитивно імпортованих файлах (core/lib, modules/finyk,
-> modules/routine) виправлено null-guards + explicit generics для `safeReadLS`/`readJSON`,
-> без runtime-змін.
+> **Оновлено 2026-05-01.** Розділ 11 (Strict TS rollout) розширено Phase 2.2:
+> `tsconfig.strict.json` тепер покриває 14 директорій — додано `src/modules/fizruk/**/*` та
+> `src/core/lib/**/*`. Типи параметрів функцій у `useFizrukWorkoutReminder.ts`,
+> `useTrainingProgram.ts`, `useRestSettings.ts` — explicit (видалено implicit `any`).
+> Розділ 2 (localStorage burndown): 9 fizruk-файлів мігровано на `safeReadLS`/`safeWriteLS`/`safeRemoveLS`,
+> ESLint allowlist скорочено з 49 до 41 файлів.
 
 > **Як читати:** позначки в стовпчику «Статус» оновлюються в момент злиття PR.
 > Це жива сторінка — не «звіт», а контроль міграцій. Кожен запис стандартизує:
@@ -352,6 +352,15 @@ Ref: PR-6.F (sergeant-audit-devin.md).
   - `core/settings/FinykSection.tsx` — 20 raw calls → `safeReadStringLS`/`safeWriteLS`/`safeRemoveLS`
   - `core/lib/chatActions/fizrukActions.ts` — 7 raw calls → `safeReadLS` + `readWorkouts()` helper
   - `core/hub/HubDashboard.tsx` — вже використовував `localStorageStore` (KVStore adapter), прибрано з allowlist
+- ✅ `no-raw-local-storage` fizruk burndown (49 → 41 файлів, Phase 2.2):
+  - `useTrainingProgram.ts` — `safeReadStringLS`/`safeWriteLS`/`safeRemoveLS`
+  - `useFizrukWorkoutReminder.ts` — `safeReadStringLS`/`safeWriteLS` + typed params
+  - `useMonthlyPlan.ts` — `safeReadLS<Partial<MonthlyPlanState>>`/`safeWriteLS`
+  - `useExerciseCatalog.ts` — `safeReadStringLS`/`safeWriteLS`
+  - `useFizrukProgramStart.ts` — `safeWriteLS`
+  - `TodayPlanCard.tsx`, `Body.tsx`, `Dashboard.tsx`, `Progress.tsx`, `Workouts.tsx` — safe helpers
+  - `useWorkouts.ts` залишився в allowlist (використовує CustomEvent для quota UX)
+- ✅ Mobile APM: `tracesSampleRate` підвищено з 0 до 0.05 в продакшн Sentry RN
 - ✅ `no-raw-local-storage` PWA + Finyk-hub burndown (52 → 49 файлів):
   - `core/app/pwaAction.ts` — `localStorage.getItem`/`removeItem` → `safeReadStringLS` + `safeRemoveLS`
   - `core/hooks/usePwaActions.ts` — `localStorage.setItem` у `useState` lazy-initializer → `safeWriteLS`

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -320,17 +320,10 @@ export default [
       "apps/web/src/core/insights/useCoachInsight.ts",
       "apps/web/src/core/insights/useWeeklyDigest.ts",
       "apps/web/src/modules/finyk/pages/Overview.tsx",
-      "apps/web/src/modules/fizruk/components/TodayPlanCard.tsx",
-      "apps/web/src/modules/fizruk/hooks/useExerciseCatalog.ts",
-      "apps/web/src/modules/fizruk/hooks/useFizrukProgramStart.ts",
-      "apps/web/src/modules/fizruk/hooks/useFizrukWorkoutReminder.ts",
-      "apps/web/src/modules/fizruk/hooks/useMonthlyPlan.ts",
-      "apps/web/src/modules/fizruk/hooks/useTrainingProgram.ts",
+      // useWorkouts.ts: intentional direct-storage access — dispatches
+      // FIZRUK_WORKOUTS_STORAGE_ERROR custom event on quota failure so the
+      // UI can show a banner. safeWriteLS swallows the error silently.
       "apps/web/src/modules/fizruk/hooks/useWorkouts.ts",
-      "apps/web/src/modules/fizruk/pages/Body.tsx",
-      "apps/web/src/modules/fizruk/pages/Dashboard.tsx",
-      "apps/web/src/modules/fizruk/pages/Progress.tsx",
-      "apps/web/src/modules/fizruk/pages/Workouts.tsx",
       "apps/web/src/modules/nutrition/hooks/useNutritionReminders.ts",
       "apps/web/src/modules/routine/components/RoutineCalendarPanel.tsx",
       "apps/web/src/modules/routine/hooks/useRoutineReminders.ts",

--- a/scripts/__tests__/check-ai-legacy.test.mjs
+++ b/scripts/__tests__/check-ai-legacy.test.mjs
@@ -13,6 +13,7 @@ import assert from "node:assert/strict";
 import {
   classifyExpiry,
   daysBetween,
+  extractIssueRef,
   extractMalformed,
   extractMarkers,
   legacyIssueBody,
@@ -190,6 +191,34 @@ describe("legacyIssueMarker / legacyIssueTitle / legacyIssueBody", () => {
     const body = legacyIssueBody("apps/web/src/foo.ts", 1, "2026-04-29", "", 1);
     assert.match(body, /1 day ago/);
     assert.doesNotMatch(body, /1 days ago/);
+  });
+});
+
+// ── extractIssueRef ──────────────────────────────────────────────────────────
+
+describe("extractIssueRef", () => {
+  it("returns bare issue number (#123)", () => {
+    assert.equal(extractIssueRef("migrate bearer token #456"), "#456");
+  });
+
+  it("returns GH-NNN shorthand", () => {
+    assert.equal(extractIssueRef("tracked in GH-789"), "GH-789");
+  });
+
+  it("returns issues/NNN path fragment (from full GitHub URL)", () => {
+    assert.equal(
+      extractIssueRef("https://github.com/Skords-01/Sergeant/issues/123"),
+      "issues/123",
+    );
+  });
+
+  it("returns null for empty note", () => {
+    assert.equal(extractIssueRef(""), null);
+    assert.equal(extractIssueRef(null), null);
+  });
+
+  it("returns null when no issue reference present", () => {
+    assert.equal(extractIssueRef("migrate after v2 rollout"), null);
   });
 });
 

--- a/scripts/check-ai-legacy.mjs
+++ b/scripts/check-ai-legacy.mjs
@@ -31,10 +31,11 @@
 // `malformed` (separate from `expired`) so the author can fix the syntax.
 //
 // Usage:
-//   node scripts/check-ai-legacy.mjs                       # human summary
-//   node scripts/check-ai-legacy.mjs --check               # CI gate (exit 1 on expired)
-//   node scripts/check-ai-legacy.mjs --json                # machine-readable
-//   node scripts/check-ai-legacy.mjs --dashboard out.html  # HTML report
+//   node scripts/check-ai-legacy.mjs                                        # human summary
+//   node scripts/check-ai-legacy.mjs --check                                # CI gate (exit 1 on expired/malformed)
+//   node scripts/check-ai-legacy.mjs --check --require-issue                # also fail on missing issue refs
+//   node scripts/check-ai-legacy.mjs --json                                 # machine-readable
+//   node scripts/check-ai-legacy.mjs --dashboard out.html                   # HTML report
 //   GITHUB_TOKEN=... node scripts/check-ai-legacy.mjs --issues
 //
 // Environment:
@@ -286,6 +287,7 @@ export function gatherMarkers({
         line: m.line,
         expires: m.expires,
         note: m.note,
+        issueRef: extractIssueRef(m.note),
         status,
         daysUntilExpiry: daysBetween(today, m.expires),
       });
@@ -476,6 +478,29 @@ async function createIssue(finding, daysExpired) {
   });
 }
 
+// ── Issue-reference validation ───────────────────────────────────────────────
+
+// Recognises any of:
+//   #123              bare issue number
+//   GH-123            GitHub shorthand
+//   issues/123        path fragment (full URL also matches)
+const RX_ISSUE_REF = /#\d+|GH-\d+|issues\/\d+/i;
+
+/**
+ * Returns the issue reference found in the marker's rationale note, or
+ * `null` if none is present.
+ *
+ * Hard Rule #10 requires every `AI-LEGACY` marker to include a tracking
+ * issue so the work is never invisible. Example:
+ *
+ *     // AI-LEGACY: expires 2026-09-01 #1234 migrate to new SDK
+ */
+export function extractIssueRef(note) {
+  if (!note) return null;
+  const m = RX_ISSUE_REF.exec(note);
+  return m ? m[0] : null;
+}
+
 // ── CLI ──────────────────────────────────────────────────────────────────────
 
 function parseArgs(argv) {
@@ -484,12 +509,14 @@ function parseArgs(argv) {
     json: false,
     issues: false,
     dashboard: null,
+    requireIssue: false,
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--check") args.check = true;
     else if (a === "--json") args.json = true;
     else if (a === "--issues") args.issues = true;
+    else if (a === "--require-issue") args.requireIssue = true;
     else if (a === "--dashboard") args.dashboard = argv[++i];
     else if (a.startsWith("--dashboard=")) args.dashboard = a.split("=", 2)[1];
   }
@@ -499,10 +526,13 @@ function parseArgs(argv) {
 function printHumanSummary(findings) {
   const totals = { expired: 0, malformed: 0, "due-soon": 0, fresh: 0 };
   for (const f of findings) totals[f.status]++;
+  const noIssue = findings.filter(
+    (f) => f.status !== "malformed" && !f.issueRef,
+  );
 
   console.log(`AI-LEGACY scan — ${findings.length} marker(s) found`);
   console.log(
-    `  expired: ${totals.expired}    due-soon: ${totals["due-soon"]}    fresh: ${totals.fresh}    malformed: ${totals.malformed}`,
+    `  expired: ${totals.expired}    due-soon: ${totals["due-soon"]}    fresh: ${totals.fresh}    malformed: ${totals.malformed}    no-issue-ref: ${noIssue.length}`,
   );
   console.log("");
 
@@ -518,6 +548,14 @@ function printHumanSummary(findings) {
     console.log("Malformed (missing `expires YYYY-MM-DD`):");
     for (const f of findings.filter((x) => x.status === "malformed")) {
       console.log(`  ⚠  ${f.file}:${f.line}  ${f.note}`);
+    }
+  }
+  if (noIssue.length) {
+    console.log("No issue reference (add `#NNN` to the marker rationale):");
+    for (const f of noIssue) {
+      console.log(
+        `  ⚠  ${f.file}:${f.line}  expires=${f.expires}${f.note ? ` — ${f.note}` : ""}`,
+      );
     }
   }
   if (totals["due-soon"]) {
@@ -587,10 +625,15 @@ async function main() {
   if (args.check) {
     const expired = findings.filter((f) => f.status === "expired").length;
     const malformed = findings.filter((f) => f.status === "malformed").length;
-    if (expired || malformed) {
-      console.error(
-        `\n❌ ${expired} expired + ${malformed} malformed AI-LEGACY marker(s) — see above.`,
-      );
+    const noIssue = args.requireIssue
+      ? findings.filter((f) => f.status !== "malformed" && !f.issueRef).length
+      : 0;
+    if (expired || malformed || noIssue) {
+      const parts = [];
+      if (expired) parts.push(`${expired} expired`);
+      if (malformed) parts.push(`${malformed} malformed`);
+      if (noIssue) parts.push(`${noIssue} without issue ref (--require-issue)`);
+      console.error(`\n❌ AI-LEGACY violations: ${parts.join(", ")} — see above.`);
       process.exit(1);
     }
     console.log("\n✅ All AI-LEGACY markers are within their expiry window.");


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

All 12 improvements implemented across the full stack.

### #1–2 · TypeScript strict + localStorage safety (web/fizruk)
- Expanded `tsconfig.strict.json` to cover `src/modules/fizruk/**` and `src/core/lib/**`
- Migrated 10 fizruk files off raw `localStorage` to the canonical `safeReadLS` / `safeWriteLS` / `safeRemoveLS` helpers from `@shared/lib/storage`
- Removed all migrated files from the ESLint `no-raw-local-storage` allowlist (only `useWorkouts.ts` remains, intentionally — it dispatches `FIZRUK_WORKOUTS_STORAGE_ERROR`)

### #3 · WorkoutsHome extraction (web/fizruk)
- Extracted `WorkoutsHome` and `RecentWorkoutSummary` from `Workouts.tsx` into a dedicated `components/workouts/WorkoutsHome.tsx`
- `Workouts.tsx` shrunk by ~221 lines

### #4 · hubChatUtils ls()/lsSet() dedup (web/core)
- Replaced the two duplicate in-file implementations with thin adapters over `safeReadLS`/`safeWriteLS`; the 6 callsites are unchanged

### #5 · Mobile APM (mobile/obs)
- Enabled Sentry `tracesSampleRate: 0.05` in production for p95/p99 latency visibility

### #6 · Coach route contract tests (server)
- Added `apps/server/src/routes/coach.route.test.ts` — supertest-based HTTP contract tests covering: auth guard (401), key guard (503), `GET /memory` shapes, `POST /memory` validation, `POST /insight` happy path

### #7 · Distributed tracing (server)
- New `apps/server/src/http/traceContext.ts` — reads W3C `traceparent` header or `x-trace-id` fallback, generates a trace ID if absent, injects into ALS `RequestContextStore.traceId`, echoes back as `X-Trace-Id` response header
- `traceId` now included in every Pino log line via the mixin
- Wired as `app.use(traceMiddleware)` immediately after `withRequestContext`

### #8 · mobile-shell auth-storage boundary tests
- Added error-propagation tests for all 3 functions (`getBearerToken`, `setBearerToken`, `clearBearerToken`)
- Added `value: undefined` normalisation test

### #9 · TypeScript Next CI
- New `.github/workflows/typescript-next.yml` — weekly (Mondays UTC 04:00) typecheck with `typescript@next`; `continue-on-error: true` so it never blocks merges; creates/updates a GitHub issue on scheduled failures

### #10 · AI-LEGACY issue-ref validation
- Added `extractIssueRef(note)` pure helper to `check-ai-legacy.mjs` — recognises `#NNN`, `GH-NNN`, `issues/NNN`
- Human summary now reports markers missing an issue reference
- New `--require-issue` flag makes `--check` fail on missing refs
- Unit tests added for all `extractIssueRef` cases

### #11 · DB sync performance
- `syncPullAll`: added `ORDER BY module` for deterministic output + EXPLAIN ANALYZE comment documenting the Bitmap Index Scan
- `syncPushAll`: replaced N per-conflict `SELECT` queries with a single pre-fetch of all existing module rows before the transaction, eliminating the N+1 pattern on all-conflict scenarios

## Test plan
- [ ] `pnpm typecheck` — no new errors
- [ ] `pnpm --filter @sergeant/server exec vitest run src/routes/coach.route.test.ts`
- [ ] `pnpm --filter @sergeant/mobile-shell exec vitest run src/auth-storage.test.ts`
- [ ] `node --test scripts/__tests__/check-ai-legacy.test.mjs`
- [ ] Verify `X-Trace-Id` header present in responses: `curl -si http://localhost:3000/api/sync | grep X-Trace-Id`
- [ ] CI green on push

https://claude.ai/code/session_01ThmZCqDFo7y1qiYJjd7DEH
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThmZCqDFo7y1qiYJjd7DEH)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1265" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves web localStorage safety and strict typing, adds server distributed tracing with `X-Trace-Id`, enables mobile APM, and adds a weekly `typescript@next` CI check. Also extracts `WorkoutsHome`, adds route and storage tests, and speeds up sync conflict handling.

- **New Features**
  - Distributed tracing on server: reads `traceparent`/`x-trace-id`, injects trace ID into ALS, echoes `X-Trace-Id`, and includes it in Pino logs.
  - Coach routes: Supertest HTTP contract tests for auth/key guards and `GET/POST /memory`, `POST /insight`.
  - Mobile APM: Sentry `tracesSampleRate` set to 0.05 in production.
  - CI: weekly typecheck with `typescript@next`; creates/updates a GitHub issue on scheduled failures.
  - `check-ai-legacy`: new `extractIssueRef` and `--require-issue` flag; human summary calls out markers missing an issue ref.

- **Refactors**
  - Web `fizruk`: migrated 10 files from raw `localStorage` to `safeReadLS`/`safeWriteLS`/`safeRemoveLS`; expanded `tsconfig.strict.json` to `src/modules/fizruk/**/*` and `src/core/lib/**/*`; shrank ESLint allowlist.
  - Extracted `WorkoutsHome` and `RecentWorkoutSummary` from `Workouts.tsx` into `components/workouts/WorkoutsHome.tsx`.
  - `hubChatUtils`: replaced in-file `ls()`/`lsSet()` with adapters over safe storage helpers.
  - DB sync: `syncPullAll` now ordered for stable output; `syncPushAll` prefetches existing rows to remove N+1 conflict SELECTs.
  - Mobile-shell auth storage: boundary tests for get/set/clear token, including `undefined` normalization and error propagation.

<sup>Written for commit caf1d88cf30080ceea8ee913b4e08ff234c92552. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added distributed tracing capabilities across server and mobile applications for improved observability.
  * Introduced new Workouts home page with active workout status, recent workout history, and quick-access template library.

* **Improvements**
  * Enhanced reliability of local storage operations throughout the app.
  * Improved error handling and validation for authentication and coach services.

* **Tests**
  * Expanded test coverage for authentication storage and coach routing endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->