### PR TITLE
feat(web): move cloud-sync offline queue from localStorage to IDB (PR #009)

### DIFF
--- a/apps/web/src/core/cloudSync/__tests__/offlineQueue.replay.test.ts
+++ b/apps/web/src/core/cloudSync/__tests__/offlineQueue.replay.test.ts
@@ -62,7 +62,11 @@ vi.mock("../logger", () => ({
 }));
 
 import { syncApi } from "@shared/api";
-import { addToOfflineQueue, getOfflineQueue } from "../queue/offlineQueue";
+import {
+  __resetOfflineQueueCacheForTests,
+  addToOfflineQueue,
+  getOfflineQueue,
+} from "../queue/offlineQueue";
 import { MAX_OFFLINE_QUEUE, OFFLINE_QUEUE_KEY } from "../config";
 import { SYNC_STATUS_EVENT } from "../state/events";
 
@@ -80,11 +84,17 @@ const mockedPushAll = syncApi.pushAll as unknown as ReturnType<typeof vi.fn>;
 // ---------------------------------------------------------------------------
 beforeEach(() => {
   localStorage.clear();
+  // PR #009 — the queue now lives in an in-memory cache (durable answer
+  // is IDB; LS is just a best-effort backup). `localStorage.clear()`
+  // alone no longer empties the queue between tests, so we must drop
+  // the cache too or state from the previous test bleeds forward.
+  __resetOfflineQueueCacheForTests();
   vi.clearAllMocks();
   mockedPushAll.mockReset();
 });
 afterEach(() => {
   localStorage.clear();
+  __resetOfflineQueueCacheForTests();
 });
 
 // =========================================================================

--- a/apps/web/src/core/cloudSync/engine/replay.ts
+++ b/apps/web/src/core/cloudSync/engine/replay.ts
@@ -1,6 +1,10 @@
 import { syncApi } from "@shared/api";
 import { collectQueuedModules } from "../queue/collectQueued";
-import { clearOfflineQueue, getOfflineQueue } from "../queue/offlineQueue";
+import {
+  clearOfflineQueue,
+  getOfflineQueue,
+  hydrateOfflineQueueFromDisk,
+} from "../queue/offlineQueue";
 import { retryAsync } from "./retryAsync";
 
 // Module-scoped re-entry guard. The original hook used a `replayingRef`; for
@@ -18,6 +22,9 @@ export async function replayOfflineQueue(): Promise<void> {
   // succession, or replay is triggered concurrently from initialSync and
   // pushDirty, we must not fire duplicate push requests for the same queue.
   if (replaying) return;
+  // PR #009 — promote any LS-only queue from a previous app version into
+  // IDB before we read it. Subsequent calls are cheap (cache short-circuit).
+  await hydrateOfflineQueueFromDisk();
   const queue = getOfflineQueue();
   if (queue.length === 0) return;
 

--- a/apps/web/src/core/cloudSync/queue/offlineQueue.ts
+++ b/apps/web/src/core/cloudSync/queue/offlineQueue.ts
@@ -1,11 +1,99 @@
 import { safeReadLS, safeWriteLS } from "@shared/lib/storage/storage";
 import { MAX_OFFLINE_QUEUE, OFFLINE_QUEUE_KEY } from "../config";
 import { emitStatusEvent } from "../state/events";
+import {
+  SYNC_META_KEYS,
+  delSyncMeta,
+  getSyncMeta,
+  setSyncMeta,
+} from "../storage/syncMetaStore";
 import type { QueueEntry, QueuePushEntry } from "../types";
 
+/**
+ * Sync source of truth for the queue. Backing store is IDB
+ * (`syncMetaStore.ts`); IDB writes are fire-and-forget so existing
+ * sync callers (`addToOfflineQueue`, `getOfflineQueue`, …) keep their
+ * contract. LS dual-write remains as a best-effort backup so the
+ * first sync read after a cold boot can hydrate from LS without
+ * waiting on the async IDB read; `hydrateOfflineQueueFromDisk()`
+ * upgrades the cache once IDB resolves.
+ *
+ * `null` means "not yet hydrated" — the first sync caller triggers a
+ * synchronous LS read to populate it.
+ */
+let queueCache: QueueEntry[] | null = null;
+
+function getQueueSync(): QueueEntry[] {
+  if (queueCache !== null) return queueCache;
+  const ls = safeReadLS<QueueEntry[]>(OFFLINE_QUEUE_KEY, []);
+  queueCache = Array.isArray(ls) ? ls : [];
+  return queueCache;
+}
+
+/**
+ * Above this length we stop dual-writing the queue to localStorage.
+ * IDB is authoritative once the queue grows past what LS can hold
+ * (~5 MB / a few hundred entries depending on payload size); past
+ * the threshold the LS row is intentionally stale, kept only as a
+ * "is there anything queued?" marker for legacy readers. Skipping
+ * the write also avoids O(N) JSON.stringify churn on every
+ * `addToOfflineQueue` once the queue grows long.
+ */
+const LS_DUAL_WRITE_MAX_ENTRIES = 100;
+
+function persistQueue(queue: QueueEntry[]): void {
+  // IDB is the durable answer (no quota cap). LS dual-write is best-
+  // effort and only happens for small queues; once we cross
+  // `LS_DUAL_WRITE_MAX_ENTRIES`, IDB is the sole source and LS will
+  // appear stale until the queue drains below the threshold again.
+  // `safeWriteLS` swallows QuotaExceededError so this is a no-op when
+  // the browser's LS budget is exhausted.
+  void setSyncMeta(SYNC_META_KEYS.OFFLINE_QUEUE, queue);
+  if (queue.length <= LS_DUAL_WRITE_MAX_ENTRIES) {
+    safeWriteLS(OFFLINE_QUEUE_KEY, queue);
+  }
+}
+
 export function getOfflineQueue(): QueueEntry[] {
-  const q = safeReadLS<QueueEntry[]>(OFFLINE_QUEUE_KEY, []);
-  return Array.isArray(q) ? q : [];
+  return getQueueSync();
+}
+
+/**
+ * Async hydration step — meant to be called once during boot, before
+ * the first reconnect/replay. Reconciles in-memory cache with IDB:
+ * if IDB has data, it wins (durable source); if IDB is empty but LS
+ * has legacy data, we migrate it into IDB and clear LS.
+ *
+ * Idempotent: subsequent calls are no-ops if the cache already matches
+ * the IDB row.
+ */
+export async function hydrateOfflineQueueFromDisk(): Promise<void> {
+  let idb: QueueEntry[] | undefined;
+  try {
+    idb = await getSyncMeta<QueueEntry[]>(SYNC_META_KEYS.OFFLINE_QUEUE);
+  } catch {
+    // IDB unavailable (Safari Private Browsing, disabled, quota) —
+    // fall through to the LS path below so the cache still warms up.
+  }
+  if (Array.isArray(idb) && idb.length > 0) {
+    queueCache = idb;
+    return;
+  }
+  const ls = safeReadLS<QueueEntry[]>(OFFLINE_QUEUE_KEY, []);
+  if (Array.isArray(ls) && ls.length > 0) {
+    queueCache = ls;
+    // One-shot migration LS → IDB so future cold-boots use IDB and the
+    // ~5 MB LS cap stops gating queue size. We deliberately keep LS
+    // populated for the next dual-write — it'll be overwritten on the
+    // first `addToOfflineQueue` call anyway.
+    try {
+      await setSyncMeta(SYNC_META_KEYS.OFFLINE_QUEUE, ls);
+    } catch {
+      /* IDB unavailable — fine, LS continues to back the queue. */
+    }
+    return;
+  }
+  queueCache = [];
 }
 
 function isPushEntryWithModules(entry: unknown): entry is QueuePushEntry {
@@ -53,28 +141,35 @@ function coalesceIsNoop(
  *     the same payload every backoff.
  */
 export function addToOfflineQueue(entry: Partial<QueuePushEntry>): void {
-  let queue = getOfflineQueue();
-  queue = normalizePushEntries(queue);
+  let queue = getQueueSync();
 
-  if (
-    entry &&
+  const isPush =
+    !!entry &&
     entry.type === "push" &&
-    entry.modules &&
-    typeof entry.modules === "object" &&
-    queue.length > 0
-  ) {
-    const last = queue[queue.length - 1];
-    if (isPushEntryWithModules(last)) {
-      if (coalesceIsNoop(last.modules, entry.modules)) {
-        // Queue already represents the exact same payload — skip the
-        // write so retry storms don't churn localStorage.
+    !!entry.modules &&
+    typeof entry.modules === "object";
+
+  if (isPush) {
+    // Only normalize for push entries — `normalizePushEntries` does an
+    // O(N) scan of the queue and is only meaningful when we're about
+    // to coalesce. Skipping it for non-push entries keeps the per-call
+    // cost O(1) even when the queue holds many thousand events.
+    queue = normalizePushEntries(queue);
+    if (queue.length > 0) {
+      const last = queue[queue.length - 1];
+      if (isPushEntryWithModules(last)) {
+        if (coalesceIsNoop(last.modules, entry.modules!)) {
+          // Queue already represents the exact same payload — skip the
+          // write so retry storms don't churn storage.
+          return;
+        }
+        last.modules = { ...last.modules, ...entry.modules! };
+        last.ts = new Date().toISOString();
+        queueCache = queue;
+        persistQueue(queue);
+        emitStatusEvent();
         return;
       }
-      last.modules = { ...last.modules, ...entry.modules };
-      last.ts = new Date().toISOString();
-      safeWriteLS(OFFLINE_QUEUE_KEY, queue);
-      emitStatusEvent();
-      return;
     }
   }
   queue.push({
@@ -84,7 +179,8 @@ export function addToOfflineQueue(entry: Partial<QueuePushEntry>): void {
   if (queue.length > MAX_OFFLINE_QUEUE) {
     queue = queue.slice(queue.length - MAX_OFFLINE_QUEUE);
   }
-  safeWriteLS(OFFLINE_QUEUE_KEY, queue);
+  queueCache = queue;
+  persistQueue(queue);
   emitStatusEvent();
 }
 
@@ -121,10 +217,21 @@ function normalizePushEntries(queue: QueueEntry[]): QueueEntry[] {
 }
 
 export function clearOfflineQueue(): void {
+  queueCache = [];
+  void delSyncMeta(SYNC_META_KEYS.OFFLINE_QUEUE);
   try {
     localStorage.removeItem(OFFLINE_QUEUE_KEY);
   } catch {
     /* swallow */
   }
   emitStatusEvent();
+}
+
+/**
+ * Test-only cache reset. Vitest reuses module instances across
+ * describe blocks; without this, a queue populated by an earlier
+ * suite leaks into the next one.
+ */
+export function __resetOfflineQueueCacheForTests(): void {
+  queueCache = null;
 }

--- a/apps/web/src/core/cloudSync/storage/syncMetaStore.test.ts
+++ b/apps/web/src/core/cloudSync/storage/syncMetaStore.test.ts
@@ -1,0 +1,191 @@
+// @vitest-environment jsdom
+/**
+ * Unit tests for the IDB-backed sync metadata store and the
+ * `hydrateOfflineQueueFromDisk()` migration glue. PR #009 in
+ * `docs/planning/storage-roadmap.md`.
+ *
+ * jsdom does NOT ship IndexedDB, so we mock `idb-keyval` with an
+ * in-memory map. That gives us deterministic get/set/del semantics
+ * without pulling `fake-indexeddb` into the dependency graph; the
+ * store wrapper itself is thin enough that exercising it through the
+ * mock catches the real bugs (key naming, IDB-unavailable fallback,
+ * LS migration handoff).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const idbStore = new Map<string, unknown>();
+const idbGetMock = vi.fn(async (key: string) => idbStore.get(key));
+const idbSetMock = vi.fn(async (key: string, value: unknown) => {
+  idbStore.set(key, value);
+});
+const idbDelMock = vi.fn(async (key: string) => {
+  idbStore.delete(key);
+});
+const idbCreateStoreMock = vi.fn(
+  (..._args: unknown[]) => ({ __mock: true }) as unknown,
+);
+
+vi.mock("idb-keyval", () => ({
+  createStore: (dbName: string, storeName: string) =>
+    idbCreateStoreMock(dbName, storeName),
+  get: (key: string, _store: unknown) => idbGetMock(key),
+  set: (key: string, value: unknown, _store: unknown) => idbSetMock(key, value),
+  del: (key: string, _store: unknown) => idbDelMock(key),
+}));
+
+import { OFFLINE_QUEUE_KEY } from "../config";
+import {
+  __resetOfflineQueueCacheForTests,
+  addToOfflineQueue,
+  clearOfflineQueue,
+  getOfflineQueue,
+  hydrateOfflineQueueFromDisk,
+} from "../queue/offlineQueue";
+import {
+  SYNC_META_KEYS,
+  __resetSyncMetaStoreForTests,
+  delSyncMeta,
+  getSyncMeta,
+  setSyncMeta,
+} from "./syncMetaStore";
+
+beforeEach(() => {
+  // Reset shared mutable state before every test.
+  idbStore.clear();
+  idbGetMock.mockClear();
+  idbSetMock.mockClear();
+  idbDelMock.mockClear();
+  idbCreateStoreMock.mockClear();
+  localStorage.clear();
+  __resetOfflineQueueCacheForTests();
+  __resetSyncMetaStoreForTests();
+
+  // jsdom doesn't ship IndexedDB. Provide a stub so the
+  // `idbAvailable()` short-circuit in syncMetaStore.ts treats the env
+  // as IDB-capable and routes to our `idb-keyval` mock above.
+  (globalThis as { indexedDB?: unknown }).indexedDB = {};
+});
+afterEach(() => {
+  delete (globalThis as { indexedDB?: unknown }).indexedDB;
+});
+
+describe("syncMetaStore", () => {
+  it("get/set/del roundtrip uses the dedicated 'sergeant-sync-meta' DB and 'v1' store", async () => {
+    await setSyncMeta(SYNC_META_KEYS.OFFLINE_QUEUE, [{ a: 1 }]);
+    expect(idbCreateStoreMock).toHaveBeenCalledWith("sergeant-sync-meta", "v1");
+    expect(idbSetMock).toHaveBeenCalledWith("offline_queue", [{ a: 1 }]);
+    expect(await getSyncMeta(SYNC_META_KEYS.OFFLINE_QUEUE)).toEqual([{ a: 1 }]);
+
+    await delSyncMeta(SYNC_META_KEYS.OFFLINE_QUEUE);
+    expect(idbDelMock).toHaveBeenCalledWith("offline_queue");
+    expect(await getSyncMeta(SYNC_META_KEYS.OFFLINE_QUEUE)).toBeUndefined();
+  });
+
+  it("get returns undefined and set/del are no-ops when IndexedDB is unavailable", async () => {
+    delete (globalThis as { indexedDB?: unknown }).indexedDB;
+
+    expect(await getSyncMeta(SYNC_META_KEYS.OFFLINE_QUEUE)).toBeUndefined();
+    await setSyncMeta(SYNC_META_KEYS.OFFLINE_QUEUE, [{ a: 1 }]);
+    await delSyncMeta(SYNC_META_KEYS.OFFLINE_QUEUE);
+
+    // None of the underlying idb-keyval helpers should have been
+    // touched — short-circuit kicked in at the wrapper level.
+    expect(idbGetMock).not.toHaveBeenCalled();
+    expect(idbSetMock).not.toHaveBeenCalled();
+    expect(idbDelMock).not.toHaveBeenCalled();
+  });
+
+  it("exposes the four documented keys (offline queue + 3 sync-meta slots)", () => {
+    // Snapshot the registry so renaming a key in the wrapper without
+    // updating production callers gets caught at test time.
+    expect(SYNC_META_KEYS).toEqual({
+      OFFLINE_QUEUE: "offline_queue",
+      VERSIONS: "sync_versions",
+      DIRTY_MODULES: "dirty_modules",
+      MODULE_MODIFIED: "module_modified",
+    });
+  });
+});
+
+describe("hydrateOfflineQueueFromDisk", () => {
+  it("hydrates the in-memory cache from IDB when IDB has data", async () => {
+    const idbQueue = [
+      {
+        type: "push",
+        modules: { finyk: { data: {} } },
+        ts: "2026-04-01T00:00:00.000Z",
+      },
+    ];
+    idbStore.set(SYNC_META_KEYS.OFFLINE_QUEUE, idbQueue);
+
+    await hydrateOfflineQueueFromDisk();
+    expect(getOfflineQueue()).toEqual(idbQueue);
+  });
+
+  it("falls back to LS and migrates legacy data into IDB when IDB is empty", async () => {
+    const lsQueue = [
+      {
+        type: "push",
+        modules: { nutrition: { data: {} } },
+        ts: "2026-04-01T00:00:00.000Z",
+      },
+    ];
+    localStorage.setItem(OFFLINE_QUEUE_KEY, JSON.stringify(lsQueue));
+
+    await hydrateOfflineQueueFromDisk();
+
+    // The cache should now reflect LS contents...
+    expect(getOfflineQueue()).toEqual(lsQueue);
+    // ...and IDB should have been populated as a one-shot migration
+    // so future cold-boots no longer depend on LS.
+    expect(idbStore.get(SYNC_META_KEYS.OFFLINE_QUEUE)).toEqual(lsQueue);
+    expect(idbSetMock).toHaveBeenCalledWith("offline_queue", lsQueue);
+  });
+
+  it("hydrates to an empty queue when neither IDB nor LS have data", async () => {
+    await hydrateOfflineQueueFromDisk();
+    expect(getOfflineQueue()).toEqual([]);
+  });
+
+  it("is robust to IDB throwing (Safari Private Browsing, quota) — falls back to LS", async () => {
+    idbGetMock.mockRejectedValueOnce(new Error("quota exceeded"));
+    const lsQueue = [{ type: "evt", payload: 1, ts: "2026-04-01T00:00:00Z" }];
+    localStorage.setItem(OFFLINE_QUEUE_KEY, JSON.stringify(lsQueue));
+
+    await hydrateOfflineQueueFromDisk();
+    expect(getOfflineQueue()).toEqual(lsQueue);
+  });
+});
+
+describe("offline queue end-to-end with IDB", () => {
+  it("addToOfflineQueue dual-writes to IDB while the queue is small", () => {
+    addToOfflineQueue({
+      type: "push",
+      modules: { finyk: { data: { v: 1 } } },
+    } as never);
+
+    // IDB write is fire-and-forget but with awaited mocks it fires
+    // synchronously enough that the call is observable.
+    expect(idbSetMock).toHaveBeenCalled();
+    const lastCall = idbSetMock.mock.calls.at(-1);
+    expect(lastCall?.[0]).toBe(SYNC_META_KEYS.OFFLINE_QUEUE);
+    expect((lastCall?.[1] as { type: string }[])[0]?.type).toBe("push");
+
+    // LS dual-write also happens for small queues.
+    const lsRaw = localStorage.getItem(OFFLINE_QUEUE_KEY);
+    expect(lsRaw).not.toBeNull();
+  });
+
+  it("clearOfflineQueue removes the row from IDB AND localStorage", () => {
+    addToOfflineQueue({
+      type: "push",
+      modules: { finyk: { data: { v: 1 } } },
+    } as never);
+    expect(getOfflineQueue()).toHaveLength(1);
+
+    clearOfflineQueue();
+    expect(getOfflineQueue()).toEqual([]);
+    expect(idbDelMock).toHaveBeenCalledWith(SYNC_META_KEYS.OFFLINE_QUEUE);
+    expect(localStorage.getItem(OFFLINE_QUEUE_KEY)).toBeNull();
+  });
+});

--- a/apps/web/src/core/cloudSync/storage/syncMetaStore.ts
+++ b/apps/web/src/core/cloudSync/storage/syncMetaStore.ts
@@ -1,0 +1,106 @@
+/**
+ * IDB-backed durable store for cloud-sync bookkeeping (offline queue,
+ * sync versions, dirty modules, last-modified timestamps). PR #009
+ * from `docs/planning/storage-roadmap.md`.
+ *
+ * Why IDB instead of localStorage:
+ *   - LS has a 5–10 MB per-origin cap; with `MAX_OFFLINE_QUEUE` raised
+ *     to 10k entries, even a single coalesced push for a power user
+ *     can cross that limit and fail with QuotaExceededError. IDB has
+ *     no such practical cap (browser-imposed, but multi-GB).
+ *   - LS writes block the main thread on JSON.stringify; IDB writes
+ *     are async and off-thread.
+ *
+ * Why we still keep an in-memory cache + LS dual-write:
+ *   - Existing call sites (`getOfflineQueue`, `addToOfflineQueue`, …)
+ *     are sync. Rewriting every consumer to async would touch dozens
+ *     of files; instead the cache becomes the sync source of truth and
+ *     IDB becomes the durable mirror behind it (writes are
+ *     fire-and-forget; reads come from cache).
+ *   - LS dual-write is a best-effort backup for two niche cases:
+ *       1. Safari Private Browsing — IDB is allowed but flushes on
+ *          tab close; LS lasts until the session ends.
+ *       2. Cold-start hydration before `hydrateFromIDB()` resolves —
+ *          the first synchronous `getOfflineQueue()` after page load
+ *          can read from LS instead of returning an empty queue.
+ *     If the LS write hits QuotaExceededError it's swallowed by
+ *     `safeWriteLS`; IDB remains authoritative.
+ *
+ * Key naming: keys live in a private namespace (`SYNC_META_*`) so
+ * future additions don't collide with the wider `STORAGE_KEYS`
+ * registry. The DB name is intentionally distinct from
+ * `sergeant-rq-cache` (React Query persister) and from the upcoming
+ * unified `sergeant` DB (PR #010) — keeping them separate while #010
+ * is in flight isolates failure modes.
+ */
+import {
+  createStore,
+  get as idbGet,
+  set as idbSet,
+  del as idbDel,
+} from "idb-keyval";
+
+const DB_NAME = "sergeant-sync-meta";
+const STORE_NAME = "v1";
+
+export const SYNC_META_KEYS = {
+  OFFLINE_QUEUE: "offline_queue",
+  VERSIONS: "sync_versions",
+  DIRTY_MODULES: "dirty_modules",
+  MODULE_MODIFIED: "module_modified",
+} as const;
+
+export type SyncMetaKey = (typeof SYNC_META_KEYS)[keyof typeof SYNC_META_KEYS];
+
+// Lazy `Store` — `createStore` does NOT open the DB; the open happens
+// on the first get/set/del call. This keeps SSR / unit-test bootstrap
+// fast and lets us avoid wrapping every test in fake-indexeddb when we
+// only need to mock the four exported functions below.
+let store: ReturnType<typeof createStore> | null = null;
+function getStore(): ReturnType<typeof createStore> {
+  if (!store) store = createStore(DB_NAME, STORE_NAME);
+  return store;
+}
+
+/**
+ * `true` when the runtime exposes IndexedDB (browsers, Electron). In
+ * Node-based unit tests under jsdom we may run without IDB; in Safari
+ * Private Browsing on older versions IDB is also stubbed out. In both
+ * cases we short-circuit get/set/del so the caller's `await` resolves
+ * to `undefined` instead of leaking unhandled rejections / pending
+ * IndexedDB transactions across the test runner heap.
+ */
+function idbAvailable(): boolean {
+  return (
+    typeof globalThis !== "undefined" &&
+    typeof (globalThis as { indexedDB?: unknown }).indexedDB !== "undefined"
+  );
+}
+
+export async function getSyncMeta<T>(key: SyncMetaKey): Promise<T | undefined> {
+  if (!idbAvailable()) return undefined;
+  return idbGet<T>(key, getStore());
+}
+
+export async function setSyncMeta<T>(
+  key: SyncMetaKey,
+  value: T,
+): Promise<void> {
+  if (!idbAvailable()) return;
+  await idbSet(key, value, getStore());
+}
+
+export async function delSyncMeta(key: SyncMetaKey): Promise<void> {
+  if (!idbAvailable()) return;
+  await idbDel(key, getStore());
+}
+
+/**
+ * Test-only reset of the cached store handle. Vitest reuses module
+ * instances across describe blocks; this lets a test that mocks
+ * `idb-keyval` swap the implementation cleanly without retaining a
+ * stale `Store` from a previous suite.
+ */
+export function __resetSyncMetaStoreForTests(): void {
+  store = null;
+}

--- a/apps/web/src/core/cloudSync/useCloudSync.behavior.test.ts
+++ b/apps/web/src/core/cloudSync/useCloudSync.behavior.test.ts
@@ -29,15 +29,21 @@ import {
   SYNC_EVENT,
   SYNC_STATUS_EVENT,
 } from "./useCloudSync";
+import { __resetOfflineQueueCacheForTests } from "./queue/offlineQueue";
 import { STORAGE_KEYS } from "@sergeant/shared";
 
 beforeEach(() => {
   // Clear all tracked state. Use the patched setItem/removeItem so behavior
   // is realistic, but also raw clear() for meta keys.
   localStorage.clear();
+  // PR #009 — the offline queue now lives in an in-memory cache backed
+  // by IDB; LS is best-effort. Reset the cache between tests so a queue
+  // populated by an earlier test doesn't bleed into the next one.
+  __resetOfflineQueueCacheForTests();
 });
 afterEach(() => {
   localStorage.clear();
+  __resetOfflineQueueCacheForTests();
 });
 
 describe("getDirtyModules", () => {

--- a/apps/web/src/core/cloudSync/useCloudSync.hardening.test.ts
+++ b/apps/web/src/core/cloudSync/useCloudSync.hardening.test.ts
@@ -19,10 +19,21 @@ import {
   __internal_addToOfflineQueue as enqueue,
   __internal_parseDateSafe as parseDate,
 } from "./useCloudSync";
+import { __resetOfflineQueueCacheForTests } from "./queue/offlineQueue";
+import { MAX_OFFLINE_QUEUE } from "./config";
 import { STORAGE_KEYS } from "@sergeant/shared";
 
-beforeEach(() => localStorage.clear());
-afterEach(() => localStorage.clear());
+beforeEach(() => {
+  localStorage.clear();
+  // PR #009 — the offline queue lives in an in-memory cache backed by
+  // IDB. `localStorage.clear()` alone no longer empties it; reset the
+  // cache too so a queue populated by an earlier test doesn't leak.
+  __resetOfflineQueueCacheForTests();
+});
+afterEach(() => {
+  localStorage.clear();
+  __resetOfflineQueueCacheForTests();
+});
 
 describe("isModulePushSuccess", () => {
   it("treats missing/non-object result as failure", () => {
@@ -172,14 +183,18 @@ describe("addToOfflineQueue coalescing", () => {
 
   it("caps queue length when many non-coalescing entries accumulate", () => {
     // Force non-push entries that don't coalesce so we can exercise the cap.
-    for (let i = 0; i < 120; i++) {
+    // Use MAX_OFFLINE_QUEUE + a small overshoot so the assertion stays
+    // tied to the documented cap (raised to 10 000 in PR #009).
+    const overshoot = 20;
+    const total = MAX_OFFLINE_QUEUE + overshoot;
+    for (let i = 0; i < total; i++) {
       enqueue({ type: `other-${i}`, payload: i } as never);
     }
     const q = getOfflineQueue();
-    expect(q.length).toBeLessThanOrEqual(50);
+    expect(q.length).toBeLessThanOrEqual(MAX_OFFLINE_QUEUE);
     // Oldest entries should be dropped, newest preserved.
     const last = q[q.length - 1];
-    expect(last.type).toBe("other-119");
+    expect(last.type).toBe(`other-${total - 1}`);
   });
 
   it("does not coalesce into a non-push last entry", () => {

--- a/packages/shared/src/sync/__tests__/modules.test.ts
+++ b/packages/shared/src/sync/__tests__/modules.test.ts
@@ -158,8 +158,8 @@ describe("SYNC_MODULES registry", () => {
       expect(SYNC_STATUS_EVENT).toBe("hub-cloud-sync-status");
     });
 
-    it("MAX_OFFLINE_QUEUE keeps the documented cap", () => {
-      expect(MAX_OFFLINE_QUEUE).toBe(50);
+    it("MAX_OFFLINE_QUEUE keeps the documented cap (raised to 10 000 in PR #009 once web moved to IDB)", () => {
+      expect(MAX_OFFLINE_QUEUE).toBe(10_000);
     });
   });
 });

--- a/packages/shared/src/sync/modules.ts
+++ b/packages/shared/src/sync/modules.ts
@@ -94,11 +94,17 @@ export const SYNC_STATUS_EVENT = "hub-cloud-sync-status";
 /**
  * Hard cap on the offline queue length. Beyond this we drop the
  * oldest entries to keep storage usage bounded for users offline
- * for extended periods. Same value on web (localStorage) and
- * mobile (MMKV); raised together when sync metadata moves to IDB
- * (PR #009 in the storage roadmap).
+ * for extended periods.
+ *
+ * PR #009 (storage-roadmap Stage 1) raised this from 50 to 10 000
+ * once web's offline queue moved off localStorage (~5 MB cap) onto
+ * IDB (multi-GB practical cap) via `apps/web/src/core/cloudSync/
+ * storage/syncMetaStore.ts`. Mobile (MMKV) had no comparable cap
+ * but inherits the same value so cross-platform replay parity holds:
+ * a user who goes offline for two weeks on web and three on mobile
+ * has the same retention guarantees on both.
  */
-export const MAX_OFFLINE_QUEUE = 50;
+export const MAX_OFFLINE_QUEUE = 10_000;
 
 /**
  * Flat read-only view of every storage key registered with any sync


### PR DESCRIPTION
Closes Stage 1 PR #009 of `docs/planning/storage-roadmap.md`.

## What's new

- New IDB-backed durable store at `apps/web/src/core/cloudSync/storage/syncMetaStore.ts` using `idb-keyval` (DB `sergeant-sync-meta`, store `v1`). Same pattern as the existing React-Query persister at `apps/web/src/shared/lib/api/queryClientPersister.ts`.
- `offlineQueue.ts` now keeps a sync **in-memory cache** as the source of truth for `getOfflineQueue` / `addToOfflineQueue` / `clearOfflineQueue` and writes through to:
  - **IDB** — durable, no quota cap (multi-GB practical).
  - **localStorage** — best-effort backup, only while the queue is ≤100 entries (otherwise we skip the write to avoid O(N) `JSON.stringify` churn). The sync API contract is preserved — no async migration of every caller.
- New `hydrateOfflineQueueFromDisk()` reconciles the cache with IDB and one-shot-migrates any LS-only legacy queue into IDB. Wired into `engine/replay.ts` so it runs lazily before each replay; subsequent calls are cheap.
- `MAX_OFFLINE_QUEUE` raised from **50 → 10 000** in `packages/shared/src/sync/modules.ts` now that LS isn't gating queue size — matches the AC in storage-roadmap (`Знімає 5–10 MB cap для offline queue`).

## Why dual-write to LS at all

1. On cold boot, the first sync `getOfflineQueue()` needs to return data immediately. LS gives a synchronous warm-start while async IDB resolves.
2. Safari Private Browsing on older iOS exposes IDB but flushes on tab close; LS at least lasts the session.

Past 100 entries we stop dual-writing — IDB is authoritative, LS is allowed to look stale, and we skip the O(N) stringify churn.

## Tests

- New `syncMetaStore.test.ts` (9 cases): get/set/del roundtrip, IDB-unavailable fallback, key registry snapshot, LS→IDB migration in `hydrateOfflineQueueFromDisk`, error path when IDB throws, end-to-end dual-write + clear.
- Existing `offlineQueue.replay.test.ts` and `useCloudSync.{behavior,hardening}.test.ts` updated to reset the in-memory cache between tests via `__resetOfflineQueueCacheForTests()` — `localStorage.clear()` alone no longer empties the queue.
- `MAX_OFFLINE_QUEUE` snapshot in `packages/shared/src/sync/__tests__/modules.test.ts` updated to `10 000`.

All 222 cloudSync tests + the shared sync registry tests pass locally; eslint + `tsc -p apps/web/tsconfig.json` + `tsc -p packages/shared/tsconfig.json` clean.

Mobile (`apps/mobile`) inherits the new `MAX_OFFLINE_QUEUE` constant from `@sergeant/shared` but is otherwise unchanged in this PR — MMKV doesn't have the same 5 MB cap, so the bump is safe; a follow-up can move sync metadata onto Drizzle/SQLite when that work lands.

## What's NOT in this PR (deferred)

- `SYNC_VERSIONS`, `SYNC_DIRTY_MODULES`, `SYNC_MODULE_MODIFIED` still live in localStorage. Their consumers do direct LS reads/writes inside synchronous code paths (see `apps/web/src/core/cloudSync/state/{versions,dirtyModules,moduleData}.ts` and the tests that assert on `localStorage.getItem(...)` directly), so promoting them to IDB requires either a wider refactor of every consumer to async or the same cache+dual-write pattern applied across three more touchpoints. Splitting that out keeps this PR focused on the highest-impact, queue-capacity-affecting change. A follow-up sub-PR will land it.

---

Stage 1 close-out series:
- PR #1520 — drain LS allowlist to 0 (final sub-PR #013)
- PR #1521 — Postgres-backed rate-limit (PR #011)
- PR #1524 — fix `format:check` on `dev-stack-roadmap.md` (must merge first)
- **this PR** — offline queue → IDB (PR #009)
- PR #010 — consolidate 4 IDB databases into one `sergeant-db` (next)

Devin run: https://app.devin.ai/sessions/36109f0d6a0843af9070d451862288e7
Requested by: dmytro.s.stakhov (@dmytro.s.stakhov@gmail.com)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the cloud-sync offline queue from localStorage to IndexedDB with an in-memory cache and selective LS backup, removing the 5–10 MB cap and raising the queue limit to 10,000. Improves reliability while keeping existing sync calls synchronous.

- **New Features**
  - Added an IDB-backed store `syncMetaStore.ts` using `idb-keyval` (DB `sergeant-sync-meta`, store `v1`).
  - Offline queue now uses an in-memory cache; writes through to IDB and to localStorage only when the queue ≤100 entries.
  - Added `hydrateOfflineQueueFromDisk()` to reconcile and one-shot migrate LS data; called before each replay.
  - Raised `MAX_OFFLINE_QUEUE` from 50 to 10_000 in `@sergeant/shared`.

- **Migration**
  - No changes required for callers. The queue auto-migrates from localStorage during replay.
  - Tests that assumed LS-only state should also reset the in-memory cache via `__resetOfflineQueueCacheForTests()`.

<sup>Written for commit c40415e6523afbf15b91853bbd9ceec76df8fc21. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Increased offline queue capacity from 50 to 10,000 entries, enabling applications to queue significantly more operations during extended offline periods.
  * Enhanced offline synchronization reliability with improved storage mechanisms.

* **Tests**
  * Expanded test suite coverage for offline queue operations and synchronization workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->