### PR TITLE
docs(planning): mark storage-roadmap PRs #014, #015, #017, #018, #019, #020 as landed

### DIFF
--- a/docs/planning/storage-roadmap.md
+++ b/docs/planning/storage-roadmap.md
@@ -260,7 +260,7 @@ payload_size, conflict, created_at)`. Запис у `syncPushAll`/`syncPullAll`
 
 ### Stage 2 — Foundation для SQLite
 
-#### **PR #014 — `feat: add Drizzle ORM as cross-platform schema source of truth`** ✅ IN PROGRESS
+#### **PR #014 — `feat: add Drizzle ORM as cross-platform schema source of truth`** ✅ LANDED — [#1290](https://github.com/Skords-01/Sergeant/pull/1290)
 
 - **Scope.**
   - `packages/db-schema/` — новий package, експортує Drizzle table definitions.
@@ -278,7 +278,7 @@ payload_size, conflict, created_at)`. Запис у `syncPushAll`/`syncPullAll`
   що Drizzle generates same SQL для існуючої схеми.
 - **Dep.** None.
 
-#### **PR #015 — `feat(web): integrate sqlite-wasm with OPFS-VFS, lazy-loaded`**
+#### **PR #015 — `feat(web): integrate sqlite-wasm with OPFS-VFS, lazy-loaded`** ✅ LANDED — [#1310](https://github.com/Skords-01/Sergeant/pull/1310)
 
 - **Scope.**
   - Додати `@sqlite.org/sqlite-wasm` як dep.
@@ -316,7 +316,7 @@ payload_size, conflict, created_at)`. Запис у `syncPushAll`/`syncPullAll`
   правил — test заздалегідь.
 - **Dep.** PR #017.
 
-#### **PR #017 — `chore(web): self-host Google Fonts via fontsource`**
+#### **PR #017 — `chore(web): self-host Google Fonts via fontsource`** ✅ LANDED — [#1297](https://github.com/Skords-01/Sergeant/pull/1297)
 
 - **Scope.** Перейти з Google Fonts CDN на `@fontsource/{family}`.
   Service Worker `CacheFirst` правило для шрифтів стає простіше (same-origin).
@@ -324,7 +324,7 @@ payload_size, conflict, created_at)`. Запис у `syncPushAll`/`syncPullAll`
   Playwright тестом.
 - **Dep.** None.
 
-#### **PR #018 — `feat(mobile): integrate expo-sqlite v15 with Drizzle adapter`**
+#### **PR #018 — `feat(mobile): integrate expo-sqlite v15 with Drizzle adapter`** ✅ LANDED — [#1307](https://github.com/Skords-01/Sergeant/pull/1307)
 
 - **Scope.**
   - Додати `expo-sqlite` (SDK 52 first-class). Drizzle через
@@ -337,7 +337,7 @@ payload_size, conflict, created_at)`. Запис у `syncPushAll`/`syncPullAll`
 - **AC.** Detox e2e: insert/select/migrate.
 - **Dep.** PR #014.
 
-#### **PR #019 — `feat: schema migration runner (cross-platform)`**
+#### **PR #019 — `feat: schema migration runner (cross-platform)`** ✅ LANDED — [#1333](https://github.com/Skords-01/Sergeant/pull/1333)
 
 - **Scope.** `packages/db-schema/migrate.ts` — runner що читає
   `*.sql` з `migrations/` і застосовує послідовно з трекінгом у
@@ -347,7 +347,7 @@ payload_size, conflict, created_at)`. Запис у `syncPushAll`/`syncPullAll`
   rollback на середині міграції залишає БД у consistent state.
 - **Dep.** PR #014.
 
-#### **PR #020 — `feat(server): create normalized routine_* tables (target shape)`**
+#### **PR #020 — `feat(server): create normalized routine_* tables (target shape)`** ✅ LANDED — [#1332](https://github.com/Skords-01/Sergeant/pull/1332)
 
 - **Scope.** `026_routine_tables.{sql,down.sql}`:
   - `routine_entries (id UUID, user_id, name, completed_at, created_at, updated_at, deleted_at)`


### PR DESCRIPTION
## Summary

Updates `docs/planning/storage-roadmap.md` to reflect the current state of Stage 2 (Foundation для SQLite). Six PR sections that were either unmarked or stale (`PR #014` was still tagged `✅ IN PROGRESS`) are now annotated `✅ LANDED — [#NNNN](…)` linking to the merged GitHub PR. No content/scope/AC text is touched — only the section headers.

| Roadmap PR | Title | Merged PR |
| --- | --- | --- |
| #014 | feat: add Drizzle ORM as cross-platform schema source of truth | [#1290](https://github.com/Skords-01/Sergeant/pull/1290) |
| #015 | feat(web): integrate sqlite-wasm with OPFS-VFS, lazy-loaded | [#1310](https://github.com/Skords-01/Sergeant/pull/1310) |
| #017 | chore(web): self-host Google Fonts via fontsource | [#1297](https://github.com/Skords-01/Sergeant/pull/1297) |
| #018 | feat(mobile): integrate expo-sqlite v15 with Drizzle adapter | [#1307](https://github.com/Skords-01/Sergeant/pull/1307) |
| #019 | feat: schema migration runner (cross-platform) | [#1333](https://github.com/Skords-01/Sergeant/pull/1333) |
| #020 | feat(server): create normalized routine_\* tables (target shape) | [#1332](https://github.com/Skords-01/Sergeant/pull/1332) |

## Governing Skill

- Primary skill: `sergeant-start-here` (docs hygiene)
- Secondary skill: n/a

## Playbook

- Primary playbook: n/a
- Why this playbook: docs-only status refresh, no automation involved
- If no playbook matched, why: pure markdown bookkeeping for a tracking doc

## Verification

```bash
git diff --stat docs/planning/storage-roadmap.md
# 1 file changed, 6 insertions(+), 6 deletions(-)
```

Additional checks:

- [x] Visual diff inspected — only six section header lines changed
- [x] All linked PR numbers verified to exist on `Skords-01/Sergeant`

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update — n/a
- [x] I checked whether a playbook or skill needed an update — n/a
- [x] I checked whether governance docs or review docs needed an update — n/a

Updated docs:

- `docs/planning/storage-roadmap.md` — six Stage 2 PR sections marked `✅ LANDED` with links

## Risk and Rollout

- **User-visible risk:** none. Markdown docs only.
- **Rollout / deploy order:** ships independently; no deploy.
- **Backout plan:** revert the commit.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian (only English status tags appended; surrounding Ukrainian prose untouched).
- [x] I did not use `--no-verify`.

## Reviewer Notes

- **Sanity-check PR numbers**, especially `#1290` for roadmap PR #014 — please confirm that's the actual merge commit for the Drizzle-ORM landing. The other five (`#1310`, `#1297`, `#1307`, `#1333`, `#1332`) were taken directly from the merged commits visible in `git log --oneline origin/main`.
- The `"✅ LANDED — [#NNNN](…)"` format mirrors the existing `"✅ IN PROGRESS"` marker convention already used on PR #014's old line — picked for consistency rather than introducing a new badge style. If you'd prefer a different convention (e.g. a checkbox or a per-stage roll-up table), happy to adjust.
- Stage 2 is now visually complete on the roadmap (six green checks back-to-back). The next unmarked item is **PR #016 (COOP/COEP headers)** — depends on #017 (now landed), so it's unblocked.

Link to Devin session: https://app.devin.ai/sessions/7635c0be4fb64dd384ab12a01fa5f8c9

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks six Stage 2 SQLite items in the storage roadmap as ✅ LANDED with links to their merged PRs (#1290, #1310, #1297, #1307, #1333, #1332). Kept these markers during a merge conflict resolution.

Only the six section headers in `docs/planning/storage-roadmap.md` were updated; no body text or scope changed.

<sup>Written for commit a5032a052830aa3372fa334b51ee339fefacbc9f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated storage & sync roadmap: several Stage 2/Foundation items marked as completed and linked to their final PRs, reflecting progress on storage, migration, and related integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->