### PR TITLE
style(web): top 3 UI polish — bottom nav active pill, bento icon, progress bar

### DIFF
--- a/apps/web/src/core/app/HubBottomNav.tsx
+++ b/apps/web/src/core/app/HubBottomNav.tsx
@@ -76,8 +76,8 @@ function HubBottomNavTab({
     >
       <span
         className={cn(
-          "relative transition-all duration-200",
-          active && "text-brand-strong",
+          "relative transition-all duration-200 w-10 h-7 flex items-center justify-center rounded-xl",
+          active ? "text-brand-strong bg-brand-500/10" : "",
         )}
         aria-hidden
       >

--- a/apps/web/src/core/hub/dashboard/BentoCard.tsx
+++ b/apps/web/src/core/hub/dashboard/BentoCard.tsx
@@ -127,7 +127,7 @@ export const BentoCard = memo(function BentoCard({
         <div className="flex items-center justify-between mb-2">
           <div
             className={cn(
-              "w-7 h-7 rounded-lg flex items-center justify-center shrink-0",
+              "w-9 h-9 rounded-xl flex items-center justify-center shrink-0",
               inactive ? "bg-line/40 text-muted" : config.iconClass,
             )}
           >
@@ -212,7 +212,7 @@ export const BentoCard = memo(function BentoCard({
 
         {showProgress && (
           <div
-            className="w-full h-1 rounded-full bg-line/40 dark:bg-white/10 overflow-hidden mt-2"
+            className="w-full h-1.5 rounded-full bg-line/60 dark:bg-white/10 overflow-hidden mt-2"
             aria-hidden
           >
             <div


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **HubBottomNav**: активна вкладка отримує фонову таблетку `bg-brand-500/10 rounded-xl` за іконкою — активний стан тепер зчитується одразу, без полювання за тонкою лінією на верхньому краї
- **BentoCard іконка**: контейнер `w-7 h-7 rounded-lg` → `w-9 h-9 rounded-xl` — більша візуальна вага, більш преміальний iOS-стиль
- **BentoCard прогрес-бар**: `h-1 bg-line/40` → `h-1.5 bg-line/60` — краща видимість прогресу цілей (Рутина, Харчування)

## Test plan

- [ ] Відкрити Головну / Звіти / Налаштування / Профіль — переконатись що активна вкладка має фонову таблетку і top-pill одночасно
- [ ] Переконатись, що неактивні вкладки таблетки не мають
- [ ] Відкрити дашборд з увімкненими модулями Рутина або Харчування — перевірити що прогрес-бар товщий і трек видніший
- [ ] Перевірити BentoCard з активними та неактивними модулями — іконка-контейнер однаково виглядає в обох станах
- [ ] Dark mode — переконатись що `bg-brand-500/10` коректно відображається на темному тлі

https://claude.ai/code/session_015PZbakQv3Z3nhfznVCApRi
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015PZbakQv3Z3nhfznVCApRi)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1266" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes three UI areas for clearer state and better readability: adds a rounded background pill to the active bottom nav tab, enlarges the Bento card icon container, and thickens the Bento progress bar for higher contrast.

<sup>Written for commit c7ea4f20982d082d698a6580d44149c12348b66f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Enhanced active navigation tab styling with subtle background color for improved visual feedback
* Improved icon sizing and progress bar appearance with increased contrast and better visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->