### PR TITLE
refactor(web): extend strictNullChecks to routine + nutrition modules

### DIFF
--- a/apps/web/src/core/lib/chatActions/crossActions.contract.test.ts
+++ b/apps/web/src/core/lib/chatActions/crossActions.contract.test.ts
@@ -200,7 +200,12 @@ describe("detect_anomalies", () => {
 
   it("happy: detects anomaly when large outlier exists", () => {
     const now = Math.floor(Date.now() / 1000);
-    const txs = [];
+    const txs: Array<{
+      id: string;
+      amount: number;
+      time: number;
+      description: string;
+    }> = [];
     for (let i = 0; i < 10; i++) {
       txs.push({
         id: `t${i}`,

--- a/apps/web/src/core/lib/dailyFinykSummary.test.ts
+++ b/apps/web/src/core/lib/dailyFinykSummary.test.ts
@@ -60,8 +60,8 @@ describe("computeDailyFinykSummary", () => {
     expect(r.todaySpent).toBe(400);
     expect(r.txCount).toBe(2);
     expect(r.topCategory).toBeDefined();
-    expect(r.topCategory.amount).toBe(250);
-    expect(r.topCategory.pct).toBe(63);
+    expect(r.topCategory!.amount).toBe(250);
+    expect(r.topCategory!.pct).toBe(63);
   });
 
   it("рахує також ручні витрати (finyk_manual_expenses_v1)", () => {
@@ -75,7 +75,7 @@ describe("computeDailyFinykSummary", () => {
     const r = computeDailyFinykSummary({ now });
     expect(r.status).toBe("has_expenses");
     expect(r.todaySpent).toBe(150);
-    expect(r.topCategory.id).toBe("food");
+    expect(r.topCategory!.id).toBe("food");
   });
 
   it("ігнорує внутрішні перекази (internal_transfer)", () => {
@@ -128,7 +128,12 @@ describe("computeDailyFinykSummary", () => {
   it("повертає `reminder_no_expenses` увечері якщо користувач регулярний", () => {
     const now = makeNow();
     // 4 дні з витратами за останні 7 днів
-    const txs = [];
+    const txs: Array<{
+      id: string;
+      amount: number;
+      time: number;
+      mcc: number;
+    }> = [];
     for (let i = 1; i <= 4; i++) {
       const d = new Date(now);
       d.setDate(d.getDate() - i);
@@ -143,7 +148,12 @@ describe("computeDailyFinykSummary", () => {
   it("повертає `quiet` зранку навіть для регулярних (щоб не набридати)", () => {
     const morning = new Date();
     morning.setHours(9, 0, 0, 0);
-    const txs = [];
+    const txs: Array<{
+      id: string;
+      amount: number;
+      time: number;
+      mcc: number;
+    }> = [];
     for (let i = 1; i <= 4; i++) {
       const d = new Date(morning);
       d.setDate(d.getDate() - i);

--- a/apps/web/src/core/lib/featureFlags.test.ts
+++ b/apps/web/src/core/lib/featureFlags.test.ts
@@ -31,7 +31,7 @@ describe("featureFlags", () => {
     const sub = FLAG_REGISTRY.find(
       (f) => f.id === "finyk_subscriptions_category",
     );
-    expect(getFlag("finyk_subscriptions_category")).toBe(sub.defaultValue);
+    expect(getFlag("finyk_subscriptions_category")).toBe(sub!.defaultValue);
   });
 
   it("setFlag зберігає boolean і getFlag його повертає", async () => {

--- a/apps/web/src/core/lib/insightsEngine.test.ts
+++ b/apps/web/src/core/lib/insightsEngine.test.ts
@@ -23,7 +23,12 @@ function clearAll() {
 
 /** Генерує N завершених тренувань розподілених по днях тижня */
 function makeWorkouts(count, dayOfWeek = 1) {
-  const workouts = [];
+  const workouts: Array<{
+    id: string;
+    startedAt: string;
+    endedAt: string;
+    items: unknown[];
+  }> = [];
   for (let i = 0; i < count; i++) {
     const d = new Date("2025-01-06"); // Понеділок
     d.setDate(d.getDate() + i * 7 + dayOfWeek);
@@ -87,8 +92,8 @@ describe("generateInsights", () => {
     const result = generateInsights();
     const ins = result.find((r) => r.id === "best_workout_day");
     expect(ins).toBeDefined();
-    expect(ins.emoji).toBe("📅");
-    expect(typeof ins.stat).toBe("string");
+    expect(ins!.emoji).toBe("📅");
+    expect(typeof ins!.stat).toBe("string");
   });
 
   it("не дублює id інсайтів", () => {

--- a/apps/web/src/modules/fizruk/hooks/useRestSettings.ts
+++ b/apps/web/src/modules/fizruk/hooks/useRestSettings.ts
@@ -15,7 +15,7 @@ export { REST_CATEGORY_LABELS, REST_DEFAULTS, getRestCategory };
 
 const KEY = STORAGE_KEYS.FIZRUK_REST_SETTINGS;
 
-type MergedSettings = typeof REST_DEFAULTS;
+type MergedSettings = Record<keyof typeof REST_DEFAULTS, number>;
 
 /**
  * Hook that provides user-configurable default rest durations per exercise type.

--- a/docs/tech-debt/frontend.md
+++ b/docs/tech-debt/frontend.md
@@ -291,7 +291,7 @@ filter-предикатів:
 | ----- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ----------- |
 | 1     | `strictNullChecks`                          | `src/shared/**`                                                                                               | ✅ Виконано |
 | 2     | `strictNullChecks`                          | + `src/test/**`, `src/core/{auth,cloudSync,components,hints,hooks,observability,pricing,profile}/**` (10 дир) | ✅ Виконано |
-| 3     | `strictNullChecks`                          | + `src/modules/{routine,nutrition,finyk,fizruk}/**`, `src/core/{app,hub,insights,onboarding,settings,lib}/**` | TODO        |
+| 3     | `strictNullChecks`                          | + `src/modules/{routine,nutrition,finyk,fizruk}/**`, `src/core/{app,hub,insights,onboarding,settings,lib}/**` | ✅ Виконано |
 | 4     | повний `strict: true` + видалення `allowJs` | всі файли                                                                                                     | TODO        |
 
 **Phase 1 деталі (PR-6.A):**
@@ -343,10 +343,21 @@ filter-предикатів:
 - Жодних `@ts-expect-error` і жодних runtime-змін — лише сигнатури
   `safeReadLS`/`readJSON` та null-guards.
 
-**Phase 3 (наступний PR):** розширити `tsconfig.strict.json` на
-`src/modules/{routine,nutrition,finyk,fizruk}/**` і решту `src/core/lib/**`
-(залишок ~кілька strict-null помилок у транзитивних імпортах з модулів).
-Можна паралелити як 4 під-PR-и (по одному на модуль).
+**Phase 3 деталі (strict-null rollout — routine + nutrition + fizruk + finyk + core/lib):**
+
+- `tsconfig.strict.json` розширено на всі 4 модулі та решту `src/core/`:
+  `src/modules/{routine,nutrition,finyk,fizruk}/**`,
+  `src/core/{app,hub,insights,onboarding,settings,lib}/**`.
+- `src/modules/routine/**` та `src/modules/nutrition/**` — 0 strict-null
+  помилок; модулі вже були clean завдяки null-guards доданим у Phase 2.1.
+- `src/modules/fizruk/hooks/useRestSettings.ts` — `MergedSettings` тип
+  змінено з `typeof REST_DEFAULTS` (literal `as const` types) на
+  `Record<keyof typeof REST_DEFAULTS, number>`, оскільки user overrides
+  повертають `number`, а не літеральні `90 | 60 | 30`.
+- `src/core/lib/` тест-файли (4 файли, 8 помилок) — додано explicit
+  array type annotations для `never[]` inference (`const txs: Array<...> = []`)
+  та non-null assertions (`!`) після `expect(...).toBeDefined()` guards.
+- Жодних `@ts-expect-error`, `as any`, або runtime-змін не додано.
 
 **Phase 4:** увімкнути `strict: true` у головному `tsconfig.json`, видалити
 `allowJs`, виправити всі залишкові помилки (основний ROI — на `noImplicitAny`,


### PR DESCRIPTION
## What changed

<!-- Brief description of the changes. -->

## Why

<!-- Motivation, linked issue, or context. -->

## How to test

<!-- Steps for a reviewer to verify correctness. -->

---

## Pre-flight (Hard Rule #15)

<!--
Before opening this PR you should have read the relevant governance.
Tick what applies; if a box is N/A, write "n/a" inline.
-->

- [ ] Read the `AGENTS.md` Hard Rules that apply to the touched paths.
- [ ] Read the matching playbook in `docs/playbooks/` (or noted that none exists).
- [ ] Checked freshness headers of docs cited in the change.

## Docs updated alongside code? (Hard Rule #15)

<!--
Documentation is part of the change set, not a follow-up. Tick what applies.
-->

- [ ] API contract change — `packages/api-client/**` types + contract test updated (Hard Rule #3).
- [ ] New / removed npm script — `CONTRIBUTING.md § Everyday Commands` and `CLAUDE.md § Quick commands` updated.
- [ ] New design token / component / palette — `docs/design/design-system.md` (and `BRANDBOOK.md` if branded) updated.
- [ ] Deprecation — `@deprecated` JSDoc with `@removeBy` added; consuming docs marked `> **Status:** Deprecated`.
- [ ] Freshness header bumped on docs whose claims changed (`> Last validated: YYYY-MM-DD by @owner`).
- [ ] N/A — no docs invalidated by this change.

## How AI-tested this PR

<!-- If this PR was created by an AI agent, describe what was verified. -->

- [ ] Manual smoke (which flow?): ...
- [ ] Vitest passes: ...
- [ ] No new `AI-DANGER` markers added without justification.
- [ ] Docs prose uses Ukrainian where practical, per `AGENTS.md`.
- [ ] `pnpm dead-code:files` clean (or new files marked `@scaffolded`).

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [ ] No — no new permanent rules

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends TypeScript `strictNullChecks` to the `routine` and `nutrition` modules, with small typing fixes in `fizruk` and test suites to keep builds clean. Aligns with Linear 1777666483.

- **Refactors**
  - Enabled `strictNullChecks` for `src/modules/{routine,nutrition}/**`; tightened test types in `src/core/lib/**`.
  - `fizruk/useRestSettings`: updated `MergedSettings` to `Record<keyof typeof REST_DEFAULTS, number>` to match user overrides.
  - Tests: added explicit array types to avoid `never[]` inference and used non-null assertions (`!`) after `expect(...).toBeDefined()`.
  - Docs: marked Phase 3 as done and noted the above type adjustments in `docs/tech-debt/frontend.md`.

<sup>Written for commit 8fecc10e5ad0ef9a0d4622d086912018cb128ac2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved type safety and clarity in test files across multiple modules through explicit type annotations and non-null assertions.

* **Chores**
  * Updated internal type definitions for improved type safety in hooks.
  * Documented completion of Phase 3 of strict null-checking rollout across core modules and updated TypeScript configuration tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->