### PR TITLE
docs(security): add hardening backlog sprint 2 (H3, H5, H6, H7, H8, H9, M1, M3)

### DIFF
--- a/docs/security/hardening/H3-session-revoke-and-binding.md
+++ b/docs/security/hardening/H3-session-revoke-and-binding.md
@@ -1,0 +1,100 @@
+# H3 — Session 30-day TTL with no revoke-on-password-change and no device binding
+
+> **Last validated:** 2026-05-03 by @Skords-01. **Next review:** 2026-08-01.
+
+| Field         | Value                                                                |
+| ------------- | -------------------------------------------------------------------- |
+| **Severity**  | High (CVSS 7.1, AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N)                 |
+| **Sprint**    | [Sprint 2](./sprint-2.md)                                            |
+| **Owner**     | backend                                                              |
+| **Effort**    | 1 person-day                                                         |
+| **Status**    | Open                                                                 |
+| **Discovered**| 2026-05-03 deep security review                                      |
+
+## Summary
+
+Better Auth is configured with a 30-day session TTL and a 1-day rolling
+`updateAge`. There is no hook on `password.update` to invalidate other sessions,
+no "log out everywhere" UI, and no binding of the session to the device that
+created it (User-Agent + IP prefix). A stolen cookie or bearer therefore stays
+valid for up to 30 days regardless of how the user reacts.
+
+## Affected files
+
+- `apps/server/src/auth.ts:104–115` — `session.expiresIn`, `updateAge`,
+  `cookieCache`.
+- `apps/server/src/http/requireSession.ts` — session resolver, no fingerprint
+  check.
+- `apps/server/src/modules/auth/changePassword.ts` (does not exist yet).
+
+## Evidence
+
+```ts
+// apps/server/src/auth.ts:104
+session: {
+  expiresIn: 60 * 60 * 24 * 30,   // 30 days
+  updateAge: 60 * 60 * 24,        // 1 day
+  cookieCache: { enabled: true, maxAge: 5 * 60 },
+},
+```
+
+`databaseHooks.session.create.before` records nothing about User-Agent or IP.
+There is no project-side wrapper around `auth.api.changePassword` to invalidate
+sibling sessions.
+
+## Impact
+
+1. **Password reset offers no immediate protection.** A user who resets a
+   compromised password keeps every other session live; the attacker keeps
+   access until the 30-day TTL expires.
+2. **Bearer-token hijack persistence.** The mobile shell carries a 30-day
+   bearer; if it is exfiltrated (see [H1](./H1-mobile-bearer-storage.md)), it
+   can be replayed for the full TTL.
+3. **No device list, no kill switch.** Founder-only support cannot tell a user
+   "log out all my devices except this one" without manual SQL.
+4. **Forensic blind spot.** No `userAgent` / `ipPrefix` columns means we cannot
+   answer "which device created this session?" during an incident.
+
+## Recommendation
+
+- On `password.update` (and on any future `session.revokeAll` admin action),
+  call `auth.api.revokeOtherSessions({ headers: req.headers })` (Better Auth
+  helper) and bust the `cookieCache`.
+- Add a "Active sessions" UI tile that lists sessions with `userAgent`,
+  `ipPrefix`, `createdAt`, and a per-row "Revoke" button.
+- Bind the session to the **first-seen User-Agent + IP-prefix** (24 bits for
+  IPv4, 64 bits for IPv6). On drift → emit `auth.session.ua_drift` log + offer a
+  re-auth challenge for high-risk routes (Mono connect, password change).
+- Reduce mobile bearer TTL to 7 days with rolling refresh — pairs with
+  [H1](./H1-mobile-bearer-storage.md).
+
+## Correction points
+
+- `apps/server/src/modules/auth/changePassword.ts` (new) — wrapper that calls
+  `auth.api.changePassword` and `auth.api.revokeOtherSessions`.
+- `apps/server/src/auth.ts` — in `databaseHooks.session.create.before`, persist
+  `userAgent`, `ipPrefix` (truncate per family).
+- `apps/server/src/http/requireSession.ts` — load session row, compare
+  `userAgent`/`ipPrefix`; on mismatch emit a `session.ua_drift` warn log and
+  optionally require step-up.
+- `apps/server/src/migrations/03X_session_fingerprint.sql` — `ALTER TABLE
+  session ADD COLUMN user_agent TEXT, ip_prefix TEXT`.
+- `apps/web/src/modules/account/sessions/SessionsList.tsx` (new) — list +
+  revoke UI.
+
+## Verification
+
+- **Unit:** `changePassword` test case asserts that `revokeOtherSessions` is
+  invoked exactly once with the same request headers.
+- **Integration:** with two browsers signed in, change password in browser A;
+  browser B's next request returns 401.
+- **Drift smoke test:** mutate `User-Agent` mid-session; expect a structured
+  `session.ua_drift` log entry.
+- **Migration smoke test:** run forward and rollback against a staging clone
+  with one historical session row to ensure the new columns default safely.
+
+## Cross-references
+
+- [`./H1-mobile-bearer-storage.md`](./H1-mobile-bearer-storage.md)
+- [`./H6-email-verification.md`](./H6-email-verification.md)
+- [`../vulnerability-sla.md`](../vulnerability-sla.md)

--- a/docs/security/hardening/H5-trusted-origins-exp-scheme.md
+++ b/docs/security/hardening/H5-trusted-origins-exp-scheme.md
@@ -1,0 +1,83 @@
+# H5 — `getTrustedOrigins()` includes `exp://` in production
+
+> **Last validated:** 2026-05-03 by @Skords-01. **Next review:** 2026-08-01.
+
+| Field          | Value                                                |
+| -------------- | ---------------------------------------------------- |
+| **Severity**   | High (CVSS 7.0, AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:N/A:N) |
+| **Sprint**     | [Sprint 2](./sprint-2.md)                            |
+| **Owner**      | backend                                              |
+| **Effort**     | 0.25 person-day                                      |
+| **Status**     | Open                                                 |
+| **Discovered** | 2026-05-03 deep security review                      |
+
+## Summary
+
+The Better Auth `expo()` plugin registers `exp://` as a trusted redirect scheme
+unconditionally. `exp://` is the Expo Go development scheme and is not bound to
+a single application — any other Expo Go app on the same device can claim it. In
+production (where users are on the published `com.sergeant.app://` scheme)
+`exp://` should not be a trusted origin.
+
+## Affected files
+
+- `apps/server/src/auth.ts` — `expo({...})` plugin invocation.
+- `apps/mobile-shell/capacitor.config.ts` / Expo config — confirms only
+  `com.sergeant.app://` is the production scheme.
+
+## Evidence
+
+The audit traced `getTrustedOrigins()` (Better Auth helper) and observed `exp://`
+in the resulting array regardless of `NODE_ENV`. The `expo()` plugin from Better
+Auth always seeds the dev scheme.
+
+## Impact
+
+1. **CSRF-like login redirect attack.** A malicious Expo Go app can host a UI
+   that triggers a login flow against our backend with a redirect to `exp://`
+   and intercept the session cookie or bearer in the deep link.
+2. **OAuth callback hijack.** Apple/Google OAuth providers honour the trusted
+   origin list when constructing redirect URIs; an attacker-controlled
+   `exp://` consumer can capture authorization codes.
+3. **Compromise scope:** any user who installs a malicious Expo Go app and
+   signs in to our service through it.
+
+## Recommendation
+
+- Gate `exp://` behind `process.env.NODE_ENV !== "production"`.
+- Introduce `BETTER_AUTH_TRUSTED_NATIVE_SCHEMES` env-var (comma-separated) with
+  production defaulting to `com.sergeant.app://` only.
+- Document the policy in `docs/security/access-policy.md` and
+  `apps/mobile-shell/README.md`.
+
+## Correction points
+
+- `apps/server/src/auth.ts` — replace the static `expo()` invocation with:
+
+```ts
+const trustedNativeSchemes = (process.env.BETTER_AUTH_TRUSTED_NATIVE_SCHEMES
+  ?? (process.env.NODE_ENV === "production"
+        ? "com.sergeant.app://"
+        : "com.sergeant.app://,exp://"))
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+expo({ trustedRedirectURLs: trustedNativeSchemes });
+```
+
+- `docs/security/access-policy.md` — document the env-var.
+- `.env.example` — add `BETTER_AUTH_TRUSTED_NATIVE_SCHEMES=com.sergeant.app://`.
+
+## Verification
+
+- **Unit:** with `NODE_ENV=production` and the env-var unset,
+  `getTrustedOrigins()` does not return `exp://`.
+- **Unit:** with `NODE_ENV=development` and no override, `exp://` is present.
+- **Manual:** in staging, attempt OAuth with `redirect_uri=exp://...`; expect
+  Better Auth to reject with `untrusted_origin`.
+
+## Cross-references
+
+- [`./H1-mobile-bearer-storage.md`](./H1-mobile-bearer-storage.md)
+- [`../access-policy.md`](../access-policy.md)

--- a/docs/security/hardening/H6-email-verification.md
+++ b/docs/security/hardening/H6-email-verification.md
@@ -1,0 +1,94 @@
+# H6 — Email verification disabled, sensitive actions not gated
+
+> **Last validated:** 2026-05-03 by @Skords-01. **Next review:** 2026-08-01.
+
+| Field          | Value                                                |
+| -------------- | ---------------------------------------------------- |
+| **Severity**   | High (CVSS 7.4, AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:N) |
+| **Sprint**     | [Sprint 2](./sprint-2.md)                            |
+| **Owner**      | backend                                              |
+| **Effort**     | 0.5 person-day                                       |
+| **Status**     | Open                                                 |
+| **Discovered** | 2026-05-03 deep security review                      |
+
+## Summary
+
+Better Auth is configured with `emailAndPassword.enabled = true` but
+`emailVerification.sendOnSignUp = false` and `requireEmailVerification = false`.
+A user can sign up with anyone's email, and the legitimate owner is locked out
+when they try to register the same address later. Sensitive actions (Mono
+connect, password change, OpenClaw linking) are not gated on
+`email_verified=true`.
+
+## Affected files
+
+- `apps/server/src/auth.ts:140–150` — Better Auth `emailAndPassword`,
+  `emailVerification` blocks.
+- `apps/server/src/modules/mono/connection.ts` — no email-verified pre-check.
+- `apps/server/src/modules/openclaw/link.ts` (or equivalent) — no pre-check.
+
+## Evidence
+
+The audit observed `sendOnSignUp: false` and noticed a dormant Drizzle column
+`user.email_verified` that is set to `true` only via the Better Auth verify
+endpoint, which itself is never advertised because the email is never sent.
+
+## Impact
+
+1. **Account-squatting.** Adversary registers `victim@gmail.com`, sets a
+   password, and uses the account to connect a Mono profile (after which the
+   victim's bank statements, AI history, etc. are accessible to the squatter).
+2. **Lock-out.** The legitimate user later attempts to sign up and receives
+   "email already exists" — no obvious recovery path.
+3. **Phishing pivot.** Squatters with control of an unverified email may be
+   able to receive password-reset tokens if reset is later wired without an
+   ownership step.
+4. **Compliance.** GDPR Article 32 expects "appropriate technical measures" —
+   ungated mailbox-based identity is a soft fail.
+
+## Recommendation
+
+- `emailVerification.sendOnSignUp: true`, `requireEmailVerification: true`.
+- For existing unverified accounts older than 3 days, mark them in a soft-gate
+  state ("verify or this account will be deleted in 7 days") rather than
+  immediate lockout.
+- Pre-check `user.email_verified` in **every** sensitive flow:
+  - Mono connect
+  - Password change / reset
+  - OpenClaw / Telegram link
+  - Push subscription registration
+- Rate-limit verification email sending per-user (1/min, 6/h, 24/24h).
+
+## Correction points
+
+- `apps/server/src/auth.ts` — flip the two booleans, configure the email
+  template (HTML + text fallback).
+- `apps/server/src/modules/mono/connection.ts` — add:
+
+```ts
+if (!session.user.emailVerified) {
+  return reply.code(403).send({ error: "email_verification_required" });
+}
+```
+
+- `apps/server/src/modules/auth/passwordChange.ts` — same gate.
+- `apps/server/src/modules/openclaw/link.ts` — same gate.
+- `apps/server/src/modules/auth/sendVerification.ts` — rate-limit wrapper +
+  Pino-redacted token.
+- `apps/web/src/modules/auth/VerifyEmailGate.tsx` (new) — UI banner for
+  unverified state.
+
+## Verification
+
+- **Unit:** signing up issues exactly one verification email through the mock
+  transport.
+- **Integration:** unverified user receives 403 on `POST /api/mono/connect`.
+- **Manual:** verification email arrives within 30 s in staging; clicking the
+  link sets `email_verified=true`.
+- **Rate-limit:** repeated `POST /api/auth/send-verification-email` calls
+  return 429 after the configured window.
+
+## Cross-references
+
+- [`./H3-session-revoke-and-binding.md`](./H3-session-revoke-and-binding.md)
+- [`../audit-exceptions.md`](../audit-exceptions.md) — no exceptions expected.

--- a/docs/security/hardening/H7-vercel-config-drift.md
+++ b/docs/security/hardening/H7-vercel-config-drift.md
@@ -1,0 +1,90 @@
+# H7 — `apps/web/vercel.json` vs root `vercel.json` config drift
+
+> **Last validated:** 2026-05-03 by @Skords-01. **Next review:** 2026-08-01.
+
+| Field          | Value                                                |
+| -------------- | ---------------------------------------------------- |
+| **Severity**   | High (CVSS 7.0, AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N) |
+| **Sprint**     | [Sprint 2](./sprint-2.md)                            |
+| **Owner**      | devops                                               |
+| **Effort**     | 0.25 person-day                                      |
+| **Status**     | Open                                                 |
+| **Discovered** | 2026-05-03 deep security review                      |
+
+## Summary
+
+Two `vercel.json` files exist: one at the repository root (91 lines) and one
+under `apps/web/vercel.json`. Vercel reads only the file that lives in the
+project's configured root directory. If the project is configured with the
+repository root, `apps/web/vercel.json` becomes dead code (and vice versa).
+Security headers (COOP/COEP/Permissions-Policy, the future CSP from
+[C2](./C2-frontend-csp.md)) only protect users via whichever file is "live".
+
+## Affected files
+
+- `vercel.json` (root)
+- `apps/web/vercel.json`
+- Vercel project setting "Root Directory" (out of repo)
+
+## Evidence
+
+Side-by-side `diff vercel.json apps/web/vercel.json` shows divergent
+`headers[*]` blocks. The root file ships richer headers; the per-app file
+predates a previous header refresh.
+
+## Impact
+
+1. **Silent header regression.** A future change to "Root Directory" in the
+   Vercel UI silently downgrades production headers without any code change or
+   PR review.
+2. **CSP rollout blocked.** [C2](./C2-frontend-csp.md) plans to ship CSP via
+   Vercel headers; if the wrong file is live, the CSP will simply be absent in
+   production.
+3. **Audit trail gap.** Header drift cannot be reconstructed from the git log
+   alone because the failure mode is "correct file, wrong project setting".
+
+## Recommendation
+
+- Pick a single source of truth. Recommended: keep the root `vercel.json`
+  (matches monorepo convention used by Turborepo + pnpm workspaces) and delete
+  `apps/web/vercel.json`.
+- Add a CI guard `scripts/check-vercel-config.sh` that fails if both files
+  exist or if the live file diverges from a checksum committed to the repo.
+- Document the Vercel "Root Directory" expected value in
+  `docs/deploy/vercel.md` (creating that page if needed).
+
+## Correction points
+
+- Delete `apps/web/vercel.json`.
+- Add `scripts/check-vercel-config.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ -f apps/web/vercel.json ]]; then
+  echo "::error::apps/web/vercel.json exists — only the root vercel.json is allowed."
+  exit 1
+fi
+```
+
+- `.github/workflows/ci.yml` — add `bash scripts/check-vercel-config.sh` to the
+  lint job.
+- `docs/deploy/vercel.md` (new) — describe the SSOT and the Vercel project
+  configuration.
+- `docs/security/access-matrix.md` — link Vercel project settings to the
+  privileged surfaces register.
+
+## Verification
+
+- **CI:** dropping a stub `apps/web/vercel.json` and pushing a PR fails the
+  lint job.
+- **Manual:** in Vercel UI, confirm "Root Directory" is `/` and deploy preview
+  responds with `Cross-Origin-Opener-Policy: same-origin`.
+- **Header smoke:** `curl -sI https://app.sergeant.example | grep -i
+  'cross-origin-opener-policy'` returns the expected value.
+
+## Cross-references
+
+- [`./C2-frontend-csp.md`](./C2-frontend-csp.md)
+- [`../disaster-recovery.md`](../disaster-recovery.md) — Vercel re-deploy
+  procedure relies on the root file.

--- a/docs/security/hardening/H8-corp-per-route.md
+++ b/docs/security/hardening/H8-corp-per-route.md
@@ -1,0 +1,103 @@
+# H8 — `Cross-Origin-Resource-Policy: cross-origin` without per-route guards
+
+> **Last validated:** 2026-05-03 by @Skords-01. **Next review:** 2026-08-01.
+
+| Field          | Value                                                |
+| -------------- | ---------------------------------------------------- |
+| **Severity**   | High (CVSS 7.1, AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N) |
+| **Sprint**     | [Sprint 2](./sprint-2.md)                            |
+| **Owner**      | backend                                              |
+| **Effort**     | 0.5 person-day                                       |
+| **Status**     | Open                                                 |
+| **Discovered** | 2026-05-03 deep security review                      |
+
+## Summary
+
+`apps/server/src/http/security.ts` configures `helmet` with
+`crossOriginResourcePolicy: "cross-origin"` so the SPA hosted on Vercel can
+fetch the API. The same header is returned for **every** API route, including
+session-protected ones (`/api/me`, `/api/mono/*`, `/api/chat/*`). This widens
+the API into a CORB-bypassed surface usable by attacker-controlled origins
+(timing oracles, `<img>`-tag tricks, side-channel login probing).
+
+## Affected files
+
+- `apps/server/src/http/security.ts` — Helmet defaults.
+- `apps/server/src/http/cors.ts` — CORS allowlist (works correctly, but `CORP`
+  is a separate header that CORS does not mediate).
+- `apps/server/src/modules/me/router.ts`,
+  `apps/server/src/modules/mono/router.ts`,
+  `apps/server/src/modules/chat/router.ts` — sensitive endpoints.
+
+## Evidence
+
+```ts
+// apps/server/src/http/security.ts
+helmet({
+  crossOriginResourcePolicy: { policy: "cross-origin" },
+  // …
+})
+```
+
+A `<img src="https://api.sergeant.example/api/me">` tag in any third-party
+origin loads the response (browser ignores pixel data but `onload` fires when
+the user is authenticated, `onerror` fires otherwise). This is a login-state
+oracle that bypasses CORS preflight because images are simple requests.
+
+## Impact
+
+1. **Login-state oracle.** Attacker pages can detect whether a visitor is
+   logged in to Sergeant using only a 1×1 hidden `<img>`.
+2. **Timing side channel.** Response size differences (logged-in `/api/me`
+   vs. 401 stub) leak per-user signal.
+3. **Future framing risk.** If a new public endpoint accidentally renders HTML
+   with user-specific data, `cross-origin` makes a Spectre-style attack
+   feasible from any origin.
+4. **Defense in depth.** Returning `same-origin` for protected routes restores
+   browser-side enforcement even if CORS is misconfigured.
+
+## Recommendation
+
+- For **session-protected** routes (`/api/me`, `/api/mono/*`, `/api/chat/*`,
+  `/api/sync/*`, etc.) override `Cross-Origin-Resource-Policy` to
+  `same-origin` per route or via a middleware that detects `req.user`.
+- For **truly cross-origin** endpoints (`/api/web-vitals`, `/api/csp-report`,
+  `/api/health`, OAuth callbacks) keep `cross-origin`.
+- Combine with [C2](./C2-frontend-csp.md) — CSP `frame-ancestors 'none'`
+  blocks framing attacks; CORP `same-origin` blocks resource embedding.
+
+## Correction points
+
+- `apps/server/src/http/security.ts` — keep Helmet default as
+  `cross-origin` (compatibility), but extract a `requireSameOriginCorp`
+  middleware:
+
+```ts
+export function requireSameOriginCorp(_req: Request, res: Response, next: NextFunction) {
+  res.setHeader("Cross-Origin-Resource-Policy", "same-origin");
+  next();
+}
+```
+
+- Apply it on:
+  - `apps/server/src/modules/me/router.ts`
+  - `apps/server/src/modules/mono/router.ts`
+  - `apps/server/src/modules/chat/router.ts`
+  - `apps/server/src/modules/sync/router.ts`
+  - All routes that call `requireSession`.
+- Add a unit test that walks the router tree and asserts the header is set.
+- Update `apps/server/README.md` with the per-route guidance.
+
+## Verification
+
+- **Unit:** Supertest hit on `/api/me` (authenticated) returns
+  `Cross-Origin-Resource-Policy: same-origin`.
+- **Unit:** Supertest hit on `/api/health` returns `cross-origin`.
+- **Browser:** an attacker-style HTML page hosted on `evil.example` embedding
+  `<img src="https://api/.../api/me">` no longer fires `onload` for a logged-in
+  visitor.
+
+## Cross-references
+
+- [`./C2-frontend-csp.md`](./C2-frontend-csp.md)
+- [`./H7-vercel-config-drift.md`](./H7-vercel-config-drift.md)

--- a/docs/security/hardening/H9-transcribe-usd-cap.md
+++ b/docs/security/hardening/H9-transcribe-usd-cap.md
@@ -1,0 +1,92 @@
+# H9 — `transcribe` accepts 10 MB raw audio with only count-based quota
+
+> **Last validated:** 2026-05-03 by @Skords-01. **Next review:** 2026-08-01.
+
+| Field          | Value                                                |
+| -------------- | ---------------------------------------------------- |
+| **Severity**   | High (CVSS 7.0, AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H) |
+| **Sprint**     | [Sprint 2](./sprint-2.md)                            |
+| **Owner**      | backend                                              |
+| **Effort**     | 0.5 person-day                                       |
+| **Status**     | Open                                                 |
+| **Discovered** | 2026-05-03 deep security review                      |
+
+## Summary
+
+`POST /api/transcribe` accepts up to 10 MB of audio per request. The router
+applies a per-user count-based quota and a global rate-limit but does not track
+**USD spent**. A hostile (or curious) user can drive Groq Whisper costs into the
+hundreds of dollars per day before tripping any guardrail, because each 10 MB
+upload is a multi-cent inference call.
+
+## Affected files
+
+- `apps/server/src/modules/transcribe/transcribe.ts:22` —
+  `MAX_AUDIO_BYTES = 10 * 1024 * 1024`.
+- `apps/server/src/modules/transcribe/router.ts` — quota / rate-limit
+  middleware order.
+- `apps/server/src/modules/quota/quota.ts` — per-user quota table.
+- `apps/server/src/http/rateLimit.ts` — the new rate-limit-buckets schema.
+
+## Evidence
+
+```ts
+// apps/server/src/modules/transcribe/transcribe.ts:22
+export const MAX_AUDIO_BYTES = 10 * 1024 * 1024; // 10 MB
+```
+
+The router enforces "max N requests/day/user". With current Groq pricing
+(`whisper-large-v3-turbo`) a single 10 MB clip is ~$0.04, so 100 quota slots
+per user equal up to $4/user/day — multiplied by N users this is unbounded
+spend.
+
+## Impact
+
+1. **Direct USD burn.** A compromised account with 100 daily slots can cost
+   $4–$8/day (10 MB × 100 calls × Whisper price).
+2. **Rate-limit bypass.** Quota slots reset at midnight UTC; "wait until reset"
+   is a trivial bypass for a determined adversary.
+3. **No abuse correlation.** No per-IP and per-user-USD ledger means we cannot
+   detect a slow-burn attack that stays under the count limit but blasts
+   maximum bytes.
+4. **Operational risk.** Founder-only billing alerts only fire after 24 h of
+   damage — there is no inline circuit breaker.
+
+## Recommendation
+
+- Add a **per-user-per-day USD cap** (e.g. $1/day default, configurable per
+  plan tier) in `usage_audit_log`. When the cap is hit, return 402/429 and emit
+  a structured alert.
+- Add **abuse detection**: 50+ rejected-quota responses per hour from one user
+  → automatic IP ban + email to founder.
+- Move large-audio uploads to a **signed pre-flight URL** (S3 multipart) so
+  Express never buffers a 10 MB body in process memory.
+- Reject `Content-Length` early (before reading body); confirm Express
+  `raw({ limit })` returns `413` without buffering.
+- Add a Sentry alert for `transcribe.cost_cap_hit` events.
+
+## Correction points
+
+- `apps/server/src/modules/quota/quota.ts` — add `usd_spent_total` and
+  `usd_cap_daily` columns; bump migration number sequentially.
+- `apps/server/src/modules/transcribe/router.ts` — pre-charge estimate based on
+  `Content-Length`; deduct after Groq returns the actual bytes processed.
+- `apps/server/src/http/rateLimit.ts` — extend the `rate_limit_buckets`
+  schema with a `usd_spent_total_micro` column for per-user cumulative cost.
+- `apps/server/src/obs/logger.ts` — add `transcribe.usd_cap_hit` event.
+- `docs/runbooks/cost-cap-incident.md` (new) — playbook for "user X exceeded
+  USD cap, what to do".
+
+## Verification
+
+- **Unit:** `POST /api/transcribe` with `Content-Length` over the daily USD
+  budget returns 402 without invoking Groq.
+- **Synthetic load:** 200 × 10 MB clips from a single user trip the cap at ~25
+  successful calls (assuming $1/day cap and $0.04/clip).
+- **Manual:** Sentry alert fires within 60 s of the first
+  `transcribe.usd_cap_hit` event.
+
+## Cross-references
+
+- [`./M1-csp-disable-runtime-flag.md`](./M1-csp-disable-runtime-flag.md)
+- [`../vulnerability-sla.md`](../vulnerability-sla.md)

--- a/docs/security/hardening/M1-csp-disable-runtime-flag.md
+++ b/docs/security/hardening/M1-csp-disable-runtime-flag.md
@@ -1,0 +1,92 @@
+# M1 — `CSP_DISABLE=1` runtime fault-injection vector
+
+> **Last validated:** 2026-05-03 by @Skords-01. **Next review:** 2026-08-01.
+
+| Field          | Value                                                |
+| -------------- | ---------------------------------------------------- |
+| **Severity**   | Medium (CVSS 6.1, AV:N/AC:H/PR:H/UI:R/S:C/C:L/I:L/A:N) |
+| **Sprint**     | [Sprint 2](./sprint-2.md)                            |
+| **Owner**      | backend                                              |
+| **Effort**     | 0.25 person-day                                      |
+| **Status**     | Open                                                 |
+| **Discovered** | 2026-05-03 deep security review                      |
+
+## Summary
+
+`apps/server/src/http/security.ts` reads two environment variables at runtime:
+`CSP_DISABLE=1` and `CSP_REPORT_ONLY=1`. Either flag completely changes the CSP
+posture without a redeploy or a git commit. If a Railway env-var write
+credential is ever leaked, an attacker can flip `CSP_DISABLE=1`, get a green
+window for XSS exfiltration, and flip it back without leaving an audit trail.
+
+## Affected files
+
+- `apps/server/src/http/security.ts` — `process.env.CSP_DISABLE`,
+  `process.env.CSP_REPORT_ONLY` branches.
+- Railway dashboard env-vars (out of repo).
+
+## Evidence
+
+```ts
+// apps/server/src/http/security.ts
+if (process.env.CSP_DISABLE === "1") {
+  // skip CSP entirely
+} else if (process.env.CSP_REPORT_ONLY === "1") {
+  // Content-Security-Policy-Report-Only
+} else {
+  // Content-Security-Policy
+}
+```
+
+## Impact
+
+1. **Audit trail gap.** Env-var changes in Railway are not recorded in the
+   project git log; flipping `CSP_DISABLE` leaves no PR to review.
+2. **Post-leak amplification.** A credential leak (Railway token, founder
+   account password reuse) becomes a CSP-bypass primitive.
+3. **CSP rollout interaction.** [C2](./C2-frontend-csp.md) ships a CSP-Report-Only
+   header — the `CSP_DISABLE` flag is wider than `Report-Only` and therefore
+   overrides everything C2 puts in place.
+
+## Recommendation
+
+- Delete `CSP_DISABLE`. Keep `CSP_REPORT_ONLY` only as a temporary toggle
+  during the C2 rollout window (delete it after Sprint 3 once production CSP
+  has been enforced for two weeks without false-positives).
+- Disabling CSP in an emergency must require **a code change + redeploy** —
+  this enforces a git audit trail and a four-eyes review.
+- Document the change in `docs/security/access-policy.md` so operators know
+  why the runtime flag is gone.
+
+## Correction points
+
+- `apps/server/src/http/security.ts` — remove the `CSP_DISABLE` branch:
+
+```ts
+const reportOnly = process.env.CSP_REPORT_ONLY === "1";
+const headerName = reportOnly
+  ? "Content-Security-Policy-Report-Only"
+  : "Content-Security-Policy";
+res.setHeader(headerName, cspString);
+```
+
+- `apps/server/src/http/security.test.ts` — add a regression test that
+  asserts the CSP header is always set regardless of `CSP_DISABLE` presence.
+- `docs/security/access-policy.md` — note "no runtime CSP kill switch".
+- Railway dashboard — remove `CSP_DISABLE` from production / staging projects
+  (record removal in `docs/security/secret-ownership-register.md`).
+
+## Verification
+
+- **Unit:** with `CSP_DISABLE=1` set in the test env, the response still
+  includes `Content-Security-Policy` (`Report-Only` if the other flag is set).
+- **Smoke:** in staging after deploy,
+  `curl -sI https://api.../api/health | grep -i content-security-policy`
+  returns the expected value.
+- **Audit trail:** `grep -r CSP_DISABLE` in the codebase returns no matches.
+
+## Cross-references
+
+- [`./C2-frontend-csp.md`](./C2-frontend-csp.md)
+- [`./M3-pino-redact-paths.md`](./M3-pino-redact-paths.md)
+- [`../secret-ownership-register.md`](../secret-ownership-register.md)

--- a/docs/security/hardening/M3-pino-redact-paths.md
+++ b/docs/security/hardening/M3-pino-redact-paths.md
@@ -1,0 +1,111 @@
+# M3 — Pino `redactPaths` is incomplete for security headers and URLs
+
+> **Last validated:** 2026-05-03 by @Skords-01. **Next review:** 2026-08-01.
+
+| Field          | Value                                                |
+| -------------- | ---------------------------------------------------- |
+| **Severity**   | Medium (CVSS 5.3, AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N) |
+| **Sprint**     | [Sprint 2](./sprint-2.md)                            |
+| **Owner**      | platform                                             |
+| **Effort**     | 0.25 person-day                                      |
+| **Status**     | Open                                                 |
+| **Discovered** | 2026-05-03 deep security review                      |
+
+## Summary
+
+`apps/server/src/obs/logger.ts` redacts a base set of fields (`authorization`,
+`cookie`, `password`) but misses several secret-bearing inputs that this audit
+discovered downstream — `X-Mono-Webhook-Secret`, `X-API-Secret`,
+`X-OpenClaw-Webhook-Secret`, `req.url` and `req.originalUrl` (relevant while
+[C1](./C1-mono-webhook-secret-in-url.md) is being fixed), provider keys
+(`groqKey`, `anthropicKey`, `voyageKey`), error-config headers from axios/got,
+and `req.body.password` / `req.body.token` safety nets.
+
+## Affected files
+
+- `apps/server/src/obs/logger.ts:24–48`
+- Sentry beforeSend (currently doesn't carry header redaction either —
+  partially covered by [C1](./C1-mono-webhook-secret-in-url.md)).
+
+## Evidence
+
+```ts
+// apps/server/src/obs/logger.ts
+const redactPaths = [
+  "req.headers.authorization",
+  "req.headers.cookie",
+  // missing: x-mono-webhook-secret, x-api-secret, x-openclaw-webhook-secret,
+  //          req.url, req.originalUrl, groqKey, anthropicKey, voyageKey,
+  //          req.body.password, req.body.token, err.config.headers.Authorization
+];
+```
+
+## Impact
+
+1. **Direct secret leak.** A debug log on the Mono webhook handler can dump the
+   incoming `req` object verbatim and expose the secret in plaintext.
+2. **Provider-key leak.** When AI calls fail, error captures often include the
+   request config (axios `err.config.headers.Authorization`).
+3. **Legacy URL leak.** While [C1](./C1-mono-webhook-secret-in-url.md) is being
+   rolled out, every access log line still contains the secret in the URL
+   path; redacting `req.url` short-circuits that exposure.
+
+## Recommendation
+
+Extend `redactPaths` to:
+
+```ts
+const redactPaths = [
+  // existing
+  "req.headers.authorization",
+  "req.headers.cookie",
+
+  // Sergeant-specific secrets
+  "req.headers['x-api-secret']",
+  "req.headers['x-mono-webhook-secret']",
+  "req.headers['x-openclaw-webhook-secret']",
+  "req.headers['x-internal-token']",
+
+  // URL leakage during C1 rollout
+  "req.url",
+  "req.originalUrl",
+
+  // provider keys
+  "groqKey",
+  "anthropicKey",
+  "voyageKey",
+
+  // body safety nets
+  "req.body.password",
+  "req.body.token",
+
+  // axios/got error captures
+  "err.config.headers.Authorization",
+  "err.config.headers['x-mono-webhook-secret']",
+];
+```
+
+## Correction points
+
+- `apps/server/src/obs/logger.ts` — extend the array.
+- `apps/server/src/obs/logger.test.ts` — table-driven test that emits a log
+  with each forbidden path and asserts `[Redacted]` in the JSON output.
+- `apps/server/src/app.ts` — Sentry `beforeSend` hook to also strip these
+  fields from `event.request` and `event.exception.values[].mechanism.data`
+  (alignment with [C1](./C1-mono-webhook-secret-in-url.md)).
+
+## Verification
+
+- **Unit:** for every entry in `redactPaths`, log an object containing that
+  path with value `"SECRETSECRETSECRET"`; the resulting JSON must not contain
+  the literal string.
+- **Integration:** issue a forged webhook call with a header
+  `X-Mono-Webhook-Secret: leaktest`; tail the Pino output and confirm
+  `[Redacted]`.
+- **Sentry:** trigger a synthetic axios error with a header authorization;
+  confirm Sentry event payload contains `[Filtered]`.
+
+## Cross-references
+
+- [`./C1-mono-webhook-secret-in-url.md`](./C1-mono-webhook-secret-in-url.md)
+- [`./M1-csp-disable-runtime-flag.md`](./M1-csp-disable-runtime-flag.md)

--- a/docs/security/hardening/sprint-2.md
+++ b/docs/security/hardening/sprint-2.md
@@ -1,0 +1,80 @@
+# Sprint 2 — Session, surface and quota hardening
+
+> **Last validated:** 2026-05-03 by @Skords-01. **Next review:** 2026-08-01.
+
+Sprint 2 closes the **High-severity backlog** that Sprint 1 left open and removes
+two Medium-severity issues that share blast radius with Sprint 1 (`CSP_DISABLE`
+runtime flag and Pino redaction gaps for the same secret families).
+
+After Sprint 2 the only High-severity item still open is **H4 (encryption-key
+rotation)** — it is intentionally deferred because it requires a DB migration
+and a maintenance window; it lands in Sprint 3 alongside the medium batch.
+
+## Scope
+
+| ID                                                 | Title                                            | Severity | Owner    | Effort |
+| -------------------------------------------------- | ------------------------------------------------ | -------- | -------- | ------ |
+| [H3](./H3-session-revoke-and-binding.md)           | Session 30 d, no revoke-on-password-change       | High     | backend  | 1 d    |
+| [H5](./H5-trusted-origins-exp-scheme.md)           | `exp://` trusted origin in production            | High     | backend  | 0.25 d |
+| [H6](./H6-email-verification.md)                   | Email verification disabled, password reset weak | High     | backend  | 0.5 d  |
+| [H7](./H7-vercel-config-drift.md)                  | `vercel.json` duplicated between root and apps   | High     | devops   | 0.25 d |
+| [H8](./H8-corp-per-route.md)                       | `CORP: cross-origin` without per-route guard     | High     | backend  | 0.5 d  |
+| [H9](./H9-transcribe-usd-cap.md)                   | `transcribe` 10 MB upload, no per-user USD cap   | High     | backend  | 0.5 d  |
+| [M1](./M1-csp-disable-runtime-flag.md)             | `CSP_DISABLE=1` env-fault-injection              | Medium   | backend  | 0.25 d |
+| [M3](./M3-pino-redact-paths.md)                    | Pino `redactPaths` is incomplete                 | Medium   | platform | 0.25 d |
+
+**Total effort:** ≈ 3.5 person-days (one engineer, one calendar week).
+
+## Rationale
+
+- **H3, H6, H8** harden the **session and authentication surface** that Sprint 1
+  did not touch. After Sprint 1 the SPA has CSP and the bearer is locked to the
+  device — Sprint 2 ensures that an active session cannot survive a password
+  change, an unverified email cannot connect Mono, and a phished
+  `<img src="https://api/me">` cannot leak login state cross-origin.
+- **H5, H7** are **paper-cut hardening** (config drift and a stale dev scheme)
+  that take less than half a day each and remove latent regression risk.
+- **H9** caps the only outbound-cost endpoint that can be triggered by a quota
+  bypass; it pairs well with Sprint 1 because the quota plumbing it touches
+  also receives the per-user-USD column.
+- **M1, M3** are the Medium items that share blast radius with Sprint 1 — they
+  ride along to keep the security log-redaction story complete in one PR
+  rather than dragging into a Sprint 3 cleanup.
+
+## Dependencies and risks
+
+- **Better Auth helper compatibility** — H3 relies on
+  `auth.api.revokeOtherSessions` from Better Auth. Confirm version in
+  `apps/server/package.json` before starting; if the helper is not exposed, fall
+  back to a custom DB delete with a Drizzle query.
+- **`exp://` impact on Expo dev** — H5 must remain enabled for non-production
+  environments. Use `process.env.NODE_ENV === "production"` to gate.
+- **Vercel single-source-of-truth** — H7 needs a Vercel project setting
+  inspection (Project → Settings → Root Directory) before deleting either file.
+- **Email-verification UX** — H6 changes signup flow; coordinate with web/mobile
+  to render the "verify your email" state.
+
+## Success metrics
+
+- **H3:** changing password invalidates all other sessions within 30 s in
+  staging integration test.
+- **H5:** in production `getTrustedOrigins()` returns no `exp://` entry.
+- **H6:** new sign-ups receive a verification email; `connectMonoAccount` rejects
+  with 403 if `email_verified=false`.
+- **H7:** only one `vercel.json` exists in repo; CI fails if a duplicate is
+  added.
+- **H8:** `/api/me` and `/api/mono/*` respond with `Cross-Origin-Resource-Policy:
+  same-origin`; `/api/health`, `/api/web-vitals`, `/api/csp-report` keep
+  `cross-origin`.
+- **H9:** Synthetic load test of 200 × 10 MB requests stops at the per-user USD
+  cap with `429`s, not at the rate-limiter alone.
+- **M1:** `CSP_DISABLE` no longer exists in `apps/server/src/http/security.ts`;
+  CSP can only be relaxed by code change + redeploy.
+- **M3:** Pino access-log of a forged `X-Mono-Webhook-Secret` header shows
+  `[Redacted]` for both header and `req.url`.
+
+## Cross-references
+
+- [`./README.md`](./README.md) — full backlog index.
+- [`./sprint-1.md`](./sprint-1.md) — preceding sprint (C1, C2, H1, H2).
+- [`../vulnerability-sla.md`](../vulnerability-sla.md) — High SLA = 14 days.


### PR DESCRIPTION
## Summary

Sprint 2 of the security hardening backlog — closes the **High-severity** items left open by Sprint 1 and folds in two related Mediums (`CSP_DISABLE` runtime flag and incomplete Pino redaction) so the log-redaction story stays coherent in a single sprint.

This PR is **documentation-only**; implementation will land in dedicated PRs that reference these cards.

> Branch is stacked on top of `devin/1777844954-security-hardening-sprint-1`. Either merge that PR first, or change this PR's base back to `main` after #1544 is merged.

## Sprint 2 — Session, surface, and quota hardening

| ID | Title | Severity | Owner | Effort |
|---|---|---|---|---|
| [H3](docs/security/hardening/H3-session-revoke-and-binding.md) | Session 30 d, no revoke-on-password-change, no device binding | High | backend | 1 d |
| [H5](docs/security/hardening/H5-trusted-origins-exp-scheme.md) | `exp://` trusted origin in production | High | backend | 0.25 d |
| [H6](docs/security/hardening/H6-email-verification.md) | Email verification disabled, sensitive actions ungated | High | backend | 0.5 d |
| [H7](docs/security/hardening/H7-vercel-config-drift.md) | `vercel.json` duplicated between root and apps | High | devops | 0.25 d |
| [H8](docs/security/hardening/H8-corp-per-route.md) | `Cross-Origin-Resource-Policy: cross-origin` without per-route guards | High | backend | 0.5 d |
| [H9](docs/security/hardening/H9-transcribe-usd-cap.md) | `transcribe` 10 MB upload, no per-user USD cap | High | backend | 0.5 d |
| [M1](docs/security/hardening/M1-csp-disable-runtime-flag.md) | `CSP_DISABLE=1` env-fault-injection vector | Medium | backend | 0.25 d |
| [M3](docs/security/hardening/M3-pino-redact-paths.md) | Pino `redactPaths` is incomplete | Medium | platform | 0.25 d |

Total effort ≈ **3.5 person-days**.

## Why these eight together

- **H3, H6, H8** harden the **session and authentication surface** Sprint 1 didn't touch: revoke-on-password-change (H3), gate sensitive actions on email-verified (H6), CORP `same-origin` for protected routes (H8).
- **H5, H7** are paper-cut hardening (config drift and a stale dev scheme) at <½ day each.
- **H9** caps the only outbound-cost endpoint that can be triggered by a quota bypass; it pairs well with Sprint 1's quota plumbing.
- **M1, M3** share blast radius with Sprint 1 — they ride along to keep the log-redaction story complete instead of dragging into Sprint 3.

The only **High** still open after this PR is **H4 (encryption-key rotation)** — intentionally deferred because it requires a DB migration + maintenance window; it lands in Sprint 3.

## Verification

- All new files include the canonical freshness header (`> **Last validated:** 2026-05-03 by @Skords-01. **Next review:** 2026-08-01.`).
- Each card is structured: severity / sprint / owner / effort / status / discovered → summary → affected files → evidence → impact → recommendation → correction points → verification → cross-references.
- Only `docs/security/hardening/` is touched.

## Cross-references

- [`docs/security/hardening/sprint-2.md`](docs/security/hardening/sprint-2.md) — sprint overview.
- [`docs/security/hardening/sprint-1.md`](docs/security/hardening/sprint-1.md) — preceding sprint (PR #1544).
- [`docs/security/vulnerability-sla.md`](docs/security/vulnerability-sla.md) — High SLA = 14 days.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds documentation for Security Hardening Sprint 2 to close the remaining High-severity items and align two related Mediums. This is documentation-only; implementation will land in follow-up PRs.

- **New Features**
  - Harden sessions and auth (H3, H6, H8): revoke on password change, device binding, email verification gates, and per-route `Cross-Origin-Resource-Policy: same-origin` on protected endpoints.
  - Fix trusted origins (H5): disable `exp://` in production and add env-controlled native schemes.
  - Prevent config drift (H7): single-source `vercel.json` with a CI guard.
  - Cap transcription costs (H9): per-user daily USD cap and early rejection based on `Content-Length`.
  - Remove CSP runtime kill switch (M1): delete `CSP_DISABLE`; keep report-only toggle for rollout only.
  - Complete log redaction (M3): extend `Pino` `redactPaths` to cover secret headers, URLs, provider keys, and error-config headers.

<sup>Written for commit 6e8b3bb157f9168f8c37426a5f96bb80d4ac11a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

