### PR TITLE
docs(docs): mark storage-roadmap Stage 0 PRs #001/#002/#004 as LANDED

### DIFF
--- a/docs/planning/storage-roadmap.md
+++ b/docs/planning/storage-roadmap.md
@@ -101,7 +101,7 @@
 
 ### Stage 0 — Security hygiene (P0)
 
-#### **PR #001 — `chore(mobile): MMKV encryption with SecureStore-derived key`**
+#### **PR #001 — `chore(mobile): MMKV encryption with SecureStore-derived key`** ✅ LANDED — [#1272](https://github.com/Skords-01/Sergeant/pull/1272)
 
 - **Scope.** `apps/mobile/src/lib/storage.ts`: при першому запуску
   згенерувати random 32-byte key, зберегти в `expo-secure-store`,
@@ -118,7 +118,7 @@
   виживають reinstall (з SecureStore key).
 - **Dep.** None.
 
-#### **PR #002 — `feat(server): rotate Mono PAT to backend-only flow, drop FINYK_TOKEN from sync keys`**
+#### **PR #002 — `feat(server): rotate Mono PAT to backend-only flow, drop FINYK_TOKEN from sync keys`** ✅ LANDED — [#1280](https://github.com/Skords-01/Sergeant/pull/1280)
 
 - **Scope.** Видалити `FINYK_TOKEN` з `SYNC_MODULES.finyk.keys` у `core/cloudSync/config.ts`
   (web) і `apps/mobile/src/sync/config.ts`. PAT уже зберігається в
@@ -140,7 +140,7 @@
 - **AC.** Unit-test ротації; integration-test mono-mock.
 - **Dep.** None.
 
-#### **PR #004 — `feat(web): exclude sensitive query keys from IDB persister`**
+#### **PR #004 — `feat(web): exclude sensitive query keys from IDB persister`** ✅ LANDED — [#1283](https://github.com/Skords-01/Sergeant/pull/1283)
 
 - **Scope.** `apps/web/src/shared/lib/queryClientPersister.ts`:
   додати `dehydrateOptions.shouldDehydrateQuery` exclude list для


### PR DESCRIPTION
## Summary

Sync `docs/planning/storage-roadmap.md` з реальним станом main: три Stage 0 PR-и вже зленджені, але документ цього не відображав. Просто додаю той самий `✅ LANDED — [#NNNN]` маркер, що вже використовується для Stage 2 (#014–#021).

| Roadmap | Реальний PR | Що зробив |
| --- | --- | --- |
| **#001** MMKV encryption | [#1272](https://github.com/Skords-01/Sergeant/pull/1272) | `feat(mobile): encrypt MMKV at rest with idempotent migration` (`apps/mobile/src/lib/storageEncryption.ts`, bootstrap у `app/_layout.tsx`, тести) |
| **#002** FINYK_TOKEN cleanup | [#1280](https://github.com/Skords-01/Sergeant/pull/1280) | `feat(eslint-plugins): drop FINYK_TOKEN from sync, add storage guard` + `useMonoTokenMigration.ts` |
| **#004** sensitive query exclusions | [#1283](https://github.com/Skords-01/Sergeant/pull/1283) | `feat(shared): exclude sensitive query keys from IDB/MMKV warm-start` (`isSensitiveQueryKey` фільтр у persister-ах) |

PR #003 (webhook rotation worker), #005 (sync_audit_log), #012 (CHECK + soft-delete) теж виглядають як landed на main, але вони не входили в обсяг цього PR — окремо потвердимо й оновимо у наступному doc-PR-і за вказівкою.

Зміна — лише три one-line суфікси у `docs/planning/storage-roadmap.md`. Жодних code-змін.

## Governing Skill

- Primary skill: `sergeant-start-here` → `sergeant-review-and-merge` (docs/governance hygiene)
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a — це 3-рядковий doc-патч, не fits a feature/bug playbook.
- Why this playbook: —
- If no playbook matched, why: чисто косметичне оновлення статус-маркерів у roadmap-документі без зміни scope, ризику чи rollout-у.

## Verification

```bash
pnpm lint:tech-debt-freshness
pnpm docs:check-links
npx prettier --check docs/planning/storage-roadmap.md
```

Усі троє — green. `lint-staged` (Husky pre-commit) також пройшов на коміті, виконавши `bump-last-validated.mjs` + `prettier --write` для `*.md`.

Additional checks:

- [x] Local smoke / manual validation completed (grep на git log + код підтверджує LANDED-статус для PR #1272/#1280/#1283)
- [x] Surface-specific checks completed (docs surface — links + freshness gate)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update. Не потребує — `AGENTS.md` не посилається на конкретні roadmap-PR-номери.
- [x] I checked whether a playbook or skill needed an update. Не потребує.
- [x] I checked whether governance docs or review docs needed an update. Не потребує.

Updated docs:

- `docs/planning/storage-roadmap.md` — додано `✅ LANDED — [#NNNN]` суфікси для PR #001, #002, #004.

## Risk and Rollout

- User-visible risk: **none.** Doc-only change, не торкає runtime.
- Rollout / deploy order: merge → next deploy не потрібен; doc оновлюється на GitHub.
- Backout plan: revert цей PR.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

- Жодних migrations, env-vars, HubChat tools чи auth.
- Формат суфіксу скопійований з тих, що вже стоять для Stage 2 PR-ів (`#### **PR #014 — \`...\`** ✅ LANDED — [#1290]...`).
- У наступному doc-PR пропоную також промаркувати #003/#005/#012 та переглянути Stage 1 (#006–#013) — їх статус змішаний, потребує точнішого аудиту перед оновленням.

---

Devin run: https://app.devin.ai/sessions/c0f6b8397fa0480891452fd586e06954
Requested by: dimastahov16012003 (dimastahov16012003@gmail.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the storage roadmap to display completion status and corresponding links for released pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->