### PR TITLE
feat(console): self-heal OpenClaw webhook race (W4.1) + warn-log on silent rejection

### DIFF
--- a/apps/console/src/openclaw/bootstrap.test.ts
+++ b/apps/console/src/openclaw/bootstrap.test.ts
@@ -8,13 +8,28 @@ import {
 
 const SECRET_OK = "a".repeat(32);
 
-function makeBotMock() {
+function makeBotMock(initialUrl = "") {
   const setWebhook = vi.fn().mockResolvedValue(true);
   const deleteWebhook = vi.fn().mockResolvedValue(true);
+  // `getWebhookInfo` returns whatever the most recent successful
+  // setWebhook stored. Tests that exercise the W4.1 race override this
+  // mock to return an empty / mismatched URL.
+  const state = { url: initialUrl };
+  setWebhook.mockImplementation(async (url: string) => {
+    state.url = url;
+    return true;
+  });
+  const getWebhookInfo = vi.fn().mockImplementation(async () => ({
+    url: state.url,
+    has_custom_certificate: false,
+    pending_update_count: 0,
+  }));
   return {
-    bot: { api: { setWebhook, deleteWebhook } },
+    bot: { api: { setWebhook, deleteWebhook, getWebhookInfo } },
     setWebhook,
     deleteWebhook,
+    getWebhookInfo,
+    state,
   };
 }
 
@@ -108,8 +123,8 @@ describe("validateWebhookConfig", () => {
 });
 
 describe("registerOpenClawWebhook", () => {
-  it("calls setWebhook with secret_token + drop_pending_updates + allowed_updates", async () => {
-    const { bot, setWebhook } = makeBotMock();
+  it("calls setWebhook with secret_token + drop_pending_updates + allowed_updates and verifies via getWebhookInfo", async () => {
+    const { bot, setWebhook, getWebhookInfo } = makeBotMock();
     await registerOpenClawWebhook(bot as never, {
       url: "https://x.example/webhook",
       secretToken: SECRET_OK,
@@ -120,6 +135,8 @@ describe("registerOpenClawWebhook", () => {
       drop_pending_updates: true,
       allowed_updates: ["message", "callback_query"],
     });
+    // The W4.1 hardening reads back the webhook URL once on success.
+    expect(getWebhookInfo).toHaveBeenCalledTimes(1);
   });
 
   it("propagates validation errors before calling Telegram (no API call on bad config)", async () => {
@@ -131,6 +148,58 @@ describe("registerOpenClawWebhook", () => {
       }),
     ).rejects.toThrow(/must use https/);
     expect(setWebhook).not.toHaveBeenCalled();
+  });
+
+  it("retries setWebhook when getWebhookInfo reports an empty url (W4.1 race)", async () => {
+    // Simulate the production race: a graceful-shutdown long-poll
+    // container clears the webhook between our `setWebhook` and our
+    // verification read. The first verify returns url="", second
+    // returns the expected URL.
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { bot, setWebhook, getWebhookInfo } = makeBotMock();
+    let calls = 0;
+    getWebhookInfo.mockImplementation(async () => {
+      calls += 1;
+      return {
+        url: calls === 1 ? "" : "https://x.example/webhook",
+        has_custom_certificate: false,
+        pending_update_count: 0,
+      };
+    });
+    await registerOpenClawWebhook(bot as never, {
+      url: "https://x.example/webhook",
+      secretToken: SECRET_OK,
+    });
+    // Two setWebhook calls: first fails verification, second succeeds.
+    expect(setWebhook).toHaveBeenCalledTimes(2);
+    expect(getWebhookInfo).toHaveBeenCalledTimes(2);
+    // Subsequent setWebhook attempts skip drop_pending_updates so we
+    // don't lose queued updates that arrived between attempts.
+    expect(setWebhook.mock.calls[0][1]).toMatchObject({
+      drop_pending_updates: true,
+    });
+    expect(setWebhook.mock.calls[1][1]).toMatchObject({
+      drop_pending_updates: false,
+    });
+  });
+
+  it("throws after WEBHOOK_VERIFY_MAX_ATTEMPTS if verification keeps failing", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { bot, setWebhook, getWebhookInfo } = makeBotMock();
+    // Force every getWebhookInfo to keep reporting an empty URL.
+    getWebhookInfo.mockResolvedValue({
+      url: "",
+      has_custom_certificate: false,
+      pending_update_count: 0,
+    });
+    await expect(
+      registerOpenClawWebhook(bot as never, {
+        url: "https://x.example/webhook",
+        secretToken: SECRET_OK,
+      }),
+    ).rejects.toThrow(/verification failed after 3 attempts/);
+    expect(setWebhook).toHaveBeenCalledTimes(3);
+    expect(getWebhookInfo).toHaveBeenCalledTimes(3);
   });
 });
 

--- a/apps/console/src/openclaw/bootstrap.ts
+++ b/apps/console/src/openclaw/bootstrap.ts
@@ -29,6 +29,24 @@ const MIN_SECRET_LEN = 32;
 const SECRET_RE = /^[A-Za-z0-9_-]+$/;
 
 /**
+ * W4.1 hardening (docs/deploy/console.md, observed 2026-05-03 21:26 UTC):
+ * during the first long-poll → webhook migration, the old long-poll
+ * container's graceful-shutdown `getUpdates` raced with the new
+ * container's `setWebhook` and silently cleared the webhook on
+ * Telegram's side (`getWebhookInfo` then returned `url=""`). The bot
+ * accepted updates again only after a manual second `setWebhook`.
+ *
+ * To make this self-healing on every redeploy, after `setWebhook` we
+ * verify with `getWebhookInfo` that Telegram actually retained the URL
+ * we just set, and retry up to N times with exponential backoff if the
+ * stored URL is wrong / empty. Caps total wall time so a permanent
+ * Telegram outage doesn't block container start indefinitely.
+ */
+const WEBHOOK_VERIFY_MAX_ATTEMPTS = 3;
+const WEBHOOK_VERIFY_BASE_DELAY_MS = 500;
+const WEBHOOK_VERIFY_MAX_DELAY_MS = 4_000;
+
+/**
  * Validate a `(url, secretToken)` pair the way Telegram does, _before_
  * calling `setWebhook` — gives a clearer error than Telegram's
  * "Bad Request: webhook secret_token is invalid".
@@ -62,20 +80,58 @@ export function validateWebhookConfig(config: OpenClawWebhookConfig): void {
 }
 
 /**
+ * Sleep helper. Inlined (instead of pulling `node:timers/promises`) so
+ * tests can stub it via `vi.useFakeTimers` without touching transitive
+ * imports.
+ */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
  * Register the webhook with Telegram. Drops any pending updates queued
  * during long-poll mode so the founder doesn't receive a flood of stale
  * messages on the first boot after migration.
+ *
+ * After `setWebhook` we read back `getWebhookInfo` and confirm the URL
+ * stuck — see W4.1 race comment above. On mismatch we retry the
+ * `setWebhook` call (max {@link WEBHOOK_VERIFY_MAX_ATTEMPTS} attempts).
+ * Verification failures are thrown so caller (`apps/console/src/index.ts`)
+ * can decide between `process.exit(1)` and falling back to long-poll.
  */
 export async function registerOpenClawWebhook(
   bot: Bot,
   config: OpenClawWebhookConfig,
 ): Promise<void> {
   validateWebhookConfig(config);
-  await bot.api.setWebhook(config.url, {
-    secret_token: config.secretToken,
-    drop_pending_updates: true,
-    allowed_updates: ["message", "callback_query"],
-  });
+  let lastInfoUrl = "";
+  for (let attempt = 1; attempt <= WEBHOOK_VERIFY_MAX_ATTEMPTS; attempt += 1) {
+    await bot.api.setWebhook(config.url, {
+      secret_token: config.secretToken,
+      drop_pending_updates: attempt === 1,
+      allowed_updates: ["message", "callback_query"],
+    });
+    const info = await bot.api.getWebhookInfo();
+    lastInfoUrl = info.url ?? "";
+    if (lastInfoUrl === config.url) return;
+    if (attempt >= WEBHOOK_VERIFY_MAX_ATTEMPTS) break;
+    const delayMs = Math.min(
+      WEBHOOK_VERIFY_BASE_DELAY_MS * 2 ** (attempt - 1),
+      WEBHOOK_VERIFY_MAX_DELAY_MS,
+    );
+    console.warn(
+      `[openclaw] getWebhookInfo url mismatch after setWebhook ` +
+        `(attempt ${attempt}/${WEBHOOK_VERIFY_MAX_ATTEMPTS}). ` +
+        `expected=${config.url} actual=${lastInfoUrl || "<empty>"}. ` +
+        `retrying in ${delayMs}ms (W4.1 race).`,
+    );
+    await sleep(delayMs);
+  }
+  throw new Error(
+    `OpenClaw webhook verification failed after ${WEBHOOK_VERIFY_MAX_ATTEMPTS} attempts: ` +
+      `Telegram reports url=${lastInfoUrl || "<empty>"}, expected=${config.url}. ` +
+      `Check OPENCLAW_WEBHOOK_URL / OPENCLAW_WEBHOOK_SECRET, then redeploy.`,
+  );
 }
 
 /**

--- a/apps/console/src/openclaw/handler.ts
+++ b/apps/console/src/openclaw/handler.ts
@@ -342,9 +342,49 @@ export function attachOpenClawHandlers(config: OpenClawBotConfig): {
     founderUserId,
   };
 
+  /**
+   * Diagnostic warn-log on silent rejection. Без цього оператор бачить лише
+   * "/help мовчить" і має гадати між (a) webhook-race, (b) DM-only check,
+   * (c) `OPENCLAW_FOUNDER_TG_USER_ID` mismatch, (d) bot crashed mid-handler.
+   * Тут (b) і (c) стають очевидними з Railway логів.
+   *
+   * Rate-limit per (user, chat_type, reason) tuple щоб флуд від групи з
+   * багатьма юзерами / botом, який зациклився на одному /команді, не
+   * поховав журнал.
+   */
+  const recentRejectionLogs = new Map<string, number>();
+  const REJECTION_LOG_TTL_MS = 60_000;
+  const logRejection = (reason: string, ctx: Context): void => {
+    const userId = ctx.from?.id ?? 0;
+    const chatType = ctx.chat?.type ?? "unknown";
+    const message = ctx.message;
+    const text =
+      message && "text" in message && typeof message.text === "string"
+        ? message.text
+        : "";
+    const firstToken = text.split(/\s+/)[0] ?? "";
+    const key = `${userId}|${chatType}|${reason}`;
+    const now = Date.now();
+    const last = recentRejectionLogs.get(key);
+    if (last !== undefined && now - last < REJECTION_LOG_TTL_MS) return;
+    recentRejectionLogs.set(key, now);
+    console.warn(
+      `[openclaw] silently rejected update: reason=${reason} ` +
+        `chat_type=${chatType} from_user_id=${userId} ` +
+        `command=${firstToken || "<non-command>"} ` +
+        `(check OPENCLAW_FOUNDER_TG_USER_ID + ensure DM)`,
+    );
+  };
+
   const isAllowedDmContext = (ctx: Context): boolean => {
-    if (!isPrivateChat(ctx.chat?.type)) return false;
-    if (!isFounderAllowed(ctx.from?.id, process.env)) return false;
+    if (!isPrivateChat(ctx.chat?.type)) {
+      logRejection("non-private-chat", ctx);
+      return false;
+    }
+    if (!isFounderAllowed(ctx.from?.id, process.env)) {
+      logRejection("non-founder", ctx);
+      return false;
+    }
     return true;
   };
 


### PR DESCRIPTION
## Why

Follow-up to #1547 (which already shipped `setMyCommands` + menu button). Two distinct problems remained on production OpenClaw bot:

### 1. W4.1 race (future-proofing)

`docs/deploy/console.md:132` documents a one-shot race observed during the first long-poll → webhook migration: the old long-poll container's graceful-shutdown `getUpdates` cleared the webhook on Telegram's side immediately after the new container's `setWebhook` succeeded. `getWebhookInfo` then returned `url=""` and the founder saw no replies until an operator ran `setWebhook` again by hand. The same race will silently re-clear the webhook on every future redeploy.

### 2. Silent rejection blindness

`isAllowedDmContext` returns `false` for two distinct reasons — non-DM chat type, or `OPENCLAW_FOUNDER_TG_USER_ID` mismatch — and every caller silently `return`s. The user-visible symptom is identical ("`/help` мовчить"), but the operator fix is opposite: tell the user "DM only" vs reconfigure Railway env var. Without a log line at the rejection point the only way to narrow it down is to detach the webhook and `getUpdates` against a live bot — which is risky and slow.

This is exactly what hit prod today: webhook + `setMyCommands` were both already correct, `getWebhookInfo` + `getMyCommands` both green, and yet `/help` silent.

## What

**Commit 1 — W4.1 hardening** (`bootstrap.ts`):
After `setWebhook`, read back `getWebhookInfo` and verify the URL Telegram stored matches `OPENCLAW_WEBHOOK_URL`. On mismatch, retry `setWebhook` (max 3 attempts, exponential backoff 0.5s/1s/2s) before throwing a clear, actionable error. Subsequent retries pass `drop_pending_updates: false` so updates that arrived between attempts aren't lost. Total wall-time worst case ~3.5s — well below Railway's healthcheck grace.

**Commit 2 — rejection log** (`handler.ts`):
Warn-level log at every `isAllowedDmContext` rejection with reason, chat_type, from_user_id, first command token, and a hint pointing at the env var. Rate-limited per (user, chat_type, reason) tuple at 1 line / 60s so a misbehaving group of strangers or a looped bot can't flood the journal.

## Tests

* `bootstrap.test.ts`: 3 new tests — happy path (one verify call, success), race recovery (first verify returns `url=""`, second succeeds, `drop_pending_updates` flips), persistent failure (3 attempts then thrown error with expected/actual URL pair).
* All 177 console tests pass; lint + typecheck clean.

## Deploy verification

On next Railway redeploy, search logs for `[openclaw] silently rejected update`. If the user is still hitting silence, that line tells the operator exactly which env var to fix.

## Diagnostic context

Live Bot API state at PR-open time (already correct):
* `getWebhookInfo`: url=`https://sergeant-hubchat-production.up.railway.app/webhook/openclaw`, pending=0
* `getMyCommands`: 22 commands incl. `/help`
* `getChatMenuButton`: `{type: "commands"}`

Therefore the W4.1 race is **not** currently happening; this PR is purely future-proofing + observability.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds self-healing webhook registration and warn-level rejection logs so OpenClaw stays live after redeploys and "/help" silence is diagnosable from logs.
Prevents the W4.1 long‑poll → webhook race and surfaces DM/owner allowlist issues.

- **New Features**
  - Webhook verify-and-retry: after `setWebhook`, read `getWebhookInfo` and ensure the URL matches `OPENCLAW_WEBHOOK_URL`. Retry up to 3 times with 0.5s/1s/2s backoff; only the first attempt uses `drop_pending_updates: true`. On persistent mismatch, throw a clear error with expected/actual URL.
  - Rejection logging: when `isAllowedDmContext` rejects, log reason (`non-private-chat` or `non-founder`), `chat_type`, `from_user_id`, and the first command token. Rate-limited to 1 line per 60s per tuple, with a hint to check `OPENCLAW_FOUNDER_TG_USER_ID` and ensure DM.

<sup>Written for commit ecfa8ce8823426df36001c1afb6c76f2150963f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

