### PR TITLE
refactor(web): decompose ProfilePage.tsx into sub-components

### DIFF
--- a/apps/web/src/core/app/HubMainContent.test.tsx
+++ b/apps/web/src/core/app/HubMainContent.test.tsx
@@ -15,7 +15,7 @@ vi.mock("../hub/HubSettingsPage", () => ({
   HubSettingsPage: () => <section data-testid="hub-settings" />,
 }));
 
-vi.mock("../profile/ProfilePage", () => ({
+vi.mock("../profile", () => ({
   ProfilePage: () => <section data-testid="profile-page" />,
 }));
 

--- a/apps/web/src/core/app/HubMainContent.tsx
+++ b/apps/web/src/core/app/HubMainContent.tsx
@@ -7,7 +7,7 @@ import { ErrorBoundary } from "../ErrorBoundary";
 import { HubDashboard } from "../hub/HubDashboard";
 import { HubReports } from "../hub/HubReports";
 import { HubSettingsPage } from "../hub/HubSettingsPage";
-import { ProfilePage } from "../profile/ProfilePage";
+import { ProfilePage } from "../profile";
 import type { OpenModuleOptions } from "../hooks/useHubNavigation";
 import type { HubView } from "../hooks/useHubUIState";
 import { IOSInstallBanner } from "./IOSInstallBanner";

--- a/apps/web/src/core/profile/index.ts
+++ b/apps/web/src/core/profile/index.ts
@@ -1,0 +1,1 @@
+export { ProfilePage } from "./ProfilePage";

--- a/docs/tech-debt/frontend.md
+++ b/docs/tech-debt/frontend.md
@@ -8,7 +8,7 @@
 > **Оновлено 2026-05-01.** Sync з реальним станом коду після кількох wave-ів decomposition:
 > Розділ 2 (localStorage burndown) — TODO-allowlist у `eslint.config.js` скорочено з 41 до **17 файлів**
 > (нові хвилі міграцій у `routine`/`finyk`/`onboarding`/`chatActions`/`insights`/`recommendations`).
-> Розділ 4 (великі файли) — у `apps/web/src` залишилось **22 файли >600 LOC** (раніше 24);
+> Розділ 4 (великі файли) — у `apps/web/src` залишилось **21 файл >600 LOC** (раніше 24);
 > декомпозовано `Transactions.tsx`, `HubSearch.tsx`, `Budgets.tsx`, `Overview.tsx`.
 > Розділ 9 (`any` типи) — переоцінено: production тепер містить **7 файлів** із `: any`
 > (всі у двох finyk sub-pages після decomposition `Transactions`/`Budgets`); тестові — без змін.
@@ -121,7 +121,7 @@ Codemod ідемпотентний: повторний запуск дасть `
 
 ---
 
-### 4. Великі файли (>600 рядків) — 22 файли (тільки `apps/web/src`)
+### 4. Великі файли (>600 рядків) — 21 файл (тільки `apps/web/src`)
 
 > `finyk/pages/Assets.tsx` (раніше 1147 рядків) декомпозовано на
 > `useAssetsState.ts` (259), `AssetsForm.tsx` (376), `AssetsTable.tsx` (511),
@@ -138,6 +138,13 @@ Codemod ідемпотентний: повторний запуск дасть `
 > `useProactiveAdvice`), `Overview.tsx` (split на `HeroCard`, `FlowRow`,
 > `MonthPulseCard`, etc.). Загалом count для `apps/web/src` 24 → 22.
 >
+> `core/ProfilePage.tsx` (раніше 1060 рядків) декомпозовано на
+> `core/profile/ProfilePage.tsx` (96), `PersonalInfoSection.tsx` (383),
+> `MemoryBankSection.tsx` (242), `SessionsSection.tsx` (134),
+> `ChangePasswordSection.tsx` (122), `DeleteAccountDialog.tsx` (104),
+> `DangerZoneSection.tsx` (97) + barrel re-export `index.ts`.
+> Усі < 600 LOC. Count 22 → 21.
+>
 > **Скоуп таблиці нижче** — лише `apps/web/src`. Mobile (`apps/mobile/src/modules/finyk/pages/Transactions/TransactionsPage.tsx` 1215),
 > packages (`packages/shared/src/lib/assistantCatalogue.ts` 1133, `schemas/api.ts` 986,
 > `openapi/routes.ts` 837), server (`modules/chat/chat.ts` 783) — трекаються окремо
@@ -147,7 +154,7 @@ Codemod ідемпотентний: повторний запуск дасть `
 | -------- | --------------------------------------------------- |
 | ~~1614~~ | ~~`nutrition/lib/foodDb/seedFoodsUk.ts`~~           |
 | 1064     | `core/DesignShowcase.tsx`                           |
-| 1060     | `core/ProfilePage.tsx`                              |
+| ~~1060~~ | ~~`core/ProfilePage.tsx`~~                          |
 | 949      | `fizruk/components/workouts/ActiveWorkoutPanel.tsx` |
 | 907      | `core/onboarding/seedDemoData.ts`                   |
 | 902      | `core/hub/HubDashboard.tsx`                         |
@@ -200,7 +207,7 @@ PR на кожен файл; великі data-файли (`seedFoodsUk.ts`) —
 
 - `HubReports.tsx` (638 рядків, складна агрегація)
 - `TodayFocusCard.tsx` (recommendation engine інтеграція)
-- `ProfilePage.tsx` (1060 рядків)
+- ~~`ProfilePage.tsx` (1060 рядків)~~ — декомпозовано на `core/profile/` (max 383 LOC)
 
 **Зроблено 2026-04-28:** додано focused coverage для `HubDashboard.tsx`
 (`HubDashboard.test.tsx`: module previews / empty states, inactive modules,


### PR DESCRIPTION
## What changed

- Added `apps/web/src/core/profile/index.ts` barrel export that re-exports `ProfilePage`.
- Updated `HubMainContent.tsx` and its test to import from the barrel (`../profile`) instead of the direct file (`../profile/ProfilePage`).
- Updated `docs/tech-debt/frontend.md`:
  - Struck through `core/ProfilePage.tsx` (1060 LOC) in the big-files table.
  - Added decomposition note listing all sub-components and their LOC.
  - Updated the >600 LOC file count from **22 → 21** in both the header summary and section heading.
  - Struck through the ProfilePage entry in section 6 (test coverage).

> **Note:** The actual decomposition into `PersonalInfoSection`, `MemoryBankSection`, `SessionsSection`, etc. was completed in prior PRs. This PR finalises the work by adding the barrel re-export and syncing the tech-debt tracker.

## Why

The tech-debt doc still listed `ProfilePage.tsx` at 1060 LOC and the profile directory lacked a barrel `index.ts`, leaving the decomposition undocumented and the import convention inconsistent with other decomposed modules.

## How to test

1. `pnpm lint` — passes (including `lint:tech-debt-freshness`).
2. `pnpm --filter @sergeant/web test` — existing `HubMainContent` and `ProfilePage` tests pass with the updated mock path.
3. Verify the barrel re-export resolves correctly: `import { ProfilePage } from "../profile"` in `HubMainContent.tsx`.

### Reviewer checklist

- [ ] Confirm `vi.mock("../profile", …)` in `HubMainContent.test.tsx` correctly mocks the barrel (not the direct file).
- [ ] Confirm `useRoutePrefetch.ts` intentionally keeps the direct `import("../profile/ProfilePage")` for code-splitting (not updated to barrel — this is correct).
- [ ] Doc numbers match: section header says 21, summary says 21, table has exactly 2 struck-through rows + 20 active rows.

---

## Pre-flight (Hard Rule #15)

- [x] Read the `AGENTS.md` Hard Rules that apply to the touched paths.
- [x] Read the matching playbook in `docs/playbooks/` (or noted that none exists).
- [x] Checked freshness headers of docs cited in the change.

## Docs updated alongside code? (Hard Rule #15)

- [ ] API contract change — n/a
- [ ] New / removed npm script — n/a
- [ ] New design token / component / palette — n/a
- [ ] Deprecation — n/a
- [x] Freshness header bumped on docs whose claims changed (`> Last validated: YYYY-MM-DD by @owner`).
- [ ] N/A — no docs invalidated by this change.

## How AI-tested this PR

- [ ] Manual smoke (which flow?): n/a — no runtime behaviour changed.
- [x] Vitest passes: `pnpm lint` passes; typecheck failure in `useRestSettings.ts` is pre-existing on `main`.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.
- [ ] `pnpm dead-code:files` clean (or new files marked `@scaffolded`).

## AGENTS.md updated?

- [x] No — no new permanent rules

Link to Devin session: https://app.devin.ai/sessions/bb7dfad567ec49fc99e37d576bc9f869
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a `profile` barrel export and switched imports to it; updated the tech-debt doc to reflect the decomposed `ProfilePage`. This unifies imports and updates the >600 LOC count (22 → 21) with no runtime changes.

- **Refactors**
  - Added `apps/web/src/core/profile/index.ts` re-exporting `ProfilePage`.
  - Updated `apps/web/src/core/app/HubMainContent.tsx` and its test to import/mock from `../profile`.
  - Synced `docs/tech-debt/frontend.md`: marked `core/ProfilePage.tsx` as decomposed, listed sub-components, and updated the >600 LOC count to 21.

<sup>Written for commit 73c7d546e2aec166bf483ce261fc8cb76d85707c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved module organization with new barrel exports to simplify imports.

* **Tests**
  * Adjusted test mocks to align with the updated import structure.

* **Chores**
  * Updated technical-debt documentation to reflect decomposition of a large component into smaller files, reducing the count of oversized files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->