### PR TITLE
docs(docs): initiative 0002 mobile platform decision (sunset deadline)

### DIFF
--- a/docs/initiatives/0002-mobile-platform-decision.md
+++ b/docs/initiatives/0002-mobile-platform-decision.md
@@ -1,0 +1,120 @@
+# 0002 — Mobile platform decision: lock the deprecation deadline
+
+> **Status:** Proposed
+> **Priority:** P0 (Sprint 1)
+> **Owner:** `@Skords-01`
+> **ETA:** 2 weeks (рішення + 1 ADR + комунікація)
+> **Sources:** Design Review 2026-05-03 §10, ADR-0010, [`docs/architecture/platforms.md`](../architecture/platforms.md), [`docs/mobile/react-native-migration.md`](../mobile/react-native-migration.md)
+
+## TL;DR
+
+[ADR-0010](../adr/0010-mobile-dual-track-capacitor-expo.md) дозволяє dual-track (Capacitor shell + Expo RN), але **без жорсткого дедлайну** на deprecation shell-у. У результаті ми платимо подвійну ціну (підтримка двох пайплайнів, два store-listing-и, два набори Sentry-проєктів, дві QA-матриці) **без зворотного відліку**. Ця ініціатива не обирає інший стек — вона **формалізує дедлайн**: проставити фіксовану дату «freeze shell, RN-only» на основі feature-parity gating і опублікувати її в ADR-0010 як **Exit decision**.
+
+## Чому зараз
+
+- Поточний стан з аудиту: для одного мейнтейнера два мобільні пайплайни — це **найбільший maintenance-tax**.
+- ADR-0010 містить **Exit criteria**, але не **Exit deadline**. Параграф «Shell переходить у `deprecated` коли всі пункти виконуються» є open-ended → коли всі пункти не виконані одночасно, нічого не відбувається.
+- `apps/mobile-shell/` отримує патчі (Capacitor 7 bumps, Android shell pipeline), які з'їдають час, що міг би піти на RN-міграцію.
+- Метрики store-presence шеллу і RN-парiтету не публікуються регулярно → рішення «коли cut-off-нути» приймається на око.
+
+## Скоуп
+
+**In:**
+
+1. Зібрати feature-parity матрицю **на 2026-05-08** (web ↔ shell ↔ RN) і опублікувати в `docs/architecture/platforms.md`.
+2. Заміряти cost dual-track-у в годинах підтримки за квартал (build-pipelines, Sentry triage, deps bumps).
+3. Прийняти **operational decision**: дата T₀ — після якої всі shell-only PR-и (крім deprecation banner) **відхиляються** на CR.
+4. Прийняти T₁ — дата remove-from-store shell-у (T₀ + 90 днів).
+5. Замінити «accepted» статус ADR-0010 на «accepted-with-sunset», додати дати T₀/T₁, посилання сюди.
+6. Усунути дрейф: lint-правило `forbid-shell-only-feature` (заборона нових modules в `apps/mobile-shell/src/`, що не існують у `apps/mobile/`).
+
+**Out:**
+
+- Сам RN-порт; він уже tracks у [`docs/mobile/react-native-migration.md`](../mobile/react-native-migration.md).
+- Декомпозиція `apps/mobile/` файлів — ініціатива [0001](./0001-module-decomposition.md) бере тільки web.
+- Mobile e2e на CI — окрема ініціатива (буде додана), see [`docs/planning/mobile-e2e-testing.md`](../planning/mobile-e2e-testing.md).
+
+## План змін
+
+### Фаза 1 — інвентаризація і метрики (3 дні)
+
+- **PR `mobile-feature-parity-matrix`** — оновити [`docs/architecture/platforms.md`](../architecture/platforms.md) з повною feature-parity таблицею:
+  | Module        | Web | Shell | RN | Notes |
+  | ------------- | --- | ----- | -- | ----- |
+  | Auth (Better) | ✅  | ✅    | ✅ | bearer контракт уніфікований |
+  | Hub chat      | ✅  | ✅    | 🟡 | RN voice ще без STT-fallback |
+  | … (повний список) |
+- **PR `mobile-tax-report`** — додати у `docs/initiatives/0002-…` секцію *Outcome → Cost baseline* з:
+  - Кількість shell-related commits / quarter
+  - Sentry shell-only events / week
+  - Час на shell-Capacitor bumps (з PR-історії, грубо)
+  - Tracker — створити простий `scripts/report-shell-tax.mjs`, що рахує комміти по `apps/mobile-shell/**` за останні 90 днів.
+
+### Фаза 2 — рішення і ADR (3 дні)
+
+- **PR `adr-0010-supersede-deadline`** — оновити [ADR-0010](../adr/0010-mobile-dual-track-capacitor-expo.md):
+  - Status: `accepted` → `accepted-with-sunset`.
+  - Додати секцію **Sunset schedule**:
+    - **T₀ (shell freeze):** YYYY-MM-DD (рекомендоване — 2026-09-01, тобто сприйнятний дедлайн на закриття RN-Nutrition, RN-Voice, RN-Detox e2e).
+    - **T₁ (remove-from-store):** T₀ + 90 днів.
+    - **T₂ (delete `apps/mobile-shell/`):** T₁ + 30 днів.
+  - Додати **Exit dashboard** — три бінарні маяки (RN Nutrition done, RN Voice done, RN Detox e2e), стан читається з `docs/architecture/platforms.md` і коментується раз на спринт.
+  - Додати посилання на цю ініціативу.
+
+### Фаза 3 — guardrails (1–2 дні)
+
+- **PR `lint-forbid-shell-only-feature`** — у `packages/eslint-plugin-sergeant-design/` додати правило, яке падає на новий файл у `apps/mobile-shell/src/**`, що не має «mirror» у `apps/mobile/` (за конвенцією path-mirror). Allowlist для shell-glue (build configs, Capacitor plugin shims).
+- **PR `ci-shell-tax-report`** — щотижневий cron у GH Actions: запускає `scripts/report-shell-tax.mjs`, постить summary у `#mobile-channel` через webhook.
+
+### Фаза 4 — комунікація (1 день)
+
+- Пост у `#mobile-channel`: «Mobile platform decision: shell sunsets at T₀, RN-only after T₀».
+- Сповіщення для бета-тестерів shell-білду (через TestFlight/Play Internal): «Shell перейде у deprecated режим у дату T₀, переключайтеся на RN-app».
+- Оновити `docs/mobile/shell.md` — секція «Sunset» з датами.
+
+## Критерії DONE
+
+- [ ] [ADR-0010](../adr/0010-mobile-dual-track-capacitor-expo.md) має поле `Sunset schedule` з трьома датами.
+- [ ] У `docs/architecture/platforms.md` є feature-parity таблиця, оновлена за останні 7 днів.
+- [ ] `scripts/report-shell-tax.mjs` бігає у CI cron щотижня.
+- [ ] У lint-плагіні є rule `forbid-shell-only-feature` із покриттям unit-тестами.
+- [ ] У `#mobile-channel` опубліковано рішення з датами.
+- [ ] `apps/mobile-shell/src/` не отримав жодного нового модуля з моменту впровадження lint-правила (грейс-період 1 спринт для in-flight PR-ів).
+
+## Ризики та митиґація
+
+| Ризик                                                                                  | Мітигація                                                                                                                               |
+| -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| До T₀ RN ще не готовий → доводиться зсувати дату                                       | Рішення про зсув приймається тільки на основі **публічної** feature-parity таблиці. Якщо хоч один маяк червоний — дата зсувається на 30 днів і це коментується у ADR-Outcome. Без таких зсувів — shell сам по собі живе тихо. |
+| Користувачі shell-білду залишаться без апдейтів після T₁                              | Перед T₀ випустити shell-білд із in-app banner «Перехід на RN-версію + deep link на store-листинг». Push-нотифікація 2× у грейс-період (T₀..T₁). |
+| Маркетингові кампанії, що ведуть на shell-листинг                                      | Координувати з marketing console (`apps/console/`): після T₁ всі shell-deeplinks redirect на RN-app store-page (через App Links / Universal Links). |
+| Sentry/Analytics історичні дані shell-у втратяться                                     | Після T₂ зробити архів `data-export/shell-events.parquet` у Sentry і покласти в `ops/data-archive/` (без PII).                                     |
+
+## Метрики
+
+| Метрика                                        | Baseline (2026-05-03) | Target (T₂)                                                |
+| ---------------------------------------------- | --------------------- | ---------------------------------------------------------- |
+| Активні мобільні платформи                     | 2 (shell + RN)        | 1 (RN-only)                                                |
+| `apps/mobile-shell/**` LOC                     | ~? (заміряти у фазі 1) | 0 (видалено)                                              |
+| Shell-only Sentry projects                     | 1                     | 0 (закрити після T₂)                                       |
+| RN feature-parity маяків зелених               | ? / 3                 | 3 / 3 до T₀                                                |
+| % Shell-installs з deep-link на RN до T₁       | n/a                   | ≥ 80% before remove-from-store                            |
+
+## Власник, ревʼюери
+
+- **Lead:** `@Skords-01`.
+- **Reviewers:** ті, хто дотикається до `apps/mobile/**` та `apps/mobile-shell/**`.
+- **Зовнішня комунікація:** beta-channel пост, marketing-console announcement.
+
+## Посилання
+
+- Design Review 2026-05-03 — §10 (Mobile strategy)
+- [ADR-0010 Mobile dual-track](../adr/0010-mobile-dual-track-capacitor-expo.md) — буде оновлено
+- [`docs/architecture/platforms.md`](../architecture/platforms.md) — feature-parity матриця
+- [`docs/mobile/react-native-migration.md`](../mobile/react-native-migration.md) — RN port roadmap
+- [`docs/mobile/shell.md`](../mobile/shell.md) — operator-ref для shell
+- [`docs/planning/mobile-e2e-testing.md`](../planning/mobile-e2e-testing.md) — e2e roadmap
+
+## Outcome
+
+_Заповнюється після завершення._


### PR DESCRIPTION
## Summary

Друга ініціатива з docs/initiatives/. Фіксує **дедлайн** для deprecation Capacitor shell-у замість open-ended exit-criteria, які стоять в [ADR-0010](https://github.com/Skords-01/Sergeant/blob/main/docs/adr/0010-mobile-dual-track-capacitor-expo.md) зараз.

**Не міняє стек.** RN лишається цільовим клієнтом, ADR-0010 не суперседиться, тільки доповнюється sunset-розкладом і guardrails-ами:

- **T₀** (рекомендоване 2026-09-01): freeze всіх shell-only PR-ів, окрім deprecation banner.
- **T₁** = T₀+90д: remove-from-store shell-білдів.
- **T₂** = T₁+30д: видалити `apps/mobile-shell/`.
- ESLint rule `forbid-shell-only-feature` — забороняє додавати модуль у shell без mirror у RN.
- Weekly cron `scripts/report-shell-tax.mjs` → постить shell-cost summary у `#mobile-channel`.

## Чому це важливо

ADR-0010 пише «Shell переходить у deprecated коли всі пункти виконуються», але без дати ці пункти можуть лежати у напівзеленому стані безкінечно — а cost dual-track-у (два пайплайни, два store-listing-и, дві Sentry-проєкти, дві QA-матриці) тримається. Один мейнтейнер не може це нести довго.

## Що в цьому PR

Тільки документ:
- `docs/initiatives/0002-mobile-platform-decision.md`

## Що НЕ в цьому PR

- Зміни ADR-0010 (PR `adr-0010-supersede-deadline` — фаза 2 ініціативи)
- ESLint rule (PR `lint-forbid-shell-only-feature` — фаза 3)
- Cron-скрипт (PR `ci-shell-tax-report` — фаза 3)
- Зміни в `docs/mobile/shell.md` (фаза 4)

## Контекст

Виходить з design-review від 2026-05-03 §10. Координується з [`docs/mobile/react-native-migration.md`](https://github.com/Skords-01/Sergeant/blob/main/docs/mobile/react-native-migration.md) і [`docs/architecture/platforms.md`](https://github.com/Skords-01/Sergeant/blob/main/docs/architecture/platforms.md).

---

🤖 Generated with [Devin](https://devin.ai/) — session: https://app.devin.ai/sessions/9c4de0ea33e14da3ae0d762ee1732de1
Co-Authored-By: dmytro.s.stakhov <dmytro.s.stakhov@gmail.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `docs/initiatives/0002-mobile-platform-decision.md` to set a firm sunset for the Capacitor shell per ADR-0010. Defines T0 freeze, T1 remove-from-store, T2 delete `apps/mobile-shell/`, and outlines guardrails (`forbid-shell-only-feature`, weekly `scripts/report-shell-tax.mjs`); RN remains the target.

<sup>Written for commit d99b748950dd475d89b773a68f74366cfbe90f49. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added initiative documentation outlining a timeline and strategy for mobile platform transition, including deprecation schedule, acceptance criteria, and migration plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
## Governing Skill

- Primary skill: docs-only initiative authoring
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: `docs/initiatives/` framework (PR #1527)
- Why this playbook: structured initiative format with TL;DR, Скоуп, План, Критерії DONE, Ризики, Метрики, Власник, Посилання, Outcome
- If no playbook matched, why: n/a

## Verification

```bash
# Лише docs-only зміни. Lint/typecheck/test проганяються через CI.
pnpm lint
pnpm typecheck
```

Additional checks:

- [x] Local smoke / manual validation completed (markdown rendering ОК, лінки локальні)
- [x] Surface-specific checks completed (структура повторює інші ініціативи у `docs/initiatives/`)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update. (не потрібно — це документ-план, не зміна контракту)
- [x] I checked whether a playbook or skill needed an update. (індекс `docs/initiatives/README.md` оновлено окремо в main)
- [x] I checked whether governance docs or review docs needed an update. (не потрібно)

Updated docs:

- `docs/initiatives/000N-*.md` (тільки нова ініціатива у цьому PR)

## Risk and Rollout

- User-visible risk: **немає** — це план, а не зміна коду чи поведінки.
- Rollout / deploy order: merge → файл доступний у репі → подальші PR-и реалізують фази, описані в плані.
- Backout plan: revert PR. Жодних migrations / runtime side-effects.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

Це **doc-only PR** із планом ініціативи. Жодних змін у коді, конфіги, міграції не зачіпаються. Зміст плану — в `docs/initiatives/000N-*.md`. Наступні PR-и реалізовуватимуть фази, описані в плані.
