### PR TITLE
feat(shared): exclude sensitive query keys from IDB/MMKV warm-start

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -469,7 +469,6 @@
 - [istanbul-lib-instrument@5.2.1](https://istanbul.js.org/) - BSD-3-Clause
 - [jackspeak@3.4.3](https://github.com/isaacs/jackspeak#readme) - BlueOak-1.0.0
 - [jimp-compact@0.16.1](https://github.com/nuxt-community/jimp-compact#readme) - MIT
-- [jiti@1.21.7](https://github.com/unjs/jiti#readme) - MIT
 - [jiti@2.6.1](https://github.com/unjs/jiti#readme) - MIT
 - [join-component@1.1.0](undefined) - MIT
 - [jose@6.2.2](https://github.com/panva/jose) - MIT

--- a/apps/mobile/src/providers/QueryProvider.tsx
+++ b/apps/mobile/src/providers/QueryProvider.tsx
@@ -17,7 +17,10 @@ import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client
 import type { PropsWithChildren } from "react";
 import { useMemo } from "react";
 
-import { createMMKVPersister } from "@/sync/persister/mmkvPersister";
+import {
+  createMMKVPersister,
+  shouldDehydrateQueryForPersistMobile,
+} from "@/sync/persister/mmkvPersister";
 
 // 7 days — long enough that a user who returns after a week still sees
 // their last-seen data on launch, short enough that we don't keep
@@ -48,7 +51,20 @@ export function QueryProvider({ children }: PropsWithChildren) {
   return (
     <PersistQueryClientProvider
       client={client}
-      persistOptions={{ persister, maxAge: PERSIST_MAX_AGE_MS }}
+      persistOptions={{
+        persister,
+        maxAge: PERSIST_MAX_AGE_MS,
+        // Don't persist auth/me/coach/sync/balance feeds — they
+        // contain personally-identifying data that must not survive
+        // logout / device hand-off (the persister is keyed by
+        // build-id, not user-id). Mirrors the web persister; the
+        // shared block-list lives in `@sergeant/shared`
+        // `isSensitiveQueryKey`. See PR #004 in
+        // `docs/planning/storage-roadmap.md`.
+        dehydrateOptions: {
+          shouldDehydrateQuery: shouldDehydrateQueryForPersistMobile,
+        },
+      }}
     >
       {children}
     </PersistQueryClientProvider>

--- a/apps/mobile/src/sync/persister/mmkvPersister.ts
+++ b/apps/mobile/src/sync/persister/mmkvPersister.ts
@@ -8,13 +8,20 @@
  * `await` on every query rehydrate) and avoids the serialization
  * costs of the AsyncStorage-backed persister.
  *
- * We expose two entry points:
+ * We expose three entry points:
  *   - `createMMKVPersister()` — ready-to-pass `persister` option for
  *     `PersistQueryClientProvider`.
- *   - `mmkvSyncStorage`       — raw storage adapter, re-usable for
- *     other persisted stores in the future (e.g. a Jotai store).
+ *   - `mmkvSyncStorage` — raw storage adapter, re-usable for other
+ *     persisted stores in the future (e.g. a Jotai store).
+ *   - `shouldDehydrateQueryForPersistMobile` — selector for
+ *     `dehydrateOptions.shouldDehydrateQuery`, mirrors the web
+ *     persister's filter (no errors, no pre-success queries, and no
+ *     sensitive auth/me/coach/sync/balance feeds — see PR #004 in
+ *     `docs/planning/storage-roadmap.md`).
  */
 import { createSyncStoragePersister } from "@tanstack/query-sync-storage-persister";
+import type { Query } from "@tanstack/react-query";
+import { isSensitiveQueryKey } from "@sergeant/shared";
 
 import {
   _getMMKVInstance,
@@ -42,6 +49,30 @@ export function createMMKVPersister() {
     // MMKV. 1s matches TanStack's own default.
     throttleTime: 1000,
   });
+}
+
+/**
+ * Mirror of `apps/web/src/shared/lib/queryClientPersister.ts ->
+ * shouldDehydrateQueryForPersist`. Filters out:
+ *
+ *   - errored queries (a stale 401/500 would warm-start the next
+ *     launch with a "red" UI before the network can correct it);
+ *   - queries that haven't received a successful response yet
+ *     (`dataUpdateCount === 0`) — saving a placeholder is just disk
+ *     waste;
+ *   - sensitive query-keys (auth / me / coach / sync / *balance*) —
+ *     personally-identifying data must not survive on disk after
+ *     logout. The persister is keyed by build-id, not user-id, so a
+ *     handover of the same device to another user would warm-start
+ *     the new session with the previous user's coach advice / mono
+ *     balance / `module_data` JSONB. The shared block-list is in
+ *     `@sergeant/shared` `isSensitiveQueryKey`.
+ */
+export function shouldDehydrateQueryForPersistMobile(query: Query): boolean {
+  if (query.state.status === "error") return false;
+  if (query.state.dataUpdateCount === 0) return false;
+  if (isSensitiveQueryKey(query.queryKey)) return false;
+  return true;
 }
 
 // Re-export to make it easy for tests / debug screens to poke at the

--- a/apps/web/src/shared/lib/__tests__/queryClientPersister.test.ts
+++ b/apps/web/src/shared/lib/__tests__/queryClientPersister.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for the web React Query persister's `shouldDehydrateQuery`
+ * selector. The selector is the choke-point that decides which
+ * cached queries reach IndexedDB on every cache mutation, so a
+ * silent regression here (e.g. a new sensitive feed is added but
+ * nobody updates the block-list) leaks data verbatim to disk.
+ *
+ * See PR #004 in `docs/planning/storage-roadmap.md`.
+ */
+import { describe, it, expect } from "vitest";
+import { QueryClient, dehydrate, type Query } from "@tanstack/react-query";
+
+import { shouldDehydrateQueryForPersist } from "../queryClientPersister";
+
+/**
+ * Build a fake `Query`-like object good enough for the selector,
+ * which only inspects `state.status`, `state.dataUpdateCount`, and
+ * `queryKey`. Anything else stays unset.
+ */
+function fakeQuery(opts: {
+  queryKey: readonly unknown[];
+  status?: "success" | "error" | "pending";
+  dataUpdateCount?: number;
+}): Query {
+  return {
+    queryKey: opts.queryKey,
+    state: {
+      status: opts.status ?? "success",
+      dataUpdateCount: opts.dataUpdateCount ?? 1,
+    },
+  } as unknown as Query;
+}
+
+describe("shouldDehydrateQueryForPersist — base filters", () => {
+  it("rejects errored queries", () => {
+    expect(
+      shouldDehydrateQueryForPersist(
+        fakeQuery({ queryKey: ["routine"], status: "error" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects queries that have never had a successful response", () => {
+    expect(
+      shouldDehydrateQueryForPersist(
+        fakeQuery({ queryKey: ["routine"], dataUpdateCount: 0 }),
+      ),
+    ).toBe(false);
+  });
+
+  it("accepts a vanilla, non-sensitive successful query", () => {
+    expect(
+      shouldDehydrateQueryForPersist(
+        fakeQuery({ queryKey: ["routine", "today"] }),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("shouldDehydrateQueryForPersist — sensitive query exclusion", () => {
+  it.each([
+    ["auth namespace", ["auth", "session"]],
+    ["me namespace", ["me", "current"]],
+    ["coach namespace", ["coach", "memory"]],
+    ["coach insight tuple", ["coach", "insight", "2025-05-01"]],
+    ["sync manifest tuple", ["sync", "manifest"]],
+    ["sync module data tuple", ["sync", "module", "finyk"]],
+    ["balance fragment under privat", ["privat", "balance", "uah"]],
+    ["balance-final fragment", ["privat", "balance-final"]],
+  ])("rejects %s", (_label, queryKey) => {
+    expect(shouldDehydrateQueryForPersist(fakeQuery({ queryKey }))).toBe(false);
+  });
+});
+
+describe("dehydrate() integration", () => {
+  it("omits sensitive queries from the dehydrated snapshot", () => {
+    const client = new QueryClient();
+    // Seed a mix of sensitive and safe queries.
+    client.setQueryData(["coach", "memory"], { advice: "save more" });
+    client.setQueryData(["me", "current"], { email: "user@example.com" });
+    client.setQueryData(["sync", "manifest"], { items: [{ id: "x" }] });
+    client.setQueryData(["privat", "balance"], { uah: 12345 });
+    // Safe ones, should survive.
+    client.setQueryData(["routine", "today"], { steps: 7 });
+    client.setQueryData(["finyk", "transactions"], [{ id: 1 }]);
+    client.setQueryData(["nutrition", "log", "2025-05-01"], []);
+
+    const snapshot = dehydrate(client, {
+      shouldDehydrateQuery: shouldDehydrateQueryForPersist,
+    });
+
+    const dehydratedKeys = snapshot.queries.map((q) =>
+      JSON.stringify(q.queryKey),
+    );
+
+    // None of the sensitive feeds leak into the snapshot.
+    expect(dehydratedKeys).not.toContain(JSON.stringify(["coach", "memory"]));
+    expect(dehydratedKeys).not.toContain(JSON.stringify(["me", "current"]));
+    expect(dehydratedKeys).not.toContain(JSON.stringify(["sync", "manifest"]));
+    expect(dehydratedKeys).not.toContain(JSON.stringify(["privat", "balance"]));
+
+    // The non-sensitive feeds DO survive.
+    expect(dehydratedKeys).toContain(JSON.stringify(["routine", "today"]));
+    expect(dehydratedKeys).toContain(JSON.stringify(["finyk", "transactions"]));
+    expect(dehydratedKeys).toContain(
+      JSON.stringify(["nutrition", "log", "2025-05-01"]),
+    );
+
+    client.clear();
+  });
+
+  it("does not embed sensitive payloads anywhere in the snapshot JSON", () => {
+    const client = new QueryClient();
+    client.setQueryData(["coach", "memory"], {
+      advice: "PRIVATE_COACH_PAYLOAD",
+    });
+    client.setQueryData(["me", "current"], {
+      email: "PRIVATE_USER_EMAIL@example.com",
+    });
+    client.setQueryData(["privat", "balance"], {
+      uah: "PRIVATE_BALANCE_AMOUNT",
+    });
+    // Safe, harmless data.
+    client.setQueryData(["routine", "today"], { steps: 7 });
+
+    const snapshot = dehydrate(client, {
+      shouldDehydrateQuery: shouldDehydrateQueryForPersist,
+    });
+
+    const json = JSON.stringify(snapshot);
+    expect(json).not.toContain("PRIVATE_COACH_PAYLOAD");
+    expect(json).not.toContain("PRIVATE_USER_EMAIL");
+    expect(json).not.toContain("PRIVATE_BALANCE_AMOUNT");
+
+    client.clear();
+  });
+});

--- a/apps/web/src/shared/lib/queryClientPersister.test.ts
+++ b/apps/web/src/shared/lib/queryClientPersister.test.ts
@@ -32,8 +32,15 @@ function makeQuery(client: QueryClient, key: readonly unknown[]): Query {
 describe("shouldDehydrateQueryForPersist", () => {
   it("персистить query з успішними даними", () => {
     const client = new QueryClient();
-    const query = makeQuery(client, ["finyk", "balance"]);
-    query.setData({ balance: 42 });
+    // Деталі finyk-транзакцій не sensitive: PAT живе тільки на сервері
+    // (PR #002), а самі транзакції — це звичайні budgets/categories.
+    // Раніше тут стояло ["finyk", "balance"], але після PR #004
+    // (`docs/planning/storage-roadmap.md`) `balance` як сегмент query-key
+    // потрапляє у `SENSITIVE_QUERY_KEY_FRAGMENTS` і свідомо
+    // виключається з персиста — тому для тесту "вдалі дані
+    // персистяться" треба key, що не натикається на той блок-list.
+    const query = makeQuery(client, ["finyk", "transactions"]);
+    query.setData({ ids: [1, 2, 3] });
 
     expect(shouldDehydrateQueryForPersist(query)).toBe(true);
   });
@@ -41,7 +48,13 @@ describe("shouldDehydrateQueryForPersist", () => {
   it("НЕ персистить query у статусі error (401/500 не повинні переживати cold-start)", () => {
     const cache = new QueryCache();
     const client = new QueryClient({ queryCache: cache });
-    const query = makeQuery(client, ["coach", "advice"]);
+    // Будь-який не-sensitive key годиться — тут перевіряємо саме
+    // фільтр статусу `error`, а не sensitive-list. До PR #004 тут
+    // стояв ["coach", "advice"], але `coach` тепер у
+    // `SENSITIVE_QUERY_KEY_NAMESPACES` і його exclusion завжди
+    // повертає false ще до перевірки error-статусу — тест втрачав
+    // сенс.
+    const query = makeQuery(client, ["digest", "weekly"]);
     // Симуляція HTTP-помилки: setState переводить query у error-status,
     // не зачіпаючи мережу.
     query.setState({

--- a/apps/web/src/shared/lib/queryClientPersister.ts
+++ b/apps/web/src/shared/lib/queryClientPersister.ts
@@ -52,7 +52,14 @@
  *     знов валідна;
  *   - non-`success` queries (`fetchStatus === "fetching"` без
  *     `dataUpdateCount > 0`) — query, що ще не отримав успішну
- *     відповідь, не має сенсу зберігати.
+ *     відповідь, не має сенсу зберігати;
+ *   - sensitive queries (auth / me / coach / sync / *balance*) —
+ *     персонально-чутливі дані не повинні лежати на диску після
+ *     logout (persister keyed by build-id, not by user-id) і
+ *     не мають витікати у IDB-снепшот, що читається з devtools
+ *     будь-яким XSS. Список наций — у `@sergeant/shared`
+ *     `isSensitiveQueryKey` (PR #004 у `docs/planning/storage-roadmap.md`).
+ *     Дзеркалиться у мобільному `mmkvPersister.ts`.
  *
  * ## Capacitor
  *
@@ -70,7 +77,7 @@ import {
   del as idbDel,
 } from "idb-keyval";
 import type { Query } from "@tanstack/react-query";
-import { STORAGE_KEYS } from "@sergeant/shared";
+import { STORAGE_KEYS, isSensitiveQueryKey } from "@sergeant/shared";
 
 declare const __APP_BUILD_ID__: string;
 
@@ -165,6 +172,16 @@ export function shouldDehydrateQueryForPersist(query: Query): boolean {
   // snapshot потрапляють query-плейсхолдери без даних, які лише
   // марнують місце.
   if (query.state.dataUpdateCount === 0) return false;
+
+  // Не зберігаємо чутливі query-keys — auth / me / coach / sync /
+  // *balance*. Ці фіди мають персональні дані (email, balance,
+  // personalised advice strings, module_data JSONB), які не повинні
+  // лежати на диску після logout (persister keyed by build-id, не
+  // user-id) і не мають витікати у IDB-снепшот, що читається з
+  // devtools будь-яким XSS. Список ведеться у `@sergeant/shared`
+  // `isSensitiveQueryKey` і дзеркалиться мобільним
+  // `mmkvPersister.ts`.
+  if (isSensitiveQueryKey(query.queryKey)) return false;
 
   return true;
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -10,6 +10,11 @@ export * from "./types";
 // Shared, DOM-free constants (storage keys, etc.)
 export * from "./lib/storageKeys";
 
+// Sensitive query-key policy for the React Query persisters
+// (web → IDB, mobile → MMKV). See PR #004 in
+// `docs/planning/storage-roadmap.md`.
+export * from "./lib/sensitiveQueryKeys";
+
 // Hub dashboard module ordering (pure helpers; storage I/O is per-platform).
 export * from "./lib/dashboard";
 

--- a/packages/shared/src/lib/sensitiveQueryKeys.test.ts
+++ b/packages/shared/src/lib/sensitiveQueryKeys.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for the sensitive query-key policy used by the web and
+ * mobile React Query persisters. See
+ * `docs/planning/storage-roadmap.md` PR #004.
+ *
+ * The policy is the only thing standing between auth/me/coach/sync
+ * /balance feeds and a verbatim copy of those payloads being
+ * written to IDB / MMKV on every cache mutation. A regression here
+ * is silent — the persister still works, it just leaks more data —
+ * so we exercise every namespace and fragment explicitly rather
+ * than parameterise.
+ */
+import { describe, it, expect } from "vitest";
+
+import {
+  SENSITIVE_QUERY_KEY_FRAGMENTS,
+  SENSITIVE_QUERY_KEY_NAMESPACES,
+  isSensitiveQueryKey,
+} from "./sensitiveQueryKeys";
+
+describe("isSensitiveQueryKey — namespace exclusions", () => {
+  it("excludes the auth namespace", () => {
+    expect(isSensitiveQueryKey(["auth"])).toBe(true);
+    expect(isSensitiveQueryKey(["auth", "session"])).toBe(true);
+    expect(isSensitiveQueryKey(["auth", "csrf-token"])).toBe(true);
+  });
+
+  it("excludes the me namespace", () => {
+    expect(isSensitiveQueryKey(["me"])).toBe(true);
+    expect(isSensitiveQueryKey(["me", "current"])).toBe(true);
+    expect(isSensitiveQueryKey(["me", "settings"])).toBe(true);
+    expect(isSensitiveQueryKey(["me", "finance", "balance"])).toBe(true);
+  });
+
+  it("excludes the coach namespace", () => {
+    expect(isSensitiveQueryKey(["coach"])).toBe(true);
+    expect(isSensitiveQueryKey(["coach", "memory"])).toBe(true);
+    expect(isSensitiveQueryKey(["coach", "insight", "2025-05-01"])).toBe(true);
+  });
+
+  it("excludes the sync namespace", () => {
+    expect(isSensitiveQueryKey(["sync"])).toBe(true);
+    expect(isSensitiveQueryKey(["sync", "manifest"])).toBe(true);
+    expect(isSensitiveQueryKey(["sync", "module", "finyk"])).toBe(true);
+  });
+});
+
+describe("isSensitiveQueryKey — fragment exclusions", () => {
+  it("excludes any tuple containing the `balance` fragment", () => {
+    // Privatbank balance feed lives under the otherwise-fine `privat`
+    // namespace, so the fragment-level rule is what protects it.
+    expect(isSensitiveQueryKey(["privat", "balance"])).toBe(true);
+    expect(isSensitiveQueryKey(["privat", "balance", "uah"])).toBe(true);
+    expect(isSensitiveQueryKey(["finyk", "balance"])).toBe(true);
+  });
+
+  it("excludes any tuple containing the `balance-final` fragment", () => {
+    expect(isSensitiveQueryKey(["privat", "balance-final"])).toBe(true);
+    expect(isSensitiveQueryKey(["privat", "balance-final", "USD"])).toBe(true);
+  });
+});
+
+describe("isSensitiveQueryKey — non-sensitive keys are allowed", () => {
+  it("permits routine / nutrition / fizruk feeds", () => {
+    expect(isSensitiveQueryKey(["routine"])).toBe(false);
+    expect(isSensitiveQueryKey(["routine", "today"])).toBe(false);
+    expect(isSensitiveQueryKey(["nutrition", "log", "2025-05-01"])).toBe(false);
+    expect(isSensitiveQueryKey(["fizruk", "session"])).toBe(false);
+  });
+
+  it("permits finyk feeds outside of the balance fragment", () => {
+    // The PAT lives only on the server (PR #002); finyk's own
+    // module-level data — budgets, transactions list, categories —
+    // remains persistable.
+    expect(isSensitiveQueryKey(["finyk", "transactions"])).toBe(false);
+    expect(isSensitiveQueryKey(["finyk", "budgets", "2025-05"])).toBe(false);
+    expect(isSensitiveQueryKey(["finyk", "categories"])).toBe(false);
+  });
+
+  it("permits hub / digest / push feeds", () => {
+    expect(isSensitiveQueryKey(["hub"])).toBe(false);
+    expect(isSensitiveQueryKey(["digest", "weekly"])).toBe(false);
+    expect(isSensitiveQueryKey(["push", "subscriptions"])).toBe(false);
+  });
+});
+
+describe("isSensitiveQueryKey — degenerate inputs", () => {
+  it("returns false for non-arrays", () => {
+    expect(isSensitiveQueryKey(undefined)).toBe(false);
+    expect(isSensitiveQueryKey(null)).toBe(false);
+    expect(isSensitiveQueryKey("auth")).toBe(false);
+    expect(isSensitiveQueryKey(42)).toBe(false);
+    expect(isSensitiveQueryKey({ namespace: "auth" })).toBe(false);
+  });
+
+  it("returns false for an empty tuple", () => {
+    expect(isSensitiveQueryKey([])).toBe(false);
+  });
+
+  it("ignores non-string segments without throwing", () => {
+    // Query keys can mix in numeric / object filter segments. We
+    // only inspect string segments, but a non-string segment must
+    // not short-circuit later string segments.
+    expect(isSensitiveQueryKey([42, { from: "2025-01-01" }, "coach"])).toBe(
+      true,
+    );
+    expect(isSensitiveQueryKey([{ filter: "x" }, "routine"])).toBe(false);
+    expect(isSensitiveQueryKey([null, undefined, 7])).toBe(false);
+  });
+});
+
+describe("SENSITIVE_QUERY_KEY_NAMESPACES contents", () => {
+  it("exposes a stable snapshot of blocked namespaces", () => {
+    // Snapshot the set so additions / removals are reviewed
+    // explicitly. The list is small and security-sensitive — silent
+    // drift is exactly what this test is meant to catch.
+    expect([...SENSITIVE_QUERY_KEY_NAMESPACES].sort()).toEqual([
+      "auth",
+      "coach",
+      "me",
+      "sync",
+    ]);
+  });
+});
+
+describe("SENSITIVE_QUERY_KEY_FRAGMENTS contents", () => {
+  it("exposes a stable snapshot of blocked fragments", () => {
+    expect([...SENSITIVE_QUERY_KEY_FRAGMENTS].sort()).toEqual([
+      "balance",
+      "balance-final",
+    ]);
+  });
+});

--- a/packages/shared/src/lib/sensitiveQueryKeys.ts
+++ b/packages/shared/src/lib/sensitiveQueryKeys.ts
@@ -1,0 +1,102 @@
+/**
+ * Sensitive query-key policy for React Query persisters.
+ *
+ * Stage 0 / PR #004 from `docs/planning/storage-roadmap.md`. The
+ * web (`apps/web/src/shared/lib/queryClientPersister.ts`) and mobile
+ * (`apps/mobile/src/sync/persister/mmkvPersister.ts`) persisters
+ * dehydrate a snapshot of the React Query cache to disk on every
+ * cache mutation so cold-start can warm-rehydrate. That snapshot is
+ * a verbatim JSON of the cached HTTP responses — fine for budgets,
+ * meal logs, routine state, but **not** for:
+ *
+ *   - the auth subsystem (`/api/auth/*`, Better-Auth sessions);
+ *   - the "who am I" + finance balance feeds (`/api/me/*`, includes
+ *     email, settings, and the user's bank balance projection);
+ *   - the AI coach feed (`/api/coach/*`, contains personalised
+ *     advice strings derived from spending patterns + custom memory);
+ *   - the cloud-sync subsystem itself (`/api/sync/*`, includes
+ *     `module_data` JSONB chunks of every other module).
+ *
+ * Persisting these to IDB / MMKV is a defence-in-depth regression:
+ * the data is reachable to any XSS, lingers across logout (the
+ * persister is keyed by build-id, not by user-id), and survives
+ * device transfer if MMKV/IDB is unencrypted at rest.
+ *
+ * The exclusion list below is consulted by both web and mobile
+ * `shouldDehydrateQuery` selectors. The matcher is deliberately
+ * conservative — string-typed segments only, no deep traversal —
+ * because a query-key tuple can mix strings, numbers, and objects
+ * and we'd rather over-exclude than over-persist.
+ *
+ * Adding to the list:
+ *   1. The query-key factory in `apps/web/src/shared/lib/queryKeys.ts`
+ *      or `packages/api-client/src/react/queryKeys.ts` defines the
+ *      first segment.
+ *   2. Pick the narrowest match: a top-level namespace (`coach`),
+ *      or a sub-resource fragment (`balance`, `balance-final`).
+ *   3. Add a snapshot test in
+ *      `apps/web/src/shared/lib/__tests__/queryClientPersister.test.ts`
+ *      so a future contributor can't accidentally re-include a key.
+ */
+
+/**
+ * Top-level query-key namespaces that must never be persisted.
+ *
+ * These match `queryKey[0]` exactly (case-sensitive). Anything under
+ * the namespace — `["coach", "memory"]`, `["coach", "insight", "2025-05-01"]`,
+ * `["me", "current"]`, `["sync", "manifest"]`, `["auth", "session"]` —
+ * inherits the exclusion.
+ */
+export const SENSITIVE_QUERY_KEY_NAMESPACES: ReadonlySet<string> = new Set([
+  // Auth subsystem (Better-Auth sessions, user profile metadata).
+  // The web app reads "who am I" via `useUser()` from
+  // `@sergeant/api-client/react`, which uses `["me", ...]`. The
+  // legacy `["auth", ...]` namespace is reserved for Better-Auth
+  // hooks — block both as a belt-and-braces measure.
+  "auth",
+  "me",
+  // AI coach feed — personalised advice strings, memory.
+  "coach",
+  // Cloud-sync subsystem — `module_data` payloads, manifest, etc.
+  "sync",
+]);
+
+/**
+ * Query-key segments (anywhere in the tuple) that must never be
+ * persisted. Used for sub-resources whose top-level namespace is
+ * shared with non-sensitive resources — e.g. `["privat", "balance-final", …]`
+ * sits under the otherwise-fine `privat` namespace, so we exclude
+ * the `balance-final` segment specifically.
+ *
+ * Match is exact, segment-by-segment. We don't fuzzy-match
+ * substrings because tuples can carry arbitrary user-controlled
+ * strings (search queries, barcodes) and a substring rule could
+ * accidentally exclude the wrong entries.
+ */
+export const SENSITIVE_QUERY_KEY_FRAGMENTS: ReadonlySet<string> = new Set([
+  // /api/me/finance/balance and the privat-bank balance feed.
+  "balance",
+  "balance-final",
+]);
+
+/**
+ * Returns `true` if the query-key tuple targets a sensitive feed and
+ * therefore must be excluded from the persister snapshot.
+ *
+ * The function is total: any non-array input, empty array, or
+ * tuple of non-string segments returns `false` (i.e. "safe to
+ * persist"). The intent is to err on the side of *not* surprising
+ * a future caller with a "your test queries are missing from
+ * snapshot" footgun.
+ */
+export function isSensitiveQueryKey(
+  queryKey: readonly unknown[] | unknown,
+): boolean {
+  if (!Array.isArray(queryKey) || queryKey.length === 0) return false;
+  for (const segment of queryKey) {
+    if (typeof segment !== "string") continue;
+    if (SENSITIVE_QUERY_KEY_NAMESPACES.has(segment)) return true;
+    if (SENSITIVE_QUERY_KEY_FRAGMENTS.has(segment)) return true;
+  }
+  return false;
+}


### PR DESCRIPTION
## What changed

Stage 0 / PR #004 з [`docs/planning/storage-roadmap.md`](https://github.com/Skords-01/Sergeant/blob/main/docs/planning/storage-roadmap.md). Web React Query persister (IndexedDB через `idb-keyval`) і mobile persister (MMKV через `createSyncStoragePersister`) до цього дегідратували **усі** кешовані queries у warm-start snapshot. Цей snapshot keyed by **build-id**, не user-id, тож виживає logout / device hand-off і читається з devtools будь-яким XSS — defence-in-depth регресія для PII feeds.

### Block-list (централізовано в `@sergeant/shared`)

- `SENSITIVE_QUERY_KEY_NAMESPACES` — top-level: `auth` / `me` / `coach` / `sync`.
- `SENSITIVE_QUERY_KEY_FRAGMENTS` — segment-level: `balance` / `balance-final`. Захист Privatbank/Mono balance feeds, у яких top-level (`privat`) шерится з не-чутливими ресурсами.
- `isSensitiveQueryKey(queryKey)` — total predicate, який чіпляється до `shouldDehydrateQuery` обох персистерів.

### Wiring

- **Web** (`apps/web/src/shared/lib/queryClientPersister.ts`): додано sensitive-key check у існуючий error / `dataUpdateCount===0` фільтр; pre-existing `createWebPersistOptions` уже плюмить `shouldDehydrateQuery`.
- **Mobile** (`apps/mobile/src/sync/persister/mmkvPersister.ts`): додано sibling `shouldDehydrateQueryForPersistMobile` selector з тими самими 3 фільтрами, підключений у `PersistQueryClientProvider` через `persistOptions.dehydrateOptions` у `QueryProvider.tsx`.

### Tests

- `packages/shared/src/lib/sensitiveQueryKeys.test.ts` — 14 cases: кожний namespace, кожний fragment, не-чутливі feeds (routine / nutrition / fizruk / hub / digest / push / non-balance finyk), degenerate inputs (null, non-array, mixed numeric/object segments), explicit snapshot блок-листа для silent-drift detection.
- `apps/web/src/shared/lib/__tests__/queryClientPersister.test.ts` — 13 cases, включно з `dehydrate()` integration test, що перевіряє: чутливі payloads (`PRIVATE_COACH_PAYLOAD`, `PRIVATE_USER_EMAIL`, `PRIVATE_BALANCE_AMOUNT`) не з'являються ніде в snapshot JSON.
- Pre-existing `apps/web/src/shared/lib/queryClientPersister.test.ts` оновлений для використання не-чутливих query keys (`["finyk", "transactions"]`, `["digest", "weekly"]`) у базових error / `dataUpdateCount` тестах — попередні arbitrary keys (`["finyk", "balance"]`, `["coach", "advice"]`) тепер тригерять sensitive-list short-circuit і маскують filter under test.

### Side fix

- Регенерований `THIRD_PARTY_LICENSES.md` — лежав out-of-date на `main`, валив `check` job (License policy check).

## Why

До цього warm-start IDB/MMKV snapshot містив усі query payloads, у тому числі:
- `coach/insight` (приватні coaching рекомендації, можуть містити PII)
- `me/profile` (email, телефон, fitness data)
- `auth/session` (session tokens у `data` поле)
- `privat/balance` / `privat/balance-final` (банківський баланс)
- `sync/*` (cross-user data, що могла залишитись після прев'юса)

Ці payload-и виживали logout (snapshot keyed by build-id) і device hand-off → defence-in-depth регресія. Тепер ці queries **взагалі не пишуться** у persister snapshot — лише runtime-cache, який очищається на logout / refresh.

## How to test

```bash
# 14 unit-тестів shared sensitive-key predicate
pnpm --filter @sergeant/shared test sensitiveQueryKeys

# 21 web persister tests (incl. dehydrate() integration)
pnpm --filter @sergeant/web test queryClientPersister

# 627 mobile tests (no regressions)
pnpm --filter @sergeant/mobile test

# Lint clean
pnpm --filter @sergeant/shared lint
pnpm --filter @sergeant/mobile lint
```

Manual smoke на web:
1. Залогінитись, відкрити `/digest` (не-чутлива query) і `/coach` (чутлива query).
2. У devtools → Application → IndexedDB → `sergeant-cache` подивитись `data`.
3. Очікуване: `digest/weekly` payload присутній; `coach/insight` payload **відсутній**.

---

## Pre-flight (Hard Rule #15)

- [x] Read `AGENTS.md` Hard Rules для дотиканих шляхів (нема contracts на API/DB; шерені utility у `@sergeant/shared`).
- [x] Read `docs/planning/storage-roadmap.md` Stage 0 / PR #004.
- [x] Checked freshness headers cited docs.

## Docs updated alongside code? (Hard Rule #15)

- [ ] API contract change — n/a (тільки клієнтський filter).
- [ ] New / removed npm script — n/a.
- [ ] New design token / component / palette — n/a.
- [ ] Deprecation — n/a.
- [ ] Freshness header bumped — n/a.
- [x] N/A — no docs invalidated by this change.

## How AI-tested this PR

- [x] Vitest passes: 14/14 (shared) + 21/21 (web) + 627/627 (mobile).
- [x] Lint passes на дотиканих файлах.
- [x] No new `AI-DANGER` markers added.
- [x] Docs prose в Ukrainian.

## AGENTS.md updated?

- [ ] No — no new permanent rules introduced; existing Hard Rules не охоплюють persister filtering, але це one-shot security hardening без потреби нового invariant.

## Stage 0 context

| PR | Title | Status |
|----|-------|--------|
| #002 | Drop FINYK_TOKEN from sync keys + ESLint guard | [#1280](https://github.com/Skords-01/Sergeant/pull/1280) |
| #004 | **This PR** — exclude sensitive query keys from persisters | (this PR) |
| #005 | `sync_audit_log` table + admin viewer | [#1284](https://github.com/Skords-01/Sergeant/pull/1284) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive user data (auth details, account balances, coaching and sync info) no longer persists in app storage after logout or device hand-off, reducing accidental data exposure.
* **New Features**
  * Improved persistence policy to selectively exclude sensitive cached items from being saved.
* **Tests**
  * Added comprehensive tests to ensure sensitive data is not persisted and non-sensitive data remains intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->