### PR TITLE
fix(migrations): cleanup orphan 032 tracking row after #1502 (+ stale 032 refs)

### DIFF
--- a/apps/server/src/migrations/033_mono_webhook_secret_rotated_at.down.sql
+++ b/apps/server/src/migrations/033_mono_webhook_secret_rotated_at.down.sql
@@ -1,4 +1,4 @@
--- Reverse of 032. Idempotent (rollback-sanity test re-runs every down twice).
+-- Reverse of 033. Idempotent (rollback-sanity test re-runs every down twice).
 DROP INDEX IF EXISTS mono_connection_webhook_secret_rotated_at_idx;
 ALTER TABLE mono_connection
   DROP COLUMN IF EXISTS webhook_secret_rotated_at;

--- a/apps/server/src/migrations/034_cleanup_orphan_032_tracking.sql
+++ b/apps/server/src/migrations/034_cleanup_orphan_032_tracking.sql
@@ -1,0 +1,43 @@
+-- Cleanup orphan tracking row left by the 032 → 033 rename of
+-- mono_webhook_secret_rotated_at (PR #1502).
+--
+-- Background. PR #1490 and PR #1497 simultaneously landed migration
+-- number 032 (one each), creating a duplicate that broke `pnpm
+-- lint:migrations` on every PR opened against main. PR #1502 fixed the
+-- duplicate by renaming the mono webhook file from 032 to 033. By the
+-- time #1502 merges, Railway's pre-deploy hook (`pnpm --filter
+-- @sergeant/server db:migrate`, ADR-0013 §13.3) has already applied the
+-- original under its old filename `032_mono_webhook_secret_rotated_at.sql`
+-- and recorded it in `schema_migrations`. The physical schema is correct —
+-- the 033 file is byte-identical and all its DDL is `IF NOT EXISTS` /
+-- `COALESCE`-guarded, so re-applying it under the new name is a full
+-- no-op. But `schema_migrations` is left with an orphan row whose name
+-- references a file that no longer exists on disk.
+--
+-- This migration deletes that orphan row so the tracking table stays in
+-- 1:1 correspondence with the on-disk migration files. On a database
+-- that was never deployed under the old filename (CI containers,
+-- developer laptops cloned after the rename) the DELETE matches zero
+-- rows and is a silent no-op.
+--
+-- The `DO $$ … information_schema` guard exists because the rollback
+-- sanity test (`apps/server/src/migrations/__tests__/rollback-sanity.test.ts`)
+-- applies forward migrations directly against a freshly-dropped public
+-- schema without first running `ensureSchema()` — so the
+-- `schema_migrations` table itself does not exist when this file is
+-- replayed in that test. Skipping the DELETE in that case is correct:
+-- the orphan row is a production-state artifact that can't appear in a
+-- clean-schema test container.
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_name = 'schema_migrations'
+  ) THEN
+    DELETE FROM schema_migrations
+    WHERE name = '032_mono_webhook_secret_rotated_at.sql';
+  END IF;
+END $$;

--- a/apps/server/src/modules/mono/rotateSecret.ts
+++ b/apps/server/src/modules/mono/rotateSecret.ts
@@ -10,7 +10,7 @@ import { decryptToken, tokenFingerprint, webhookSecretHash } from "./crypto.js";
  * — the secret in the URL we register stays valid until we replace it.
  * That makes a silent leak (proxy access-log, screenshot, packet capture)
  * a forge-anyone's-statements primitive forever, so we age the secret out
- * on a fixed schedule. Migration 032 added `webhook_secret_rotated_at` to
+ * on a fixed schedule. Migration 033 added `webhook_secret_rotated_at` to
  * `mono_connection`; this module owns the actual rotation flow.
  *
  * One rotation = (1) decrypt the user's persisted Monobank token, (2)


### PR DESCRIPTION
## Summary

Follow-up до PR #1502 (`renumber mono webhook rotation 032 -> 033 + gitleaks allow on test fixture`).

#1502 використав простий `git mv` для перейменування `032_mono_webhook_secret_rotated_at.sql` → `033_*`, що залишило три loose ends на main:

1. **Orphan row у `schema_migrations`.** Railway pre-deploy hook (ADR-0013 §13.3) ще до мерджу #1502 застосував 032 під старим іменем і записав його у `schema_migrations` як `032_mono_webhook_secret_rotated_at.sql`. Після rename ця tracking-row посилається на файл, якого вже немає на диску. 033 при наступному deploy re-apply-иться (no-op DDL — `IF NOT EXISTS` / `COALESCE`) і додасть свою tracking-row. Тобто `schema_migrations` опиниться в 1:N стані замість 1:1 з on-disk файлами.

2. **Stale comment у 033.down.sql:** header досі `-- Reverse of 032`.

3. **Stale JSDoc у rotateSecret.ts:** посилається на `Migration 032 added` хоча колонку зараз додає 033.

Цей PR закриває всі три:

| Файл | Зміна |
|---|---|
| `apps/server/src/migrations/034_cleanup_orphan_032_tracking.sql` | **NEW** — `DELETE FROM schema_migrations WHERE name = '032_mono_webhook_secret_rotated_at.sql'` обгорнутий у `DO $$ IF EXISTS (information_schema.tables) $$` для сумісності з rollback-sanity тестом |
| `apps/server/src/migrations/033_mono_webhook_secret_rotated_at.down.sql` | `-- Reverse of 032` → `-- Reverse of 033` |
| `apps/server/src/modules/mono/rotateSecret.ts` | JSDoc `Migration 032 added` → `Migration 033 added` |

## Чому DO-block guard на DELETE

`apps/server/src/migrations/__tests__/rollback-sanity.test.ts` rollback-ить `public` schema (`DROP SCHEMA public CASCADE; CREATE SCHEMA public`) і потім re-apply-ить кожну forward-міграцію напряму через `pool.query(file)` — БЕЗ виклику `ensureSchema()`, який створює `schema_migrations`. Тому в test-контейнері тієї таблиці не існує, і простий `DELETE FROM schema_migrations …` впав би з `ERROR: relation "schema_migrations" does not exist`. `IF EXISTS (information_schema.tables …)` робить DELETE conditional: на проді (де таблиця існує) — виконується; в тест-середовищі — silently no-op.

## Verification

```bash
# 1. Migration lint
pnpm lint:migrations
# ✅ Migration lint passed.

# 2. Rollback sanity (Docker pgvector/pgvector:pg16)
pnpm --filter @sergeant/server vitest run src/migrations/__tests__/rollback-sanity.test.ts
# ✅ 4/4 tests passed (4242ms)

# 3. End-to-end migrate runner against fresh container
docker run -d --rm --name pg-mig-test \
  -e POSTGRES_USER=hub -e POSTGRES_PASSWORD=hub -e POSTGRES_DB=hub_test \
  -p 55432:5432 pgvector/pgvector:pg16
DATABASE_URL=postgresql://hub:hub@localhost:55432/hub_test \
MIGRATE_DATABASE_URL=postgresql://hub:hub@localhost:55432/hub_test \
  pnpm --filter @sergeant/server db:migrate:dev
# ✅ migrations 001..034 applied, migrate_ok, durationMs=646

# 4. Simulate prod state: insert orphan row, re-run
docker exec pg-mig-test psql -U hub -d hub_test -c "
  INSERT INTO schema_migrations (name) VALUES ('032_mono_webhook_secret_rotated_at.sql');
  DELETE FROM schema_migrations WHERE name = '034_cleanup_orphan_032_tracking.sql';
"
# Re-run migrate.mjs
# ✅ 034 re-applies, orphan row deleted, schema_migrations contains
#    033_mono_webhook_secret_rotated_at.sql + 034_cleanup_orphan_032_tracking.sql

# 5. Idempotency
pnpm --filter @sergeant/server db:migrate:dev
# ✅ migrate_ok, 0 new migrations applied (durationMs=50)

# 6. Server-package checks
pnpm exec turbo run lint typecheck --filter=@sergeant/server
# ✅ 3/3 successful (lint, typecheck, deps)
```

## Governing Skill

- Primary skill: `.agents/skills/sergeant-data-and-migrations/SKILL.md`
- Why this skill: цей PR створює нову SQL міграцію та виправляє stale-references на номер міграції — точно в скоупі data-and-migrations skill.

## Playbook

- Primary playbook: `docs/playbooks/pre-merge-migration-checklist.md` (Hard Rule #4 — sequential migration numbers, idempotency)
- Why this playbook: `034_cleanup_orphan_032_tracking.sql` — нова SQL міграція. Checklist стосується безпосередньо: idempotent (DELETE з 0 affected — no-op), forward-only (немає `.down.sql`), guarded (DO-block + IF EXISTS).

## Risk and Rollout

- **User-visible risk: minimal.** Mono webhook rotation worker (PR #1497) уже у проді з ~18:10Z. Колонка `webhook_secret_rotated_at` створена, дані backfill-нуті. 033 (вже на main через #1502) повторно застосується — повний no-op на schema-рівні (`ALTER TABLE … ADD COLUMN IF NOT EXISTS` / `COALESCE` / `IF NOT EXISTS`).
- **schema_migrations side-effect.** ДО deploy-у цього PR прод-БД має row `032_mono_webhook_secret_rotated_at.sql` (orphan після #1502 rename). ПІСЛЯ deploy-у цього PR:
  1. Раннер бачить `034_cleanup_orphan_032_tracking.sql` як unapplied → виконує `DELETE FROM schema_migrations WHERE name = '032_mono_webhook_secret_rotated_at.sql'` (1 row affected) → INSERT тracking row для 034.
  2. Кінцевий стан `schema_migrations`: `033_mono_webhook_secret_rotated_at.sql` + `034_cleanup_orphan_032_tracking.sql`. 1:1 кореспонденція з on-disk файлами відновлена.
- **Backout plan.** Revert цього PR залишає orphan row у проді (косметичний debt, не функціональний bug). Якщо `034` колись треба буде переробити — нова forward-only міграція згідно ADR-0013 §13.3 (ніколи не запускаємо `down.sql` проти прод-БД).

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

- `034_cleanup_orphan_032_tracking.sql` НЕ має `.down.sql`. ADR-0013 §13.3 явно дозволяє опційні down-файли; додавати reverse «re-INSERT orphan» не має сенсу — це штучне відтворення зламаного стану.
- Альтернатива, яку НЕ обрав: amend manual SQL у Railway dashboard (`DELETE FROM schema_migrations …`). Не репрезентовано в коді → новий developer чи rebuild контейнер не побачить, що orphan-row був прибраний. Forward-only migration — єдиний source-of-truth-friendly спосіб.
- Pre-existing test failure у `apps/server/src/registerRoutes.test.ts` snapshot (нові `/api/internal/alerts/*` endpoints від PR #1496) — НЕ зачіпає цей PR. Падає однаково на main.
