### PR TITLE
feat(web): wire dashboard density + move Finyk «Оновити» to settings

### DIFF
--- a/apps/web/src/core/hub/HubDashboard.tsx
+++ b/apps/web/src/core/hub/HubDashboard.tsx
@@ -3,16 +3,22 @@ import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { CollapsibleSection } from "@shared/components/ui/CollapsibleSection";
 import { Icon } from "@shared/components/ui/Icon";
 import { cn } from "@shared/lib/cn";
+import { safeReadStringLS } from "@shared/lib/storage";
 import {
+  DASHBOARD_DENSITY_EVENT,
+  DEFAULT_DASHBOARD_DENSITY,
+  STORAGE_KEYS,
   countRealEntries,
   getActiveModules,
   getActiveNudge,
   getHideInactiveModules,
   getVibePicks,
   isActiveModule,
+  normalizeDashboardDensity,
   recordLastActiveDate,
   setHideInactiveModules,
   shouldShowReengagement,
+  type DashboardDensity,
   type User,
 } from "@sergeant/shared";
 import { openHubModule, openHubModuleWithAction } from "@shared/lib/hubNav";
@@ -82,6 +88,60 @@ export {
   resetDashboardOrder,
 } from "./dashboard/dashboardStore";
 
+/**
+ * Tailwind class lookup for dashboard density. Static literals (not template
+ * strings) so the JIT picks them up at build time.
+ *
+ * Spacing comes from `DASHBOARD_DENSITY_SPACING` in `@sergeant/shared`; the
+ * values are mirrored here (compact: 2/3, comfortable: 3/4, spacious: 4/5)
+ * because Tailwind cannot consume runtime numbers — only literal class names.
+ */
+const DENSITY_OUTER_SPACE: Record<DashboardDensity, string> = {
+  compact: "space-y-3",
+  comfortable: "space-y-4",
+  spacious: "space-y-5",
+};
+const DENSITY_BENTO_GAP: Record<DashboardDensity, string> = {
+  compact: "gap-2",
+  comfortable: "gap-3",
+  spacious: "gap-4",
+};
+
+/**
+ * Reactive read of the user's dashboard-density preference.
+ *
+ * Same-window `localStorage` writes do NOT fire `storage`, so the picker in
+ * Settings → Дашборд dispatches a `DASHBOARD_DENSITY_EVENT` we listen to
+ * here. Cross-tab writes are still handled via the standard `storage` event.
+ */
+function useDashboardDensity(): DashboardDensity {
+  const [density, setDensity] = useState<DashboardDensity>(() => {
+    const raw = safeReadStringLS(STORAGE_KEYS.DASHBOARD_DENSITY);
+    return raw === null
+      ? DEFAULT_DASHBOARD_DENSITY
+      : normalizeDashboardDensity(raw);
+  });
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onCustom = (e: Event) => {
+      const detail = (e as CustomEvent<unknown>).detail;
+      setDensity(normalizeDashboardDensity(detail));
+    };
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEYS.DASHBOARD_DENSITY) {
+        setDensity(normalizeDashboardDensity(e.newValue));
+      }
+    };
+    window.addEventListener(DASHBOARD_DENSITY_EVENT, onCustom);
+    window.addEventListener("storage", onStorage);
+    return () => {
+      window.removeEventListener(DASHBOARD_DENSITY_EVENT, onCustom);
+      window.removeEventListener("storage", onStorage);
+    };
+  }, []);
+  return density;
+}
+
 // Ukrainian 1 / 2-4 / 5+ plural. Inline because this file is the only
 // current consumer; `AssistantCataloguePage` has its own copy with a
 // slightly different (tuple-based) signature. Kept intentionally small;
@@ -106,6 +166,7 @@ export function HubDashboard({
   onShowAuth,
 }: HubDashboardProps) {
   const [order, setOrder] = useState(loadDashboardOrder);
+  const density = useDashboardDensity();
   useMondayAutoDigest();
 
   const [firstActionVisible, setFirstActionVisible] = useState(() =>
@@ -396,7 +457,7 @@ export function HubDashboard({
   // of fades on slower devices and shifted whenever a section toggled.
   // Stable group indices keep the reveal under ~250ms and predictable.
   return (
-    <div className="space-y-4">
+    <div className={DENSITY_OUTER_SPACE[density]}>
       {/* GROUP 0 — Hero block (re-engagement OR streak + hero + checklist) */}
       <StaggerChild index={0}>
         <div className="space-y-4">
@@ -497,7 +558,12 @@ export function HubDashboard({
               items={displayOrder}
               strategy={rectSortingStrategy}
             >
-              <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+              <div
+                className={cn(
+                  "grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4",
+                  DENSITY_BENTO_GAP[density],
+                )}
+              >
                 {displayOrder.map((id) => (
                   <SortableCard
                     key={id}

--- a/apps/web/src/core/settings/DashboardSection.tsx
+++ b/apps/web/src/core/settings/DashboardSection.tsx
@@ -10,6 +10,7 @@ import {
   DASHBOARD_DENSITIES,
   DASHBOARD_DENSITY_LABELS,
   DASHBOARD_DENSITY_DESCRIPTIONS,
+  DASHBOARD_DENSITY_EVENT,
   DEFAULT_DASHBOARD_DENSITY,
   normalizeDashboardDensity,
   STORAGE_KEYS,
@@ -101,6 +102,11 @@ export function DashboardSection() {
   const handleDensityChange = useCallback((next: DashboardDensity) => {
     setDensityState(next);
     safeWriteLS(STORAGE_KEYS.DASHBOARD_DENSITY, next);
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(
+        new CustomEvent(DASHBOARD_DENSITY_EVENT, { detail: next }),
+      );
+    }
   }, []);
   const [order, setOrder] = useState<ModuleId[]>(
     () => loadDashboardOrder() as ModuleId[],

--- a/apps/web/src/core/settings/FinykSection.tsx
+++ b/apps/web/src/core/settings/FinykSection.tsx
@@ -218,6 +218,21 @@ export function FinykSection() {
     queryClient.invalidateQueries({ queryKey: finykKeys.monoSyncState });
   };
 
+  const [refreshing, setRefreshing] = useState(false);
+  const refreshAllData = async () => {
+    if (refreshing) return;
+    setRefreshing(true);
+    try {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: finykKeys.mono }),
+        queryClient.invalidateQueries({ queryKey: finykKeys.monoSyncState }),
+        queryClient.invalidateQueries({ queryKey: hubKeys.preview("finyk") }),
+      ]);
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
   const catInputClass =
     "input-focus-finyk flex-1 min-w-0 h-11 rounded-xl border border-line bg-panelHi px-3 text-sm text-text";
 
@@ -408,9 +423,19 @@ export function FinykSection() {
 
       <SettingsSubGroup title="Сервіс">
         <p className="text-xs text-subtle leading-snug">
-          Якщо список операцій виглядає некоректно — очисти кеш і синхронізуй
-          знову.
+          Дані Monobank приходять автоматично через webhook та оновлюються при
+          поверненні у вкладку. Якщо потрібно примусово перепитати сервер —
+          натисни «Оновити дані». Якщо список операцій виглядає некоректно —
+          очисти кеш і синхронізуй знову.
         </p>
+        <Button
+          variant="ghost"
+          className="w-full h-11"
+          onClick={refreshAllData}
+          disabled={refreshing}
+        >
+          {refreshing ? "Оновлення…" : "🔄 Оновити дані"}
+        </Button>
         <Button
           variant="ghost"
           className="w-full h-11"

--- a/apps/web/src/modules/finyk/pages/transactions/Transactions.tsx
+++ b/apps/web/src/modules/finyk/pages/transactions/Transactions.tsx
@@ -47,7 +47,6 @@ export function Transactions({
     realTx,
     loadingTx,
     lastUpdated,
-    refresh,
     syncState,
     accounts,
     fetchMonth,
@@ -145,8 +144,6 @@ export function Transactions({
             showHidden={filters.showHidden}
             setShowHidden={filters.setShowHidden}
             hiddenCount={hiddenTxIds.length}
-            refresh={refresh}
-            loading={filters.activeLoading}
           />
           <TransactionSyncPill
             syncState={syncState}

--- a/apps/web/src/modules/finyk/pages/transactions/TransactionsHeader.tsx
+++ b/apps/web/src/modules/finyk/pages/transactions/TransactionsHeader.tsx
@@ -10,17 +10,17 @@ export interface TransactionsHeaderProps {
   showHidden: boolean;
   setShowHidden: (updater: (v: boolean) => boolean) => void;
   hiddenCount: number;
-  refresh: () => void;
-  loading: boolean;
 }
 
 /**
  * Top header for the Transactions page: month switcher on the left,
- * action buttons (toggle-hidden / select-mode / refresh) on the right.
+ * action buttons (toggle-hidden / select-mode) on the right.
  *
  * The "select-mode" toggle replaces the action cluster with a single
  * "Скасувати" button while batch selection is active — the actions
- * only make sense outside of select-mode anyway.
+ * only make sense outside of select-mode anyway. Manual refresh lives in
+ * Hub → Налаштування → Фінік → Сервіс (mono webhook means data already
+ * refetches on focus / staleness; the manual button is a fallback).
  */
 export function TransactionsHeader({
   monthLabel,
@@ -32,8 +32,6 @@ export function TransactionsHeader({
   showHidden,
   setShowHidden,
   hiddenCount,
-  refresh,
-  loading,
 }: TransactionsHeaderProps) {
   return (
     <div className="flex items-center justify-between mb-3">
@@ -112,28 +110,6 @@ export function TransactionsHeader({
               >
                 <polyline points="9 11 12 14 22 4" />
                 <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" />
-              </svg>
-            </button>
-            <button
-              onClick={refresh}
-              disabled={loading}
-              className="text-xs px-3 py-2 rounded-full border border-line text-subtle hover:text-text hover:border-muted transition-colors disabled:opacity-40 min-h-[36px]"
-              aria-label="Оновити"
-            >
-              <svg
-                width="14"
-                height="14"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2.2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                className={loading ? "motion-safe:animate-spin" : ""}
-                aria-hidden
-              >
-                <polyline points="23 4 23 10 17 10" />
-                <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
               </svg>
             </button>
           </>

--- a/packages/shared/src/lib/dashboard.ts
+++ b/packages/shared/src/lib/dashboard.ts
@@ -66,6 +66,17 @@ export const DASHBOARD_DENSITY_SPACING: Record<
   spacious: { cardGap: 4, cardPadding: 5, sectionGap: 6 },
 };
 
+/**
+ * Custom DOM event name that the Settings → Дашборд density picker
+ * dispatches on `window` so that an already-mounted Hub dashboard re-renders
+ * with the new spacing without waiting for the next remount or storage event.
+ *
+ * Same-window `localStorage` writes do NOT fire `storage` events, so the
+ * picker has to nudge listeners explicitly. Cross-tab updates are still
+ * picked up via the standard `storage` event in parallel.
+ */
+export const DASHBOARD_DENSITY_EVENT = "sergeant:dashboard-density-changed";
+
 export function isDashboardDensity(value: unknown): value is DashboardDensity {
   return (
     typeof value === "string" &&


### PR DESCRIPTION
## Summary

Дві UX-правки у відповідь на повідомлення з 02.05:

1. **Перенесено кнопку «Оновити» з шапки `Transactions` у налаштування модуля Фінік** (`Hub → Налаштування → Фінік → Сервіс`). Після того як активувався Monobank webhook, дані приходять автоматично, а ручний refresh — лише запасний invalidate React-Query кешу. У хедері «Операції» лишається лише місяць / select-mode / прихов. — щоб не змагатись з фільтр-чіпсами за горизонтальний простір.
2. **Підключено `density` дашборду до реального рендеру.** Пікер у `Settings → Дашборд` зберігав `compact / comfortable / spacious` у `localStorage`, але жоден споживач `DASHBOARD_DENSITY_SPACING` не читав — кнопки лише підсвічувались. Тепер `HubDashboard` читає щільність на mount та реактивно оновлюється:
   - same-window — через `DASHBOARD_DENSITY_EVENT` (custom event, бо `localStorage` write у тому ж вікні не тригерить `storage`);
   - cross-tab — через стандартний `storage` event.

   Класи статичні (`gap-2/3/4`, `space-y-3/4/5`), щоб Tailwind JIT їх упіймав.

## Governing Skill

- Primary skill: `sergeant-web-ui`
- Secondary skill (if truly needed): `sergeant-monorepo-boundaries` (для нового експорту в `@sergeant/shared`)

## Playbook

- Primary playbook: n/a
- Why this playbook: точкова UX-правка, без міграцій / API-контрактів / auth.
- If no playbook matched, why: жоден з playbook-ів у репо не покриває «move button between surfaces» / «wire dead setting».

## Verification

```bash
pnpm --filter @sergeant/web lint           # PASS
pnpm --filter @sergeant/web typecheck      # PASS
pnpm --filter @sergeant/shared typecheck   # PASS
pnpm format                                # PASS
pnpm --filter @sergeant/web exec vitest run --no-coverage \
  src/core/settings/FinykSection.test.tsx  # 4/4 PASS
```

`HubDashboard.test.tsx` — 1 наявний failing тест на `EXPECTED_FINYK_MAIN = "1 250 грн"` vs рендериться `"1 250 ₴"`; той самий fail відтворюється на чистому `main` (перевірено через `git stash`), не пов'язаний з цим PR.

Additional checks:

- [x] Local smoke / manual validation completed (lint + typecheck + targeted vitest)
- [x] Surface-specific checks completed (web only, без міграцій / без API-змін)

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a — поведінка кнопок видима в UI; внутрішній JSDoc на `DASHBOARD_DENSITY_EVENT` пояснює same-window vs cross-tab контракт.

## Risk and Rollout

- User-visible risk: **низький.** Кнопка «Оновити» нікуди не зникає — переїжджає в Settings (з пояснювальним текстом). Density тепер реально працює, але дефолтне значення `comfortable` ≡ старим хардкодним `gap-3 / space-y-4`, тож для юзерів які не чіпали налаштування — нульова видима зміна.
- Rollout / deploy order: standard Vercel auto-deploy on merge.
- Backout plan: revert merge-commit (один клік), всі три коміти атомарні.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

- Новий експорт `DASHBOARD_DENSITY_EVENT` у `packages/shared/src/lib/dashboard.ts` — звичайна string-константа, без runtime-ефекту поза підпискою у HubDashboard / диспатчем з DashboardSection.
- Класи Tailwind у `DENSITY_OUTER_SPACE` / `DENSITY_BENTO_GAP` навмисно прописані як string literals (а не template-strings), щоб Tailwind JIT їх безпомилково упіймав — без safelist.
- Mobile dashboard щільність так само не використовує (`apps/mobile/src/core/hub/...` рендерить інший компонент); якщо це потрібно — окремий PR. У цьому PR — тільки web.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the manual Finyk refresh to module settings and wired the dashboard density so spacing updates instantly across tabs. This cleans up the Transactions header and makes compact/comfortable/spacious actually change the layout.

- **New Features**
  - Dashboard density now updates layout in `HubDashboard`. Reads from `localStorage` on mount and reacts via `DASHBOARD_DENSITY_EVENT` (same tab) and `storage` (cross‑tab). Event name exported from `@sergeant/shared`.
  - Moved Finyk "Оновити" (Refresh) to Hub → Settings → Finyk → Service. It invalidates `finyk` and hub preview caches. Removed the refresh icon from the Transactions header.

<sup>Written for commit f0ad23506d834babaa4a09642b6d98404e7c3643. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dashboard density settings: Users can now customize spacing preferences, with settings persisted across sessions and tabs.
  * Added data refresh button in settings to refresh Finyk information.

* **Improvements**
  * Streamlined transaction page loading indicators for clearer user feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->