### PR TITLE
docs: mark PR #019 as in progress in storage roadmap

### DIFF
--- a/docs/planning/storage-roadmap.md
+++ b/docs/planning/storage-roadmap.md
@@ -1,6 +1,6 @@
 # Storage & Sync — Roadmap до production-ready
 
-> **Last validated:** 2026-05-02 by @claude. **Next review:** 2026-07-31.
+> **Last validated:** 2026-05-02 by @Skords-01. **Next review:** 2026-07-31.
 > **Status:** Active
 
 > Зріз: 2026-05-01. Базується на storage-аудиті + поточний стек:
@@ -337,7 +337,7 @@ payload_size, conflict, created_at)`. Запис у `syncPushAll`/`syncPullAll`
 - **AC.** Detox e2e: insert/select/migrate.
 - **Dep.** PR #014.
 
-#### **PR #019 — `feat: schema migration runner (cross-platform)`**
+#### **PR #019 — `feat: schema migration runner (cross-platform)`** ✅ IN PROGRESS
 
 - **Scope.** `packages/db-schema/migrate.ts` — runner що читає
   `*.sql` з `migrations/` і застосовує послідовно з трекінгом у


### PR DESCRIPTION
## Summary

Doc-only follow-up to the merged PR #1333 (`feat: schema migration runner (cross-platform)`). Appends `✅ IN PROGRESS` to the `#### **PR #019 — …**` header in `docs/planning/storage-roadmap.md` so the deliverable status is visible in the roadmap, mirroring how PR #014 is annotated on line ~263.

The `Last validated` line at the top of the file was bumped from `@claude` to `@Skords-01` automatically by the `scripts/docs/bump-last-validated.mjs` lint-staged hook — it is a side effect of the pre-commit pipeline, not a manual edit. No other PR sections in the roadmap are touched.

## Governing Skill

- Primary skill: `sergeant-start-here` (governance / docs-touch checklist)
- Secondary skill (if truly needed): none — this is a one-line annotation update.

## Playbook

- Primary playbook: none.
- Why this playbook: n/a — the change is a single-line status annotation explicitly requested by the maintainer; no module-specific recipe applies.
- If no playbook matched, why: trivial doc edit; AGENTS.md and the maintainer's instruction (mirror PR #014's annotation) are the only authoritative inputs.

## Verification

```bash
git diff --cached docs/planning/storage-roadmap.md   # 2 lines changed (the appended badge + auto-bumped "Last validated" author)
git commit                                           # husky lint-staged: bump-last-validated.mjs ✓, prettier --write ✓, commitlint ✓
```

Additional checks:

- [x] Local smoke / manual validation completed (visual diff of the edited section)
- [x] Surface-specific checks completed (no source / config touched; pure doc change)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- `docs/planning/storage-roadmap.md` — append `✅ IN PROGRESS` to the PR #019 header.

## Risk and Rollout

- **User-visible risk:** none. Documentation only; no code, no schema, no runtime behaviour change.
- **Rollout / deploy order:** safe to merge any time.
- **Backout plan:** revert this PR.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian (the file is already mixed Ukrainian / code-identifiers; only the English status badge is added, matching the PR #014 precedent).
- [x] I did not use `--no-verify`. Husky lint-staged ran on the commit (bump-last-validated.mjs + prettier).

## Reviewer Notes

- The `Last validated` line bump from `@claude` → `@Skords-01` is a **hook-generated side effect** of `scripts/docs/bump-last-validated.mjs`, not a manual edit. Flagging because the maintainer asked not to touch unrelated content; if this should be reverted, please advise and I'll roll it back.
- The appended badge text `✅ IN PROGRESS` exactly mirrors the annotation on PR #014 (line ~263). No other PR sections in the roadmap are modified.
- No PR number is included in the badge per the maintainer's instruction (it'll be added when the PR opens).

Link to Devin session: https://app.devin.ai/sessions/629eeedf38dc46b6a9330185be0ef1b6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added '✅ IN PROGRESS' to the PR #019 header in docs/planning/storage-roadmap.md to show the schema migration runner is underway, mirroring PR #014. The 'Last validated' line auto-updated to `@Skords-01`; nothing else changed.

<sup>Written for commit 1f1b62f9d349031e52055c526bb74c0abd3759cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated storage roadmap planning documentation with metadata revisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->