### PR TITLE
feat(web): migrate Tailwind CSS v3 → v4 (Phase 1)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -29,7 +29,7 @@
       "name": "CSS",
       "path": "../server/dist/assets/*.css",
       "brotli": true,
-      "limit": "22 kB"
+      "limit": "28 kB"
     }
   ],
   "dependencies": {
@@ -83,6 +83,7 @@
     "@sergeant/config": "workspace:*",
     "@sergeant/db-schema": "workspace:^",
     "@size-limit/file": "^12.1.0",
+    "@tailwindcss/vite": "^4.2.4",
     "@tanstack/react-query-devtools": "^5.99.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
@@ -91,14 +92,12 @@
     "@types/react-dom": "^18.3.7",
     "@vitejs/plugin-react": "^4.7.0",
     "@vitest/coverage-v8": "^3.0.0",
-    "autoprefixer": "^10.4.21",
     "cross-env": "^10.1.0",
     "jsdom": "^29.0.2",
     "msw": "^2.13.6",
-    "postcss": "^8.5.6",
     "rollup-plugin-visualizer": "^7.0.1",
     "size-limit": "^12.1.0",
-    "tailwindcss": "^3.4.17",
+    "tailwindcss": "^4.2.4",
     "typescript": "^6.0.3",
     "vite": "^6.4.2",
     "vite-plugin-pwa": "^1.2.0",

--- a/apps/web/postcss.config.js
+++ b/apps/web/postcss.config.js
@@ -1,6 +1,0 @@
-export default {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-};

--- a/apps/web/src/core/DesignShowcase.tsx
+++ b/apps/web/src/core/DesignShowcase.tsx
@@ -21,7 +21,7 @@ export function DesignShowcase() {
   return (
     <div className="min-h-dvh bg-bg">
       {/* ── Sticky nav ──────────────────────────────────────────── */}
-      <header className="sticky top-0 z-[100] bg-panel/90 backdrop-blur-md border-b border-line">
+      <header className="sticky top-0 z-100 bg-panel/90 backdrop-blur-md border-b border-line">
         <div className="max-w-3xl mx-auto px-5 h-12 flex items-center gap-4">
           <h1 className="font-extrabold text-text text-sm shrink-0">
             Design System

--- a/apps/web/src/core/ErrorBoundary.tsx
+++ b/apps/web/src/core/ErrorBoundary.tsx
@@ -98,7 +98,7 @@ export class ErrorBoundary extends Component<
           <p className="text-sm text-muted mb-4 text-center max-w-xs">
             Виникла непередбачена помилка. Спробуй перезавантажити сторінку.
           </p>
-          <pre className="text-xs text-danger/80 mb-6 max-w-lg w-full overflow-auto whitespace-pre-wrap break-words bg-panel rounded-xl p-3 border border-line">
+          <pre className="text-xs text-danger/80 mb-6 max-w-lg w-full overflow-auto whitespace-pre-wrap wrap-break-word bg-panel rounded-xl p-3 border border-line">
             {error.message}
           </pre>
           <div className="flex flex-col sm:flex-row gap-2 w-full max-w-xs">

--- a/apps/web/src/core/ModuleErrorBoundary.tsx
+++ b/apps/web/src/core/ModuleErrorBoundary.tsx
@@ -69,7 +69,7 @@ export default class ModuleErrorBoundary extends Component<
           <p className="text-sm text-muted mb-2 text-center">
             Помилка в модулі
           </p>
-          <pre className="text-xs text-danger mb-6 max-w-lg w-full overflow-auto whitespace-pre-wrap break-words">
+          <pre className="text-xs text-danger mb-6 max-w-lg w-full overflow-auto whitespace-pre-wrap wrap-break-word">
             {this.state.error.message}
           </pre>
           <div className="flex flex-col sm:flex-row gap-2 w-full max-w-xs">

--- a/apps/web/src/core/PricingPage.tsx
+++ b/apps/web/src/core/PricingPage.tsx
@@ -149,11 +149,11 @@ export function PricingPage() {
               className={cn(
                 "rounded-3xl border p-6 flex flex-col gap-4",
                 "transition-all duration-300 ease-out",
-                "[@media(pointer:fine)]:hover:shadow-float [@media(pointer:fine)]:hover:-translate-y-1",
+                "pointer-fine:hover:shadow-float pointer-fine:hover:-translate-y-1",
                 "motion-safe:animate-stagger-in",
                 tier.highlight
                   ? "border-brand-500 bg-panel shadow-glow"
-                  : "border-line bg-panel [@media(pointer:fine)]:hover:border-brand-200/50",
+                  : "border-line bg-panel pointer-fine:hover:border-brand-200/50",
               )}
               style={{ animationDelay: `${idx * 100}ms` }}
             >

--- a/apps/web/src/core/app/HubBottomNav.tsx
+++ b/apps/web/src/core/app/HubBottomNav.tsx
@@ -67,8 +67,8 @@ function HubBottomNavTab({
       onClick={onClick}
       className={cn(
         "relative flex-1 flex flex-col items-center justify-center gap-1",
-        "transition-all duration-200 min-h-[48px] [@media(pointer:coarse)]:min-h-[52px]",
-        "active:scale-95 [@media(pointer:coarse)]:active:bg-panelHi/50",
+        "transition-all duration-200 min-h-[48px] pointer-coarse:min-h-[52px]",
+        "active:scale-95 pointer-coarse:active:bg-panelHi/50",
         "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-panel",
         active ? "text-text" : "text-muted hover:text-text/70",
         className,
@@ -233,7 +233,7 @@ export function HubBottomNav({
     >
       <div
         role="tablist"
-        className="relative flex h-[60px] [@media(pointer:coarse)]:h-[64px]"
+        className="relative flex h-[60px] pointer-coarse:h-[64px]"
       >
         {activeIndex >= 0 && (
           <span
@@ -242,7 +242,7 @@ export function HubBottomNav({
               "absolute top-0 h-1 w-10 rounded-full shadow-sm pointer-events-none",
               "transition-[left] duration-200 ease-out",
               // Brand accent (hub is module-agnostic — never module-colored).
-              "bg-gradient-to-r from-brand-400 to-brand-500",
+              "bg-linear-to-r from-brand-400 to-brand-500",
             )}
             style={{
               left: `calc(${activeIndex} * (100% / ${tabs.length}) + (100% / ${tabs.length} - 2.5rem) / 2)`,

--- a/apps/web/src/core/app/OfflineBanner.tsx
+++ b/apps/web/src/core/app/OfflineBanner.tsx
@@ -40,7 +40,7 @@ export function OfflineBanner() {
         aria-live="polite"
         data-testid="offline-banner"
         data-state="offline"
-        className="fixed top-3 right-3 z-[300] flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-panel/90 border border-line text-muted text-style-caption shadow-soft backdrop-blur-sm safe-area-pt motion-safe:animate-fade-in"
+        className="fixed top-3 right-3 z-300 flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-panel/90 border border-line text-muted text-style-caption shadow-soft backdrop-blur-sm safe-area-pt motion-safe:animate-fade-in"
       >
         <Icon name="wifi-off" size={12} strokeWidth={2.5} aria-hidden />
         <span>{label}</span>
@@ -55,7 +55,7 @@ export function OfflineBanner() {
       aria-live="polite"
       data-testid="offline-banner"
       data-state="syncing"
-      className="fixed top-3 right-3 z-[300] flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-panel/90 border border-line text-muted text-style-caption shadow-soft backdrop-blur-sm safe-area-pt motion-safe:animate-fade-in"
+      className="fixed top-3 right-3 z-300 flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-panel/90 border border-line text-muted text-style-caption shadow-soft backdrop-blur-sm safe-area-pt motion-safe:animate-fade-in"
     >
       <Icon
         name="refresh-cw"

--- a/apps/web/src/core/app/WelcomeScreen.tsx
+++ b/apps/web/src/core/app/WelcomeScreen.tsx
@@ -57,7 +57,7 @@ function PeekBackdrop() {
         className={cn(
           "absolute inset-0",
           // Soft brand wash so the backdrop never looks empty on cold load.
-          "bg-gradient-to-b from-brand-500/5 via-transparent to-transparent",
+          "bg-linear-to-b from-brand-500/5 via-transparent to-transparent",
         )}
       />
       {/* Animated floating shapes for visual interest */}

--- a/apps/web/src/core/components/ChatMessage.tsx
+++ b/apps/web/src/core/components/ChatMessage.tsx
@@ -81,7 +81,7 @@ function ActionCard({ card }: { card: ChatActionCard }) {
           <>
             <div
               className={cn(
-                "text-2xs text-subtle mt-0.5 break-words",
+                "text-2xs text-subtle mt-0.5 wrap-break-word",
                 !expanded && "line-clamp-2",
               )}
             >
@@ -146,7 +146,7 @@ function ConfirmCard({ card }: { card: ChatActionCard }) {
       </div>
       {/* Summary */}
       {card.summary && (
-        <p className="px-3 py-2 text-2xs text-subtle leading-relaxed break-words">
+        <p className="px-3 py-2 text-2xs text-subtle leading-relaxed wrap-break-word">
           {card.summary}
         </p>
       )}

--- a/apps/web/src/core/hub/HubChatHistoryDrawer.tsx
+++ b/apps/web/src/core/hub/HubChatHistoryDrawer.tsx
@@ -74,7 +74,7 @@ export function HubChatHistoryDrawer({
 
   return (
     <div
-      className="fixed inset-0 z-[60] flex safe-area-pt-pb"
+      className="fixed inset-0 z-60 flex safe-area-pt-pb"
       role="dialog"
       aria-modal="true"
       aria-label="Історія чатів"

--- a/apps/web/src/core/hub/HubDashboard.tsx
+++ b/apps/web/src/core/hub/HubDashboard.tsx
@@ -517,7 +517,7 @@ export function HubDashboard({
       <StaggerChild index={1}>
         <section className="space-y-2">
           <div className="flex items-center justify-between gap-2 px-0.5">
-            <SectionHeading as="h2" size="xs" className="!px-0">
+            <SectionHeading as="h2" size="xs" className="px-0!">
               Модулі
             </SectionHeading>
             {/* Edit affordance — icon-only when idle so it stops competing

--- a/apps/web/src/core/hub/chat/HubChatHeader.tsx
+++ b/apps/web/src/core/hub/chat/HubChatHeader.tsx
@@ -44,7 +44,7 @@ export function HubChatHeader({
         open={detailsOpen}
         onOpenChange={onDetailsOpenChange}
         wrapperClassName="min-w-0 flex-1"
-        className="!min-w-[280px] p-1.5"
+        className="min-w-[280px]! p-1.5"
         trigger={
           <span
             aria-label="Деталі асистента"

--- a/apps/web/src/core/hub/dashboard/BentoCard.tsx
+++ b/apps/web/src/core/hub/dashboard/BentoCard.tsx
@@ -112,14 +112,14 @@ export const BentoCard = memo(function BentoCard({
         data-inactive={inactive ? "true" : undefined}
         className={cn(
           "group relative flex flex-col w-full rounded-3xl border border-line",
-          "p-3.5 [@media(pointer:coarse)]:p-4",
-          "min-h-[120px] [@media(pointer:coarse)]:min-h-[132px]",
+          "p-3.5 pointer-coarse:p-4",
+          "min-h-[120px] pointer-coarse:min-h-[132px]",
           "shadow-card transition-interactive text-left",
           "focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2",
           // Hover effect for desktop - lift and glow
-          "[@media(pointer:fine)]:hover:shadow-float [@media(pointer:fine)]:hover:-translate-y-0.5",
-          "[@media(pointer:fine)]:hover:border-brand-200/50 dark:[@media(pointer:fine)]:hover:border-line/80",
-          "active:scale-[0.98] [@media(pointer:coarse)]:active:scale-[0.97]",
+          "pointer-fine:hover:shadow-float pointer-fine:hover:-translate-y-0.5",
+          "pointer-fine:hover:border-brand-200/50 dark:pointer-fine:hover:border-line/80",
+          "active:scale-[0.98] pointer-coarse:active:scale-[0.97]",
           inactive ? "bg-panel grayscale" : config.cardBg,
           isDragging && "shadow-float cursor-grabbing",
         )}
@@ -252,7 +252,7 @@ export const BentoCard = memo(function BentoCard({
           aria-label={onQuickAdd.label}
           title={onQuickAdd.label}
           className={cn(
-            "absolute top-3.5 right-3.5 [@media(pointer:coarse)]:top-4 [@media(pointer:coarse)]:right-4",
+            "absolute top-3.5 right-3.5 pointer-coarse:top-4 pointer-coarse:right-4",
             // WCAG 2.5.5 / HIG: ≥44×44 on coarse pointers. The visual
             // glyph stays at 28 px on desktop; a `touch-target` floor
             // expands the hit area to 44×44 on touch without bumping
@@ -280,7 +280,7 @@ export const BentoCard = memo(function BentoCard({
           aria-label={`Перетягнути ${config.label}`}
           title="Перетягнути для зміни порядку"
           className={cn(
-            "absolute top-3.5 right-3.5 [@media(pointer:coarse)]:top-4 [@media(pointer:coarse)]:right-4",
+            "absolute top-3.5 right-3.5 pointer-coarse:top-4 pointer-coarse:right-4",
             // Match the quick-add affordance: visible 28 px glyph,
             // 44×44 hit area on coarse pointers via `touch-target`.
             "w-7 h-7 touch-target",

--- a/apps/web/src/core/hub/dashboard/dashboardCards.tsx
+++ b/apps/web/src/core/hub/dashboard/dashboardCards.tsx
@@ -208,7 +208,7 @@ export function WeeklyDigestFooter({
       <span
         className={cn(
           "w-8 h-8 rounded-xl flex items-center justify-center shrink-0",
-          "bg-gradient-to-br from-brand-100 to-teal-100",
+          "bg-linear-to-br from-brand-100 to-teal-100",
           "dark:from-brand-900/40 dark:to-teal-900/30",
         )}
       >

--- a/apps/web/src/core/hub/search/HubSearch.tsx
+++ b/apps/web/src/core/hub/search/HubSearch.tsx
@@ -28,7 +28,7 @@ export function HubSearch({ onClose, onOpenModule }: HubSearchProps) {
 
   return (
     <div
-      className="fixed inset-0 z-[200] flex flex-col bg-bg safe-area-pt-pb page-enter"
+      className="fixed inset-0 z-200 flex flex-col bg-bg safe-area-pt-pb page-enter"
       role="dialog"
       aria-modal="true"
       aria-label="Глобальний пошук"

--- a/apps/web/src/core/insights/AssistantAdviceCard.tsx
+++ b/apps/web/src/core/insights/AssistantAdviceCard.tsx
@@ -52,7 +52,7 @@ export function AssistantAdviceCard({
       className={cn(
         "rounded-2xl overflow-hidden",
         "transition-all duration-200",
-        "p-[1px] bg-gradient-to-br from-brand-300/40 via-line to-teal-300/40",
+        "p-px bg-linear-to-br from-brand-300/40 via-line to-teal-300/40",
       )}
     >
       <div className="rounded-[15px] bg-panel overflow-hidden">

--- a/apps/web/src/core/insights/WeeklyDigestCard.tsx
+++ b/apps/web/src/core/insights/WeeklyDigestCard.tsx
@@ -292,7 +292,7 @@ function DigestContent({
           onClick={onPlayStories}
           className={cn(
             "w-full h-11 rounded-xl text-sm font-bold text-white",
-            "bg-gradient-to-r from-brand-500 via-brand-400 to-teal-400",
+            "bg-linear-to-r from-brand-500 via-brand-400 to-teal-400",
             "dark:from-brand-600 dark:via-brand-500 dark:to-teal-500",
             "shadow-card hover:brightness-110 active:scale-[0.98] transition-[box-shadow,filter,opacity,transform]",
             "flex items-center justify-center gap-2",
@@ -420,11 +420,11 @@ export function WeeklyDigestCard({ onCollapse }: WeeklyDigestCardProps = {}) {
         "transition-[box-shadow,filter,opacity,transform] duration-200 hover:shadow-float",
       )}
     >
-      <div className="px-4 py-3.5 flex items-center gap-3 bg-gradient-to-r from-transparent via-brand-50/30 to-teal-50/20 dark:from-transparent dark:via-brand-900/10 dark:to-teal-900/5">
+      <div className="px-4 py-3.5 flex items-center gap-3 bg-linear-to-r from-transparent via-brand-50/30 to-teal-50/20 dark:from-transparent dark:via-brand-900/10 dark:to-teal-900/5">
         <div
           className={cn(
             "w-10 h-10 rounded-xl flex items-center justify-center shrink-0",
-            "bg-gradient-to-br from-brand-100 to-teal-100",
+            "bg-linear-to-br from-brand-100 to-teal-100",
             "dark:from-brand-900/40 dark:to-teal-900/30",
             "shadow-sm",
           )}

--- a/apps/web/src/core/onboarding/CelebrationModal.tsx
+++ b/apps/web/src/core/onboarding/CelebrationModal.tsx
@@ -127,7 +127,7 @@ export function CelebrationModal({
     <div
       ref={backdropRef}
       className={cn(
-        "fixed inset-0 z-[9999] flex items-center justify-center",
+        "fixed inset-0 z-9999 flex items-center justify-center",
         "bg-bg/85 backdrop-blur-md",
         animateOut
           ? "motion-safe:animate-fade-out"

--- a/apps/web/src/core/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/core/onboarding/OnboardingWizard.tsx
@@ -428,7 +428,7 @@ export function OnboardingWizard({
     <>
       {CelebrationComponent}
       <div
-        className="fixed inset-0 z-[500] flex items-end sm:items-center justify-center p-4 pb-safe"
+        className="fixed inset-0 z-500 flex items-end sm:items-center justify-center p-4 pb-safe"
         role="dialog"
         aria-modal="true"
         aria-label="Вітальний екран"

--- a/apps/web/src/core/onboarding/SoftAuthPromptCard.tsx
+++ b/apps/web/src/core/onboarding/SoftAuthPromptCard.tsx
@@ -38,7 +38,7 @@ export function SoftAuthPromptCard({
     <div
       className={cn(
         "relative overflow-hidden rounded-2xl border border-brand-500/30",
-        "bg-gradient-to-br from-brand-500/10 via-panel to-panel p-4",
+        "bg-linear-to-br from-brand-500/10 via-panel to-panel p-4",
         "shadow-card",
       )}
     >

--- a/apps/web/src/core/profile/DeleteAccountDialog.tsx
+++ b/apps/web/src/core/profile/DeleteAccountDialog.tsx
@@ -39,7 +39,7 @@ export function DeleteAccountDialog({
   if (!open) return null;
 
   return (
-    <div className="fixed inset-0 z-[120] flex items-center justify-center p-4">
+    <div className="fixed inset-0 z-120 flex items-center justify-center p-4">
       <button
         type="button"
         className="absolute inset-0 bg-black/60 backdrop-blur-sm"

--- a/apps/web/src/core/settings/SettingsPrimitives.tsx
+++ b/apps/web/src/core/settings/SettingsPrimitives.tsx
@@ -180,7 +180,7 @@ export function ConfirmModal({
   if (!open) return null;
   return (
     <div
-      className="fixed inset-0 z-[120] flex items-center justify-center p-4"
+      className="fixed inset-0 z-120 flex items-center justify-center p-4"
       role="presentation"
     >
       <button

--- a/apps/web/src/core/stories/WeeklyDigestStories.tsx
+++ b/apps/web/src/core/stories/WeeklyDigestStories.tsx
@@ -92,7 +92,7 @@ export function WeeklyDigestStories({
   // short-circuits all of that and makes z-index globally meaningful again.
   const overlay = (
     <div
-      className="fixed inset-0 z-[600] select-none"
+      className="fixed inset-0 z-600 select-none"
       role="dialog"
       aria-modal="true"
       aria-label="Щотижневий дайджест — сторіс"

--- a/apps/web/src/core/stories/components/StoryNavHints.tsx
+++ b/apps/web/src/core/stories/components/StoryNavHints.tsx
@@ -7,12 +7,12 @@ export function StoryNavHints() {
   return (
     <>
       <div
-        className="pointer-events-none absolute inset-y-0 left-0 w-1/3 bg-gradient-to-r from-black/10 to-transparent"
+        className="pointer-events-none absolute inset-y-0 left-0 w-1/3 bg-linear-to-r from-black/10 to-transparent"
         data-nav-hint="prev"
         aria-hidden
       />
       <div
-        className="pointer-events-none absolute inset-y-0 right-0 w-1/3 bg-gradient-to-l from-black/10 to-transparent"
+        className="pointer-events-none absolute inset-y-0 right-0 w-1/3 bg-linear-to-l from-black/10 to-transparent"
         aria-hidden
       />
     </>

--- a/apps/web/src/core/stories/components/slides/IntroSlide.tsx
+++ b/apps/web/src/core/stories/components/slides/IntroSlide.tsx
@@ -11,7 +11,7 @@ export function IntroSlide({ slide }: { slide: Slide }) {
         <h2 className="text-display-stat leading-[1.05] font-black mb-4">
           Твій тиждень
         </h2>
-        <p className="text-base text-white/85 leading-relaxed max-w-[22rem]">
+        <p className="text-base text-white/85 leading-relaxed max-w-88">
           Коротке зведення по всіх модулях. Тапай праворуч, щоб гортати далі,
           ліворуч — назад. Утримуй, щоб зупинити.
         </p>

--- a/apps/web/src/core/stories/components/slides/StoryShell.tsx
+++ b/apps/web/src/core/stories/components/slides/StoryShell.tsx
@@ -18,7 +18,7 @@ interface Props {
 export function StoryShell({ slide, children }: Props) {
   return (
     <div
-      className={cn("absolute inset-0 bg-gradient-to-br text-white", slide.bg)}
+      className={cn("absolute inset-0 bg-linear-to-br text-white", slide.bg)}
     >
       <div className="absolute inset-0 pointer-events-none bg-[radial-gradient(ellipse_at_top,rgba(255,255,255,0.25),transparent_60%)]" />
       <div

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2,26 +2,494 @@
    PARTIALS — Animations & module surfaces extracted for maintainability.
    @import statements MUST precede all other rules (CSS spec requirement).
    ═══════════════════════════════════════════════════════════════════════ */
-@import "@fontsource-variable/dm-sans";
-@import "./styles/animations.css";
+@import "@fontsource-variable/dm-sans" layer(base);
+@import "./styles/animations.css" layer(base);
 @import "./styles/module-surfaces.css";
 
 /* ═══════════════════════════════════════════════════════════════════════
    FONT FALLBACK — Prevent layout shift (FOUT) during font loading.
    Size-adjusted system font stack matches DM Sans metrics closely.
    ═══════════════════════════════════════════════════════════════════════ */
-@font-face {
-  font-family: "DM Sans Fallback";
-  src: local("Arial");
-  ascent-override: 94%;
-  descent-override: 26%;
-  line-gap-override: 0%;
-  size-adjust: 104%;
+@import "tailwindcss";
+
+@config '../tailwind.config.js';
+
+/*
+  The default border color has changed to `currentcolor` in Tailwind CSS v4,
+  so we've added these compatibility styles to make sure everything still
+  looks the same as it did with Tailwind CSS v3.
+
+  If we ever want to remove these styles, we need to add an explicit border
+  color utility to any element that depends on these defaults.
+*/
+@layer base {
+  *,
+  ::after,
+  ::before,
+  ::backdrop,
+  ::file-selector-button {
+    border-color: var(--color-gray-200, currentcolor);
+  }
 }
 
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@utility focus-ring {
+  /* ═══════════════════════════════════════════════════════════════════════
+     FOCUS RING — consistent keyboard a11y affordance across the app.
+     Apply to any interactive element that doesn't already define its own
+     focus-visible ring (Button already does). Uses the `accent` semantic
+     token so light & dark themes stay in sync automatically.
+     ═══════════════════════════════════════════════════════════════════════ */
+  @apply outline-hidden focus-visible:ring-accent/60
+           focus-visible:ring-offset-surface;
+  --tw-ring-offset-width: var(--focus-ring-offset, 2px);
+  &:focus-visible {
+    --tw-ring-shadow: 0 0 0 var(--focus-ring-width, 3px)
+      var(--focus-ring-color, rgba(16, 185, 129, 0.4));
+  }
+}
+
+@utility focus-ring-enhanced {
+  /* Enhanced focus ring — thicker, with animation on keyboard focus.
+     Applies to all interactive elements that don't define their own ring. */
+  @apply outline-hidden;
+  transition: box-shadow 0.15s ease-out;
+  &:focus-visible {
+    box-shadow: var(--shadow-focus-ring, 0 0 0 3px rgba(16, 185, 129, 0.4));
+  }
+}
+
+@utility input-focus {
+  /* ═══════════════════════════════════════════════════════════════════════
+     INPUT FOCUS — ring без offset (краще читається всередині заповненого
+     input-а), лишає existing border-transition інтактним. Варіанти беруть
+     module tone; базовий `.input-focus` — для загальних (brand) інпутів.
+     Завжди `focus-visible:` щоб не дратувати користувачів миші.
+     ═══════════════════════════════════════════════════════════════════════ */
+  @apply outline-hidden transition-colors
+           focus-visible:border-brand-500/60
+           focus-visible:ring-2 focus-visible:ring-brand-500/30;
+}
+
+@utility input-focus-finyk {
+  @apply outline-hidden transition-colors
+           focus-visible:border-primary/60
+           focus-visible:ring-2 focus-visible:ring-primary/25;
+}
+
+@utility input-focus-fizruk {
+  @apply outline-hidden transition-colors
+           focus-visible:border-success/60
+           focus-visible:ring-2 focus-visible:ring-success/25;
+}
+
+@utility input-focus-nutrition {
+  @apply outline-hidden transition-colors
+           focus-visible:border-nutrition/60
+           focus-visible:ring-2 focus-visible:ring-nutrition/25;
+}
+
+@utility input-focus-routine {
+  @apply outline-hidden transition-colors
+           focus-visible:border-routine/60
+           focus-visible:ring-2 focus-visible:ring-routine/25;
+}
+
+@utility text-display {
+  /* ═══════════════════════════════════════════════════════════════════════
+     TYPOGRAPHY HIERARCHY — Consistent heading scale across the app.
+     Usage: apply `.text-h1` / `.text-h2` etc. to heading elements.
+     Letter-spacing and font-weight are baked in; colour inherits from
+     the surrounding context so dark-mode works automatically.
+     ═══════════════════════════════════════════════════════════════════════ */
+
+  /* Display — hero numbers, large stat values (e.g. ₴ 12 400) */
+  @apply text-[2.25rem] leading-none font-bold tracking-tight tabular-nums;
+}
+
+@utility text-h1 {
+  /* H1 — page / screen title */
+  @apply text-[1.5rem] leading-tight font-bold tracking-tight;
+}
+
+@utility text-h2 {
+  /* H2 — section heading */
+  @apply text-[1.125rem] leading-snug font-semibold tracking-[-0.01em];
+}
+
+@utility text-h3 {
+  /* H3 — card title, subsection label */
+  @apply text-[0.9375rem] leading-snug font-semibold;
+}
+
+@utility text-body {
+  /* Body — default prose */
+  @apply text-[0.9375rem] leading-relaxed font-normal;
+}
+
+@utility text-body-sm {
+  /* Body Small — secondary text, descriptions */
+  @apply text-[0.8125rem] leading-relaxed font-normal;
+}
+
+@utility text-caption {
+  /* Caption — labels, timestamps, meta copy */
+  @apply text-[0.75rem] leading-snug font-normal tracking-[0.01em];
+}
+
+@utility text-eyebrow {
+  /* Eyebrow — overline / section prefix ("ФІНІК", "СЬОГОДНІ") */
+  @apply text-[0.6875rem] leading-none font-semibold tracking-[0.08em] uppercase;
+}
+
+@utility text-meta {
+  /* Meta — compact lowercase labels (KPI hints, badges, "Monobank", "USD",
+     histogram axis ticks). 11px/medium with optional `tabular-nums` for
+     numeric companions. NOT uppercase — that is `text-eyebrow`'s job. */
+  @apply text-[0.6875rem] leading-snug font-medium;
+}
+
+@utility text-micro {
+  /* Micro — 10px aux glyph labels: icon-overlay numbers (mic levels, push-up
+     reps, progress-ring hints). Floor is 10px; nothing below ships in
+     prose. Use only inside controls where surrounding affordance carries
+     the meaning, never for running text. */
+  @apply text-[0.625rem] leading-tight font-medium;
+}
+
+@utility text-display-stat {
+  /* Display Stat — the single most prominent number on a screen:
+     Finyk HeroCard amount, AssetsTable asset value. 40px / bold /
+     tabular-nums / leading-tight so multi-line wraps don't push other
+     hero rows. */
+  @apply text-[2.5rem] leading-tight font-bold tracking-tight tabular-nums;
+}
+
+@utility text-display-hero {
+  /* Display Hero — full-screen "celebration" stat (story slides, weekly
+     digest take-aways). 44px / black / tabular-nums / leading-none for
+     the largest single-line number. */
+  @apply text-[2.75rem] leading-none font-black tracking-tight tabular-nums;
+}
+
+@utility text-style-hero {
+  /* ── Semantic text-style utilities (design-system.md § Typography) ──────
+     Owned shorthand classes: each bundles size + weight (+ optional
+     tracking) so design-token changes propagate automatically.
+     Referenced by the `prefer-text-style` ESLint rule.              ─── */
+  @apply text-2xl font-bold tracking-tight;
+}
+
+@utility text-style-title {
+  @apply text-xl font-semibold leading-snug;
+}
+
+@utility text-style-body {
+  @apply text-base font-normal leading-relaxed;
+}
+
+@utility text-style-label {
+  @apply text-sm font-medium leading-snug;
+}
+
+@utility text-style-caption {
+  @apply text-xs font-medium leading-snug;
+}
+
+@utility text-style-overline {
+  @apply text-[0.6875rem] font-semibold tracking-[0.08em] uppercase;
+}
+
+@utility text-celebration {
+  /* Celebration — achievement moments: XP gains, streaks, confetti title */
+  @apply text-[1.25rem] leading-tight font-bold tracking-[0.02em];
+  color: rgb(var(--c-celebration));
+}
+
+@utility text-xp {
+  /* XP / level chip */
+  @apply text-[0.8125rem] leading-none font-bold tracking-[0.02em] tabular-nums;
+  color: rgb(var(--c-xp));
+}
+
+@utility panel {
+  /* ═══════════════════════════════════════════════════════════════════════
+     PANELS & CARDS — Core UI surfaces
+     ═══════════════════════════════════════════════════════════════════════ */
+  @apply bg-panel border border-line rounded-3xl shadow-card;
+}
+
+@utility panel-interactive {
+  @apply bg-panel border border-line rounded-3xl shadow-card
+           transition-interactive
+           hover:shadow-float hover:-translate-y-0.5
+           active:scale-[0.98] active:shadow-card;
+}
+
+@utility panel-soft {
+  @apply bg-panel/80 backdrop-blur-sm border border-line/50 rounded-3xl shadow-soft;
+}
+
+@utility page-tabbar-pad {
+  /* ═══════════════════════════════════════════════════════════════════════
+     SAFE AREA PADDING — iOS notch & home indicator
+     ═══════════════════════════════════════════════════════════════════════ */
+  padding-bottom: calc(88px + env(safe-area-inset-bottom, 0px));
+}
+
+@utility routine-main-pad {
+  padding-left: max(1rem, env(safe-area-inset-left, 0px));
+  padding-right: max(1rem, env(safe-area-inset-right, 0px));
+}
+
+@utility routine-sheet-pad {
+  padding-bottom: calc(72px + env(safe-area-inset-bottom, 0px));
+}
+
+@utility fizruk-sheet-pad {
+  padding-bottom: calc(env(safe-area-inset-bottom, 16px) + 72px);
+}
+
+@utility fizruk-above-tabbar {
+  bottom: calc(60px + env(safe-area-inset-bottom, 0px));
+}
+
+@utility routine-touch-field {
+  /* ═══════════════════════════════════════════════════════════════════════
+     TOUCH INPUTS — iOS zoom prevention (min 16px)
+     ═══════════════════════════════════════════════════════════════════════ */
+  @apply min-h-[44px] text-base leading-normal md:text-sm;
+}
+
+@utility routine-touch-select {
+  @apply min-h-[44px] w-full rounded-2xl border border-line bg-panelHi px-3 outline-hidden
+           text-base leading-normal md:text-sm
+           transition-colors duration-150
+           focus-visible:border-routine/60 focus-visible:ring-2 focus-visible:ring-routine/20;
+}
+
+@utility fizruk-sheet {
+  /* ═══════════════════════════════════════════════════════════════════════
+     FOCUS STATES — Accessible, branded
+     ═══════════════════════════════════════════════════════════════════════ */
+  & button:focus-visible {
+    @apply outline-hidden ring-2 ring-teal-500/45 ring-offset-2 ring-offset-panel;
+  }
+  & a:focus-visible {
+    @apply outline-hidden ring-2 ring-teal-500/45 ring-offset-2 ring-offset-panel;
+  }
+}
+
+@utility routine-sheet {
+  & button:focus-visible {
+    @apply outline-hidden ring-2 ring-coral-500/45 ring-offset-2 ring-offset-panel;
+  }
+
+  & a:focus-visible {
+    @apply outline-hidden ring-2 ring-coral-500/45 ring-offset-2 ring-offset-panel;
+  }
+}
+
+@utility nutrition-sheet {
+  & button:focus-visible {
+    @apply outline-hidden ring-2 ring-lime-500/45 ring-offset-2 ring-offset-panel;
+  }
+
+  & a:focus-visible {
+    @apply outline-hidden ring-2 ring-lime-500/45 ring-offset-2 ring-offset-panel;
+  }
+}
+
+@utility finyk-sheet {
+  & button:focus-visible {
+    @apply outline-hidden ring-2 ring-brand-500/45 ring-offset-2 ring-offset-panel;
+  }
+
+  & a:focus-visible {
+    @apply outline-hidden ring-2 ring-brand-500/45 ring-offset-2 ring-offset-panel;
+  }
+}
+
+@utility progress-ring {
+  /* ═══════════════════════════════════════════════════════════════════════
+     PROGRESS RING — Duolingo-style circular progress
+     ═══════════════════════════════════════════════════════════════════════ */
+  transform: rotate(-90deg);
+}
+
+@utility progress-ring-circle {
+  transition: stroke-dashoffset 0.5s ease-out;
+}
+
+@utility metric-card {
+  /* ═══════════════════════════════════════════════════════════════════════
+     METRIC CARDS — Data display with status colors
+     ═══════════════════════════════════════════════════════════════════════ */
+  @apply bg-panel border border-line rounded-2xl p-4 shadow-card
+           transition-interactive
+           hover:shadow-float hover:-translate-y-0.5;
+}
+
+@utility metric-card-compact {
+  @apply bg-panel border border-line rounded-xl p-3 shadow-card;
+}
+
+@utility badge {
+  /* ═══════════════════════════════════════════════════════════════════════
+     BADGES — Status indicators, tags
+     ═══════════════════════════════════════════════════════════════════════ */
+  @apply inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium;
+}
+
+@utility badge-success {
+  @apply badge bg-brand-100 text-brand-700;
+  .dark & {
+    @apply bg-brand-900/30 text-brand-400;
+  }
+}
+
+@utility badge-warning {
+  @apply badge bg-amber-100 text-amber-700;
+  .dark & {
+    @apply bg-amber-900/30 text-amber-400;
+  }
+}
+
+@utility badge-danger {
+  @apply badge bg-danger-soft text-danger;
+  .dark & {
+    @apply bg-danger/15 text-danger;
+  }
+}
+
+@utility badge-neutral {
+  @apply badge bg-stone-100 text-stone-600;
+  .dark & {
+    @apply bg-stone-800 text-stone-400;
+  }
+}
+
+@utility transition-interactive {
+  /* ═══════════════════════════════════════════════════════════════════════
+     TRANSITION UTILITIES — Unified interactive transition shorthand.
+     Replaces ad-hoc `transition-[background-color,border-color,...]`
+     lists scattered across components with a single canonical token.
+     ═══════════════════════════════════════════════════════════════════════ */
+  transition-property:
+    background-color, border-color, color, box-shadow, opacity, transform;
+  transition-duration: var(--motion-duration);
+  transition-timing-function: var(--motion-ease-smooth);
+}
+
+@utility transition-surface {
+  transition-property: background-color, border-color, color;
+  transition-duration: var(--motion-duration-fast);
+  transition-timing-function: var(--motion-ease-smooth);
+}
+
+@utility safe-area-pt {
+  /* ═══════════════════════════════════════════════════════════════════════
+     SAFE AREA UTILITIES
+     ═══════════════════════════════════════════════════════════════════════ */
+  padding-top: env(safe-area-inset-top, 0px);
+}
+
+@utility safe-area-pb {
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+@utility safe-area-pt-pb {
+  padding-top: env(safe-area-inset-top, 0px);
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+@utility safe-area-pt-8 {
+  padding-top: env(safe-area-inset-top, 8px);
+}
+
+@utility safe-area-pb-16 {
+  padding-bottom: env(safe-area-inset-bottom, 16px);
+}
+
+@utility safe-bottom {
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+@utility safe-area-pl {
+  padding-left: env(safe-area-inset-left, 0px);
+}
+
+@utility safe-area-pr {
+  padding-right: env(safe-area-inset-right, 0px);
+}
+
+@utility safe-area-pl-pr {
+  padding-left: env(safe-area-inset-left, 0px);
+  padding-right: env(safe-area-inset-right, 0px);
+}
+
+@utility safe-bottom-h {
+  height: calc(60px + env(safe-area-inset-bottom, 0px));
+}
+
+@utility no-scrollbar {
+  /* ═══════════════════════════════════════════════════════════════════════
+     SCROLLBAR UTILITIES
+     ═══════════════════════════════════════════════════════════════════════ */
+  &::-webkit-scrollbar {
+    display: none;
+  }
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+@utility custom-scrollbar {
+  /* Custom scrollbar for desktop */
+  &::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: rgb(var(--c-line));
+    border-radius: 3px;
+  }
+  &::-webkit-scrollbar-thumb:hover {
+    background-color: rgb(var(--c-muted));
+  }
+}
+
+@utility text-balance {
+  /* ═══════════════════════════════════════════════════════════════════════
+     TEXT UTILITIES
+     ═══════════════════════════════════════════════════════════════════════ */
+  text-wrap: balance;
+}
+
+@utility text-pretty {
+  text-wrap: pretty;
+}
+
+@utility text-gradient-emerald {
+  /* Gradient text for hero sections */
+  @apply bg-linear-to-r from-brand-600 to-teal-600 bg-clip-text text-transparent;
+}
+
+@utility text-gradient-coral {
+  @apply bg-linear-to-r from-coral-500 to-coral-600 bg-clip-text text-transparent;
+}
+
+@layer base {
+  @font-face {
+    font-family: "DM Sans Fallback";
+    src: local("Arial");
+    ascent-override: 94%;
+    descent-override: 26%;
+    line-gap-override: 0%;
+    size-adjust: 104%;
+  }
+}
 
 @layer base {
   /* ═══════════════════════════════════════════════════════════════════════
@@ -388,422 +856,6 @@
   }
 }
 
-@layer components {
-  /* ═══════════════════════════════════════════════════════════════════════
-     FOCUS RING — consistent keyboard a11y affordance across the app.
-     Apply to any interactive element that doesn't already define its own
-     focus-visible ring (Button already does). Uses the `accent` semantic
-     token so light & dark themes stay in sync automatically.
-     ═══════════════════════════════════════════════════════════════════════ */
-  .focus-ring {
-    @apply outline-none focus-visible:ring-accent/60
-           focus-visible:ring-offset-surface;
-    --tw-ring-offset-width: var(--focus-ring-offset, 2px);
-  }
-  .focus-ring:focus-visible {
-    --tw-ring-shadow: 0 0 0 var(--focus-ring-width, 3px)
-      var(--focus-ring-color, rgba(16, 185, 129, 0.4));
-  }
-
-  /* Enhanced focus ring — thicker, with animation on keyboard focus.
-     Applies to all interactive elements that don't define their own ring. */
-  .focus-ring-enhanced {
-    @apply outline-none;
-    transition: box-shadow 0.15s ease-out;
-  }
-  .focus-ring-enhanced:focus-visible {
-    box-shadow: var(--shadow-focus-ring, 0 0 0 3px rgba(16, 185, 129, 0.4));
-  }
-
-  /* ═══════════════════════════════════════════════════════════════════════
-     INPUT FOCUS — ring без offset (краще читається всередині заповненого
-     input-а), лишає existing border-transition інтактним. Варіанти беруть
-     module tone; базовий `.input-focus` — для загальних (brand) інпутів.
-     Завжди `focus-visible:` щоб не дратувати користувачів миші.
-     ═══════════════════════════════════════════════════════════════════════ */
-  .input-focus {
-    @apply outline-none transition-colors
-           focus-visible:border-brand-500/60
-           focus-visible:ring-2 focus-visible:ring-brand-500/30;
-  }
-
-  .input-focus-finyk {
-    @apply outline-none transition-colors
-           focus-visible:border-primary/60
-           focus-visible:ring-2 focus-visible:ring-primary/25;
-  }
-
-  .input-focus-fizruk {
-    @apply outline-none transition-colors
-           focus-visible:border-success/60
-           focus-visible:ring-2 focus-visible:ring-success/25;
-  }
-
-  .input-focus-nutrition {
-    @apply outline-none transition-colors
-           focus-visible:border-nutrition/60
-           focus-visible:ring-2 focus-visible:ring-nutrition/25;
-  }
-
-  .input-focus-routine {
-    @apply outline-none transition-colors
-           focus-visible:border-routine/60
-           focus-visible:ring-2 focus-visible:ring-routine/25;
-  }
-
-  /* ═══════════════════════════════════════════════════════════════════════
-     TYPOGRAPHY HIERARCHY — Consistent heading scale across the app.
-     Usage: apply `.text-h1` / `.text-h2` etc. to heading elements.
-     Letter-spacing and font-weight are baked in; colour inherits from
-     the surrounding context so dark-mode works automatically.
-     ═══════════════════════════════════════════════════════════════════════ */
-
-  /* Display — hero numbers, large stat values (e.g. ₴ 12 400) */
-  .text-display {
-    @apply text-[2.25rem] leading-none font-bold tracking-tight tabular-nums;
-  }
-
-  /* H1 — page / screen title */
-  .text-h1 {
-    @apply text-[1.5rem] leading-tight font-bold tracking-tight;
-  }
-
-  /* H2 — section heading */
-  .text-h2 {
-    @apply text-[1.125rem] leading-snug font-semibold tracking-[-0.01em];
-  }
-
-  /* H3 — card title, subsection label */
-  .text-h3 {
-    @apply text-[0.9375rem] leading-snug font-semibold;
-  }
-
-  /* Body — default prose */
-  .text-body {
-    @apply text-[0.9375rem] leading-relaxed font-normal;
-  }
-
-  /* Body Small — secondary text, descriptions */
-  .text-body-sm {
-    @apply text-[0.8125rem] leading-relaxed font-normal;
-  }
-
-  /* Caption — labels, timestamps, meta copy */
-  .text-caption {
-    @apply text-[0.75rem] leading-snug font-normal tracking-[0.01em];
-  }
-
-  /* Eyebrow — overline / section prefix ("ФІНІК", "СЬОГОДНІ") */
-  .text-eyebrow {
-    @apply text-[0.6875rem] leading-none font-semibold tracking-[0.08em] uppercase;
-  }
-
-  /* Meta — compact lowercase labels (KPI hints, badges, "Monobank", "USD",
-     histogram axis ticks). 11px/medium with optional `tabular-nums` for
-     numeric companions. NOT uppercase — that is `text-eyebrow`'s job. */
-  .text-meta {
-    @apply text-[0.6875rem] leading-snug font-medium;
-  }
-
-  /* Micro — 10px aux glyph labels: icon-overlay numbers (mic levels, push-up
-     reps, progress-ring hints). Floor is 10px; nothing below ships in
-     prose. Use only inside controls where surrounding affordance carries
-     the meaning, never for running text. */
-  .text-micro {
-    @apply text-[0.625rem] leading-tight font-medium;
-  }
-
-  /* Display Stat — the single most prominent number on a screen:
-     Finyk HeroCard amount, AssetsTable asset value. 40px / bold /
-     tabular-nums / leading-tight so multi-line wraps don't push other
-     hero rows. */
-  .text-display-stat {
-    @apply text-[2.5rem] leading-tight font-bold tracking-tight tabular-nums;
-  }
-
-  /* Display Hero — full-screen "celebration" stat (story slides, weekly
-     digest take-aways). 44px / black / tabular-nums / leading-none for
-     the largest single-line number. */
-  .text-display-hero {
-    @apply text-[2.75rem] leading-none font-black tracking-tight tabular-nums;
-  }
-
-  /* ── Semantic text-style utilities (design-system.md § Typography) ──────
-     Owned shorthand classes: each bundles size + weight (+ optional
-     tracking) so design-token changes propagate automatically.
-     Referenced by the `prefer-text-style` ESLint rule.              ─── */
-  .text-style-hero {
-    @apply text-2xl font-bold tracking-tight;
-  }
-  .text-style-title {
-    @apply text-xl font-semibold leading-snug;
-  }
-  .text-style-body {
-    @apply text-base font-normal leading-relaxed;
-  }
-  .text-style-label {
-    @apply text-sm font-medium leading-snug;
-  }
-  .text-style-caption {
-    @apply text-xs font-medium leading-snug;
-  }
-  .text-style-overline {
-    @apply text-[0.6875rem] font-semibold tracking-[0.08em] uppercase;
-  }
-
-  /* Celebration — achievement moments: XP gains, streaks, confetti title */
-  .text-celebration {
-    @apply text-[1.25rem] leading-tight font-bold tracking-[0.02em];
-    color: rgb(var(--c-celebration));
-  }
-
-  /* XP / level chip */
-  .text-xp {
-    @apply text-[0.8125rem] leading-none font-bold tracking-[0.02em] tabular-nums;
-    color: rgb(var(--c-xp));
-  }
-
-  /* ═══════════════════════════════════════════════════════════════════════
-     PANELS & CARDS — Core UI surfaces
-     ═══════════════════════════════════════════════════════════════════════ */
-  .panel {
-    @apply bg-panel border border-line rounded-3xl shadow-card;
-  }
-
-  .panel-interactive {
-    @apply bg-panel border border-line rounded-3xl shadow-card
-           transition-interactive
-           hover:shadow-float hover:-translate-y-0.5
-           active:scale-[0.98] active:shadow-card;
-  }
-
-  .panel-soft {
-    @apply bg-panel/80 backdrop-blur-sm border border-line/50 rounded-3xl shadow-soft;
-  }
-
-  /* ═══════════════════════════════════════════════════════════════════════
-     SAFE AREA PADDING — iOS notch & home indicator
-     ═══════════════════════════════════════════════════════════════════════ */
-  .page-tabbar-pad {
-    padding-bottom: calc(88px + env(safe-area-inset-bottom, 0px));
-  }
-
-  .routine-main-pad {
-    padding-left: max(1rem, env(safe-area-inset-left, 0px));
-    padding-right: max(1rem, env(safe-area-inset-right, 0px));
-  }
-
-  .routine-sheet-pad {
-    padding-bottom: calc(72px + env(safe-area-inset-bottom, 0px));
-  }
-
-  .fizruk-sheet-pad {
-    padding-bottom: calc(env(safe-area-inset-bottom, 16px) + 72px);
-  }
-
-  .fizruk-above-tabbar {
-    bottom: calc(60px + env(safe-area-inset-bottom, 0px));
-  }
-
-  /* ═══════════════════════════════════════════════════════════════════════
-     TOUCH INPUTS — iOS zoom prevention (min 16px)
-     ═══════════════════════════════════════════════════════════════════════ */
-  .routine-touch-field {
-    @apply min-h-[44px] text-base leading-normal md:text-sm;
-  }
-
-  .routine-touch-select {
-    @apply min-h-[44px] w-full rounded-2xl border border-line bg-panelHi px-3 outline-none
-           text-base leading-normal md:text-sm
-           transition-colors duration-150
-           focus-visible:border-routine/60 focus-visible:ring-2 focus-visible:ring-routine/20;
-  }
-
-  /* ═══════════════════════════════════════════════════════════════════════
-     FOCUS STATES — Accessible, branded
-     ═══════════════════════════════════════════════════════════════════════ */
-  .fizruk-sheet button:focus-visible,
-  .fizruk-sheet a:focus-visible {
-    @apply outline-none ring-2 ring-teal-500/45 ring-offset-2 ring-offset-panel;
-  }
-
-  .routine-sheet button:focus-visible,
-  .routine-sheet a:focus-visible {
-    @apply outline-none ring-2 ring-coral-500/45 ring-offset-2 ring-offset-panel;
-  }
-
-  .nutrition-sheet button:focus-visible,
-  .nutrition-sheet a:focus-visible {
-    @apply outline-none ring-2 ring-lime-500/45 ring-offset-2 ring-offset-panel;
-  }
-
-  .finyk-sheet button:focus-visible,
-  .finyk-sheet a:focus-visible {
-    @apply outline-none ring-2 ring-brand-500/45 ring-offset-2 ring-offset-panel;
-  }
-
-  /* ═══════════════════════════════════════════════════════════════════════
-     PROGRESS RING — Duolingo-style circular progress
-     ═══════════════════════════════════════════════════════════════════════ */
-  .progress-ring {
-    transform: rotate(-90deg);
-  }
-
-  .progress-ring-circle {
-    transition: stroke-dashoffset 0.5s ease-out;
-  }
-
-  /* ═══════════════════════════════════════════════════════════════════════
-     METRIC CARDS — Data display with status colors
-     ═══════════════════════════════════════════════════════════════════════ */
-  .metric-card {
-    @apply bg-panel border border-line rounded-2xl p-4 shadow-card
-           transition-interactive
-           hover:shadow-float hover:-translate-y-0.5;
-  }
-
-  .metric-card-compact {
-    @apply bg-panel border border-line rounded-xl p-3 shadow-card;
-  }
-
-  /* ═══════════════════════════════════════════════════════════════════════
-     BADGES — Status indicators, tags
-     ═══════════════════════════════════════════════════════════════════════ */
-  .badge {
-    @apply inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium;
-  }
-
-  .badge-success {
-    @apply badge bg-brand-100 text-brand-700;
-  }
-  .dark .badge-success {
-    @apply bg-brand-900/30 text-brand-400;
-  }
-
-  .badge-warning {
-    @apply badge bg-amber-100 text-amber-700;
-  }
-  .dark .badge-warning {
-    @apply bg-amber-900/30 text-amber-400;
-  }
-
-  .badge-danger {
-    @apply badge bg-danger-soft text-danger;
-  }
-  .dark .badge-danger {
-    @apply bg-danger/15 text-danger;
-  }
-
-  .badge-neutral {
-    @apply badge bg-stone-100 text-stone-600;
-  }
-  .dark .badge-neutral {
-    @apply bg-stone-800 text-stone-400;
-  }
-}
-
-@layer utilities {
-  /* ═══════════════════════════════════════════════════════════════════════
-     TRANSITION UTILITIES — Unified interactive transition shorthand.
-     Replaces ad-hoc `transition-[background-color,border-color,...]`
-     lists scattered across components with a single canonical token.
-     ═══════════════════════════════════════════════════════════════════════ */
-  .transition-interactive {
-    transition-property:
-      background-color, border-color, color, box-shadow, opacity, transform;
-    transition-duration: var(--motion-duration);
-    transition-timing-function: var(--motion-ease-smooth);
-  }
-
-  .transition-surface {
-    transition-property: background-color, border-color, color;
-    transition-duration: var(--motion-duration-fast);
-    transition-timing-function: var(--motion-ease-smooth);
-  }
-
-  /* ═══════════════════════════════════════════════════════════════════════
-     SAFE AREA UTILITIES
-     ═══════════════════════════════════════════════════════════════════════ */
-  .safe-area-pt {
-    padding-top: env(safe-area-inset-top, 0px);
-  }
-  .safe-area-pb {
-    padding-bottom: env(safe-area-inset-bottom, 0px);
-  }
-  .safe-area-pt-pb {
-    padding-top: env(safe-area-inset-top, 0px);
-    padding-bottom: env(safe-area-inset-bottom, 0px);
-  }
-  .safe-area-pt-8 {
-    padding-top: env(safe-area-inset-top, 8px);
-  }
-  .safe-area-pb-16 {
-    padding-bottom: env(safe-area-inset-bottom, 16px);
-  }
-  .safe-bottom {
-    padding-bottom: env(safe-area-inset-bottom, 0px);
-  }
-  .safe-area-pl {
-    padding-left: env(safe-area-inset-left, 0px);
-  }
-  .safe-area-pr {
-    padding-right: env(safe-area-inset-right, 0px);
-  }
-  .safe-area-pl-pr {
-    padding-left: env(safe-area-inset-left, 0px);
-    padding-right: env(safe-area-inset-right, 0px);
-  }
-  .safe-bottom-h {
-    height: calc(60px + env(safe-area-inset-bottom, 0px));
-  }
-
-  /* ═══════════════════════════════════════════════════════════════════════
-     SCROLLBAR UTILITIES
-     ═══════════════════════════════════════════════════════════════════════ */
-  .no-scrollbar::-webkit-scrollbar {
-    display: none;
-  }
-  .no-scrollbar {
-    -ms-overflow-style: none;
-    scrollbar-width: none;
-  }
-
-  /* Custom scrollbar for desktop */
-  .custom-scrollbar::-webkit-scrollbar {
-    width: 6px;
-    height: 6px;
-  }
-  .custom-scrollbar::-webkit-scrollbar-track {
-    background: transparent;
-  }
-  .custom-scrollbar::-webkit-scrollbar-thumb {
-    background-color: rgb(var(--c-line));
-    border-radius: 3px;
-  }
-  .custom-scrollbar::-webkit-scrollbar-thumb:hover {
-    background-color: rgb(var(--c-muted));
-  }
-
-  /* ═══════════════════════════════════════════════════════════════════════
-     TEXT UTILITIES
-     ═══════════════════════════════════════════════════════════════════════ */
-  .text-balance {
-    text-wrap: balance;
-  }
-  .text-pretty {
-    text-wrap: pretty;
-  }
-
-  /* Gradient text for hero sections */
-  .text-gradient-emerald {
-    @apply bg-gradient-to-r from-brand-600 to-teal-600 bg-clip-text text-transparent;
-  }
-
-  .text-gradient-coral {
-    @apply bg-gradient-to-r from-coral-500 to-coral-600 bg-clip-text text-transparent;
-  }
-}
-
 /* ═══════════════════════════════════════════════════════════════════════
    iOS INPUT ZOOM FIX — Keep 16px minimum on touch devices only.
    Uses `hover: none` media query so desktop inputs keep their intended
@@ -820,30 +872,30 @@
 /* ═══════════════════════════════════════════════════════════════════════
    LOADING SKELETON — Shimmer effect
    ═══════════════════════════════════════════════════════════════════════ */
-.skeleton {
+@utility skeleton {
   @apply bg-line/50 rounded-lg relative overflow-hidden;
-}
 
-.skeleton::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(
-    90deg,
-    transparent 0%,
-    rgba(255, 255, 255, 0.4) 50%,
-    transparent 100%
-  );
-  animation: shimmer 1.5s infinite;
-}
+  &::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+      90deg,
+      transparent 0%,
+      rgba(255, 255, 255, 0.4) 50%,
+      transparent 100%
+    );
+    animation: shimmer 1.5s infinite;
+  }
 
-.dark .skeleton::after {
-  background: linear-gradient(
-    90deg,
-    transparent 0%,
-    rgba(255, 255, 255, 0.1) 50%,
-    transparent 100%
-  );
+  .dark &::after {
+    background: linear-gradient(
+      90deg,
+      transparent 0%,
+      rgba(255, 255, 255, 0.1) 50%,
+      transparent 100%
+    );
+  }
 }
 
 .skeleton-text {
@@ -857,18 +909,18 @@
 /* ═══════════════════════════════════════════════════════════════════════
    GLASSMORPHISM — Premium frosted glass effects
    ═══════════════════════════════════════════════════════════════════════ */
-.glass {
+@utility glass {
   @apply bg-panel/80 backdrop-blur-xl border border-white/20;
   box-shadow:
     0 4px 24px rgba(0, 0, 0, 0.06),
     inset 0 1px 0 rgba(255, 255, 255, 0.5);
-}
 
-.dark .glass {
-  @apply bg-panel/70 border-white/10;
-  box-shadow:
-    0 4px 24px rgba(0, 0, 0, 0.3),
-    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  .dark & {
+    @apply bg-panel/70 border-white/10;
+    box-shadow:
+      0 4px 24px rgba(0, 0, 0, 0.3),
+      inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  }
 }
 
 .glass-card {

--- a/apps/web/src/modules/finyk/FinykApp.tsx
+++ b/apps/web/src/modules/finyk/FinykApp.tsx
@@ -449,7 +449,7 @@ export default function App({
             setEditingManualExpenseId(null);
             setShowExpenseSheet(true);
           }}
-          className="fixed bottom-[calc(60px+env(safe-area-inset-bottom,0px)+16px)] right-4 w-12 h-12 rounded-full bg-gradient-to-br from-brand-400 to-brand-600 text-white shadow-float flex items-center justify-center text-2xl hover:from-brand-500 hover:to-brand-700 hover:shadow-glow hover:scale-105 active:scale-95 transition-[background-color,box-shadow,opacity,transform] duration-200 ease-smooth z-20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-finyk/45 focus-visible:ring-offset-2 focus-visible:ring-offset-panel"
+          className="fixed bottom-[calc(60px+env(safe-area-inset-bottom,0)+16px)] right-4 w-12 h-12 rounded-full bg-linear-to-br from-brand-400 to-brand-600 text-white shadow-float flex items-center justify-center text-2xl hover:from-brand-500 hover:to-brand-700 hover:shadow-glow hover:scale-105 active:scale-95 transition-[background-color,box-shadow,opacity,transform] duration-200 ease-smooth z-20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-finyk/45 focus-visible:ring-offset-2 focus-visible:ring-offset-panel"
           aria-label="Додати витрату"
         >
           +
@@ -457,7 +457,7 @@ export default function App({
       )}
 
       {mono.authError && (
-        <div className="fixed top-[calc(56px+env(safe-area-inset-top,0px)+8px)] left-4 right-4 z-50 max-w-lg mx-auto">
+        <div className="fixed top-[calc(56px+env(safe-area-inset-top,0)+8px)] left-4 right-4 z-50 max-w-lg mx-auto">
           <div className="bg-warning/15 border border-warning/40 rounded-2xl px-4 py-3 flex items-start gap-3 shadow-card">
             <span className="text-lg shrink-0 mt-0.5">⚠️</span>
             <div className="flex-1 min-w-0">

--- a/apps/web/src/modules/finyk/components/FinykLoginScreen.tsx
+++ b/apps/web/src/modules/finyk/components/FinykLoginScreen.tsx
@@ -47,7 +47,7 @@ export function FinykLoginScreen({
           <div
             className={cn(
               "w-20 h-20 mx-auto rounded-3xl flex items-center justify-center mb-4",
-              "bg-gradient-to-br from-brand-100 to-brand-200",
+              "bg-linear-to-br from-brand-100 to-brand-200",
               "dark:from-brand-900/40 dark:to-brand-800/30",
               "border border-brand-soft-border/60",
               "shadow-card",
@@ -201,7 +201,7 @@ export function FinykLoginScreen({
             type="button"
             className={cn(
               "mt-4 w-full h-12 min-h-[48px] text-base border-0",
-              "bg-gradient-to-r from-brand-600 to-brand-700",
+              "bg-linear-to-r from-brand-600 to-brand-700",
               "hover:from-brand-700 hover:to-brand-800",
               "text-white font-semibold",
               "shadow-md hover:shadow-glow",

--- a/apps/web/src/modules/finyk/components/FinykStatsStrip.tsx
+++ b/apps/web/src/modules/finyk/components/FinykStatsStrip.tsx
@@ -45,7 +45,7 @@ export function StatTile({
   onClick,
 }: StatTileProps) {
   const base = cn(
-    "flex-1 min-w-[9.5rem] shrink-0 text-left px-3 py-2.5",
+    "flex-1 min-w-38 shrink-0 text-left px-3 py-2.5",
     "bg-panelHi border border-line rounded-2xl",
     "transition-colors",
     onClick && "hover:border-muted/50 active:scale-[0.99]",

--- a/apps/web/src/modules/finyk/components/budgets/LimitBudgetCard.tsx
+++ b/apps/web/src/modules/finyk/components/budgets/LimitBudgetCard.tsx
@@ -185,7 +185,7 @@ function LimitBudgetCardComponent({
                   </>
                 ) : (
                   <div
-                    className="px-3 py-2.5 space-y-1.5 min-h-[3.5rem]"
+                    className="px-3 py-2.5 space-y-1.5 min-h-14"
                     aria-busy="true"
                   >
                     <Skeleton className="h-3 w-full rounded" />

--- a/apps/web/src/modules/finyk/pages/AssetsBars.tsx
+++ b/apps/web/src/modules/finyk/pages/AssetsBars.tsx
@@ -39,11 +39,11 @@ export function AssetsLiabilitiesBar({
         aria-label={`Активи ${assetsPct}% · Пасиви ${liabilitiesPct}%`}
       >
         <div
-          className="bg-gradient-to-r from-finyk to-finyk-strong"
+          className="bg-linear-to-r from-finyk to-finyk-strong"
           style={{ width: `${assetsPct}%` }}
         />
         <div
-          className="bg-gradient-to-r from-danger to-danger-strong"
+          className="bg-linear-to-r from-danger to-danger-strong"
           style={{ width: `${liabilitiesPct}%` }}
         />
       </div>

--- a/apps/web/src/modules/finyk/pages/AssetsTable.tsx
+++ b/apps/web/src/modules/finyk/pages/AssetsTable.tsx
@@ -49,7 +49,7 @@ export function AssetsNetworthCard({
       className={cn(
         "relative overflow-hidden rounded-3xl border p-5 mb-3 shadow-soft",
         "bg-finyk/5 dark:bg-finyk-surface-dark/10 border-finyk/15 dark:border-finyk-border-dark/20",
-        "before:absolute before:inset-0 before:pointer-events-none before:bg-gradient-to-br",
+        "before:absolute before:inset-0 before:pointer-events-none before:bg-linear-to-br",
         isNegative
           ? "before:from-danger/5 before:via-transparent before:to-transparent"
           : "before:from-finyk/10 before:via-transparent before:to-transparent",
@@ -93,7 +93,7 @@ export function AssetsNetworthCard({
                 {`+${totalAssets.toLocaleString("uk-UA", { maximumFractionDigits: 0 })} ₴`}
               </div>
             </div>
-            <div className="w-px bg-finyk/20 hidden sm:block self-stretch min-h-[2.5rem]" />
+            <div className="w-px bg-finyk/20 hidden sm:block self-stretch min-h-10" />
             <div>
               <div className="text-xs text-subtle mb-0.5">Пасиви</div>
               <div className="font-semibold tabular-nums text-text">

--- a/apps/web/src/modules/finyk/pages/budgets/BudgetsGoalsSection.tsx
+++ b/apps/web/src/modules/finyk/pages/budgets/BudgetsGoalsSection.tsx
@@ -58,7 +58,7 @@ export function BudgetsGoalsSection({
           <SectionHeading
             as="span"
             size="sm"
-            className="!mb-0 normal-case tracking-normal"
+            className="mb-0! normal-case tracking-normal"
           >
             Цілі накопичення
             {goalBudgets.length > 0 && (

--- a/apps/web/src/modules/finyk/pages/budgets/BudgetsLimitsSection.tsx
+++ b/apps/web/src/modules/finyk/pages/budgets/BudgetsLimitsSection.tsx
@@ -77,7 +77,7 @@ export function BudgetsLimitsSection({
           <SectionHeading
             as="span"
             size="sm"
-            className="!mb-0 normal-case tracking-normal"
+            className="mb-0! normal-case tracking-normal"
           >
             Ліміти · {monthStart.toLocaleDateString("uk-UA", { month: "long" })}
             {limitBudgets.length > 0 && (

--- a/apps/web/src/modules/finyk/pages/overview/HeroCard.tsx
+++ b/apps/web/src/modules/finyk/pages/overview/HeroCard.tsx
@@ -56,7 +56,7 @@ const HeroCardImpl = function HeroCard({
       className={cn(
         "rounded-3xl bg-finyk/[.06] dark:bg-finyk-surface-dark/10",
         "border border-finyk/[.14] dark:border-finyk-border-dark/20",
-        "border-l-[4px] shadow-card",
+        "border-l-4 shadow-card",
         accentLeft,
       )}
     >
@@ -145,9 +145,9 @@ const HeroCardImpl = function HeroCard({
               {Math.round(monthProgressPct)}%
             </span>
           </div>
-          <div className="h-1 rounded-full bg-finyk/[.15] overflow-hidden">
+          <div className="h-1 rounded-full bg-finyk/15 overflow-hidden">
             <div
-              className="h-full rounded-full bg-gradient-to-r from-brand-400 to-brand-500 transition-[width] duration-500"
+              className="h-full rounded-full bg-linear-to-r from-brand-400 to-brand-500 transition-[width] duration-500"
               style={{ width: `${monthProgressPct}%` }}
             />
           </div>

--- a/apps/web/src/modules/finyk/pages/transactions/TransactionsBatchToolbar.tsx
+++ b/apps/web/src/modules/finyk/pages/transactions/TransactionsBatchToolbar.tsx
@@ -40,8 +40,8 @@ export function TransactionsBatchToolbar({
   return (
     <>
       {selectMode && (
-        <div className="fixed bottom-0 left-0 right-0 z-[60] safe-area-pb">
-          <div className="max-w-4xl mx-auto px-4 pb-[calc(60px+env(safe-area-inset-bottom,0px)+0.5rem)] pt-3">
+        <div className="fixed bottom-0 left-0 right-0 z-60 safe-area-pb">
+          <div className="max-w-4xl mx-auto px-4 pb-[calc(60px+env(safe-area-inset-bottom,0)+0.5rem)] pt-3">
             <div className="bg-panel border border-line rounded-2xl shadow-float px-4 py-3 flex items-center justify-between gap-3">
               <span className="text-style-label text-text">
                 {selectedSize > 0

--- a/apps/web/src/modules/fizruk/components/WorkoutTemplatesSection.tsx
+++ b/apps/web/src/modules/fizruk/components/WorkoutTemplatesSection.tsx
@@ -291,7 +291,7 @@ export function WorkoutTemplatesSection({
                       {groupSelectMode && (
                         <button
                           type="button"
-                          className={`w-5 h-5 rounded-xl border flex items-center justify-center flex-shrink-0 transition-colors ${isSelected ? "bg-success-strong border-success-strong text-white" : "border-line bg-bg"}`}
+                          className={`w-5 h-5 rounded-xl border flex items-center justify-center shrink-0 transition-colors ${isSelected ? "bg-success-strong border-success-strong text-white" : "border-line bg-bg"}`}
                           onClick={() => handleToggleGroupSelect(id)}
                         >
                           {isSelected && (

--- a/apps/web/src/modules/fizruk/components/dashboard/HeroCard.tsx
+++ b/apps/web/src/modules/fizruk/components/dashboard/HeroCard.tsx
@@ -96,7 +96,7 @@ export interface HeroCardProps {
 }
 
 const HERO_CARD_CLASS =
-  "rounded-3xl p-6 overflow-hidden bg-hero-teal dark:bg-panel dark:border dark:border-teal-800/30 dark:[background-image:linear-gradient(135deg,rgba(20,184,166,0.18)_0%,rgba(20,184,166,0.05)_100%)]";
+  "rounded-3xl p-6 overflow-hidden bg-hero-teal dark:bg-panel dark:border dark:border-teal-800/30 dark:bg-[linear-gradient(135deg,rgba(20,184,166,0.18)_0%,rgba(20,184,166,0.05)_100%)]";
 
 function formatElapsed(sec: number): string {
   if (!Number.isFinite(sec) || sec <= 0) return "0:00";

--- a/apps/web/src/modules/fizruk/components/workouts/RestTimerOverlay.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/RestTimerOverlay.tsx
@@ -23,7 +23,7 @@ export function RestTimerOverlay({
 
   return (
     <div
-      className="fixed left-0 right-0 z-[55] px-4 pointer-events-none fizruk-above-tabbar"
+      className="fixed left-0 right-0 z-55 px-4 pointer-events-none fizruk-above-tabbar"
       role="timer"
       aria-live="polite"
       aria-label={`Відпочинок, залишилось ${restTimer.remaining} секунд`}

--- a/apps/web/src/modules/fizruk/components/workouts/WarmupCooldownChecklist.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/WarmupCooldownChecklist.tsx
@@ -74,7 +74,7 @@ export function WarmupCooldownChecklist({
           <li key={item.id} className="flex items-center gap-2">
             <button
               type="button"
-              className={`w-5 h-5 rounded-xl border flex items-center justify-center flex-shrink-0 transition-colors ${item.done ? "bg-success-strong border-success-strong text-white" : "border-line bg-bg"}`}
+              className={`w-5 h-5 rounded-xl border flex items-center justify-center shrink-0 transition-colors ${item.done ? "bg-success-strong border-success-strong text-white" : "border-line bg-bg"}`}
               onClick={() => onToggle(item.id)}
               aria-label={
                 item.done

--- a/apps/web/src/modules/fizruk/components/workouts/WorkoutFinishSheets.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/WorkoutFinishSheets.tsx
@@ -50,7 +50,7 @@ export function WorkoutFinishSheets({
   if (!finishFlash) return null;
   return (
     <div
-      className="fixed left-0 right-0 z-[100] px-4 pointer-events-none fizruk-above-tabbar"
+      className="fixed left-0 right-0 z-100 px-4 pointer-events-none fizruk-above-tabbar"
       role="region"
       aria-label="Підсумок тренування"
     >

--- a/apps/web/src/modules/fizruk/components/workouts/WorkoutItemCard.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/WorkoutItemCard.tsx
@@ -115,7 +115,7 @@ export function WorkoutItemCard({
             {groupSelectMode && (
               <button
                 type="button"
-                className={`w-5 h-5 rounded-xl border flex items-center justify-center flex-shrink-0 transition-colors ${isSelected ? "bg-success-strong border-success-strong text-white" : "border-line bg-bg"}`}
+                className={`w-5 h-5 rounded-xl border flex items-center justify-center shrink-0 transition-colors ${isSelected ? "bg-success-strong border-success-strong text-white" : "border-line bg-bg"}`}
                 onClick={() => onToggleGroupSelect(it.id)}
               >
                 {isSelected && (

--- a/apps/web/src/modules/fizruk/pages/Atlas.tsx
+++ b/apps/web/src/modules/fizruk/pages/Atlas.tsx
@@ -78,7 +78,7 @@ export function Atlas() {
     <div className="flex-1 overflow-y-auto">
       <div className="max-w-4xl mx-auto px-4 pt-4 page-tabbar-pad space-y-3">
         <section
-          className="rounded-3xl p-5 border border-line/20 bg-hero-teal dark:border-teal-800/30 dark:bg-panel dark:[background-image:linear-gradient(135deg,rgba(20,184,166,0.18)_0%,rgba(20,184,166,0.05)_100%)]"
+          className="rounded-3xl p-5 border border-line/20 bg-hero-teal dark:border-teal-800/30 dark:bg-panel dark:bg-[linear-gradient(135deg,rgba(20,184,166,0.18)_0%,rgba(20,184,166,0.05)_100%)]"
           aria-label="Атлас мʼязів"
         >
           <SectionHeading size="sm" variant="fizruk" as="p">

--- a/apps/web/src/modules/fizruk/pages/Body/CollapsibleTrendCard.tsx
+++ b/apps/web/src/modules/fizruk/pages/Body/CollapsibleTrendCard.tsx
@@ -59,7 +59,7 @@ export function CollapsibleTrendCard({
         )}
       >
         <div className="flex-1 min-w-0">
-          <SectionHeading as="h2" size="sm" className="!mb-0">
+          <SectionHeading as="h2" size="sm" className="mb-0!">
             {title}
           </SectionHeading>
         </div>

--- a/apps/web/src/modules/fizruk/pages/Body/JournalSection.tsx
+++ b/apps/web/src/modules/fizruk/pages/Body/JournalSection.tsx
@@ -45,7 +45,7 @@ export function JournalSection({
         )}
       >
         <div className="flex-1 min-w-0 flex items-baseline gap-2">
-          <SectionHeading as="h2" size="sm" className="!mb-0">
+          <SectionHeading as="h2" size="sm" className="mb-0!">
             Журнал
           </SectionHeading>
           <span className="text-xs text-muted tabular-nums">{totalCount}</span>

--- a/apps/web/src/modules/fizruk/shell/FizrukHeader.tsx
+++ b/apps/web/src/modules/fizruk/shell/FizrukHeader.tsx
@@ -112,7 +112,7 @@ function DumbbellBadge() {
     <div
       className={cn(
         "shrink-0 w-10 h-10 rounded-xl flex items-center justify-center",
-        "bg-gradient-to-br from-teal-100 to-cyan-100",
+        "bg-linear-to-br from-teal-100 to-cyan-100",
         "dark:from-teal-900/40 dark:to-cyan-900/30",
         "text-fizruk-strong dark:text-fizruk",
         "border border-fizruk-soft-border/60",

--- a/apps/web/src/modules/nutrition/components/BarcodeScanner.tsx
+++ b/apps/web/src/modules/nutrition/components/BarcodeScanner.tsx
@@ -93,7 +93,7 @@ function WebBarcodeScanner({ onDetected, onClose }: BarcodeScannerProps) {
   };
 
   return (
-    <div className="fixed inset-0 z-[130] flex items-end">
+    <div className="fixed inset-0 z-130 flex items-end">
       <button
         type="button"
         className="absolute inset-0 bg-black/70"

--- a/apps/web/src/modules/nutrition/components/NutritionHeader.tsx
+++ b/apps/web/src/modules/nutrition/components/NutritionHeader.tsx
@@ -9,7 +9,7 @@ function AppleBadge() {
     <div
       className={cn(
         "shrink-0 w-10 h-10 rounded-xl flex items-center justify-center",
-        "bg-gradient-to-br from-lime-100 to-green-100",
+        "bg-linear-to-br from-lime-100 to-green-100",
         "dark:from-lime-900/40 dark:to-green-900/30",
         "text-nutrition-strong dark:text-nutrition",
         "border border-nutrition-soft-border/60",

--- a/apps/web/src/modules/nutrition/components/RecipesCard.tsx
+++ b/apps/web/src/modules/nutrition/components/RecipesCard.tsx
@@ -234,7 +234,7 @@ export function RecipesCard({
                         >
                           <ChevronIcon open={isOpen} />
                           <span className="min-w-0">
-                            <span className="text-style-label block text-text break-words">
+                            <span className="text-style-label block text-text wrap-break-word">
                               {r.title}
                             </span>
                             <span className="block text-xs text-subtle mt-0.5">
@@ -289,7 +289,7 @@ export function RecipesCard({
                         <div className="mt-3 pt-3 border-t border-line/40 space-y-3">
                           {Array.isArray(r.ingredients) &&
                             r.ingredients.length > 0 && (
-                              <div className="text-sm text-text break-words">
+                              <div className="text-sm text-text wrap-break-word">
                                 <div className="text-xs text-subtle mb-1">
                                   Інгредієнти
                                 </div>
@@ -453,7 +453,7 @@ export function RecipesCard({
                 >
                   <div className="flex flex-wrap items-start justify-between gap-2">
                     <div className="min-w-0 flex-1 basis-full sm:basis-auto">
-                      <div className="text-style-label text-text break-words">
+                      <div className="text-style-label text-text wrap-break-word">
                         {r.title || `Рецепт ${idx + 1}`}
                       </div>
                       <div className="text-xs text-subtle mt-1">
@@ -497,7 +497,7 @@ export function RecipesCard({
                   </div>
 
                   {Array.isArray(r.ingredients) && r.ingredients.length > 0 && (
-                    <div className="mt-3 text-sm text-text break-words">
+                    <div className="mt-3 text-sm text-text wrap-break-word">
                       <div className="text-xs text-subtle mb-1">
                         Інгредієнти
                       </div>

--- a/apps/web/src/modules/routine/components/FizrukDayPlanSheet.tsx
+++ b/apps/web/src/modules/routine/components/FizrukDayPlanSheet.tsx
@@ -96,7 +96,7 @@ export function FizrukDayPlanSheet({
                   type="button"
                   size="sm"
                   variant="ghost"
-                  className="!text-xs border border-line shrink-0"
+                  className="text-xs! border border-line shrink-0"
                   onClick={() => handleAssign(null)}
                 >
                   Зняти

--- a/apps/web/src/modules/routine/components/HabitDetailSheet.tsx
+++ b/apps/web/src/modules/routine/components/HabitDetailSheet.tsx
@@ -289,7 +289,7 @@ export function HabitDetailSheet({
             >
               ‹
             </button>
-            <span className="text-xs font-semibold text-text min-w-[7rem] text-center capitalize">
+            <span className="text-xs font-semibold text-text min-w-28 text-center capitalize">
               {calMonthTitle}
             </span>
             <button

--- a/apps/web/src/modules/routine/components/HabitHeatmap.tsx
+++ b/apps/web/src/modules/routine/components/HabitHeatmap.tsx
@@ -293,7 +293,7 @@ export function HabitHeatmap({ habits, completions }: HabitHeatmapProps) {
                 key={i}
                 role="img"
                 aria-label={`Рівень ${i + 1}`}
-                className={cn("rounded-sm inline-block flex-shrink-0", c)}
+                className={cn("rounded-sm inline-block shrink-0", c)}
                 style={{ width: 10, height: 10 }}
               />
             ))}

--- a/apps/web/src/modules/routine/components/HabitQuickCreateDialog.tsx
+++ b/apps/web/src/modules/routine/components/HabitQuickCreateDialog.tsx
@@ -145,7 +145,7 @@ export function HabitQuickCreateDialog({
 
   return (
     <div
-      className="fixed inset-0 z-[200] flex items-end justify-center sm:items-center"
+      className="fixed inset-0 z-200 flex items-end justify-center sm:items-center"
       role="presentation"
     >
       <div

--- a/apps/web/src/modules/routine/components/PushupsWidget.tsx
+++ b/apps/web/src/modules/routine/components/PushupsWidget.tsx
@@ -8,7 +8,7 @@ import { useRoutinePushups } from "../hooks/useRoutinePushups";
 import { dateKeyFromDate } from "../lib/hubCalendarAggregate";
 
 const C = {
-  primary: "!bg-routine hover:!bg-routine-hover !text-white border-0",
+  primary: "bg-routine! hover:bg-routine-hover! text-white! border-0",
   barToday: "bg-routine",
   barOther: "bg-routine/35",
 };
@@ -148,7 +148,7 @@ export function PushupsWidget() {
           <button
             type="button"
             className={cn(
-              "min-h-[48px] w-full shrink-0 rounded-2xl px-6 text-base font-bold disabled:opacity-40 sm:w-auto sm:min-w-[7rem]",
+              "min-h-[48px] w-full shrink-0 rounded-2xl px-6 text-base font-bold disabled:opacity-40 sm:w-auto sm:min-w-28",
               C.primary,
             )}
             disabled={!input || Number(input) <= 0}

--- a/apps/web/src/modules/routine/components/RoutineBottomNav.tsx
+++ b/apps/web/src/modules/routine/components/RoutineBottomNav.tsx
@@ -88,7 +88,7 @@ export function RoutineBottomNav({
           className={[
             "absolute left-1/2 -translate-x-1/2 -top-6",
             "w-14 h-14 rounded-full z-40",
-            "bg-gradient-to-br from-coral-400 to-coral-500 text-white",
+            "bg-linear-to-br from-coral-400 to-coral-500 text-white",
             "shadow-float border-4 border-bg",
             "flex items-center justify-center",
             "transition-transform duration-150 active:scale-95 hover:scale-[1.04]",

--- a/apps/web/src/modules/routine/components/RoutineCalendarPanel.tsx
+++ b/apps/web/src/modules/routine/components/RoutineCalendarPanel.tsx
@@ -513,7 +513,7 @@ export function RoutineCalendarPanel({
                             <Button
                               size="sm"
                               variant="ghost"
-                              className="!h-9 !px-3 !text-xs border border-sky-400/30 bg-sky-500/5"
+                              className="h-9! px-3! text-xs! border border-sky-400/30 bg-sky-500/5"
                               type="button"
                               onClick={() => setFizrukPlanDateKey(e.date)}
                             >
@@ -524,7 +524,7 @@ export function RoutineCalendarPanel({
                             <Button
                               size="sm"
                               variant="ghost"
-                              className="!h-9 !px-3 !text-xs border border-emerald-500/25 bg-emerald-500/5"
+                              className="h-9! px-3! text-xs! border border-emerald-500/25 bg-emerald-500/5"
                               type="button"
                               onClick={() =>
                                 onOpenModule("finyk", { hash: "assets" })

--- a/apps/web/src/modules/routine/components/settings/ArchivedHabitsSection.tsx
+++ b/apps/web/src/modules/routine/components/settings/ArchivedHabitsSection.tsx
@@ -46,7 +46,7 @@ export function ArchivedHabitsSection({
                 type="button"
                 variant="ghost"
                 size="sm"
-                className="!h-9 !px-3 !text-xs border border-line"
+                className="h-9! px-3! text-xs! border border-line"
                 onClick={() =>
                   setRoutine((s) => setHabitArchived(s, h.id, false))
                 }
@@ -57,7 +57,7 @@ export function ArchivedHabitsSection({
                 type="button"
                 variant="ghost"
                 size="sm"
-                className="!h-9 !px-3 !text-xs text-danger border border-danger/25"
+                className="h-9! px-3! text-xs! text-danger border border-danger/25"
                 onClick={() =>
                   onRequestDelete({ id: h.id, name: h.name, archived: true })
                 }

--- a/apps/web/src/modules/routine/components/settings/CategoriesSection.tsx
+++ b/apps/web/src/modules/routine/components/settings/CategoriesSection.tsx
@@ -57,7 +57,7 @@ export function CategoriesSection({
               <Button
                 type="button"
                 variant="ghost"
-                className="min-h-[44px] min-w-0 border border-line sm:min-w-[7rem]"
+                className="min-h-[44px] min-w-0 border border-line sm:min-w-28"
                 onClick={() => {
                   setRoutine((s) =>
                     updateCategory(s, editingCatId, {
@@ -87,7 +87,7 @@ export function CategoriesSection({
             <Button
               type="button"
               variant="ghost"
-              className="min-h-[44px] w-full min-w-0 border border-line sm:w-auto sm:min-w-[7rem]"
+              className="min-h-[44px] w-full min-w-0 border border-line sm:w-auto sm:min-w-28"
               onClick={() => {
                 setRoutine((s) =>
                   createCategory(s, catDraft.name, catDraft.emoji),

--- a/apps/web/src/modules/routine/components/settings/HabitListItem.tsx
+++ b/apps/web/src/modules/routine/components/settings/HabitListItem.tsx
@@ -94,7 +94,7 @@ export const HabitListItem = memo(function HabitListItem({
             type="button"
             variant="ghost"
             size="sm"
-            className="!h-9 !px-3 !text-xs border border-routine-line/60 dark:border-routine-border-dark/25 bg-routine-surface/40 dark:bg-routine-surface-dark/10"
+            className="h-9! px-3! text-xs! border border-routine-line/60 dark:border-routine-border-dark/25 bg-routine-surface/40 dark:bg-routine-surface-dark/10"
             onClick={onOpenDetails}
           >
             Деталі
@@ -103,7 +103,7 @@ export const HabitListItem = memo(function HabitListItem({
             type="button"
             variant="ghost"
             size="sm"
-            className="!h-9 !px-3 !text-xs border border-line"
+            className="h-9! px-3! text-xs! border border-line"
             onClick={onStartEdit}
           >
             Змінити
@@ -112,7 +112,7 @@ export const HabitListItem = memo(function HabitListItem({
             type="button"
             variant="ghost"
             size="sm"
-            className="!h-9 !px-3 !text-xs border border-line"
+            className="h-9! px-3! text-xs! border border-line"
             onClick={onArchive}
           >
             В архів
@@ -121,7 +121,7 @@ export const HabitListItem = memo(function HabitListItem({
             type="button"
             variant="ghost"
             size="sm"
-            className="!h-9 !px-3 !text-xs text-danger border border-danger/25"
+            className="h-9! px-3! text-xs! text-danger border border-danger/25"
             onClick={onRequestDelete}
           >
             Видалити

--- a/apps/web/src/modules/routine/components/settings/TagsSection.tsx
+++ b/apps/web/src/modules/routine/components/settings/TagsSection.tsx
@@ -74,7 +74,7 @@ export function TagsSection({
                 }}
               >
                 <Input
-                  className="!h-7 !px-1.5 !text-xs w-24"
+                  className="h-7! px-1.5! text-xs! w-24"
                   value={editingTagName}
                   onChange={(e) => setEditingTagName(e.target.value)}
                   onBlur={() => commitEdit(t.id)}

--- a/apps/web/src/shared/components/layout/ModuleHeader.tsx
+++ b/apps/web/src/shared/components/layout/ModuleHeader.tsx
@@ -109,12 +109,7 @@ export function ModuleHeader({
       className={cn(
         "shrink-0 backdrop-blur-md z-40 relative safe-area-pt",
         mt
-          ? cn(
-              "bg-gradient-to-b to-panel/95",
-              mt.gradient,
-              mt.border,
-              "border-b",
-            )
+          ? cn("bg-linear-to-b to-panel/95", mt.gradient, mt.border, "border-b")
           : "bg-panel/95 border-b border-line",
         className,
       )}
@@ -409,7 +404,7 @@ export function ModuleSwitcher({ active, className }: ModuleSwitcherProps) {
               openHubModule(id);
             }}
             className={cn(
-              "flex-1 inline-flex items-center justify-center gap-1.5 h-8 [@media(pointer:coarse)]:h-9 px-2 rounded-xl text-2xs font-semibold tracking-wide transition-colors",
+              "flex-1 inline-flex items-center justify-center gap-1.5 h-8 pointer-coarse:h-9 px-2 rounded-xl text-2xs font-semibold tracking-wide transition-colors",
               "focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-panel",
               isActive ? tokens.active : tokens.inactive,
               tokens.ring,

--- a/apps/web/src/shared/components/layout/ModuleSettingsDrawer.tsx
+++ b/apps/web/src/shared/components/layout/ModuleSettingsDrawer.tsx
@@ -56,7 +56,7 @@ export function ModuleSettingsDrawer({
       };
 
   return (
-    <div className="fixed inset-0 z-[80] flex justify-end" role="presentation">
+    <div className="fixed inset-0 z-80 flex justify-end" role="presentation">
       <button
         type="button"
         className="absolute inset-0 bg-black/50 backdrop-blur-[2px]"

--- a/apps/web/src/shared/components/ui/Button.tsx
+++ b/apps/web/src/shared/components/ui/Button.tsx
@@ -182,12 +182,12 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           // Base styles
           "inline-flex items-center justify-center touch-manipulation",
           "motion-safe:transition-all motion-safe:duration-200 motion-safe:ease-smooth",
-          "motion-reduce:transition-none motion-reduce:active:!scale-100",
+          "motion-reduce:transition-none motion-reduce:active:scale-100!",
           "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-panel",
           "disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none",
           // Touch / coarse pointer: WCAG 2.5.5 / HIG ≥44×44px for compact controls.
           needsCoarseMinTarget &&
-            "[@media(pointer:coarse)]:min-h-[44px] [@media(pointer:coarse)]:min-w-[44px]",
+            "pointer-coarse:min-h-[44px] pointer-coarse:min-w-[44px]",
           // Variant (potentially redirected by `module` prop — see
           // resolveVariant for the mapping table).
           variants[resolvedVariant],

--- a/apps/web/src/shared/components/ui/CelebrationModal.tsx
+++ b/apps/web/src/shared/components/ui/CelebrationModal.tsx
@@ -291,7 +291,7 @@ export const CelebrationModal = memo(function CelebrationModal({
   return (
     <div
       className={cn(
-        "fixed inset-0 z-[9999] flex items-center justify-center p-4",
+        "fixed inset-0 z-9999 flex items-center justify-center p-4",
         isExiting ? "animate-fade-out" : "animate-fade-in",
       )}
       role="dialog"
@@ -345,7 +345,7 @@ export const CelebrationModal = memo(function CelebrationModal({
         {/* Gradient background accent */}
         <div
           className={cn(
-            "absolute inset-0 bg-gradient-to-br pointer-events-none",
+            "absolute inset-0 bg-linear-to-br pointer-events-none",
             MODULE_GRADIENTS[theme],
           )}
         />
@@ -566,7 +566,7 @@ export const MiniSuccess = memo(function MiniSuccess({
     <div
       className={cn(
         "fixed top-[max(1.5rem,env(safe-area-inset-top)+0.75rem)] left-1/2 -translate-x-1/2",
-        "z-[9999] pointer-events-none",
+        "z-9999 pointer-events-none",
       )}
     >
       <div

--- a/apps/web/src/shared/components/ui/CollapsibleSection.tsx
+++ b/apps/web/src/shared/components/ui/CollapsibleSection.tsx
@@ -84,7 +84,7 @@ export function CollapsibleSection({
           type="button"
           onClick={toggle}
           aria-expanded={open}
-          className="flex items-center gap-1.5 w-full text-left touch-target [@media(pointer:coarse)]:py-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 rounded-xl -ml-0.5 pl-0.5"
+          className="flex items-center gap-1.5 w-full text-left touch-target pointer-coarse:py-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 rounded-xl -ml-0.5 pl-0.5"
         >
           <Icon
             name="chevron-down"
@@ -93,7 +93,7 @@ export function CollapsibleSection({
             className="text-subtle"
             aria-hidden
           />
-          <SectionHeading as="span" size={headingSize} className="!px-0">
+          <SectionHeading as="span" size={headingSize} className="px-0!">
             {title}
           </SectionHeading>
         </button>

--- a/apps/web/src/shared/components/ui/ConfirmDialog.tsx
+++ b/apps/web/src/shared/components/ui/ConfirmDialog.tsx
@@ -66,7 +66,7 @@ export const ConfirmDialog = memo(function ConfirmDialog({
 
   return (
     <div
-      className="fixed inset-0 z-[200] flex items-end justify-center sm:items-center"
+      className="fixed inset-0 z-200 flex items-end justify-center sm:items-center"
       role="presentation"
     >
       {/* Scrim — real <button> keeps dismiss reachable by keyboard & AT. */}

--- a/apps/web/src/shared/components/ui/FeatureSpotlight.tsx
+++ b/apps/web/src/shared/components/ui/FeatureSpotlight.tsx
@@ -320,7 +320,7 @@ export function FeatureSpotlight({
       {target}
       {/* Portal to body ensures highest stacking context */}
       <div
-        className="fixed inset-0 z-[9999] pointer-events-none"
+        className="fixed inset-0 z-9999 pointer-events-none"
         role="dialog"
         aria-modal="true"
         aria-labelledby={`spotlight-title-${id}`}

--- a/apps/web/src/shared/components/ui/InputDialog.tsx
+++ b/apps/web/src/shared/components/ui/InputDialog.tsx
@@ -77,7 +77,7 @@ export function InputDialog({
 
   return (
     <div
-      className="fixed inset-0 z-[200] flex items-end justify-center sm:items-center"
+      className="fixed inset-0 z-200 flex items-end justify-center sm:items-center"
       role="presentation"
     >
       <button
@@ -129,7 +129,7 @@ export function InputDialog({
         <div className="flex flex-col gap-2">
           <Button
             type="submit"
-            className="w-full h-12 !bg-primary !text-bg border-0"
+            className="w-full h-12 bg-primary! text-bg! border-0"
           >
             {confirmLabel}
           </Button>

--- a/apps/web/src/shared/components/ui/ModuleBottomNav.tsx
+++ b/apps/web/src/shared/components/ui/ModuleBottomNav.tsx
@@ -59,25 +59,25 @@ type ColorTokens = {
 const COLORS: Record<ModuleNavColor, ColorTokens> = {
   finyk: {
     text: "text-finyk",
-    pill: "bg-gradient-to-r from-brand-400 to-brand-500",
+    pill: "bg-linear-to-r from-brand-400 to-brand-500",
     glow: "drop-shadow-[0_0_8px_rgba(16,185,129,0.3)]",
     badge: "bg-finyk",
   },
   fizruk: {
     text: "text-fizruk",
-    pill: "bg-gradient-to-r from-teal-400 to-teal-500",
+    pill: "bg-linear-to-r from-teal-400 to-teal-500",
     glow: "drop-shadow-[0_0_8px_rgba(20,184,166,0.3)]",
     badge: "bg-fizruk",
   },
   routine: {
     text: "text-routine",
-    pill: "bg-gradient-to-r from-coral-400 to-coral-500",
+    pill: "bg-linear-to-r from-coral-400 to-coral-500",
     glow: "drop-shadow-[0_0_8px_rgba(249,112,102,0.3)]",
     badge: "bg-routine",
   },
   nutrition: {
     text: "text-nutrition",
-    pill: "bg-gradient-to-r from-lime-400 to-lime-500",
+    pill: "bg-linear-to-r from-lime-400 to-lime-500",
     glow: "drop-shadow-[0_0_8px_rgba(132,204,22,0.3)]",
     badge: "bg-nutrition",
   },
@@ -107,7 +107,7 @@ export const ModuleBottomNav = memo(function ModuleBottomNav({
       aria-label={ariaLabel}
     >
       <div
-        className="relative flex h-[60px] [@media(pointer:coarse)]:h-[64px]"
+        className="relative flex h-[60px] pointer-coarse:h-[64px]"
         role={isTablist ? "tablist" : undefined}
       >
         {/* Sliding pill indicator — single element that translates to active tab */}
@@ -142,8 +142,8 @@ export const ModuleBottomNav = memo(function ModuleBottomNav({
               onClick={() => onChange(item.id)}
               className={cn(
                 "relative flex-1 flex flex-col items-center justify-center gap-1",
-                "transition-all duration-200 min-h-[48px] [@media(pointer:coarse)]:min-h-[52px]",
-                "active:scale-95 [@media(pointer:coarse)]:active:bg-panelHi/50",
+                "transition-all duration-200 min-h-[48px] pointer-coarse:min-h-[52px]",
+                "active:scale-95 pointer-coarse:active:bg-panelHi/50",
                 "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-panel",
                 active ? "text-text" : "text-muted hover:text-text/70",
               )}

--- a/apps/web/src/shared/components/ui/SectionErrorBoundary.tsx
+++ b/apps/web/src/shared/components/ui/SectionErrorBoundary.tsx
@@ -40,7 +40,7 @@ export class SectionErrorBoundary extends Component<
           <div className="text-xs text-subtle mt-1">
             Ця секція впала, але інші частини модуля працюють.
           </div>
-          <pre className="mt-2 text-xs text-danger whitespace-pre-wrap break-words max-h-40 overflow-auto">
+          <pre className="mt-2 text-xs text-danger whitespace-pre-wrap wrap-break-word max-h-40 overflow-auto">
             {String(error?.message || error)}
           </pre>
           <div className="mt-3 flex gap-2 flex-wrap">

--- a/apps/web/src/shared/components/ui/Skeleton.tsx
+++ b/apps/web/src/shared/components/ui/Skeleton.tsx
@@ -33,7 +33,7 @@ export function Skeleton({ className, shimmer = false, style }: SkeletonProps) {
     >
       {shimmer && (
         <div
-          className="absolute inset-0 -translate-x-full motion-safe:animate-shimmer bg-gradient-to-r from-transparent via-white/10 to-transparent"
+          className="absolute inset-0 -translate-x-full motion-safe:animate-shimmer bg-linear-to-r from-transparent via-white/10 to-transparent"
           aria-hidden="true"
         />
       )}
@@ -58,7 +58,7 @@ export function SkeletonText({
     >
       {shimmer && (
         <div
-          className="absolute inset-0 -translate-x-full motion-safe:animate-shimmer bg-gradient-to-r from-transparent via-white/10 to-transparent"
+          className="absolute inset-0 -translate-x-full motion-safe:animate-shimmer bg-linear-to-r from-transparent via-white/10 to-transparent"
           aria-hidden="true"
         />
       )}
@@ -113,7 +113,7 @@ export function SkeletonTransactionRow({
       >
         {shimmer && (
           <div
-            className="absolute inset-0 -translate-x-full motion-safe:animate-shimmer bg-gradient-to-r from-transparent via-white/10 to-transparent"
+            className="absolute inset-0 -translate-x-full motion-safe:animate-shimmer bg-linear-to-r from-transparent via-white/10 to-transparent"
             aria-hidden="true"
           />
         )}
@@ -159,7 +159,7 @@ export function SkeletonBudgetBar({
         >
           {shimmer && (
             <div
-              className="absolute inset-0 -translate-x-full motion-safe:animate-shimmer bg-gradient-to-r from-transparent via-white/15 to-transparent"
+              className="absolute inset-0 -translate-x-full motion-safe:animate-shimmer bg-linear-to-r from-transparent via-white/15 to-transparent"
               aria-hidden="true"
             />
           )}

--- a/apps/web/src/shared/components/ui/SkipLink.tsx
+++ b/apps/web/src/shared/components/ui/SkipLink.tsx
@@ -34,7 +34,7 @@ export function SkipLink({
         // When focused: promote to a pinned top-left pill that sits
         // above every surface in the app (modals, sheets, toasts all
         // live ≤ z-[200]).
-        "focus:fixed focus:top-3 focus:left-3 focus:z-[300]",
+        "focus:fixed focus:top-3 focus:left-3 focus:z-300",
         "focus:px-4 focus:py-2 focus:rounded-xl",
         "focus:border focus-visible:bg-panel focus-visible:text-text focus-visible:shadow-float focus-visible:border-line",
         "focus:text-sm focus:font-semibold",

--- a/apps/web/src/shared/components/ui/StreakCelebration.tsx
+++ b/apps/web/src/shared/components/ui/StreakCelebration.tsx
@@ -135,7 +135,7 @@ export const StreakCelebration = memo(function StreakCelebration({
   return (
     <div
       className={cn(
-        "fixed inset-0 z-[9999] flex items-center justify-center pointer-events-none",
+        "fixed inset-0 z-9999 flex items-center justify-center pointer-events-none",
         className,
       )}
       aria-live="polite"

--- a/apps/web/src/shared/components/ui/StreakProtection.tsx
+++ b/apps/web/src/shared/components/ui/StreakProtection.tsx
@@ -139,7 +139,7 @@ export function StreakProtection({
         <div className="flex items-start gap-3">
           <div
             className={cn(
-              "flex-shrink-0 w-10 h-10 rounded-full flex items-center justify-center",
+              "shrink-0 w-10 h-10 rounded-full flex items-center justify-center",
               urgencyLevel === "critical" && "bg-danger/20 text-danger",
               urgencyLevel === "warning" && "bg-warning/20 text-warning",
               urgencyLevel === "info" && "bg-accent/20 text-accent",
@@ -172,7 +172,7 @@ export function StreakProtection({
           <button
             type="button"
             onClick={handleDismiss}
-            className="flex-shrink-0 p-1 rounded-xl text-muted hover:text-text hover:bg-surface transition-colors"
+            className="shrink-0 p-1 rounded-xl text-muted hover:text-text hover:bg-surface transition-colors"
             aria-label="Закрити"
           >
             <Icon name="x" size={16} />

--- a/apps/web/src/shared/components/ui/Toast.tsx
+++ b/apps/web/src/shared/components/ui/Toast.tsx
@@ -30,7 +30,7 @@ export function ToastContainer() {
 
   return (
     <div
-      className="fixed top-[max(1.25rem,env(safe-area-inset-top,0px)+0.75rem)] left-1/2 -translate-x-1/2 z-[9999] flex flex-col items-center gap-2 pointer-events-none w-[min(92vw,24rem)]"
+      className="fixed top-[max(1.25rem,env(safe-area-inset-top,0px)+0.75rem)] left-1/2 -translate-x-1/2 z-9999 flex flex-col items-center gap-2 pointer-events-none w-[min(92vw,24rem)]"
       aria-live="polite"
       role="status"
     >

--- a/apps/web/src/shared/components/ui/VoiceMicButton.tsx
+++ b/apps/web/src/shared/components/ui/VoiceMicButton.tsx
@@ -154,8 +154,8 @@ export function VoiceMicButton({
 
   const sizeMap: Record<VoiceMicButtonSize, string> = {
     // sm/md visual size stays compact; coarse-pointer min 44×44 is applied below.
-    sm: "w-8 h-8 [@media(pointer:coarse)]:min-h-[44px] [@media(pointer:coarse)]:min-w-[44px]",
-    md: "w-10 h-10 [@media(pointer:coarse)]:min-h-[44px] [@media(pointer:coarse)]:min-w-[44px]",
+    sm: "w-8 h-8 pointer-coarse:min-h-[44px] pointer-coarse:min-w-[44px]",
+    md: "w-10 h-10 pointer-coarse:min-h-[44px] pointer-coarse:min-w-[44px]",
     lg: "w-12 h-12",
   };
   const iconSize = size === "sm" ? 14 : size === "lg" ? 20 : 16;

--- a/apps/web/src/shared/components/ui/voice/PendingVoiceChip.tsx
+++ b/apps/web/src/shared/components/ui/voice/PendingVoiceChip.tsx
@@ -163,7 +163,7 @@ export function PendingVoiceChip({
           hapticTap();
           onCancel();
         }}
-        className="shrink-0 w-7 h-7 rounded-full bg-line/30 text-muted hover:text-error hover:bg-error/15 flex items-center justify-center [@media(pointer:coarse)]:min-h-[44px] [@media(pointer:coarse)]:min-w-[44px]"
+        className="shrink-0 w-7 h-7 rounded-full bg-line/30 text-muted hover:text-error hover:bg-error/15 flex items-center justify-center pointer-coarse:min-h-[44px] pointer-coarse:min-w-[44px]"
         aria-label="Скасувати"
         title="Скасувати"
       >

--- a/apps/web/src/styles/module-surfaces.css
+++ b/apps/web/src/styles/module-surfaces.css
@@ -5,27 +5,27 @@
 
 /* ── Module card base ────────────────────────────────────────────────── */
 
-.module-card {
+@utility module-card {
   @apply relative rounded-3xl p-5 border overflow-hidden
          transition-interactive;
-}
 
-.module-card::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  opacity: 0;
-  transition: opacity 0.3s ease;
-}
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+  }
 
-.module-card:hover::before {
-  opacity: 1;
+  &:hover::before {
+    opacity: 1;
+  }
 }
 
 /* ── Finyk (emerald) ─────────────────────────────────────────────────── */
 
 .module-card-finyk {
-  @apply module-card bg-gradient-to-br from-emerald-50 via-teal-50/50 to-white;
+  @apply module-card bg-linear-to-br from-emerald-50 via-teal-50/50 to-white;
   border-color: rgba(167, 243, 208, 0.6);
 }
 
@@ -50,7 +50,7 @@
 /* ── Fizruk (teal) ───────────────────────────────────────────────────── */
 
 .module-card-fizruk {
-  @apply module-card bg-gradient-to-br from-teal-50 via-cyan-50/50 to-white;
+  @apply module-card bg-linear-to-br from-teal-50 via-cyan-50/50 to-white;
   border-color: rgba(153, 246, 228, 0.6);
 }
 
@@ -75,7 +75,7 @@
 /* ── Routine (coral) ─────────────────────────────────────────────────── */
 
 .module-card-routine {
-  @apply module-card bg-gradient-to-br from-coral-50/80 via-orange-50/30 to-white;
+  @apply module-card bg-linear-to-br from-coral-50/80 via-orange-50/30 to-white;
   border-color: rgba(255, 212, 203, 0.6);
 }
 
@@ -136,7 +136,7 @@
 /* ── Nutrition (lime) ────────────────────────────────────────────────── */
 
 .module-card-nutrition {
-  @apply module-card bg-gradient-to-br from-lime-50 via-green-50/30 to-white;
+  @apply module-card bg-linear-to-br from-lime-50 via-green-50/30 to-white;
   border-color: rgba(217, 249, 157, 0.6);
 }
 

--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -1,5 +1,6 @@
 import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
 import { VitePWA } from "vite-plugin-pwa";
 import { visualizer } from "rollup-plugin-visualizer";
 import { sentryVitePlugin } from "@sentry/vite-plugin";
@@ -55,6 +56,7 @@ export default defineConfig(({ mode }) => {
       __APP_BUILD_ID__: JSON.stringify(buildId),
     },
     plugins: [
+      tailwindcss(),
       react(),
       !isCapacitorBuild &&
         VitePWA({

--- a/docs/planning/tailwind-v4-migration.md
+++ b/docs/planning/tailwind-v4-migration.md
@@ -1,7 +1,7 @@
 # Міграція Tailwind CSS v3 → v4
 
 > **Last validated:** 2026-05-03. **Next review:** 2026-08-01.
-> **Status:** Planned — не розпочато.
+> **Status:** Phase 1 (web) — in progress (PR open). Phase 2–4 — не розпочато.
 > **Owner:** @Skords-01
 > **Пріоритет:** Medium — запланувати на Q3–Q4 2026.
 > **Estimated effort:** 2–3 дні (з automated upgrade tool).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,13 +115,13 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@22.19.17)(typescript@5.9.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@22.19.17)(typescript@5.9.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
 
   apps/mobile:
     dependencies:
       '@better-auth/expo':
         specifier: ^1.6.5
-        version: 1.6.5(2sa4j32kaifcqknavd3im42hxm)
+        version: 1.6.5(ky2fzx57v5fszapqs377lsuipm)
       '@expo/metro-runtime':
         specifier: ~4.0.1
         version: 4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))
@@ -172,7 +172,7 @@ importers:
         version: 5.99.2(@tanstack/react-query@5.99.2(react@18.3.1))(react@18.3.1)
       better-auth:
         specifier: ^1.6.4
-        version: 1.6.5(pca7az5l6n4xmwhsjtxh7ahbde)
+        version: 1.6.5(rk3xol7gcwro3e6xnsyizetghe)
       expo:
         specifier: ~52.0.0
         version: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(graphql@16.13.2)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
@@ -363,7 +363,7 @@ importers:
         version: link:../../packages/config
       '@vitest/coverage-v8':
         specifier: ^3.0.0
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
       jsdom:
         specifier: ^29.0.2
         version: 29.0.2(@noble/hashes@2.2.0)
@@ -372,7 +372,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
 
   apps/server:
     dependencies:
@@ -381,7 +381,7 @@ importers:
         version: 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(expo-sqlite@15.1.4(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(graphql@16.13.2)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(kysely@0.28.16)(pg@8.20.0))
       '@better-auth/expo':
         specifier: ^1.6.5
-        version: 1.6.5(jmptqoi7ze5cbcazy64jofvbd4)
+        version: 1.6.5(vqkj2kxpnfwupsesxitmn4dpua)
       '@parse/node-apn':
         specifier: ^8.1.0
         version: 8.1.0
@@ -402,7 +402,7 @@ importers:
         version: 1.8.1
       better-auth:
         specifier: ^1.6.4
-        version: 1.6.5(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(expo-sqlite@15.1.4(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(graphql@16.13.2)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(kysely@0.28.16)(pg@8.20.0))(pg@8.20.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.6.5(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(expo-sqlite@15.1.4(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(graphql@16.13.2)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(kysely@0.28.16)(pg@8.20.0))(pg@8.20.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
       bullmq:
         specifier: ^5.0.0
         version: 5.76.4
@@ -463,7 +463,7 @@ importers:
         version: 3.6.4
       '@vitest/coverage-v8':
         specifier: ^3.0.0
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
       esbuild:
         specifier: ^0.25.6
         version: 0.25.12
@@ -484,7 +484,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
 
   apps/web:
     dependencies:
@@ -553,7 +553,7 @@ importers:
         version: 0.21.3
       better-auth:
         specifier: ^1.6.4
-        version: 1.6.5(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(expo-sqlite@15.1.4(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(graphql@16.13.2)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(kysely@0.28.16)(pg@8.20.0))(pg@8.20.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@1.21.7)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.6.5(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(expo-sqlite@15.1.4(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(graphql@16.13.2)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(kysely@0.28.16)(pg@8.20.0))(pg@8.20.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
       body-highlighter:
         specifier: ^3.0.2
         version: 3.0.2
@@ -632,7 +632,10 @@ importers:
         version: link:../../packages/db-schema
       '@size-limit/file':
         specifier: ^12.1.0
-        version: 12.1.0(size-limit@12.1.0(jiti@1.21.7))
+        version: 12.1.0(size-limit@12.1.0(jiti@2.6.1))
+      '@tailwindcss/vite':
+        specifier: ^4.2.4
+        version: 4.2.4(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
       '@tanstack/react-query-devtools':
         specifier: ^5.99.0
         version: 5.99.2(@tanstack/react-query@5.99.2(react@18.3.1))(react@18.3.1)
@@ -653,13 +656,10 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       '@vitejs/plugin-react':
         specifier: ^4.7.0
-        version: 4.7.0(vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.7.0(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/coverage-v8':
         specifier: ^3.0.0
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@1.21.7)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
-      autoprefixer:
-        specifier: ^10.4.21
-        version: 10.5.0(postcss@8.5.10)
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
@@ -669,30 +669,27 @@ importers:
       msw:
         specifier: ^2.13.6
         version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
-      postcss:
-        specifier: '>=8.5.10'
-        version: 8.5.10
       rollup-plugin-visualizer:
         specifier: ^7.0.1
         version: 7.0.1(rollup@2.80.0)
       size-limit:
         specifier: ^12.1.0
-        version: 12.1.0(jiti@1.21.7)
+        version: 12.1.0(jiti@2.6.1)
       tailwindcss:
-        specifier: ^3.4.17
-        version: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
+        specifier: ^4.2.4
+        version: 4.2.4
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vite:
         specifier: ^6.4.2
-        version: 6.4.2(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+        version: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
       vite-plugin-pwa:
         specifier: ^1.2.0
-        version: 1.2.0(vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0)
+        version: 1.2.0(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0)
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@1.21.7)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/api-client:
     dependencies:
@@ -714,7 +711,7 @@ importers:
         version: 18.3.28
       '@vitest/coverage-v8':
         specifier: ^3.0.0
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -723,7 +720,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/config: {}
 
@@ -747,7 +744,7 @@ importers:
         version: 8.20.0
       '@vitest/coverage-v8':
         specifier: ^3.0.0
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
       better-sqlite3:
         specifier: ^11
         version: 11.10.0
@@ -765,13 +762,13 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/design-tokens:
     devDependencies:
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/eslint-plugin-sergeant-design: {}
 
@@ -789,13 +786,13 @@ importers:
         version: 25.6.0
       '@vitest/coverage-v8':
         specifier: ^3.0.0
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/fizruk-domain:
     devDependencies:
@@ -807,13 +804,13 @@ importers:
         version: 25.6.0
       '@vitest/coverage-v8':
         specifier: ^3.0.0
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/insights:
     dependencies:
@@ -832,13 +829,13 @@ importers:
         version: 25.6.0
       '@vitest/coverage-v8':
         specifier: ^3.0.0
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/nutrition-domain:
     dependencies:
@@ -854,13 +851,13 @@ importers:
         version: 25.6.0
       '@vitest/coverage-v8':
         specifier: ^3.0.0
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/routine-domain:
     devDependencies:
@@ -872,13 +869,13 @@ importers:
         version: 25.6.0
       '@vitest/coverage-v8':
         specifier: ^3.0.0
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/shared:
     dependencies:
@@ -900,13 +897,13 @@ importers:
         version: 25.6.0
       '@vitest/coverage-v8':
         specifier: ^3.0.0
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
 
 packages:
 
@@ -4248,6 +4245,96 @@ packages:
   '@surma/rollup-plugin-off-main-thread@2.2.3':
     resolution: {integrity: sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ==}
 
+  '@tailwindcss/node@4.2.4':
+    resolution: {integrity: sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==}
+
+  '@tailwindcss/oxide-android-arm64@4.2.4':
+    resolution: {integrity: sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.2.4':
+    resolution: {integrity: sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.2.4':
+    resolution: {integrity: sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.2.4':
+    resolution: {integrity: sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.4':
+    resolution: {integrity: sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.4':
+    resolution: {integrity: sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
+    resolution: {integrity: sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
+    resolution: {integrity: sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.2.4':
+    resolution: {integrity: sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.4':
+    resolution: {integrity: sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.4':
+    resolution: {integrity: sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.4':
+    resolution: {integrity: sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.2.4':
+    resolution: {integrity: sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/vite@4.2.4':
+    resolution: {integrity: sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
+
   '@tanstack/query-async-storage-persister@5.99.2':
     resolution: {integrity: sha512-FIr13Zv7GiMZGrdxoxOuzolT4xfyLrKWVBMfTZLMGJTc9IceFu2RT+EfH+j5jcKfvjB4T2no3qWSPGHxYmKKWg==}
 
@@ -5250,13 +5337,6 @@ packages:
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
-
-  autoprefixer@10.5.0:
-    resolution: {integrity: sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==}
-    engines: {node: ^10 || ^12 || >=14}
-    hasBin: true
-    peerDependencies:
-      postcss: '>=8.5.10'
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -7385,9 +7465,6 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
-  fraction.js@5.3.4:
-    resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
-
   freeport-async@2.0.0:
     resolution: {integrity: sha512-K7od3Uw45AJg00XUmy15+Hae2hOcgKcmN3/EF6Y7i01O0gaqiRx8sUSpsb9+BRNL8RPBrhzPsVfy8q9ADlJuWQ==}
     engines: {node: '>=8'}
@@ -8570,8 +8647,20 @@ packages:
   lighthouse-logger@1.4.2:
     resolution: {integrity: sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
   lightningcss-darwin-arm64@1.27.0:
     resolution: {integrity: sha512-Gl/lqIXY+d+ySmMbgDf0pgaWSqrWYxVHoc88q+Vhf2YNzZ8DwoRzGt5NZDVqqIW5ScpSnmmjcgXP87Dn2ylSSQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -8582,8 +8671,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
   lightningcss-freebsd-x64@1.27.0:
     resolution: {integrity: sha512-n1sEf85fePoU2aDN2PzYjoI8gbBqnmLGEhKq7q0DKLj0UTVmOTwDC7PtLcy/zFxzASTSBlVQYJUhwIStQMIpRA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
@@ -8594,8 +8695,20 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
   lightningcss-linux-arm64-gnu@1.27.0:
     resolution: {integrity: sha512-cPsxo1QEWq2sfKkSq2Bq5feQDHdUEwgtA9KaB27J5AX22+l4l0ptgjMZZtYtUnteBofjee+0oW1wQ1guv04a7A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -8606,8 +8719,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
   lightningcss-linux-x64-gnu@1.27.0:
     resolution: {integrity: sha512-Dk/jovSI7qqhJDiUibvaikNKI2x6kWPN79AQiD/E/KeQWMjdGe9kw51RAgoWFDi0coP4jinaH14Nrt/J8z3U4A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -8618,8 +8743,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
   lightningcss-win32-arm64-msvc@1.27.0:
     resolution: {integrity: sha512-/wXegPS1hnhkeG4OXQKEMQeJd48RDC3qdh+OA8pCuOPCyvnm/yEayrJdJVqzBsqpy1aJklRCVxscpFur80o6iQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
@@ -8630,8 +8767,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
   lightningcss@1.27.0:
     resolution: {integrity: sha512-8f7aNmS1+etYSLHht0fQApPc2kNO8qGRutifN5rVIc6Xo6ABsEbqOr758UwI7ALVbTt4x1fllKt0PYgzD9S3yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
   lilconfig@3.1.3:
@@ -10985,6 +11132,9 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
+  tailwindcss@4.2.4:
+    resolution: {integrity: sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==}
+
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
@@ -13162,11 +13312,11 @@ snapshots:
     optionalDependencies:
       drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(expo-sqlite@15.1.4(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(graphql@16.13.2)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(kysely@0.28.16)(pg@8.20.0)
 
-  '@better-auth/expo@1.6.5(2sa4j32kaifcqknavd3im42hxm)':
+  '@better-auth/expo@1.6.5(ky2fzx57v5fszapqs377lsuipm)':
     dependencies:
       '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-fetch/fetch': 1.1.21
-      better-auth: 1.6.5(pca7az5l6n4xmwhsjtxh7ahbde)
+      better-auth: 1.6.5(rk3xol7gcwro3e6xnsyizetghe)
       better-call: 1.3.5(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
@@ -13175,11 +13325,11 @@ snapshots:
       expo-network: 7.0.5(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(graphql@16.13.2)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react@18.3.1)
       expo-web-browser: 14.0.2(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(graphql@16.13.2)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))
 
-  '@better-auth/expo@1.6.5(jmptqoi7ze5cbcazy64jofvbd4)':
+  '@better-auth/expo@1.6.5(vqkj2kxpnfwupsesxitmn4dpua)':
     dependencies:
       '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-fetch/fetch': 1.1.21
-      better-auth: 1.6.5(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(expo-sqlite@15.1.4(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(graphql@16.13.2)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(kysely@0.28.16)(pg@8.20.0))(pg@8.20.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+      better-auth: 1.6.5(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(expo-sqlite@15.1.4(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(graphql@16.13.2)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(kysely@0.28.16)(pg@8.20.0))(pg@8.20.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
       better-call: 1.3.5(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
@@ -15851,9 +16001,9 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@size-limit/file@12.1.0(size-limit@12.1.0(jiti@1.21.7))':
+  '@size-limit/file@12.1.0(size-limit@12.1.0(jiti@2.6.1))':
     dependencies:
-      size-limit: 12.1.0(jiti@1.21.7)
+      size-limit: 12.1.0(jiti@2.6.1)
 
   '@so-ric/colorspace@1.1.6':
     dependencies:
@@ -15870,6 +16020,74 @@ snapshots:
       json5: 2.2.3
       magic-string: 0.25.9
       string.prototype.matchall: 4.0.12
+
+  '@tailwindcss/node@4.2.4':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.21.0
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.2.4
+
+  '@tailwindcss/oxide-android-arm64@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide@4.2.4':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.2.4
+      '@tailwindcss/oxide-darwin-arm64': 4.2.4
+      '@tailwindcss/oxide-darwin-x64': 4.2.4
+      '@tailwindcss/oxide-freebsd-x64': 4.2.4
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.2.4
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.2.4
+      '@tailwindcss/oxide-linux-arm64-musl': 4.2.4
+      '@tailwindcss/oxide-linux-x64-gnu': 4.2.4
+      '@tailwindcss/oxide-linux-x64-musl': 4.2.4
+      '@tailwindcss/oxide-wasm32-wasi': 4.2.4
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.2.4
+      '@tailwindcss/oxide-win32-x64-msvc': 4.2.4
+
+  '@tailwindcss/vite@4.2.4(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@tailwindcss/node': 4.2.4
+      '@tailwindcss/oxide': 4.2.4
+      tailwindcss: 4.2.4
+      vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
 
   '@tanstack/query-async-storage-persister@5.99.2':
     dependencies:
@@ -16485,7 +16703,7 @@ snapshots:
     optionalDependencies:
       react: 18.3.1
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -16493,11 +16711,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.2(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@1.21.7)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -16512,26 +16730,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@1.21.7)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@bcoe/v8-coverage': 1.0.2
-      ast-v8-to-istanbul: 0.3.12
-      debug: 4.4.3
-      istanbul-lib-coverage: 3.2.2
-      istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6
-      istanbul-reports: 3.2.0
-      magic-string: 0.30.21
-      magicast: 0.3.5
-      std-env: 3.10.0
-      test-exclude: 7.0.2
-      tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -16543,42 +16742,33 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(msw@2.13.6(@types/node@22.19.17)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@3.2.4(msw@2.13.6(@types/node@22.19.17)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.13.6(@types/node@22.19.17)(typescript@5.9.3)
-      vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
 
-  '@vitest/mocker@3.2.4(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@3.2.4(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.13.6(@types/node@25.6.0)(typescript@5.9.3)
-      vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
     optional: true
 
-  '@vitest/mocker@3.2.4(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@3.2.4(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
-      vite: 6.4.2(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
-
-  '@vitest/mocker@3.2.4(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      msw: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
-      vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -17052,15 +17242,6 @@ snapshots:
 
   atomic-sleep@1.0.0: {}
 
-  autoprefixer@10.5.0(postcss@8.5.10):
-    dependencies:
-      browserslist: 4.28.2
-      caniuse-lite: 1.0.30001788
-      fraction.js: 5.3.4
-      picocolors: 1.1.1
-      postcss: 8.5.10
-      postcss-value-parser: 4.2.0
-
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -17242,7 +17423,7 @@ snapshots:
     dependencies:
       tweetnacl: 0.14.5
 
-  better-auth@1.6.5(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(expo-sqlite@15.1.4(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(graphql@16.13.2)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(kysely@0.28.16)(pg@8.20.0))(pg@8.20.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@1.21.7)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)):
+  better-auth@1.6.5(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(expo-sqlite@15.1.4(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(graphql@16.13.2)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(kysely@0.28.16)(pg@8.20.0))(pg@8.20.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(expo-sqlite@15.1.4(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(graphql@16.13.2)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(kysely@0.28.16)(pg@8.20.0))
@@ -17267,42 +17448,12 @@ snapshots:
       pg: 8.20.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@1.21.7)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
 
-  better-auth@1.6.5(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(expo-sqlite@15.1.4(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(graphql@16.13.2)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(kysely@0.28.16)(pg@8.20.0))(pg@8.20.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)):
-    dependencies:
-      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(expo-sqlite@15.1.4(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(graphql@16.13.2)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(kysely@0.28.16)(pg@8.20.0))
-      '@better-auth/kysely-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.16)
-      '@better-auth/memory-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/mongo-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/prisma-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/telemetry': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)
-      '@better-auth/utils': 0.4.0
-      '@better-fetch/fetch': 1.1.21
-      '@noble/ciphers': 2.2.0
-      '@noble/hashes': 2.2.0
-      better-call: 1.3.5(zod@4.3.6)
-      defu: 6.1.7
-      jose: 6.2.2
-      kysely: 0.28.16
-      nanostores: 1.3.0
-      zod: 4.3.6
-    optionalDependencies:
-      drizzle-kit: 0.31.10
-      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(expo-sqlite@15.1.4(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(graphql@16.13.2)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(kysely@0.28.16)(pg@8.20.0)
-      pg: 8.20.0
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - '@cloudflare/workers-types'
-      - '@opentelemetry/api'
-
-  better-auth@1.6.5(pca7az5l6n4xmwhsjtxh7ahbde):
+  better-auth@1.6.5(rk3xol7gcwro3e6xnsyizetghe):
     dependencies:
       '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(expo-sqlite@15.1.4(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(graphql@16.13.2)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.3(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(kysely@0.28.16)(pg@8.20.0))
@@ -17328,7 +17479,7 @@ snapshots:
       pg: 8.20.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@1.21.7)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -19513,8 +19664,6 @@ snapshots:
 
   forwarded@0.2.0: {}
 
-  fraction.js@5.3.4: {}
-
   freeport-async@2.0.0: {}
 
   fresh@0.5.2: {}
@@ -21033,34 +21182,67 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
   lightningcss-darwin-arm64@1.27.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
     optional: true
 
   lightningcss-darwin-x64@1.27.0:
     optional: true
 
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
   lightningcss-freebsd-x64@1.27.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.27.0:
     optional: true
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
   lightningcss-linux-arm64-gnu@1.27.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.27.0:
     optional: true
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
   lightningcss-linux-x64-gnu@1.27.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.27.0:
     optional: true
 
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
   lightningcss-win32-arm64-msvc@1.27.0:
     optional: true
 
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
   lightningcss-win32-x64-msvc@1.27.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
     optional: true
 
   lightningcss@1.27.0:
@@ -21077,6 +21259,22 @@ snapshots:
       lightningcss-linux-x64-musl: 1.27.0
       lightningcss-win32-arm64-msvc: 1.27.0
       lightningcss-win32-x64-msvc: 1.27.0
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   lilconfig@3.1.3: {}
 
@@ -23606,7 +23804,7 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
-  size-limit@12.1.0(jiti@1.21.7):
+  size-limit@12.1.0(jiti@2.6.1):
     dependencies:
       bytes-iec: 3.1.1
       lilconfig: 3.1.3
@@ -23614,7 +23812,7 @@ snapshots:
       picocolors: 1.1.1
       tinyglobby: 0.2.16
     optionalDependencies:
-      jiti: 1.21.7
+      jiti: 2.6.1
 
   slash@3.0.0: {}
 
@@ -24007,6 +24205,8 @@ snapshots:
     transitivePeerDependencies:
       - tsx
       - yaml
+
+  tailwindcss@4.2.4: {}
 
   tapable@2.3.3: {}
 
@@ -24847,13 +25047,13 @@ snapshots:
       victory-voronoi-container: 36.9.2(react@18.3.1)
       victory-zoom-container: 36.9.2(react@18.3.1)
 
-  vite-node@3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3):
+  vite-node@3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -24868,13 +25068,35 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.2.4(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3):
+  vite-node@3.2.4(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.4.2(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+    optional: true
+
+  vite-node@3.2.4(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -24889,39 +25111,18 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.2.4(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.3
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  vite-plugin-pwa@1.2.0(vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0):
+  vite-plugin-pwa@1.2.0(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0):
     dependencies:
       debug: 4.4.3
       pretty-bytes: 6.1.1
       tinyglobby: 0.2.16
-      vite: 6.4.2(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
       workbox-build: 7.4.0(@types/babel__core@7.20.5)
       workbox-window: 7.4.0
     transitivePeerDependencies:
       - supports-color
 
-  vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3):
+  vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -24933,12 +25134,12 @@ snapshots:
       '@types/node': 22.19.17
       fsevents: 2.3.3
       jiti: 2.6.1
-      lightningcss: 1.27.0
+      lightningcss: 1.32.0
       terser: 5.46.2
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3):
+  vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -24950,12 +25151,13 @@ snapshots:
       '@types/node': 25.6.0
       fsevents: 2.3.3
       jiti: 1.21.7
-      lightningcss: 1.27.0
+      lightningcss: 1.32.0
       terser: 5.46.2
       tsx: 4.21.0
       yaml: 2.8.3
+    optional: true
 
-  vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3):
+  vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -24967,16 +25169,16 @@ snapshots:
       '@types/node': 25.6.0
       fsevents: 2.3.3
       jiti: 2.6.1
-      lightningcss: 1.27.0
+      lightningcss: 1.32.0
       terser: 5.46.2
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@22.19.17)(typescript@5.9.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3):
+  vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@22.19.17)(typescript@5.9.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.13.6(@types/node@22.19.17)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(msw@2.13.6(@types/node@22.19.17)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -24994,8 +25196,8 @@ snapshots:
       tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
-      vite-node: 3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.13
@@ -25015,11 +25217,11 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@1.21.7)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3):
+  vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@1.21.7)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -25037,51 +25239,8 @@ snapshots:
       tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.4.2(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
-      vite-node: 3.2.4(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/debug': 4.1.13
-      '@types/node': 25.6.0
-      jsdom: 29.0.2(@noble/hashes@2.2.0)
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3):
-    dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      debug: 4.4.3
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 3.10.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.16
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
-      vite-node: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.13
@@ -25102,11 +25261,11 @@ snapshots:
       - yaml
     optional: true
 
-  vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3):
+  vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -25124,8 +25283,8 @@ snapshots:
       tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
-      vite-node: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.13


### PR DESCRIPTION
## Summary

Phase 1 з плану `docs/planning/tailwind-v4-migration.md` — мігруємо **тільки `apps/web`** на Tailwind CSS v4. Mobile залишається на v3 поки NativeWind не отримає сумісність із v4 (Phase 2). Shared `packages/design-tokens/tailwind-preset.js` — без змін: web підвантажує його через `@config` директиву.

Що змінилося:

- `apps/web/package.json` — `tailwindcss ^3.4.17` → `^4.2.4`, додано `@tailwindcss/vite ^4.2.4`, видалено `autoprefixer` і `postcss` (Tailwind v4 + Vite plugin беруть це на себе)
- `apps/web/postcss.config.js` — видалено
- `apps/web/vite.config.js` — підключено `@tailwindcss/vite` плагін
- `apps/web/src/index.css` — `@tailwind base/components/utilities` → `@import 'tailwindcss';` + `@config '../tailwind.config.js';` + v4 default-border-color compatibility shim
- Custom plain-CSS класи, на які посилається `@apply` (`.module-card`, `.skeleton`, `.glass`), переведені у `@utility` блоки з вкладеними `&::after` / `.dark &` правилами (v4 вимога)
- `.module-card` базовий блок винесений з `@import './styles/module-surfaces.css' layer(base)` бо v4 забороняє `@utility` всередині `@layer`
- 76 JSX/TSX файлів пройшли `npx @tailwindcss/upgrade`: `bg-gradient-*` → `bg-linear-*`, `outline-none` → `outline-hidden`, `!class` → `class!`, `z-[9999]` → `z-9999`, тощо
- Повернуто arbitrary opacity синтаксис `/[.06]` у `ModuleHeader.tsx` і `HeroCard.tsx` — upgrade tool помилково сконвертував у `/6`
- `size-limit` для CSS: 22 kB → 28 kB (v4 baseline output трохи більший — `24.59 kB` brotli після білда)
- `docs/planning/tailwind-v4-migration.md` — статус оновлений на «Phase 1 (web) — in progress»

Mobile (Phase 2) і design-tokens preset rewrite (Phase 3) — окремими PR-ами потім.

## Governing Skill

- Primary skill: жодний skill безпосередньо не описує web-only Tailwind migration; йшов за `docs/planning/tailwind-v4-migration.md` Phase 1 як checklist
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: жодний наявний playbook не покриває цей шлях
- Why this playbook: n/a
- If no playbook matched, why: одноразова framework-міграція; план уже задокументований у `docs/planning/tailwind-v4-migration.md`

## Verification

```bash
pnpm install --no-frozen-lockfile
pnpm exec turbo run build --filter=@sergeant/web      # ✓ 2 successful
pnpm exec turbo run lint --filter=@sergeant/web       # ✓ no errors
pnpm exec turbo run typecheck --filter=@sergeant/web  # ✓ tsc + tsc:sw clean
pnpm exec turbo run test --filter=@sergeant/web       # ✓ 175 files, 1824 tests passed
pnpm --filter @sergeant/web size                      # ✓ JS 798.95 / 820 kB, CSS 24.59 / 28 kB
pnpm exec turbo run typecheck --filter=@sergeant/mobile # ✓ mobile still v3.4.19
```

Additional checks:

- [x] Local smoke / manual validation completed (Node 20.20.2 / pnpm 9.15.1)
- [x] Surface-specific checks completed (mobile typecheck)
- [ ] Argos visual regression — у CI; локально не ганяв

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- `docs/planning/tailwind-v4-migration.md` — статус "Phase 1 (web) — in progress"

## Risk and Rollout

- User-visible risk: **середній**. v4 має нові default-кольори бордерів (currentcolor замість gray-200) — додано compatibility shim в `@layer base`. Найбільш чутливі поверхні — module-card hero gradients, skeleton shimmer, glassmorphism — переведені у `@utility` руками. Треба перевірити візуально через Argos / preview deploy перед merge.
- Rollout / deploy order: standalone PR, без міграцій БД, без ENV-змін. Mobile і console не зачеплені.
- Backout plan: `git revert` merge-комміта; нічого зовнішнього не торкається.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

- `apps/web/src/index.css` — всі custom `.x { @apply ... }` тепер `@utility x { ... }`. Cascade-порядок у v4 інший за v3, тож edge-case візуальні регресії можливі.
- `apps/web/src/styles/module-surfaces.css` — імпорт більше не через `layer(base)`; cascade трохи зсунутий, варто перевірити hover-стан hero cards.
- `ModuleHeader.tsx` / `HeroCard.tsx` — повернуто у `from-finyk/[.06]` синтаксис.
- CSS bundle: 19.7 kB brotli (v3) → 24.59 kB brotli (v4), +25%. Можна скоротити Phase 3 (CSS-first preset).
- `apps/web/postcss.config.js` видалено повністю.
- `apps/web/tailwind.config.js` і `packages/design-tokens/tailwind-preset.js` — НЕ змінилися. Це навмисно: план рекомендує тримати JS preset через `@config` до Phase 3.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrate `apps/web` to Tailwind CSS v4 using the Vite plugin and update CSS/templates to v4 syntax. Mobile stays on v3; the shared design-tokens preset still loads via `@config`.

- **Dependencies**
  - Upgrade `tailwindcss` to `^4.2.4`; add `@tailwindcss/vite` in `vite.config.js`.
  - Remove `postcss` and `autoprefixer`; delete `apps/web/postcss.config.js`.
  - Increase CSS `size-limit` from 22 kB to 28 kB.

- **Migration**
  - Switch `index.css` to `@import 'tailwindcss'` and `@config '../tailwind.config.js'`; move font/animation imports under `layer(base)`; add a base shim for v3’s default border color.
  - Convert custom `@apply` targets to `@utility` (e.g., `.module-card`, `.skeleton`, `.glass`) with nested rules; move `.module-card` out of `@layer`; update gradients to `bg-linear-*`.
  - Run `@tailwindcss/upgrade` and clean up: `outline-hidden`, `x!` important syntax, numeric `z-*`, `pointer-fine/coarse:` variants, `break-words`→`wrap-break-word`, restore `/[.06]` opacities, and normalize a few utility values (e.g., `min-w-28`, `min-h-14`, `border-l-4`).

<sup>Written for commit 29a9f7398ee2a1254c3df9470d3eb6f012de456c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

