### PR TITLE
fix(hub): equalize bento card heights and unify empty-state CTA

### DIFF
--- a/apps/web/src/core/hub/dashboard/BentoCard.tsx
+++ b/apps/web/src/core/hub/dashboard/BentoCard.tsx
@@ -91,7 +91,7 @@ export const BentoCard = memo(function BentoCard({
   return (
     <div
       className={cn(
-        "relative",
+        "relative h-full",
         isDragging && "opacity-70 z-50",
         inactive && "opacity-60",
         // Edit-mode wiggle. Suppressed while a card is being dragged so
@@ -111,7 +111,7 @@ export const BentoCard = memo(function BentoCard({
         }
         data-inactive={inactive ? "true" : undefined}
         className={cn(
-          "group relative flex flex-col w-full rounded-3xl border border-line",
+          "group relative flex flex-col w-full h-full rounded-3xl border border-line",
           "p-3.5 pointer-coarse:p-4",
           "min-h-[120px] pointer-coarse:min-h-[132px]",
           "shadow-card transition-interactive text-left",
@@ -194,12 +194,16 @@ export const BentoCard = memo(function BentoCard({
               </span>
             )}
           </>
-        ) : onQuickAdd && !editMode ? (
+        ) : !editMode ? (
           // Empty-state CTA — promoted from a single inline pill (icon + label
           // glyph) to a two-row layout with a tinted leading icon-box and an
           // explicit «Натисни, щоб почати» helper. The richer treatment makes
           // the card read as an *invitation* (clear affordance + verb) instead
           // of a generic «+ Почни тут →» eyebrow that the eye skipped past.
+          // Rendered for every empty card (with or without a quick-add
+          // affordance) so the bento grid does not visibly mix two empty-
+          // state heights — the previous split between rich/simple variants
+          // produced the uneven row the IA pass is fixing.
           <div className="mt-1.5 flex flex-col gap-1">
             <div className="flex items-center gap-1.5">
               <span
@@ -379,7 +383,7 @@ export const SortableCard = memo(function SortableCard({
   if (!cfg) return null;
 
   return (
-    <div ref={setNodeRef} style={style} className="min-w-0">
+    <div ref={setNodeRef} style={style} className="min-w-0 h-full">
       <BentoCard
         config={cfg}
         onClick={handleClick}


### PR DESCRIPTION
## Summary

Cards у бенто-сітці модулів дашборду мали помітно різну висоту: модулі з quick-add (наприклад, Фінік / Харчування) рендерили багату двохрядкову empty-state (іконка-плюс + label + підпис «Натисни, щоб почати»), а модулі без сигналу (Фізрук / Рутина) фолбекали на одинокий рядок «Почни тут →». Через це ряд сітки осідав за висотою найвищого сусіда, а простіші картки виглядали короткими з мертвим простором внизу.

- Додано `h-full` на `SortableCard` wrapper, `BentoCard` wrapper і primary `<button>` — всі картки тепер тягнуться до висоти ряду через дефолтний `align-items: stretch` грід-контейнера.
- Уніфіковано empty-state: повний CTA (іконка-плюс + emptyLabel + «Натисни, щоб почати») рендериться для будь-якої порожньої активної картки, незалежно від наявності `onQuickAdd`. Сама картка і так навігаційний афорданс, тому дієслово «Натисни» читається коректно навіть без quick-add.

## Governing Skill

- Primary skill: `apps/web/src/core/hub` (UI / dashboard)
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a — точкове UI-виправлення
- Why this playbook: суто візуальна правка bento-сітки в одному файлі
- If no playbook matched, why: зміна обмежена `apps/web/src/core/hub/dashboard/BentoCard.tsx`, окремого playbook'у під такі IA-tweaks немає

## Verification

```bash
pnpm exec eslint apps/web/src/core/hub/dashboard/BentoCard.tsx
# → 0 errors / 0 warnings
```

Additional checks:

- [x] Local smoke / manual validation completed (lint clean for зачеплений файл)
- [ ] Surface-specific checks completed

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. — n/a, чисто візуальна зміна
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a

## Risk and Rollout

- User-visible risk: низький — empty-state та висота карток у головному дашборді. Cards з даними не змінюються (та сама гілка `hasData`).
- Rollout / deploy order: standard `apps/web` deploy.
- Backout plan: revert цього PR — зміни локалізовані в одному файлі.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

Зміни обмежені одним файлом — `apps/web/src/core/hub/dashboard/BentoCard.tsx`. Тест `apps/web/src/core/hub/HubDashboard.test.tsx` шукає `MODULE_CONFIGS.fizruk.emptyLabel` (== «Почни тут →») і він і далі рендериться у новій уніфікованій empty-state, тому існуючі очікування не ламаються.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Card layouts now properly fill available vertical space for improved visual consistency
  - Empty module tiles now display a consistent action prompt to help users get started

<!-- end of auto-generated comment: release notes by coderabbit.ai -->