### PR TITLE
fix(root): rewire WF-19 with Merge + simplify WF-98 (no broken email)

### DIFF
--- a/ops/n8n-workflows/19-db-health-report.json
+++ b/ops/n8n-workflows/19-db-health-report.json
@@ -21,14 +21,15 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "SELECT\n  pg_size_pretty(pg_database_size(current_database())) AS db_size,\n  current_database() AS db_name,\n  (SELECT COUNT(*) FROM mono_transaction) AS tx_count,\n  (SELECT COUNT(*) FROM push_subscriptions WHERE deleted_at IS NULL) AS active_push_subs,\n  (SELECT COUNT(*) FROM \"user\") AS user_count",
+        "query": "SELECT\n  'db_info' AS kind,\n  pg_size_pretty(pg_database_size(current_database())) AS db_size,\n  current_database() AS db_name,\n  (SELECT COUNT(*) FROM mono_transaction) AS tx_count,\n  (SELECT COUNT(*) FROM push_subscriptions WHERE deleted_at IS NULL) AS active_push_subs,\n  (SELECT COUNT(*) FROM \"user\") AS user_count",
         "options": {}
       },
       "id": "query-db-size",
       "name": "DB size & counts",
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2.5,
-      "position": [460, 200],
+      "position": [460, 180],
+      "onError": "continueRegularOutput",
       "credentials": {
         "postgres": {
           "id": "pwwVNTLBw43PJgey",
@@ -39,15 +40,15 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "SELECT\n  relname AS table_name,\n  pg_size_pretty(pg_total_relation_size(relid)) AS total_size,\n  n_live_tup AS row_count\nFROM pg_stat_user_tables\nORDER BY pg_total_relation_size(relid) DESC\nLIMIT 5",
+        "query": "SELECT\n  'table' AS kind,\n  relname AS table_name,\n  pg_size_pretty(pg_total_relation_size(relid)) AS total_size,\n  n_live_tup AS row_count\nFROM pg_stat_user_tables\nORDER BY pg_total_relation_size(relid) DESC\nLIMIT 5",
         "options": {}
       },
       "id": "query-top-tables",
       "name": "Top 5 tables by size",
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2.5,
-      "position": [460, 380],
-      "executeOnce": true,
+      "position": [460, 360],
+      "onError": "continueRegularOutput",
       "credentials": {
         "postgres": {
           "id": "pwwVNTLBw43PJgey",
@@ -58,18 +59,15 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "SELECT\n  calls,\n  ROUND(mean_exec_time::numeric, 1) AS avg_ms,\n  LEFT(query, 80) AS query_preview\nFROM pg_stat_statements\nWHERE query NOT LIKE '%pg_stat%'\nORDER BY mean_exec_time DESC\nLIMIT 3",
-        "options": {
-          "continueOnFail": true
-        }
+        "query": "SELECT\n  'slow_query' AS kind,\n  calls,\n  ROUND(mean_exec_time::numeric, 1) AS avg_ms,\n  LEFT(query, 80) AS query_preview\nFROM pg_stat_statements\nWHERE query NOT LIKE '%pg_stat%'\nORDER BY mean_exec_time DESC\nLIMIT 3",
+        "options": {}
       },
       "id": "query-slow",
       "name": "Slow queries (pg_stat_statements)",
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2.5,
-      "position": [460, 560],
-      "executeOnce": true,
-      "continueOnFail": true,
+      "position": [460, 540],
+      "onError": "continueRegularOutput",
       "credentials": {
         "postgres": {
           "id": "pwwVNTLBw43PJgey",
@@ -79,14 +77,23 @@
     },
     {
       "parameters": {
-        "jsCode": "// Defensive cross-node access. n8n throws when referencing a node that\n// hasn't been executed (e.g. upstream Postgres step returned 0 items, or\n// `executeOnce`+`continueOnFail` left it without an output run). Wrap each\n// $() access so the report still goes out with partial data.\nfunction safeFirst(node) {\n  try { return $(node).first()?.json ?? {}; } catch { return {}; }\n}\nfunction safeAll(node) {\n  try { return $(node).all().map(i => i.json); } catch { return []; }\n}\n\nconst dbInfo = safeFirst('DB size & counts');\nconst tables = safeAll('Top 5 tables by size');\nconst slow = safeAll('Slow queries (pg_stat_statements)').filter(r => !r.error);\n\nconst tableLines = tables.map(t =>\n  `  \\`${t.table_name}\\` — ${t.total_size} (${Number(t.row_count).toLocaleString()} rows)`\n).join('\\n') || '  —';\n\nconst slowLines = slow.length\n  ? slow.map(q => `  ${q.avg_ms}ms (×${q.calls}) \\`${q.query_preview}\\``).join('\\n')\n  : '  pg\\_stat\\_statements не встановлено або немає даних';\n\nconst text = [\n  `🗄 *DB: ${dbInfo.db_name ?? 'unknown'}*`,\n  `📦 Розмір: \\`${dbInfo.db_size ?? 'unknown'}\\``,\n  `👥 Користувачів: ${dbInfo.user_count ?? '—'}`,\n  `💳 Транзакцій Mono: ${dbInfo.tx_count != null ? Number(dbInfo.tx_count).toLocaleString() : '—'}`,\n  `🔔 Push-підписок: ${dbInfo.active_push_subs ?? '—'}`,\n  ``,\n  `📋 *Топ таблиці:*`,\n  tableLines,\n  ``,\n  `🐢 *Повільні запити:*`,\n  slowLines,\n].join('\\n');\n\nreturn [{ json: { text } }];"
+        "numberInputs": 3
+      },
+      "id": "merge-results",
+      "name": "Merge query results",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3,
+      "position": [680, 360]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Format DB report from merged $input.all() — no cross-node refs.\n// Each upstream Postgres query tags its rows with `kind`, so we filter\n// by kind here. `onError: continueRegularOutput` on each Postgres means\n// a missing extension or permission error becomes an empty stream, not\n// a workflow-level failure.\nconst items = $input.all().map(i => i.json);\n\nconst dbInfo = items.find(r => r && r.kind === 'db_info') ?? {};\nconst tables = items.filter(r => r && r.kind === 'table');\nconst slow = items.filter(r => r && r.kind === 'slow_query');\n\nconst tableLines = tables.map(t =>\n  `  \\`${t.table_name}\\` — ${t.total_size} (${Number(t.row_count).toLocaleString()} rows)`\n).join('\\n') || '  —';\n\nconst slowLines = slow.length\n  ? slow.map(q => `  ${q.avg_ms}ms (×${q.calls}) \\`${q.query_preview}\\``).join('\\n')\n  : '  pg\\\\_stat\\\\_statements не встановлено або немає даних';\n\nconst text = [\n  `🗄 *DB: ${dbInfo.db_name ?? 'unknown'}*`,\n  `📦 Розмір: \\`${dbInfo.db_size ?? 'unknown'}\\``,\n  `👥 Користувачів: ${dbInfo.user_count ?? '—'}`,\n  `💳 Транзакцій Mono: ${dbInfo.tx_count != null ? Number(dbInfo.tx_count).toLocaleString() : '—'}`,\n  `🔔 Push-підписок: ${dbInfo.active_push_subs ?? '—'}`,\n  ``,\n  `📋 *Топ таблиці:*`,\n  tableLines,\n  ``,\n  `🐢 *Повільні запити:*`,\n  slowLines,\n].join('\\n');\n\nreturn [{ json: { text } }];"
       },
       "id": "format-report",
       "name": "Format DB report",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [680, 380],
-      "executeOnce": true
+      "position": [900, 360]
     },
     {
       "parameters": {
@@ -100,7 +107,7 @@
       "name": "Telegram → #ops",
       "type": "n8n-nodes-base.telegram",
       "typeVersion": 1.2,
-      "position": [900, 380],
+      "position": [1120, 360],
       "credentials": {
         "telegramApi": {
           "id": "ggxeCc1ALZKLuMPV",
@@ -117,6 +124,16 @@
             "node": "DB size & counts",
             "type": "main",
             "index": 0
+          },
+          {
+            "node": "Top 5 tables by size",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Slow queries (pg_stat_statements)",
+            "type": "main",
+            "index": 0
           }
         ]
       ]
@@ -125,7 +142,7 @@
       "main": [
         [
           {
-            "node": "Top 5 tables by size",
+            "node": "Merge query results",
             "type": "main",
             "index": 0
           }
@@ -136,14 +153,25 @@
       "main": [
         [
           {
-            "node": "Slow queries (pg_stat_statements)",
+            "node": "Merge query results",
             "type": "main",
-            "index": 0
+            "index": 1
           }
         ]
       ]
     },
     "Slow queries (pg_stat_statements)": {
+      "main": [
+        [
+          {
+            "node": "Merge query results",
+            "type": "main",
+            "index": 2
+          }
+        ]
+      ]
+    },
+    "Merge query results": {
       "main": [
         [
           {

--- a/ops/n8n-workflows/98-error-handler.json
+++ b/ops/n8n-workflows/98-error-handler.json
@@ -20,6 +20,7 @@
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2.5,
       "position": [420, 300],
+      "onError": "continueRegularOutput",
       "credentials": {
         "postgres": {
           "id": "pwwVNTLBw43PJgey",
@@ -39,56 +40,11 @@
       "name": "Telegram failure alert",
       "type": "n8n-nodes-base.telegram",
       "typeVersion": 1.2,
-      "position": [660, 220],
+      "position": [660, 300],
       "credentials": {
         "telegramApi": {
           "id": "ggxeCc1ALZKLuMPV",
           "name": "Telegram (Sergeant_alert_bot)"
-        }
-      }
-    },
-    {
-      "parameters": {
-        "conditions": {
-          "conditions": [
-            {
-              "id": "has-email-env",
-              "leftValue": "={{ ($env.OPS_ALERT_EMAIL || '').trim() }}",
-              "rightValue": "",
-              "operator": {
-                "type": "string",
-                "operation": "notEquals"
-              }
-            }
-          ]
-        }
-      },
-      "id": "has-email-env",
-      "name": "OPS_ALERT_EMAIL set?",
-      "type": "n8n-nodes-base.if",
-      "typeVersion": 2,
-      "position": [440, 420]
-    },
-    {
-      "parameters": {
-        "method": "POST",
-        "url": "https://api.resend.com/emails",
-        "authentication": "genericCredentialType",
-        "genericAuthType": "httpHeaderAuth",
-        "sendBody": true,
-        "specifyBody": "json",
-        "jsonBody": "={\n  \"from\": \"Sergeant Ops <ops@sergeant.app>\",\n  \"to\": [\"{{ $env.OPS_ALERT_EMAIL }}\"],\n  \"subject\": \"n8n workflow failed: {{ $('Error Trigger').first().json.workflow.name || 'unknown' }}\",\n  \"html\": \"<p>Workflow: <strong>{{ $('Error Trigger').first().json.workflow.name || 'unknown' }}</strong></p><p>Execution: {{ $('Error Trigger').first().json.execution.id || 'unknown' }}</p><p>Error: {{ $('Error Trigger').first().json.execution.error.message || 'unknown error' }}</p>\"\n}",
-        "options": {}
-      },
-      "id": "email-fallback",
-      "name": "Email failure fallback",
-      "type": "n8n-nodes-base.httpRequest",
-      "typeVersion": 4.2,
-      "position": [660, 420],
-      "credentials": {
-        "httpHeaderAuth": {
-          "id": "E765p971FMV4eDbY",
-          "name": "Resend (Bearer)"
         }
       }
     }
@@ -112,25 +68,8 @@
             "node": "Telegram failure alert",
             "type": "main",
             "index": 0
-          },
-          {
-            "node": "OPS_ALERT_EMAIL set?",
-            "type": "main",
-            "index": 0
           }
         ]
-      ]
-    },
-    "OPS_ALERT_EMAIL set?": {
-      "main": [
-        [
-          {
-            "node": "Email failure fallback",
-            "type": "main",
-            "index": 0
-          }
-        ],
-        []
       ]
     }
   },


### PR DESCRIPTION
## What changed

**`ops/n8n-workflows/19-db-health-report.json` — DB Health Report**
- Restructured from a serial chain (`Cron → DB size → Top 5 tables → Slow queries → Format DB`) to a fan-out:
  `Cron → {DB size, Top 5 tables, Slow queries} → Merge (3 inputs) → Format DB → Telegram`.
- Each Postgres query now tags rows with a literal `kind` column (`'db_info' | 'table' | 'slow_query'`) so the Code node filters via `$input.all()` instead of `$('Node').first()/all()` cross-refs.
- Replaced the mix of `executeOnce` / `continueOnFail` flags with `onError: "continueRegularOutput"` on every Postgres node, so a missing extension or 0 rows becomes an empty stream rather than a workflow failure.
- New `Merge query results` node (`n8n-nodes-base.merge` v3, `numberInputs: 3`).

**`ops/n8n-workflows/98-error-handler.json` — Global Error Handler**
- Removed the `OPS_ALERT_EMAIL set?` IF gate and the `Email failure fallback` HTTP node.
- Connection collapses to `Error Trigger → Insert n8n failure event → Telegram failure alert`.
- Added `onError: "continueRegularOutput"` on the dead-letter Postgres insert so a DB hiccup never blocks the Telegram alert.

## Why

Production failures over the last few days surfaced two distinct bugs that the previous defensive code did not actually catch:

- **WF-19** kept failing with `TypeError: Cannot assign to read only property 'name' of object 'Error: Node 'Top 5 tables by size' hasn't been executed'`. The `safeFirst`/`safeAll` `try/catch` wrappers in the Code node weren't enough — n8n's `ExecutionBaseError` constructor re-threw the underlying frozen Error during error reporting, escaping the handler. The only robust fix was to stop using cross-node refs entirely.
- **WF-98** kept failing because the IF gate did not actually block the email branch — `runData` from production execution `40` shows the IF node missing entirely while `Email failure fallback` ran with `to: [""]`, which Resend rejects. Since `OPS_ALERT_EMAIL` and `RESEND_API_KEY` are unset on the n8n service in Railway, the email path has never worked. Telegram was already the working alert path; dropping the dead branch removes the failure source.

Phase 2 (Grafana Cloud + Alloy scraper, dashboards, Mimir rules) was set up in PRs #1281 and #1286 — this PR is the follow-up that addresses the actual failing executions surfaced after that work.

## How to test

Schema validation:
```
pnpm ops:n8n:validate
```

Functional verification (after re-importing both workflows to prod via n8n API):
1. **WF-98 dead-letter path**
   - Trigger any failing workflow (or manually run `Error Trigger` test).
   - Expect: row appended to `n8n_failure_events`, Telegram alert posted to `$env.TELEGRAM_ALERT_CHAT_ID`, execution status `success`.
2. **WF-19 happy path**
   - Manually execute the workflow.
   - Expect: 3 Postgres nodes all green, Merge emits 1+ items, Format DB emits 1 item, Telegram message sent. Run `up{project="sergeant"}` in Grafana Cloud should still report the trigger fire.
3. **WF-19 degraded path**
   - Temporarily deny perms on `pg_stat_statements` (or just rely on the extension already being absent).
   - Expect: `Slow queries` exits successfully via `continueRegularOutput`, report still goes out with `pg_stat_statements не встановлено або немає даних`.

Note: prod n8n is being updated separately via n8n API (`PUT /api/v1/workflows/{id}`) so `active` state is preserved — this PR is just the source-of-truth update.

## Things worth a careful look

- **Merge node mode** — `Merge query results` is `n8n-nodes-base.merge` v3 with only `numberInputs: 3` set. The default mode for Merge v3 is `append` (which is what we want — concatenate all 3 streams). Worth a sanity check that the default in your installed n8n version is still `append`, because if it falls back to `combine`/position the Code node will only see one row.
- **`kind` column** — the SQL queries gained a literal `'…' AS kind` projection. No other node consumes these query outputs, so this should be safe, but if the workflow gets cloned later the extra column is now part of the row shape.
- **Loss of email alerts** — WF-98 no longer has any email branch. If/when `OPS_ALERT_EMAIL` + `RESEND_API_KEY` are configured, this needs to be re-added (preferably via a dedicated Resend-credential-aware node, not env-driven).

---

## Pre-flight (Hard Rule #15)

- [x] Read the `AGENTS.md` Hard Rules that apply to the touched paths.
- [x] Read the matching playbook in `docs/playbooks/` (`docs/playbooks/modify-n8n-workflow.md`).
- [x] Checked freshness headers of docs cited in the change. n/a — no docs cited.

## Docs updated alongside code? (Hard Rule #15)

- [x] N/A — no docs invalidated by this change. Workflow JSONs are the source of truth; no API contract / npm script / design token / deprecation involved.

## How AI-tested this PR

- [x] Manual smoke (which flow?): pulled prod `runData` for failing execs `40` (WF-98) and `39` (WF-19) via n8n API to confirm the failure mode before refactoring.
- [x] Vitest passes: n/a — no JS/TS code touched. Schema check `pnpm ops:n8n:validate` — `Validated 19 n8n workflows.`
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md` (Telegram message text preserved as-is).
- [x] `pnpm dead-code:files` clean (or new files marked `@scaffolded`). n/a — no new TS/JS files.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

Link to Devin session: https://app.devin.ai/sessions/65b7e82a3ae043f89991b135f0ed7841
Requested by: @Skords-01

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored WF-19 (DB Health Report) to run queries in parallel and merge results, eliminating cross-node errors and keeping reports green even when data is missing. Simplified WF-98 (Global Error Handler) by removing the broken email path so Telegram alerts always send.

- **Bug Fixes**
  - WF-19: Fan-out Cron to 3 Postgres queries, then merge via `n8n-nodes-base.merge` (3 inputs); tag rows with `kind` and format via `$input.all()`; set `onError: "continueRegularOutput"` on queries to handle empty/missing `pg_stat_statements`.
  - WF-98: Remove IF gate and email HTTP request; keep flow as Error Trigger → dead-letter insert → Telegram; add `onError: "continueRegularOutput"` to the insert so DB hiccups don’t block alerts.

<sup>Written for commit 6fcc157cb0e3f12d5f3df5944a520648a4671713. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in database health report workflow to gracefully continue processing when data retrieval encounters issues.
  * Enhanced error handler workflow to continue normal execution if database event logging fails, ensuring operational resilience.

* **Chores**
  * Simplified alert notification system by streamlining the alert pathway and removing redundant fallback logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->