### PR TITLE
feat: schema migration runner (cross-platform)

### DIFF
--- a/packages/db-schema/package.json
+++ b/packages/db-schema/package.json
@@ -21,6 +21,18 @@
     "./shared": {
       "types": "./dist/shared/index.d.ts",
       "import": "./dist/shared/index.js"
+    },
+    "./migrate": {
+      "types": "./dist/migrate/index.d.ts",
+      "import": "./dist/migrate/index.js"
+    },
+    "./migrate/pg": {
+      "types": "./dist/migrate/pg.d.ts",
+      "import": "./dist/migrate/pg.js"
+    },
+    "./migrate/sqlite": {
+      "types": "./dist/migrate/sqlite.d.ts",
+      "import": "./dist/migrate/sqlite.js"
     }
   },
   "scripts": {
@@ -36,9 +48,14 @@
   },
   "devDependencies": {
     "@sergeant/config": "workspace:*",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^25.6.0",
+    "@types/pg": "^8.20.0",
     "@vitest/coverage-v8": "^3.0.0",
+    "better-sqlite3": "^11",
     "drizzle-kit": "^0.31.10",
+    "pg": "^8.20.0",
+    "pg-mem": "^3.0.14",
     "typescript": "^6.0.3",
     "vitest": "^3.0.0"
   }

--- a/packages/db-schema/src/__tests__/migrate.files.test.ts
+++ b/packages/db-schema/src/__tests__/migrate.files.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { loadMigrationFiles } from "../migrate/files.js";
+
+/**
+ * Tests for the Node-only `loadMigrationFiles` helper. Browser/mobile
+ * bundles do not import this — the runner itself is fs-free.
+ */
+
+let tmpDir: string;
+
+beforeAll(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "sergeant-migrations-"));
+});
+
+afterAll(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("loadMigrationFiles", () => {
+  it("loads NNN_*.sql files in lexicographic order", async () => {
+    const dir = await mkSubdir("ordered");
+    await fs.writeFile(path.join(dir, "002_b.sql"), "SELECT 2;");
+    await fs.writeFile(path.join(dir, "001_a.sql"), "SELECT 1;");
+    await fs.writeFile(path.join(dir, "010_j.sql"), "SELECT 10;");
+    const files = await loadMigrationFiles(dir);
+    expect(files.map((f) => f.name)).toEqual([
+      "001_a.sql",
+      "002_b.sql",
+      "010_j.sql",
+    ]);
+    expect(files.map((f) => f.sql)).toEqual([
+      "SELECT 1;",
+      "SELECT 2;",
+      "SELECT 10;",
+    ]);
+  });
+
+  it("excludes .down.sql companions", async () => {
+    const dir = await mkSubdir("downs");
+    await fs.writeFile(path.join(dir, "001_a.sql"), "SELECT 1;");
+    await fs.writeFile(path.join(dir, "001_a.down.sql"), "DROP TABLE a;");
+    const files = await loadMigrationFiles(dir);
+    expect(files.map((f) => f.name)).toEqual(["001_a.sql"]);
+  });
+
+  it("ignores non-SQL files and files that don't match the pattern", async () => {
+    const dir = await mkSubdir("mixed");
+    await fs.writeFile(path.join(dir, "001_a.sql"), "SELECT 1;");
+    await fs.writeFile(path.join(dir, "README.md"), "# notes");
+    await fs.writeFile(path.join(dir, "no-prefix.sql"), "SELECT 2;");
+    await fs.writeFile(path.join(dir, "abc_word.sql"), "SELECT 3;");
+    const files = await loadMigrationFiles(dir);
+    expect(files.map((f) => f.name)).toEqual(["001_a.sql"]);
+  });
+
+  it("returns an empty list for an empty directory", async () => {
+    const dir = await mkSubdir("empty");
+    const files = await loadMigrationFiles(dir);
+    expect(files).toEqual([]);
+  });
+
+  it("rejects when the directory does not exist", async () => {
+    await expect(
+      loadMigrationFiles(path.join(tmpDir, "does-not-exist")),
+    ).rejects.toThrow();
+  });
+});
+
+async function mkSubdir(name: string): Promise<string> {
+  const dir = path.join(tmpDir, name);
+  await fs.mkdir(dir, { recursive: true });
+  return dir;
+}

--- a/packages/db-schema/src/__tests__/migrate.pg.test.ts
+++ b/packages/db-schema/src/__tests__/migrate.pg.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { newDb, type IMemoryDb } from "pg-mem";
+import { runMigrations, MigrationFailedError } from "../migrate/runner.js";
+import { createPgAdapter, type PgQueryClient } from "../migrate/adapters/pg.js";
+import type { MigrationFile } from "../migrate/types.js";
+
+/**
+ * End-to-end tests against a real Postgres surface via `pg-mem`. We
+ * deliberately use pg-mem rather than testcontainers here so the suite
+ * stays fast (~hundreds of ms) and runs in environments without
+ * Docker. The wider rollback-sanity guard for the server's actual
+ * SQL files lives in `apps/server/src/migrations/__tests__/rollback-sanity.test.ts`
+ * — that one needs real Postgres because it exercises FK + check
+ * constraint syntax pg-mem ignores.
+ */
+
+interface PgMemHarness {
+  db: IMemoryDb;
+  client: PgQueryClient;
+}
+
+function harness(): PgMemHarness {
+  // `noAstCoverageCheck` works around a pg-mem strictness check that
+  // trips on `CREATE TABLE IF NOT EXISTS` re-runs against an existing
+  // table whose default expression includes `NOW()`. The check is a
+  // pg-mem-internal warning, not a real Postgres incompatibility — the
+  // SQL is valid Postgres and runs fine in production. See pg-mem's
+  // `MemoryDbOptions.noAstCoverageCheck` doc for the upstream advice.
+  const db = newDb({ noAstCoverageCheck: true });
+  const adapters = db.adapters.createPg();
+  const pool = new adapters.Pool();
+  const client: PgQueryClient = {
+    query: async (sql: string, params?: unknown[]) => {
+      const result = await pool.query(sql, params ?? []);
+      return { rows: result.rows as Array<Record<string, unknown>> };
+    },
+  };
+  return { db, client };
+}
+
+function rowsToString(
+  rows: ReadonlyArray<Record<string, unknown>>,
+  key: string,
+): string[] {
+  return rows.map((r) => {
+    const value = r[key];
+    if (typeof value !== "string") {
+      throw new Error(
+        `Expected string at "${key}", got ${JSON.stringify(value)}`,
+      );
+    }
+    return value;
+  });
+}
+
+const FILES: MigrationFile[] = [
+  {
+    name: "001_create_alpha.sql",
+    sql: "CREATE TABLE alpha (id INTEGER PRIMARY KEY, label TEXT NOT NULL);",
+  },
+  {
+    name: "002_create_beta.sql",
+    sql: "CREATE TABLE beta (id INTEGER PRIMARY KEY, alpha_id INTEGER);",
+  },
+  {
+    name: "003_seed_alpha.sql",
+    sql: "INSERT INTO alpha (id, label) VALUES (1, 'first'), (2, 'second');",
+  },
+];
+
+describe("runMigrations × pg adapter (pg-mem)", () => {
+  let h: PgMemHarness;
+  beforeEach(() => {
+    h = harness();
+  });
+
+  it("rolls forward: applies all files and populates the ledger + schema", async () => {
+    const result = await runMigrations({
+      adapter: createPgAdapter(h.client),
+      files: FILES,
+    });
+    expect(result.applied).toEqual(FILES.map((f) => f.name));
+    expect(result.skipped).toEqual([]);
+
+    // Ledger populated with one row per file, in insertion order.
+    const ledger = await h.client.query(
+      'SELECT name FROM "__migrations" ORDER BY id ASC',
+    );
+    expect(rowsToString(ledger.rows, "name")).toEqual(FILES.map((f) => f.name));
+
+    // Schema actually exists.
+    const tables = await h.client.query(
+      `SELECT table_name FROM information_schema.tables
+       WHERE table_schema = 'public' ORDER BY table_name`,
+    );
+    expect(rowsToString(tables.rows, "table_name")).toEqual([
+      "__migrations",
+      "alpha",
+      "beta",
+    ]);
+
+    // Seed migration ran — verify rows exist in `alpha`.
+    const alpha = await h.client.query(
+      "SELECT label FROM alpha ORDER BY id ASC",
+    );
+    expect(rowsToString(alpha.rows, "label")).toEqual(["first", "second"]);
+  });
+
+  it("re-running over an already-migrated db inserts no rows and runs no migration SQL", async () => {
+    const adapter = createPgAdapter(h.client);
+    await runMigrations({ adapter, files: FILES });
+
+    // Snapshot the alpha contents — the seed migration must NOT
+    // re-run, otherwise we'd see 4 rows instead of 2.
+    const before = await h.client.query("SELECT count(*) AS count FROM alpha");
+    expect(Number(before.rows[0]!["count"])).toBe(2);
+
+    const second = await runMigrations({ adapter, files: FILES });
+    expect(second.applied).toEqual([]);
+    expect(second.skipped).toEqual(FILES.map((f) => f.name));
+
+    const after = await h.client.query("SELECT count(*) AS count FROM alpha");
+    expect(Number(after.rows[0]!["count"])).toBe(2);
+
+    const ledger = await h.client.query(
+      'SELECT name FROM "__migrations" ORDER BY id ASC',
+    );
+    expect(rowsToString(ledger.rows, "name")).toEqual(FILES.map((f) => f.name));
+  });
+
+  it("aborts on a broken migration and resumes on retry once the file is fixed", async () => {
+    const adapter = createPgAdapter(h.client);
+    const broken: MigrationFile = {
+      name: "002_create_beta.sql",
+      sql: "CREATE TABLE beta (id INTEGER PRIMARY KEY); SYNTAX ERROR HERE;",
+    };
+    const firstBatch: MigrationFile[] = [FILES[0]!, broken, FILES[2]!];
+
+    await expect(
+      runMigrations({ adapter, files: firstBatch }),
+    ).rejects.toBeInstanceOf(MigrationFailedError);
+
+    // Ledger keeps the first migration; the broken one is NOT recorded
+    // and the third one was never attempted.
+    const ledgerAfterFail = await h.client.query(
+      'SELECT name FROM "__migrations" ORDER BY id ASC',
+    );
+    expect(rowsToString(ledgerAfterFail.rows, "name")).toEqual([
+      "001_create_alpha.sql",
+    ]);
+
+    // The schema reflects the first migration only. Beta was rolled
+    // back atomically by the adapter's BEGIN/ROLLBACK pair.
+    const tables = await h.client.query(
+      `SELECT table_name FROM information_schema.tables
+       WHERE table_schema = 'public' ORDER BY table_name`,
+    );
+    expect(rowsToString(tables.rows, "table_name")).toEqual([
+      "__migrations",
+      "alpha",
+    ]);
+
+    // Retry with the file fixed — runner resumes from the broken file.
+    const second = await runMigrations({ adapter, files: FILES });
+    expect(second.applied).toEqual([
+      "002_create_beta.sql",
+      "003_seed_alpha.sql",
+    ]);
+    expect(second.skipped).toEqual(["001_create_alpha.sql"]);
+
+    const ledgerAfterFix = await h.client.query(
+      'SELECT name FROM "__migrations" ORDER BY id ASC',
+    );
+    expect(rowsToString(ledgerAfterFix.rows, "name")).toEqual(
+      FILES.map((f) => f.name),
+    );
+  });
+
+  it("respects a custom ledger table name", async () => {
+    const adapter = createPgAdapter(h.client);
+    const result = await runMigrations({
+      adapter,
+      files: FILES,
+      tableName: "schema_migrations",
+    });
+    expect(result.tableName).toBe("schema_migrations");
+    const rows = await h.client.query(
+      'SELECT name FROM "schema_migrations" ORDER BY id ASC',
+    );
+    expect(rowsToString(rows.rows, "name")).toEqual(FILES.map((f) => f.name));
+  });
+});

--- a/packages/db-schema/src/__tests__/migrate.runner.test.ts
+++ b/packages/db-schema/src/__tests__/migrate.runner.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it, vi } from "vitest";
+import { MigrationFailedError, runMigrations } from "../migrate/runner.js";
+import {
+  DEFAULT_MIGRATIONS_TABLE,
+  type MigrationAdapter,
+  type MigrationFile,
+  type MigrationLogEvent,
+} from "../migrate/types.js";
+
+/**
+ * Adapter-agnostic tests. They drive the runner with a tiny in-memory
+ * fake adapter so the contract is locked independently of any real
+ * dialect. Dialect-specific tests live in `migrate.pg.test.ts` and
+ * `migrate.sqlite.test.ts` and exercise the same scenarios end-to-end
+ * over real Postgres / SQLite engines.
+ */
+
+interface FakeAdapterState {
+  ledgerExists: boolean;
+  applied: { name: string; sql: string }[];
+  failOn?: { name: string; phase: "sql" | "ledger" };
+  ensureLedgerCalls: number;
+  applyCalls: { name: string; sql: string }[];
+}
+
+function makeFakeAdapter(state: FakeAdapterState): MigrationAdapter {
+  return {
+    async ensureLedger() {
+      state.ensureLedgerCalls += 1;
+      state.ledgerExists = true;
+    },
+    async getAppliedNames() {
+      if (!state.ledgerExists) return [];
+      return state.applied.map((m) => m.name);
+    },
+    async applyMigration(_table, name, sql) {
+      state.applyCalls.push({ name, sql });
+      if (state.failOn?.name === name && state.failOn.phase === "sql") {
+        throw new Error(`forced failure on ${name}`);
+      }
+      // Atomicity simulation: only insert into ledger if SQL phase
+      // succeeded. Mid-batch failures must not leave the ledger row.
+      state.applied.push({ name, sql });
+      if (state.failOn?.name === name && state.failOn.phase === "ledger") {
+        // Roll back simulation — drop the row we just appended.
+        state.applied.pop();
+        throw new Error(`forced ledger insert failure on ${name}`);
+      }
+    },
+  };
+}
+
+const FILES: MigrationFile[] = [
+  { name: "001_a.sql", sql: "CREATE TABLE a (id INT);" },
+  { name: "002_b.sql", sql: "CREATE TABLE b (id INT);" },
+  { name: "003_c.sql", sql: "CREATE TABLE c (id INT);" },
+];
+
+describe("runMigrations — runner contract", () => {
+  it("applies all files on a fresh ledger and reports them as applied", async () => {
+    const state: FakeAdapterState = {
+      ledgerExists: false,
+      applied: [],
+      ensureLedgerCalls: 0,
+      applyCalls: [],
+    };
+    const result = await runMigrations({
+      adapter: makeFakeAdapter(state),
+      files: FILES,
+    });
+    expect(result.applied).toEqual(["001_a.sql", "002_b.sql", "003_c.sql"]);
+    expect(result.skipped).toEqual([]);
+    expect(result.tableName).toBe(DEFAULT_MIGRATIONS_TABLE);
+    expect(state.applyCalls.map((c) => c.name)).toEqual([
+      "001_a.sql",
+      "002_b.sql",
+      "003_c.sql",
+    ]);
+  });
+
+  it("re-running over an already-migrated ledger is a no-op (idempotent)", async () => {
+    const state: FakeAdapterState = {
+      ledgerExists: false,
+      applied: [],
+      ensureLedgerCalls: 0,
+      applyCalls: [],
+    };
+    const adapter = makeFakeAdapter(state);
+    await runMigrations({ adapter, files: FILES });
+    const firstRunApplyCount = state.applyCalls.length;
+
+    const second = await runMigrations({ adapter, files: FILES });
+
+    // No new applies: the runner saw all three names in the ledger
+    // and skipped them.
+    expect(state.applyCalls.length).toBe(firstRunApplyCount);
+    expect(second.applied).toEqual([]);
+    expect(second.skipped).toEqual(["001_a.sql", "002_b.sql", "003_c.sql"]);
+  });
+
+  it("applies files in lexicographic order regardless of input order", async () => {
+    const state: FakeAdapterState = {
+      ledgerExists: false,
+      applied: [],
+      ensureLedgerCalls: 0,
+      applyCalls: [],
+    };
+    const reversed: MigrationFile[] = [...FILES].reverse();
+    const result = await runMigrations({
+      adapter: makeFakeAdapter(state),
+      files: reversed,
+    });
+    expect(result.applied).toEqual(["001_a.sql", "002_b.sql", "003_c.sql"]);
+    expect(state.applyCalls.map((c) => c.name)).toEqual([
+      "001_a.sql",
+      "002_b.sql",
+      "003_c.sql",
+    ]);
+  });
+
+  it("aborts on mid-batch failure, preserving prior ledger rows", async () => {
+    const state: FakeAdapterState = {
+      ledgerExists: false,
+      applied: [],
+      failOn: { name: "002_b.sql", phase: "sql" },
+      ensureLedgerCalls: 0,
+      applyCalls: [],
+    };
+    const adapter = makeFakeAdapter(state);
+
+    await expect(
+      runMigrations({ adapter, files: FILES }),
+    ).rejects.toBeInstanceOf(MigrationFailedError);
+
+    // Only the first migration is committed. The failing one and the
+    // one after it are untouched.
+    expect(state.applied.map((m) => m.name)).toEqual(["001_a.sql"]);
+    // The runner attempted the failing file but did not attempt the
+    // file after it.
+    expect(state.applyCalls.map((c) => c.name)).toEqual([
+      "001_a.sql",
+      "002_b.sql",
+    ]);
+  });
+
+  it("a fixed migration in a follow-up run resumes from the previously-failed file", async () => {
+    const state: FakeAdapterState = {
+      ledgerExists: false,
+      applied: [],
+      failOn: { name: "002_b.sql", phase: "sql" },
+      ensureLedgerCalls: 0,
+      applyCalls: [],
+    };
+    const adapter = makeFakeAdapter(state);
+
+    await expect(
+      runMigrations({ adapter, files: FILES }),
+    ).rejects.toBeInstanceOf(MigrationFailedError);
+
+    // "Fix" the broken migration — drop the failure flag.
+    state.failOn = undefined;
+
+    const second = await runMigrations({ adapter, files: FILES });
+
+    expect(second.applied).toEqual(["002_b.sql", "003_c.sql"]);
+    expect(second.skipped).toEqual(["001_a.sql"]);
+    expect(state.applied.map((m) => m.name)).toEqual([
+      "001_a.sql",
+      "002_b.sql",
+      "003_c.sql",
+    ]);
+  });
+
+  it("ensureLedger runs every invocation (idempotent in adapter)", async () => {
+    const state: FakeAdapterState = {
+      ledgerExists: false,
+      applied: [],
+      ensureLedgerCalls: 0,
+      applyCalls: [],
+    };
+    const adapter = makeFakeAdapter(state);
+    await runMigrations({ adapter, files: FILES });
+    await runMigrations({ adapter, files: FILES });
+    expect(state.ensureLedgerCalls).toBe(2);
+  });
+
+  it("respects custom tableName option", async () => {
+    const state: FakeAdapterState = {
+      ledgerExists: false,
+      applied: [],
+      ensureLedgerCalls: 0,
+      applyCalls: [],
+    };
+    const result = await runMigrations({
+      adapter: makeFakeAdapter(state),
+      files: FILES,
+      tableName: "schema_migrations",
+    });
+    expect(result.tableName).toBe("schema_migrations");
+  });
+
+  it("rejects an invalid migrations ledger table name", async () => {
+    const state: FakeAdapterState = {
+      ledgerExists: false,
+      applied: [],
+      ensureLedgerCalls: 0,
+      applyCalls: [],
+    };
+    await expect(
+      runMigrations({
+        adapter: makeFakeAdapter(state),
+        files: FILES,
+        tableName: 'evil"; DROP TABLE users; --',
+      }),
+    ).rejects.toThrow(/Invalid migrations ledger table name/);
+  });
+
+  it("rejects malformed migration filenames before applying anything", async () => {
+    const state: FakeAdapterState = {
+      ledgerExists: false,
+      applied: [],
+      ensureLedgerCalls: 0,
+      applyCalls: [],
+    };
+    await expect(
+      runMigrations({
+        adapter: makeFakeAdapter(state),
+        files: [{ name: "bad-name.sql", sql: "" }],
+      }),
+    ).rejects.toThrow(/Invalid migration filename/);
+    // Critically: the runner threw before touching the adapter.
+    expect(state.ensureLedgerCalls).toBe(0);
+    expect(state.applyCalls.length).toBe(0);
+  });
+
+  it("emits log events in order: ensure → applying → applied → skipped", async () => {
+    const state: FakeAdapterState = {
+      ledgerExists: false,
+      applied: [],
+      ensureLedgerCalls: 0,
+      applyCalls: [],
+    };
+    const events: MigrationLogEvent[] = [];
+    const logger = vi.fn((e: MigrationLogEvent) => {
+      events.push(e);
+    });
+    await runMigrations({
+      adapter: makeFakeAdapter(state),
+      files: FILES,
+      logger,
+    });
+    // Subsequent run — re-uses the same in-memory ledger.
+    await runMigrations({
+      adapter: makeFakeAdapter(state),
+      files: FILES,
+      logger,
+    });
+    const types = events.map((e) => e.type);
+    expect(types).toEqual([
+      "ensure_ledger",
+      "applying",
+      "applied",
+      "applying",
+      "applied",
+      "applying",
+      "applied",
+      "ensure_ledger",
+      "skipped",
+      "skipped",
+      "skipped",
+    ]);
+  });
+});

--- a/packages/db-schema/src/__tests__/migrate.sqlite.test.ts
+++ b/packages/db-schema/src/__tests__/migrate.sqlite.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import type { Database as BetterSqliteDatabase } from "better-sqlite3";
+import { runMigrations, MigrationFailedError } from "../migrate/runner.js";
+import {
+  createSqliteAdapter,
+  type SqliteMigrationClient,
+} from "../migrate/adapters/sqlite.js";
+import type { MigrationFile } from "../migrate/types.js";
+
+/**
+ * End-to-end tests for the SQLite adapter. We use `better-sqlite3`
+ * here because it ships a synchronous in-process SQLite engine
+ * (already a devDependency on `apps/mobile`) and because the adapter
+ * intentionally accepts both sync and async clients via the same
+ * surface — wrapping a sync engine in awaited promises is exactly the
+ * shape `expo-sqlite` and the sqlite-wasm proxy expose at runtime.
+ */
+
+function syncClient(db: BetterSqliteDatabase): SqliteMigrationClient {
+  return {
+    exec(sql) {
+      db.exec(sql);
+    },
+    run(sql, params) {
+      db.prepare(sql).run(...(params as unknown[]));
+    },
+    all<R extends Record<string, unknown>>(
+      sql: string,
+      params?: readonly unknown[],
+    ): R[] {
+      const stmt = db.prepare(sql);
+      const result = params ? stmt.all(...(params as unknown[])) : stmt.all();
+      return result as R[];
+    },
+  };
+}
+
+const FILES: MigrationFile[] = [
+  {
+    name: "001_create_alpha.sql",
+    sql: "CREATE TABLE alpha (id INTEGER PRIMARY KEY, label TEXT NOT NULL);",
+  },
+  {
+    name: "002_create_beta.sql",
+    sql: "CREATE TABLE beta (id INTEGER PRIMARY KEY, alpha_id INTEGER);",
+  },
+  {
+    name: "003_seed_alpha.sql",
+    sql: "INSERT INTO alpha (id, label) VALUES (1, 'first'), (2, 'second');",
+  },
+];
+
+describe("runMigrations × sqlite adapter (better-sqlite3)", () => {
+  let db: BetterSqliteDatabase;
+  let client: SqliteMigrationClient;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    client = syncClient(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("rolls forward: applies all files and populates the ledger + schema", async () => {
+    const result = await runMigrations({
+      adapter: createSqliteAdapter(client),
+      files: FILES,
+    });
+    expect(result.applied).toEqual(FILES.map((f) => f.name));
+    expect(result.skipped).toEqual([]);
+
+    const ledger = db
+      .prepare('SELECT name FROM "__migrations" ORDER BY id ASC')
+      .all() as { name: string }[];
+    expect(ledger.map((r) => r.name)).toEqual(FILES.map((f) => f.name));
+
+    const tables = db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+      )
+      .all() as { name: string }[];
+    expect(tables.map((r) => r.name)).toEqual([
+      "__migrations",
+      "alpha",
+      "beta",
+    ]);
+
+    const alpha = db
+      .prepare("SELECT label FROM alpha ORDER BY id ASC")
+      .all() as { label: string }[];
+    expect(alpha.map((r) => r.label)).toEqual(["first", "second"]);
+  });
+
+  it("re-running over an already-migrated db inserts no rows and runs no migration SQL", async () => {
+    const adapter = createSqliteAdapter(client);
+    await runMigrations({ adapter, files: FILES });
+
+    const before = db.prepare("SELECT count(*) AS c FROM alpha").get() as {
+      c: number;
+    };
+    expect(before.c).toBe(2);
+
+    const second = await runMigrations({ adapter, files: FILES });
+    expect(second.applied).toEqual([]);
+    expect(second.skipped).toEqual(FILES.map((f) => f.name));
+
+    const after = db.prepare("SELECT count(*) AS c FROM alpha").get() as {
+      c: number;
+    };
+    expect(after.c).toBe(2);
+
+    const ledger = db
+      .prepare('SELECT name FROM "__migrations" ORDER BY id ASC')
+      .all() as { name: string }[];
+    expect(ledger.map((r) => r.name)).toEqual(FILES.map((f) => f.name));
+  });
+
+  it("aborts on a broken migration and resumes on retry once the file is fixed", async () => {
+    const adapter = createSqliteAdapter(client);
+    const broken: MigrationFile = {
+      name: "002_create_beta.sql",
+      sql: "CREATE TABLE beta (id INTEGER PRIMARY KEY); SYNTAX ERROR HERE;",
+    };
+    const firstBatch: MigrationFile[] = [FILES[0]!, broken, FILES[2]!];
+
+    await expect(
+      runMigrations({ adapter, files: firstBatch }),
+    ).rejects.toBeInstanceOf(MigrationFailedError);
+
+    const ledgerAfterFail = db
+      .prepare('SELECT name FROM "__migrations" ORDER BY id ASC')
+      .all() as { name: string }[];
+    expect(ledgerAfterFail.map((r) => r.name)).toEqual([
+      "001_create_alpha.sql",
+    ]);
+
+    // Critically: SQLite can leave a half-applied DDL hanging open if
+    // the adapter forgot to issue ROLLBACK. Verify `beta` does NOT
+    // exist after the failure.
+    const tables = db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+      )
+      .all() as { name: string }[];
+    expect(tables.map((r) => r.name)).toEqual(["__migrations", "alpha"]);
+
+    // Retry with the file fixed.
+    const second = await runMigrations({ adapter, files: FILES });
+    expect(second.applied).toEqual([
+      "002_create_beta.sql",
+      "003_seed_alpha.sql",
+    ]);
+    expect(second.skipped).toEqual(["001_create_alpha.sql"]);
+
+    const ledgerAfterFix = db
+      .prepare('SELECT name FROM "__migrations" ORDER BY id ASC')
+      .all() as { name: string }[];
+    expect(ledgerAfterFix.map((r) => r.name)).toEqual(FILES.map((f) => f.name));
+  });
+
+  it("works when the client surface is asynchronous (Promise-returning)", async () => {
+    // Mirror the expo-sqlite / sqlite-proxy contract by wrapping the
+    // synchronous engine in awaited promises. The adapter must not
+    // care.
+    const asyncClient: SqliteMigrationClient = {
+      async exec(sql) {
+        await Promise.resolve();
+        db.exec(sql);
+      },
+      async run(sql, params) {
+        await Promise.resolve();
+        db.prepare(sql).run(...(params as unknown[]));
+      },
+      async all<R extends Record<string, unknown>>(
+        sql: string,
+        params?: readonly unknown[],
+      ): Promise<R[]> {
+        await Promise.resolve();
+        const stmt = db.prepare(sql);
+        const result = params ? stmt.all(...(params as unknown[])) : stmt.all();
+        return result as R[];
+      },
+    };
+
+    const result = await runMigrations({
+      adapter: createSqliteAdapter(asyncClient),
+      files: FILES,
+    });
+    expect(result.applied).toEqual(FILES.map((f) => f.name));
+  });
+});

--- a/packages/db-schema/src/migrate/adapters/pg.ts
+++ b/packages/db-schema/src/migrate/adapters/pg.ts
@@ -1,0 +1,99 @@
+import type { MigrationAdapter } from "../types.js";
+
+/**
+ * Postgres adapter for the cross-platform migration runner.
+ *
+ * Accepts any object with a `pg`-shaped `query` function — concretely:
+ *
+ * - `pg.Pool` from `node-postgres`
+ * - `pg.PoolClient` (preferred, since the runner can serialise calls
+ *   on the same connection — important when pairing with
+ *   `pg_advisory_lock` in a higher-level wrapper)
+ * - the `client.query` exposed by drizzle-orm/node-postgres internals
+ * - any test fake matching the same shape (see pg-mem in
+ *   `__tests__/migrate.pg.test.ts`)
+ *
+ * Transactional safety: each call to {@link MigrationAdapter.applyMigration}
+ * runs `BEGIN` / migration SQL / `INSERT INTO __migrations` / `COMMIT`
+ * inline. On any error we issue `ROLLBACK` and re-throw — leaving the
+ * Postgres session in a clean state and the ledger untouched for the
+ * failed file.
+ *
+ * Lazy-import: this module is only loaded by callers that actually run
+ * Postgres migrations, so client bundles (web / mobile) never pay the
+ * `pg` typing cost.
+ */
+
+export interface PgQueryResult {
+  readonly rows: ReadonlyArray<Record<string, unknown>>;
+}
+
+export interface PgQueryClient {
+  query(sql: string, params?: unknown[]): Promise<PgQueryResult>;
+}
+
+export function createPgAdapter(client: PgQueryClient): MigrationAdapter {
+  return {
+    async ensureLedger(tableName) {
+      const ident = quoteIdentifier(tableName);
+      // Postgres-side shape matches the spec: `id INTEGER PK, name TEXT,
+      // applied_at TIMESTAMP`. We use SERIAL for the PK and TIMESTAMPTZ
+      // for `applied_at` so the ledger plays nicely with the rest of
+      // the server schema (see AGENTS.md domain invariants — Kyiv-day
+      // bucketing relies on TIMESTAMPTZ at rest).
+      await client.query(
+        `CREATE TABLE IF NOT EXISTS ${ident} (
+          id SERIAL PRIMARY KEY,
+          name TEXT NOT NULL UNIQUE,
+          applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )`,
+      );
+    },
+
+    async getAppliedNames(tableName) {
+      const ident = quoteIdentifier(tableName);
+      const result = await client.query(
+        `SELECT name FROM ${ident} ORDER BY id ASC`,
+      );
+      return result.rows.map((r) => {
+        const value = r["name"];
+        if (typeof value !== "string") {
+          throw new Error(
+            `Migrations ledger row missing "name" column: ${JSON.stringify(r)}`,
+          );
+        }
+        return value;
+      });
+    },
+
+    async applyMigration(tableName, name, sql) {
+      const ident = quoteIdentifier(tableName);
+      await client.query("BEGIN");
+      try {
+        if (sql.trim().length > 0) {
+          await client.query(sql);
+        }
+        await client.query(`INSERT INTO ${ident} (name) VALUES ($1)`, [name]);
+        await client.query("COMMIT");
+      } catch (err) {
+        try {
+          await client.query("ROLLBACK");
+        } catch {
+          // Best-effort: if rollback itself fails, surface the original
+          // error rather than the rollback's. The Postgres session will
+          // self-heal once the connection is released back to the pool.
+        }
+        throw err;
+      }
+    },
+  };
+}
+
+/**
+ * Quote a Postgres identifier, doubling embedded quotes per the spec.
+ * The runner already validates the table name against
+ * `/^[A-Za-z_][A-Za-z0-9_]*$/`, so this is a defence-in-depth pass.
+ */
+function quoteIdentifier(name: string): string {
+  return `"${name.replace(/"/g, '""')}"`;
+}

--- a/packages/db-schema/src/migrate/adapters/sqlite.ts
+++ b/packages/db-schema/src/migrate/adapters/sqlite.ts
@@ -1,0 +1,110 @@
+import type { MigrationAdapter } from "../types.js";
+
+/**
+ * SQLite adapter for the cross-platform migration runner.
+ *
+ * Accepts a thin "session" interface so the same adapter works with
+ * every SQLite client we ship:
+ *
+ * - **`better-sqlite3`** (synchronous, used in tests).
+ * - **`drizzle-orm/expo-sqlite`** wrapper around expo-sqlite — the
+ *   adapter awaits the resulting promises so sync and async clients
+ *   share one code path.
+ * - **`drizzle-orm/sqlite-proxy`** (sqlite-wasm in `apps/web`) — the
+ *   proxy callback signature is async-by-construction.
+ *
+ * Transactional safety: `applyMigration` runs `BEGIN` / migration SQL /
+ * `INSERT INTO __migrations` / `COMMIT` inline. On error we issue
+ * `ROLLBACK` and re-throw, mirroring the pg adapter so callers get the
+ * same partial-failure semantics on either dialect.
+ *
+ * Lazy-import: server bundles do not import this module so they don't
+ * pay for SQLite shims, and vice-versa.
+ */
+
+/**
+ * Minimal SQLite client surface the adapter needs. Keep the API tiny so
+ * adapter shims for new SQLite drivers are short to write.
+ */
+export interface SqliteMigrationClient {
+  /**
+   * Execute one or more raw SQL statements (no parameter binding).
+   * Used for DDL, transaction control, and the migration body itself.
+   * `better-sqlite3.prototype.exec` and sqlite-wasm's `oo1.DB#exec`
+   * both run multi-statement strings; expo-sqlite exposes
+   * `execAsync(sql)` with the same semantics.
+   */
+  exec(sql: string): void | Promise<void>;
+  /**
+   * Run a single parameterised statement. Used for the ledger writes
+   * (`INSERT INTO __migrations (name) VALUES (?)`). No row results.
+   */
+  run(sql: string, params: readonly unknown[]): void | Promise<void>;
+  /**
+   * Run a SELECT and return its rows. Used to read applied migrations
+   * back out of the ledger.
+   */
+  all<R extends Record<string, unknown> = Record<string, unknown>>(
+    sql: string,
+    params?: readonly unknown[],
+  ): R[] | Promise<R[]>;
+}
+
+export function createSqliteAdapter(
+  client: SqliteMigrationClient,
+): MigrationAdapter {
+  return {
+    async ensureLedger(tableName) {
+      const ident = quoteIdentifier(tableName);
+      // SQLite-side shape mirrors the Postgres ledger but uses
+      // `INTEGER PRIMARY KEY AUTOINCREMENT` (rowid by default does not
+      // guarantee monotonic ids across deletes — autoincrement does)
+      // and stores `applied_at` as ISO-8601 text via `datetime('now')`,
+      // matching the existing client schemas in
+      // `packages/db-schema/src/sqlite/*`.
+      await client.exec(
+        `CREATE TABLE IF NOT EXISTS ${ident} (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          name TEXT NOT NULL UNIQUE,
+          applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )`,
+      );
+    },
+
+    async getAppliedNames(tableName) {
+      const ident = quoteIdentifier(tableName);
+      const rows = await client.all<{ name: string }>(
+        `SELECT name FROM ${ident} ORDER BY id ASC`,
+      );
+      return rows.map((r) => r.name);
+    },
+
+    async applyMigration(tableName, name, sql) {
+      const ident = quoteIdentifier(tableName);
+      await client.exec("BEGIN");
+      try {
+        if (sql.trim().length > 0) {
+          await client.exec(sql);
+        }
+        await client.run(`INSERT INTO ${ident} (name) VALUES (?)`, [name]);
+        await client.exec("COMMIT");
+      } catch (err) {
+        try {
+          await client.exec("ROLLBACK");
+        } catch {
+          // Best-effort: surface the original migration error.
+        }
+        throw err;
+      }
+    },
+  };
+}
+
+/**
+ * Quote a SQLite identifier with double quotes, doubling embedded
+ * quotes per SQL spec. The runner already validates the table name
+ * against `/^[A-Za-z_][A-Za-z0-9_]*$/`, so this is defence-in-depth.
+ */
+function quoteIdentifier(name: string): string {
+  return `"${name.replace(/"/g, '""')}"`;
+}

--- a/packages/db-schema/src/migrate/files.ts
+++ b/packages/db-schema/src/migrate/files.ts
@@ -1,0 +1,40 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { MIGRATION_FILENAME_RE, type MigrationFile } from "./types.js";
+
+/**
+ * Node-only helper that loads `NNN_description.sql` files from `dir`
+ * into the {@link MigrationFile} shape that {@link runMigrations}
+ * accepts. Browser / mobile bundles must NOT import this module —
+ * they should ship migrations as pre-bundled string constants. The
+ * runner itself stays Node-free; this helper is the convenience layer
+ * for server-side and CLI consumers.
+ *
+ * Behaviour:
+ *
+ * - Reads the directory, filters to `*.sql` matching
+ *   {@link MIGRATION_FILENAME_RE}, and **excludes** `.down.sql`
+ *   companions (those are documented manual rollbacks per AGENTS.md
+ *   hard rule #4 — production never auto-applies them).
+ * - Returns the files sorted lexicographically by filename so the
+ *   runner's apply order is stable across platforms.
+ * - Empty SQL bodies are passed through. The runner happily applies
+ *   them; the existing `apps/server/migrate.mjs` skipped empties — we
+ *   leave that judgement to the adapter so the runner stays mechanical.
+ */
+export async function loadMigrationFiles(
+  dir: string,
+): Promise<MigrationFile[]> {
+  const entries = await fs.readdir(dir);
+  const sqlFiles = entries
+    .filter((f) => f.endsWith(".sql") && !f.endsWith(".down.sql"))
+    .filter((f) => MIGRATION_FILENAME_RE.test(f))
+    .sort();
+
+  const out: MigrationFile[] = [];
+  for (const name of sqlFiles) {
+    const sql = await fs.readFile(path.join(dir, name), "utf8");
+    out.push({ name, sql });
+  }
+  return out;
+}

--- a/packages/db-schema/src/migrate/index.ts
+++ b/packages/db-schema/src/migrate/index.ts
@@ -1,0 +1,49 @@
+/**
+ * Cross-platform schema migration runner — public entry.
+ *
+ * Implements PR #019 of `docs/planning/storage-roadmap.md`. The runner
+ * itself is dialect-free; dialect adapters live in dedicated entry
+ * points so server bundles do not pull in SQLite shims and client
+ * bundles do not pull in `pg`.
+ *
+ * Typical usage on the server (lazy-imported):
+ *
+ * ```ts
+ * import { runMigrations, loadMigrationFiles } from "@sergeant/db-schema/migrate";
+ * import { createPgAdapter } from "@sergeant/db-schema/migrate/pg";
+ *
+ * const files = await loadMigrationFiles("./migrations");
+ * await runMigrations({ adapter: createPgAdapter(client), files });
+ * ```
+ *
+ * Typical usage on a SQLite client (sync `better-sqlite3` / expo-sqlite):
+ *
+ * ```ts
+ * import { runMigrations } from "@sergeant/db-schema/migrate";
+ * import { createSqliteAdapter } from "@sergeant/db-schema/migrate/sqlite";
+ *
+ * await runMigrations({
+ *   adapter: createSqliteAdapter({ db }),
+ *   files: BUNDLED_MIGRATIONS,
+ * });
+ * ```
+ *
+ * Note: nothing here executes at module load. Consumers must call
+ * `runMigrations` explicitly. PR #019 ships the runner only; wiring
+ * into specific consumers is tracked as PR #020 (server) and PR #022
+ * (client SPIKE).
+ */
+export {
+  DEFAULT_MIGRATIONS_TABLE,
+  MIGRATION_FILENAME_RE,
+  type MigrationAdapter,
+  type MigrationFile,
+  type MigrationLogEvent,
+  type MigrationLogger,
+  type RunMigrationsOptions,
+  type RunMigrationsResult,
+} from "./types.js";
+
+export { runMigrations, MigrationFailedError } from "./runner.js";
+
+export { loadMigrationFiles } from "./files.js";

--- a/packages/db-schema/src/migrate/pg.ts
+++ b/packages/db-schema/src/migrate/pg.ts
@@ -1,0 +1,9 @@
+/**
+ * Re-export of the Postgres adapter so callers can do
+ *   `import { createPgAdapter } from "@sergeant/db-schema/migrate/pg";`
+ * without reaching into the package's internal `adapters/` folder.
+ *
+ * Server / Node-only — this module pulls the `pg`-style typing surface
+ * onto the import graph and must not be imported from web/mobile bundles.
+ */
+export { createPgAdapter, type PgQueryClient } from "./adapters/pg.js";

--- a/packages/db-schema/src/migrate/runner.ts
+++ b/packages/db-schema/src/migrate/runner.ts
@@ -1,0 +1,121 @@
+import {
+  DEFAULT_MIGRATIONS_TABLE,
+  MIGRATION_FILENAME_RE,
+  type MigrationFile,
+  type RunMigrationsOptions,
+  type RunMigrationsResult,
+} from "./types.js";
+
+/**
+ * Cross-platform schema migration runner. Walks the supplied list of
+ * `*.sql` files in order, skipping any whose name is already present in
+ * the ledger and applying the rest one-at-a-time inside an
+ * adapter-managed transaction.
+ *
+ * Contract:
+ *
+ * - **Sequential.** Files are applied in lexicographic order — the
+ *   caller's responsibility to provide them sorted (helpers in
+ *   `./files.ts` do this for filesystem inputs).
+ * - **Idempotent.** A second invocation with no new files writes
+ *   nothing: it only reads the ledger and returns `applied: []`.
+ * - **Transaction per file.** Each migration is wrapped by the
+ *   adapter so a syntax error mid-file rolls back without recording
+ *   the file in the ledger; the next attempt picks up from there.
+ * - **Fails fast on partial failure.** When a migration throws, the
+ *   runner re-throws after asking the adapter to roll back. Earlier
+ *   migrations in the same batch keep their ledger rows so a retry
+ *   with the failing file fixed resumes from the broken file.
+ *
+ * See `packages/db-schema/src/__tests__/migrate.*.test.ts` for the
+ * roll-forward / no-op / mid-batch-failure scenarios that lock this
+ * behaviour in.
+ */
+export async function runMigrations(
+  opts: RunMigrationsOptions,
+): Promise<RunMigrationsResult> {
+  const tableName = opts.tableName ?? DEFAULT_MIGRATIONS_TABLE;
+  validateTableName(tableName);
+  const files = [...opts.files];
+  for (const file of files) {
+    validateFilename(file.name);
+  }
+  // Apply in lexicographic order regardless of the caller's input order.
+  files.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  const log = opts.logger ?? noopLogger;
+
+  log({ type: "ensure_ledger", tableName });
+  await opts.adapter.ensureLedger(tableName);
+
+  const appliedSet = new Set(await opts.adapter.getAppliedNames(tableName));
+  const applied: string[] = [];
+  const skipped: string[] = [];
+
+  for (const file of files) {
+    if (appliedSet.has(file.name)) {
+      skipped.push(file.name);
+      log({ type: "skipped", name: file.name });
+      continue;
+    }
+    log({ type: "applying", name: file.name });
+    const startedAt = Date.now();
+    try {
+      await opts.adapter.applyMigration(tableName, file.name, file.sql);
+    } catch (err) {
+      const error =
+        err instanceof Error
+          ? err
+          : new Error(typeof err === "string" ? err : String(err));
+      log({ type: "failed", name: file.name, error });
+      throw new MigrationFailedError(file.name, error);
+    }
+    applied.push(file.name);
+    log({
+      type: "applied",
+      name: file.name,
+      durationMs: Date.now() - startedAt,
+    });
+  }
+
+  return { applied, skipped, tableName };
+}
+
+/**
+ * Error thrown by {@link runMigrations} when a single migration fails.
+ * Wraps the underlying adapter / SQL error so callers can match on a
+ * stable type instead of brittle string compares.
+ */
+export class MigrationFailedError extends Error {
+  readonly migration: string;
+  readonly cause: Error;
+  constructor(migration: string, cause: Error) {
+    super(`Migration "${migration}" failed: ${cause.message}`);
+    this.name = "MigrationFailedError";
+    this.migration = migration;
+    this.cause = cause;
+  }
+}
+
+const TABLE_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function validateTableName(tableName: string): void {
+  if (!TABLE_NAME_RE.test(tableName)) {
+    throw new Error(
+      `Invalid migrations ledger table name: "${tableName}". ` +
+        "Must match /^[A-Za-z_][A-Za-z0-9_]*$/.",
+    );
+  }
+}
+
+function validateFilename(name: MigrationFile["name"]): void {
+  if (!MIGRATION_FILENAME_RE.test(name)) {
+    throw new Error(
+      `Invalid migration filename: "${name}". ` +
+        "Expected pattern NNN_description.sql (matches /^\\d+_[A-Za-z0-9._-]+\\.sql$/).",
+    );
+  }
+}
+
+function noopLogger(): void {
+  /* no-op */
+}

--- a/packages/db-schema/src/migrate/sqlite.ts
+++ b/packages/db-schema/src/migrate/sqlite.ts
@@ -1,0 +1,13 @@
+/**
+ * Re-export of the SQLite adapter so callers can do
+ *   `import { createSqliteAdapter } from "@sergeant/db-schema/migrate/sqlite";`
+ * without reaching into the package's internal `adapters/` folder.
+ *
+ * Pure dialect glue — works with `better-sqlite3` (tests),
+ * `drizzle-orm/expo-sqlite` (mobile), and the sqlite-wasm proxy used
+ * by `apps/web/src/core/db/sqlite.ts`.
+ */
+export {
+  createSqliteAdapter,
+  type SqliteMigrationClient,
+} from "./adapters/sqlite.js";

--- a/packages/db-schema/src/migrate/types.ts
+++ b/packages/db-schema/src/migrate/types.ts
@@ -1,0 +1,111 @@
+/**
+ * Public types for the cross-platform schema migration runner.
+ *
+ * The runner is dialect-free: it operates against a {@link MigrationAdapter}
+ * that hides the difference between Postgres (`drizzle-orm/node-postgres` or
+ * raw `pg`) and SQLite (`drizzle-orm/expo-sqlite`, sqlite-wasm proxy, or
+ * `better-sqlite3` in tests). Adapter factories live in
+ * {@link "./adapters/pg"} and {@link "./adapters/sqlite"} and are imported
+ * lazily by callers — the runner itself never references either dialect.
+ *
+ * Implements PR #019 of `docs/planning/storage-roadmap.md`.
+ */
+
+/**
+ * A single migration file resolved into memory. Filenames must match
+ * `^\d+_[A-Za-z0-9._-]+\.sql$` and are applied in lexicographic order.
+ */
+export interface MigrationFile {
+  /** Filename — used as the primary key in the migrations ledger. */
+  readonly name: string;
+  /** Raw SQL body. Multiple statements separated by `;` are allowed. */
+  readonly sql: string;
+}
+
+/**
+ * Adapter contract that the {@link runMigrations} runner depends on. One
+ * implementation per dialect; both ship in `@sergeant/db-schema/migrate/pg`
+ * and `@sergeant/db-schema/migrate/sqlite`.
+ *
+ * Implementations are responsible for transactional safety: the
+ * {@link applyMigration} call must apply the migration SQL **and** insert
+ * the ledger row in a single atomic unit so that a partial failure leaves
+ * the database in a clean state.
+ */
+export interface MigrationAdapter {
+  /**
+   * Create the migrations ledger table if it does not exist. Must be
+   * idempotent — the runner calls this on every invocation.
+   *
+   * Required ledger shape (column names are stable, types are
+   * dialect-appropriate):
+   *
+   * - `id`     — INTEGER PRIMARY KEY (autoincrement)
+   * - `name`   — TEXT NOT NULL UNIQUE
+   * - `applied_at` — timestamp default `now()`
+   */
+  ensureLedger(tableName: string): Promise<void>;
+  /**
+   * Return the names of every migration that has already been applied,
+   * in insertion order. Used to compute the diff against the requested
+   * file list.
+   */
+  getAppliedNames(tableName: string): Promise<string[]>;
+  /**
+   * Apply a single migration in a transaction: execute `sql`, then
+   * record the migration in the ledger. Throws if either side fails;
+   * implementations must roll the transaction back on failure so the
+   * ledger never reflects a partially applied migration.
+   */
+  applyMigration(tableName: string, name: string, sql: string): Promise<void>;
+}
+
+/**
+ * Logger callback emitted by {@link runMigrations}. Optional — pass it
+ * if the consumer wants per-migration visibility (server logs, Sentry
+ * breadcrumbs, etc.). The runner stays silent if no logger is provided.
+ */
+export type MigrationLogEvent =
+  | { type: "ensure_ledger"; tableName: string }
+  | { type: "skipped"; name: string }
+  | { type: "applying"; name: string }
+  | { type: "applied"; name: string; durationMs: number }
+  | { type: "failed"; name: string; error: Error };
+
+export type MigrationLogger = (event: MigrationLogEvent) => void;
+
+export interface RunMigrationsOptions {
+  /** Adapter created via `createPgAdapter` or `createSqliteAdapter`. */
+  readonly adapter: MigrationAdapter;
+  /** Migrations to apply, in the order they should run. */
+  readonly files: readonly MigrationFile[];
+  /**
+   * Override the ledger table name. Defaults to `__migrations`. The
+   * server's existing `apps/server/migrate.mjs` uses `schema_migrations`
+   * — pass that here if/when consumers wire the new runner to share the
+   * existing ledger.
+   */
+  readonly tableName?: string;
+  /** Optional sink for per-migration log events. */
+  readonly logger?: MigrationLogger;
+}
+
+export interface RunMigrationsResult {
+  /** Names of migrations applied during this invocation. */
+  readonly applied: string[];
+  /** Names of migrations skipped because the ledger already had them. */
+  readonly skipped: string[];
+  /** Ledger table name actually used (defaulted or caller-provided). */
+  readonly tableName: string;
+}
+
+/** Default ledger table name. Matches PR #019's roadmap spec. */
+export const DEFAULT_MIGRATIONS_TABLE = "__migrations";
+
+/**
+ * Filename contract: starts with one or more digits, an underscore, a
+ * description, and ends in `.sql`. We deliberately reject `.down.sql`
+ * (the existing server convention treats those as manual rollbacks
+ * that production never auto-applies — see AGENTS.md hard rule #4).
+ */
+export const MIGRATION_FILENAME_RE = /^\d+_[A-Za-z0-9._-]+\.sql$/;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -727,15 +727,30 @@ importers:
       '@sergeant/config':
         specifier: workspace:*
         version: link:../config
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
+      '@types/pg':
+        specifier: ^8.20.0
+        version: 8.20.0
       '@vitest/coverage-v8':
         specifier: ^3.0.0
         version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+      better-sqlite3:
+        specifier: ^11
+        version: 11.10.0
       drizzle-kit:
         specifier: ^0.31.10
         version: 0.31.10
+      pg:
+        specifier: ^8.20.0
+        version: 8.20.0
+      pg-mem:
+        specifier: ^3.0.14
+        version: 3.0.14(kysely@0.28.16)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -6196,6 +6211,9 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
+  discontinuous-range@1.0.0:
+    resolution: {integrity: sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==}
+
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
@@ -7176,6 +7194,9 @@ packages:
     resolution: {integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==}
     engines: {node: '>= 0.4'}
 
+  functional-red-black-tree@1.0.1:
+    resolution: {integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==}
+
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
@@ -7508,6 +7529,9 @@ packages:
     resolution: {integrity: sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==}
     engines: {node: '>=16.x'}
     hasBin: true
+
+  immutable@4.3.8:
+    resolution: {integrity: sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==}
 
   import-fresh@2.0.0:
     resolution: {integrity: sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==}
@@ -8202,6 +8226,10 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  json-stable-stringify@1.3.0:
+    resolution: {integrity: sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==}
+    engines: {node: '>= 0.4'}
+
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
 
@@ -8215,6 +8243,9 @@ packages:
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+
+  jsonify@0.0.1:
+    resolution: {integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==}
 
   jsonpointer@5.0.1:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
@@ -8484,6 +8515,10 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
 
   lucide-react-native@1.11.0:
     resolution: {integrity: sha512-/dEt+/noOpsvgH1dbMHHSv+f8+npB1BJSKCqK9v9yvHbssN3OJJJXrih6N1prJGG3vj0e1zKiVLtet+OKYmiXg==}
@@ -8848,6 +8883,9 @@ packages:
   moment@2.30.1:
     resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
 
+  moo@0.5.3:
+    resolution: {integrity: sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA==}
+
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
@@ -8930,6 +8968,10 @@ packages:
 
   ncp@2.0.0:
     resolution: {integrity: sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==}
+    hasBin: true
+
+  nearley@2.20.1:
+    resolution: {integrity: sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==}
     hasBin: true
 
   negotiator@0.6.3:
@@ -9040,6 +9082,10 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  object-hash@2.2.0:
+    resolution: {integrity: sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==}
+    engines: {node: '>= 6'}
 
   object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
@@ -9311,6 +9357,41 @@ packages:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
 
+  pg-mem@3.0.14:
+    resolution: {integrity: sha512-G9m8OD0A+YS083smidSUJddTX2dEDPT8mRMG3sQGNiGfS/mkvAgd9Kf1/onD5633bFN7HcQK/Tn2x7qjBMFRUQ==}
+    peerDependencies:
+      '@mikro-orm/core': '>=4.5.3'
+      '@mikro-orm/postgresql': '>=4.5.3'
+      knex: '>=0.20'
+      kysely: '>=0.26'
+      mikro-orm: '*'
+      pg-promise: '>=10.8.7'
+      pg-server: ^0.1.5
+      postgres: ^3.4.4
+      slonik: '>=23.0.1'
+      typeorm: '>=0.2.29'
+    peerDependenciesMeta:
+      '@mikro-orm/core':
+        optional: true
+      '@mikro-orm/postgresql':
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mikro-orm:
+        optional: true
+      pg-promise:
+        optional: true
+      pg-server:
+        optional: true
+      postgres:
+        optional: true
+      slonik:
+        optional: true
+      typeorm:
+        optional: true
+
   pg-pool@3.13.0:
     resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
     peerDependencies:
@@ -9334,6 +9415,9 @@ packages:
 
   pgpass@1.0.5:
     resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
+  pgsql-ast-parser@12.0.2:
+    resolution: {integrity: sha512-1WWa96Sw6h4uv9GLw98EzH/+xoBTC8j2TwV/AMW3E+Ir/fHOu/jLLbj6kPiz3y2bGISTKNYvKWwHoqvQ5FLuAw==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -9636,6 +9720,13 @@ packages:
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  railroad-diagrams@1.0.0:
+    resolution: {integrity: sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==}
+
+  randexp@0.4.6:
+    resolution: {integrity: sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==}
+    engines: {node: '>=0.12'}
 
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
@@ -9992,6 +10083,10 @@ packages:
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
+
+  ret@0.1.15:
+    resolution: {integrity: sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==}
+    engines: {node: '>=0.12'}
 
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
@@ -17724,6 +17819,8 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
+  discontinuous-range@1.0.0: {}
+
   dlv@1.1.3: {}
 
   docker-compose@1.4.2:
@@ -18914,6 +19011,8 @@ snapshots:
       hasown: 2.0.3
       is-callable: 1.2.7
 
+  functional-red-black-tree@1.0.1: {}
+
   functions-have-names@1.2.3: {}
 
   funpermaproxy@1.1.0: {}
@@ -19294,6 +19393,8 @@ snapshots:
   image-size@1.2.1:
     dependencies:
       queue: 6.0.2
+
+  immutable@4.3.8: {}
 
   import-fresh@2.0.0:
     dependencies:
@@ -20240,6 +20341,14 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  json-stable-stringify@1.3.0:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      isarray: 2.0.5
+      jsonify: 0.0.1
+      object-keys: 1.1.1
+
   json-stringify-safe@5.0.1: {}
 
   json5@2.2.3: {}
@@ -20253,6 +20362,8 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jsonify@0.0.1: {}
 
   jsonpointer@5.0.1: {}
 
@@ -20528,6 +20639,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lru-cache@6.0.0:
+    dependencies:
+      yallist: 4.0.0
 
   lucide-react-native@1.11.0(react-native-svg@15.8.0(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -21091,8 +21206,9 @@ snapshots:
 
   module-details-from-path@1.0.4: {}
 
-  moment@2.30.1:
-    optional: true
+  moment@2.30.1: {}
+
+  moo@0.5.3: {}
 
   ms@2.0.0: {}
 
@@ -21271,6 +21387,13 @@ snapshots:
   ncp@2.0.0:
     optional: true
 
+  nearley@2.20.1:
+    dependencies:
+      commander: 2.20.3
+      moo: 0.5.3
+      railroad-diagrams: 1.0.0
+      randexp: 0.4.6
+
   negotiator@0.6.3: {}
 
   negotiator@0.6.4: {}
@@ -21376,6 +21499,8 @@ snapshots:
       flow-enums-runtime: 0.0.6
 
   object-assign@4.1.1: {}
+
+  object-hash@2.2.0: {}
 
   object-hash@3.0.0: {}
 
@@ -21709,6 +21834,18 @@ snapshots:
 
   pg-int8@1.0.1: {}
 
+  pg-mem@3.0.14(kysely@0.28.16):
+    dependencies:
+      functional-red-black-tree: 1.0.1
+      immutable: 4.3.8
+      json-stable-stringify: 1.3.0
+      lru-cache: 6.0.0
+      moment: 2.30.1
+      object-hash: 2.2.0
+      pgsql-ast-parser: 12.0.2
+    optionalDependencies:
+      kysely: 0.28.16
+
   pg-pool@3.13.0(pg@8.20.0):
     dependencies:
       pg: 8.20.0
@@ -21736,6 +21873,11 @@ snapshots:
   pgpass@1.0.5:
     dependencies:
       split2: 4.2.0
+
+  pgsql-ast-parser@12.0.2:
+    dependencies:
+      moo: 0.5.3
+      nearley: 2.20.1
 
   picocolors@1.1.1: {}
 
@@ -22064,6 +22206,13 @@ snapshots:
       inherits: 2.0.4
 
   quick-format-unescaped@4.0.4: {}
+
+  railroad-diagrams@1.0.0: {}
+
+  randexp@0.4.6:
+    dependencies:
+      discontinuous-range: 1.0.0
+      ret: 0.1.15
 
   range-parser@1.2.1: {}
 
@@ -22545,6 +22694,8 @@ snapshots:
     dependencies:
       onetime: 7.0.0
       signal-exit: 4.1.0
+
+  ret@0.1.15: {}
 
   retry@0.12.0: {}
 


### PR DESCRIPTION
## Summary

Implements PR #019 of [`docs/planning/storage-roadmap.md`](docs/planning/storage-roadmap.md) — a dialect-aware schema migration runner inside `packages/db-schema/`. The runner reads `*.sql` files, applies them sequentially in a transaction-per-file, tracks state in a `__migrations` ledger, and is idempotent and safe on partial failure. Both Postgres (`pg` / pg-mem) and SQLite (`better-sqlite3` / `expo-sqlite` / sqlite-wasm proxy) are covered through small adapter modules that are lazy-imported behind the runner's call site, so the server bundle never pulls in SQLite shims and client bundles never pull in `pg`.

This PR ships the runner only. `apps/server/migrate.mjs` and the existing `apps/web/src/core/db/sqlite.ts` / `apps/mobile/src/core/db/sqlite.ts` clients are intentionally untouched. No app's startup path runs migrations as a result of this PR — wiring is PR #020 (server) and PR #022 (client SPIKE).

Public API (added to `packages/db-schema/package.json` exports):

- `@sergeant/db-schema/migrate` — `runMigrations`, `MigrationFailedError`, `loadMigrationFiles`, types (no dialect imports).
- `@sergeant/db-schema/migrate/pg` — `createPgAdapter`, `PgQueryClient`.
- `@sergeant/db-schema/migrate/sqlite` — `createSqliteAdapter`, `SqliteMigrationClient`.

Tests live next to the source per the AGENTS.md soft rule and cover the full AC matrix on both dialects:

- `migrate.runner.test.ts` — adapter-agnostic contract via fake adapter (10 tests).
- `migrate.files.test.ts` — Node-only file loader (5 tests).
- `migrate.pg.test.ts` — pg-mem end-to-end (4 tests).
- `migrate.sqlite.test.ts` — better-sqlite3 end-to-end including async-client variant (4 tests).

## Governing Skill

- Primary skill: `sergeant-data-and-migrations`
- Secondary skill (if truly needed): `sergeant-monorepo-boundaries` (to keep dialect adapters lazy-imported and exports cleanly bounded)

## Playbook

- Primary playbook: none — PR #019's spec in `docs/planning/storage-roadmap.md` is the authoritative recipe and was treated as the playbook.
- Why this playbook: storage-roadmap PR #019 is a multi-step deliverable with explicit AC; quoting it into the todo list and matching exactly was the most direct path.
- If no playbook matched, why: this is foundation work for PRs #020 / #022, so no module-specific playbook applies; the storage roadmap entry is the spec.

## Verification

```bash
pnpm --filter @sergeant/db-schema typecheck   # OK
pnpm --filter @sergeant/db-schema lint        # OK
pnpm --filter @sergeant/db-schema test        # 28 / 28 passed (5 files)
npx prettier --check packages/db-schema/      # OK
pnpm lint                                     # OK
pnpm typecheck                                # FAILS only in apps/mobile (pre-existing on origin/main)
```

The `apps/mobile` typecheck failure in `apps/mobile/src/providers/QueryProvider.tsx` (TanStack `query-persist-client-core` duplicating `query-core`) is **pre-existing on `origin/main`** — reproduced by checking out the file from origin without my changes. Not caused by this PR.

Additional checks:

- [x] Local smoke / manual validation completed (28 vitest tests, both dialects)
- [x] Surface-specific checks completed (no app startup path touched; runner exercised end-to-end against pg-mem and better-sqlite3)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs: none. PR #019's scope in `docs/planning/storage-roadmap.md` already documents the deliverable; no other doc needed touching since the runner is unwired.

## Risk and Rollout

- **User-visible risk:** none. No app loads or runs the new code on startup; only consumers that explicitly `import` from `@sergeant/db-schema/migrate` will exercise it.
- **Rollout / deploy order:** safe to merge any time. The follow-up wiring (PR #020 server, PR #022 routine SPIKE clients) will turn this on.
- **Backout plan:** revert this PR. `apps/server/migrate.mjs` continues to handle production migrations independently.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian. (No internal docs touched in this PR; only TSDoc on new code in English per the AGENTS.md "code identifiers in English" carve-out.)
- [x] I did not use `--no-verify`. Husky lint-staged ran on every commit.

Note on commit subject scope: the PR title is exactly `feat: schema migration runner (cross-platform)` per the spec, but commitlint enforces `scope-empty: never`, so the commit subject uses the AGENTS.md-permitted fallback `feat(root): …`.

## Reviewer Notes

Things that deserve extra attention:

- **`noAstCoverageCheck: true` in `migrate.pg.test.ts`.** pg-mem trips its internal AST-coverage check when re-running `CREATE TABLE IF NOT EXISTS` on an existing table whose default is `NOW()`. The SQL is valid Postgres and runs fine in production; the flag only relaxes a pg-mem-internal warning. The cross-dialect equivalent in `apps/server/src/migrations/__tests__/rollback-sanity.test.ts` (when it lands later in the roadmap) should run against real Postgres for the FK / check-constraint surface pg-mem does not model. Worth confirming the team is comfortable with the `noAstCoverageCheck` flag here.
- **Adapter atomicity contract.** Each `applyMigration` runs `BEGIN` / migration SQL / `INSERT INTO __migrations` / `COMMIT` and `ROLLBACK`s on error. The mid-batch-failure tests verify both the ledger AND the schema after failure (the SQLite test asserts a half-applied DDL `beta` table is NOT present after rollback). Worth a careful read of the two `applyMigration` impls in `packages/db-schema/src/migrate/adapters/{pg,sqlite}.ts` to confirm the rollback paths are tight.
- **Identifier quoting.** Both adapters double-quote the ledger table name as defence-in-depth on top of the runner's `^[A-Za-z_][A-Za-z0-9_]*$` validation. There's a deliberate test (`runMigrations — runner contract > rejects an invalid migrations ledger table name`) for the SQL-injection-shaped input.
- **Lazy dialect imports.** The runner (`packages/db-schema/src/migrate/runner.ts`) imports nothing dialect-specific. Adapter factories live in dedicated entry points (`./migrate/pg`, `./migrate/sqlite`) so server / web / mobile bundles only pull in their own dialect.
- **Filename validation excludes `.down.sql`.** Matches the existing `apps/server/migrate.mjs` convention — production never auto-applies down migrations. The loader silently filters them out; the runner-level validator rejects malformed names before any adapter call.
- **devDependency additions:** `pg`, `pg-mem`, `better-sqlite3`, `@types/pg`, `@types/better-sqlite3`. No production dependencies added. `better-sqlite3` was already a devDependency of `apps/mobile`, so it's a known quantity in the workspace.
- **Pre-existing main breakage flagged in Verification** — please don't attribute the `apps/mobile` `QueryProvider.tsx` typecheck error to this PR.

Link to Devin session: https://app.devin.ai/sessions/629eeedf38dc46b6a9330185be0ef1b6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a cross‑platform schema migration runner in `@sergeant/db-schema` that applies `*.sql` files in order with a transaction per file and a `__migrations` ledger. Adapters for Postgres and SQLite are lazy‑imported; nothing is wired into apps yet, so there’s no runtime change.

- **New Features**
  - Dialect‑agnostic `runMigrations` with idempotent re-runs and safe rollback on failure.
  - Validates `NNN_description.sql` names; Node‑only `loadMigrationFiles` filters `.down.sql` and sorts files.
  - Adapters: `createPgAdapter` for `pg` and `createSqliteAdapter` for sync/async SQLite clients.
  - Public API: `@sergeant/db-schema/migrate`, `@sergeant/db-schema/migrate/pg`, `@sergeant/db-schema/migrate/sqlite`.
  - Tests cover contract and end‑to‑end for Postgres (pg‑mem) and SQLite (better‑sqlite3).

- **Dependencies**
  - Dev dependencies only: `pg`, `pg-mem`, `better-sqlite3`, `@types/pg`, `@types/better-sqlite3`.

<sup>Written for commit 21eef147e4a165d5540864a3281bc00970ba4451. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added database schema migration framework supporting PostgreSQL and SQLite
  * Migrations are idempotent and can be safely re-run
  * Automatic ledger tracking prevents duplicate execution
  * Built-in error recovery and rollback capabilities
  * Optional migration logging for monitoring and debugging
  * File-based migration loading with lexicographic ordering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->