### PR TITLE
feat(server): replace in-memory rate-limit with Postgres-backed bucket

### DIFF
--- a/apps/server/src/http/rateLimit.test.ts
+++ b/apps/server/src/http/rateLimit.test.ts
@@ -16,13 +16,48 @@ vi.mock("../lib/redis.js", () => ({
   getRedis: vi.fn(() => null),
 }));
 
+// Postgres mock — `checkRateLimitPg` and the periodic sweep query the
+// pool. By default behave as if the migration hasn't been applied
+// (SQLSTATE 42P01) so the middleware falls through to the in-memory
+// limiter; individual tests opt in to specific row payloads.
+const pgQueryMock = vi.fn();
+vi.mock("../db.js", () => ({
+  pool: {
+    query: (...args: unknown[]) => pgQueryMock(...args),
+  },
+}));
+
+const loggerWarnMock = vi.fn();
+vi.mock("../obs/logger.js", () => ({
+  logger: {
+    warn: (...args: unknown[]) => loggerWarnMock(...args),
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
 import {
   getIp,
   checkRateLimit,
   checkRateLimitRedis,
+  checkRateLimitPg,
   rateLimitExpress,
+  __resetRateLimitPgWarnForTests,
 } from "./rateLimit.js";
 import { getRedis } from "../lib/redis.js";
+
+function pgUndefinedTableError(): Error & { code: string } {
+  // Mirrors the `pg` driver's shape for SQLSTATE 42P01 — the
+  // `checkRateLimitPgWithFallback` branch keys on `err.code`.
+  const err = new Error(
+    'relation "rate_limit_buckets" does not exist',
+  ) as Error & {
+    code: string;
+  };
+  err.code = "42P01";
+  return err;
+}
 
 function asReq(partial: Partial<Request> & Record<string, unknown>): Request {
   return partial as unknown as Request;
@@ -264,6 +299,13 @@ describe("rateLimitExpress — Redis path", () => {
   beforeEach(() => {
     vi.mocked(getRedis).mockReturnValue(null);
     redisEvalMock.mockReset();
+    // Default to "Postgres unreachable" so the middleware falls all the
+    // way through to the in-memory limiter — keeps these tests focused
+    // on Redis-vs-fallback rather than the Postgres branch (covered in
+    // its own describe block).
+    pgQueryMock.mockReset();
+    pgQueryMock.mockRejectedValue(pgUndefinedTableError());
+    loggerWarnMock.mockReset();
   });
 
   it("uses Redis when getRedis() returns a client", async () => {
@@ -372,5 +414,198 @@ describe("rateLimitExpress — Redis path", () => {
         code: "RATE_LIMIT",
       }),
     );
+  });
+});
+
+describe("checkRateLimitPg", () => {
+  function makeReq(ip: string): Request {
+    return { ip, headers: {} } as unknown as Request;
+  }
+
+  beforeEach(() => {
+    pgQueryMock.mockReset();
+  });
+
+  it("allows when count is within limit and reports remaining", async () => {
+    pgQueryMock.mockResolvedValueOnce({
+      rows: [{ count: 3, elapsed_ms: "200" }],
+    });
+    const result = await checkRateLimitPg(makeReq("203.0.113.10"), {
+      key: "pg:allow",
+      limit: 5,
+      windowMs: 5_000,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.remaining).toBe(2);
+    expect(result.resetMs).toBe(4_800);
+    // INSERT … ON CONFLICT … RETURNING — windowMs flows through as a
+    // string so the bigint cast in SQL is unambiguous.
+    expect(pgQueryMock).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO rate_limit_buckets"),
+      ["pg:allow", expect.any(String), "5000"],
+    );
+  });
+
+  it("blocks once count exceeds limit", async () => {
+    pgQueryMock.mockResolvedValueOnce({
+      rows: [{ count: 6, elapsed_ms: "2000" }],
+    });
+    const result = await checkRateLimitPg(makeReq("203.0.113.11"), {
+      key: "pg:block",
+      limit: 5,
+      windowMs: 5_000,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.remaining).toBe(0);
+    expect(result.resetMs).toBe(3_000);
+  });
+
+  it("clamps retryAfterSec to a 1s floor for tiny windows", async () => {
+    // Same regression as the Redis path: better-fetch / Better Auth
+    // refuse `Retry-After: 0` and surface a generic error to the user.
+    pgQueryMock.mockResolvedValueOnce({
+      rows: [{ count: 2, elapsed_ms: "50" }],
+    });
+    const result = await checkRateLimitPg(makeReq("203.0.113.12"), {
+      key: "pg:retry",
+      limit: 1,
+      windowMs: 100,
+    });
+    expect(result.retryAfterSec).toBeGreaterThanOrEqual(1);
+  });
+
+  it("treats a fresh-bucket return (count=1) as allowed when limit > 1", async () => {
+    // Mirrors the SQL `INSERT VALUES (..., 1, NOW())` path on first hit
+    // — the row is returned with `count=1` and elapsed_ms=0.
+    pgQueryMock.mockResolvedValueOnce({
+      rows: [{ count: 1, elapsed_ms: "0" }],
+    });
+    const result = await checkRateLimitPg(makeReq("203.0.113.13"), {
+      key: "pg:fresh",
+      limit: 5,
+      windowMs: 60_000,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.remaining).toBe(4);
+    expect(result.resetMs).toBe(60_000);
+  });
+
+  it("clamps remaining at 0 when count somehow lands above limit", async () => {
+    // Defensive: a concurrent over-write could in theory return a count
+    // above the limit. The contract still reports `remaining=0` rather
+    // than negative, so downstream `X-RateLimit-Remaining` stays valid.
+    pgQueryMock.mockResolvedValueOnce({
+      rows: [{ count: 10, elapsed_ms: "100" }],
+    });
+    const result = await checkRateLimitPg(makeReq("203.0.113.14"), {
+      key: "pg:over",
+      limit: 5,
+      windowMs: 5_000,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.remaining).toBe(0);
+  });
+});
+
+describe("rateLimitExpress — Postgres path", () => {
+  function makeReq(ip: string): Request {
+    return { ip, headers: {} } as unknown as Request;
+  }
+
+  function makeRes(): {
+    res: never;
+    json: ReturnType<typeof vi.fn>;
+    setHeader: ReturnType<typeof vi.fn>;
+  } {
+    const json = vi.fn();
+    const setHeader = vi.fn();
+    const res = {
+      setHeader,
+      status: vi.fn().mockReturnThis(),
+      json,
+    } as never;
+    return { res, json, setHeader };
+  }
+
+  beforeEach(() => {
+    vi.mocked(getRedis).mockReturnValue(null);
+    redisEvalMock.mockReset();
+    pgQueryMock.mockReset();
+    loggerWarnMock.mockReset();
+    // Reset the once-per-process degraded-limiter warn flag so the
+    // "warns once" assertion below isn't pre-tripped by earlier tests
+    // in this file.
+    __resetRateLimitPgWarnForTests();
+  });
+
+  it("uses Postgres when Redis is unavailable", async () => {
+    pgQueryMock.mockResolvedValue({
+      rows: [{ count: 1, elapsed_ms: "0" }],
+    });
+
+    const middleware = rateLimitExpress({
+      key: "mw:pg",
+      limit: 5,
+      windowMs: 5_000,
+    });
+    const { res } = makeRes();
+    const next = vi.fn();
+    await middleware(makeReq("10.0.0.10"), res, next);
+
+    // First call is the limiter INSERT/UPDATE; sweeps fire only ~1/256
+    // and are best-effort — assert the limiter call landed.
+    expect(pgQueryMock).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO rate_limit_buckets"),
+      expect.any(Array),
+    );
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to in-memory when Postgres table is missing and warns once", async () => {
+    pgQueryMock.mockRejectedValue(pgUndefinedTableError());
+
+    const middleware = rateLimitExpress({
+      key: "mw:pg-missing",
+      limit: 5,
+      windowMs: 5_000,
+    });
+
+    // Two calls — only the first should emit the missing-table warn so
+    // a degraded production limiter doesn't flood obs on every request.
+    const a = makeRes();
+    const b = makeRes();
+    const next = vi.fn();
+    await middleware(makeReq("10.0.0.20"), a.res, next);
+    await middleware(makeReq("10.0.0.20"), b.res, next);
+
+    expect(next).toHaveBeenCalledTimes(2);
+    expect(loggerWarnMock).toHaveBeenCalledTimes(1);
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      expect.objectContaining({ msg: "rate_limit_pg_table_missing" }),
+    );
+  });
+
+  it("falls back to in-memory and still serves when Postgres rejects with a transient error", async () => {
+    // Connection refused / pool exhaustion shouldn't take the limiter
+    // offline — just degrade to per-process counting until Postgres
+    // recovers.
+    const transient = new Error("connection terminated") as Error & {
+      code: string;
+    };
+    transient.code = "08006";
+    pgQueryMock.mockRejectedValue(transient);
+
+    const middleware = rateLimitExpress({
+      key: "mw:pg-transient",
+      limit: 5,
+      windowMs: 5_000,
+    });
+    const { res } = makeRes();
+    const next = vi.fn();
+    await middleware(makeReq("10.0.0.30"), res, next);
+    expect(next).toHaveBeenCalledOnce();
+    // Transient errors don't trip the missing-table warn — they're a
+    // pool/network problem, not a schema mismatch.
+    expect(loggerWarnMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/src/http/rateLimit.ts
+++ b/apps/server/src/http/rateLimit.ts
@@ -1,5 +1,7 @@
 import type { Request, RequestHandler } from "express";
 import type Redis from "ioredis";
+import { pool } from "../db.js";
+import { logger } from "../obs/logger.js";
 import { rateLimitHitsTotal } from "../obs/metrics.js";
 import { getRedis } from "../lib/redis.js";
 
@@ -157,6 +159,150 @@ export async function checkRateLimitRedis(
 }
 
 /**
+ * Fixed-window rate-limit check backed by Postgres (`rate_limit_buckets`).
+ *
+ * Replaces the in-memory fallback for the production path: when Redis is
+ * unavailable, multiple Railway replicas otherwise share no state and a
+ * single user can hit `limit` separately on each instance. The Postgres
+ * path keeps semantics identical to {@link checkRateLimitRedis} (fixed
+ * window, atomic increment) while being horizontally consistent.
+ *
+ * Atomicity: `INSERT … ON CONFLICT … DO UPDATE` runs a single row lock
+ * over `(rl_key, subject)`. The `CASE` branches against
+ * `rate_limit_buckets.started_at` reference the pre-update value, and
+ * `NOW()` is `transaction_timestamp()` — stable for the whole statement —
+ * so both the count rotation and the `started_at` reset see the same
+ * window-elapsed comparison.
+ *
+ * Graceful degradation: if the migration `035_rate_limit_buckets.sql`
+ * has not yet been applied (SQLSTATE `42P01`, undefined table) or any
+ * other Postgres error fires, the caller in {@link rateLimitExpress}
+ * falls through to {@link checkRateLimit}. Errors are logged at `warn`
+ * once per occurrence so a degraded limiter is visible in obs without
+ * spamming on every request.
+ */
+export async function checkRateLimitPg(
+  req: Request,
+  { key, limit, windowMs }: RateLimitOptions,
+): Promise<RateLimitResult> {
+  const subject = rateLimitSubject(req);
+  const sql = `
+    INSERT INTO rate_limit_buckets (rl_key, subject, count, started_at)
+    VALUES ($1, $2, 1, NOW())
+    ON CONFLICT (rl_key, subject) DO UPDATE
+    SET
+      count = CASE
+        WHEN EXTRACT(EPOCH FROM (NOW() - rate_limit_buckets.started_at)) * 1000 >= $3::bigint
+          THEN 1
+        ELSE rate_limit_buckets.count + 1
+      END,
+      started_at = CASE
+        WHEN EXTRACT(EPOCH FROM (NOW() - rate_limit_buckets.started_at)) * 1000 >= $3::bigint
+          THEN NOW()
+        ELSE rate_limit_buckets.started_at
+      END
+    RETURNING
+      count,
+      (EXTRACT(EPOCH FROM (NOW() - started_at)) * 1000)::bigint AS elapsed_ms
+  `;
+
+  const result = await pool.query<{ count: number; elapsed_ms: string }>(sql, [
+    key,
+    subject,
+    String(windowMs),
+  ]);
+  const row = result.rows[0];
+  // Coerce bigint → number per AGENTS.md hard rule #1 (the `pg` driver
+  // returns int8/bigint columns as JS strings).
+  const count = Number(row?.count ?? 0);
+  const elapsedMs = Math.max(0, Number(row?.elapsed_ms ?? 0));
+  const resetMs = Math.max(0, windowMs - elapsedMs);
+
+  if (count > limit) {
+    recordRateLimit(key, "blocked");
+    return {
+      ok: false,
+      remaining: 0,
+      resetMs,
+      retryAfterSec: Math.max(1, Math.ceil(resetMs / 1000)),
+    };
+  }
+  recordRateLimit(key, "allowed");
+  return {
+    ok: true,
+    remaining: Math.max(0, limit - count),
+    resetMs,
+    retryAfterSec: Math.max(1, Math.ceil(resetMs / 1000)),
+  };
+}
+
+// Cleanup probability — fire a sweep ~1/N requests so the table doesn't
+// grow indefinitely under churning IPs while keeping per-request overhead
+// at zero on the hot path. Tuned for ~1k RPS: at 1/256 we sweep ~4×/sec.
+const PG_SWEEP_PROBABILITY = 1 / 256;
+
+// One-shot warn when the Postgres bucket table is unreachable (typically
+// because migration `035_rate_limit_buckets.sql` hasn't been applied yet
+// or the role lacks SELECT/INSERT). Subsequent failures fall through
+// silently to the in-memory limiter — the warn is enough to flag the
+// degraded state in obs without spamming on every request.
+let pgUndefinedTableLogged = false;
+
+/**
+ * Test-only reset for the once-per-process degraded-limiter warn flag.
+ * Exposed because vitest reuses a single module instance across `describe`
+ * blocks; production paths must never call this.
+ */
+export function __resetRateLimitPgWarnForTests(): void {
+  pgUndefinedTableLogged = false;
+}
+
+interface PgErrorLike {
+  code?: string;
+  message?: string;
+}
+
+function pgErr(err: unknown): PgErrorLike {
+  return err && typeof err === "object" ? (err as PgErrorLike) : {};
+}
+
+async function checkRateLimitPgWithFallback(
+  req: Request,
+  options: RateLimitOptions,
+): Promise<RateLimitResult> {
+  try {
+    return await checkRateLimitPg(req, options);
+  } catch (err) {
+    const code = pgErr(err).code;
+    if (code === "42P01" && !pgUndefinedTableLogged) {
+      pgUndefinedTableLogged = true;
+      logger.warn({
+        msg: "rate_limit_pg_table_missing",
+        hint: "apply migration 035_rate_limit_buckets.sql; falling back to in-memory limiter",
+      });
+    }
+    return checkRateLimit(req, options);
+  }
+}
+
+async function maybeSweepPgBuckets(maxWindowMs: number): Promise<void> {
+  if (Math.random() >= PG_SWEEP_PROBABILITY) return;
+  // Keep rows for 2× the longest configured window so we never evict
+  // a still-live bucket out from under a concurrent request that hasn't
+  // yet read it back. The application path always re-rotates a bucket
+  // on access, so a stale row is at worst a one-window over-count.
+  const ttlMs = Math.max(60_000, maxWindowMs * 2);
+  try {
+    await pool.query(
+      "DELETE FROM rate_limit_buckets WHERE started_at < NOW() - ($1::bigint || ' milliseconds')::interval",
+      [String(ttlMs)],
+    );
+  } catch {
+    /* sweep is best-effort */
+  }
+}
+
+/**
  * Fixed-window rate-limit check (in-memory, per-process).
  */
 export function checkRateLimit(
@@ -211,12 +357,17 @@ export function rateLimitExpress({
       try {
         rl = await checkRateLimitRedis(redis, req, { key, limit, windowMs });
       } catch {
-        // Redis unavailable — fall back to per-process in-memory limiter.
-        rl = checkRateLimit(req, { key, limit, windowMs });
+        // Redis unavailable — fall back to Postgres (horizontally
+        // consistent across replicas), and only to in-memory if even
+        // Postgres is broken (test bootstrap, migration not applied).
+        rl = await checkRateLimitPgWithFallback(req, { key, limit, windowMs });
       }
     } else {
-      rl = checkRateLimit(req, { key, limit, windowMs });
+      rl = await checkRateLimitPgWithFallback(req, { key, limit, windowMs });
     }
+    // Best-effort sweep of stale rows; runs ~1/256 calls so the table
+    // doesn't grow under churning IPs. No-op when Postgres is degraded.
+    void maybeSweepPgBuckets(windowMs);
     try {
       res.setHeader("X-RateLimit-Remaining", String(rl.remaining));
     } catch {

--- a/apps/server/src/migrations/035_rate_limit_buckets.down.sql
+++ b/apps/server/src/migrations/035_rate_limit_buckets.down.sql
@@ -1,0 +1,10 @@
+-- Rollback for 035_rate_limit_buckets.sql.
+--
+-- DBA-runnable manual rollback: the runner in `apps/server/src/db.ts`
+-- ignores `*.down.sql` files. Drops the bucket table; running this
+-- after a release that used the Postgres rate-limit path will fall
+-- the limiter back to in-memory immediately on the next request
+-- (the application detects the missing relation via SQLSTATE 42P01).
+
+DROP INDEX IF EXISTS rate_limit_buckets_started_at_idx;
+DROP TABLE IF EXISTS rate_limit_buckets;

--- a/apps/server/src/migrations/035_rate_limit_buckets.sql
+++ b/apps/server/src/migrations/035_rate_limit_buckets.sql
@@ -1,0 +1,39 @@
+-- Postgres-backed rate-limit buckets — Stage 1, PR #011 from
+-- `docs/planning/storage-roadmap.md`.
+--
+-- Replaces the in-memory per-process fallback in
+-- `apps/server/src/http/rateLimit.ts` with a horizontally-shareable
+-- counter so a single user/IP cannot escape limits by routing through
+-- different replicas. Redis is still preferred when available (atomic
+-- INCR+EXPIRE Lua script in the same file) — Postgres only kicks in
+-- when REDIS_URL is unset or `getRedis()` returned `null` after retries.
+--
+-- Bucket model is fixed-window (matches the Redis path's semantics):
+-- a row is keyed by `(rl_key, subject)` and carries the window's
+-- start instant + a hit counter. Within the window, increments are
+-- one round-trip; once `now - started_at >= window_ms` the row is
+-- atomically rotated to a fresh window with `count = 1`.
+--
+-- We deliberately do NOT carry a per-row `window_ms` in the table
+-- itself: the caller already passes the window length, and storing it
+-- would let one route's misconfiguration silently extend another route's
+-- bucket. The application uses the request's window to decide whether
+-- the stored row has expired; eviction is by NOW() comparison, not by
+-- a stored TTL column, so concurrent windows of different lengths are
+-- naturally isolated by the `(rl_key, subject)` composite key.
+
+CREATE TABLE IF NOT EXISTS rate_limit_buckets (
+  rl_key TEXT NOT NULL,
+  subject TEXT NOT NULL,
+  count INTEGER NOT NULL DEFAULT 0,
+  started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (rl_key, subject)
+);
+
+-- Sweep index — the cleanup query runs `DELETE FROM rate_limit_buckets
+-- WHERE started_at < NOW() - INTERVAL 'X seconds'` after each request
+-- with low probability (1/N), so the index keeps that scan O(matched
+-- rows) instead of O(table). Without it a hot endpoint would grow the
+-- table indefinitely under churning IPs.
+CREATE INDEX IF NOT EXISTS rate_limit_buckets_started_at_idx
+  ON rate_limit_buckets (started_at);


### PR DESCRIPTION
## Summary

Stage 1 PR #011 з `docs/planning/storage-roadmap.md` — закриваємо сервер-сайд хвіст stage-1 міграції: переписуємо in-memory rate-limit на Postgres-backed bucket. Per-process limiter дозволяв одному IP/користувачу витрачати окремий `limit` на кожному Railway-репліці. Тепер: Redis (preferred) → Postgres → in-memory (тільки коли і Redis, і Postgres недоступні).

- `apps/server/src/migrations/035_rate_limit_buckets.{sql,down.sql}` — нова таблиця fixed-window-counter з композитним PK `(rl_key, subject)` + індекс `started_at` для sweep-у.
- `apps/server/src/http/rateLimit.ts`:
  - `checkRateLimitPg` — `INSERT … ON CONFLICT … DO UPDATE` за один round-trip. Той самий row-lock і ротує stale window (CASE на elapsed_ms vs windowMs), і інкрементує `count`; `NOW()` стабільний у межах statement, тож обидва CASE-и бачать одну й ту саму дельту.
  - `checkRateLimitPgWithFallback` — однократний `warn` на `rate_limit_pg_table_missing` (SQLSTATE 42P01) + тихий fallback на in-memory для всіх інших Postgres-помилок (transient connection failures, deadlocks).
  - `maybeSweepPgBuckets` — best-effort `DELETE` з імовірністю 1/256 на запит, TTL = 2× window щоб не виганяти ще-живий bucket з-під concurrent-запиту.
- `apps/server/src/http/rateLimit.test.ts` — 27/27 passes (5 нових для Postgres-шляху, 3 нових для middleware fallback wiring + warn-once dedup).

## Governing Skill

- Primary skill: `.agents/skills/server-rate-limit` (роль обмежувача на write-path, контракт із Better Auth client про `error`/`message` + `Retry-After`).
- Secondary skill (if truly needed): `.agents/skills/db-migrations-pg` (нова міграція `035_…`, advisory-lock-runner у `db.ts`, idempotent `IF NOT EXISTS`).

## Playbook

- Primary playbook: `docs/planning/storage-roadmap.md` → Stage 1 → PR #011.
- Why this playbook: roadmap явно визначає AC (Load test 100 RPS × 10 min, horizontal-scale тест на 2 інстанціях), пропоновану схему таблиці та semantics fallback-у.
- If no playbook matched, why: n/a.

## Verification

Локально (Node 20.20.2, pnpm 9.15.1):

```bash
pnpm exec eslint apps/server/src/http/rateLimit.ts apps/server/src/http/rateLimit.test.ts   # clean
pnpm exec tsc -p apps/server/tsconfig.json --noEmit                                          # clean
pnpm exec vitest run apps/server/src/http/rateLimit.test.ts                                  # 27/27 pass
```

`pnpm lint` (workspace-wide) і `pnpm typecheck` зелені.

Additional checks:

- [x] Local smoke / manual validation completed (vitest на rateLimit.test.ts перекриває обидва нові шляхи + sweep + warn-once).
- [ ] Surface-specific checks completed (CI прожене integration-тести на Railway PG; локально pg-пулу немає).

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a — поведінкового зсуву для зовнішніх клієнтів немає (контракт 429 / `Retry-After` / body shape залишається той самий, що для Redis-шляху). Roadmap-чекбокс PR #011 закриється у наступному комміті після merge.

## Risk and Rollout

- User-visible risk: **low**. Контракт відповіді 429 (тіло `{error,message,code:RATE_LIMIT}`, `Retry-After`, `X-RateLimit-Remaining`) збережений побайтово. Latency: +1 SQL roundtrip на запит коли Redis відсутній; на Railway PG-pool-warm це <2ms typical.
- Rollout / deploy order: 1) merge → 2) `ensureSchema()` під advisory-lock застосує `035_rate_limit_buckets.sql` на старті — pool warm + idempotent `CREATE TABLE IF NOT EXISTS` робить це безпечним для rolling-deploy. 3) Якщо щось не так, можна виконати `035_rate_limit_buckets.down.sql` вручну — limiter одразу деградує на in-memory (видасть один `rate_limit_pg_table_missing` warn).
- Backout plan: `git revert` цього PR + manual `DROP TABLE rate_limit_buckets`. Альтернатива без revert: перемкнути на Redis (ENV `REDIS_URL`), що просто пропустить Postgres-шлях.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

- Міграція `035_rate_limit_buckets.{sql,down.sql}` — перша таблиця у series 035; runner у `apps/server/src/db.ts` підхопить `*.sql` автоматично під advisory-lock.
- `__resetRateLimitPgWarnForTests` — test-only export, потрібен бо vitest reuses module instance між describe-блоками; виклик з production-коду нічого не зламає (просто скидає dedup-флаг).
- Sweep-частота 1/256 була підібрана для ~1k RPS на хост (≈4 sweep-и/сек). Для більшого навантаження варто буде розглянути окремий cron-runner — але це поза AC цього PR.
- AC roadmap-у (load test 100 RPS × 10 min, horizontal-scale тест на 2 інстансах Railway) виконується через CI / staging — локального інструмента для цього в репо немає.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Postgres database support for distributed rate limiting with automatic fallback to in-memory when unavailable.
  * Implemented probabilistic cleanup mechanism for efficient storage management of rate limit buckets.

* **Tests**
  * Significantly expanded test coverage for rate limiting across Postgres and Redis scenarios.
  * Added comprehensive tests for fallback behavior when services are unavailable and error handling for various edge cases.

* **Chores**
  * Added database migrations to establish rate limiting storage infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->