### PR TITLE
test(mobile-shell): add boundary tests for barcodeNative + pushNative

### DIFF
--- a/apps/mobile-shell/src/barcodeNative.test.ts
+++ b/apps/mobile-shell/src/barcodeNative.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * `barcodeNative.ts` — тонка адаптер-обгортка над
+ * `@capacitor-mlkit/barcode-scanning`. Як і у `auth-storage.test.ts`,
+ * мокуємо плагін і перевіряємо контракт боундарі: правильні методи
+ * викликаються в правильному порядку, дозволи послідовно перевіряються
+ * перед `requestPermissions()`, перший знайдений barcode нормалізується
+ * у `NativeBarcodeResult`, відсутність barcode → `null`.
+ */
+
+type CameraPermissionState =
+  | "granted"
+  | "denied"
+  | "prompt"
+  | "prompt-with-rationale"
+  | "limited";
+
+type BarcodeFixture = {
+  rawValue?: string;
+  displayValue?: string;
+  format?: string;
+  bytes?: number[];
+};
+
+const checkPermissions =
+  vi.fn<() => Promise<{ camera: CameraPermissionState }>>();
+const requestPermissions =
+  vi.fn<() => Promise<{ camera: CameraPermissionState }>>();
+const scan = vi.fn<() => Promise<{ barcodes: BarcodeFixture[] }>>();
+
+vi.mock("@capacitor-mlkit/barcode-scanning", () => ({
+  BarcodeScanner: {
+    checkPermissions: () => checkPermissions(),
+    requestPermissions: () => requestPermissions(),
+    scan: () => scan(),
+  },
+}));
+
+beforeEach(() => {
+  checkPermissions.mockReset();
+  requestPermissions.mockReset();
+  scan.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ensureCameraPermission", () => {
+  it("повертає true і НЕ викликає requestPermissions, якщо вже granted", async () => {
+    checkPermissions.mockResolvedValue({ camera: "granted" });
+    const { ensureCameraPermission } = await import("./barcodeNative.js");
+
+    await expect(ensureCameraPermission()).resolves.toBe(true);
+
+    expect(checkPermissions).toHaveBeenCalledTimes(1);
+    expect(requestPermissions).not.toHaveBeenCalled();
+  });
+
+  it("повертає true для 'limited' (iOS partial-photos parity)", async () => {
+    checkPermissions.mockResolvedValue({ camera: "limited" });
+    const { ensureCameraPermission } = await import("./barcodeNative.js");
+
+    await expect(ensureCameraPermission()).resolves.toBe(true);
+    expect(requestPermissions).not.toHaveBeenCalled();
+  });
+
+  it("повертає false і НЕ перепитує, якщо денід (щоб UI вів у системні налаштування)", async () => {
+    checkPermissions.mockResolvedValue({ camera: "denied" });
+    const { ensureCameraPermission } = await import("./barcodeNative.js");
+
+    await expect(ensureCameraPermission()).resolves.toBe(false);
+
+    expect(checkPermissions).toHaveBeenCalledTimes(1);
+    expect(requestPermissions).not.toHaveBeenCalled();
+  });
+
+  it("на 'prompt' викликає requestPermissions і повертає granted-результат", async () => {
+    checkPermissions.mockResolvedValue({ camera: "prompt" });
+    requestPermissions.mockResolvedValue({ camera: "granted" });
+    const { ensureCameraPermission } = await import("./barcodeNative.js");
+
+    await expect(ensureCameraPermission()).resolves.toBe(true);
+
+    expect(checkPermissions).toHaveBeenCalledTimes(1);
+    expect(requestPermissions).toHaveBeenCalledTimes(1);
+  });
+
+  it("на 'prompt-with-rationale' просить і повертає false, якщо знов денід", async () => {
+    checkPermissions.mockResolvedValue({ camera: "prompt-with-rationale" });
+    requestPermissions.mockResolvedValue({ camera: "denied" });
+    const { ensureCameraPermission } = await import("./barcodeNative.js");
+
+    await expect(ensureCameraPermission()).resolves.toBe(false);
+    expect(requestPermissions).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("scanBarcodeNative", () => {
+  it("кидає 'camera-permission-denied', якщо дозвіл не отримано", async () => {
+    checkPermissions.mockResolvedValue({ camera: "denied" });
+    const { scanBarcodeNative } = await import("./barcodeNative.js");
+
+    await expect(scanBarcodeNative()).rejects.toThrow(
+      "camera-permission-denied",
+    );
+    expect(scan).not.toHaveBeenCalled();
+  });
+
+  it("повертає null, якщо плагін не знайшов жодного штрихкоду", async () => {
+    checkPermissions.mockResolvedValue({ camera: "granted" });
+    scan.mockResolvedValue({ barcodes: [] });
+    const { scanBarcodeNative } = await import("./barcodeNative.js");
+
+    await expect(scanBarcodeNative()).resolves.toBeNull();
+  });
+
+  it("нормалізує перший barcode в NativeBarcodeResult із rawValue + format", async () => {
+    checkPermissions.mockResolvedValue({ camera: "granted" });
+    scan.mockResolvedValue({
+      barcodes: [
+        { rawValue: "4820000000000", format: "EAN_13" },
+        { rawValue: "ignored", format: "QR_CODE" },
+      ],
+    });
+    const { scanBarcodeNative } = await import("./barcodeNative.js");
+
+    await expect(scanBarcodeNative()).resolves.toEqual({
+      code: "4820000000000",
+      format: "EAN_13",
+      rawBytes: undefined,
+    });
+  });
+
+  it("робить fallback на displayValue, коли rawValue відсутнє", async () => {
+    checkPermissions.mockResolvedValue({ camera: "granted" });
+    scan.mockResolvedValue({
+      barcodes: [{ displayValue: "https://example.com", format: "QR_CODE" }],
+    });
+    const { scanBarcodeNative } = await import("./barcodeNative.js");
+
+    await expect(scanBarcodeNative()).resolves.toEqual({
+      code: "https://example.com",
+      format: "QR_CODE",
+      rawBytes: undefined,
+    });
+  });
+
+  it("обгортає bytes у Uint8Array, коли плагін повернув raw-payload", async () => {
+    checkPermissions.mockResolvedValue({ camera: "granted" });
+    scan.mockResolvedValue({
+      barcodes: [{ rawValue: "X", format: "PDF_417", bytes: [0xde, 0xad] }],
+    });
+    const { scanBarcodeNative } = await import("./barcodeNative.js");
+
+    const result = await scanBarcodeNative();
+    expect(result?.rawBytes).toBeInstanceOf(Uint8Array);
+    expect(Array.from(result?.rawBytes ?? [])).toEqual([0xde, 0xad]);
+  });
+
+  it("нормалізує відсутні rawValue + displayValue у порожній рядок", async () => {
+    checkPermissions.mockResolvedValue({ camera: "granted" });
+    scan.mockResolvedValue({ barcodes: [{ format: "EAN_13" }] });
+    const { scanBarcodeNative } = await import("./barcodeNative.js");
+
+    await expect(scanBarcodeNative()).resolves.toEqual({
+      code: "",
+      format: "EAN_13",
+      rawBytes: undefined,
+    });
+  });
+
+  it("пробрасує помилку плагіна `scan()`", async () => {
+    checkPermissions.mockResolvedValue({ camera: "granted" });
+    scan.mockRejectedValue(new Error("scanner-unavailable"));
+    const { scanBarcodeNative } = await import("./barcodeNative.js");
+
+    await expect(scanBarcodeNative()).rejects.toThrow("scanner-unavailable");
+  });
+});

--- a/apps/mobile-shell/src/pushNative.test.ts
+++ b/apps/mobile-shell/src/pushNative.test.ts
@@ -1,0 +1,319 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * `pushNative.ts` — boundary-тести для адаптера native push-notification
+ * реєстрації. Як і у `auth-storage.test.ts` / `barcodeNative.test.ts`,
+ * мокуємо `@capacitor/*` плагіни і перевіряємо контракт:
+ *   - guard на не-native платформу,
+ *   - permission gate перед register(),
+ *   - resolve через `registration` listener,
+ *   - reject через `registrationError` listener,
+ *   - cache токена у `Preferences` під namespaced ключем,
+ *   - ідемпотентність `unsubscribe` навіть при `unregister()` rejection.
+ *
+ * Слухачі моделюємо як прості реєстри, які тест-сценарій сам тригерить
+ * через хелпер `fireRegistration` / `fireRegistrationError`.
+ */
+
+const NATIVE_PUSH_TOKEN_KEY = "push.native.token";
+
+type RegistrationToken = { value: string };
+type RegistrationFailure = { error: string };
+type ListenerKind = "registration" | "registrationError";
+
+type Listener = (payload: RegistrationToken | RegistrationFailure) => void;
+
+const listeners: Record<ListenerKind, Listener[]> = {
+  registration: [],
+  registrationError: [],
+};
+
+const handleRemove = vi.fn<() => Promise<void>>();
+let nextHandleFails = false;
+
+const requestPermissions =
+  vi.fn<() => Promise<{ receive: "granted" | "denied" | "prompt" }>>();
+const removeAllListeners = vi.fn<() => Promise<void>>();
+const register = vi.fn<() => Promise<void>>();
+const unregister = vi.fn<() => Promise<void>>();
+const addListener =
+  vi.fn<
+    (
+      kind: ListenerKind,
+      fn: Listener,
+    ) => Promise<{ remove: () => Promise<void> }>
+  >();
+
+const prefGet =
+  vi.fn<(args: { key: string }) => Promise<{ value: string | null }>>();
+const prefSet =
+  vi.fn<(args: { key: string; value: string }) => Promise<void>>();
+const prefRemove = vi.fn<(args: { key: string }) => Promise<void>>();
+
+const getPlatform = vi.fn<() => string>();
+
+vi.mock("@capacitor/push-notifications", () => ({
+  PushNotifications: {
+    requestPermissions: () => requestPermissions(),
+    removeAllListeners: () => removeAllListeners(),
+    register: () => register(),
+    unregister: () => unregister(),
+    addListener: (kind: ListenerKind, fn: Listener) => addListener(kind, fn),
+  },
+}));
+
+vi.mock("@capacitor/preferences", () => ({
+  Preferences: {
+    get: (args: { key: string }) => prefGet(args),
+    set: (args: { key: string; value: string }) => prefSet(args),
+    remove: (args: { key: string }) => prefRemove(args),
+  },
+}));
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: {
+    getPlatform: () => getPlatform(),
+  },
+}));
+
+beforeEach(() => {
+  listeners.registration = [];
+  listeners.registrationError = [];
+  nextHandleFails = false;
+
+  handleRemove.mockReset().mockResolvedValue(undefined);
+  requestPermissions.mockReset();
+  removeAllListeners.mockReset().mockResolvedValue(undefined);
+  register.mockReset().mockResolvedValue(undefined);
+  unregister.mockReset().mockResolvedValue(undefined);
+  prefGet.mockReset();
+  prefSet.mockReset().mockResolvedValue(undefined);
+  prefRemove.mockReset().mockResolvedValue(undefined);
+  getPlatform.mockReset();
+
+  addListener.mockReset();
+  addListener.mockImplementation(async (kind, fn) => {
+    if (nextHandleFails) {
+      throw new Error("addListener-failed");
+    }
+    listeners[kind].push(fn);
+    return { remove: () => handleRemove() };
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function fireRegistration(token: string): void {
+  for (const fn of listeners.registration) fn({ value: token });
+}
+
+function fireRegistrationError(message: string): void {
+  for (const fn of listeners.registrationError) fn({ error: message });
+}
+
+describe("subscribeNativePush — guard layer", () => {
+  it("кидає 'push-native-unavailable' на web-платформі", async () => {
+    getPlatform.mockReturnValue("web");
+    const { subscribeNativePush } = await import("./pushNative.js");
+
+    await expect(subscribeNativePush()).rejects.toThrow(
+      "push-native-unavailable",
+    );
+
+    expect(requestPermissions).not.toHaveBeenCalled();
+    expect(register).not.toHaveBeenCalled();
+  });
+
+  it("кидає 'push-permission-denied', якщо OS відмовила", async () => {
+    getPlatform.mockReturnValue("ios");
+    requestPermissions.mockResolvedValue({ receive: "denied" });
+    const { subscribeNativePush } = await import("./pushNative.js");
+
+    await expect(subscribeNativePush()).rejects.toThrow(
+      "push-permission-denied",
+    );
+
+    expect(register).not.toHaveBeenCalled();
+    expect(removeAllListeners).not.toHaveBeenCalled();
+  });
+});
+
+describe("subscribeNativePush — registration flow", () => {
+  it("резолвиться токеном від `registration` listener-а і кешує його у Preferences", async () => {
+    getPlatform.mockReturnValue("android");
+    requestPermissions.mockResolvedValue({ receive: "granted" });
+    register.mockImplementation(async () => {
+      // Імітуємо OS, що віддає токен ПІСЛЯ register()
+      queueMicrotask(() => fireRegistration("fcm-token-123"));
+    });
+    const { subscribeNativePush } = await import("./pushNative.js");
+
+    await expect(subscribeNativePush()).resolves.toEqual({
+      platform: "android",
+      token: "fcm-token-123",
+    });
+
+    expect(removeAllListeners).toHaveBeenCalled();
+    expect(register).toHaveBeenCalledTimes(1);
+    expect(prefSet).toHaveBeenCalledWith({
+      key: NATIVE_PUSH_TOKEN_KEY,
+      value: "fcm-token-123",
+    });
+  });
+
+  it("реджектиться 'push-registration-empty-token', якщо плагін повернув порожній токен", async () => {
+    getPlatform.mockReturnValue("ios");
+    requestPermissions.mockResolvedValue({ receive: "granted" });
+    register.mockImplementation(async () => {
+      queueMicrotask(() => fireRegistration(""));
+    });
+    const { subscribeNativePush } = await import("./pushNative.js");
+
+    await expect(subscribeNativePush()).rejects.toThrow(
+      "push-registration-empty-token",
+    );
+    expect(prefSet).not.toHaveBeenCalled();
+  });
+
+  it("реджектиться через `registrationError` listener", async () => {
+    getPlatform.mockReturnValue("android");
+    requestPermissions.mockResolvedValue({ receive: "granted" });
+    register.mockImplementation(async () => {
+      queueMicrotask(() => fireRegistrationError("FCM_NO_TOKEN"));
+    });
+    const { subscribeNativePush } = await import("./pushNative.js");
+
+    await expect(subscribeNativePush()).rejects.toThrow("FCM_NO_TOKEN");
+    expect(prefSet).not.toHaveBeenCalled();
+  });
+
+  it("ігнорує другий `registration` (settled-once)", async () => {
+    getPlatform.mockReturnValue("ios");
+    requestPermissions.mockResolvedValue({ receive: "granted" });
+    register.mockImplementation(async () => {
+      queueMicrotask(() => {
+        fireRegistration("first");
+        fireRegistration("second");
+      });
+    });
+    const { subscribeNativePush } = await import("./pushNative.js");
+
+    await expect(subscribeNativePush()).resolves.toEqual({
+      platform: "ios",
+      token: "first",
+    });
+
+    expect(prefSet).toHaveBeenCalledTimes(1);
+    expect(prefSet).toHaveBeenCalledWith({
+      key: NATIVE_PUSH_TOKEN_KEY,
+      value: "first",
+    });
+  });
+
+  it("реджектиться, якщо `register()` синхронно провалився", async () => {
+    getPlatform.mockReturnValue("ios");
+    requestPermissions.mockResolvedValue({ receive: "granted" });
+    register.mockRejectedValue(new Error("apns-not-configured"));
+    const { subscribeNativePush } = await import("./pushNative.js");
+
+    await expect(subscribeNativePush()).rejects.toThrow("apns-not-configured");
+  });
+
+  it("реджектиться, якщо `addListener` сам кидає помилку", async () => {
+    getPlatform.mockReturnValue("android");
+    requestPermissions.mockResolvedValue({ receive: "granted" });
+    nextHandleFails = true;
+    register.mockResolvedValue(undefined);
+    const { subscribeNativePush } = await import("./pushNative.js");
+
+    await expect(subscribeNativePush()).rejects.toThrow("addListener-failed");
+  });
+});
+
+describe("unsubscribeNativePush", () => {
+  it("повертає кешований токен і прибирає всі listener-и + кеш", async () => {
+    prefGet.mockResolvedValue({ value: "cached-token" });
+    const { unsubscribeNativePush } = await import("./pushNative.js");
+
+    await expect(unsubscribeNativePush()).resolves.toBe("cached-token");
+
+    expect(removeAllListeners).toHaveBeenCalled();
+    expect(unregister).toHaveBeenCalled();
+    expect(prefRemove).toHaveBeenCalledWith({ key: NATIVE_PUSH_TOKEN_KEY });
+  });
+
+  it("ідемпотентний: ковтає помилку `unregister()` і все одно чистить кеш", async () => {
+    prefGet.mockResolvedValue({ value: "cached" });
+    unregister.mockRejectedValue(new Error("not-implemented"));
+    const { unsubscribeNativePush } = await import("./pushNative.js");
+
+    await expect(unsubscribeNativePush()).resolves.toBe("cached");
+    expect(prefRemove).toHaveBeenCalledWith({ key: NATIVE_PUSH_TOKEN_KEY });
+  });
+
+  it("повертає null, якщо токен не кешовано", async () => {
+    prefGet.mockResolvedValue({ value: null });
+    const { unsubscribeNativePush } = await import("./pushNative.js");
+
+    await expect(unsubscribeNativePush()).resolves.toBeNull();
+  });
+
+  it("ковтає помилку `Preferences.get` і не валить flow", async () => {
+    prefGet.mockRejectedValue(new Error("storage-down"));
+    const { unsubscribeNativePush } = await import("./pushNative.js");
+
+    await expect(unsubscribeNativePush()).resolves.toBeNull();
+    expect(prefRemove).toHaveBeenCalledWith({ key: NATIVE_PUSH_TOKEN_KEY });
+  });
+});
+
+describe("getStoredNativePushToken / setStoredNativePushToken / clearStoredNativePushToken", () => {
+  it("get — повертає value під namespaced ключем", async () => {
+    prefGet.mockResolvedValue({ value: "stored-token" });
+    const { getStoredNativePushToken } = await import("./pushNative.js");
+
+    await expect(getStoredNativePushToken()).resolves.toBe("stored-token");
+    expect(prefGet).toHaveBeenCalledWith({ key: NATIVE_PUSH_TOKEN_KEY });
+  });
+
+  it("get — нормалізує undefined у null", async () => {
+    prefGet.mockResolvedValue({ value: undefined as unknown as null });
+    const { getStoredNativePushToken } = await import("./pushNative.js");
+
+    await expect(getStoredNativePushToken()).resolves.toBeNull();
+  });
+
+  it("get — ковтає помилку Preferences і повертає null", async () => {
+    prefGet.mockRejectedValue(new Error("kv-unavailable"));
+    const { getStoredNativePushToken } = await import("./pushNative.js");
+
+    await expect(getStoredNativePushToken()).resolves.toBeNull();
+  });
+
+  it("set — пише під правильним ключем", async () => {
+    const { setStoredNativePushToken } = await import("./pushNative.js");
+    await setStoredNativePushToken("fresh");
+
+    expect(prefSet).toHaveBeenCalledWith({
+      key: NATIVE_PUSH_TOKEN_KEY,
+      value: "fresh",
+    });
+  });
+
+  it("set — мовчки ковтає помилку Preferences (best-effort кеш)", async () => {
+    prefSet.mockRejectedValue(new Error("write-failed"));
+    const { setStoredNativePushToken } = await import("./pushNative.js");
+
+    await expect(setStoredNativePushToken("x")).resolves.toBeUndefined();
+  });
+
+  it("clear — викликає Preferences.remove і ковтає помилку", async () => {
+    prefRemove.mockRejectedValue(new Error("remove-failed"));
+    const { clearStoredNativePushToken } = await import("./pushNative.js");
+
+    await expect(clearStoredNativePushToken()).resolves.toBeUndefined();
+    expect(prefRemove).toHaveBeenCalledWith({ key: NATIVE_PUSH_TOKEN_KEY });
+  });
+});


### PR DESCRIPTION
## Summary

Closes the last gap in `apps/mobile-shell` test coverage: the two `@capacitor/*`-adapter modules that previously had no unit tests. Drains the P2 row "Capacitor shell — 0 unit/boundary тестів" from `docs/tech-debt/frontend.md` (paired with a follow-up doc-hygiene PR that re-counts mobile-shell coverage from 5 → 7 test files / ~120 tests).

- **`barcodeNative.test.ts`** (12 tests, mocks `@capacitor-mlkit/barcode-scanning`):
  - `ensureCameraPermission` — `granted` / `limited` short-circuit, `denied` does **not** re-prompt (so UI can route to system settings), `prompt` / `prompt-with-rationale` defer to `requestPermissions()`.
  - `scanBarcodeNative` — permission gate before `scan()`, empty `barcodes[]` → `null`, first-barcode normalisation, `displayValue` fallback when `rawValue` is missing, `bytes[]` → `Uint8Array`, empty-string fallback when both `rawValue` and `displayValue` are absent, error pass-through.
- **`pushNative.test.ts`** (18 tests, mocks `@capacitor/core` + `@capacitor/push-notifications` + `@capacitor/preferences`):
  - Guards: `push-native-unavailable` on `web` platform, `push-permission-denied` when OS denies.
  - Registration flow: resolves with the value of the first `registration` listener payload, caches under `push.native.token`, rejects on empty token, rejects via `registrationError` listener, ignores second `registration` (settled-once), rejects when `register()` itself throws synchronously, rejects when `addListener` throws.
  - Unsubscribe: returns the cached token, removes all listeners, swallows `unregister()` rejection (idempotent) and still clears the Preferences key, returns `null` when no cache, swallows `Preferences.get` failure.
  - Storage helpers: namespaced key contract, `undefined` → `null` normalisation, best-effort error swallowing for `set` / `clear`.

No production code changes — only new test files.

## Governing Skill

- Primary skill: n/a (pure unit-test addition for an existing adapter)
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a
- Why this playbook: n/a
- If no playbook matched, why: Single-package test-only change to drain a known coverage gap; no playbook trigger fits.

## Verification

```bash
pnpm --filter @sergeant/mobile-shell exec eslint src/barcodeNative.test.ts src/pushNative.test.ts
pnpm --filter @sergeant/mobile-shell typecheck
pnpm --filter @sergeant/mobile-shell exec vitest run
```

Result: lint clean, typecheck clean, `7 test files / 120 tests passed` (was `5 / 90` on `main`).

Additional checks:

- [x] Local smoke / manual validation completed (vitest + eslint + tsc)
- [ ] Surface-specific checks: did **not** boot Capacitor on a device — these are pure mocked boundary tests against the `@capacitor/*` SDKs.

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update — no changes required.
- [x] I checked whether a playbook or skill needed an update — none triggered.
- [x] I checked whether governance docs or review docs needed an update — `docs/tech-debt/frontend.md` row "Capacitor shell — 0 unit/boundary тестів" will be moved to "Уже закрито" in the same doc-hygiene follow-up PR.

Updated docs:

- n/a (follow-up doc-hygiene PR records the closed debt row)

## Risk and Rollout

- **User-visible risk:** none. Test-only files; no production import graph touched, no plugin behaviour changed, no shipped artefact rebuilt.
- **Rollout / deploy order:** merge directly. CI runs vitest and that's the only surface.
- **Backout plan:** `git revert` on the single commit. No state, no migration, no env change.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian (test-file commentary).
- [x] I did not use `--no-verify`.

## Reviewer Notes

Things worth scrutinising:

1. **Async timing.** Several `subscribeNativePush` tests fire the OS-side listener via `queueMicrotask` inside `register.mockImplementation`. This is the correct pattern for "OS resolves after `register()` returns", but if vitest's microtask draining ever changes (or the test runs under a different runtime), these are the first tests that would flake. If you'd prefer something deterministic, swap to a manually-flushed promise (`await Promise.resolve()` after `register()`).
2. **Listener typing is loose.** I unioned `RegistrationToken | RegistrationFailure` into one `Listener` to keep the mock simple, instead of mirroring the plugin's per-event overloads. The mock only ever feeds the right shape into the right kind, but it does mean a buggy production change (e.g. firing a `registrationError` shape on the `registration` channel) would still pass through the mock. Fine for boundary coverage, worth knowing.
3. **`nextHandleFails` toggle.** Module-level mutable used to simulate `addListener` itself throwing. Reset in `beforeEach` so test order is irrelevant, but it's the only piece of state that isn't a `vi.fn()`.
4. **Empty-payload tests.** `barcodeNative.test.ts` includes a case where the plugin returns a barcode with neither `rawValue` nor `displayValue` — production code normalises that to `code: ""`, which the test pins. If you'd rather treat that as an error condition, this is the test to flag.
5. **No native-runtime check.** I did not run the Capacitor sync / device build. Coverage is pure mocked adapter contract; the actual ML Kit / FCM / APNs plumbing remains untouched.

Link to Devin session: https://app.devin.ai/sessions/c30916bcc95f491fabcbb2a7080ee5a1
Requested by: @Skords-01

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds boundary tests for `barcodeNative` and `pushNative` in `apps/mobile-shell`, mocking `@capacitor-mlkit/barcode-scanning`, `@capacitor/core`, `@capacitor/push-notifications`, and `@capacitor/preferences` to lock down permission gates, barcode normalization, push registration flow, and token storage helpers.
Increases coverage to 7 files (~120 tests) with no production code changes.

<sup>Written for commit 73e020e8bd27a19ee15ceb2a410f2402133a42fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

