### PR TITLE
docs(docs): align ADR-0030 metadata format + register in README (fixes ADR-graph CI on main)

### DIFF
--- a/docs/adr/0030-telegram-reporting-channel-structure.md
+++ b/docs/adr/0030-telegram-reporting-channel-structure.md
@@ -1,7 +1,16 @@
-# 0030 — Структура Telegram-каналів для n8n reporting
+# ADR-0030: Структура Telegram-каналів для n8n reporting
 
-> **Last validated:** 2026-05-02 by @Skords-01. **Next review:** 2026-08-01.
-> **Status:** Accepted
+- **Status:** Accepted
+- **Date:** 2026-05-02
+- **Deciders:** @Skords-01
+- **Supersedes:** —
+- **Related:**
+  - [`ops/n8n-workflows/REPORTING-MATRIX.md`](../../ops/n8n-workflows/REPORTING-MATRIX.md) — workflow → topic routing matrix.
+  - [`docs/observability/telegram-control-plane.md`](../observability/telegram-control-plane.md) — architectural review.
+  - [ADR-0026 — n8n workflow source of truth](./0026-n8n-workflow-source-of-truth.md) — Git-as-truth для workflow JSON.
+  - [`docs/playbooks/modify-n8n-workflow.md`](../playbooks/modify-n8n-workflow.md) — playbook оновлення matrix-у разом з workflow.
+
+---
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -97,7 +97,8 @@ pnpm gen:adr
 | 0026 | n8n — джерело істини для воркфлоу               | accepted | 2026-04-27 | Git — джерело істини для n8n; JSON у `ops/n8n-workflows/` + manifest з owner / risk / secrets.            |
 | 0027 | Політика OpenClaw, Console та MCP               | accepted | 2026-04-27 | `apps/console` як internal admin; allowlist по Telegram user-id; вивід агента — untrusted.                |
 | 0028 | pgvector + AI memory                            | accepted | 2026-05-01 | Voyage embeddings → `halfvec(1024)` у Postgres з HNSW + hash-партиціонуванням; vector-store-agnostic API. |
+| 0030 | Telegram reporting channel structure            | accepted | 2026-05-02 | Single supergroup + Forum mode (8 канонічних топіків) + P0/P1/P2 escalation hierarchy + WF-98 fan-out.    |
 
-> **Note on numbering 0016–0022 jump:** ADRs `0016`–`0022` — це retroactive batch, що був написаний паралельно з `0006`–`0012`. Через паралельне виконання Devin-сесій виникли колізії номерів `0003`–`0012`. Розв'язано через PR `docs(adr): resolve numbering collisions` — same-topic дублі (refund, anthropic, PII) видалено, late-comers перенумеровано в `0016`+. ADRs нумеруються **sequentially without gaps** надалі — наступний номер `0029`.
+> **Note on numbering 0016–0022 jump:** ADRs `0016`–`0022` — це retroactive batch, що був написаний паралельно з `0006`–`0012`. Через паралельне виконання Devin-сесій виникли колізії номерів `0003`–`0012`. Розв'язано через PR `docs(adr): resolve numbering collisions` — same-topic дублі (refund, anthropic, PII) видалено, late-comers перенумеровано в `0016`+. ADRs нумеруються **sequentially without gaps** надалі — наступний номер `0031`.
 
 > **Graph integrity:** Парсинг метаданих ADR (`Status:` / `Supersedes:`, з підтримкою англо- та україномовних назв полів — див. ADR-0026/0027) і перевірка індексу + бідіректіонального supersede-зв'язку автоматизовані: `node scripts/docs/check-adr-graph.mjs` (CI gate в `docs-automation.yml`).


### PR DESCRIPTION
## Summary

Hot-fix CI gate `ADR graph (statuses, supersede, README index)` яка зламалася на main після merge PR #1340.

ADR-0030 (доданий у #1340) використовував block-quote freshness header замість канонічного bullet-list metadata. `scripts/docs/check-adr-graph.mjs` парсить лише форму `- **Status:** ...` / `- **Supersedes:** ...` (як решта 28 ADR-ів) — тому ADR-0030 був відкинутий як «missing required fields», а заодно — не зареєстрований у README-таблиці.

Зміни:

- `docs/adr/0030-telegram-reporting-channel-structure.md` — block-quote header → bullet metadata (Status / Date / Deciders / Supersedes / Related).
- `docs/adr/README.md` — додано рядок ADR-0030 у таблицю «Поточні ADR»; bumped «наступний номер» note з 0029 → 0031.

## Governing Skill

- Primary skill: `sergeant-start-here` (governance entry-point — ADR conventions у `docs/adr/README.md` + check-adr-graph CI gate).
- Secondary skill (if truly needed): `sergeant-deploy-and-observability` (PR-1340 контекст).

## Playbook

- Primary playbook: n/a — це CI hot-fix, не workflow modification.
- Why this playbook: ADR-format alignment не покривається жодним playbook у `docs/playbooks/`. Найближчий guidance — `docs/adr/README.md` + `docs/adr/TEMPLATE.md`.
- If no playbook matched, why: hot-fix категорія для відновлення зламаного CI gate. Альтернатива — `docs/playbooks/modify-adr.md` — не існує.

## Verification

```bash
node scripts/docs/check-adr-graph.mjs
# → [check-adr-graph] OK — 29 ADR(s) checked, graph is consistent.

node --test scripts/docs/__tests__/check-adr-graph.test.mjs
# → tests passed (graph integrity invariants intact)
```

Additional checks:

- [x] Local smoke / manual validation completed (graph integrity restored)
- [x] Surface-specific checks completed (метадані ADR-0030 = ADR-0028 канонічна форма; README-table має 0030 row)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- `docs/adr/0030-telegram-reporting-channel-structure.md` — metadata format alignment (no semantic change to decision content).
- `docs/adr/README.md` — added ADR-0030 row to «Поточні ADR» table.

## Risk and Rollout

- User-visible risk: **none.** Doc-only PR; не торкає workflow JSON / runtime / Railway env vars.
- Rollout / deploy order: merge → CI gate `ADR graph` зеленіє на main; жодних деплоїв.
- Backout plan: revert PR — поверне попередній стан (з зламаним CI gate). Безпечно.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

- Жодних змін у тексті ADR-0030 рішення — лише format metadata header. Решту контенту залишено as-is.
- Цей PR відкриває я (Devin) як follow-up до #1340; merge PR-1340 був форсований через `mergeable_state: blocked`, що залишило ADR-CI у failing-стані на main. Перевірено локально проти 13c71727 (поточний main): без цього патчу `node scripts/docs/check-adr-graph.mjs` падає з 3 помилками; з патчем — 29 ADR pass.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the “ADR graph” CI on main by aligning ADR-0030 to the canonical metadata format and adding it to the ADR index. No runtime or workflow changes.

- **Bug Fixes**
  - Converted `docs/adr/0030-telegram-reporting-channel-structure.md` header to bullet-list metadata (Status/Date/Deciders/Supersedes/Related). No change to the decision text.
  - Added ADR-0030 to the “Поточні ADR” table in `docs/adr/README.md` and updated the “next number” note from 0029 to 0031 so `scripts/docs/check-adr-graph.mjs` and the README index check pass.

<sup>Written for commit e0da35d361ea4e85424354e771445fa17ae5fe25. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

