### PR TITLE
docs(docs): list ADR-0031 in adr/README.md index (fix CI on main)

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -67,37 +67,38 @@ pnpm gen:adr
 
 ## Поточні ADR
 
-| #    | Назва                                           | Статус   | Створено   | Контекст                                                                                                  |
-| ---- | ----------------------------------------------- | -------- | ---------- | --------------------------------------------------------------------------------------------------------- |
-| 0001 | Monetization architecture                       | proposed | 2026-04-27 | 11 рішень перед стартом monetization-MVP (provider, cache, trial, tax, cancel, ...)                       |
-| 0002 | AI tool lifecycle                               | accepted | 2026-04-27 | 4-фазний процес для Anthropic tools: Proposal → Safety → Rollout → KPIs.                                  |
-| 0003 | Refund and dispute handling                     | proposed | 2026-04-27 | Stripe refund/dispute flow + fraud_blocklist; 90-day window; повернення Pro-status.                       |
-| 0004 | CloudSync LWW conflict resolution               | accepted | 2026-04-27 | Last-Write-Wins на module-рівні + offline queue + Phase 4 tie-breaker.                                    |
-| 0005 | Anthropic model selection and prompt caching    | accepted | 2026-04-27 | Claude 3.5 Sonnet primary, Haiku fallback; prompt-cache strategy + cache-hit metrics.                     |
-| 0006 | RQ keys via centralized factory                 | accepted | 2026-04-27 | `queryKeys.ts` factories + ESLint rule `rq-keys-only-from-factory`.                                       |
-| 0007 | Tailwind opacity scale + WCAG-AA `-strong` tier | accepted | 2026-04-27 | Підтримуваний opacity-набір 5/10/15/...; saturated brand-fill behind `text-white` → `-strong` companion.  |
-| 0008 | Feature flags                                   | accepted | 2026-04-27 | Client-only registry поверх `typedStore`; немає сервер-сайд гейтінгу на MVP.                              |
-| 0009 | Hosting split Railway + Vercel                  | accepted | 2026-04-27 | API + Postgres на Railway, web + edge-proxy на Vercel; single-origin cookie boundary.                     |
-| 0010 | Mobile dual-track (Capacitor+Expo)              | accepted | 2026-04-27 | Shell + RN паралельно, окремі bundle-ID, спільний API та domain-пакети.                                   |
-| 0011 | Local-first storage                             | accepted | 2026-04-27 | Клієнт — primary, сервер — LWW-реплікатор на module-рівні; offline queue.                                 |
-| 0012 | RLS as authz boundary                           | proposed | 2026-04-27 | Цільова модель RLS + `withUserContext`; поточно — app-enforced `WHERE user_id`.                           |
-| 0013 | DB migrations conventions                       | accepted | 2026-04-27 | Sequential `NNN_*.sql`, forward-only, two-phase DROP, idempotent, tests first.                            |
-| 0014 | bigint → number policy                          | accepted | 2026-04-27 | Серіалізатори коерсять `BIGINT` → JS `number`; snapshot-тести лочать contract.                            |
-| 0015 | Observability stack                             | accepted | 2026-04-27 | Pino (logs) + Prometheus (metrics) + Sentry (errors); SLO-first burn-rate alerts.                         |
-| 0016 | User deletion and PII handling                  | proposed | 2026-04-27 | GDPR delete-flow, fraud_blocklist retention, IP-cron 90-day window.                                       |
-| 0017 | Better Auth choice and session model            | accepted | 2026-04-27 | Better Auth (OSS, $0); cookie + bearer dual-channel; 30-day session; expo plugin.                         |
-| 0018 | API versioning policy (`/api/v1`)               | accepted | 2026-04-27 | `/api/v1/*` для domain endpoints; `/api/auth/*` без versioning; rewrite-middleware.                       |
-| 0019 | Push notifications                              | accepted | 2026-04-27 | Server-driven fan-out (web Push API + APNs + FCM); subscription lifecycle.                                |
-| 0020 | Testing pyramid                                 | accepted | 2026-04-27 | Unit / integration / a11y / smoke-e2e — частки, owners, CI gating.                                        |
-| 0021 | Memory Bank                                     | accepted | 2026-04-27 | Local-first AI user-fact store; `key/value`-схема + Anthropic-tool integration.                           |
-| 0022 | Atomic SQL daily quotas                         | accepted | 2026-04-27 | `INSERT ... ON CONFLICT DO UPDATE WHERE` для idempotent quota counters.                                   |
-| 0023 | Turborepo as monorepo task runner               | accepted | 2026-04-27 | `turbo@2` поверх pnpm-workspace; task-граф у `turbo.json`; remote-cache opt-in через `TURBO_TOKEN`.       |
-| 0024 | Monorepo split — `apps/*` + `packages/*`        | accepted | 2026-04-27 | Деплоюються `apps/*`, перевикористовуються `packages/*`; `packages/*` ніколи не імпортує з `apps/*`.      |
-| 0025 | OpenAPI 3.1 spec — generated from zod-схем      | accepted | 2026-04-27 | `docs/api/openapi.json` згенеровано з canonical zod-схем; freshness-скрипт ловить drift у rule #3.        |
-| 0026 | n8n — джерело істини для воркфлоу               | accepted | 2026-04-27 | Git — джерело істини для n8n; JSON у `ops/n8n-workflows/` + manifest з owner / risk / secrets.            |
-| 0027 | Політика OpenClaw, Console та MCP               | accepted | 2026-04-27 | `apps/console` як internal admin; allowlist по Telegram user-id; вивід агента — untrusted.                |
-| 0028 | pgvector + AI memory                            | accepted | 2026-05-01 | Voyage embeddings → `halfvec(1024)` у Postgres з HNSW + hash-партиціонуванням; vector-store-agnostic API. |
-| 0030 | Telegram reporting channel structure            | accepted | 2026-05-02 | Single supergroup + Forum mode (8 канонічних топіків) + P0/P1/P2 escalation hierarchy + WF-98 fan-out.    |
+| #    | Назва                                           | Статус   | Створено   | Контекст                                                                                                      |
+| ---- | ----------------------------------------------- | -------- | ---------- | ------------------------------------------------------------------------------------------------------------- |
+| 0001 | Monetization architecture                       | proposed | 2026-04-27 | 11 рішень перед стартом monetization-MVP (provider, cache, trial, tax, cancel, ...)                           |
+| 0002 | AI tool lifecycle                               | accepted | 2026-04-27 | 4-фазний процес для Anthropic tools: Proposal → Safety → Rollout → KPIs.                                      |
+| 0003 | Refund and dispute handling                     | proposed | 2026-04-27 | Stripe refund/dispute flow + fraud_blocklist; 90-day window; повернення Pro-status.                           |
+| 0004 | CloudSync LWW conflict resolution               | accepted | 2026-04-27 | Last-Write-Wins на module-рівні + offline queue + Phase 4 tie-breaker.                                        |
+| 0005 | Anthropic model selection and prompt caching    | accepted | 2026-04-27 | Claude 3.5 Sonnet primary, Haiku fallback; prompt-cache strategy + cache-hit metrics.                         |
+| 0006 | RQ keys via centralized factory                 | accepted | 2026-04-27 | `queryKeys.ts` factories + ESLint rule `rq-keys-only-from-factory`.                                           |
+| 0007 | Tailwind opacity scale + WCAG-AA `-strong` tier | accepted | 2026-04-27 | Підтримуваний opacity-набір 5/10/15/...; saturated brand-fill behind `text-white` → `-strong` companion.      |
+| 0008 | Feature flags                                   | accepted | 2026-04-27 | Client-only registry поверх `typedStore`; немає сервер-сайд гейтінгу на MVP.                                  |
+| 0009 | Hosting split Railway + Vercel                  | accepted | 2026-04-27 | API + Postgres на Railway, web + edge-proxy на Vercel; single-origin cookie boundary.                         |
+| 0010 | Mobile dual-track (Capacitor+Expo)              | accepted | 2026-04-27 | Shell + RN паралельно, окремі bundle-ID, спільний API та domain-пакети.                                       |
+| 0011 | Local-first storage                             | accepted | 2026-04-27 | Клієнт — primary, сервер — LWW-реплікатор на module-рівні; offline queue.                                     |
+| 0012 | RLS as authz boundary                           | proposed | 2026-04-27 | Цільова модель RLS + `withUserContext`; поточно — app-enforced `WHERE user_id`.                               |
+| 0013 | DB migrations conventions                       | accepted | 2026-04-27 | Sequential `NNN_*.sql`, forward-only, two-phase DROP, idempotent, tests first.                                |
+| 0014 | bigint → number policy                          | accepted | 2026-04-27 | Серіалізатори коерсять `BIGINT` → JS `number`; snapshot-тести лочать contract.                                |
+| 0015 | Observability stack                             | accepted | 2026-04-27 | Pino (logs) + Prometheus (metrics) + Sentry (errors); SLO-first burn-rate alerts.                             |
+| 0016 | User deletion and PII handling                  | proposed | 2026-04-27 | GDPR delete-flow, fraud_blocklist retention, IP-cron 90-day window.                                           |
+| 0017 | Better Auth choice and session model            | accepted | 2026-04-27 | Better Auth (OSS, $0); cookie + bearer dual-channel; 30-day session; expo plugin.                             |
+| 0018 | API versioning policy (`/api/v1`)               | accepted | 2026-04-27 | `/api/v1/*` для domain endpoints; `/api/auth/*` без versioning; rewrite-middleware.                           |
+| 0019 | Push notifications                              | accepted | 2026-04-27 | Server-driven fan-out (web Push API + APNs + FCM); subscription lifecycle.                                    |
+| 0020 | Testing pyramid                                 | accepted | 2026-04-27 | Unit / integration / a11y / smoke-e2e — частки, owners, CI gating.                                            |
+| 0021 | Memory Bank                                     | accepted | 2026-04-27 | Local-first AI user-fact store; `key/value`-схема + Anthropic-tool integration.                               |
+| 0022 | Atomic SQL daily quotas                         | accepted | 2026-04-27 | `INSERT ... ON CONFLICT DO UPDATE WHERE` для idempotent quota counters.                                       |
+| 0023 | Turborepo as monorepo task runner               | accepted | 2026-04-27 | `turbo@2` поверх pnpm-workspace; task-граф у `turbo.json`; remote-cache opt-in через `TURBO_TOKEN`.           |
+| 0024 | Monorepo split — `apps/*` + `packages/*`        | accepted | 2026-04-27 | Деплоюються `apps/*`, перевикористовуються `packages/*`; `packages/*` ніколи не імпортує з `apps/*`.          |
+| 0025 | OpenAPI 3.1 spec — generated from zod-схем      | accepted | 2026-04-27 | `docs/api/openapi.json` згенеровано з canonical zod-схем; freshness-скрипт ловить drift у rule #3.            |
+| 0026 | n8n — джерело істини для воркфлоу               | accepted | 2026-04-27 | Git — джерело істини для n8n; JSON у `ops/n8n-workflows/` + manifest з owner / risk / secrets.                |
+| 0027 | Політика OpenClaw, Console та MCP               | accepted | 2026-04-27 | `apps/console` як internal admin; allowlist по Telegram user-id; вивід агента — untrusted.                    |
+| 0028 | pgvector + AI memory                            | accepted | 2026-05-01 | Voyage embeddings → `halfvec(1024)` у Postgres з HNSW + hash-партиціонуванням; vector-store-agnostic API.     |
+| 0030 | Telegram reporting channel structure            | accepted | 2026-05-02 | Single supergroup + Forum mode (8 канонічних топіків) + P0/P1/P2 escalation hierarchy + WF-98 fan-out.        |
+| 0031 | OpenClaw v0 — Telegram-only co-founder bot      | accepted | 2026-05-02 | Окремий @OpenClaw_sergeant_bot (DM-only, allowlist) з 7 read-only tools, strict memory isolation, $5/day cap. |
 
 > **Note on numbering 0016–0022 jump:** ADRs `0016`–`0022` — це retroactive batch, що був написаний паралельно з `0006`–`0012`. Через паралельне виконання Devin-сесій виникли колізії номерів `0003`–`0012`. Розв'язано через PR `docs(adr): resolve numbering collisions` — same-topic дублі (refund, anthropic, PII) видалено, late-comers перенумеровано в `0016`+. ADRs нумеруються **sequentially without gaps** надалі — наступний номер `0031`.
 


### PR DESCRIPTION
## Summary

Follow-up to PR #1372 (OpenClaw v0). PR #1372 was merged with `docs/adr/0031-openclaw-v0-telegram-cofounder.md` already in place, but the corresponding row in the `docs/adr/README.md` index table was missing. As a result, `main` is currently red on two governance checks:

- **ADR graph (statuses, supersede, README index)** — `check-adr-graph.mjs` reports `ADR-0031 is not listed in docs/adr/README.md`
- **Docs-automation scripts unit tests** — the on-disk graph parity tests (`README.md ↔ ADR file count parity`) fail for the same reason

This PR adds the missing row so both checks go green again.

## Governing Skill

- Primary skill: n/a (clerical docs sync — no behavior change)
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a
- Why this playbook: n/a — single-line docs index sync, no playbook-level decision involved.
- If no playbook matched, why: ADR-0031 was already accepted in PR #1372; this is purely the missing index entry.

## Verification

```bash
node scripts/docs/check-adr-graph.mjs
node --test scripts/docs/__tests__/check-adr-graph.test.mjs
```

Both commands now pass locally on this branch (cherry-picked from commit `a870ad15` originally pushed to PR #1372 after merge).

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- `docs/adr/README.md` — added the ADR-0031 row to the "Поточні ADR" table so the graph check can resolve it.

## Risk and Rollout

- User-visible risk: none — pure docs index sync.
- Rollout / deploy order: merge → CI on `main` re-runs → `ADR graph` and `Docs-automation scripts unit tests` go green.
- Backout plan: revert this PR; the ADR file itself stays accepted, only the README row drops out (returning to the pre-PR red state).

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

- Single-file change to `docs/adr/README.md` (+1 row, table re-aligned for column padding).
- Cherry-pick of commit `a870ad15` originally pushed to PR #1372 — that commit was made after the merge, so it never landed on `main`.
- Pre-existing red checks on `main` (`check`, `Test coverage (vitest)`, `Critical-flow E2E (Playwright)`, `Visual regression (Argos)`) are not touched by this PR and remain as separate work.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `ADR-0031` to `docs/adr/README.md` to fix CI on `main`. This resolves the ADR graph listing error and the README ↔ ADR file-count parity test failures.

<sup>Written for commit b08bfe501e4710d5df1ca531a7729ddbbcd7485b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  - Updated Architecture Decision Records with a new entry for OpenClaw v0 Telegram-only co-founder bot
  - Added clarifications about ADR numbering conventions and collision resolution methods
  - Enhanced documentation with automated integrity checks for ADR metadata and supersede-graph validation in CI pipelines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->