### PR TITLE
fix(mobile): type tx parameter in finyk TxRow and TxListItem

### DIFF
--- a/apps/mobile/src/modules/finyk/components/TxListItem.tsx
+++ b/apps/mobile/src/modules/finyk/components/TxListItem.tsx
@@ -18,18 +18,15 @@ import { View } from "react-native";
 
 import { SwipeToAction } from "@/components/ui/SwipeToAction";
 
-import { TxRow, type TxRowProps } from "./TxRow";
+import { TxRow, type TxRowProps, type TxRowTx } from "./TxRow";
 
-// Legacy untyped shapes — see `TxRow.tsx` for details.
-/* eslint-disable @typescript-eslint/no-explicit-any */
 export interface TxListItemProps extends Omit<TxRowProps, "onPress"> {
   rowIndex?: number;
-  onPressManual?: (tx: any) => void;
+  onPressManual?: (tx: TxRowTx) => void;
   onSwipeHideTx?: (id: string) => void;
-  onSwipeDeleteManual?: (tx: any) => void;
+  onSwipeDeleteManual?: (tx: TxRowTx) => void;
   onSwipeUnhideTx?: (id: string) => void;
 }
-/* eslint-enable @typescript-eslint/no-explicit-any */
 
 function TxListItemImpl({
   tx,

--- a/apps/mobile/src/modules/finyk/components/TxRow.tsx
+++ b/apps/mobile/src/modules/finyk/components/TxRow.tsx
@@ -45,21 +45,42 @@ import {
   getCategory,
   getIncomeCategory,
 } from "@sergeant/finyk-domain";
+import type { CustomCategoryInput } from "@sergeant/finyk-domain/constants";
+import type { TxSplitsMap } from "@sergeant/finyk-domain/domain/types";
+import type { MonoAccount } from "@sergeant/finyk-domain/lib/accounts";
 
-// Legacy untyped shapes — pages/storage hand us heterogeneous records
-// and the categorisation / split / account code paths predate static
-// typing. Mirrors the web file.
-/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * Мінімальна форма транзакції, яку рендерить рядок. Свідомо НЕ імпортуємо
+ * повний `Transaction` з finyk-domain — рядок бачить і нормалізовані, і
+ * сирі monobank-записи (різні точки виклику persist різні shape-и: Mono
+ * statement entries, manual-expenses, merged splits), тому лишаємо тільки
+ * реально читані поля. Mirrors the web twin (`TxRowTx`) byte-for-byte —
+ * shapes drift in lockstep across web/mobile.
+ */
+export interface TxRowTx {
+  id: string;
+  amount: number;
+  description?: string;
+  mcc?: number;
+  time?: number;
+  currencyCode?: number;
+  operationAmount?: number;
+  _accountId?: string | null;
+  _source?: string;
+  _manual?: boolean;
+  _manualId?: string;
+}
+
 export interface TxRowProps {
-  tx: any;
+  tx: TxRowTx;
   onPress?: () => void;
   highlighted?: boolean;
   hidden?: boolean;
   overrideCatId?: string | null;
-  accounts?: any[];
+  accounts?: readonly MonoAccount[];
   hideAmount?: boolean;
-  txSplits?: Record<string, any[]>;
-  customCategories?: any[];
+  txSplits?: TxSplitsMap;
+  customCategories?: readonly CustomCategoryInput[];
   /**
    * Propagated to the row's outer `Pressable` / `View` so Detox E2E
    * can match a specific transaction by id (see the first suite in
@@ -67,7 +88,6 @@ export interface TxRowProps {
    */
   testID?: string;
 }
-/* eslint-enable @typescript-eslint/no-explicit-any */
 
 const INCOME_ICONS: Record<string, string> = {
   in_salary: "💰",
@@ -88,7 +108,7 @@ const ACCOUNT_TYPE_LABEL: Record<string, string> = {
 };
 
 function getAccountShortName(
-  acc: { type?: string } | undefined | null,
+  acc: MonoAccount | undefined | null,
 ): string | null {
   if (!acc) return null;
   return ACCOUNT_TYPE_LABEL[acc.type ?? ""] || acc.type || "Рахунок";
@@ -121,8 +141,13 @@ function TxRowImpl({
   const cat = useMemo(
     () =>
       isIncome
-        ? getIncomeCategory(tx.description, overrideCatId)
-        : getCategory(tx.description, tx.mcc, overrideCatId, customCategories),
+        ? getIncomeCategory(tx.description ?? "", overrideCatId)
+        : getCategory(
+            tx.description ?? "",
+            tx.mcc ?? 0,
+            overrideCatId,
+            customCategories,
+          ),
     [isIncome, tx.description, tx.mcc, overrideCatId, customCategories],
   );
 
@@ -203,7 +228,9 @@ function TxRowImpl({
                 </Text>
               </View>
             )}
-            <Text className="text-xs text-fg-muted">· {fmtDate(tx.time)}</Text>
+            <Text className="text-xs text-fg-muted">
+              · {fmtDate(tx.time ?? 0)}
+            </Text>
           </View>
         </View>
       </View>


### PR DESCRIPTION
## Summary

`apps/mobile`'s finyk `TxRow` and `TxListItem` leaked `tx: any` (and a few neighbouring `any[]`) into the props surface, blocking the strict-TS hygiene push. The escape hatch was tagged "legacy untyped shapes" but the web twin already exposes a `TxRowTx` interface that covers every field the mobile component reads.

This PR mirrors that shape into the mobile module byte-for-byte, narrows `accounts` to `readonly MonoAccount[]`, `txSplits` to `TxSplitsMap`, `customCategories` to `readonly CustomCategoryInput[]`, and switches the `TxListItem` callbacks (`onPressManual` / `onSwipeDeleteManual`) from `(tx: any) => void` to `(tx: TxRowTx) => void`. The `eslint-disable @typescript-eslint/no-explicit-any` directive in both files is no longer needed and gets removed.

No behaviour change. The optional `time` field uses the same `fmtDate(tx.time ?? 0)` guard as the web twin.

Before (TxRow.tsx):
```ts
export interface TxRowProps {
  tx: any;
  accounts?: any[];
  txSplits?: Record<string, any[]>;
  customCategories?: any[];
  ...
}
```

After:
```ts
export interface TxRowTx {
  id: string;
  amount: number;
  description?: string;
  mcc?: number;
  time?: number;
  currencyCode?: number;
  operationAmount?: number;
  _accountId?: string | null;
  _source?: string;
  _manual?: boolean;
  _manualId?: string;
}

export interface TxRowProps {
  tx: TxRowTx;
  accounts?: readonly MonoAccount[];
  txSplits?: TxSplitsMap;
  customCategories?: readonly CustomCategoryInput[];
  ...
}
```

## Governing Skill

- Primary skill: `sergeant-mobile-expo` (only files touched live under `apps/mobile/src/modules/finyk/components`)
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a
- Why this playbook: n/a
- If no playbook matched, why: small type-safety tightening on existing mobile components; no playbook covers strict-TS retro-fits to a single React Native module.

## Verification

```bash
pnpm --filter @sergeant/db-schema build
pnpm --filter @sergeant/mobile typecheck
# → tsc -p tsconfig.json --noEmit (clean exit)

pnpm --filter @sergeant/mobile exec jest --testPathPattern "finyk/components/Tx"
# → Test Suites: 2 passed, Tests: 7 passed

pnpm --filter @sergeant/mobile lint
# → eslint clean

pnpm exec prettier --check apps/mobile/src/modules/finyk/components/TxRow.tsx apps/mobile/src/modules/finyk/components/TxListItem.tsx
# → All matched files use Prettier code style!
```

Additional checks:

- [x] Local smoke / manual validation completed (mobile typecheck + Jest green; web twin unchanged)
- [x] Surface-specific checks completed (`@sergeant/mobile lint` + `typecheck` + targeted `jest` all clean)

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a — `docs/tech-debt/frontend.md` already lists "`apps/mobile/src/modules/finyk/components/Tx*.tsx` still ship `tx: any`" as a tracked item; this PR removes the entry from reality, the doc tidy-up can ride a follow-up sweep.

## Risk and Rollout

- User-visible risk: none — types-only change; runtime branches stay identical (only added `?? 0` / `?? ""` to satisfy the new optional fields, which previously already short-circuited via `any`).
- Rollout / deploy order: standard merge to `main`; mobile build picks it up on next Expo release.
- Backout plan: revert this PR — both files restore the prior `any`-typed surface.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

- `TxRowTx` is intentionally duplicated between `apps/web/.../TxRow.tsx` and `apps/mobile/.../TxRow.tsx` — the comment in both files calls this out, and the docstring asks future editors to drift them in lockstep. Happy to extract into `@sergeant/finyk-domain` in a follow-up if you'd prefer one source of truth (would need to live alongside the existing `Transaction` interface, since the row deliberately accepts a wider/looser shape than the canonical `Transaction`).
- `TransactionsFeedItem` already pulls its prop types via `React.ComponentProps<typeof TxRow>`, so the narrower types flow through without any caller-side change.
- No `@sergeant/finyk-domain` API change; only adding type-only imports of already-exported `TxSplitsMap`, `MonoAccount`, `CustomCategoryInput`.