### PR TITLE
fix(web): pre-build @sergeant/db-schema in apps/web/vercel.json buildCommand

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "installCommand": "corepack enable && corepack prepare pnpm@9.15.1 --activate && pnpm install --frozen-lockfile",
-  "buildCommand": "pnpm --filter @sergeant/web build",
+  "buildCommand": "pnpm --filter @sergeant/db-schema build && pnpm --filter @sergeant/web build",
   "outputDirectory": "dist",
   "headers": [
     {


### PR DESCRIPTION
## Summary

Production Vercel deploys (and PR previews) have been failing on every commit since the routine SPIKE landed with:

```
[vite]: Rollup failed to resolve import "@sergeant/db-schema/sqlite" from "/vercel/path0/apps/web/src/core/db/sqlite.ts"
```

`@sergeant/db-schema`'s `exports` map points `./sqlite` → `dist/sqlite/index.js`, so the package must be tsc-built before vite runs in `apps/web`. CI already does this (`.github/workflows/ci.yml` step "Build @sergeant/db-schema"), but Vercel did not.

PR #1386 patched the root `vercel.json` but the deploy on the merge commit (`460e72e`) still failed with the exact same Rollup error. Reason: the Vercel project for `sergeant` has `rootDirectory: apps/web` set in project settings, so Vercel reads `apps/web/vercel.json` — not the repo-root one — for `installCommand`/`buildCommand`. (Confirmed via `GET /v9/projects/prj_WTfB58gEl6CKaLYGRz2SYOQzmnJQ` → `"rootDirectory": "apps/web"`.)

This PR mirrors the same one-liner inside `apps/web/vercel.json` so the prod build actually picks it up:

```diff
- "buildCommand": "pnpm --filter @sergeant/web build",
+ "buildCommand": "pnpm --filter @sergeant/db-schema build && pnpm --filter @sergeant/web build",
```

## Governing Skill

- Primary skill: n/a (single-line build-config hotfix)
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a
- Why this playbook: n/a
- If no playbook matched, why: ops/build-config hotfix; not workflow/feature work covered by an existing playbook.

## Verification

```bash
pnpm install --frozen-lockfile
pnpm --filter @sergeant/db-schema build
pnpm --filter @sergeant/web build
# → vite build succeeded locally; no "failed to resolve import" errors
```

Additional checks:

- [x] Reproduced the failing buildCommand → identical Rollup error as Vercel logs
- [x] Verified `pnpm --filter @sergeant/db-schema build` produces `packages/db-schema/dist/sqlite/index.js`
- [x] Confirmed Vercel project `rootDirectory=apps/web` via `/v9/projects/...` (so `apps/web/vercel.json` is the file Vercel actually reads)
- [ ] Vercel preview on this PR turns green (will verify after CI / preview lands)

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [ ] I checked whether `AGENTS.md` needed an update.
- [ ] I checked whether a playbook or skill needed an update.
- [ ] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a (build-config only; CI already documents the equivalent step)

## Risk and Rollout

- User-visible risk: minimal — adds ~5s of `tsc` (db-schema build) to each Vercel build; turbo cache absorbs it on no-op changes to `packages/db-schema`.
- Rollout / deploy order: merge → Vercel auto-deploy of `main` should go green again; production alias will swap to the new deployment automatically.
- Backout plan: revert this commit; you'll be back to the current broken state but no data/state migration involved.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian. (no docs touched)
- [x] I did not use `--no-verify`.

## Reviewer Notes

- The repo-root `vercel.json` change from PR #1386 is now effectively dead code for `installCommand`/`buildCommand` (Vercel ignores it because of `rootDirectory=apps/web`). It still governs cross-project `headers`/`rewrites` if Vercel merges those, but consider a follow-up to either remove the duplication or document which file is authoritative.
- Only `@sergeant/db-schema` has a buildable workspace dep that `apps/web` consumes (verified across `packages/*/package.json`); no other pre-build is needed.
- If we add another buildable workspace dep used by web, switch to `pnpm turbo run build --filter=@sergeant/web` so `turbo.json`'s `dependsOn: ["^build"]` handles ordering automatically instead of growing this `&&` chain.
- The real proof is the Vercel preview check on this PR — please wait for it before merging.

Link to Devin session: https://app.devin.ai/sessions/1a4fd8b67fb9413ab5e7f7c9b3322587
Requested by: @Skords-01

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pre-build `@sergeant/db-schema` in `apps/web/vercel.json` so Vite can resolve `@sergeant/db-schema/sqlite` when bundling `@sergeant/web`. Fixes failing Vercel deploys (production and previews) by building `@sergeant/db-schema` before the web app.

<sup>Written for commit 085e6d4d166cfb37d194dc17685cc42c495cd253. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to streamline the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->