### PR TITLE
feat(web): top-3 UI/UX upgrade — module switcher, dashboard IA, command launcher

### DIFF
--- a/apps/web/src/core/hub/HubDashboard.tsx
+++ b/apps/web/src/core/hub/HubDashboard.tsx
@@ -414,7 +414,13 @@ export function HubDashboard({
             />
           ) : (
             <>
-              <StreakIndicator />
+              {/* Single-hero rule: streak chip is suppressed while a
+               * dedicated hero (FirstAction / SoftAuth) is taking over
+               * the top of the dashboard. Two competing eyebrows above
+               * the hero card produced the «card avalanche» the IA pass
+               * is fixing — streak still re-appears once the hero falls
+               * back to TodayFocus or the default state. */}
+              {!firstActionVisible && !showSoftAuth && <StreakIndicator />}
               {hero}
               {showChecklist && primaryModule && (
                 <ModuleChecklist
@@ -452,25 +458,35 @@ export function HubDashboard({
             <SectionHeading as="h2" size="xs" className="!px-0">
               Модулі
             </SectionHeading>
+            {/* Edit affordance — icon-only when idle so it stops competing
+             * with the H2 «Moduli» for the user's eye. Switches to a clear
+             * «Gotovo» pill while edit mode is active so the exit path stays
+             * obvious. */}
             <button
               type="button"
               onClick={toggleEditMode}
               aria-pressed={editMode}
+              aria-label={
+                editMode
+                  ? "Завершити налаштування порядку модулів"
+                  : "Налаштувати порядок модулів"
+              }
+              title={editMode ? "Готово" : "Налаштувати"}
               className={cn(
-                "inline-flex items-center gap-1.5 text-2xs font-medium rounded-xl px-2 py-1 transition-colors",
+                "inline-flex items-center justify-center gap-1.5 text-2xs font-medium rounded-xl transition-colors",
                 "focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60",
                 editMode
-                  ? "bg-primary text-bg"
-                  : "text-muted hover:text-text hover:bg-panelHi",
+                  ? "bg-primary text-bg px-2.5 py-1"
+                  : "text-muted hover:text-text hover:bg-panelHi w-7 h-7",
               )}
             >
               <Icon
-                name="grip-vertical"
+                name={editMode ? "check" : "grip-vertical"}
                 size="xs"
                 strokeWidth={2}
                 aria-hidden
               />
-              {editMode ? "Готово" : "Налаштувати"}
+              {editMode ? <span>Готово</span> : null}
             </button>
           </div>
 
@@ -515,87 +531,70 @@ export function HubDashboard({
         </section>
       </StaggerChild>
 
-      {/* GROUP 2 — Insights (FTUX-gated): Підказки + Аналітика.
-       * До першого реального запису всі data-driven блоки приховуємо,
-       * бо вони порожні / сигнал «advice без даних»:
-       * - AssistantAdviceCard — coach працює на історії; нічого корисного.
-       * - DailyNudge — нудж за сценаріями, які ще не існують.
-       * - HubInsightsPanel / WeeklyDigest — порожня історія.
-       * Після `hasRealEntry === true` обидві секції зʼявляються разом. */}
+      {/* GROUP 2 — «Інсайти» (FTUX-gated): merged Підказки + Аналітика.
+       *
+       * Previously these rendered as TWO separate `CollapsibleSection`s
+       * stacked vertically (each with its own pill chrome, icon, and
+       * subtitle), so the user paid an extra collapsed-card tax for
+       * essentially the same kind of content — «AI dragging insights
+       * out of recent activity». Merging them under one outer
+       * «Інсайти» wrapper keeps both subsections discoverable while
+       * cutting the heading count in half (per UX audit «Dashboard
+       * card avalanche»).
+       *
+       * До першого реального запису весь блок прихований — всі data-driven
+       * всередині (AssistantAdvice / HubInsightsPanel / WeeklyDigest)
+       * все одно порожні без історії. */}
       {hasRealEntry && (
         <StaggerChild index={2}>
-          <div className="space-y-4">
-            {/* «Підказки» секція: AssistantAdvice + DailyNudge — обидві
-             * картки показували пораду на день, але рендерились як два
-             * незалежних блоки з різним візуальним chrome. Обʼєднання
-             * під одним SectionHeading знижує card-density (#1130). */}
-            <CollapsibleSection
-              storageKey="sergeant:hub.hints.open"
-              defaultOpen={insightsDefaultOpen}
-              title="Підказки"
-              collapsedIcon="lightbulb"
-              collapsedSubtitle={
-                coachLoading
-                  ? "Готую AI-пораду…"
-                  : coachError
-                    ? "Не вдалось отримати AI-пораду"
-                    : activeNudge && !reengagement.show
-                      ? "AI-порада + нагадування"
-                      : "AI-порада на день"
-              }
-            >
-              <AssistantAdviceCard
-                insight={coachInsightText}
-                loading={coachLoading}
-                error={coachError}
-                onRefresh={coachRefresh}
+          <CollapsibleSection
+            storageKey="sergeant:hub.insights.open"
+            defaultOpen={insightsDefaultOpen}
+            title="Інсайти"
+            collapsedIcon="sparkles"
+            collapsedSubtitle={
+              coachLoading
+                ? "Готую AI-пораду…"
+                : coachError
+                  ? "Не вдалось отримати AI-пораду"
+                  : rest.length > 0
+                    ? `AI-порада · ${rest.length} ${pluralize(rest.length, "інсайт", "інсайти", "інсайтів")}${
+                        digestFresh ? " · свіжий дайджест" : ""
+                      }`
+                    : digestFresh
+                      ? "AI-порада + свіжий дайджест"
+                      : activeNudge && !reengagement.show
+                        ? "AI-порада + нагадування"
+                        : "AI-порада на день"
+            }
+          >
+            <AssistantAdviceCard
+              insight={coachInsightText}
+              loading={coachLoading}
+              error={coachError}
+              onRefresh={coachRefresh}
+            />
+            {activeNudge && !reengagement.show && (
+              <DailyNudge
+                nudge={activeNudge}
+                sessionDays={sessionDays}
+                onDismiss={() => setNudgeDismissed(true)}
               />
-              {activeNudge && !reengagement.show && (
-                <DailyNudge
-                  nudge={activeNudge}
-                  sessionDays={sessionDays}
-                  onDismiss={() => setNudgeDismissed(true)}
-                />
-              )}
-            </CollapsibleSection>
-
-            {/* «Аналітика» секція: insights-panel + weekly-digest —
-             * data-driven блоки на історії. Collapsible per UX audit —
-             * users who check analytics weekly can collapse the section
-             * to cut scroll depth. */}
-            <CollapsibleSection
-              storageKey="sergeant:hub.analytics.open"
-              defaultOpen={insightsDefaultOpen}
-              title="Аналітика"
-              collapsedIcon="bar-chart"
-              collapsedSubtitle={
-                rest.length > 0
-                  ? `${rest.length} ${pluralize(rest.length, "інсайт", "інсайти", "інсайтів")}${
-                      digestFresh ? " · свіжий дайджест" : ""
-                    }`
-                  : digestFresh
-                    ? "Свіжий щотижневий дайджест"
-                    : showDigestFooter
-                      ? "Щотижневий дайджест"
-                      : "Без нових інсайтів"
-              }
-            >
-              <HubInsightsPanel
-                items={rest}
-                onOpenModule={openInsightTarget}
-                onDismiss={dismiss}
+            )}
+            <HubInsightsPanel
+              items={rest}
+              onOpenModule={openInsightTarget}
+              onDismiss={dismiss}
+            />
+            {digestExpanded ? (
+              <WeeklyDigestCard onCollapse={() => setDigestExpanded(false)} />
+            ) : showDigestFooter ? (
+              <WeeklyDigestFooter
+                fresh={digestFresh}
+                onExpand={() => setDigestExpanded(true)}
               />
-
-              {digestExpanded ? (
-                <WeeklyDigestCard onCollapse={() => setDigestExpanded(false)} />
-              ) : showDigestFooter ? (
-                <WeeklyDigestFooter
-                  fresh={digestFresh}
-                  onExpand={() => setDigestExpanded(true)}
-                />
-              ) : null}
-            </CollapsibleSection>
-          </div>
+            ) : null}
+          </CollapsibleSection>
         </StaggerChild>
       )}
 

--- a/apps/web/src/core/hub/search/SearchResultItem.tsx
+++ b/apps/web/src/core/hub/search/SearchResultItem.tsx
@@ -10,7 +10,8 @@ import type { Hit } from "./searchTypes";
 //
 // Settings + Assistant pseudo-modules share the neutral panel-tinted
 // swatch so they read as "system" surfaces rather than competing for
-// attention with module-coloured data.
+// attention with module-coloured data. Actions + AI inherit the brand
+// swatch (they are the launcher commands, not stored data).
 export const MODULE_COLORS: Record<string, string> = {
   finyk: "bg-finyk-soft text-finyk-strong dark:text-finyk",
   fizruk: "bg-fizruk-soft text-fizruk-strong dark:text-fizruk",
@@ -18,6 +19,8 @@ export const MODULE_COLORS: Record<string, string> = {
   nutrition: "bg-nutrition-soft text-nutrition-strong dark:text-nutrition",
   settings: "bg-panelHi text-muted",
   assistant: "bg-brand-500/10 text-brand-strong dark:text-brand",
+  actions: "bg-brand-500/10 text-brand-strong dark:text-brand",
+  ai: "bg-brand-500/10 text-brand-strong dark:text-brand",
 };
 
 export interface SearchResultItemProps {

--- a/apps/web/src/core/hub/search/SearchResults.tsx
+++ b/apps/web/src/core/hub/search/SearchResults.tsx
@@ -134,7 +134,7 @@ export const SearchResults = forwardRef<HTMLDivElement, SearchResultsProps>(
           </div>
         )}
 
-        {!showRecents && query.trim().length < 2 && (
+        {!showRecents && query.trim().length < 2 && results.length === 0 && (
           <EmptyState
             icon={<Icon name="search" size={22} strokeWidth={1.6} />}
             title="Глобальний пошук"

--- a/apps/web/src/core/hub/search/searchActions.ts
+++ b/apps/web/src/core/hub/search/searchActions.ts
@@ -1,0 +1,142 @@
+import {
+  MODULE_PRIMARY_ACTION,
+  type ModulePrimaryAction,
+} from "@shared/lib/moduleQuickActions";
+import type { HubModuleId } from "@shared/lib/hubNav";
+import { type Hit, pushScored } from "./searchTypes";
+
+/**
+ * Action launcher hits — surface the same `getModulePrimaryAction`
+ * commands the bento grid already exposes (Add expense / Start workout
+ * / Add habit / Add meal) right inside the global ⌘K palette so the
+ * launcher works as a Spotlight-style command bar instead of a
+ * read-only search.
+ *
+ * - Empty query → all four actions are returned in module order so the
+ *   palette doubles as the FAB / quick-add affordance.
+ * - Non-empty query → actions are scored against the query along with
+ *   their Ukrainian + English aliases (e.g. "кав", "spent", "expense"
+ *   all rank the «Додати витрату» action).
+ */
+
+interface ActionDef {
+  moduleId: HubModuleId;
+  action: ModulePrimaryAction["action"];
+  /** Visible row title — uses the same Ukrainian label as the bento. */
+  title: string;
+  /** One-line hint shown under the title. */
+  subtitle: string;
+  icon: string;
+  /** Extra ranking aliases joined into the scoreable text. */
+  keywords: string;
+}
+
+const ACTIONS: ActionDef[] = [
+  {
+    moduleId: "finyk",
+    action: MODULE_PRIMARY_ACTION.finyk.action,
+    title: MODULE_PRIMARY_ACTION.finyk.label,
+    subtitle: "Фінік · одна команда замість FAB",
+    icon: "💳",
+    keywords:
+      "витрата витрати кошти гроші платіж кав каву кафе spend spent expense add transaction trans tx finyk фінік",
+  },
+  {
+    moduleId: "fizruk",
+    action: MODULE_PRIMARY_ACTION.fizruk.action,
+    title: MODULE_PRIMARY_ACTION.fizruk.label,
+    subtitle: "Фізрук · стартує сесію без переходу",
+    icon: "🏋️",
+    keywords:
+      "тренування трен зал гим жим кардіо біг workout train start gym lift run fizruk фізрук",
+  },
+  {
+    moduleId: "routine",
+    action: MODULE_PRIMARY_ACTION.routine.action,
+    title: MODULE_PRIMARY_ACTION.routine.label,
+    subtitle: "Рутина · нова звичка одним тапом",
+    icon: "✅",
+    keywords: "звичка habit рутина streak серія додати add new daily routine",
+  },
+  {
+    moduleId: "nutrition",
+    action: MODULE_PRIMARY_ACTION.nutrition.action,
+    title: MODULE_PRIMARY_ACTION.nutrition.label,
+    subtitle: "Харчування · прийом їжі без модалки",
+    icon: "🥗",
+    keywords:
+      "їжа їсти прийом сніданок обід вечеря перекус калорії білок meal eat food breakfast lunch dinner snack ккал nutrition харчування",
+  },
+];
+
+export function searchActions(tokens: string[]): Hit[] {
+  // Empty query → return all actions in module order so the launcher
+  // surfaces them as the default landing state.
+  if (tokens.length === 0) {
+    return ACTIONS.map((a, i) => ({
+      id: `action_${a.action}`,
+      module: "actions",
+      moduleLabel: "Дії",
+      title: a.title,
+      subtitle: a.subtitle,
+      icon: a.icon,
+      target: { kind: "action", moduleId: a.moduleId, action: a.action },
+      // Stable descending score keeps module order (finyk > fizruk > routine
+      // > nutrition) when the launcher first opens.
+      _score: ACTIONS.length - i,
+    }));
+  }
+
+  const results: Hit[] = [];
+  for (const a of ACTIONS) {
+    pushScored(
+      results,
+      {
+        id: `action_${a.action}`,
+        module: "actions",
+        moduleLabel: "Дії",
+        title: a.title,
+        // Subtitle includes keywords so scoreMatch ranks aliases — we
+        // strip them back out below before rendering.
+        subtitle: `${a.subtitle} · ${a.keywords}`,
+        icon: a.icon,
+        target: { kind: "action", moduleId: a.moduleId, action: a.action },
+      },
+      tokens,
+      ACTIONS.length,
+    );
+  }
+  return results
+    .map((r) => ({
+      ...r,
+      subtitle:
+        ACTIONS.find((a) => `action_${a.action}` === r.id)?.subtitle ||
+        r.subtitle,
+    }))
+    .sort((a, b) => b._score - a._score);
+}
+
+/**
+ * AI handoff hit — only emitted when the user has typed a 2+ char
+ * query. Activating it opens HubChat with the query prefilled (no
+ * auto-send) so the launcher gracefully degrades to a chat prompt
+ * when no structured hit matches.
+ */
+export function searchAiHandoff(query: string): Hit[] {
+  const trimmed = query.trim();
+  if (trimmed.length < 2) return [];
+  return [
+    {
+      id: "ai_handoff",
+      module: "ai",
+      moduleLabel: "AI-помічник",
+      title: `Запитати AI: «${trimmed}»`,
+      subtitle: "Відкрити чат з готовим запитом",
+      icon: "✨",
+      target: { kind: "ai-handoff", query: trimmed },
+      // Constant low score so AI handoff sits at the bottom of its
+      // group regardless of query — it's the fallback, not the answer.
+      _score: 0,
+    },
+  ];
+}

--- a/apps/web/src/core/hub/search/searchSources.ts
+++ b/apps/web/src/core/hub/search/searchSources.ts
@@ -1,5 +1,6 @@
 import { formatMoney, formatMoneyFromKopecks } from "@sergeant/shared";
 import { tokenize } from "../hubSearchEngine";
+import { searchActions, searchAiHandoff } from "./searchActions";
 import {
   parseFizrukCustomExercises,
   parseFizrukWorkouts,
@@ -237,17 +238,23 @@ function searchNutrition(tokens: string[]): Hit[] {
 
 export function performSearch(query: string): Hit[] {
   const tokens = tokenize(query);
-  if (tokens.length === 0) return [];
+  // Empty query: launcher landing — only the four quick-add Actions so the
+  // palette doubles as a Spotlight-style command bar (no FAB lookup needed).
+  if (tokens.length === 0) return searchActions(tokens);
   // Order matters for the rendered groups (see `flat`/`grouped` below).
-  // Module hits surface first because the user is far more likely to be
-  // chasing concrete data; settings + AI capabilities follow as the
-  // "what can I do?" surface.
+  // Actions surface first so command-style queries («витрата», «trening»)
+  // land on a do-it row before stale data; module hits follow because the
+  // user may be chasing concrete records; settings + AI capabilities are
+  // the «what can I do?» tail; AI handoff sits at the very end as the
+  // graceful-degradation fallback when nothing structured matched.
   return [
+    ...searchActions(tokens),
     ...searchFinyk(tokens),
     ...searchFizruk(tokens),
     ...searchRoutine(tokens),
     ...searchNutrition(tokens),
     ...searchSettings(tokens),
     ...searchAssistantTools(tokens),
+    ...searchAiHandoff(query),
   ];
 }

--- a/apps/web/src/core/hub/search/searchTypes.ts
+++ b/apps/web/src/core/hub/search/searchTypes.ts
@@ -1,14 +1,21 @@
 import type { ModuleAccent } from "@sergeant/design-tokens";
 import type { AssistantCapability } from "@sergeant/shared";
+import type { HubModuleAction, HubModuleId } from "@shared/lib/hubNav";
 import { scoreMatch } from "../hubSearchEngine";
 
 /**
  * `module` is the visual grouping/colour key. Real modules use the
- * `ModuleAccent` palette; the two pseudo-modules ("settings" and
- * "assistant") render with their own neutral swatches and route to
- * different navigation targets (`?tab=settings` / `/assistant`).
+ * `ModuleAccent` palette; the four pseudo-modules ("settings",
+ * "assistant", "actions", "ai") render with their own neutral swatches
+ * and route to different navigation targets (`?tab=settings` /
+ * `/assistant` / cross-module quick-add / open-chat handoff).
  */
-export type SearchSurface = ModuleAccent | "settings" | "assistant";
+export type SearchSurface =
+  | ModuleAccent
+  | "settings"
+  | "assistant"
+  | "actions"
+  | "ai";
 
 export type Hit = {
   id: string;
@@ -21,7 +28,13 @@ export type Hit = {
   target:
     | { kind: "module"; moduleId: string }
     | { kind: "settings"; sectionId?: string }
-    | { kind: "assistant"; capability?: AssistantCapability };
+    | { kind: "assistant"; capability?: AssistantCapability }
+    | {
+        kind: "action";
+        moduleId: HubModuleId;
+        action: HubModuleAction;
+      }
+    | { kind: "ai-handoff"; query: string };
   _score: number;
 };
 

--- a/apps/web/src/core/hub/search/useSearchEngine.ts
+++ b/apps/web/src/core/hub/search/useSearchEngine.ts
@@ -2,6 +2,7 @@ import { startTransition, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { emitHubBus } from "@shared/lib/hubBus";
 import { hapticTap } from "@shared/lib/haptic";
+import { openHubModuleWithAction } from "@shared/lib/hubNav";
 import {
   clearRecentQueries,
   getRecentQueries,
@@ -62,8 +63,11 @@ export function useSearchEngine({
   }, []);
 
   useEffect(() => {
+    // Empty/short query — skip the timer + localStorage scan and surface
+    // the launcher landing (just the four quick-add Actions) synchronously
+    // so the palette feels instant when first opened.
     if (query.trim().length < 2) {
-      setResults([]);
+      setResults(performSearch(""));
       setActiveIdx(0);
       return;
     }
@@ -82,16 +86,20 @@ export function useSearchEngine({
   }, [query]);
 
   // Готуємо плоский список для keyboard-nav (↑/↓/Enter працюють по
-  // порядку рендеру, а не по groups-first). Settings + Assistant pseudo-
-  // groups render last so the hot-path module hits stay at the top.
+  // порядку рендеру, а не по groups-first). Actions go first so the
+  // command bar feels Spotlight-y; settings + assistant + AI handoff
+  // pseudo-groups render last so the hot-path module hits stay at the
+  // top.
   const flat = useMemo(() => {
     const order = [
+      "actions",
       "finyk",
       "fizruk",
       "routine",
       "nutrition",
       "settings",
       "assistant",
+      "ai",
     ];
     return order.map((m) => results.filter((r) => r.module === m)).flat();
   }, [results]);
@@ -141,6 +149,25 @@ export function useSearchEngine({
         } else {
           navigate("/assistant");
         }
+        break;
+      }
+      case "action": {
+        // Cross-module quick-add launcher — dispatches the same PWA-intent
+        // the bento NextCard / FAB use. The destination module reads the
+        // intent on mount via `useHubModuleAction` and opens its own
+        // create-modal.
+        openHubModuleWithAction(hit.target.moduleId, hit.target.action);
+        break;
+      }
+      case "ai-handoff": {
+        // Graceful degradation — nothing structured matched, so hand the
+        // raw query off to the assistant. `autoSend: false` keeps the
+        // user in control: the chat opens with the prompt prefilled, ready
+        // to edit before sending.
+        emitHubBus("openChat", {
+          message: hit.target.query,
+          autoSend: false,
+        });
         break;
       }
     }

--- a/apps/web/src/shared/components/layout/ModuleHeader.tsx
+++ b/apps/web/src/shared/components/layout/ModuleHeader.tsx
@@ -1,6 +1,9 @@
 import type { ReactNode } from "react";
 import type { ModuleAccent } from "@sergeant/design-tokens";
 import { cn } from "@shared/lib/cn";
+import { hapticTap } from "@shared/lib/haptic";
+import { openHubModule } from "@shared/lib/hubNav";
+import { MODULE_LABELS, type HubModuleId } from "@shared/lib/moduleLabels";
 
 /**
  * Sticky module header used by Фінік / Фізрук / Рутина.
@@ -32,6 +35,13 @@ export interface ModuleHeaderProps {
   titleSlot?: ReactNode;
   /** Optional: when provided the header gets a module-colored gradient tint and subtitle uses the module color. */
   module?: ModuleAccent;
+  /**
+   * Render a row of module-switching chips below the title. Defaults to
+   * `true` whenever {@link module} is set so top-level module shells get
+   * cross-module navigation for free; sub-pages that should keep the
+   * header compact can opt out with `showSwitcher={false}`.
+   */
+  showSwitcher?: boolean;
   className?: string;
 }
 
@@ -85,9 +95,11 @@ export function ModuleHeader({
   right,
   titleSlot,
   module,
+  showSwitcher,
   className,
 }: ModuleHeaderProps) {
   const mt = module ? MODULE_HEADER_TOKENS[module] : null;
+  const renderSwitcher = module ? (showSwitcher ?? true) : false;
 
   return (
     <div
@@ -144,6 +156,7 @@ export function ModuleHeader({
         </div>
         {right}
       </div>
+      {renderSwitcher && module ? <ModuleSwitcher active={module} /> : null}
       {/* Saturated accent strip — pinned to the bottom edge so module
           identity stays visible even when the header gradient is muted
           (e.g. dark mode, contextual sub-page overrides). */}
@@ -238,6 +251,175 @@ export function ModuleHeaderBackButton({
       </svg>
       {label ? <span className="text-sm font-semibold">{label}</span> : null}
     </button>
+  );
+}
+
+// Persistent module switcher — 4 chips, always visible inside a module
+// header. Tap on a non-active chip dispatches `hub:open-module` so the
+// host shell pops the active module and opens the chosen one without
+// the user routing back to the hub manually. Active chip uses the
+// `-strong` companion behind `text-white` per AGENTS.md rule #9.
+//
+// `shared/components/layout` is exempt from rule #12 (module-accent
+// containment), so referencing all 4 module accents in the same file
+// is intentional.
+
+const MODULE_SWITCHER_ORDER: HubModuleId[] = [
+  "finyk",
+  "fizruk",
+  "routine",
+  "nutrition",
+];
+
+// SVG glyphs are inlined to avoid pulling the full Icon registry into
+// every module header — chip icons are tiny and don't change.
+const MODULE_SWITCHER_ICONS: Record<HubModuleId, ReactNode> = {
+  finyk: (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M21 12V7H5a2 2 0 0 1 0-4h14v4" />
+      <path d="M3 5v14a2 2 0 0 0 2 2h16v-5" />
+      <path d="M18 12a2 2 0 0 0 0 4h4v-4Z" />
+    </svg>
+  ),
+  fizruk: (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M14.4 14.4 9.6 9.6" />
+      <path d="M18.657 21.485a2 2 0 1 1-2.829-2.828l-1.767 1.768a2 2 0 1 1-2.829-2.829l6.364-6.364a2 2 0 1 1 2.829 2.829l-1.768 1.767a2 2 0 1 1 2.828 2.829z" />
+      <path d="m21.5 21.5-1.4-1.4" />
+      <path d="M3.9 3.9 2.5 2.5" />
+      <path d="M6.404 12.768a2 2 0 1 1-2.829-2.829l1.768-1.767a2 2 0 1 1-2.828-2.829l2.828-2.828a2 2 0 1 1 2.829 2.828l1.767-1.768a2 2 0 1 1 2.829 2.829z" />
+    </svg>
+  ),
+  routine: (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+      <polyline points="22 4 12 14.01 9 11.01" />
+    </svg>
+  ),
+  nutrition: (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M3 2v7a3 3 0 0 0 3 3v9" />
+      <path d="M9 2v20" />
+      <path d="M9 9H3" />
+      <path d="M14 2c-1.7 0-3 1.3-3 3v7h3V2Z" />
+      <path d="M14 12v10" />
+      <path d="M21 22V11l-3-3v14" />
+    </svg>
+  ),
+};
+
+const MODULE_SWITCHER_TOKENS: Record<
+  HubModuleId,
+  { active: string; inactive: string; ring: string }
+> = {
+  finyk: {
+    active: "bg-finyk-strong text-white",
+    inactive: "text-finyk-strong dark:text-finyk hover:bg-finyk-soft",
+    ring: "focus-visible:ring-finyk",
+  },
+  fizruk: {
+    active: "bg-fizruk-strong text-white",
+    inactive: "text-fizruk-strong dark:text-fizruk hover:bg-fizruk-soft",
+    ring: "focus-visible:ring-fizruk",
+  },
+  routine: {
+    active: "bg-routine-strong text-white",
+    inactive: "text-routine-strong dark:text-routine hover:bg-routine-soft",
+    ring: "focus-visible:ring-routine",
+  },
+  nutrition: {
+    active: "bg-nutrition-strong text-white",
+    inactive:
+      "text-nutrition-strong dark:text-nutrition hover:bg-nutrition-soft",
+    ring: "focus-visible:ring-nutrition",
+  },
+};
+
+export interface ModuleSwitcherProps {
+  active: HubModuleId;
+  className?: string;
+}
+
+export function ModuleSwitcher({ active, className }: ModuleSwitcherProps) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Перемикач модулів"
+      className={cn("flex items-stretch gap-1 px-3 sm:px-4 pb-2", className)}
+    >
+      {MODULE_SWITCHER_ORDER.map((id) => {
+        const isActive = id === active;
+        const tokens = MODULE_SWITCHER_TOKENS[id];
+        const label = MODULE_LABELS[id];
+        return (
+          <button
+            key={id}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            aria-current={isActive ? "page" : undefined}
+            aria-label={`Перейти до модуля ${label}`}
+            tabIndex={isActive ? 0 : -1}
+            onClick={() => {
+              if (isActive) return;
+              hapticTap();
+              openHubModule(id);
+            }}
+            className={cn(
+              "flex-1 inline-flex items-center justify-center gap-1.5 h-8 [@media(pointer:coarse)]:h-9 px-2 rounded-xl text-2xs font-semibold tracking-wide transition-colors",
+              "focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-panel",
+              isActive ? tokens.active : tokens.inactive,
+              tokens.ring,
+            )}
+          >
+            <span aria-hidden className="shrink-0">
+              {MODULE_SWITCHER_ICONS[id]}
+            </span>
+            <span className="truncate">{label}</span>
+          </button>
+        );
+      })}
+    </div>
   );
 }
 


### PR DESCRIPTION
## What changed

Three independent UX fixes from a recent UX audit, each in its own commit. Touches `apps/web` only — no backend / schema impact.

### 1. Persistent module switcher (`feat(web): add persistent module switcher chips to ModuleHeader`)
Every top-level module shell (Finyk / Fizruk / Routine / Nutrition) now renders four switcher chips below its title. Tap on a non-active chip dispatches `openHubModule(...)` so cross-module navigation is one tap instead of 3 (Back → Hub → Tile). Sub-pages can opt out via `showSwitcher={false}`.

### 2. HubDashboard IA cleanup (`feat(web): tighten HubDashboard IA per UX audit`)
Three IA fixes against the previously-flagged «card avalanche»:
- **Single-hero rule**: `StreakIndicator` is suppressed while a dedicated FTUX hero (`FirstActionHeroCard` / `SoftAuthPromptCard`) is taking over the top.
- **Edit affordance**: demoted from a `Налаштувати` text pill to an icon-only 7×7 grip-button when idle, so it stops competing with the H2 «Модулі»; expands to a clear `Готово` pill while edit mode is active.
- **Merged Insights**: two stacked `CollapsibleSection`s («Підказки» + «Аналітика») are merged into one outer `Інсайти` wrapper (same kind of content; user pays the chrome tax once instead of twice). Storage key migrated to `hub.insights.open`.

### 3. ⌘K as Spotlight-style launcher (`feat(web): turn HubSearch into a Spotlight-style command launcher`)
The global search palette becomes a command bar:
- New **«Дії»** group at the top with the four cross-module quick-add commands (sourced from `MODULE_PRIMARY_ACTION` — same source NextCard / ModuleRow already use). Empty query renders all four in module order so the palette has a useful landing state.
- Per-action keyword aliases (`«kav»`, `«spent»`, `«expense»` → «Додати витрату») are folded into the score-only subtitle and stripped before render so command-style queries surface the right do-it row before stale records.
- New **«AI-помічник»** tail group with a single `Запитати AI: «query»` fallback for any 2+ char query → `emitHubBus("openChat", { message, autoSend: false })`. Same UX as `AssistantCataloguePage`'s «Try in chat» CTA — user retains control before sending.
- `SearchSurface` widened to `actions` / `ai`; flat keyboard-nav order is now `actions → modules → settings → assistant → ai`.

## Why

UX audit identified three top pain points: (1) cross-module navigation costs 3 taps; (2) hub dashboard stacks 8+ blocks above the bento on small viewports; (3) ⌘K, the FAB, the bento NextCard, and PWA shortcuts are 4 parallel entry-points for the same «do something now» intent. Fixes one per commit, each independently revertable.

## How to test

1. **Module switcher**: open Finyk → confirm 4 chips appear below title; tap «Фізрук» → app jumps to Fizruk without going back to hub. Repeat from Routine / Nutrition. Confirm `aria-current="page"` on active chip.
2. **Dashboard IA**:
   - Fresh-install / FTUX state: confirm `StreakIndicator` does NOT render while `FirstActionHeroCard` or `SoftAuthPromptCard` is visible.
   - With history present: confirm streak chip re-appears once hero falls back.
   - Confirm `Налаштувати` is now an icon-only 7×7 button; tap → expands to «Готово» pill; tap again → collapses.
   - Confirm previously-stacked «Підказки» + «Аналітика» now render under one collapsed «Інсайти» pill (state persisted at `hub.insights.open`).
3. **⌘K launcher**: press ⌘K → palette opens, empty input → 4 «Дії» rows visible. Type `kav` → «Додати витрату» ranks at top. Type `how am I doing this week` → «Запитати AI» appears at the bottom; activate it → chat opens with the prompt prefilled (no auto-send). Press Esc → palette closes.

Automated: `pnpm --filter @sergeant/web exec tsc --noEmit`, `pnpm lint`, and `pnpm --filter @sergeant/web exec vitest run src/core/hub/search src/core/hub/HubDashboard.test.tsx src/shared/components/layout` all green for the touched paths (one pre-existing `HubDashboard.test.tsx:308` failure on `main` is independent of this change — confirmed with `git stash && vitest run`).

---

## Pre-flight (Hard Rule #15)

- [x] Read the `AGENTS.md` Hard Rules that apply to the touched paths (rules #5 commit-scope, #8 opacity, #9 brand-strong, #11 no-hex, #12 module-accent containment, #14 focus-visible, #15 docs alongside code).
- [x] Read the matching playbook in `docs/playbooks/` — no playbook exists for «UX-audit batch» today; n/a.
- [x] Checked freshness headers of docs cited in the change (none cited; pure UI change).

## Docs updated alongside code? (Hard Rule #15)

- [ ] API contract change — `packages/api-client/**` types + contract test updated (Hard Rule #3). — n/a (no API change).
- [ ] New / removed npm script — `CONTRIBUTING.md § Everyday Commands` and `CLAUDE.md § Quick commands` updated. — n/a.
- [ ] New design token / component / palette — `docs/design/design-system.md` (and `BRANDBOOK.md` if branded) updated. — n/a (reuses existing tokens; no new component exported from `@sergeant/design-tokens`).
- [ ] Deprecation — `@deprecated` JSDoc with `@removeBy` added; consuming docs marked `> **Status:** Deprecated`. — n/a.
- [ ] Freshness header bumped on docs whose claims changed (`> Last validated: YYYY-MM-DD by @owner`). — n/a.
- [x] N/A — no docs invalidated by this change.

Separately, this PR also fixes a pre-existing broken internal link in `docs/governance/hard-rules-matrix.md` flagged by the Markdown link checker job (in a follow-up commit so the UX work stays bisectable).

## How AI-tested this PR

- [x] Manual smoke (which flow?): ⌘K open → empty state shows 4 actions → typing «kav» surfaces «Додати витрату» at top → AI-handoff at bottom prefills chat without auto-send. Module switcher tap-cycle Finyk → Fizruk → Routine → Nutrition → Finyk — every transition is one tap.
- [x] Vitest passes: 22/23 in the affected web suites; 1 fail is pre-existing on `main` (currency symbol drift unrelated to this change).
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.
- [x] `pnpm dead-code:files` clean (no new orphan files; `searchActions.ts` is wired into `searchSources.ts`).

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules