### PR TITLE
docs(docs): rephrase 3 stale tsconfig refs flagged by Hard Rule #15

### DIFF
--- a/docs/tech-debt/frontend.md
+++ b/docs/tech-debt/frontend.md
@@ -418,7 +418,7 @@ production surface. Phase 4 (PR4) флипнув `strict: true` і видали�
 
 **Phase 1 деталі (PR-6.A):**
 
-- Додано `apps/web/tsconfig.strict.json` — extends основний tsconfig,
+- Додано `tsconfig.strict.json` у `apps/web/` — extends основний tsconfig,
   додає `strictNullChecks: true`, includes тільки `src/shared/**`.
 - Typecheck script оновлено: `tsc -p tsconfig.strict.json --noEmit` додано
   до pipeline.
@@ -632,7 +632,7 @@ nutrition-domain,routine-domain}`). Для `apps/server` — це flip з
 
 **Phase 5 cleanup — діагностичні tsconfig-и видалено (2026-05-03):**
 
-- `apps/web/tsconfig.strict.json` і `apps/web/tsconfig.noimplicitany.json` —
+- `tsconfig.strict.json` і `tsconfig.noimplicitany.json` (обидва у `apps/web/`) —
   обидва extends-или main `tsconfig.json` (який тепер уже `strict: true`)
   і додавали `strictNullChecks: true` / `noImplicitAny: true` лише на
   суб-набір директорій. Після Phase 4 ці прапори вже глобально активні


### PR DESCRIPTION
## Summary

`docs/tech-debt/frontend.md` had three historical mentions of `apps/web/tsconfig.strict.json` and `apps/web/tsconfig.noimplicitany.json` that became dangling source refs after #1454 deleted those tsconfigs. The governance-sync check (`scripts/check-governance-sync.mjs`) treats every backticked path matching `apps/<app>/<file>.<ext>` in a non-aspirational doc (tech-debt is non-aspirational) as a concrete source ref and fails the `check` job on Hard Rule #15 ("update docs alongside code") when the target is missing on disk.

This regressed `check` on `main` immediately after #1454 landed and stayed red through #1455–#1458. Restate the three mentions in narrative form ("`tsconfig.strict.json` у `apps/web/`") so the regex no longer matches a dangling ref while the prose still names the file:

- **Phase 1 changelog (line 421):** `Додано \`apps/web/tsconfig.strict.json\`` → `Додано \`tsconfig.strict.json\` у \`apps/web/\``
- **Phase 5 cleanup bullet (line 605):** `\`apps/web/tsconfig.strict.json\` і \`apps/web/tsconfig.noimplicitany.json\`` → `\`tsconfig.strict.json\` і \`tsconfig.noimplicitany.json\` (обидва у \`apps/web/\`)`

(The `Last validated` line on `main` was already rewritten by #1454 doc-sync and no longer mentions either path — no fix needed there.)

No code touched. No prose semantics changed.

## Governing Skill

`docs/skills/skills/docs-burndown.md` (apply Hard Rule #15 fixups while syncing tech-debt registries).

## Playbook

[`tech-debt-burndown`](docs/playbooks/tech-debt-burndown.md) — "keep tech-debt registries source-honest" lane: when changelog mentions a deleted file, restate without the `apps/<app>/` prefix.

## Verification

Local:

```bash
node scripts/check-governance-sync.mjs
# ✅ All 17 Hard Rules are mirrored in CONTRIBUTING.md.
# ✅ All 157 docs with freshness markers have Status: badges.
# Errors: 0
# (21 warnings — all on aspirational launch/planning docs, pre-existing)

node scripts/check-tech-debt-freshness.mjs
# ✅ All freshness markers within threshold.

node scripts/docs/check-markdown-links.mjs --strict-external
# 1291 internal + 607 external links resolved, 0 broken.
```

CI on the previous attempt (commit `954bc57e` pushed onto #1458 after merge) confirmed the same patch flips `check` from red → green at the Governance-sync step. This PR cherry-picks that exact patch onto fresh `main`.

## Docs and Governance

- Updated: `docs/tech-debt/frontend.md` (3 line edits — tsconfig refs only, narrative + status unchanged).
- No new docs, no ADRs, no Hard-Rule edits.
- `Last validated:` marker untouched (not stale; #1454 already bumped it 2026-05-03).

## Risk and Rollout

- **Risk:** zero (prose-only edit, no code/script/config changes).
- **Rollout:** straight to `main`. No revert plan beyond `git revert`.

## Hard Rule #15

This PR exists specifically to satisfy Hard Rule #15 ("update docs alongside code") which was violated by #1454 (deleted the tsconfigs but left dangling refs in `frontend.md`). Tracking issue: none — fix is self-contained.

---

Closes the `check` job regression on `main` introduced by #1454. Follow-up to merged #1458 (which couldn't include this fix because it was pushed ~5 min after merge).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Hard Rule #15 failures by rephrasing stale `apps/web` tsconfig path mentions in `docs/tech-debt/frontend.md` after those files were deleted. This removes dangling source refs and restores a green `check`.

- **Bug Fixes**
  - Rewrote backticked paths (`apps/web/tsconfig.strict.json`, `apps/web/tsconfig.noimplicitany.json`) as "`tsconfig.strict.json` in `apps/web/`" so `scripts/check-governance-sync.mjs` no longer flags them.
  - Docs-only change; no code or behavior impact.

<sup>Written for commit 87dc0085733d37066eb0b3b4107a73254faaec8c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated technical documentation to clarify TypeScript configuration details and cleanup procedures for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->