### PR TITLE
docs(docs): document redis maxmemory-policy noeviction fix (BullMQ safety)

### DIFF
--- a/docs/launch/ai-memory-activation.md
+++ b/docs/launch/ai-memory-activation.md
@@ -155,6 +155,69 @@ Master-flag `AI_MEMORY_ENABLED=true` сам по собі ще не почина
 
 ---
 
+## Redis startup configuration
+
+`Sergeant.redis` (Railway service `humorous-eagerness/redis`,
+id `51da2282-8cf4-47bb-b632-92e060704b78`) хостить BullMQ-стейт двох черг
+(`auth-mail`, `ai-memory-ingest`, prefix `sergeant:`) і rate-limit
+counters. Конфігурація задається у `startCommand` сервіс-інстансу
+(`production` env, id `81b68dcb-0107-44ba-b719-df445ea71c71`) — у репо її
+немає, бо Redis провіжнений з template-image `redis:7-alpine` без
+own-Dockerfile-у.
+
+**Поточний `startCommand` (2026-05-02):**
+
+```sh
+sh -c 'exec redis-server \
+  --requirepass "$REDIS_PASSWORD" \
+  --maxmemory 200mb \
+  --maxmemory-policy noeviction \
+  --appendonly no \
+  --save ""'
+```
+
+**Чому `noeviction`, а не `allkeys-lru`:** BullMQ docs
+(<https://docs.bullmq.io/guide/going-to-production#maxmemory-policy>) явно
+вимагають `noeviction`. Із `allkeys-lru` Redis під memory-pressure може
+evict-ити enqueued jobs до того, як worker їх підхопить — це viewable
+data-loss всередині черги (job було записано, але worker його ніколи не
+побачить). Спочатку (2026-05-02) Redis підняли з default-template
+`--maxmemory-policy allkeys-lru` → BullMQ при connect-і логував warning. У
+той самий день переключили через Railway GraphQL `serviceInstanceUpdate` +
+`serviceInstanceRedeploy`. Тепер worker-и логують лише
+`bullmq_connection_ready` без warning-у.
+
+**Як змінити повторно:**
+
+```sh
+RAILWAY_TOKEN="…" \
+  ENVIRONMENT_ID="81b68dcb-0107-44ba-b719-df445ea71c71" \
+  SERVICE_ID="51da2282-8cf4-47bb-b632-92e060704b78"
+
+curl -sS -X POST https://backboard.railway.com/graphql/v2 \
+  -H "Authorization: Bearer $RAILWAY_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"query\":\"mutation Q(\$eid: String!, \$sid: String!, \$cmd: String!) { serviceInstanceUpdate(environmentId: \$eid, serviceId: \$sid, input: { startCommand: \$cmd }) }\",\"variables\":{\"eid\":\"$ENVIRONMENT_ID\",\"sid\":\"$SERVICE_ID\",\"cmd\":\"<новий startCommand>\"}}"
+
+curl -sS -X POST https://backboard.railway.com/graphql/v2 \
+  -H "Authorization: Bearer $RAILWAY_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"query\":\"mutation Q(\$eid: String!, \$sid: String!) { serviceInstanceRedeploy(environmentId: \$eid, serviceId: \$sid) }\",\"variables\":{\"eid\":\"$ENVIRONMENT_ID\",\"sid\":\"$SERVICE_ID\"}}"
+```
+
+**Verify:** `curl -sS https://sergeant-production.up.railway.app/healthz |
+jq .checks.redis` має повертати `connected: true, reconnectAttempts: 0`,
+а Sergeant logs — `redis_connected` + `bullmq_connection_ready` без
+`Eviction policy is allkeys-lru` warning-у.
+
+**Persistence trade-off:** `--appendonly no --save ""` означає, що Redis
+ephemeral — на restart-і всі in-flight BullMQ jobs губляться. Для нашого
+use case (finyk → ingest, weekly digest, auth-mail) це OK: продюсери
+ретраяться (`mono-webhook` re-fires, `weekly-digest` cron-працює щонеділі).
+Якщо колись захочемо durability — окремий PR з recreate volume + chown.
+
+---
+
 ## Roadmap після активації
 
 Технічні TODO, які не блокують rollout, але треба підбити:


### PR DESCRIPTION
## Summary

Документує застосований інфра-фікс: Redis на проді переключено з `--maxmemory-policy allkeys-lru` на `noeviction` (BullMQ docs explicitly require це, бо із `allkeys-lru` enqueued jobs можуть бути evicted до того, як worker їх підхопить — silent data-loss всередині черги). Redis у репо не описаний (template `redis:7-alpine`, без Dockerfile-у), тож сам `startCommand` оновлений через Railway GraphQL `serviceInstanceUpdate` + `serviceInstanceRedeploy`. Цей PR додає секцію `Redis startup configuration` у `docs/launch/ai-memory-activation.md` як SSOT для production startCommand + ready-to-run curl-команди для повторного оновлення.

## Governing Skill

- Primary skill: ops / Redis-config — інфра-runbook для Railway-managed Redis.
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a — discrete docs-only PR після того, як інфра-зміна вже застосована live.
- Why this playbook: тільки оновлення runbook-у, без зміни коду чи конфігів у репо.
- If no playbook matched, why: zero-code change по інфра-зміні зовнішнього (Railway-managed) сервісу — playbook-и repo-зорієнтовані.

## Verification

```bash
pnpm exec prettier --check docs/launch/ai-memory-activation.md
# All matched files use Prettier code style!

curl -sS https://sergeant-production.up.railway.app/healthz | jq .checks.redis
# {
#   "status": "healthy",
#   "details": { "connected": true, "reconnectAttempts": 0 }
# }
```

Railway GraphQL `serviceInstance(environmentId, serviceId)` query повертає `startCommand` з `--maxmemory-policy noeviction` і latest deployment `status: SUCCESS`. Sergeant logs мають `redis_connected` + `bullmq_connection_ready` без `Eviction policy is allkeys-lru` warning-у.

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- `docs/launch/ai-memory-activation.md` — нова секція `Redis startup configuration` між `Observability checklist` і `Roadmap після активації` з актуальним `startCommand`, поясненням чому `noeviction`, ready-to-run curl-командами через Railway GraphQL і verify-кроками.

## Risk and Rollout

- User-visible risk: відсутній — це pure docs-PR. Реальна інфра-зміна на Redis уже застосована live до open-у цього PR-а (Railway GraphQL mutation, 2026-05-02). Sergeant `/healthz` healthy, `redis.connected=true`.
- Rollout / deploy order: merge → жодних додаткових кроків не потрібно. Інфра вже у цільовому стані.
- Backout plan: revert цього PR-а нічого не змінить у проді (текст у doc-у). Якщо колись треба буде відкотити сам Redis-config — повторити Railway GraphQL mutation з `--maxmemory-policy allkeys-lru` (за процедурою у самому doc-у).

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

- Без міграцій, без env-changes, без HubChat tools, без auth-змін.
- Інфра-зміна (Redis startCommand) уже застосована до open-у цього PR-а — це навмисне, бо Redis Railway-managed і у репо нема файлу, який міг би бути SSOT-ом для config-у. Doc — це SSOT.
- BullMQ warning має зникнути з логів після цього deployment-у Redis (вже задеплоєний, latest status `SUCCESS`).
