### PR TITLE
fix(web): urgent UI/UX improvements — focus-visible, a11y, toast errors

### DIFF
--- a/apps/mobile/app/(auth)/index.tsx
+++ b/apps/mobile/app/(auth)/index.tsx
@@ -1,13 +1,13 @@
 import { useRouter } from "expo-router";
 import { View, Text, Pressable, StyleSheet } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { colors, spacing, radius } from "@/theme";
+import { colors, spacing, radius, moduleColors } from "@/theme";
 
 const modules = [
-  { label: "Фінанси", color: "#7c6af7" },
-  { label: "Фітнес", color: "#0d9488" },
-  { label: "Рутина", color: "#dc5e5e" },
-  { label: "Харчування", color: "#84cc16" },
+  { label: "Фінанси", color: moduleColors.finyk.primary },
+  { label: "Фітнес", color: moduleColors.fizruk.primary },
+  { label: "Рутина", color: moduleColors.routine.primary },
+  { label: "Харчування", color: moduleColors.nutrition.primary },
 ];
 
 export default function WelcomeScreen() {
@@ -75,7 +75,7 @@ const s = StyleSheet.create({
     width: 88,
     height: 88,
     borderRadius: 24,
-    backgroundColor: "#7c6af7",
+    backgroundColor: colors.accent,
     alignItems: "center",
     justifyContent: "center",
   },
@@ -106,12 +106,12 @@ const s = StyleSheet.create({
   chipText: { fontSize: 12, fontWeight: "600" },
   actions: { gap: spacing.md, paddingBottom: spacing.xl },
   primaryBtn: {
-    backgroundColor: "#7c6af7",
+    backgroundColor: colors.accent,
     borderRadius: radius.md,
     paddingVertical: 16,
     alignItems: "center",
   },
   primaryBtnText: { color: "#fff", fontSize: 16, fontWeight: "700" },
   signInLink: { color: colors.textMuted, fontSize: 14, textAlign: "center" },
-  signInLinkBold: { color: "#7c6af7", fontWeight: "600" },
+  signInLinkBold: { color: colors.accent, fontWeight: "600" },
 });

--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -14,7 +14,7 @@ import { useUser } from "@sergeant/api-client/react";
 import { shouldShowOnboarding } from "@sergeant/shared";
 import { OnboardingWizard, getOnboardingStore } from "@/core/OnboardingWizard";
 import { useTabBadges } from "@/hooks/useTabBadges";
-import { colors } from "@/theme";
+import { colors, moduleColors } from "@/theme";
 
 type TabIconProps = {
   color: string;
@@ -124,6 +124,7 @@ export default function TabsLayout() {
             tabBarIcon: createTabIcon(CheckSquare),
             tabBarButtonTestID: "tab-routine",
             tabBarBadge: badges.routine,
+            tabBarBadgeStyle: { backgroundColor: moduleColors.routine.primary },
           }}
         />
         <Tabs.Screen

--- a/apps/web/src/core/hub/HubChatHistoryDrawer.tsx
+++ b/apps/web/src/core/hub/HubChatHistoryDrawer.tsx
@@ -173,7 +173,7 @@ export function HubChatHistoryDrawer({
                   <button
                     type="button"
                     onClick={(e) => handleDelete(e, s.id)}
-                    className="w-9 h-9 shrink-0 flex items-center justify-center rounded-xl text-subtle/60 sm:opacity-0 sm:group-hover:opacity-100 sm:focus:opacity-100 hover:text-danger hover:bg-danger/10 transition-[color,background-color,opacity]"
+                    className="w-9 h-9 shrink-0 flex items-center justify-center rounded-xl text-subtle/60 sm:opacity-0 sm:group-hover:opacity-100 sm:focus-visible:opacity-100 hover:text-danger hover:bg-danger/10 transition-[color,background-color,opacity]"
                     aria-label={`Видалити бесіду ${s.title}`}
                     title="Видалити"
                   >

--- a/apps/web/src/modules/finyk/pages/transactions/TransactionFilters.tsx
+++ b/apps/web/src/modules/finyk/pages/transactions/TransactionFilters.tsx
@@ -44,8 +44,10 @@ export function TransactionFilters({
             key={f.id}
             data-compact
             onClick={() => onChangeFilter(f.id)}
+            aria-pressed={filter === f.id}
             className={cn(
               "shrink-0 inline-flex items-center h-7 px-3 text-style-caption font-medium rounded-full border transition-colors",
+              "focus:outline-none focus-visible:ring-2 focus-visible:ring-finyk/50 focus-visible:ring-offset-1",
               filter === f.id
                 ? "bg-primary border-primary text-bg shadow-sm"
                 : "bg-panelHi border-line text-text hover:border-muted",

--- a/apps/web/src/modules/nutrition/components/LogCard.tsx
+++ b/apps/web/src/modules/nutrition/components/LogCard.tsx
@@ -723,7 +723,7 @@ function MealRow({ meal, onRemove, onEdit }: MealRowProps) {
       <button
         type="button"
         onClick={onRemove}
-        className="w-8 h-8 flex items-center justify-center rounded-full text-muted hover:text-danger hover:bg-danger/10 transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100"
+        className="w-8 h-8 flex items-center justify-center rounded-full text-muted hover:text-danger hover:bg-danger/10 transition-colors opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
         aria-label="Видалити запис"
       >
         ✕

--- a/apps/web/src/modules/nutrition/components/PantryCard.tsx
+++ b/apps/web/src/modules/nutrition/components/PantryCard.tsx
@@ -74,7 +74,7 @@ function ItemRow({
         type="button"
         onClick={() => removeItemAtOrByName(idx, item?.name)}
         disabled={busy}
-        className="w-6 h-6 rounded-xl flex items-center justify-center text-subtle/60 sm:opacity-0 sm:group-hover:opacity-100 sm:focus:opacity-100 hover:text-danger hover:bg-danger/10 transition-[color,background-color,opacity] text-sm leading-none shrink-0"
+        className="w-6 h-6 rounded-xl flex items-center justify-center text-subtle/60 sm:opacity-0 sm:group-hover:opacity-100 sm:focus-visible:opacity-100 hover:text-danger hover:bg-danger/10 transition-[color,background-color,opacity] text-sm leading-none shrink-0"
         aria-label={`Прибрати ${item?.name || "продукт"}`}
         title="Прибрати"
       >

--- a/apps/web/src/modules/nutrition/hooks/useNutritionLog.test.tsx
+++ b/apps/web/src/modules/nutrition/hooks/useNutritionLog.test.tsx
@@ -1,11 +1,11 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
-import type { MockInstance } from "vitest";
 import { useNutritionLog } from "./useNutritionLog";
 import { NUTRITION_LOG_KEY } from "../lib/nutritionStorage";
+import { ToastProvider } from "@shared/hooks/useToast";
 
 function makeWrapper() {
   const client = new QueryClient({
@@ -13,21 +13,16 @@ function makeWrapper() {
   });
   return function Wrapper({ children }: { children: ReactNode }) {
     return (
-      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+      <ToastProvider>
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+      </ToastProvider>
     );
   };
 }
 
 describe("useNutritionLog – defensive imports", () => {
-  let errorSpy: MockInstance;
-
   beforeEach(() => {
     localStorage.clear();
-    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    errorSpy.mockRestore();
   });
 
   it("replaceLogFromJsonText returns false and does not throw on malformed JSON", () => {
@@ -39,7 +34,6 @@ describe("useNutritionLog – defensive imports", () => {
       ok = result.current.replaceLogFromJsonText("{not: valid json");
     });
     expect(ok).toBe(false);
-    expect(errorSpy).toHaveBeenCalled();
     // previous state preserved (empty log)
     expect(result.current.nutritionLog).toEqual({});
   });
@@ -77,7 +71,6 @@ describe("useNutritionLog – defensive imports", () => {
       ok = result.current.mergeLogFromJsonText("not json at all");
     });
     expect(ok).toBe(false);
-    expect(errorSpy).toHaveBeenCalled();
     expect(result.current.nutritionLog["2025-01-01"].meals).toHaveLength(1);
   });
 

--- a/apps/web/src/modules/nutrition/hooks/useNutritionLog.ts
+++ b/apps/web/src/modules/nutrition/hooks/useNutritionLog.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
+import { useToast } from "@shared/hooks/useToast";
 import { coachKeys, digestKeys } from "@shared/lib/queryKeys";
 import {
   NUTRITION_LOG_KEY,
@@ -40,6 +41,7 @@ function collectMealIds(log: NutritionLog): Set<string> {
  */
 export function useNutritionLog() {
   const queryClient = useQueryClient();
+  const toast = useToast();
   const [nutritionLog, setNutritionLog] = useState<NutritionLog>(() =>
     loadNutritionLog(NUTRITION_LOG_KEY),
   );
@@ -172,8 +174,8 @@ export function useNutritionLog() {
     let parsed;
     try {
       parsed = JSON.parse(text);
-    } catch (err) {
-      console.error("[nutrition] replaceLogFromJsonText: invalid JSON", err);
+    } catch {
+      toast.error("Не вдалося завантажити лог харчування — невалідний формат JSON.");
       return false;
     }
     setNutritionLog((_prev) => {
@@ -196,8 +198,8 @@ export function useNutritionLog() {
     let parsed;
     try {
       parsed = JSON.parse(text);
-    } catch (err) {
-      console.error("[nutrition] mergeLogFromJsonText: invalid JSON", err);
+    } catch {
+      toast.error("Не вдалося об'єднати лог харчування — невалідний формат JSON.");
       return false;
     }
     setNutritionLog((log) => mergeNutritionLogs(log, parsed));


### PR DESCRIPTION
## Summary

5 targeted UI/UX fixes found via real code audit (not docs):

- **mobile/welcome**: replace orphan `#7c6af7` (purple, not in `brandColors`) with `colors.accent` on logo, primary button, sign-in link; module chips now use `moduleColors.{finyk,fizruk,routine,nutrition}.primary` — first screen every new user sees now follows the design system
- **mobile/tabs**: add `tabBarBadgeStyle: { backgroundColor: moduleColors.routine.primary }` to the Routine tab — was the only module tab without an explicit badge colour, showing iOS default red instead of coral-500
- **web/nutrition+hub**: `focus:opacity-100` → `focus-visible:opacity-100` on delete action buttons in `LogCard`, `PantryCard`, `HubChatHistoryDrawer` — prevents the delete button flashing into view on every mouse click (Hard Rule #14)
- **web/finyk**: add `focus:outline-none focus-visible:ring-2 focus-visible:ring-finyk/50` + `aria-pressed` to `TransactionFilters` pill buttons — keyboard/AT users can now navigate the filter strip
- **web/nutrition**: `console.error` → `toast.error` in `replaceLogFromJsonText` / `mergeLogFromJsonText`; users now see a visible error when their nutrition log JSON is malformed instead of silent failure; test wrapper updated with `ToastProvider`

## Governing Skill

- Primary skill: `sergeant-web-ui`
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: no dedicated playbook for UI/UX polish fixes
- Why this playbook: changes are targeted single-file edits across mobile and web; no new routes, no migrations, no API contract changes
- If no playbook matched: mini-plan in Summary above covers the change set

## Verification

```bash
pnpm lint
pnpm typecheck
```

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

Changed files reviewed manually for type correctness:
- `colors.accent` / `moduleColors.*` confirmed exported from `@/theme`
- `toast.error` API confirmed in `useToast.tsx` (`error: (msg, duration?, action?) => number`)
- `focus-visible:ring-finyk/50` uses registered opacity step (50 ∈ allowed scale)
- `ToastProvider` added to test wrapper in `useNutritionLog.test.tsx`

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a — pure code fixes; no contract, token, or playbook changes; `UX-IMPROVEMENT-PLAN.md` tracker will be updated in a follow-up pass when the full audit cycle closes

## Risk and Rollout

- User-visible risk: low — all changes are visual/a11y only; no data model or API contract touched
- Rollout / deploy order: standard — web and mobile deploy independently; no coordination needed
- Backout plan: revert commit `420d537`; no DB/migration involved

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

No migrations, no env changes, no HubChat tool changes, no auth changes. Pure UI/a11y polish across 8 files.

https://claude.ai/code/session_01NhkNo3mqLe4qDNWNxW84kL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nutrition log import now displays error messages when JSON format is invalid.

* **Style**
  * Updated theme styling across mobile and web applications using theme tokens.
  * Improved focus and hover visibility for interactive elements and buttons.

* **Tests**
  * Updated nutrition log tests to reflect current error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->