### PR TITLE
feat(eslint-plugins): extend no-raw-local-storage and no-strict-bypass to apps/mobile

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -338,6 +338,30 @@ export default [
       "sergeant-design/no-raw-local-storage": "error",
     },
   },
+  // Mobile localStorage guardrail — same rule, applied to `apps/mobile/src`
+  // and `apps/mobile/app` so the RN/Expo codebase stays MMKV-only.
+  // Mobile uses `react-native-mmkv` via `apps/mobile/src/lib/storage.ts`
+  // (the `safeRead*LS`/`safeWriteLS`/`safeRemoveLS` adapters) — there is
+  // no `localStorage` global in React Native at all, so any direct
+  // `localStorage.*` reference would be a runtime crash on device.
+  // No allowlist needed: at the time of introduction every mention of
+  // the symbol on mobile lives inside JSDoc comments documenting the
+  // web→mobile port (which the rule's AST traversal ignores).
+  {
+    files: [
+      "apps/mobile/src/**/*.{js,jsx,ts,tsx}",
+      "apps/mobile/app/**/*.{js,jsx,ts,tsx}",
+    ],
+    ignores: [
+      "apps/mobile/src/**/*.test.{js,jsx,ts,tsx}",
+      "apps/mobile/src/**/__tests__/**",
+      "apps/mobile/app/**/*.test.{js,jsx,ts,tsx}",
+      "apps/mobile/app/**/__tests__/**",
+    ],
+    rules: {
+      "sergeant-design/no-raw-local-storage": "error",
+    },
+  },
   // AuthContext migration (Session 4B, PR after #390): "who am I" is
   // single-sourced via `useUser()` from `@sergeant/api-client/react` → GET
   // `/api/v1/me`. Better Auth stays only as the actions layer. Block
@@ -443,6 +467,42 @@ export default [
       "apps/server/src/lib/anthropic.ts",
       "apps/server/src/lib/bankProxy.ts",
       "apps/server/src/lib/webpushSend.ts",
+    ],
+    rules: {
+      "sergeant-design/no-strict-bypass": "error",
+    },
+  },
+  // Mobile counterpart of `no-strict-bypass`. Extends the same rule to
+  // `apps/mobile/src/**` + `apps/mobile/app/**` so type-safety bypasses
+  // can no longer accumulate on the React Native side unnoticed.
+  //
+  // Allowlist below names every existing `as unknown as X` call-site
+  // on mobile as of rule extension (2026-05-01). Migrate a file → drop
+  // it from the list. See `docs/tech-debt/mobile.md` §no-strict-bypass
+  // (registry tracked separately in PR 3).
+  {
+    files: ["apps/mobile/src/**/*.{ts,tsx}", "apps/mobile/app/**/*.{ts,tsx}"],
+    ignores: [
+      // Tests can use type bypasses freely as fixtures.
+      "apps/mobile/src/**/*.test.{ts,tsx}",
+      "apps/mobile/src/**/__tests__/**",
+      "apps/mobile/app/**/*.test.{ts,tsx}",
+      "apps/mobile/app/**/__tests__/**",
+      // ── Existing `as unknown as` call-sites (do not add new ones) ──
+      // Domain-shape adapters: web ↔ mobile share `@sergeant/{finyk,fizruk,
+      // routine,nutrition}-domain` shapes that mobile RN partial views /
+      // chart palettes don't yet match precisely. Migrate by aligning the
+      // local view-model type to the domain shape.
+      "apps/mobile/src/modules/finyk/pages/Overview/CategoryChartSection.tsx",
+      "apps/mobile/src/modules/finyk/pages/Transactions/TransactionsPage.tsx",
+      "apps/mobile/src/modules/fizruk/components/workouts/WorkoutJournalSection.tsx",
+      "apps/mobile/src/modules/fizruk/hooks/useCustomExercises.ts",
+      "apps/mobile/src/modules/fizruk/hooks/useRecovery.ts",
+      "apps/mobile/src/modules/fizruk/pages/Exercise.tsx",
+      // Notifications API — Expo trigger union widened in SDK 52, mobile
+      // codebase hasn't caught up yet. Drop after `expo-notifications`
+      // type alignment.
+      "apps/mobile/src/modules/routine/hooks/useRoutineReminders.ts",
     ],
     rules: {
       "sergeant-design/no-strict-bypass": "error",


### PR DESCRIPTION
## What changed

Розширюю два custom ESLint guardrail-и на `apps/mobile`:

1. **`sergeant-design/no-raw-local-storage`** — раніше скоп був лише `apps/web/src/**`. Додано окремий блок для `apps/mobile/src/**` + `apps/mobile/app/**` **без allowlist**: у React Native немає `localStorage` як глобала взагалі, тож будь-який прямий `localStorage.*` був би runtime-крешем на пристрої. На момент розширення усі `localStorage` згадки у mobile — у JSDoc-коментарях, що документують web→mobile порт (rule AST не торкається коментарів).
2. **`sergeant-design/no-strict-bypass`** — раніше скоп `apps/server/src` + `apps/web/src`. Додано окремий блок для `apps/mobile/src/**` + `apps/mobile/app/**` з allowlist на **7 існуючих call-сайтів** з `as unknown as X`:
   - 6 — domain-shape adapters (`CategoryChartSection`, `TransactionsPage`, `WorkoutJournalSection`, `useCustomExercises`, `useRecovery`, `Exercise`): локальні view-model-и не точно збігаються з `@sergeant/{finyk,fizruk,routine,nutrition}-domain` shape-ами.
   - 1 — `useRoutineReminders`: `expo-notifications` SDK 52 розширило trigger-union, mobile код не дотягнули.

Тестові файли (`*.test.{ts,tsx}`, `__tests__/`) — повний opt-out, як і на web/server.

## Why

`docs/tech-debt/frontend.md` лише про `apps/web`, mobile-частина монорепо лишалась повністю без guardrail-ів цього класу. У production:
- 7 файлів з `as unknown as` (потенційні runtime-сюрпризи на shape mismatch),
- ~5 production-файлів із `: any` (трекаються окремим PR).

Без правила нові кейси накопичувались би непомітно. Цей PR — **guardrail-only**, а не виправлення: 7 наявних кейсів у allowlist (пізніше виноситься окремими fix-PR-ами), і будь-який *новий* `as unknown as X` / `as any` / `@ts-ignore` / `@ts-expect-error` / `localStorage.*` у mobile production-коді тепер ламає CI.

PR 3 (docs/tech-debt/mobile.md, follow-up) додасть живий registry для трекінгу цих 7 файлів та інших mobile-специфічних боргів.

## How to test

```bash
pnpm lint:plugins                    # 250/250 pass — custom rule unit tests
pnpm exec eslint --no-warn-ignored apps/mobile/src apps/mobile/app   # exit 0
pnpm exec eslint --print-config apps/mobile/src/modules/fizruk/hooks/useDailyLog.ts \
  | grep -E '"sergeant-design/(no-strict-bypass|no-raw-local-storage)"'
# обидва правила повертаються з level 2 (error) для не-allowlisted файла
```

**Smoke test (тимчасова ін'єкція):** додано `const _x = 1 as unknown as string;` + `as any` + `localStorage.getItem("foo")` у `apps/mobile/src/modules/fizruk/hooks/useDailyLog.ts`, ESLint видав 3 помилки (`no-strict-bypass` × 2 + `no-raw-local-storage` × 1), потім файл відкочено.

---

## Pre-flight (Hard Rule #15)

- [x] Read the `AGENTS.md` Hard Rules that apply to the touched paths. (Module ownership map для `eslint-plugin-sergeant-design`; rule #5 conventional-commits scope `eslint-plugins`).
- [x] Read the matching playbook in `docs/playbooks/` (or noted that none exists). — n/a (`docs/playbooks/` не має playbook-а для розширення скопу custom ESLint правил; патерн копіюю з існуючих rule-блоків у `eslint.config.js`).
- [x] Checked freshness headers of docs cited in the change. (PR 3 створить `docs/tech-debt/mobile.md` з власним freshness header.)

## Docs updated alongside code? (Hard Rule #15)

- [ ] API contract change — n/a.
- [ ] New / removed npm script — n/a.
- [ ] New design token / component / palette — n/a.
- [ ] Deprecation — n/a.
- [ ] Freshness header bumped on docs whose claims changed — n/a (mobile registry йде окремо в PR 3).
- [x] N/A — no docs invalidated by this change.

## How AI-tested this PR

- [x] Manual smoke (which flow?): print-config + ін'єкція 3-х violation-ів → ESLint flagged як треба; allowlist verifying — `Exercise.tsx` (allowlisted) НЕ дає помилок.
- [x] Vitest passes: n/a — лінт plugin tests (`pnpm lint:plugins`) пройшли 250/250.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.
- [x] `pnpm dead-code:files` clean (or new files marked `@scaffolded`) — n/a, нових файлів не додано.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend ESLint guardrails to `apps/mobile` by enabling `sergeant-design/no-raw-local-storage` and `sergeant-design/no-strict-bypass`. This avoids RN crashes from `localStorage` and blocks new type-safety bypasses; seven current sites are allowlisted.

- **New Features**
  - Enforce `sergeant-design/no-raw-local-storage` in `apps/mobile/src/**` and `apps/mobile/app/**` (tests excluded). RN has no `localStorage`; mobile uses `react-native-mmkv` via app storage adapters.
  - Enforce `sergeant-design/no-strict-bypass` in mobile `.ts/.tsx` (tests excluded) with an allowlist for 7 existing `as unknown as` call sites. CI fails on new bypasses.

- **Migration**
  - No action needed. When an allowlisted file is fixed, remove it from `eslint.config.js`.

<sup>Written for commit e41936440ba409f8b8ec410632ffd13d167c3788. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened ESLint configuration for mobile development with additional validation rules to enhance code quality and maintain consistency standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->