### PR TITLE
fix(agents): flip WF-16 PostHog metrics active=true in source-of-truth

### DIFF
--- a/ops/n8n-workflows/16-posthog-daily-metrics.json
+++ b/ops/n8n-workflows/16-posthog-daily-metrics.json
@@ -134,5 +134,5 @@
       "name": "metrics"
     }
   ],
-  "active": false
+  "active": true
 }


### PR DESCRIPTION
## Summary

PR #1300 fixed the WF-16 (PostHog Daily Metrics, 09:00 Kyiv → Telegram #metrics, `gFd41GXrEFdc2hQo`) schedule trigger shape, EU host default, modern HogQL `/query/` endpoint, and graceful Code-node fallback — but left `"active": false` in the JSON source-of-truth. WF-16 has now been activated on live n8n (`POST /api/v1/workflows/gFd41GXrEFdc2hQo/activate` → `active=True`); this commit aligns git with live state.

Diff is a single character: `"active": false → true` at the bottom of `ops/n8n-workflows/16-posthog-daily-metrics.json`. No node, parameter, or connection changes.

## Governing Skill

- Primary skill: `ops/n8n-workflows/AGENTS.md` (n8n source-of-truth conventions)
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: ad-hoc n8n source-of-truth follow-up (no curated playbook covers the "PR #1300 missed flipping `active`" case)
- Why this playbook: surgical follow-up to PR #1300, no broader process change
- If no playbook matched, why: single-flag drift fix; doesn't warrant a new playbook

## Verification

```bash
pnpm prettier --check ops/n8n-workflows/16-posthog-daily-metrics.json
node -e "console.log(require('./ops/n8n-workflows/16-posthog-daily-metrics.json').active)"  # → true
curl -sS "https://n8n-production-09ac.up.railway.app/api/v1/workflows/gFd41GXrEFdc2hQo" \
  -H "X-N8N-API-KEY: $n8n_API" | jq '.active'
# → true
```

Cron next fire: 09:00 Europe/Kyiv. Without `POSTHOG_*` env vars on Railway the workflow takes the graceful error path and posts a `⚠️ PostHog API error` Telegram message to `#metrics` instead of crashing — `errorWorkflow=iC82EFJzqBny9kxI` (WF-98) catches anything else.

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a — single `active` flag flip; no doc invalidation.

## Risk and Rollout

- User-visible risk: extremely low; once cron fires, a Telegram message lands in `#metrics` (with config-warning text until `POSTHOG_*` env vars are set on Railway).
- Rollout / deploy order: merge → live n8n is already updated; no additional deploy.
- Backout plan: `POST /api/v1/workflows/gFd41GXrEFdc2hQo/deactivate` and revert the JSON.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

Outstanding manual ops on n8n Railway (informational, not a blocker for this PR):

- `POSTHOG_PROJECT_ID`
- `POSTHOG_API_KEY` (Personal API key, `phx_…`)
- `POSTHOG_HOST` (only if not EU; otherwise defaults to `https://eu.i.posthog.com`)

Until those are set, the workflow still runs daily and posts an actionable alert to `#metrics` so the gap is visible.
