### PR TITLE
feat(web): consolidate 5 IndexedDB databases into one (Stage 1 PR #010)

### DIFF
--- a/apps/web/src/core/cloudSync/storage/syncMetaStore.test.ts
+++ b/apps/web/src/core/cloudSync/storage/syncMetaStore.test.ts
@@ -1,36 +1,59 @@
 // @vitest-environment jsdom
 /**
  * Unit tests for the IDB-backed sync metadata store and the
- * `hydrateOfflineQueueFromDisk()` migration glue. PR #009 in
- * `docs/planning/storage-roadmap.md`.
+ * `hydrateOfflineQueueFromDisk()` migration glue.  PR #009 in
+ * `docs/planning/storage-roadmap.md` introduced syncMetaStore as a
+ * dedicated `sergeant-sync-meta` IDB; PR #010 consolidates it into the
+ * shared `sergeant-db` connection.
  *
- * jsdom does NOT ship IndexedDB, so we mock `idb-keyval` with an
- * in-memory map. That gives us deterministic get/set/del semantics
- * without pulling `fake-indexeddb` into the dependency graph; the
- * store wrapper itself is thin enough that exercising it through the
- * mock catches the real bugs (key naming, IDB-unavailable fallback,
- * LS migration handoff).
+ * jsdom does NOT ship IndexedDB.  We mock the shared sergeant-db
+ * module directly with an in-memory map keyed by
+ * `${storeName}:${key}`, so the wrapper's get/set/del paths run end
+ * to end without `fake-indexeddb`.  The mock keeps the same shape as
+ * the real module (`dbGet/dbSet/dbDel/openSergeantDb/migrateLegacyDbOnce`)
+ * so the production module under test is exercised unchanged.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const idbStore = new Map<string, unknown>();
-const idbGetMock = vi.fn(async (key: string) => idbStore.get(key));
-const idbSetMock = vi.fn(async (key: string, value: unknown) => {
-  idbStore.set(key, value);
-});
-const idbDelMock = vi.fn(async (key: string) => {
-  idbStore.delete(key);
-});
-const idbCreateStoreMock = vi.fn(
-  (..._args: unknown[]) => ({ __mock: true }) as unknown,
-);
+const sharedStore = new Map<string, unknown>();
+const cellKey = (storeName: string, key: IDBValidKey): string =>
+  `${storeName}:${String(key)}`;
 
-vi.mock("idb-keyval", () => ({
-  createStore: (dbName: string, storeName: string) =>
-    idbCreateStoreMock(dbName, storeName),
-  get: (key: string, _store: unknown) => idbGetMock(key),
-  set: (key: string, value: unknown, _store: unknown) => idbSetMock(key, value),
-  del: (key: string, _store: unknown) => idbDelMock(key),
+const dbGetMock = vi.fn(async (storeName: string, key: IDBValidKey) =>
+  sharedStore.get(cellKey(storeName, key)),
+);
+const dbSetMock = vi.fn(
+  async (storeName: string, key: IDBValidKey, value: unknown) => {
+    sharedStore.set(cellKey(storeName, key), value);
+  },
+);
+const dbDelMock = vi.fn(async (storeName: string, key: IDBValidKey) => {
+  sharedStore.delete(cellKey(storeName, key));
+});
+const migrateLegacyDbOnceMock = vi.fn(async (_opts: unknown) => {
+  /* no-op — tests that need migration semantics override this */
+});
+const openSergeantDbMock = vi.fn(async () => null);
+
+vi.mock("../../../shared/lib/idb/sergeantDb", () => ({
+  SERGEANT_STORE: {
+    RQ_CACHE: "rq_cache",
+    SYNC_META: "sync_meta",
+    NUTRITION_RECIPES: "nutrition_recipes",
+    NUTRITION_FOODS: "nutrition_foods",
+    NUTRITION_BARCODES: "nutrition_barcodes",
+    NUTRITION_MEAL_THUMBS: "nutrition_meal_thumbs",
+    MIGRATION_META: "migration_meta",
+  },
+  dbGet: (storeName: string, key: IDBValidKey) => dbGetMock(storeName, key),
+  dbSet: (storeName: string, key: IDBValidKey, value: unknown) =>
+    dbSetMock(storeName, key, value),
+  dbDel: (storeName: string, key: IDBValidKey) => dbDelMock(storeName, key),
+  migrateLegacyDbOnce: (opts: unknown) => migrateLegacyDbOnceMock(opts),
+  openSergeantDb: () => openSergeantDbMock(),
+  __resetSergeantDbForTests: () => {
+    /* mock-only no-op */
+  },
 }));
 
 import { OFFLINE_QUEUE_KEY } from "../config";
@@ -50,49 +73,56 @@ import {
 } from "./syncMetaStore";
 
 beforeEach(() => {
-  // Reset shared mutable state before every test.
-  idbStore.clear();
-  idbGetMock.mockClear();
-  idbSetMock.mockClear();
-  idbDelMock.mockClear();
-  idbCreateStoreMock.mockClear();
+  sharedStore.clear();
+  dbGetMock.mockClear();
+  dbSetMock.mockClear();
+  dbDelMock.mockClear();
+  migrateLegacyDbOnceMock.mockClear();
+  openSergeantDbMock.mockClear();
+  // Restore default mock implementations in case a test overrode
+  // them with mockRejectedValueOnce / mockReturnValueOnce.
+  dbGetMock.mockImplementation(async (storeName, key) =>
+    sharedStore.get(cellKey(storeName, key)),
+  );
+  dbSetMock.mockImplementation(async (storeName, key, value) => {
+    sharedStore.set(cellKey(storeName, key), value);
+  });
+  dbDelMock.mockImplementation(async (storeName, key) => {
+    sharedStore.delete(cellKey(storeName, key));
+  });
+  migrateLegacyDbOnceMock.mockImplementation(async () => {});
   localStorage.clear();
   __resetOfflineQueueCacheForTests();
   __resetSyncMetaStoreForTests();
-
-  // jsdom doesn't ship IndexedDB. Provide a stub so the
-  // `idbAvailable()` short-circuit in syncMetaStore.ts treats the env
-  // as IDB-capable and routes to our `idb-keyval` mock above.
-  (globalThis as { indexedDB?: unknown }).indexedDB = {};
 });
 afterEach(() => {
-  delete (globalThis as { indexedDB?: unknown }).indexedDB;
+  localStorage.clear();
 });
 
 describe("syncMetaStore", () => {
-  it("get/set/del roundtrip uses the dedicated 'sergeant-sync-meta' DB and 'v1' store", async () => {
+  it("get/set/del roundtrip routes through the shared sergeant-db 'sync_meta' store", async () => {
     await setSyncMeta(SYNC_META_KEYS.OFFLINE_QUEUE, [{ a: 1 }]);
-    expect(idbCreateStoreMock).toHaveBeenCalledWith("sergeant-sync-meta", "v1");
-    expect(idbSetMock).toHaveBeenCalledWith("offline_queue", [{ a: 1 }]);
+    expect(dbSetMock).toHaveBeenCalledWith("sync_meta", "offline_queue", [
+      { a: 1 },
+    ]);
     expect(await getSyncMeta(SYNC_META_KEYS.OFFLINE_QUEUE)).toEqual([{ a: 1 }]);
 
     await delSyncMeta(SYNC_META_KEYS.OFFLINE_QUEUE);
-    expect(idbDelMock).toHaveBeenCalledWith("offline_queue");
+    expect(dbDelMock).toHaveBeenCalledWith("sync_meta", "offline_queue");
     expect(await getSyncMeta(SYNC_META_KEYS.OFFLINE_QUEUE)).toBeUndefined();
   });
 
-  it("get returns undefined and set/del are no-ops when IndexedDB is unavailable", async () => {
-    delete (globalThis as { indexedDB?: unknown }).indexedDB;
-
-    expect(await getSyncMeta(SYNC_META_KEYS.OFFLINE_QUEUE)).toBeUndefined();
-    await setSyncMeta(SYNC_META_KEYS.OFFLINE_QUEUE, [{ a: 1 }]);
-    await delSyncMeta(SYNC_META_KEYS.OFFLINE_QUEUE);
-
-    // None of the underlying idb-keyval helpers should have been
-    // touched — short-circuit kicked in at the wrapper level.
-    expect(idbGetMock).not.toHaveBeenCalled();
-    expect(idbSetMock).not.toHaveBeenCalled();
-    expect(idbDelMock).not.toHaveBeenCalled();
+  it("invokes the lazy LS→IDB migration once per call before touching the store", async () => {
+    await getSyncMeta(SYNC_META_KEYS.VERSIONS);
+    await setSyncMeta(SYNC_META_KEYS.VERSIONS, { finyk: 1 });
+    await delSyncMeta(SYNC_META_KEYS.VERSIONS);
+    expect(migrateLegacyDbOnceMock).toHaveBeenCalledTimes(3);
+    // Migration descriptor names the legacy DB so the shim knows
+    // which connection to drain.
+    const firstArg = migrateLegacyDbOnceMock.mock.calls[0]?.[0] as
+      | { legacyDbName?: string }
+      | undefined;
+    expect(firstArg?.legacyDbName).toBe("sergeant-sync-meta");
   });
 
   it("exposes the four documented keys (offline queue + 3 sync-meta slots)", () => {
@@ -116,7 +146,7 @@ describe("hydrateOfflineQueueFromDisk", () => {
         ts: "2026-04-01T00:00:00.000Z",
       },
     ];
-    idbStore.set(SYNC_META_KEYS.OFFLINE_QUEUE, idbQueue);
+    sharedStore.set(cellKey("sync_meta", "offline_queue"), idbQueue);
 
     await hydrateOfflineQueueFromDisk();
     expect(getOfflineQueue()).toEqual(idbQueue);
@@ -138,8 +168,14 @@ describe("hydrateOfflineQueueFromDisk", () => {
     expect(getOfflineQueue()).toEqual(lsQueue);
     // ...and IDB should have been populated as a one-shot migration
     // so future cold-boots no longer depend on LS.
-    expect(idbStore.get(SYNC_META_KEYS.OFFLINE_QUEUE)).toEqual(lsQueue);
-    expect(idbSetMock).toHaveBeenCalledWith("offline_queue", lsQueue);
+    expect(sharedStore.get(cellKey("sync_meta", "offline_queue"))).toEqual(
+      lsQueue,
+    );
+    expect(dbSetMock).toHaveBeenCalledWith(
+      "sync_meta",
+      "offline_queue",
+      lsQueue,
+    );
   });
 
   it("hydrates to an empty queue when neither IDB nor LS have data", async () => {
@@ -148,7 +184,7 @@ describe("hydrateOfflineQueueFromDisk", () => {
   });
 
   it("is robust to IDB throwing (Safari Private Browsing, quota) — falls back to LS", async () => {
-    idbGetMock.mockRejectedValueOnce(new Error("quota exceeded"));
+    dbGetMock.mockRejectedValueOnce(new Error("quota exceeded"));
     const lsQueue = [{ type: "evt", payload: 1, ts: "2026-04-01T00:00:00Z" }];
     localStorage.setItem(OFFLINE_QUEUE_KEY, JSON.stringify(lsQueue));
 
@@ -158,25 +194,29 @@ describe("hydrateOfflineQueueFromDisk", () => {
 });
 
 describe("offline queue end-to-end with IDB", () => {
-  it("addToOfflineQueue dual-writes to IDB while the queue is small", () => {
+  it("addToOfflineQueue dual-writes to IDB while the queue is small", async () => {
     addToOfflineQueue({
       type: "push",
       modules: { finyk: { data: { v: 1 } } },
     } as never);
 
-    // IDB write is fire-and-forget but with awaited mocks it fires
-    // synchronously enough that the call is observable.
-    expect(idbSetMock).toHaveBeenCalled();
-    const lastCall = idbSetMock.mock.calls.at(-1);
-    expect(lastCall?.[0]).toBe(SYNC_META_KEYS.OFFLINE_QUEUE);
-    expect((lastCall?.[1] as { type: string }[])[0]?.type).toBe("push");
+    // IDB write is fire-and-forget (`void setSyncMeta(…)`).  The mock
+    // pipeline crosses several microtask boundaries (ensureMigrated
+    // → dbSet), so we need to flush the queue before asserting.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(dbSetMock).toHaveBeenCalled();
+    const lastCall = dbSetMock.mock.calls.at(-1);
+    expect(lastCall?.[0]).toBe("sync_meta");
+    expect(lastCall?.[1]).toBe(SYNC_META_KEYS.OFFLINE_QUEUE);
+    expect((lastCall?.[2] as { type: string }[])[0]?.type).toBe("push");
 
     // LS dual-write also happens for small queues.
     const lsRaw = localStorage.getItem(OFFLINE_QUEUE_KEY);
     expect(lsRaw).not.toBeNull();
   });
 
-  it("clearOfflineQueue removes the row from IDB AND localStorage", () => {
+  it("clearOfflineQueue removes the row from IDB AND localStorage", async () => {
     addToOfflineQueue({
       type: "push",
       modules: { finyk: { data: { v: 1 } } },
@@ -184,8 +224,11 @@ describe("offline queue end-to-end with IDB", () => {
     expect(getOfflineQueue()).toHaveLength(1);
 
     clearOfflineQueue();
+    // `delSyncMeta` is also fire-and-forget — flush microtasks.
+    await new Promise((r) => setTimeout(r, 0));
+
     expect(getOfflineQueue()).toEqual([]);
-    expect(idbDelMock).toHaveBeenCalledWith(SYNC_META_KEYS.OFFLINE_QUEUE);
+    expect(dbDelMock).toHaveBeenCalledWith("sync_meta", "offline_queue");
     expect(localStorage.getItem(OFFLINE_QUEUE_KEY)).toBeNull();
   });
 });

--- a/apps/web/src/core/cloudSync/storage/syncMetaStore.ts
+++ b/apps/web/src/core/cloudSync/storage/syncMetaStore.ts
@@ -1,7 +1,8 @@
 /**
  * IDB-backed durable store for cloud-sync bookkeeping (offline queue,
  * sync versions, dirty modules, last-modified timestamps). PR #009
- * from `docs/planning/storage-roadmap.md`.
+ * from `docs/planning/storage-roadmap.md`; consolidated into the
+ * shared `sergeant-db` connection by PR #010.
  *
  * Why IDB instead of localStorage:
  *   - LS has a 5–10 MB per-origin cap; with `MAX_OFFLINE_QUEUE` raised
@@ -28,20 +29,18 @@
  *
  * Key naming: keys live in a private namespace (`SYNC_META_*`) so
  * future additions don't collide with the wider `STORAGE_KEYS`
- * registry. The DB name is intentionally distinct from
- * `sergeant-rq-cache` (React Query persister) and from the upcoming
- * unified `sergeant` DB (PR #010) — keeping them separate while #010
- * is in flight isolates failure modes.
+ * registry. The data lives in the `sync_meta` object store of the
+ * shared `sergeant-db` (PR #010); the legacy `sergeant-sync-meta`
+ * database is migrated lazily on the first read/write of this
+ * session and then dropped.
  */
 import {
-  createStore,
-  get as idbGet,
-  set as idbSet,
-  del as idbDel,
-} from "idb-keyval";
-
-const DB_NAME = "sergeant-sync-meta";
-const STORE_NAME = "v1";
+  SERGEANT_STORE,
+  dbDel,
+  dbGet,
+  dbSet,
+  migrateLegacyDbOnce,
+} from "../../../shared/lib/idb/sergeantDb";
 
 export const SYNC_META_KEYS = {
   OFFLINE_QUEUE: "offline_queue",
@@ -52,55 +51,70 @@ export const SYNC_META_KEYS = {
 
 export type SyncMetaKey = (typeof SYNC_META_KEYS)[keyof typeof SYNC_META_KEYS];
 
-// Lazy `Store` — `createStore` does NOT open the DB; the open happens
-// on the first get/set/del call. This keeps SSR / unit-test bootstrap
-// fast and lets us avoid wrapping every test in fake-indexeddb when we
-// only need to mock the four exported functions below.
-let store: ReturnType<typeof createStore> | null = null;
-function getStore(): ReturnType<typeof createStore> {
-  if (!store) store = createStore(DB_NAME, STORE_NAME);
-  return store;
-}
+const LEGACY_DB_NAME = "sergeant-sync-meta";
+const LEGACY_STORE_NAME = "v1";
 
-/**
- * `true` when the runtime exposes IndexedDB (browsers, Electron). In
- * Node-based unit tests under jsdom we may run without IDB; in Safari
- * Private Browsing on older versions IDB is also stubbed out. In both
- * cases we short-circuit get/set/del so the caller's `await` resolves
- * to `undefined` instead of leaking unhandled rejections / pending
- * IndexedDB transactions across the test runner heap.
- */
-function idbAvailable(): boolean {
-  return (
-    typeof globalThis !== "undefined" &&
-    typeof (globalThis as { indexedDB?: unknown }).indexedDB !== "undefined"
-  );
-}
+const ensureMigrated = (): Promise<void> =>
+  migrateLegacyDbOnce({
+    legacyDbName: LEGACY_DB_NAME,
+    copy: async (legacyDb, sergeantDb) => {
+      if (!legacyDb.objectStoreNames.contains(LEGACY_STORE_NAME)) return;
+      const tx = legacyDb.transaction(LEGACY_STORE_NAME, "readonly");
+      const store = tx.objectStore(LEGACY_STORE_NAME);
+      const keys = await new Promise<IDBValidKey[]>((resolve, reject) => {
+        const r = store.getAllKeys();
+        r.onsuccess = () => resolve(Array.isArray(r.result) ? r.result : []);
+        r.onerror = () => reject(r.error);
+      });
+      const values = await new Promise<unknown[]>((resolve, reject) => {
+        const r = store.getAll();
+        r.onsuccess = () => resolve(Array.isArray(r.result) ? r.result : []);
+        r.onerror = () => reject(r.error);
+      });
+      const writeTx = sergeantDb.transaction(
+        SERGEANT_STORE.SYNC_META,
+        "readwrite",
+      );
+      const writeStore = writeTx.objectStore(SERGEANT_STORE.SYNC_META);
+      for (let i = 0; i < keys.length; i++) {
+        writeStore.put(values[i], keys[i]);
+      }
+      await new Promise<void>((resolve, reject) => {
+        writeTx.oncomplete = () => resolve();
+        writeTx.onerror = () => reject(writeTx.error);
+        writeTx.onabort = () => reject(writeTx.error);
+      });
+    },
+  });
 
 export async function getSyncMeta<T>(key: SyncMetaKey): Promise<T | undefined> {
-  if (!idbAvailable()) return undefined;
-  return idbGet<T>(key, getStore());
+  await ensureMigrated();
+  return dbGet<T>(SERGEANT_STORE.SYNC_META, key);
 }
 
 export async function setSyncMeta<T>(
   key: SyncMetaKey,
   value: T,
 ): Promise<void> {
-  if (!idbAvailable()) return;
-  await idbSet(key, value, getStore());
+  await ensureMigrated();
+  await dbSet(SERGEANT_STORE.SYNC_META, key, value);
 }
 
 export async function delSyncMeta(key: SyncMetaKey): Promise<void> {
-  if (!idbAvailable()) return;
-  await idbDel(key, getStore());
+  await ensureMigrated();
+  await dbDel(SERGEANT_STORE.SYNC_META, key);
 }
 
 /**
- * Test-only reset of the cached store handle. Vitest reuses module
- * instances across describe blocks; this lets a test that mocks
- * `idb-keyval` swap the implementation cleanly without retaining a
- * stale `Store` from a previous suite.
+ * Test-only reset of any module-scoped state. Vitest reuses module
+ * instances across describe blocks; tests that mock `sergeantDb`
+ * mid-suite call this to drop any cached handles.
+ *
+ * Currently a no-op — the shared sergeant-db connection itself
+ * exposes `__resetSergeantDbForTests()` and that is the source of
+ * truth. We keep this stub for backwards-compatible imports from
+ * tests written against the pre-PR-#010 module layout.
  */
 export function __resetSyncMetaStoreForTests(): void {
-  store = null;
+  /* no-op — see docstring above */
 }

--- a/apps/web/src/modules/nutrition/lib/foodDb/foodDb.ts
+++ b/apps/web/src/modules/nutrition/lib/foodDb/foodDb.ts
@@ -1,5 +1,10 @@
 import type { Macros } from "../macros";
 import type { SeedFood } from "./seedFoodsUk";
+import {
+  SERGEANT_STORE,
+  migrateLegacyDbOnce,
+  openSergeantDb,
+} from "../../../../shared/lib/idb/sergeantDb";
 
 /**
  * Lazy-loader для 1600+ seed-продуктів. Статичний import затягував весь
@@ -12,10 +17,19 @@ async function loadSeedFoods(): Promise<readonly SeedFood[]> {
   return mod.SEED_FOODS_UK;
 }
 
-const DB_NAME = "hub_nutrition_food_db";
-const DB_VERSION = 1;
-const STORE_PRODUCTS = "products";
-const STORE_BARCODES = "barcodes";
+/**
+ * Pre-PR-#010 the food catalogue + barcode lookup lived in a dedicated
+ * `hub_nutrition_food_db` IndexedDB. PR #010 folds them into the shared
+ * `sergeant-db` under the `nutrition_foods` (keyPath="id",
+ * index="by_norm") and `nutrition_barcodes` (out-of-line) object stores.
+ * Both old stores are migrated lazily on the first read/write of this
+ * app session and the legacy DB is then dropped.
+ */
+const LEGACY_DB_NAME = "hub_nutrition_food_db";
+const LEGACY_STORE_PRODUCTS = "products";
+const LEGACY_STORE_BARCODES = "barcodes";
+const STORE_PRODUCTS = SERGEANT_STORE.NUTRITION_FOODS;
+const STORE_BARCODES = SERGEANT_STORE.NUTRITION_BARCODES;
 
 export interface FoodProduct {
   id: string;
@@ -67,23 +81,49 @@ function normalizeMacros(per100: unknown): Macros {
   };
 }
 
-function openDb(): Promise<IDBDatabase> {
-  return new Promise((resolve, reject) => {
-    const req = indexedDB.open(DB_NAME, DB_VERSION);
-    req.onerror = () => reject(req.error);
-    req.onsuccess = () => resolve(req.result);
-    req.onupgradeneeded = () => {
-      const db = req.result;
-      if (!db.objectStoreNames.contains(STORE_PRODUCTS)) {
-        const s = db.createObjectStore(STORE_PRODUCTS, { keyPath: "id" });
-        s.createIndex("by_norm", "norm", { unique: false });
+const ensureMigrated = (): Promise<void> =>
+  migrateLegacyDbOnce({
+    legacyDbName: LEGACY_DB_NAME,
+    copy: async (legacyDb, sergeantDb) => {
+      // Products store: keyPath="id" — entries carry their own keys, so
+      // we just put() them as-is into the new keyPath store.
+      if (legacyDb.objectStoreNames.contains(LEGACY_STORE_PRODUCTS)) {
+        const tx = legacyDb.transaction(LEGACY_STORE_PRODUCTS, "readonly");
+        const all = await new Promise<FoodProduct[]>((resolve, reject) => {
+          const r = tx.objectStore(LEGACY_STORE_PRODUCTS).getAll();
+          r.onsuccess = () =>
+            resolve(Array.isArray(r.result) ? (r.result as FoodProduct[]) : []);
+          r.onerror = () => reject(r.error);
+        });
+        const writeTx = sergeantDb.transaction(STORE_PRODUCTS, "readwrite");
+        const writeStore = writeTx.objectStore(STORE_PRODUCTS);
+        for (const product of all) writeStore.put(product);
+        await txDone(writeTx);
       }
-      if (!db.objectStoreNames.contains(STORE_BARCODES)) {
-        db.createObjectStore(STORE_BARCODES);
+      // Barcodes store: out-of-line keys (the barcode string is the
+      // key, the food id is the value), so copy keys+values together.
+      if (legacyDb.objectStoreNames.contains(LEGACY_STORE_BARCODES)) {
+        const tx = legacyDb.transaction(LEGACY_STORE_BARCODES, "readonly");
+        const store = tx.objectStore(LEGACY_STORE_BARCODES);
+        const keys = await new Promise<IDBValidKey[]>((resolve, reject) => {
+          const r = store.getAllKeys();
+          r.onsuccess = () => resolve(Array.isArray(r.result) ? r.result : []);
+          r.onerror = () => reject(r.error);
+        });
+        const values = await new Promise<unknown[]>((resolve, reject) => {
+          const r = store.getAll();
+          r.onsuccess = () => resolve(Array.isArray(r.result) ? r.result : []);
+          r.onerror = () => reject(r.error);
+        });
+        const writeTx = sergeantDb.transaction(STORE_BARCODES, "readwrite");
+        const writeStore = writeTx.objectStore(STORE_BARCODES);
+        for (let i = 0; i < keys.length; i++) {
+          writeStore.put(values[i], keys[i]);
+        }
+        await txDone(writeTx);
       }
-    };
+    },
   });
-}
 
 function txDone(tx: IDBTransaction): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -119,15 +159,16 @@ export function makeFoodProduct(partial: unknown): FoodProduct {
 
 export async function ensureSeedFoods(): Promise<boolean> {
   try {
-    const db = await openDb();
-    const tx = db.transaction([STORE_PRODUCTS], "readonly");
+    await ensureMigrated();
+    const db = await openSergeantDb();
+    if (!db) return false;
+    const tx = db.transaction(STORE_PRODUCTS, "readonly");
     const store = tx.objectStore(STORE_PRODUCTS);
     const count = await new Promise<number>((resolve, reject) => {
       const r = store.count();
       r.onsuccess = () => resolve(r.result || 0);
       r.onerror = () => reject(r.error);
     });
-    db.close();
 
     const seeds = await loadSeedFoods();
 
@@ -156,8 +197,10 @@ export async function ensureSeedFoods(): Promise<boolean> {
 
 export async function listFoods(limit = 500): Promise<FoodProduct[]> {
   try {
-    const db = await openDb();
-    const tx = db.transaction([STORE_PRODUCTS], "readonly");
+    await ensureMigrated();
+    const db = await openSergeantDb();
+    if (!db) return [];
+    const tx = db.transaction(STORE_PRODUCTS, "readonly");
     const store = tx.objectStore(STORE_PRODUCTS);
     const items = await new Promise<FoodProduct[]>((resolve, reject) => {
       const r = store.getAll();
@@ -166,7 +209,6 @@ export async function listFoods(limit = 500): Promise<FoodProduct[]> {
       r.onerror = () => reject(r.error);
     });
     await txDone(tx);
-    db.close();
     return items
       .sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0))
       .slice(0, Math.max(1, Number(limit) || 500));
@@ -207,11 +249,12 @@ export async function upsertFood(product: unknown): Promise<UpsertFoodResult> {
   const p = makeFoodProduct(product);
   if (!p.name) return { ok: false, error: "Назва продукту порожня" };
   try {
-    const db = await openDb();
-    const tx = db.transaction([STORE_PRODUCTS], "readwrite");
+    await ensureMigrated();
+    const db = await openSergeantDb();
+    if (!db) return { ok: false, error: "Не вдалося зберегти продукт" };
+    const tx = db.transaction(STORE_PRODUCTS, "readwrite");
     tx.objectStore(STORE_PRODUCTS).put(p);
     await txDone(tx);
-    db.close();
     return { ok: true, product: p };
   } catch {
     return { ok: false, error: "Не вдалося зберегти продукт" };
@@ -239,11 +282,12 @@ export async function bindBarcodeToFood(
   if (!bc || !id) return false;
   if (!/^\d{8,14}$/.test(bc)) return false;
   try {
-    const db = await openDb();
-    const tx = db.transaction([STORE_BARCODES], "readwrite");
+    await ensureMigrated();
+    const db = await openSergeantDb();
+    if (!db) return false;
+    const tx = db.transaction(STORE_BARCODES, "readwrite");
     tx.objectStore(STORE_BARCODES).put(id, bc);
     await txDone(tx);
-    db.close();
     return true;
   } catch {
     return false;
@@ -256,7 +300,9 @@ export async function lookupFoodByBarcode(
   const bc = String(barcode || "").trim();
   if (!/^\d{8,14}$/.test(bc)) return null;
   try {
-    const db = await openDb();
+    await ensureMigrated();
+    const db = await openSergeantDb();
+    if (!db) return null;
     const tx = db.transaction([STORE_BARCODES, STORE_PRODUCTS], "readonly");
     const id = await new Promise<string>((resolve, reject) => {
       const r = tx.objectStore(STORE_BARCODES).get(bc);
@@ -264,7 +310,6 @@ export async function lookupFoodByBarcode(
       r.onerror = () => reject(r.error);
     });
     if (!id) {
-      db.close();
       return null;
     }
     const product = await new Promise<FoodProduct | null>((resolve, reject) => {
@@ -273,7 +318,6 @@ export async function lookupFoodByBarcode(
       r.onerror = () => reject(r.error);
     });
     await txDone(tx);
-    db.close();
     return product || null;
   } catch {
     return null;
@@ -285,14 +329,15 @@ export async function replaceAllFoodsFromList(list: unknown): Promise<boolean> {
     const foods = Array.isArray(list)
       ? (list as unknown[]).map((x) => makeFoodProduct(x)).filter((x) => x.name)
       : [];
-    const db = await openDb();
+    await ensureMigrated();
+    const db = await openSergeantDb();
+    if (!db) return false;
     const tx = db.transaction([STORE_PRODUCTS, STORE_BARCODES], "readwrite");
     const s = tx.objectStore(STORE_PRODUCTS);
     s.clear();
     for (const p of foods) s.put(p);
     tx.objectStore(STORE_BARCODES).clear();
     await txDone(tx);
-    db.close();
     return true;
   } catch {
     return false;

--- a/apps/web/src/modules/nutrition/lib/mealPhotoStorage.ts
+++ b/apps/web/src/modules/nutrition/lib/mealPhotoStorage.ts
@@ -1,25 +1,54 @@
 /**
  * Мініатюри страв у IndexedDB (окремо від localStorage).
  * Ключ — id запису їжі.
+ *
+ * Pre-PR-#010 lived in a dedicated `hub_nutrition_meal_photos` IndexedDB.
+ * PR #010 folds the thumbnails into the shared `sergeant-db` under the
+ * `nutrition_meal_thumbs` object store — the legacy DB is migrated
+ * lazily on the first read/write of this app session and then dropped.
  */
+import {
+  SERGEANT_STORE,
+  migrateLegacyDbOnce,
+  openSergeantDb,
+} from "../../../shared/lib/idb/sergeantDb";
 
-const DB_NAME = "hub_nutrition_meal_photos";
-const STORE = "thumbs";
-const DB_VERSION = 1;
+const LEGACY_DB_NAME = "hub_nutrition_meal_photos";
+const LEGACY_STORE_NAME = "thumbs";
+const STORE = SERGEANT_STORE.NUTRITION_MEAL_THUMBS;
 
-function openDb(): Promise<IDBDatabase> {
-  return new Promise((resolve, reject) => {
-    const req = indexedDB.open(DB_NAME, DB_VERSION);
-    req.onerror = () => reject(req.error);
-    req.onsuccess = () => resolve(req.result);
-    req.onupgradeneeded = () => {
-      const db = req.result;
-      if (!db.objectStoreNames.contains(STORE)) {
-        db.createObjectStore(STORE);
+const ensureMigrated = (): Promise<void> =>
+  migrateLegacyDbOnce({
+    legacyDbName: LEGACY_DB_NAME,
+    copy: async (legacyDb, sergeantDb) => {
+      if (!legacyDb.objectStoreNames.contains(LEGACY_STORE_NAME)) return;
+      const tx = legacyDb.transaction(LEGACY_STORE_NAME, "readonly");
+      const store = tx.objectStore(LEGACY_STORE_NAME);
+      const keys = await new Promise<IDBValidKey[]>((resolve, reject) => {
+        const r = store.getAllKeys();
+        r.onsuccess = () => resolve(Array.isArray(r.result) ? r.result : []);
+        r.onerror = () => reject(r.error);
+      });
+      const values = await new Promise<unknown[]>((resolve, reject) => {
+        const r = store.getAll();
+        r.onsuccess = () => resolve(Array.isArray(r.result) ? r.result : []);
+        r.onerror = () => reject(r.error);
+      });
+      const writeTx = sergeantDb.transaction(STORE, "readwrite");
+      const writeStore = writeTx.objectStore(STORE);
+      for (let i = 0; i < keys.length; i++) {
+        // Preserve thumbnail Blob payloads as-is — IDB stores blobs
+        // by structured clone, so a put() with the original value
+        // round-trips losslessly across DBs.
+        writeStore.put(values[i], keys[i]);
       }
-    };
+      await new Promise<void>((resolve, reject) => {
+        writeTx.oncomplete = () => resolve();
+        writeTx.onerror = () => reject(writeTx.error);
+        writeTx.onabort = () => reject(writeTx.error);
+      });
+    },
   });
-}
 
 export async function saveMealThumbnail(
   mealId: string | null | undefined,
@@ -27,14 +56,15 @@ export async function saveMealThumbnail(
 ): Promise<boolean> {
   if (!mealId || !blob) return false;
   try {
-    const db = await openDb();
+    await ensureMigrated();
+    const db = await openSergeantDb();
+    if (!db) return false;
     await new Promise<void>((resolve, reject) => {
       const tx = db.transaction(STORE, "readwrite");
       tx.objectStore(STORE).put(blob, mealId);
       tx.oncomplete = () => resolve();
       tx.onerror = () => reject(tx.error);
     });
-    db.close();
     return true;
   } catch {
     return false;
@@ -46,14 +76,15 @@ export async function getMealThumbnailBlob(
 ): Promise<Blob | null> {
   if (!mealId) return null;
   try {
-    const db = await openDb();
+    await ensureMigrated();
+    const db = await openSergeantDb();
+    if (!db) return null;
     const blob = await new Promise<unknown>((resolve, reject) => {
       const tx = db.transaction(STORE, "readonly");
       const req = tx.objectStore(STORE).get(mealId);
       req.onsuccess = () => resolve(req.result || null);
       req.onerror = () => reject(req.error);
     });
-    db.close();
     return blob instanceof Blob ? blob : null;
   } catch {
     return null;
@@ -65,14 +96,15 @@ export async function deleteMealThumbnail(
 ): Promise<void> {
   if (!mealId) return;
   try {
-    const db = await openDb();
+    await ensureMigrated();
+    const db = await openSergeantDb();
+    if (!db) return;
     await new Promise<void>((resolve, reject) => {
       const tx = db.transaction(STORE, "readwrite");
       tx.objectStore(STORE).delete(mealId);
       tx.oncomplete = () => resolve();
       tx.onerror = () => reject(tx.error);
     });
-    db.close();
   } catch {
     /* ignore */
   }
@@ -93,7 +125,9 @@ export async function gcMealThumbnails(
           Array.isArray(validMealIds) ? (validMealIds as string[]) : [],
         );
   try {
-    const db = await openDb();
+    await ensureMigrated();
+    const db = await openSergeantDb();
+    if (!db) return { ok: false, deleted: 0 };
     const tx = db.transaction(STORE, "readwrite");
     const store = tx.objectStore(STORE);
     const keys = await new Promise<string[]>((resolve, reject) => {
@@ -114,7 +148,6 @@ export async function gcMealThumbnails(
       tx.oncomplete = () => resolve();
       tx.onerror = () => reject(tx.error);
     });
-    db.close();
     return { ok: true, deleted };
   } catch {
     return { ok: false, deleted: 0 };

--- a/apps/web/src/modules/nutrition/lib/recipeBook.ts
+++ b/apps/web/src/modules/nutrition/lib/recipeBook.ts
@@ -1,8 +1,21 @@
 import type { NullableMacros } from "./macros";
+import {
+  SERGEANT_STORE,
+  migrateLegacyDbOnce,
+  openSergeantDb,
+} from "../../../shared/lib/idb/sergeantDb";
 
-const DB_NAME = "hub_nutrition_recipe_book";
-const DB_VERSION = 1;
-const STORE = "recipes";
+/**
+ * Pre-PR-#010 saved recipes lived in a dedicated `hub_nutrition_recipe_book`
+ * IndexedDB. PR #010 folds them into the shared `sergeant-db` under the
+ * `nutrition_recipes` object store (same schema: keyPath="id",
+ * index="by_updatedAt"). The legacy DB is migrated lazily on the
+ * first read/write of this app session and then dropped — see
+ * `apps/web/src/shared/lib/idb/sergeantDb.ts`.
+ */
+const LEGACY_DB_NAME = "hub_nutrition_recipe_book";
+const LEGACY_STORE_NAME = "recipes";
+const STORE = SERGEANT_STORE.NUTRITION_RECIPES;
 
 export interface SavedRecipe {
   id: string;
@@ -21,20 +34,25 @@ export type SaveRecipeResult =
   | { ok: true; recipe: SavedRecipe }
   | { ok: false; error: string };
 
-function openDb(): Promise<IDBDatabase> {
-  return new Promise((resolve, reject) => {
-    const req = indexedDB.open(DB_NAME, DB_VERSION);
-    req.onerror = () => reject(req.error);
-    req.onsuccess = () => resolve(req.result);
-    req.onupgradeneeded = () => {
-      const db = req.result;
-      if (!db.objectStoreNames.contains(STORE)) {
-        const s = db.createObjectStore(STORE, { keyPath: "id" });
-        s.createIndex("by_updatedAt", "updatedAt", { unique: false });
-      }
-    };
+const ensureMigrated = (): Promise<void> =>
+  migrateLegacyDbOnce({
+    legacyDbName: LEGACY_DB_NAME,
+    copy: async (legacyDb, sergeantDb) => {
+      if (!legacyDb.objectStoreNames.contains(LEGACY_STORE_NAME)) return;
+      const tx = legacyDb.transaction(LEGACY_STORE_NAME, "readonly");
+      const store = tx.objectStore(LEGACY_STORE_NAME);
+      const all = await new Promise<SavedRecipe[]>((resolve, reject) => {
+        const r = store.getAll();
+        r.onsuccess = () =>
+          resolve(Array.isArray(r.result) ? (r.result as SavedRecipe[]) : []);
+        r.onerror = () => reject(r.error);
+      });
+      const writeTx = sergeantDb.transaction(STORE, "readwrite");
+      const writeStore = writeTx.objectStore(STORE);
+      for (const recipe of all) writeStore.put(recipe);
+      await txDone(writeTx);
+    },
   });
-}
 
 function txDone(tx: IDBTransaction): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -100,8 +118,10 @@ export function normalizeRecipeForSave(r: unknown): SavedRecipe {
 
 export async function listSavedRecipes(limit = 200): Promise<SavedRecipe[]> {
   try {
-    const db = await openDb();
-    const tx = db.transaction([STORE], "readonly");
+    await ensureMigrated();
+    const db = await openSergeantDb();
+    if (!db) return [];
+    const tx = db.transaction(STORE, "readonly");
     const store = tx.objectStore(STORE);
     const all = await new Promise<SavedRecipe[]>((resolve, reject) => {
       const r = store.getAll();
@@ -110,7 +130,6 @@ export async function listSavedRecipes(limit = 200): Promise<SavedRecipe[]> {
       r.onerror = () => reject(r.error);
     });
     await txDone(tx);
-    db.close();
     return all
       .sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0))
       .slice(0, Math.max(1, Number(limit) || 200));
@@ -125,11 +144,12 @@ export async function saveRecipeToBook(
   const r = normalizeRecipeForSave(recipe);
   if (!r.title) return { ok: false, error: "Порожня назва рецепту" };
   try {
-    const db = await openDb();
-    const tx = db.transaction([STORE], "readwrite");
+    await ensureMigrated();
+    const db = await openSergeantDb();
+    if (!db) return { ok: false, error: "Не вдалося зберегти рецепт" };
+    const tx = db.transaction(STORE, "readwrite");
     tx.objectStore(STORE).put(r);
     await txDone(tx);
-    db.close();
     return { ok: true, recipe: r };
   } catch {
     return { ok: false, error: "Не вдалося зберегти рецепт" };
@@ -140,11 +160,12 @@ export async function deleteSavedRecipe(id: unknown): Promise<boolean> {
   const key = String(id || "").trim();
   if (!key) return false;
   try {
-    const db = await openDb();
-    const tx = db.transaction([STORE], "readwrite");
+    await ensureMigrated();
+    const db = await openSergeantDb();
+    if (!db) return false;
+    const tx = db.transaction(STORE, "readwrite");
     tx.objectStore(STORE).delete(key);
     await txDone(tx);
-    db.close();
     return true;
   } catch {
     return false;

--- a/apps/web/src/shared/lib/api/queryClientPersister.ts
+++ b/apps/web/src/shared/lib/api/queryClientPersister.ts
@@ -70,14 +70,15 @@
  */
 import { createAsyncStoragePersister } from "@tanstack/query-async-storage-persister";
 import type { AsyncStorage } from "@tanstack/query-persist-client-core";
-import {
-  createStore,
-  get as idbGet,
-  set as idbSet,
-  del as idbDel,
-} from "idb-keyval";
 import type { Query } from "@tanstack/react-query";
 import { STORAGE_KEYS, isSensitiveQueryKey } from "@sergeant/shared";
+import {
+  SERGEANT_STORE,
+  dbDel,
+  dbGet,
+  dbSet,
+  migrateLegacyDbOnce,
+} from "../idb/sergeantDb";
 
 declare const __APP_BUILD_ID__: string;
 
@@ -101,40 +102,72 @@ function getBuildBuster(): string {
 }
 
 /**
- * idb-keyval `Store` обмежений на одну DB/store пару. Ім'я DB
- * ("sergeant-rq-cache") і store ("v1") навмисно стабільні: якщо ми
- * колись захочемо змінити схему IDB, краще буде створити нову DB
- * (`sergeant-rq-cache-v2`) і дропнути стару, ніж ламати
- * `idb-keyval`-сесії в льоту.
+ * Pre-PR-#010 the persister lived in its own DB ("sergeant-rq-cache",
+ * store "v1"). PR #010 folds it into the shared `sergeant-db` so the
+ * browser only has to keep one connection warm and DevTools shows
+ * one row instead of five — see `apps/web/src/shared/lib/idb/sergeantDb.ts`.
+ *
+ * The `sergeant-rq-cache` legacy DB is migrated lazily on the first
+ * `getItem`/`setItem` of this app session and then dropped. If
+ * migration is interrupted, the next session retries.
  */
-const RQ_DB_NAME = "sergeant-rq-cache";
-const RQ_STORE_NAME = "v1";
+const LEGACY_RQ_DB_NAME = "sergeant-rq-cache";
+const LEGACY_RQ_STORE_NAME = "v1";
+
+const ensureMigrated = (): Promise<void> =>
+  migrateLegacyDbOnce({
+    legacyDbName: LEGACY_RQ_DB_NAME,
+    copy: async (legacyDb, sergeantDb) => {
+      // Legacy DB has a single store keyed by the persister's key;
+      // copy every key as-is into the shared `rq_cache` store.
+      if (!legacyDb.objectStoreNames.contains(LEGACY_RQ_STORE_NAME)) return;
+      const tx = legacyDb.transaction(LEGACY_RQ_STORE_NAME, "readonly");
+      const store = tx.objectStore(LEGACY_RQ_STORE_NAME);
+      const keys = await new Promise<IDBValidKey[]>((resolve, reject) => {
+        const r = store.getAllKeys();
+        r.onsuccess = () => resolve(Array.isArray(r.result) ? r.result : []);
+        r.onerror = () => reject(r.error);
+      });
+      const values = await new Promise<unknown[]>((resolve, reject) => {
+        const r = store.getAll();
+        r.onsuccess = () => resolve(Array.isArray(r.result) ? r.result : []);
+        r.onerror = () => reject(r.error);
+      });
+      const writeTx = sergeantDb.transaction(
+        SERGEANT_STORE.RQ_CACHE,
+        "readwrite",
+      );
+      const writeStore = writeTx.objectStore(SERGEANT_STORE.RQ_CACHE);
+      for (let i = 0; i < keys.length; i++) {
+        writeStore.put(values[i], keys[i]);
+      }
+      await new Promise<void>((resolve, reject) => {
+        writeTx.oncomplete = () => resolve();
+        writeTx.onerror = () => reject(writeTx.error);
+        writeTx.onabort = () => reject(writeTx.error);
+      });
+    },
+  });
 
 /**
- * Окремий `Store` робить `get`/`set` 100% незалежними від глобальної
- * default-store, яку могли б створити інші бібліотеки на тій же
- * сторінці. Це pure: створення store не відкриває IDB — IDB
- * відкривається лише при першому доступі.
- */
-const idbStore = createStore(RQ_DB_NAME, RQ_STORE_NAME);
-
-/**
- * Тонкий адаптер `idb-keyval` → `AsyncStorage`-контракт TanStack.
- * `getItem`/`setItem`/`removeItem` приймають один ключ — той, що ми
- * передамо у `createAsyncStoragePersister`. Решта ключів у store
- * можуть жити паралельно (на майбутнє: feature flags / локальні
- * snapshot-и інших систем).
+ * AsyncStorage adapter over the shared sergeant-db `rq_cache` store.
+ * `getItem`/`setItem`/`removeItem` each await the lazy LS→IDB
+ * migration so the very first cold-boot read still sees data
+ * persisted by the previous (pre-PR-#010) version of the app.
  */
 export const idbKeyvalStorage: AsyncStorage<string> = {
   getItem: async (key) => {
-    const value = await idbGet<string>(key, idbStore);
+    await ensureMigrated();
+    const value = await dbGet<string>(SERGEANT_STORE.RQ_CACHE, key);
     return value ?? null;
   },
   setItem: async (key, value) => {
-    await idbSet(key, value, idbStore);
+    await ensureMigrated();
+    await dbSet(SERGEANT_STORE.RQ_CACHE, key, value);
   },
   removeItem: async (key) => {
-    await idbDel(key, idbStore);
+    await ensureMigrated();
+    await dbDel(SERGEANT_STORE.RQ_CACHE, key);
   },
 };
 

--- a/apps/web/src/shared/lib/idb/sergeantDb.test.ts
+++ b/apps/web/src/shared/lib/idb/sergeantDb.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+/**
+ * Unit tests for the shared `sergeant-db` connection introduced in
+ * Stage 1 PR #010 (`docs/planning/storage-roadmap.md`).
+ *
+ * jsdom does not ship IndexedDB, so this suite focuses on the
+ * runtime-safety contract:  every public helper must degrade
+ * gracefully when `globalThis.indexedDB` is undefined (SSR, hardened
+ * iframes, Safari Private Browsing on older iOS).  The IDB happy
+ * path is exercised end-to-end by the existing consumer test suites
+ * (`syncMetaStore.test.ts`, the nutrition/* tests, etc.) which mock
+ * this module at the boundary.
+ *
+ * The schema-creation logic in `onupgradeneeded` is intentionally
+ * not asserted at unit level — that lives behind a real IDB and is
+ * covered by the Playwright/CI e2e flows.  Unit tests would have to
+ * pull in `fake-indexeddb` for marginal value.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  SERGEANT_STORE,
+  __resetSergeantDbForTests,
+  dbDel,
+  dbGet,
+  dbSet,
+  migrateLegacyDbOnce,
+  openSergeantDb,
+} from "./sergeantDb";
+
+const originalIndexedDB = (globalThis as { indexedDB?: unknown }).indexedDB;
+
+beforeEach(() => {
+  // Drop the cached open promise so each test gets a clean slate.
+  __resetSergeantDbForTests();
+  // jsdom doesn't expose `indexedDB`, but explicitly tear it down so
+  // a previous test that injected a stub can't leak across.
+  delete (globalThis as { indexedDB?: unknown }).indexedDB;
+});
+afterEach(() => {
+  if (originalIndexedDB === undefined) {
+    delete (globalThis as { indexedDB?: unknown }).indexedDB;
+  } else {
+    (globalThis as { indexedDB?: unknown }).indexedDB = originalIndexedDB;
+  }
+  __resetSergeantDbForTests();
+});
+
+describe("SERGEANT_STORE registry", () => {
+  it("declares the seven object stores backing the consolidated DB", () => {
+    // Snapshot guards against accidental rename.  Every consumer module
+    // imports SERGEANT_STORE.* by symbol, so a typo here would break
+    // them at runtime.
+    expect(SERGEANT_STORE).toEqual({
+      RQ_CACHE: "rq_cache",
+      SYNC_META: "sync_meta",
+      NUTRITION_RECIPES: "nutrition_recipes",
+      NUTRITION_FOODS: "nutrition_foods",
+      NUTRITION_BARCODES: "nutrition_barcodes",
+      NUTRITION_MEAL_THUMBS: "nutrition_meal_thumbs",
+      MIGRATION_META: "migration_meta",
+    });
+  });
+});
+
+describe("openSergeantDb — SSR / no-IDB safety", () => {
+  it("resolves to null when `globalThis.indexedDB` is undefined", async () => {
+    expect(await openSergeantDb()).toBeNull();
+  });
+
+  it("never throws even if IndexedDB later becomes available mid-session", async () => {
+    // First call resolves to null; ensure the cached promise is null
+    // and a follow-up call after `__resetSergeantDbForTests()` doesn't
+    // explode.  This protects against SSR → hydration handoffs where
+    // the polyfill arrives after the first call returns.
+    expect(await openSergeantDb()).toBeNull();
+    __resetSergeantDbForTests();
+    expect(await openSergeantDb()).toBeNull();
+  });
+});
+
+describe("dbGet / dbSet / dbDel — SSR / no-IDB safety", () => {
+  it("dbGet resolves to undefined", async () => {
+    expect(await dbGet(SERGEANT_STORE.SYNC_META, "anything")).toBeUndefined();
+  });
+
+  it("dbSet is a silent no-op", async () => {
+    await expect(
+      dbSet(SERGEANT_STORE.SYNC_META, "k", { v: 1 }),
+    ).resolves.toBeUndefined();
+    // No way to read the value back without IDB; the contract is
+    // simply "doesn't throw".
+  });
+
+  it("dbDel is a silent no-op", async () => {
+    await expect(dbDel(SERGEANT_STORE.SYNC_META, "k")).resolves.toBeUndefined();
+  });
+});
+
+describe("migrateLegacyDbOnce — SSR / no-IDB safety", () => {
+  it("returns immediately without invoking the copy callback", async () => {
+    let copyCalled = false;
+    await migrateLegacyDbOnce({
+      legacyDbName: "hub_nutrition_recipe_book",
+      copy: async () => {
+        copyCalled = true;
+      },
+    });
+    expect(copyCalled).toBe(false);
+  });
+});

--- a/apps/web/src/shared/lib/idb/sergeantDb.ts
+++ b/apps/web/src/shared/lib/idb/sergeantDb.ts
@@ -1,0 +1,304 @@
+/**
+ * Single point of entry for every web-side IndexedDB store.
+ *
+ * Stage 1 PR #010 in `docs/planning/storage-roadmap.md` — folds the
+ * historical fleet of per-feature IDB databases into one shared
+ * `sergeant-db` so the browser only has to open and warm up a single
+ * connection, the storage estimate quota is pooled, and DevTools
+ * shows one row instead of five.
+ *
+ * Pre-PR-#010 layout (each line = one IndexedDB database):
+ *   - `sergeant-rq-cache`         — TanStack Query persister
+ *   - `sergeant-sync-meta`        — cloud-sync offline queue + meta (PR #009)
+ *   - `hub_nutrition_recipe_book` — Nutrition saved recipes
+ *   - `hub_nutrition_food_db`     — Nutrition food catalogue + barcodes
+ *   - `hub_nutrition_meal_photos` — Nutrition meal thumbnail blobs
+ *
+ * Post-PR-#010 layout (one IndexedDB database, six object stores):
+ *   sergeant-db
+ *     ├── rq_cache               (out-of-line keys; serialised RQ payload)
+ *     ├── sync_meta              (out-of-line keys; offline queue + meta)
+ *     ├── nutrition_recipes      (keyPath="id", idx="by_updatedAt")
+ *     ├── nutrition_foods        (keyPath="id", idx="by_norm")
+ *     ├── nutrition_barcodes     (out-of-line keys; barcode → food id)
+ *     ├── nutrition_meal_thumbs  (out-of-line keys; Blob)
+ *     └── migration_meta         (one row per legacy DB migrated)
+ *
+ * Each legacy database is migrated lazily on the first call from its
+ * dedicated module via `migrateLegacyDbOnce()` — we never block app
+ * boot on migration, and a failure in one module's migration cannot
+ * affect the others.  Old DBs are deleted only AFTER their migration
+ * row is written, so an interrupted migration can be retried without
+ * data loss.
+ *
+ * The implementation deliberately uses raw IndexedDB (no `idb` /
+ * `idb-keyval` wrappers) because the food-DB store needs an index
+ * with `keyPath` semantics that idb-keyval's flat KV API can't
+ * express, and we want a single connection used uniformly by every
+ * consumer in the codebase.
+ */
+
+const DB_NAME = "sergeant-db";
+const DB_VERSION = 1;
+
+export const SERGEANT_STORE = {
+  RQ_CACHE: "rq_cache",
+  SYNC_META: "sync_meta",
+  NUTRITION_RECIPES: "nutrition_recipes",
+  NUTRITION_FOODS: "nutrition_foods",
+  NUTRITION_BARCODES: "nutrition_barcodes",
+  NUTRITION_MEAL_THUMBS: "nutrition_meal_thumbs",
+  MIGRATION_META: "migration_meta",
+} as const;
+
+export type SergeantStoreName =
+  (typeof SERGEANT_STORE)[keyof typeof SERGEANT_STORE];
+
+let openPromise: Promise<IDBDatabase> | null = null;
+
+/**
+ * Returns the (lazily) opened sergeant-db instance.  All consumers
+ * share a single connection — IndexedDB serialises transactions per
+ * store, so cross-store traffic stays parallel.
+ *
+ * Resolves to `null` when IndexedDB is unavailable (server-side
+ * render, hardened iframe, Safari Private Browsing on older iOS).
+ * Callers MUST handle that case — the four nutrition modules do so
+ * with `catch { return … fallback … }` blocks.
+ */
+export function openSergeantDb(): Promise<IDBDatabase | null> {
+  if (typeof indexedDB === "undefined") return Promise.resolve(null);
+  if (!openPromise) openPromise = doOpen();
+  return openPromise.catch(() => null);
+}
+
+function doOpen(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onerror = () => reject(req.error);
+    req.onsuccess = () => resolve(req.result);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      // v1 — initial schema, all stores created upfront. Future
+      // versions should add new stores in additional `if` blocks
+      // and bump DB_VERSION; existing stores are touched only via
+      // additive migrations (e.g. `createIndex`).
+      if (!db.objectStoreNames.contains(SERGEANT_STORE.RQ_CACHE)) {
+        db.createObjectStore(SERGEANT_STORE.RQ_CACHE);
+      }
+      if (!db.objectStoreNames.contains(SERGEANT_STORE.SYNC_META)) {
+        db.createObjectStore(SERGEANT_STORE.SYNC_META);
+      }
+      if (!db.objectStoreNames.contains(SERGEANT_STORE.NUTRITION_RECIPES)) {
+        const s = db.createObjectStore(SERGEANT_STORE.NUTRITION_RECIPES, {
+          keyPath: "id",
+        });
+        s.createIndex("by_updatedAt", "updatedAt", { unique: false });
+      }
+      if (!db.objectStoreNames.contains(SERGEANT_STORE.NUTRITION_FOODS)) {
+        const s = db.createObjectStore(SERGEANT_STORE.NUTRITION_FOODS, {
+          keyPath: "id",
+        });
+        s.createIndex("by_norm", "norm", { unique: false });
+      }
+      if (!db.objectStoreNames.contains(SERGEANT_STORE.NUTRITION_BARCODES)) {
+        db.createObjectStore(SERGEANT_STORE.NUTRITION_BARCODES);
+      }
+      if (!db.objectStoreNames.contains(SERGEANT_STORE.NUTRITION_MEAL_THUMBS)) {
+        db.createObjectStore(SERGEANT_STORE.NUTRITION_MEAL_THUMBS);
+      }
+      if (!db.objectStoreNames.contains(SERGEANT_STORE.MIGRATION_META)) {
+        db.createObjectStore(SERGEANT_STORE.MIGRATION_META);
+      }
+    };
+  });
+}
+
+/* -------------------------------------------------------------------------- */
+/* Thin idb-keyval-shaped helpers around the shared connection.               */
+/* -------------------------------------------------------------------------- */
+
+export async function dbGet<T>(
+  storeName: SergeantStoreName,
+  key: IDBValidKey,
+): Promise<T | undefined> {
+  const db = await openSergeantDb();
+  if (!db) return undefined;
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(storeName, "readonly");
+    const req = tx.objectStore(storeName).get(key);
+    req.onsuccess = () => resolve(req.result as T | undefined);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function dbSet(
+  storeName: SergeantStoreName,
+  key: IDBValidKey,
+  value: unknown,
+): Promise<void> {
+  const db = await openSergeantDb();
+  if (!db) return;
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(storeName, "readwrite");
+    tx.objectStore(storeName).put(value, key);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error);
+  });
+}
+
+export async function dbDel(
+  storeName: SergeantStoreName,
+  key: IDBValidKey,
+): Promise<void> {
+  const db = await openSergeantDb();
+  if (!db) return;
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(storeName, "readwrite");
+    tx.objectStore(storeName).delete(key);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error);
+  });
+}
+
+/* -------------------------------------------------------------------------- */
+/* Legacy database migration                                                  */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Idempotent guard: read-modify-write the migration_meta row.
+ *
+ * Each migration writes `{<legacyDbName>: true}` so subsequent boots
+ * can skip the work. Stored under a single bucket key so we don't
+ * pollute the store namespace.
+ */
+const MIGRATION_FLAGS_KEY = "legacy_db_flags";
+
+type MigrationFlags = Record<string, true>;
+
+async function isLegacyMigrated(legacyDbName: string): Promise<boolean> {
+  const flags =
+    (await dbGet<MigrationFlags>(
+      SERGEANT_STORE.MIGRATION_META,
+      MIGRATION_FLAGS_KEY,
+    )) ?? {};
+  return !!flags[legacyDbName];
+}
+
+async function markLegacyMigrated(legacyDbName: string): Promise<void> {
+  const flags =
+    (await dbGet<MigrationFlags>(
+      SERGEANT_STORE.MIGRATION_META,
+      MIGRATION_FLAGS_KEY,
+    )) ?? {};
+  flags[legacyDbName] = true;
+  await dbSet(SERGEANT_STORE.MIGRATION_META, MIGRATION_FLAGS_KEY, flags);
+}
+
+/**
+ * Open a *legacy* database without running upgrades. Returns `null`
+ * when the DB does not exist (no rows to migrate). We use
+ * `databases()` first when available because attempting to
+ * `indexedDB.open()` a non-existent DB silently creates it, which
+ * would defeat the cleanup logic afterwards.
+ */
+async function openLegacyDbReadOnly(
+  legacyDbName: string,
+): Promise<IDBDatabase | null> {
+  if (typeof indexedDB === "undefined") return null;
+  // Probe for existence when the runtime supports the API. Older
+  // browsers (Safari < 18) don't ship `databases()` — there we just
+  // attempt the open and accept the no-op create as a small
+  // imperfection.
+  if (typeof indexedDB.databases === "function") {
+    try {
+      const list = await indexedDB.databases();
+      const present = list.some((d) => d?.name === legacyDbName);
+      if (!present) return null;
+    } catch {
+      /* fall through to optimistic open */
+    }
+  }
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(legacyDbName);
+    req.onerror = () => reject(req.error);
+    req.onsuccess = () => resolve(req.result);
+  });
+}
+
+function deleteIdbDatabase(name: string): Promise<void> {
+  return new Promise((resolve) => {
+    if (typeof indexedDB === "undefined") {
+      resolve();
+      return;
+    }
+    const req = indexedDB.deleteDatabase(name);
+    // Ignore errors — at worst the legacy DB sticks around taking
+    // up quota; we still wrote its data into the new DB so user
+    // experience is unaffected.
+    req.onsuccess = () => resolve();
+    req.onerror = () => resolve();
+    req.onblocked = () => resolve();
+  });
+}
+
+export interface MigrateLegacyDbOptions {
+  /** Name of the legacy IDB database to migrate from. */
+  legacyDbName: string;
+  /**
+   * Async function that copies rows from `legacyDb` into the shared
+   * sergeant-db. Receives the legacy connection and the shared
+   * connection. Throw on irrecoverable errors — caller swallows.
+   */
+  copy: (legacyDb: IDBDatabase, sergeantDb: IDBDatabase) => Promise<void>;
+}
+
+/**
+ * Run a one-shot per-module migration the first time the module is
+ * exercised. Subsequent calls return immediately after consulting
+ * the `migration_meta` flag, so this can sit on every consumer's
+ * hot path.
+ */
+export async function migrateLegacyDbOnce({
+  legacyDbName,
+  copy,
+}: MigrateLegacyDbOptions): Promise<void> {
+  const db = await openSergeantDb();
+  if (!db) return;
+  if (await isLegacyMigrated(legacyDbName)) return;
+
+  const legacyDb = await openLegacyDbReadOnly(legacyDbName).catch(() => null);
+  if (!legacyDb) {
+    // Fresh install — nothing to migrate. Still mark done so we
+    // don't attempt the open every load.
+    await markLegacyMigrated(legacyDbName);
+    return;
+  }
+  try {
+    await copy(legacyDb, db);
+  } catch {
+    // Migration failure: leave the flag unset so the next boot
+    // retries. Old DB stays in place (data is not lost).
+    legacyDb.close();
+    return;
+  }
+  legacyDb.close();
+  await markLegacyMigrated(legacyDbName);
+  // Best-effort cleanup. If `deleteDatabase` is blocked by another
+  // tab, the user will end up with one extra empty DB — harmless.
+  await deleteIdbDatabase(legacyDbName);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Test-only escape hatches                                                   */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Reset the cached open promise so a test that swaps `indexedDB` /
+ * mocks `idb` mid-suite gets a fresh connection on the next call.
+ */
+export function __resetSergeantDbForTests(): void {
+  openPromise = null;
+}


### PR DESCRIPTION
Stage 1 PR #010 in `docs/planning/storage-roadmap.md` — fold the five separate IndexedDB databases into a single `sergeant-db` connection.

## What

Pre-PR-#010 the web app opened five separate IndexedDB databases:
- `sergeant-rq-cache` — React-Query persister
- `sergeant-sync-meta` — cloud-sync metadata + offline queue (added in PR #009 / #1526)
- `hub_nutrition_recipe_book` — nutrition recipes
- `hub_nutrition_food_db` — food catalogue + barcode lookup
- `hub_nutrition_meal_photos` — meal-photo Blob thumbnails

Each had its own version, upgrade handler and DevTools row. PR #010 folds all five into a single `sergeant-db` connection with seven prefixed object stores (`rq_cache`, `sync_meta`, `nutrition_recipes`, `nutrition_foods`, `nutrition_barcodes`, `nutrition_meal_thumbs`, `migration_meta`) so the browser only has to keep one connection warm and the storage-estimate quota is pooled.

## How

- **`apps/web/src/shared/lib/idb/sergeantDb.ts`** (new) — unified IDB connection layer. Exposes the `SERGEANT_STORE` enum, lazy `openSergeantDb()`, an `idb-keyval`-shaped helper trio (`dbGet`/`dbSet`/`dbDel`) and the lazy migration shim `migrateLegacyDbOnce({ legacyDbName, copy })`. Falls back to no-op when `globalThis.indexedDB` is undefined (SSR, hardened iframes, Safari Private Browsing on older iOS).
- **Each legacy DB is migrated lazily on the first read/write of the owning module.** Migration writes a `{ migrated: true, at }` row to `migration_meta` *before* deleting the old DB, so an interrupted run can be retried without data loss. Per-module copy callbacks preserve `keyPath` stores, indexes (`by_norm`, `by_updatedAt`) and Blob payloads (meal thumbnails) via structured-clone roundtrip.
- **Consumers updated** to call `ensureMigrated()` before each read/write and to share the open connection:
  - `apps/web/src/shared/lib/api/queryClientPersister.ts`
  - `apps/web/src/core/cloudSync/storage/syncMetaStore.ts`
  - `apps/web/src/modules/nutrition/lib/recipeBook.ts`
  - `apps/web/src/modules/nutrition/lib/foodDb/foodDb.ts`
  - `apps/web/src/modules/nutrition/lib/mealPhotoStorage.ts`
- `idb-keyval` is no longer imported from production code (kept in `package.json` for now; removal will be a follow-up cleanup PR once this lands and bakes in prod).

## Tests

- **`apps/web/src/shared/lib/idb/sergeantDb.test.ts`** (new, 7 tests) — pins the `SERGEANT_STORE` registry and exercises every public helper through the no-IDB code path so jsdom/SSR/Safari-private-browsing degrades gracefully.
- **`syncMetaStore.test.ts`** — re-wired from mocking `idb-keyval` to mocking the new `sergeantDb` module; in-memory map keyed by `${storeName}:${key}` matches the old contract. Two fire-and-forget tests now flush the microtask queue before asserting (the new `setSyncMeta`/`delSyncMeta` cross an extra `await ensureMigrated()` boundary).
- 231 cloudSync + 126 nutrition + 7 sergeantDb tests are green locally.

## Docs

Second commit (`docs(docs): sync storage roadmap + audit with closed Stage 1 tails`) brings `docs/planning/storage-roadmap.md` and `docs/architecture/data-exchange-storage-audit.md` in sync with all of Stage 1 closure work (#1520, #1521, #1524, #1526, this PR). After this PR, only PR #008 (storagePatch removal) is outstanding from Stage 1.

## Roll-out

The migration is one-shot and idempotent — first read after deploy migrates each legacy DB and deletes it, subsequent reads short-circuit on the `migration_meta` flag. No flag, no manual step. If a user keeps the tab open across deploys, the migration runs on next page-load.
