### PR TITLE
fix(finyk-domain): allow null in Debt/Receivable dueDate to fix typecheck

### DIFF
--- a/packages/finyk-domain/src/domain/debtEngine.ts
+++ b/packages/finyk-domain/src/domain/debtEngine.ts
@@ -16,7 +16,7 @@ export interface Debt {
   totalAmount?: number;
   name?: string;
   emoji?: string;
-  dueDate?: string;
+  dueDate?: string | null;
   currency?: string;
   [extra: string]: unknown;
 }
@@ -27,7 +27,7 @@ export interface Receivable {
   linkedTxIds?: string[];
   name?: string;
   emoji?: string;
-  dueDate?: string;
+  dueDate?: string | null;
   currency?: string;
   [extra: string]: unknown;
 }


### PR DESCRIPTION
## Summary

The `Debt` and `Receivable` interfaces in `debtEngine.ts` declared `dueDate?: string`, but child types (`AssetsDebt`, `AssetsReceivable` in `types.ts` and `DebtLike`, `ReceivableLike` in `overview.ts`) extend them with `dueDate?: string | null`. This mismatch caused 5 TypeScript errors in `@sergeant/finyk-domain#typecheck`, breaking the CI `check` job on main.

Fix: widen `Debt.dueDate` and `Receivable.dueDate` to `string | null` in the base interfaces. All call sites already guard with truthiness checks (`d.dueDate && ...`), so `null` is handled identically to `undefined`.

## Governing Skill

- Primary skill: `sergeant-bugfix-and-regression`
- Secondary skill: `sergeant-deploy-and-observability`

## Playbook

- Primary playbook: n/a
- If no playbook matched, why: single-file type fix, no playbook needed.

## Verification

```bash
pnpm --filter @sergeant/finyk-domain typecheck   # passes
pnpm --filter @sergeant/finyk-domain test         # 224/224 tests pass
pnpm --filter @sergeant/finyk-domain lint         # passes
```

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs: n/a (type-only change, no behavior/contract/doc impact)

## Risk and Rollout

- User-visible risk: none — no runtime behavior change, only widens a TS type.
- Rollout / deploy order: standard merge to main.
- Backout plan: revert the single commit.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

Single-line change in `packages/finyk-domain/src/domain/debtEngine.ts` — adds `| null` to `dueDate` on both `Debt` and `Receivable` interfaces to match all child types and test fixtures.

---
[Devin session](https://app.devin.ai/sessions/e4458c08372541f996f77437127befcc)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Widened `dueDate` from `string` to `string | null` on `Debt` and `Receivable` to match child types and resolve `@sergeant/finyk-domain` typecheck failures. This aligns base interfaces with usage, unblocks CI, and does not change runtime behavior.

<sup>Written for commit d18d02dabb24baa2bfc8b7a6fe8ffc62aa525618. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Debts and receivables can now be recorded without specifying a due date, providing greater flexibility when entering transactions with uncertain or unscheduled timelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->