### PR TITLE
docs(docs): add AI memory activation runbook + register feature flags

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -1,6 +1,6 @@
 # Feature Flags Registry
 
-> **Last validated:** 2026-05-02 by @claude. **Next review:** 2026-07-31.
+> **Last validated:** 2026-05-02 by @Skords-01. **Next review:** 2026-07-31.
 > **Status:** Active
 
 Operational registry for release toggles, experiments, and kill switches in Sergeant. Code remains the executable source of truth; this file is the human-readable operating registry for rollout and cleanup.
@@ -20,11 +20,10 @@ Every production flag must have:
 
 ## Active flags
 
-| Flag                 | Owner        | Default | Rollout plan                                                                                             | Kill switch                                                  | Created    | Expected removal | Touched surfaces                                   | Linked issue / PR             |
-| -------------------- | ------------ | ------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ | ---------- | ---------------- | -------------------------------------------------- | ----------------------------- |
-| `example_replace_me` | `@Skords-01` | `false` | start with internal validation, enable for narrow cohort, monitor errors and UX, then graduate or remove | disable in flag registry or client settings without redeploy | 2026-05-02 | 2026-06-30       | web, mobile, API notes if mirrored behavior exists | replace with real issue or PR |
-
-Replace placeholder rows with real flags as part of the first flag-touching PR after this document lands.
+| Flag                            | Owner        | Default | Rollout plan                                                                                                                                                                                                | Kill switch                                                                                               | Created    | Expected removal                                | Touched surfaces                                                                          | Linked issue / PR                                                        |
+| ------------------------------- | ------------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | ---------- | ----------------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `AI_MEMORY_ENABLED`             | `@Skords-01` | `false` | dormant after PR1/2/3 land; activate via Railway env after `VOYAGE_API_KEY` provisioned. Per-source toggles роздільно. Runbook — [`docs/launch/ai-memory-activation.md`](./launch/ai-memory-activation.md). | Set `false` in Railway env → `remember()` / `recall()` no-op миттєво без redeploy-у callers               | 2026-05-01 | TBD (graduate after >30d stable in prod)        | `apps/server/src/modules/ai-memory/`, `/api/chat` (RAG), `/api/ai-memory/{recall,ingest}` | [ADR-0028](./adr/0028-pgvector-ai-memory.md) · #1305 (PR2) · #1347 (PR3) |
+| `MONO_AI_MEMORY_INGEST_ENABLED` | `@Skords-01` | `false` | per-source gate для finyk-ingestion з mono webhook-у. Активація після `AI_MEMORY_ENABLED=true` і ≥1 день quiet master-flag-у.                                                                               | Set `false` → mono webhook припиняє enqueue jobs у `sergeant:ai-memory-ingest`; інші source-и продовжують | 2026-05-01 | TBD (об'єднати з master-flag-ом коли graduated) | `apps/server/src/modules/mono/webhook.ts`                                                 | [ADR-0028](./adr/0028-pgvector-ai-memory.md) · #1305                     |
 
 ## Rules
 

--- a/docs/launch/ai-memory-activation.md
+++ b/docs/launch/ai-memory-activation.md
@@ -1,0 +1,179 @@
+# AI Memory — activation runbook
+
+> **Last validated:** 2026-05-02 by @Skords-01. **Next review:** 2026-08-01.
+> **Status:** Active
+
+Як перевести pgvector AI memory підсистему з dormant у production-active після
+landing PR1 (foundation) + PR2 (ingestion) + PR3 (retrieval). Усі три PR-и
+змержені dormant: `AI_MEMORY_ENABLED=false` за замовчуванням → `remember()` /
+`recall()` no-op-лять без HTTP до Voyage / БД, нема ніяких side-effects.
+
+ADR — [`docs/adr/0028-pgvector-ai-memory.md`](../adr/0028-pgvector-ai-memory.md).
+Інтеграційний doc — [`docs/integrations/voyage-pgvector.md`](../integrations/voyage-pgvector.md).
+
+---
+
+## Pre-flight checklist
+
+Перед першим toggle-ом:
+
+- [ ] **Voyage rate-limit + billing.** Підтвердити, що Voyage акаунт має
+      достатній quota: на горизонті 1k активних × 500 memories/міс × 200 tokens
+      ≈ 100M tokens/міс ≈ **~$2/міс**. Free tier дає 50M tokens/міс — достатньо
+      для пілоту, але прод-rollout потребує paid акаунту. Dashboard:
+      <https://dash.voyageai.com/>.
+- [ ] **pgvector extension у Railway Postgres.** Перевірити, що міграція 025
+      (`025_ai_memories_pgvector.sql`) виконана на prod-БД:
+      `SELECT to_regclass('ai_memories');` має повернути не-null.
+      Якщо null — `pnpm --filter @sergeant/server db:migrate` спочатку.
+- [ ] **Anthropic prompt cache warm-up budget.** `SYSTEM_PROMPT_VERSION v6→v7`
+      інвалідує cache на першому request-і кожного активного юзера після
+      deploy. Очікуваний spike: ~5хв elevated cost (≈ $1–2 на 1k активних).
+- [ ] **Redis BullMQ доступний.** Ingestion-черга `sergeant:ai-memory-ingest`
+      потребує Redis. Якщо `REDIS_URL` відсутній — fallback на in-process
+      dispatch (працює, але без retry-семантики).
+- [ ] **Метрики dashboard.** Налаштувати Grafana panel-и для
+      `ai_memory_ingest_*` (PR2) і `voyage_external_http_*` (PR1) метрик.
+
+---
+
+## Activation steps
+
+### Step 1. Provision `VOYAGE_API_KEY` (Railway)
+
+1. Створити прод-API-ключ на <https://dash.voyageai.com/api-keys>. Назва
+   рекомендована: `sergeant-prod` (для traceability у Voyage billing).
+2. У Railway dashboard для сервісу `hub-api`:
+   - Variables → New Variable
+   - Name: `VOYAGE_API_KEY`
+   - Value: `pa-...` (без quotes, без trailing whitespace)
+   - Service: `hub-api` тільки (НЕ `hub-web` — клієнт не дзвонить Voyage).
+3. **Redeploy не потрібен** — Voyage-клієнт читає env при першому виклику
+   `recall()` / `remember()`. Якщо `AI_MEMORY_ENABLED=false`, ключ читається
+   тільки коли flag вмикається (Step 2).
+
+### Step 2. Toggle `AI_MEMORY_ENABLED=true` (Railway)
+
+1. У Railway dashboard для `hub-api`:
+   - Variables → знайти `AI_MEMORY_ENABLED` → Edit
+   - Value: `true`
+2. Railway автоматично redeploy-ить сервіс (~30s). Це **хот toggle** —
+   жодних DDL змін не відбувається.
+3. **Верифікація:** після redeploy зробити sanity-curl з production-сесією:
+   ```bash
+   curl -X POST https://sergeant-production.up.railway.app/api/ai-memory/recall \
+     -H "Cookie: better-auth.session_token=<token>" \
+     -H "Content-Type: application/json" \
+     -d '{"query":"тест активації memory","top_k":3}'
+   ```
+   Очікуваний результат: 200 з `{"memories":[]}` (порожньо, бо ще ніхто
+   нічого не зберігав). Якщо 503 з `EMBEDDING_PROVIDER_UNAVAILABLE` →
+   ключ не підхопився → перевірити Step 1.
+
+### Step 3. Enable per-source ingestion (за бажанням, поетапно)
+
+Master-flag `AI_MEMORY_ENABLED=true` сам по собі ще не починає писати у
+`ai_memories`. Producer-и керуються окремими прапорцями:
+
+| Producer                                                             | Flag                             | Default | Що робити                                                  |
+| -------------------------------------------------------------------- | -------------------------------- | ------- | ---------------------------------------------------------- |
+| `mono/webhook`                                                       | `MONO_AI_MEMORY_INGEST_ENABLED`  | `false` | Виставити `true` коли готові індексувати транзакції        |
+| `weekly-digest`                                                      | _no flag_ — auto-on після master | —       | Перший digest-cron запише через ~24h                       |
+| `POST /api/ai-memory/ingest` (chat/fizruk/nutrition/routine/journal) | _no flag_ — клієнт-driven        | —       | Web-/mobile-клієнти будуть викликати, як зараз заплановано |
+
+**Рекомендований порядок (дні 1–7 після Step 2):**
+
+- **День 1.** Тільки master-flag. `recall()` працює (через `recall_memory`
+  HubChat tool + RAG-injection), але `ai_memories` порожня → жодних
+  results. Це **safe rollout** — перевіряємо латенцію Voyage embed без
+  write-навантаження на БД.
+- **День 2–3.** Увімкнути `MONO_AI_MEMORY_INGEST_ENABLED=true`. Спостерігати
+  `ai_memory_ingest_processed_total{source="finyk", outcome=...}` — має
+  ростити `ok` метрику на кожній mono-webhook-транзакції.
+- **День 4–7.** Спостерігати `ai_memory_ingest_queue_depth` — має триматися
+  низькою (< 100 jobs). Якщо росте → Voyage rate-limit-ить (`429`) →
+  знизити `AI_MEMORY_INGEST_CONCURRENCY` з 4 до 2.
+
+### Step 4. End-to-end smoke test
+
+Після Step 3, день 7+: перевірити, що memory повертається через chat.
+
+1. У web/mobile-клієнті як test-user-а зробити фінансову транзакцію через
+   Mono-webhook (потрібно нову, щоб точно відіндексувалась після Step 3).
+2. Чекати ~5–30 секунд (BullMQ + Voyage embed).
+3. Відкрити HubChat і запитати: «нагадай мою останню транзакцію».
+4. **Очікуваний flow:**
+   - RAG-injection додає в system prompt блок `[Релевантні спогади:]`
+     з топ-4 memory-фактами (видно у `apps/server/src/modules/chat/chat.ts`
+     debug-логах: `rag_context_built` з `count`).
+   - Anthropic може власноруч викликати tool `recall_memory` для
+     уточнення → `POST /api/ai-memory/recall` → top-K results.
+5. Якщо асистент відповідає з реальними даними транзакції — flow працює.
+   Якщо відповідає generic-text-ом — перевірити логи Pino:
+   - `rag_context_skipped` з `reason=*` — короткий query / немає user-id
+   - `rag_context_failed` — Voyage timeout / 5xx → no-op fallback працює
+   - `recall_memory_called` — tool-call успішний
+
+---
+
+## Rollback / kill-switch
+
+Якщо щось пішло не так:
+
+1. **Швидкий kill (≤30s):** `AI_MEMORY_ENABLED=false` у Railway → redeploy.
+   Усі гілки (`recall_memory` tool, RAG-injection, ingestion-producer-и)
+   no-op-лять негайно. Existing data у `ai_memories` лишається — нема
+   destructive truncate.
+2. **Selective ingestion kill:** залишити master-flag, виставити
+   `MONO_AI_MEMORY_INGEST_ENABLED=false` — finyk-source перестає писати,
+   решта продовжує. Корисно якщо Mono-webhook генерує 429 на Voyage.
+3. **Voyage outage:** circuit-breaker сам розмикається після 3 послідовних
+   5xx. Метрика `voyage_external_http_breaker_state` = `open` → ingestion
+   park-иться у BullMQ retry-черзі, retrieval повертає 503 (graceful).
+   Жодних додаткових toggle-ів не треба.
+4. **GDPR forget-user-request:** `forgetUser(userId)` працює **незалежно**
+   від master-flag-а — це GDPR escape-hatch. `DELETE /api/me` (Better Auth)
+   вже cascade-ить через FK `ON DELETE CASCADE`.
+
+---
+
+## Observability checklist
+
+Після активації моніторити:
+
+| Метрика                                                      | Поріг алерту                     | Де дивитись                       |
+| ------------------------------------------------------------ | -------------------------------- | --------------------------------- |
+| `voyage_external_http_requests_total`                        | `outcome=error` > 5% — alert     | Grafana `Voyage` panel            |
+| `voyage_external_http_breaker_state`                         | `open` > 5min — alert            | Grafana `Voyage` panel            |
+| `ai_memory_ingest_queue_depth{state="waiting"}`              | > 1000 sustained — alert         | Grafana `AI memory` panel         |
+| `ai_memory_ingest_processed_total{outcome="permanent_fail"}` | > 1% — alert                     | Grafana `AI memory` panel         |
+| `http_request_duration_ms{path="/api/chat"}` p95             | +500ms vs baseline — investigate | Grafana `HTTP` panel              |
+| Voyage billing                                               | $50/міс — soft cap               | <https://dash.voyageai.com/usage> |
+
+Дашборд-панелі ще не створені — окремий PR (див. roadmap нижче).
+
+---
+
+## Roadmap після активації
+
+Технічні TODO, які не блокують rollout, але треба підбити:
+
+- **ESLint guard** — заблокувати direct-import з `vectorStore.ts` /
+  `embeddings.ts` через `@typescript-eslint/no-restricted-imports` у
+  `eslint-plugin-sergeant-design`. TODO зафіксований в [ADR-0028 § Compliance](../adr/0028-pgvector-ai-memory.md#compliance).
+- **Re-embed worker (PR2.1)** — batch-job для re-embed-у при зміні
+  `voyage-3-lite` / `embedding_version`.
+- **Prometheus dashboard** — рознести `ai_memory_*` і `voyage_external_http_*`
+  у окрему Grafana-панель.
+- **PR4: hybrid hot/cold storage** — `user_memory_summaries` + pgvector
+  тільки для hot 90 днів. Threshold-и в [ADR-0028 § Scaling thresholds](../adr/0028-pgvector-ai-memory.md#scaling-thresholds).
+  Не зараз — потрібно для >100k активних юзерів.
+
+---
+
+## Related
+
+- [ADR-0028: pgvector + Voyage embeddings](../adr/0028-pgvector-ai-memory.md)
+- [Voyage AI + pgvector integration doc](../integrations/voyage-pgvector.md)
+- [Feature flags registry](../feature-flags.md)
+- [Observability runbook](../observability/runbook.md)


### PR DESCRIPTION
## Summary

Docs-only follow-up до landed pgvector AI memory циклу (PR1 foundation, #1305 PR2 ingestion, #1347 PR3 retrieval). Додає:

- **`docs/launch/ai-memory-activation.md`** — runbook на 4 кроки для toggle-у з dormant у production-active: pre-flight checklist, provision `VOYAGE_API_KEY` + toggle `AI_MEMORY_ENABLED` у Railway, поетапна активація per-source ingestion (`MONO_AI_MEMORY_INGEST_ENABLED`), e2e smoke test через chat. Окремі секції: rollback / kill-switch, observability thresholds, roadmap після активації (ESLint guard, re-embed worker, dashboard, PR4 hot/cold).
- **`docs/feature-flags.md`** — замінено placeholder `example_replace_me` на реальні `AI_MEMORY_ENABLED` (master) і `MONO_AI_MEMORY_INGEST_ENABLED` (per-source) entries з owner / kill-switch / linked PRs.

Жодних коду, тестів, міграцій. Поведінка системи не змінюється.

## Governing Skill

- Primary skill: n/a (docs-only)
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: [`docs/playbooks/add-feature-flag.md`](./docs/playbooks/add-feature-flag.md) — for the registry entries
- Why this playbook: PR оформляє два нових прод-flag-и за каноном "every flag must be in registry".
- If no playbook matched, why: для самого runbook-у спеціалізованого playbook-у нема — стиль наслідує `docs/observability/runbook.md` і `docs/launch/04-launch-readiness.md`.

## Verification

```bash
# Pre-commit hooks (prettier + commitlint scope-enum) пройшли
git commit -m "docs(docs): ..."   # green after switching scope from launch → docs
```

Тестів нема (docs-only). Пройшов через lint-staged prettier + markdownlint без правок.

Additional checks:

- [x] Local smoke / manual validation completed (читабельність, перевірка cross-link-ів на існуючі файли)
- [x] Surface-specific checks completed (Hard Rule #15: docs українською)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update — без змін.
- [x] I checked whether a playbook or skill needed an update — без змін.
- [x] I checked whether governance docs or review docs needed an update — без змін.

Updated docs:

- `docs/launch/ai-memory-activation.md` (new)
- `docs/feature-flags.md` (registry entries)

## Risk and Rollout

- **User-visible risk:** немає, документація.
- **Rollout / deploy order:** mergeable будь-коли. Сам runbook не автоматизує нічого — описує ручні Railway-toggle-и.
- **Backout plan:** revert PR-а; жодних env / DDL змін у diff-і.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

Найризикованіше до уваги ревьюера (всі речі — фактологічні, не код):

1. **Railway service names.** Runbook ссилається на сервіси `hub-api` і `hub-web`. Перевірте, що це реальні імена сервісів у Railway-проекті — інакше intern прийде по runbook-у і не знайде куди ставити змінну.
2. **Voyage billing math.** Sanity-check: 1k активних × 500 memories/міс × 200 tokens ≈ 100M tokens/міс ≈ ~$2/міс. Вільний tier — 50M/міс. Якщо у вас інші припущення (більше memories на юзера, інший model — `voyage-3` замість `voyage-3-lite`) — поправте.
3. **Метрики, на які ссилається observability checklist.** Назви: `voyage_external_http_requests_total`, `voyage_external_http_breaker_state`, `ai_memory_ingest_queue_depth{state="waiting"}`, `ai_memory_ingest_processed_total{outcome="permanent_fail"}`. Перевірте, що вони реально emit-яться у `apps/server/src/obs/metrics.ts` (або заплановані). Якщо назви розійдуться — операторам не буде що дивитися.
4. **`weekly-digest` без окремого gate.** Я вказав, що `weekly-digest` auto-on після master-flag-у. Якщо насправді є окремий toggle (схожий на `MONO_AI_MEMORY_INGEST_ENABLED`) — підкажіть, додам.
5. **Curl-приклад у Step 2.** Використовує hardcoded `sergeant-production.up.railway.app` і `better-auth.session_token` cookie name. Якщо prod-домен інший або cookie-name змінювався — поправити.
6. **`forgetUser()` GDPR claim.** У Rollback § написано, що `forgetUser()` працює незалежно від `AI_MEMORY_ENABLED`. Перевірте по `apps/server/src/modules/ai-memory/service.ts` — чи дійсно `forgetUser()` не короткозамикає на master-flag-у (він має працювати завжди для GDPR).
7. **Placeholder removal у feature-flags.md.** Я видалив `example_replace_me` row повністю замість залишити закоментованим. Якщо у вашому workflow placeholder мав лишитися як приклад — приверніть.

Link to Devin session: https://app.devin.ai/sessions/f3550c8f21ac421080466f39724aa7a5
Requested by: @Skords-01

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an activation runbook for the pgvector AI memory subsystem and registers production feature flags. Docs-only; no code or behavior changes.

- **Docs**
  - Added `docs/launch/ai-memory-activation.md`: 4-step activation guide from dormant to production; covers pre-flight checks, provisioning `VOYAGE_API_KEY`, toggling `AI_MEMORY_ENABLED`, staged `MONO_AI_MEMORY_INGEST_ENABLED`, e2e smoke test, rollback, observability thresholds, and a post-activation roadmap.
  - Updated `docs/feature-flags.md`: registered `AI_MEMORY_ENABLED` (master) and `MONO_AI_MEMORY_INGEST_ENABLED` (per-source) with owner, kill-switch notes, and ADR/PR links; set “Last validated” to `@Skords-01`.

<sup>Written for commit d4472e78dff7fd6e049cae38ba8960e90d4a9d1f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

