### PR TITLE
build(root): scope railway.toml per-service for grafana-alloy

### DIFF
--- a/ops/grafana-alloy/railway.toml
+++ b/ops/grafana-alloy/railway.toml
@@ -1,0 +1,5 @@
+# Per-service Railway config for the grafana-alloy scraper.
+# Overrides the repo-root `railway.toml` (which targets apps/server).
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile"


### PR DESCRIPTION
## What changed

Adds `ops/grafana-alloy/railway.toml` so the new `grafana-alloy` Railway service uses its own `Dockerfile` instead of the repo-root `Dockerfile.api`.

```toml
[build]
builder = "DOCKERFILE"
dockerfilePath = "Dockerfile"
```

## Why

The repo-root `railway.toml` pins `dockerfilePath = "Dockerfile.api"` for the Sergeant API service. When I provisioned a sibling `grafana-alloy` service on Railway (Phase 2 metrics scraper, see <ref_file file="/home/ubuntu/repos/Sergeant/ops/grafana-alloy/README.md" />), it inherited the root config and tried to build the Node monorepo, failing with `failed to compute cache key … "/apps/server": not found`.

Railway resolves `railwayConfigFile` relative to the repo root, so pointing the alloy service at `ops/grafana-alloy/railway.toml` (with `rootDirectory=ops/grafana-alloy`) gives it a scoped override without touching the API service's config.

After this change the alloy service deploys successfully and metrics are flowing to Grafana Cloud:
```
up{job="n8n", project="sergeant"} = 1
up{job="sergeant-server", project="sergeant"} = 1
```

## How to test

- Sergeant API service (`humorous-eagerness` project) — `rootDirectory=null`, `railwayConfigFile=null` → still reads `/railway.toml` and builds `Dockerfile.api`. Unchanged.
- `grafana-alloy` service (`grateful-nurturing` project) — `rootDirectory=ops/grafana-alloy`, `railwayConfigFile=ops/grafana-alloy/railway.toml` → reads this new file and builds `ops/grafana-alloy/Dockerfile`. Verified deploy `ad7b80b7-01db-4338-a5f5-b81e37a14c67` = SUCCESS.

⚠️ **Reviewer attention**: the `rootDirectory` + `railwayConfigFile` settings live on the Railway service (not in this repo). They were set via the Railway GraphQL API as part of the alloy service provisioning. If someone re-creates the service from scratch they need to set both fields, otherwise this file is ignored.

---

## Pre-flight (Hard Rule #15)

- [x] Read the `AGENTS.md` Hard Rules that apply to the touched paths. — n/a (build-only config under `ops/`).
- [x] Read the matching playbook in `docs/playbooks/` (or noted that none exists). — none for Railway service config.
- [x] Checked freshness headers of docs cited in the change. — n/a, no doc claims invalidated.

## Docs updated alongside code? (Hard Rule #15)

- [x] N/A — no docs invalidated by this change. The existing <ref_file file="/home/ubuntu/repos/Sergeant/ops/grafana-alloy/README.md" /> already documents `rootDirectory=ops/grafana-alloy`; this PR just makes that setting actually take effect.

## How AI-tested this PR

- [x] End-to-end on production Railway: the alloy service redeployed with this commit and now ships metrics to Grafana Cloud Mimir (verified `up{project="sergeant"}=1` for both n8n and sergeant-server targets).
- [x] Repo-root `railway.toml` left untouched → Sergeant API service unaffected.
- [x] No new `AI-DANGER` markers.
- [x] `pnpm dead-code:files` — n/a (config-only).

## AGENTS.md updated?

- [x] No — no new permanent rules.

Link to Devin session: https://app.devin.ai/sessions/65b7e82a3ae043f89991b135f0ed7841
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1286" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a per-service `ops/grafana-alloy/railway.toml` so the `grafana-alloy` Railway service builds with its own `Dockerfile` instead of the repo-root `Dockerfile.api`. This stops it from building the Node app and fixes deploys so metrics ship correctly.

- **Migration**
  - In the `grafana-alloy` Railway service, set `rootDirectory=ops/grafana-alloy` and `railwayConfigFile=ops/grafana-alloy/railway.toml`.

<sup>Written for commit cd125e35bf8839f82417f19d6d62bdd76a49f9d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration for the Grafana Alloy monitoring service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->