### PR TITLE
feat(root): provision all observability dashboards + add phase 2 grafana cloud setup

### DIFF
--- a/docs/launch/03-services-and-toolstack.md
+++ b/docs/launch/03-services-and-toolstack.md
@@ -1,6 +1,6 @@
 # 03. Сервіси та тулстек
 
-> **Last validated:** 2026-04-30 by @Skords-01. **Next review:** 2026-07-29.
+> **Last validated:** 2026-05-01 by @dmytro.s.stakhov. **Next review:** 2026-07-30.
 > **Status:** Active
 
 > Повний аудит зовнішніх сервісів, інфраструктури, dev-інструментів: що є, що додати, що змінити.
@@ -98,12 +98,12 @@
 
 ### 2.3 Моніторинг / observability
 
-| Сервіс                         | Сайт                                       | Free tier                                                               | Paid tier                                                    | Date checked | Why this / Why not                                                                                                                                                  | Status |
-| ------------------------------ | ------------------------------------------ | ----------------------------------------------------------------------- | ------------------------------------------------------------ | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
-| **Sentry**                     | [sentry.io](https://sentry.io)             | Developer: 1 user, 5K errors/mo, 5M spans, 50 replays, 30-day retention | Team: $26/mo, 50K errors, 90-day retention. Business: $80/mo | 2026-04      | Error tracking web + server. SDK вже інтегровано (`@sentry/react`, `@sentry/node`). Free tier достатній для раннього етапу.                                         | in use |
-| **Prometheus** + `prom-client` | [prometheus.io](https://prometheus.io)     | Self-hosted, $0                                                         | N/A (open-source)                                            | 2026-04      | HTTP RED metrics, DB, AI quota. `/metrics` ендпоінт вже є.                                                                                                          | in use |
-| **Grafana Cloud**              | [grafana.com](https://grafana.com)         | Forever free: 10K metrics, 50 GB logs, 50 GB traces                     | Pro: $29/mo + usage                                          | 2026-04      | Дашборди для Prometheus. Безкоштовний tier покриває потреби до ~10K MAU.                                                                                            | to add |
-| **UptimeRobot**                | [uptimerobot.com](https://uptimerobot.com) | 50 monitors, 5-min interval                                             | Pro: $7/mo, 1-min interval                                   | 2026-04      | Зовнішній uptime моніторинг + status page. Деталі конфігурації алертів — див. [05-operations-and-automation.md](./05-operations-and-automation.md#зона-1--product). | to add |
+| Сервіс                         | Сайт                                       | Free tier                                                               | Paid tier                                                    | Date checked | Why this / Why not                                                                                                                                                  | Status      |
+| ------------------------------ | ------------------------------------------ | ----------------------------------------------------------------------- | ------------------------------------------------------------ | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| **Sentry**                     | [sentry.io](https://sentry.io)             | Developer: 1 user, 5K errors/mo, 5M spans, 50 replays, 30-day retention | Team: $26/mo, 50K errors, 90-day retention. Business: $80/mo | 2026-04      | Error tracking web + server. SDK вже інтегровано (`@sentry/react`, `@sentry/node`). Free tier достатній для раннього етапу.                                         | in use      |
+| **Prometheus** + `prom-client` | [prometheus.io](https://prometheus.io)     | Self-hosted, $0                                                         | N/A (open-source)                                            | 2026-04      | HTTP RED metrics, DB, AI quota. `/metrics` ендпоінт вже є.                                                                                                          | in use      |
+| **Grafana Cloud**              | [grafana.com](https://grafana.com)         | Forever free: 10K metrics, 50 GB logs, 50 GB traces                     | Pro: $29/mo + usage                                          | 2026-05      | Дашборди для Prometheus. Безкоштовний tier покриває потреби до ~10K MAU. Конфіг скрейпера — `ops/grafana-alloy/` (Phase 2 trigger).                                 | setup-ready |
+| **UptimeRobot**                | [uptimerobot.com](https://uptimerobot.com) | 50 monitors, 5-min interval                                             | Pro: $7/mo, 1-min interval                                   | 2026-04      | Зовнішній uptime моніторинг + status page. Деталі конфігурації алертів — див. [05-operations-and-automation.md](./05-operations-and-automation.md#зона-1--product). | to add      |
 
 ### 2.4 Платежі
 

--- a/ops/.env.ops.example
+++ b/ops/.env.ops.example
@@ -68,3 +68,22 @@ SERVER_INTERNAL_URL=http://host.docker.internal:3000
 # METRICS_TOKEN=<generate with: openssl rand -hex 32>
 SERVER_METRICS_HOST=host.docker.internal
 SERVER_PORT=3000
+
+# ── Grafana ────────────────────────────────────────────────────
+# Override the local Grafana admin password. Defaults to `admin` if unset
+# (fine for local dev; set this when exposing the stack publicly).
+# GF_ADMIN_PASSWORD=<generate with: openssl rand -base64 24>
+
+# ── Grafana Cloud (Phase 2 — public launch) ────────────────────
+# Required only when running the `cloud` compose profile (grafana-alloy)
+# or deploying ops/grafana-alloy as a standalone Railway service.
+# Get these from https://grafana.com/orgs/<your-org> → My Account → Stacks
+# → Prometheus → "Send Metrics".
+# GRAFANA_CLOUD_PROMETHEUS_URL=https://prometheus-prod-XX-XXXX.grafana.net/api/prom/push
+# GRAFANA_CLOUD_PROMETHEUS_USERNAME=<numeric instance ID>
+# GRAFANA_CLOUD_PROMETHEUS_API_KEY=<API token with metrics:write scope>
+# Override these when running the alloy container outside the local compose
+# network (e.g. Railway → use *.railway.internal hostnames).
+# N8N_METRICS_TARGET=n8n:5678
+# SERGEANT_SERVER_TARGET=host.docker.internal:3000
+# SERGEANT_SERVER_SCHEME=http

--- a/ops/README.md
+++ b/ops/README.md
@@ -218,19 +218,37 @@ docker compose -f ops/docker-compose.ops.yml logs n8n
 
 Prometheus і Grafana включені в той самий compose-файл.
 
-| Сервіс     | URL                   | Логін             |
-| ---------- | --------------------- | ----------------- |
-| Prometheus | http://localhost:9090 | —                 |
-| Grafana    | http://localhost:3001 | `admin` / `admin` |
+| Сервіс     | URL                   | Логін                                               |
+| ---------- | --------------------- | --------------------------------------------------- |
+| Prometheus | http://localhost:9090 | —                                                   |
+| Grafana    | http://localhost:3001 | `admin` / `${GF_ADMIN_PASSWORD}` (default: `admin`) |
 
-Grafana автоматично підключає Prometheus як datasource та імпортує dashboard "Sergeant Ops Overview".
+Grafana автоматично підключає Prometheus як datasource та провіжнить
+дашборди з двох локацій:
 
-### Що показує dashboard
+- `ops/grafana/dashboards/n8n-overview.json` — n8n + Sergeant server health
+- `docs/observability/dashboards/*.json` — `http-red`, `db-use`, `slo-burn-rate`, `sync`, `auth`, `ai-cost`, `hubchat`, `frontend-cwv`
+
+Усі дашборди потрапляють у папку **Sergeant Ops** у Grafana UI. Дашборди з
+`docs/observability/dashboards/` — сирі JSON-файли з `__inputs`-секцією; під
+час провіженінгу Grafana 11 підставляє єдину Prometheus datasource у
+`DS_PROMETHEUS`-змінну автоматично.
+
+### Що показує `n8n-overview` dashboard
 
 - **n8n Instance Health** — UP/DOWN, uptime, RAM, event loop lag
 - **Workflow Executions** — success/error counters, rate, success rate over time
 - **n8n Process Resources** — CPU, memory, heap, GC, event loop
 - **Sergeant Server** — UP/DOWN, CPU, memory
+
+### Server-side дашборди
+
+Покладаються на recording rules з
+[`docs/observability/prometheus/recording_rules.yml`](../docs/observability/prometheus/recording_rules.yml)
+(особливо `slo-burn-rate.json`). Локально вони ще не вантажаться у Prometheus
+— потрібно або руками скопіювати правила у `ops/prometheus/rules/`, або
+дочекатись Phase 2 (Grafana Cloud — див. нижче), де `mimirtool rules sync`
+це робить безболісно.
 
 ### Alert rules (Prometheus)
 
@@ -271,6 +289,34 @@ http://localhost:9090/targets
 2. Перевір збіг `METRICS_TOKEN` у `.env.ops` і `.env`
 3. `curl -H "Authorization: Bearer <token>" http://localhost:3000/metrics`
 4. Для n8n: `curl http://localhost:5678/metrics` (без auth)
+
+### Phase 2 — Grafana Cloud + Alloy (production scrape)
+
+Як тільки доходимо до публічного лаунчу
+([`docs/architecture/hosting-evolution.md`](../docs/architecture/hosting-evolution.md)
+§Фаза 2) — локальний `prometheus`/`grafana` лишається для дев-дебагу, а
+production-метрики йдуть у Grafana Cloud free tier через лёгкого
+[Grafana Alloy](https://grafana.com/docs/alloy/latest/) агента.
+
+Конфіг агента, Dockerfile і повна інструкція деплою на Railway —
+[`ops/grafana-alloy/README.md`](./grafana-alloy/README.md).
+
+TL;DR:
+
+```bash
+# 1. Створи безкоштовний Grafana Cloud stack: https://grafana.com/auth/sign-up
+# 2. Заповни у ops/.env.ops:
+#    GRAFANA_CLOUD_PROMETHEUS_URL, GRAFANA_CLOUD_PROMETHEUS_USERNAME,
+#    GRAFANA_CLOUD_PROMETHEUS_API_KEY (scope metrics:write)
+# 3. Локальна перевірка конфіга:
+docker compose -f ops/docker-compose.ops.yml --env-file ops/.env.ops --profile cloud up -d grafana-alloy
+# 4. Production: задеплой ops/grafana-alloy/ як окремий Railway сервіс
+```
+
+Після того як `up{project="sergeant"} == 1` для обох targets — імпортуй
+дашборди з `docs/observability/dashboards/` через Grafana Cloud UI та
+завантаж recording + alert rules через `mimirtool rules sync`. Деталі — у
+[`ops/grafana-alloy/README.md`](./grafana-alloy/README.md#імпорт-дашбордів-у-grafana-cloud).
 
 ## Додавання нового workflow-у
 

--- a/ops/docker-compose.ops.yml
+++ b/ops/docker-compose.ops.yml
@@ -108,13 +108,16 @@ services:
     environment:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
-      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_SECURITY_ADMIN_PASSWORD=${GF_ADMIN_PASSWORD:-admin}
       - GF_USERS_ALLOW_SIGN_UP=false
     volumes:
       - grafana-data:/var/lib/grafana
       - ./grafana/datasources:/etc/grafana/provisioning/datasources:ro
       - ./grafana/dashboards/dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml:ro
       - ./grafana/dashboards/n8n-overview.json:/etc/grafana/provisioning/dashboards/n8n-overview.json:ro
+      # Server-side dashboards (HTTP RED, DB USE, SLO burn-rate, sync, auth, AI cost, hubchat, frontend CWV)
+      # — JSON sources of truth live next to the docs.
+      - ../docs/observability/dashboards:/etc/grafana/provisioning/dashboards/sergeant:ro
     depends_on:
       - prometheus
     healthcheck:
@@ -123,6 +126,33 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
+
+  # Phase 2 (public launch): Grafana Cloud scraper.
+  # Disabled by default. Enable with `--profile cloud` once Grafana Cloud
+  # creds are in `.env.ops`. Lightweight; no local TSDB. See ops/README.md.
+  grafana-alloy:
+    profiles: ["cloud"]
+    image: grafana/alloy:v1.4.2
+    restart: unless-stopped
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      - METRICS_TOKEN=${METRICS_TOKEN:?Set METRICS_TOKEN in .env.ops}
+      - GRAFANA_CLOUD_PROMETHEUS_URL=${GRAFANA_CLOUD_PROMETHEUS_URL:?Set GRAFANA_CLOUD_PROMETHEUS_URL in .env.ops}
+      - GRAFANA_CLOUD_PROMETHEUS_USERNAME=${GRAFANA_CLOUD_PROMETHEUS_USERNAME:?Set GRAFANA_CLOUD_PROMETHEUS_USERNAME in .env.ops}
+      - GRAFANA_CLOUD_PROMETHEUS_API_KEY=${GRAFANA_CLOUD_PROMETHEUS_API_KEY:?Set GRAFANA_CLOUD_PROMETHEUS_API_KEY in .env.ops}
+      # Targets — defaults work for the local stack. Override with public
+      # URLs when running the alloy container outside the local compose
+      # network (e.g. on Railway as a standalone service).
+      - N8N_METRICS_TARGET=${N8N_METRICS_TARGET:-n8n:5678}
+      - SERGEANT_SERVER_TARGET=${SERGEANT_SERVER_TARGET:-host.docker.internal:3000}
+      - SERGEANT_SERVER_SCHEME=${SERGEANT_SERVER_SCHEME:-http}
+    volumes:
+      - ./grafana-alloy/config.alloy:/etc/alloy/config.alloy:ro
+    command:
+      - run
+      - --server.http.listen-addr=0.0.0.0:12345
+      - /etc/alloy/config.alloy
 
 volumes:
   n8n-data:

--- a/ops/grafana-alloy/Dockerfile
+++ b/ops/grafana-alloy/Dockerfile
@@ -1,0 +1,14 @@
+# Grafana Alloy — Sergeant Phase 2 metrics scraper.
+# Deployed as a standalone Railway service that scrapes n8n + apps/server
+# and ships everything to Grafana Cloud Prometheus.
+#
+# Build context is `ops/grafana-alloy/`.
+
+FROM grafana/alloy:v1.4.2
+
+COPY config.alloy /etc/alloy/config.alloy
+
+EXPOSE 12345
+
+ENTRYPOINT ["/bin/alloy"]
+CMD ["run", "--server.http.listen-addr=0.0.0.0:12345", "/etc/alloy/config.alloy"]

--- a/ops/grafana-alloy/README.md
+++ b/ops/grafana-alloy/README.md
@@ -1,0 +1,94 @@
+# Grafana Alloy — Phase 2 metrics scraper
+
+> **Last validated:** 2026-05-01 by @dmytro.s.stakhov. **Next review:** 2026-08-01.
+> **Status:** Active
+
+Лёгкий scrape-only агент, який ходить по `/metrics` n8n + apps/server і пушить
+все у Grafana Cloud Prometheus. Без локального TSDB — це робота Grafana Cloud.
+
+Контекст рішення — [`docs/architecture/hosting-evolution.md`](../../docs/architecture/hosting-evolution.md)
+§Фаза 2 та [`docs/adr/0015-observability-stack.md`](../../docs/adr/0015-observability-stack.md)
+§ADR-15.2 (exit criterion: scrape-інфра).
+
+## Що скрейпиться
+
+| Job               | Endpoint                            | Auth                   |
+| ----------------- | ----------------------------------- | ---------------------- |
+| `n8n`             | `${N8N_METRICS_TARGET}/metrics`     | none                   |
+| `sergeant-server` | `${SERGEANT_SERVER_TARGET}/metrics` | bearer `METRICS_TOKEN` |
+
+External label `project=sergeant` додається до кожної серії — щоб у Grafana
+Cloud (де може бути кілька проектів) фільтр був прозорий.
+
+## Локально (для перевірки конфіга)
+
+```bash
+# 1. Заповни Grafana Cloud creds у ops/.env.ops:
+#    GRAFANA_CLOUD_PROMETHEUS_URL, GRAFANA_CLOUD_PROMETHEUS_USERNAME, GRAFANA_CLOUD_PROMETHEUS_API_KEY
+
+# 2. Підніми стек з cloud-профілем (alloy додасться поряд з prometheus/grafana):
+docker compose -f ops/docker-compose.ops.yml --env-file ops/.env.ops --profile cloud up -d grafana-alloy
+
+# 3. Перевір UI агента (debug graph + targets):
+open http://localhost:12345/graph
+```
+
+## Production (Railway)
+
+1. Railway → New Service → Deploy from GitHub Repo
+2. **Root Directory:** `ops/grafana-alloy`
+3. **Build:** Dockerfile (auto-detected)
+4. **Variables:**
+
+   | Змінна                              | Значення                                                    |
+   | ----------------------------------- | ----------------------------------------------------------- |
+   | `GRAFANA_CLOUD_PROMETHEUS_URL`      | `https://prometheus-prod-XX-XXXX.grafana.net/api/prom/push` |
+   | `GRAFANA_CLOUD_PROMETHEUS_USERNAME` | numeric instance ID (Grafana Cloud → My Account)            |
+   | `GRAFANA_CLOUD_PROMETHEUS_API_KEY`  | API token, scope `metrics:write`                            |
+   | `METRICS_TOKEN`                     | той самий, що у `apps/server` сервісу Railway               |
+   | `N8N_METRICS_TARGET`                | `n8n.railway.internal:5678` (private network)               |
+   | `SERGEANT_SERVER_TARGET`            | `<server>.railway.internal:3000`                            |
+   | `SERGEANT_SERVER_SCHEME`            | `http` (private network — без TLS)                          |
+
+   Railway автоматично резолвить `*.railway.internal` для сервісів у тому ж
+   проекті — публічні URL не потрібні, метрики не залишають Railway VPC.
+
+5. Деплой → перевір логи `Alloy started`. У Grafana Cloud → Explore →
+   Prometheus datasource → запит `up{project="sergeant"}` має показати 2
+   targets зі значенням `1`.
+
+## Імпорт дашбордів у Grafana Cloud
+
+Після того як `up{project="sergeant"} == 1` для обох targets — імпортуй
+дашборди з `docs/observability/dashboards/` через **Dashboards → Import →
+Upload JSON**. Datasource — той самий `grafanacloud-<instance>-prom`.
+
+`slo-burn-rate.json` залежить від recording rules з
+[`docs/observability/prometheus/recording_rules.yml`](../../docs/observability/prometheus/recording_rules.yml)
+— завантаж їх у Grafana Cloud → Alerts & IRM → Alert rules → Recording rules
+(або `mimirtool rules sync`).
+
+## Алерти
+
+Alert rules у [`docs/observability/prometheus/alert_rules.yml`](../../docs/observability/prometheus/alert_rules.yml)
+вантажаться так само (`mimirtool rules sync`). Contact point — Telegram
+через webhook (див. `ops/n8n-workflows/03-sentry-alert-routing.json` як
+референс для формату повідомлень).
+
+## Чому Alloy, а не повний Prometheus
+
+- Прометеус потребує persistent volume під TSDB — Railway хоче окремих
+  грошей за volume і CPU при розборі retention.
+- Alloy не зберігає метрики локально, лише ретранслює — RAM ~50 МБ, CPU
+  мінорний. Усі 30-day retention робить Grafana Cloud free tier.
+- Якщо Grafana Cloud впаде — Alloy буфер ~2h (WAL on disk у контейнері),
+  після чого drop-ить семпли. Це прийнятно для phase 2.
+
+## Troubleshooting
+
+- **`up == 0` для `sergeant-server`** — перевір `METRICS_TOKEN` збігається
+  у Railway env vars обох сервісів (`apps/server` + `grafana-alloy`).
+- **`401 Unauthorized` у логах Alloy** — `GRAFANA_CLOUD_PROMETHEUS_API_KEY`
+  без scope `metrics:write` або зіпсувався при копіюванні.
+- **`429 Too Many Requests`** — впираєшся у rate limit free tier (10K
+  active series). Зменш `scrape_interval` до 60s або упрости labels.

--- a/ops/grafana-alloy/config.alloy
+++ b/ops/grafana-alloy/config.alloy
@@ -1,0 +1,64 @@
+// Grafana Alloy — scrape-only config that ships /metrics to Grafana Cloud.
+//
+// Used by Phase 2 (`docs/architecture/hosting-evolution.md`): no local TSDB,
+// just scrape n8n + apps/server and `remote_write` everything to the
+// Prometheus endpoint of a Grafana Cloud free-tier stack.
+//
+// Inputs (env vars):
+//   - GRAFANA_CLOUD_PROMETHEUS_URL       https://prometheus-prod-XX-XXXX.grafana.net/api/prom/push
+//   - GRAFANA_CLOUD_PROMETHEUS_USERNAME  numeric instance ID
+//   - GRAFANA_CLOUD_PROMETHEUS_API_KEY   API token with `metrics:write` scope
+//   - METRICS_TOKEN                      bearer for apps/server /metrics
+//   - N8N_METRICS_TARGET                 host:port (default: n8n:5678)
+//   - SERGEANT_SERVER_TARGET             host:port (default: host.docker.internal:3000)
+//   - SERGEANT_SERVER_SCHEME             http | https (default: http)
+//
+// Run locally with:  docker compose -f ops/docker-compose.ops.yml --profile cloud up -d grafana-alloy
+// Run on Railway:    deploy ops/grafana-alloy as a standalone service (Dockerfile included).
+
+prometheus.remote_write "grafana_cloud" {
+  endpoint {
+    url = sys.env("GRAFANA_CLOUD_PROMETHEUS_URL")
+
+    basic_auth {
+      username = sys.env("GRAFANA_CLOUD_PROMETHEUS_USERNAME")
+      password = sys.env("GRAFANA_CLOUD_PROMETHEUS_API_KEY")
+    }
+  }
+
+  external_labels = {
+    project = "sergeant",
+  }
+}
+
+prometheus.scrape "n8n" {
+  job_name        = "n8n"
+  scrape_interval = "30s"
+  scrape_timeout  = "10s"
+  metrics_path    = "/metrics"
+
+  targets = [{
+    __address__ = sys.env("N8N_METRICS_TARGET"),
+  }]
+
+  forward_to = [prometheus.remote_write.grafana_cloud.receiver]
+}
+
+prometheus.scrape "sergeant_server" {
+  job_name        = "sergeant-server"
+  scrape_interval = "15s"
+  scrape_timeout  = "10s"
+  metrics_path    = "/metrics"
+  scheme          = sys.env("SERGEANT_SERVER_SCHEME")
+
+  targets = [{
+    __address__ = sys.env("SERGEANT_SERVER_TARGET"),
+  }]
+
+  authorization {
+    type        = "Bearer"
+    credentials = sys.env("METRICS_TOKEN")
+  }
+
+  forward_to = [prometheus.remote_write.grafana_cloud.receiver]
+}


### PR DESCRIPTION
## What changed

Three improvements to the Grafana/Prometheus observability stack:

1. **Provision all 8 server-side dashboards** in the local ops compose. `ops/docker-compose.ops.yml` now mounts `docs/observability/dashboards/` into Grafana provisioning, so on `docker compose up` you immediately get `n8n-overview` (existing) plus `http-red`, `db-use`, `slo-burn-rate`, `sync`, `auth`, `ai-cost`, `hubchat`, `frontend-cwv`. Grafana 11 auto-substitutes the single Prometheus datasource into the `DS_PROMETHEUS` template variable each JSON expects.

2. **Move Grafana admin password to env var.** `GF_SECURITY_ADMIN_PASSWORD` now reads `${GF_ADMIN_PASSWORD:-admin}` (default `admin` for local dev; `.env.ops.example` documents how to override).

3. **Phase 2 Grafana Cloud + Alloy setup (opt-in).** New `ops/grafana-alloy/` directory with:
   - `config.alloy` — scrape-only Alloy config (`n8n` + `sergeant-server` jobs, bearer auth, `remote_write` to Grafana Cloud Prometheus, external label `project=sergeant`)
   - `Dockerfile` — Railway-ready image
   - `README.md` — full deploy guide (local cloud-profile + Railway standalone service)

   Disabled by default behind the `cloud` compose profile. `ops/.env.ops.example` documents the new `GRAFANA_CLOUD_*` and target vars.

Docs:

- `ops/README.md` — explains new dashboard sources, recording-rules dependency, Phase 2 Grafana Cloud setup linking to `ops/grafana-alloy/README.md`.
- `docs/launch/03-services-and-toolstack.md` — Grafana Cloud `to add` -> `setup-ready`.

## Why

Follow-up to the conversation thread about Grafana/Prometheus status:

- 8 server-side dashboards already existed as JSON in `docs/observability/dashboards/` (HTTP RED, DB USE, SLO burn-rate, sync, auth, AI cost, HubChat, frontend CWV) — but only `n8n-overview.json` was wired into Grafana provisioning. Manual UI imports defeat the point of having the JSONs in the repo.
- Production `apps/server` and Railway n8n already expose `/metrics` (n8n metrics confirmed enabled on Railway). Phase 1 of `docs/architecture/hosting-evolution.md` says "don't set up Grafana Cloud yet — it distracts from features". This PR doesn't change Phase 1; it just lands the Phase 2 trigger so it's a one-step config when we hit public launch (100–1000 users).
- Hardcoded `GF_SECURITY_ADMIN_PASSWORD=admin` is fine for local dev but blocks publicly exposing the Grafana for staging/demo without editing the compose file.

ADR/architecture references:

- `docs/architecture/hosting-evolution.md` §Phase 2 — Grafana Cloud + Agent as exit criterion for public launch
- `docs/adr/0015-observability-stack.md` §ADR-15.2 — exit criterion: scrape-інфра

## How to test

```bash
# 1. Validate compose still resolves clean (default profile)
docker compose -f ops/docker-compose.ops.yml --env-file ops/.env.ops config | grep -E '^\s*grafana:'

# 2. Validate compose with the new cloud profile (alloy gets added)
GRAFANA_CLOUD_PROMETHEUS_URL=https://example.com \
  GRAFANA_CLOUD_PROMETHEUS_USERNAME=t \
  GRAFANA_CLOUD_PROMETHEUS_API_KEY=t \
  docker compose -f ops/docker-compose.ops.yml --profile cloud config | grep -E '^\s*(grafana|grafana-alloy):'

# 3. Local stack — admin pwd via env
GF_ADMIN_PASSWORD=hunter2 docker compose -f ops/docker-compose.ops.yml --env-file ops/.env.ops up -d grafana
# Login http://localhost:3001 with admin/hunter2.
# Dashboards landing page should show 9 entries (n8n-overview + 8 from docs/observability/dashboards/).

# 4. Markdown link checker
pnpm docs:check-links

# 5. Tech-debt freshness
node scripts/check-tech-debt-freshness.mjs
```

Not exercising `grafana-alloy` against a real Grafana Cloud stack in this PR — that's the actual Phase 2 trigger and requires creating the free-tier account.

---

## Pre-flight (Hard Rule #15)

- [x] Read the `AGENTS.md` Hard Rules that apply to the touched paths (Hard Rule #5 conventional commits, Hard Rule #15 docs alongside code).
- [x] Read the matching playbook in `docs/playbooks/` (or noted that none exists). n/a — no playbook for ops/grafana provisioning.
- [x] Checked freshness headers of docs cited in the change. `docs/architecture/hosting-evolution.md`, `docs/adr/0015-observability-stack.md`, `docs/launch/03-services-and-toolstack.md` all current; `docs/launch/03-services-and-toolstack.md` Date checked bumped 2026-04 -> 2026-05 for the Grafana Cloud row.

## Docs updated alongside code? (Hard Rule #15)

- [ ] API contract change — `packages/api-client/**` types + contract test updated (Hard Rule #3). n/a
- [ ] New / removed npm script — `CONTRIBUTING.md § Everyday Commands` and `CLAUDE.md § Quick commands` updated. n/a
- [ ] New design token / component / palette — `docs/design/design-system.md` (and `BRANDBOOK.md` if branded) updated. n/a
- [ ] Deprecation — `@deprecated` JSDoc with `@removeBy` added; consuming docs marked `> **Status:** Deprecated`. n/a
- [x] Freshness header bumped on docs whose claims changed (`> Last validated: YYYY-MM-DD by @owner`). `docs/launch/03-services-and-toolstack.md` Grafana Cloud row Date checked bumped to 2026-05; `ops/grafana-alloy/README.md` ships with fresh header.
- [ ] N/A — no docs invalidated by this change.

## How AI-tested this PR

- [x] Manual smoke (which flow?): `docker compose ... config` for both default and `--profile cloud` resolves clean; both `grafana` and `grafana-alloy` services materialize; markdown link checker green.
- [ ] Vitest passes: n/a — no `apps/*` code touched. Existing `Test coverage (vitest)` failure is pre-existing on `main` (`syncPushAll` deadlock test + `pushTest` apns mock).
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.
- [ ] `pnpm dead-code:files` clean (or new files marked `@scaffolded`). n/a — only ops/docs files added.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules