### PR TITLE
fix(server): harden nutrition backup IDOR + drop monobank upstream body leak

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -321,6 +321,14 @@ VITE_API_PROXY_TARGET=http://127.0.0.1:3000
 # Dev: https://xxx.trycloudflare.com (cloudflared tunnel --url http://localhost:3000)
 # PUBLIC_API_BASE_URL=
 
+# ── Nutrition backups ────────────────────────────────────────
+# Серверний секрет для HMAC-SHA256, що формує ім'я файлу
+# nutrition-backup на диску. Без нього /api/nutrition/backup-{upload,
+# download} відповідає 503. У production обов'язковий — інакше шлях
+# до бекапу можна перебрати (історично було 32-bit FNV-1a, IDOR).
+# Згенерувати: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+# NUTRITION_BACKUP_KEY_SECRET=
+
 # ── Monobank / PrivatBank (legacy polling proxy) ─────────────
 # УВАГА: токени банків НЕ читаються з env — вони надходять від клієнта через
 # заголовок `X-Token` і форвардяться до upstream. Сервер їх зберігає лише у

--- a/apps/server/src/env/env.ts
+++ b/apps/server/src/env/env.ts
@@ -166,6 +166,18 @@ const envSchema = z.object({
   /** Публічна базова URL API (Railway) для реєстрації webhook у Monobank. */
   PUBLIC_API_BASE_URL: z.string().optional(),
 
+  // ── Nutrition backups ──────────────────────────────────────────────
+  /**
+   * Серверний секрет для HMAC-SHA256, що формує ім'я файлу
+   * nutrition-backup на диску. Без секрету `safeBackupKeyFromToken`
+   * кидає помилку, тому `/api/nutrition/backup-{upload,download}`
+   * повертають 503 і не торкаються файлової системи.
+   *
+   * У production обов'язковий — інакше ключ можна перебрати, як це
+   * було з 32-bit FNV-1a (IDOR). Згенеруй: `openssl rand -hex 32`.
+   */
+  NUTRITION_BACKUP_KEY_SECRET: z.string().optional(),
+
   // ── External APIs ──────────────────────────────────────────────────
   /** USDA FoodData Central API key. Fallback: `DEMO_KEY`. */
   USDA_API_KEY: z.string().optional(),
@@ -236,6 +248,16 @@ export function assertStartupEnv(): void {
   if (isProduction && !env.METRICS_TOKEN) {
     warnings.push(
       "METRICS_TOKEN is not set — /metrics endpoint is unprotected.",
+    );
+  }
+
+  if (isProduction && !env.NUTRITION_BACKUP_KEY_SECRET) {
+    throw new Error(
+      "NUTRITION_BACKUP_KEY_SECRET is required in production. Without it nutrition backup file paths are derivable per-user and brute-forceable. Generate one with `openssl rand -hex 32`.",
+    );
+  } else if (!env.NUTRITION_BACKUP_KEY_SECRET) {
+    warnings.push(
+      "NUTRITION_BACKUP_KEY_SECRET is not set — /api/nutrition/backup-{upload,download} will return 503.",
     );
   }
 

--- a/apps/server/src/lib/backupKey.test.ts
+++ b/apps/server/src/lib/backupKey.test.ts
@@ -1,18 +1,60 @@
 import { describe, expect, it } from "vitest";
 import { safeBackupKeyFromToken } from "./backupKey.js";
 
+const SECRET =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
 describe("safeBackupKeyFromToken", () => {
-  it("keeps stable FNV-1a base36 keys for backup tokens", () => {
-    expect(safeBackupKeyFromToken("abc")).toBe("7aigaz");
-    expect(safeBackupKeyFromToken("token-123")).toBe("mgkkb7");
+  it("returns a stable 32-char hex digest for a fixed (userId, token, secret)", () => {
+    const a = safeBackupKeyFromToken("user_1", "abc", SECRET);
+    const b = safeBackupKeyFromToken("user_1", "abc", SECRET);
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{32}$/);
   });
 
-  it("uses the public backup key when the token is missing", () => {
-    expect(safeBackupKeyFromToken(undefined)).toBe("1krc8zk");
-    expect(safeBackupKeyFromToken("")).toBe("1krc8zk");
+  it("uses the public bucket when the token is absent or empty", () => {
+    const explicit = safeBackupKeyFromToken("user_1", "public", SECRET);
+    expect(safeBackupKeyFromToken("user_1", undefined, SECRET)).toBe(explicit);
+    expect(safeBackupKeyFromToken("user_1", "", SECRET)).toBe(explicit);
+  });
+
+  it("isolates backups per user — same token, different userId → different key", () => {
+    const a = safeBackupKeyFromToken("user_1", "shared-token", SECRET);
+    const b = safeBackupKeyFromToken("user_2", "shared-token", SECRET);
+    expect(a).not.toBe(b);
+  });
+
+  it("isolates backups per token within the same user", () => {
+    const a = safeBackupKeyFromToken("user_1", "token-a", SECRET);
+    const b = safeBackupKeyFromToken("user_1", "token-b", SECRET);
+    expect(a).not.toBe(b);
+  });
+
+  it("rotates with the server secret — different secrets → different keys", () => {
+    const a = safeBackupKeyFromToken("user_1", "abc", SECRET);
+    const b = safeBackupKeyFromToken(
+      "user_1",
+      "abc",
+      "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    );
+    expect(a).not.toBe(b);
   });
 
   it("matches existing header coercion for multi-value tokens", () => {
-    expect(safeBackupKeyFromToken(["a", "b"])).toBe("2d6yx2");
+    expect(safeBackupKeyFromToken("user_1", ["a", "b"], SECRET)).toBe(
+      safeBackupKeyFromToken("user_1", "a,b", SECRET),
+    );
+  });
+
+  it("throws if the server secret is missing", () => {
+    expect(() => safeBackupKeyFromToken("user_1", "abc", "")).toThrow(
+      /missing server secret/,
+    );
+  });
+
+  it("throws if the userId is missing — auth must be enforced upstream", () => {
+    expect(() => safeBackupKeyFromToken("", "abc", SECRET)).toThrow(
+      /missing userId/,
+    );
   });
 });

--- a/apps/server/src/lib/backupKey.ts
+++ b/apps/server/src/lib/backupKey.ts
@@ -1,11 +1,38 @@
+import crypto from "node:crypto";
+
 export type BackupToken = string | string[] | undefined;
 
-export function safeBackupKeyFromToken(token: BackupToken): string {
-  const raw = token ? String(token) : "public";
-  let h = 2166136261;
-  for (let i = 0; i < raw.length; i++) {
-    h ^= raw.charCodeAt(i);
-    h = Math.imul(h, 16777619);
+/**
+ * Resolves the storage key used for nutrition backup files. Authorization
+ * is bound to the authenticated `userId` (Better Auth opaque id) so that
+ * even leaked client `x-token` headers cannot reach another user's backup.
+ *
+ * The previous implementation used 32-bit FNV-1a без серверного секрету —
+ * це давало ~4.3 млрд можливих імен файлів, тому атакер міг перебрати
+ * простір за хвилини і витягти будь-чий nutrition-blob (IDOR). Тут уже
+ * HMAC-SHA256 з серверним секретом, ключ — `userId\0token`, тож:
+ *   - без секрету ключ непередбачуваний навіть при відомих userId/token,
+ *   - різні юзери з однаковим `x-token` потрапляють у різні файли,
+ *   - простір ключів — 2^128 (truncated digest), brute-force нерелевантний.
+ *
+ * Повертає 32 hex-символи (128 біт) — досить для унікальності у файловій
+ * системі і коротко для шляху.
+ */
+export function safeBackupKeyFromToken(
+  userId: string,
+  token: BackupToken,
+  secret: string,
+): string {
+  if (!secret) {
+    throw new Error("safeBackupKeyFromToken: missing server secret");
   }
-  return (h >>> 0).toString(36);
+  if (!userId) {
+    throw new Error("safeBackupKeyFromToken: missing userId");
+  }
+  const tokenStr = token ? String(token) : "public";
+  return crypto
+    .createHmac("sha256", secret)
+    .update(`${userId}\u0000${tokenStr}`)
+    .digest("hex")
+    .slice(0, 32);
 }

--- a/apps/server/src/modules/mono/connection.test.ts
+++ b/apps/server/src/modules/mono/connection.test.ts
@@ -58,6 +58,7 @@ const dbQuery = _query as unknown as Mock;
 interface TestResBody {
   ok?: boolean;
   error?: string;
+  code?: string;
   status?: string;
   accountsCount?: number;
   webhookActive?: boolean;
@@ -144,6 +145,10 @@ describe("connectHandler", () => {
     await connectHandler(makeReq({ token: "bad_token_12345" }), res);
     expect(res.statusCode).toBe(401);
     expect(res.body.error).toBe("Invalid Monobank token");
+    expect(res.body.code).toBe("MONO_TOKEN_INVALID");
+    // Upstream body не має витікати до клієнта (може містити internal
+    // details upstream-сервісу) — тільки нормалізований error/code.
+    expect(res.body.upstream).toBeUndefined();
   });
 
   it("connects successfully: calls Monobank, upserts connection + accounts", async () => {
@@ -199,6 +204,9 @@ describe("connectHandler", () => {
     await connectHandler(makeReq({ token: "valid_personal_token_12345" }), res);
     expect(res.statusCode).toBe(502);
     expect(res.body.error).toMatch(/register webhook/i);
+    expect(res.body.code).toBe("MONO_UPSTREAM_ERROR");
+    // Сирий upstream-боді ("Internal Server Error") не повертаємо клієнту.
+    expect(res.body.upstream).toBeUndefined();
   });
 
   it("returns 504 when client-info fetch times out", async () => {

--- a/apps/server/src/modules/mono/connection.ts
+++ b/apps/server/src/modules/mono/connection.ts
@@ -109,18 +109,26 @@ export async function connectHandler(
     return;
   }
   if (!clientInfoRes.ok) {
+    // Upstream body може містити внутрішні деталі Monobank (стек/чужі
+    // header-и в HTML, ID запиту тощо) — фронту воно ні до чого і часто
+    // мінливе, тож логуємо в server-only warn і повертаємо лише наш
+    // нормалізований error/code.
     const body = await clientInfoRes.text();
     logger.warn({
       msg: "mono_connect_client_info_failed",
       status: clientInfoRes.status,
       fingerprint: tokenFingerprint(token),
+      upstreamBody: body,
     });
     res.status(clientInfoRes.status === 401 ? 401 : 502).json({
       error:
         clientInfoRes.status === 401
           ? "Invalid Monobank token"
           : "Failed to reach Monobank API",
-      upstream: body,
+      code:
+        clientInfoRes.status === 401
+          ? "MONO_TOKEN_INVALID"
+          : "MONO_UPSTREAM_ERROR",
     });
     return;
   }
@@ -161,10 +169,11 @@ export async function connectHandler(
       msg: "mono_webhook_register_failed",
       status: registerRes.status,
       fingerprint: tokenFingerprint(token),
+      upstreamBody: body,
     });
     res.status(502).json({
       error: "Failed to register webhook with Monobank",
-      upstream: body,
+      code: "MONO_UPSTREAM_ERROR",
     });
     return;
   }

--- a/apps/server/src/modules/nutrition/backup-download.ts
+++ b/apps/server/src/modules/nutrition/backup-download.ts
@@ -2,11 +2,22 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { Request, Response } from "express";
 import { safeBackupKeyFromToken } from "../../lib/backupKey.js";
-import { NotFoundError } from "../../obs/errors.js";
+import { env } from "../../env/env.js";
+import {
+  AppError,
+  NotFoundError,
+  UnauthorizedError,
+} from "../../obs/errors.js";
+
+type AuthedRequest = Request & { user?: { id: string } };
 
 /**
  * POST /api/nutrition/backup-download — відновити збережений бекап.
- * CORS / token / rate-limit виставляє роутер.
+ * CORS / token / rate-limit / `requireSession()` виставляє роутер.
+ *
+ * Storage key bind-иться до Better Auth `req.user.id` через
+ * `safeBackupKeyFromToken`, тому юзер фізично не може прочитати чужий
+ * бекап навіть якщо знає чужий `x-token`.
  *
  * Вузький catch тільки на очікувану ситуацію "файл відсутній" (ENOENT).
  * Пошкоджений JSON і файлові помилки летять наверх в errorHandler.
@@ -15,8 +26,21 @@ export default async function handler(
   req: Request,
   res: Response,
 ): Promise<void> {
+  const userId = (req as AuthedRequest).user?.id;
+  if (!userId) {
+    throw new UnauthorizedError("Потрібна автентифікація");
+  }
+
+  const secret = env.NUTRITION_BACKUP_KEY_SECRET;
+  if (!secret) {
+    throw new AppError("Бекапи nutrition тимчасово недоступні", {
+      status: 503,
+      code: "BACKUP_DISABLED",
+    });
+  }
+
   const dir = path.join(process.cwd(), ".data");
-  const key = safeBackupKeyFromToken(req.headers["x-token"]);
+  const key = safeBackupKeyFromToken(userId, req.headers["x-token"], secret);
   const file = path.join(dir, `nutrition-backup-${key}.json`);
 
   let raw: string;

--- a/apps/server/src/modules/nutrition/backup-upload.ts
+++ b/apps/server/src/modules/nutrition/backup-upload.ts
@@ -4,16 +4,37 @@ import type { Request, Response } from "express";
 import { validateBody } from "../../http/validate.js";
 import { BackupUploadSchema } from "../../http/schemas.js";
 import { safeBackupKeyFromToken } from "../../lib/backupKey.js";
-import { AppError } from "../../obs/errors.js";
+import { env } from "../../env/env.js";
+import { AppError, UnauthorizedError } from "../../obs/errors.js";
+
+type AuthedRequest = Request & { user?: { id: string } };
 
 /**
  * POST /api/nutrition/backup-upload — залити шифрований бекап.
- * CORS / token / rate-limit виставляє роутер.
+ * CORS / token / rate-limit / `requireSession()` виставляє роутер.
+ *
+ * Storage key bind-иться до Better Auth `req.user.id` через
+ * `safeBackupKeyFromToken`, тому навіть якщо leaked `x-token` потрапив
+ * до іншого юзера, він фізично не дотягнеться до чужого файлу: різні
+ * `userId` дають різний HMAC і різний шлях на диску.
  */
 export default async function handler(
   req: Request,
   res: Response,
 ): Promise<void> {
+  const userId = (req as AuthedRequest).user?.id;
+  if (!userId) {
+    throw new UnauthorizedError("Потрібна автентифікація");
+  }
+
+  const secret = env.NUTRITION_BACKUP_KEY_SECRET;
+  if (!secret) {
+    throw new AppError("Бекапи nutrition тимчасово недоступні", {
+      status: 503,
+      code: "BACKUP_DISABLED",
+    });
+  }
+
   const parsed = validateBody(BackupUploadSchema, req, res);
   if (!parsed.ok) return;
   const { blob } = parsed.data;
@@ -30,7 +51,7 @@ export default async function handler(
 
   const dir = path.join(process.cwd(), ".data");
   await fs.mkdir(dir, { recursive: true });
-  const key = safeBackupKeyFromToken(req.headers["x-token"]);
+  const key = safeBackupKeyFromToken(userId, req.headers["x-token"], secret);
   const file = path.join(dir, `nutrition-backup-${key}.json`);
   await fs.writeFile(file, raw, "utf8");
 

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -929,7 +929,7 @@
     "/api/nutrition/backup-download": {
       "post": {
         "summary": "Отримати останній зашифрований backup nutrition-blob",
-        "description": "Token-authenticated через header `x-token`. Повертає 404, якщо для наданого токена бекапів ще немає. Роут під `requireSession()` — потрібна активна сесія ЧИ Bearer-токен НА ДОДАЧУ до запитуваного `x-token`.",
+        "description": "Роут під `requireSession()` — потрібна активна сесія або Bearer-токен. Storage key bind-иться до `req.user.id` через HMAC-SHA256(`NUTRITION_BACKUP_KEY_SECRET`, `userId|x-token`), тому `x-token` лише namespace-ить кілька бекапів одного юзера (наприклад, по пристроях) і НЕ використовується для авторизації. Повертає 404, якщо для пари (userId, x-token) бекапів ще немає.",
         "tags": [
           "nutrition"
         ],
@@ -948,10 +948,10 @@
             "schema": {
               "type": "string",
               "minLength": 1,
-              "description": "Опаковий токен, який хешується для формування імені файлу бекапу."
+              "description": "Опаковий namespace-токен для розрізнення кількох бекапів одного юзера (наприклад, per device)."
             },
             "required": true,
-            "description": "Опаковий токен, який хешується для формування імені файлу бекапу."
+            "description": "Опаковий namespace-токен для розрізнення кількох бекапів одного юзера (наприклад, per device)."
           }
         ],
         "responses": {

--- a/packages/shared/src/openapi/routes.ts
+++ b/packages/shared/src/openapi/routes.ts
@@ -339,14 +339,17 @@ export const paths: ZodOpenApiPathsObject = {
     post: {
       summary: "Отримати останній зашифрований backup nutrition-blob",
       description:
-        "Token-authenticated через header `x-token`. Повертає 404, якщо " +
-        "для наданого токена бекапів ще немає. Роут під `requireSession()` — " +
-        "потрібна активна сесія ЧИ Bearer-токен НА ДОДАЧУ до запитуваного `x-token`.",
+        "Роут під `requireSession()` — потрібна активна сесія або " +
+        "Bearer-токен. Storage key bind-иться до `req.user.id` через " +
+        "HMAC-SHA256(`NUTRITION_BACKUP_KEY_SECRET`, `userId|x-token`), " +
+        "тому `x-token` лише namespace-ить кілька бекапів одного юзера " +
+        "(наприклад, по пристроях) і НЕ використовується для авторизації. " +
+        "Повертає 404, якщо для пари (userId, x-token) бекапів ще немає.",
       tags: ["nutrition"],
       security: cookieOrBearer,
       requestParams: {
-        // `x-token` формує ключ для пошуку бекап-файлу в файловій сховищі сервера
-        // (див. `apps/server/src/modules/nutrition/backup-download.ts:safeKeyFromToken`).
+        // `x-token` формує namespace для бекап-файлу в межах одного юзера
+        // (див. `apps/server/src/lib/backupKey.ts:safeBackupKeyFromToken`).
         // Без цього хедера в контракті generated-клієнти і люди-читачі не можуть
         // виявити який вхід потрібен для отримання бекапу.
         header: z.object({
@@ -354,7 +357,8 @@ export const paths: ZodOpenApiPathsObject = {
             .string()
             .min(1)
             .describe(
-              "Опаковий токен, який хешується для формування імені файлу бекапу.",
+              "Опаковий namespace-токен для розрізнення кількох бекапів " +
+                "одного юзера (наприклад, per device).",
             ),
         }),
       },


### PR DESCRIPTION
## Summary

Three security fixes shipping together because they all touch how requests prove who they are і що саме вони бачать у відповіді.

- **Backup IDOR (`apps/server/src/lib/backupKey.ts`)** — раніше ім'я файлу `nutrition-backup-${key}.json` обчислювалось як 32-bit FNV-1a від `x-token`. Простір ключів ~4.3·10⁹, без серверного секрету і без bind-у до `userId`, тож атакер банальним перебором витягує чужі `nutrition`-blob-и (IDOR). Замінив на HMAC-SHA256 із серверним секретом `NUTRITION_BACKUP_KEY_SECRET`, ключ-материал — `userId\0token`, дайджест truncated до 128 біт. Це водночас закриває brute-force (2¹²⁸) і прив'язує файл до конкретного юзера: leaked `x-token` фізично не дотягнеться до чужого backup-у.
- **Backup без session auth (`apps/server/src/modules/nutrition/backup-{upload,download}.ts`)** — auth опирався тільки на router-level `requireSession()` + `x-token` header. Додав явну перевірку `req.user.id` у handler-ах (defence-in-depth), щоб маршрут не міг тихо втратити middleware у майбутньому, плюс 503 якщо серверний секрет відсутній.
- **Upstream body leak (`apps/server/src/modules/mono/connection.ts`)** — два error-branch віддавали raw `text()` Monobank API у поле `upstream`. Це могло протекти HTML-помилки/internal трасування з upstream-у. Тепер upstream body тільки в `logger.warn` (server-only), а клієнту — лише `error` + нормалізований `code` (`MONO_TOKEN_INVALID` / `MONO_UPSTREAM_ERROR`).

Розміри payload-у і успішні відповіді не змінено, контракт `MonoConnectResponse` (success) — без правок.

## Governing Skill

- Primary skill: sergeant-server-api
- Secondary skill (if truly needed): sergeant-data-and-migrations (немає міграцій, але file-keying на диску — суміжна тема)

## Playbook

- Primary playbook: n/a — точкова security-правка без бізнес-логіки
- Why this playbook: окремого security-плейбуку в репо немає; зміни локалізовані в трьох handler-файлах + env + openapi
- If no playbook matched, why: hardening наявних endpoint-ів без зміни контракту/успішних відповідей

## Verification

```bash
pnpm --filter @sergeant/server exec vitest run \
  src/lib/backupKey.test.ts src/modules/mono/connection.test.ts
# Test Files  2 passed (2)
# Tests       24 passed (24)

pnpm --filter @sergeant/server typecheck
# tsc -p tsconfig.json --noEmit  → exit 0

pnpm api:generate-openapi
# Wrote docs/api/openapi.json (44 paths, 39 components)

pnpm lint   # тільки warnings, 0 errors; api:check-openapi → актуальна
```

Pre-existing failures на `main` (підтверджено `git stash` + повторним прогоном): `apps/mobile` typecheck (TanStack Query duplicate types у QueryProvider, BudgetAlertsList), `apps/server` `registerRoutes.test.ts` snapshot drift по `/api/internal/openclaw/write/*`, `ragContext.test.ts` (vitest fake-timers `delay undefined`). Жоден не торкається змінених файлів.

Additional checks:

- [x] Local smoke / manual validation completed — нові unit-тести покривають user-isolation, secret-rotation, missing-secret/missing-userId, multi-value header, upstream-body redaction
- [x] Surface-specific checks completed — server typecheck + lint + openapi freshness

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- `.env.example` — задокументовано `NUTRITION_BACKUP_KEY_SECRET` з рецептом генерації
- `packages/shared/src/openapi/routes.ts` + `docs/api/openapi.json` — описано, що `x-token` тепер namespace, не auth-ключ; storage key bind-иться до `req.user.id`

## Risk and Rollout

- **User-visible risk:** після деплою старі бекапи (на FNV-ключі) фізично не resolve-ляться у новий HMAC-ключ. Це власне і є фікс — старий key-space був небезпечний. Користувач при першому `backup-download` побачить 404 і має перезалити блоб. Web-клієнт має локальну копію (encrypted blob у localStorage), тож відновлення тривіальне.
- **Rollout / deploy order:** перед merge — додати `NUTRITION_BACKUP_KEY_SECRET` (32-byte hex) у Railway → server. Без секрету в production startup впаде з зрозумілою помилкою (`assertStartupEnv`); у dev/staging — warning + 503 на endpoint-ах (фронт залишається з локальним blob-ом).
- **Backout plan:** revert PR; старі бекапи не повернуться, але endpoint знову відкриється під FNV-ключем (повернеться до попередньої IDOR-поведінки — не робити це довше за rollback-вікно).

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

- **Env change:** `NUTRITION_BACKUP_KEY_SECRET` обов'язковий у production (`assertStartupEnv` кидає при відсутності). Згенерувати: `openssl rand -hex 32`. Зберегти у Railway → service env перед merge.
- **Контракт `mono/connect` error-responses:** прибрано поле `upstream` з 401/502 JSON, додано `code` (`MONO_TOKEN_INVALID`/`MONO_UPSTREAM_ERROR`). Success path не торкався, `MonoConnectResponse` (api-client) — без змін, тому SDK consumer-и не падають. Якщо є зовнішні споживачі, що логували `error.upstream`, цей дебаг-канал переїхав у server-логи (`upstreamBody` у warn-event).
- **Backup-сумісність:** старі файли `nutrition-backup-${fnvKey}.json` залишаться на диску, але новим алгоритмом не знайдуться. Окремий cleanup-job не додавав, бо `.data` директорія короткостроковий cache.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened nutrition backups to prevent IDOR by binding file keys to the authenticated user and a server secret; removed Monobank upstream body from client errors and returned normalized codes instead.

- **Bug Fixes**
  - Replaced 32-bit FNV-1a with HMAC-SHA256(`NUTRITION_BACKUP_KEY_SECRET`) over `userId\0x-token`; returns a 32-char hex key scoped per user and token.
  - Enforced `req.user.id` in `backup-upload` and `backup-download`; 503 when the secret is missing.
  - Removed raw upstream body from `mono/connect` error responses; log server-side only and return `code` (`MONO_TOKEN_INVALID`, `MONO_UPSTREAM_ERROR`). Success contract unchanged.

- **Migration**
  - Add `NUTRITION_BACKUP_KEY_SECRET` in production before deploy.
  - Old FNV-keyed backups won’t resolve; first download returns 404 and users should re-upload (clients keep the encrypted blob locally).
  - Without the secret in dev/staging, backup endpoints return 503.

<sup>Written for commit 370e67a7a23f0eca66f3c89cd893a6aaaa273392. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nutrition backup operations now require user authentication
  * Added support for backup secret configuration to enhance security

* **Bug Fixes**
  * Improved error handling for third-party integration failures with normalized error responses

* **Documentation**
  * Updated API documentation to clarify backup authorization mechanisms and storage key derivation
  * Improved backup feature descriptions in endpoint documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->