### PR TITLE
docs(docs): initiative 0003 sync v2 rollout & v1 sunset

### DIFF
--- a/docs/initiatives/0003-sync-v2-rollout-and-v1-sunset.md
+++ b/docs/initiatives/0003-sync-v2-rollout-and-v1-sunset.md
@@ -1,0 +1,164 @@
+# 0003 — Sync v2 rollout & v1 sunset
+
+> **Status:** Proposed
+> **Priority:** P0 (Sprint 1–2)
+> **Owner:** `@Skords-01`
+> **ETA:** 4 weeks (rollout — 2 sprints, sunset v1 — третій спринт)
+> **Sources:** Design Review 2026-05-03 §2.2, §5.2; ADR-0004 (CloudSync LWW), [`docs/planning/storage-roadmap.md`](../planning/storage-roadmap.md)
+
+## TL;DR
+
+Sergeant зараз **паралельно тримає два sync-механізми**: LWW-blob v1 (legacy CloudSync) і op-log v2 ([`/v2/sync/push|pull|stream`](../planning/storage-roadmap.md), PR #021/#040). Це означає, що та сама зміна може йти двома шляхами одночасно → ризик split-brain і конфліктів LWW vs op-log. План: жорстко **газувати rollout v2** з метриками (queue lag, conflict rate, op-log throughput), оголосити **`Sunset:` HTTP-header** для v1-ендпоінтів і визначити **дату вимкнення v1** (T₀). Все це — без зміни клієнтських API: feature-flag «cloudSyncMode = v1|dual|v2».
+
+## Чому зараз
+
+- v1 (LWW-blob) і v2 (op-log) **обоє в production**, обидва пишуть у БД (`module_data` blob ↔ `sync_op_log` rows). Замикається тільки на client-side merge — жоден сервер не валідує, що домен пише в один канал.
+- Аудит [`docs/audits/2026-04-28-sergeant-comprehensive-audit.md`](../audits/2026-04-28-sergeant-comprehensive-audit.md) і design-review від 2026-05-03 окремо позначили це як високопріоритетний ризик.
+- v2 уже працює **для routine + fizruk + nutrition (новий цикл)**, але v1 не має дедлайну на видалення. Кожна нова фіча має приймати рішення «v1 чи v2» — drift накопичується.
+- Серверний `module_data` blob — найшвидший спосіб втратити дані при write-skew (два клієнти пишуть з різних девайсів).
+
+## Скоуп
+
+**In:**
+
+1. Server-side метрики rollout-у v2 та v1-traffic (Pino + Grafana).
+2. `Sunset:` HTTP-header на v1-ендпоінтах ([RFC 8594](https://www.rfc-editor.org/rfc/rfc8594) сумісний).
+3. Feature-flag `cloudSyncMode` per-user / per-module (web + RN).
+4. **Shadow mode** — клієнт пише і v1, і v2; сервер порівнює і логує дельту.
+5. Migration-скрипт (idempotent), який бекфілить історію `module_data` → `sync_op_log` для активних користувачів.
+6. ADR `0040+ — Sunset of CloudSync v1 (LWW-blob)`.
+7. Дата T₀ — після якої v1-ендпоінти повертають `410 Gone` з посиланням на migration guide.
+
+**Out:**
+
+- CRDT для routine streak — окрема ініціатива (тривіально вкладається у v2 op-log пізніше).
+- SSE-стрим у v2 (`GET /v2/sync/stream`) — описаний у roadmap-і, не блокує цю ініціативу.
+- Mobile (Expo RN) — підключиться через окремий PR після того, як web стабілізує v2 (1-тижневе lag).
+
+## План змін
+
+### Фаза 1 — observability (1 PR)
+
+**PR `sync-v1-v2-grafana-dashboards`:**
+
+- У `apps/server/src/modules/sync/` додати Pino-метрики:
+  - `sync_v1_blob_writes_total` (counter)
+  - `sync_v2_oplog_writes_total` (counter)
+  - `sync_v1_v2_dual_writes_total` (counter — обидва канали для одного user × module за 60s window)
+  - `sync_v2_pull_lag_ms` (histogram, p50/p95/p99)
+  - `sync_v2_conflict_rate` (gauge, % LWW-rejects)
+  - `sync_v2_queue_depth` (gauge, кількість unflushed op-log entries у клієнтському outbox)
+- У `ops/grafana/dashboards/` додати `sync.json` із 6 panels.
+- Алерти у `ops/grafana/alerts/`: conflict_rate > 5%, queue_depth > 100, lag p99 > 5s — slack ping.
+
+### Фаза 2 — `Sunset:` header + ADR (1 PR)
+
+**PR `adr-0040-sunset-cloudsync-v1`:**
+
+- Створити ADR `docs/adr/0040+-sunset-cloudsync-v1.md` (наступний номер після 0040 — перевірити поточний максимум).
+- Додати `Sunset: <T₀>` + `Deprecation: true` + `Link: <…>; rel="successor-version"` headers на:
+  - `GET/PUT /api/v1/sync/module/:moduleId`
+  - `GET/POST /api/v1/sync/cloudsync/*`
+  - решту v1-routes (повний список — у `apps/server/src/modules/sync/sync.ts`).
+- Логувати `sync_v1_request_total` з `userAgent` і `appVersion` тегами — щоб знати, **хто ще викликає v1** до T₀.
+
+### Фаза 3 — feature-flag + shadow mode (1 PR)
+
+**PR `feat-cloudsync-mode-flag`:**
+
+- У `apps/web/src/core/cloudSync/` додати feature-flag `cloudSyncMode: "v1" | "dual" | "v2"`. Default — `dual`.
+- У `dual`-режимі клієнт пише v1 і v2 паралельно (existing v1 path + новий outbox-flush у v2). Мердж робиться local — v2 — leader, v1 — write-only-mirror.
+- Сервер у `dual` **read** повертає v1 blob + порівнює з op-log → якщо є diverge, лог:
+  ```ts
+  log.warn('cloudsync.dual.diverge', { userId, moduleId, hashV1, hashV2, lastOpId });
+  ```
+- На rollout: 5% → 25% → 50% → 100% за 2 тижні. Кожен step gated на conflict_rate < 1%.
+
+### Фаза 4 — backfill (1 PR)
+
+**PR `backfill-cloudsync-v1-to-v2-oplog`:**
+
+- Idempotent migration-скрипт `apps/server/src/scripts/backfill-v1-to-oplog.ts`:
+  - Читає `module_data` blob → робить diff проти `sync_op_log` (по `client_ts`) → emiт-ить додаткові op-log entries для зниклих змін.
+  - Запуск як CLI, не як автоматична міграція (надто часозатратно).
+  - Має `--dry-run` (вмикається CI-ом для регресій).
+- Лог metric `backfill_v1_to_v2_inserted_total` per-module → закидається у Grafana.
+- Запуск **на всіх активних юзерах** (last_seen ≤ 90 днів) під час фази 5.
+
+### Фаза 5 — sunset (1 PR)
+
+**PR `feat-cloudsync-v1-readonly-mode`:**
+
+- Перед T₀ у клієнта примусити `cloudSyncMode = "v2"` (web + RN). Перехід — на наступному launch (перевірка через feature-flag remote).
+- На T₀:
+  - v1 PUT/POST → `410 Gone` з body:
+    ```json
+    {
+      "error": "cloudsync_v1_sunset",
+      "successor": "/api/v2/sync",
+      "since": "T₀ ISO date",
+      "guide": "https://docs/initiatives/0003-..."
+    }
+    ```
+  - v1 GET → ще працює 30 днів read-only (рятувальний канал для застарілих клієнтів).
+- На T₀+30: видалити v1-routes повністю + видалити колонку `module_data` (двофазний DROP per AGENTS.md hard rule #4).
+
+### Фаза 6 — clean-up (1 PR)
+
+**PR `chore-remove-cloudsync-v1`:**
+
+- Видалити `apps/server/src/modules/sync/sync.ts` v1-handlers + `apps/web/src/core/cloudSync/v1/`.
+- Зберегти minimal `successor-redirect` middleware на 30 днів — потім теж видалити.
+- Закрити tech-debt запис у [`docs/tech-debt/backend.md`](../tech-debt/backend.md) → перейменувати з «In progress» в «Done».
+
+## Критерії DONE
+
+- [ ] У Grafana є dashboard `sync.json` з 6 panels і трьома алертами.
+- [ ] `Sunset:` header виставляється на всіх v1-ендпоінтах.
+- [ ] `cloudSyncMode = "v2"` для 100% web/RN користувачів за 30 днів до T₀.
+- [ ] `dual`-mode diverge-rate стабільно < 0.5% за останні 2 тижні перед cut-off.
+- [ ] Backfill запущений для 100% активних юзерів (`last_seen ≤ 90d`).
+- [ ] T₀: `/api/v1/sync/*` повертає `410 Gone`.
+- [ ] T₀ + 30 днів: v1-handlers і колонка `module_data` видалені (двофазний DROP).
+- [ ] ADR `0040+-sunset-cloudsync-v1.md` змерджено.
+- [ ] Tech-debt запис «CloudSync v1/v2 dual-stack» закрито.
+
+## Ризики та митиґація
+
+| Ризик                                                              | Мітигація                                                                                                                                       |
+| ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Старі мобільні клієнти (TestFlight beta, internal test track) вб'ються на T₀ | Перед T₀ broadcast push «оновіться, інакше sync не працюватиме». Force-update через app version check у Better Auth (existing). |
+| Backfill міксує LWW і op-log → подвоєння                          | Idempotency-key на op-log entries (existing PR #021). Backfill emit-ить тільки entries, чий hash не присутній.                                  |
+| `dual`-mode подвоює write-навантаження на DB                      | Rollout 5% → 100% з моніторингом p99 latency. Якщо p99 росте >20% — пауза.                                                                     |
+| Користувачі з конфліктами між v1/v2 під час dual-mode             | Логуємо diverge, але **не «блокуємо» юзера**. Recovery-flow: «Resync» кнопка у Settings, що робить fresh pull v2 і перезаписує local.          |
+| Бекап-стратегія для blob `module_data` перед drop                 | Перед T₀+30 робимо `pg_dump module_data → s3://sergeant-archive/module_data-T₀.sql.gz`. Зберігається 1 рік.                                     |
+
+## Метрики
+
+| Метрика                                              | Baseline (2026-05-03)           | Target (T₀)                    | Target (T₀ + 30 днів) |
+| ---------------------------------------------------- | ------------------------------- | ------------------------------ | --------------------- |
+| % users on `cloudSyncMode = "v2"`                    | ? (заміряти у фазі 1)           | 100%                           | 100%                  |
+| `sync_v1_request_total` per hour                     | ?                               | < 5/hour (тільки legacy bots)  | 0                     |
+| `sync_v1_v2_dual_writes_total`                       | ?                               | 0 (cleanup)                    | 0                     |
+| Conflict rate (`sync_v2_conflict_rate`)              | ?                               | < 1%                           | < 1%                  |
+| Diverge events / 100k requests (`dual` mode)         | n/a                             | < 50                           | n/a (mode disabled)   |
+| `module_data` колонка існує                          | yes                             | yes                            | no                    |
+
+## Власник, ревʼюери
+
+- **Lead:** `@Skords-01`.
+- **Required review:** будь-який PR, що чіпає `apps/server/src/modules/sync/**` або `apps/web/src/core/cloudSync/**`, потребує review від маршрутних code-owner-ів за CODEOWNERS.
+
+## Посилання
+
+- Design Review 2026-05-03 — §2.2, §5.2
+- [ADR-0004 CloudSync LWW conflict resolution](../adr/0004-cloudsync-lww-conflict-resolution.md)
+- [`docs/planning/storage-roadmap.md`](../planning/storage-roadmap.md) — Stage 5 sync-v2
+- [`docs/tech-debt/backend.md`](../tech-debt/backend.md) — запис «CloudSync v1/v2 dual-stack»
+- [`apps/server/src/modules/sync/sync.ts`](../../apps/server/src/modules/sync/sync.ts) — v1-handlers
+- [`apps/web/src/core/cloudSync/`](../../apps/web/src/core/cloudSync/) — v2 outbox
+- RFC 8594 — `Sunset` HTTP header
+
+## Outcome
+
+_Заповнюється після завершення._


### PR DESCRIPTION
## Summary

Третя ініціатива з docs/initiatives/. Адресує **split-brain ризик** через паралельне існування CloudSync v1 (LWW-blob) і v2 (op-log), описаний у design-review 2026-05-03 §2.2.

Не змінює клієнтський API. План — feature-flag `cloudSyncMode = v1|dual|v2`, observability, потім `Sunset:` header, потім T₀ cut-off і двофазний DROP колонки `module_data`.

## Чому це важливо

`apps/server/src/modules/sync/sync.ts` досі обслуговує v1 (whole-blob LWW), а `/v2/sync/push|pull|stream` (PR #021/#040) уже працює для routine + fizruk + nutrition. Кожна нова фіча приймає окреме рішення «v1 чи v2» — drift накопичується, і split-brain між двома каналами тільки питання часу.

Без формального дедлайну на v1 — ми тримаємо два пайплайни безкінечно.

## Що в цьому PR

Тільки документ:
- `docs/initiatives/0003-sync-v2-rollout-and-v1-sunset.md`

## Що НЕ в цьому PR

- 6 фаз rollout-у (по PR на фазу): observability dashboards, `Sunset:` header + ADR-0040+, feature-flag + shadow mode, backfill, sunset (410 Gone), final cleanup.
- ADR `0040+-sunset-cloudsync-v1.md` (фаза 2)
- Зміни в `apps/server/src/modules/sync/` і `apps/web/src/core/cloudSync/`

## Ключові точки

- **Shadow mode (`dual`)** — клієнт пише обидва канали, сервер логує diverge.
- **Rollout-gates** — 5% → 25% → 50% → 100% за 2 тижні, gated на conflict_rate < 1%.
- **T₀** — після цієї дати v1 повертає `410 Gone` з посиланням на migration guide.
- **T₀+30 днів** — двофазний DROP колонки `module_data` (per AGENTS.md hard rule #4) + `pg_dump` archive у S3 (1 рік).
- **Idempotent backfill** з v1 blob → v2 op-log для активних юзерів.
- 6 нових Grafana metrics + 3 алерти.

## Контекст

Design Review 2026-05-03 §2.2 / §5.2. Координується з [`docs/planning/storage-roadmap.md`](https://github.com/Skords-01/Sergeant/blob/main/docs/planning/storage-roadmap.md) Stage 5, [ADR-0004 CloudSync LWW](https://github.com/Skords-01/Sergeant/blob/main/docs/adr/0004-cloudsync-lww-conflict-resolution.md), та існуючим PR #021/#040.

---

🤖 Generated with [Devin](https://devin.ai/) — session: https://app.devin.ai/sessions/9c4de0ea33e14da3ae0d762ee1732de1
Co-Authored-By: dmytro.s.stakhov <dmytro.s.stakhov@gmail.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an initiative doc that defines the rollout for CloudSync v2 and the sunset of v1 to remove split‑brain risk. No code changes; adds `docs/initiatives/0003-sync-v2-rollout-and-v1-sunset.md`.

- **Migration**
  - Introduces `cloudSyncMode` (`v1` | `dual` | `v2`) with `dual` shadow writes and gated rollout.
  - Adds `Sunset` deprecation plan for v1 with T0 cutover and 30‑day read‑only period.
  - Sets up Grafana metrics/alerts for conflict rate, lag, and queue depth.
  - Specifies idempotent backfill v1 blobs → v2 op‑log and two‑phase drop of `module_data`.

<sup>Written for commit 3b9ac9327d28dbd6003f055d96e9353b6acf8821. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added initiative document outlining a planned transition for CloudSync with a phased rollout strategy and sunset timeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
## Governing Skill

- Primary skill: docs-only initiative authoring
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: `docs/initiatives/` framework (PR #1527)
- Why this playbook: structured initiative format with TL;DR, Скоуп, План, Критерії DONE, Ризики, Метрики, Власник, Посилання, Outcome
- If no playbook matched, why: n/a

## Verification

```bash
# Лише docs-only зміни. Lint/typecheck/test проганяються через CI.
pnpm lint
pnpm typecheck
```

Additional checks:

- [x] Local smoke / manual validation completed (markdown rendering ОК, лінки локальні)
- [x] Surface-specific checks completed (структура повторює інші ініціативи у `docs/initiatives/`)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update. (не потрібно — це документ-план, не зміна контракту)
- [x] I checked whether a playbook or skill needed an update. (індекс `docs/initiatives/README.md` оновлено окремо в main)
- [x] I checked whether governance docs or review docs needed an update. (не потрібно)

Updated docs:

- `docs/initiatives/000N-*.md` (тільки нова ініціатива у цьому PR)

## Risk and Rollout

- User-visible risk: **немає** — це план, а не зміна коду чи поведінки.
- Rollout / deploy order: merge → файл доступний у репі → подальші PR-и реалізують фази, описані в плані.
- Backout plan: revert PR. Жодних migrations / runtime side-effects.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

Це **doc-only PR** із планом ініціативи. Жодних змін у коді, конфіги, міграції не зачіпаються. Зміст плану — в `docs/initiatives/000N-*.md`. Наступні PR-и реалізовуватимуть фази, описані в плані.
