### PR TITLE
docs(docs): initiative 0001 phase 1 — max-lines lint guard + allowlist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -538,6 +538,51 @@ Rules:
 - Never wrap a component that has its own internal entry animation in `StaggerChild` (double-animation).
 - `showConfetti` on `AnimatedCheckbox` / `HabitCheckbox` must only be `true` at streak milestones (7, 30, 100, 365) — never on every tick.
 
+### 18. Module-size discipline — `max-lines: 600` for web TS/TSX
+
+> Why a hard rule? Топ-15 файлів `apps/web/src/**` мали ≥600 LOC і одночасно тримали стейт, ефекти, бізнес-правила, навігацію та UI — рев'ю стає неможливим, регресії множаться, нові контриб'ютори не знають куди шукати. Прецедент — `apps/server/src/modules/chat/` (`chat.ts` thin orchestrator + `tools.ts` + `coach.ts` + `aiQuota.ts` + `toolMetrics.ts` + `toolDefs/`) довів цінність декомпозиції в продакшні. Без жорсткого ліміту декомпозиція — це постійний «уторгований борг» (зробили — наповзло знову).
+
+**Rule.** Кожен `.ts` / `.tsx` файл під `apps/web/src/**` має мати ≤ 600 LOC (skipBlankLines + skipComments). Перевищення — `error` у `pnpm lint`. Тести (`*.{test,spec}.{ts,tsx}`, `__tests__/**`) і генеровані файли (`apps/web/src/generated/**`) виключені.
+
+```js
+// eslint.config.js — see initiative 0001 for the canonical block
+{
+  files: ["apps/web/src/**/*.{ts,tsx}"],
+  ignores: [
+    "apps/web/src/**/*.test.{ts,tsx}",
+    "apps/web/src/**/*.spec.{ts,tsx}",
+    "apps/web/src/**/__tests__/**",
+    "apps/web/src/generated/**",
+  ],
+  rules: {
+    "max-lines": [
+      "error",
+      { max: 600, skipBlankLines: true, skipComments: true },
+    ],
+  },
+}
+```
+
+**Allowlist.** Існуючі файли-моноліти (16 на 2026-05-03) виключені окремим блоком `eslint.config.js` з `TODO(0001-module-decomposition): deadline 2026-06-15`. Кожна декомпозиція = видалення одного рядка з allowlist (видно у `git blame`). Allowlist — _не_ постійна fixture: dropping rate відстежується в [`docs/initiatives/0001-module-decomposition.md`](docs/initiatives/0001-module-decomposition.md) метрикою «Файлів `apps/web/src/**` ≥600 LOC: 16 → ≤ 2».
+
+**Як декомпонувати.** Розкладаємо за роллю, не за алфавітом: окремо state (custom hook / `useReducer` / state-machine), окремо ефекти (один `useEffect` = один named hook), окремо UI (presentational sub-components без логіки). Прецедент — `apps/server/src/modules/chat/agent.ts → agent.handlers.ts / agent.tools.ts / agent.cache.ts`. Для web cookbook див. опис фази 2 в [`docs/initiatives/0001-module-decomposition.md`](docs/initiatives/0001-module-decomposition.md).
+
+**Scope rationale.**
+
+- `apps/server/src/**` — поза правилом (моноліти вже розкладено, нові не з'являються).
+- `apps/mobile/**` — поза правилом (mobile-стратегія обговорюється в [`docs/initiatives/0002-mobile-platform-decision.md`](docs/initiatives/0002-mobile-platform-decision.md); декомпозиція ≠ заморозка платформи).
+- `packages/**/src/**` — поза правилом (бібліотечні файли — публічний API, поріг для них інший; зачепимо в окремій ініціативі).
+
+**Що блокує:**
+
+- Новий `apps/web/src/**/*.tsx` ≥ 600 LOC падає на `pnpm lint` — mandatory у CI (Hard Rule #15).
+- Декомпонований файл, який «розпух» назад > 600 LOC, теж падає (allowlist треба свідомо знову додати + апрув ревьюерів).
+
+**What this rule does NOT block:**
+
+- Тимчасові experiment-файли в `apps/web/src/generated/**` або в test-fixture-ах.
+- Декомпозовані файли під 600 LOC (rule passes silently).
+
 ## Touch targets
 
 All interactive elements must clear **WCAG 2.5.5** / Apple HIG **≥44×44px** on touch devices (`@media (pointer: coarse)`). Three layers cooperate:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Sergeant
 
-> **Last validated:** 2026-05-01 by @dmytro.s.stakhov. **Next review:** 2026-07-30.
+> **Last validated:** 2026-05-03 by @Skords-01. **Next review:** 2026-08-01.
 > **Status:** Active
 
 `CONTRIBUTING.md` - канонічний manual для людей. Repo policy і hard rules описані в [AGENTS.md](./AGENTS.md), а repeatable execution recipes - у [docs/playbooks/README.md](./docs/playbooks/README.md).
@@ -122,6 +122,7 @@ Reviewer checklist живе в [docs/governance/review-checklist.md](./docs/gove
 15. **Read governance before coding; update docs alongside code; internal docs in Ukrainian**
 16. **Typography scale — semantic styles + 12px floor**
 17. **Animation budget — max 2 concurrent, 3 tiers**
+18. **Module-size discipline — `max-lines: 600` for web TS/TSX**
 
 Джерела істини:
 

--- a/docs/governance/hard-rules.json
+++ b/docs/governance/hard-rules.json
@@ -286,6 +286,29 @@
         },
         { "type": "agents", "ref": "#17" }
       ]
+    },
+    {
+      "id": 18,
+      "title": "Module-size discipline — `max-lines: 600` for web TS/TSX",
+      "scope": ["apps/web/src/**"],
+      "severity": "blocker",
+      "enforced_by": [
+        {
+          "kind": "convention",
+          "ref": "eslint.config.js → max-lines: [error, { max: 600, skipBlankLines: true, skipComments: true }] (scoped to apps/web/src/**/*.{ts,tsx}; tests, __tests__, and apps/web/src/generated/** exempt; explicit allowlist for legacy monoliths)"
+        },
+        {
+          "kind": "doc",
+          "ref": "docs/initiatives/0001-module-decomposition.md (allowlist + Phase 2 decomposition queue)"
+        }
+      ],
+      "links": [
+        {
+          "type": "doc",
+          "ref": "docs/initiatives/0001-module-decomposition.md"
+        },
+        { "type": "agents", "ref": "#18" }
+      ]
     }
   ]
 }

--- a/docs/tech-debt/frontend.md
+++ b/docs/tech-debt/frontend.md
@@ -139,7 +139,24 @@ Codemod ідемпотентний: повторний запуск дасть `
 
 ---
 
-### 4. Великі файли (>600 рядків) — 16 файлів (тільки `apps/web/src`)
+### 4. Великі файли (>600 рядків) — 16 файлів (тільки `apps/web/src`) — **In progress (Initiative 0001)**
+
+> **Status (2026-05-03):** Переведено в активну роботу через
+> [`docs/initiatives/0001-module-decomposition.md`](../initiatives/0001-module-decomposition.md).
+> Phase 1 (lint guard + allowlist) — додано Hard Rule #18 в `AGENTS.md`,
+> правило `max-lines: [error, 600]` для `apps/web/src/**/*.{ts,tsx}` в
+> `eslint.config.js` + явний allowlist по 16 файлах нижче. Будь-який новий
+> файл `apps/web/src/**` ≥ 600 LOC падає на `pnpm lint`.
+>
+> Phase 2 (декомпозиція top-7) — заплановано: `RoutineApp.tsx`,
+> `useStorage.ts`, `chatActions/types.ts`, `sw.ts`, `Icon.tsx`,
+> `HubDashboard.tsx`, `Workouts.tsx`. Кожна декомпозиція = окремий PR і
+> видалення відповідного рядка з allowlist в `eslint.config.js`. Метрика
+> успіху: 16 → ≤ 2 файлів `apps/web/src/**` ≥ 600 LOC до 2026-06-15.
+>
+> Свіжість таблиці нижче — на 2026-05-03; перерахунок виконується вручну
+> через `find apps/web/src -type f \( -name '*.ts' -o -name '*.tsx' \) -exec wc -l {} +`
+> (см. також `pnpm lint` — `max-lines` правило точне джерело істини).
 
 > `finyk/pages/Assets.tsx` (раніше 1147 рядків) декомпозовано на
 > `useAssetsState.ts` (259), `AssetsForm.tsx` (376), `AssetsTable.tsx` (511),

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -707,5 +707,69 @@ export default [
       ],
     },
   },
+  // Module-size guardrail (initiative 0001) — `max-lines: [error, 600]`
+  // for `apps/web/src/**/*.{ts,tsx}`. Enforces decomposition discipline:
+  // a single TS/TSX file in the web bundle must not exceed 600 LOC
+  // (skipBlankLines + skipComments). New violations fail CI; existing
+  // monoliths are explicitly allowlisted with a deadline TODO so the
+  // queue stays visible. See `docs/initiatives/0001-module-decomposition.md`.
+  //
+  // Scope rationale:
+  // - Limited to `apps/web/src/**` — the audit's red-flag table flagged
+  //   web-only monoliths; `apps/server/src/modules/chat/agent.ts` was
+  //   already decomposed (handlers / tools / cache) and is the precedent.
+  //   `apps/mobile/**` is out of scope (initiative 0002 owns that surface).
+  // - `**/__tests__/**` and `*.{test,spec}.{ts,tsx}` are exempt — large
+  //   fixture files and snapshot-style suites are legitimate.
+  // - Generated files (`apps/web/src/generated/**`) are exempt for the
+  //   same reason — they are regenerated and never hand-edited.
+  {
+    files: ["apps/web/src/**/*.{ts,tsx}"],
+    ignores: [
+      "apps/web/src/**/*.test.{ts,tsx}",
+      "apps/web/src/**/*.spec.{ts,tsx}",
+      "apps/web/src/**/__tests__/**",
+      "apps/web/src/generated/**",
+    ],
+    rules: {
+      "max-lines": [
+        "error",
+        { max: 600, skipBlankLines: true, skipComments: true },
+      ],
+    },
+  },
+  // Allowlist for existing >600 LOC monoliths in `apps/web/src/**`.
+  // Each entry MUST stay paired with a Phase 2 PR in
+  // `docs/initiatives/0001-module-decomposition.md`. When a file is
+  // decomposed below 600 LOC, drop its entry from this list — the
+  // top-level rule above will then enforce it going forward.
+  //
+  // TODO(0001-module-decomposition): deadline 2026-06-15 — drop entries
+  // as the matching PR (decomp-routine-app, decomp-finyk-storage, etc.)
+  // ships. The allowlist is intentionally explicit (not a glob) so each
+  // file shows up in `git blame` / `git log` against this rule.
+  {
+    files: [
+      "apps/web/src/modules/routine/RoutineApp.tsx",
+      "apps/web/src/modules/nutrition/components/LogCard.tsx",
+      "apps/web/src/modules/fizruk/pages/Workouts.tsx",
+      "apps/web/src/modules/fizruk/pages/Progress.tsx",
+      "apps/web/src/modules/nutrition/NutritionApp.tsx",
+      "apps/web/src/modules/finyk/hooks/useStorage.ts",
+      "apps/web/src/core/lib/hubChatContext.ts",
+      "apps/web/src/core/hub/HubDashboard.tsx",
+      "apps/web/src/modules/nutrition/components/DailyPlanCard.tsx",
+      "apps/web/src/core/lib/chatActions/types.ts",
+      "apps/web/src/core/lib/chatActions/fizrukActions.ts",
+      "apps/web/src/modules/fizruk/pages/Exercise.tsx",
+      "apps/web/src/modules/finyk/pages/AssetsTable.tsx",
+      "apps/web/src/shared/components/ui/Icon.tsx",
+      "apps/web/src/sw.ts",
+      "apps/web/src/modules/routine/components/RoutineCalendarPanel.tsx",
+    ],
+    rules: {
+      "max-lines": "off",
+    },
+  },
   eslintConfigPrettier,
 ];


### PR DESCRIPTION
## Summary

Phase 1 of [`docs/initiatives/0001-module-decomposition.md`](docs/initiatives/0001-module-decomposition.md). Adds an ESLint `max-lines: [error, 600]` guardrail for `apps/web/src/**/*.{ts,tsx}` (skipBlankLines + skipComments) plus an explicit allowlist of the 16 existing >600 LOC monoliths so any **new** file ≥600 LOC fails `pnpm lint`. Each allowlist entry stays paired with a Phase 2 decomposition PR; dropping it = the rule then enforces the file.

**Files changed:**

- `eslint.config.js` — new flat-config block scoped to `apps/web/src/**/*.{ts,tsx}` with `max-lines: [error, 600]`; second block disables the rule for the 16 legacy monoliths (each entry annotated with the `0001-module-decomposition` deadline TODO).
- `AGENTS.md` — new **Hard Rule #18** — full rule body, scope rationale, allowlist semantics, and a decomposition cookbook (state / effects / UI split, with the `apps/server/src/modules/chat/*` precedent).
- `CONTRIBUTING.md` — Hard rules list extended to 18.
- `docs/governance/hard-rules.json` — registry entry #18 (`kind=convention`, points at `eslint.config.js` and the initiative doc).
- `docs/tech-debt/frontend.md` §4 — marked **In progress (Initiative 0001)** with status block linking to the initiative; manual freshness recipe replaces the previously aspirational `scripts/large-files-report.mjs` reference.

**What this does NOT change:**

- No file is decomposed in this PR. Phase 2 PRs (top-7: `RoutineApp.tsx`, `useStorage.ts`, `chatActions/types.ts`, `sw.ts`, `Icon.tsx`, `HubDashboard.tsx`, `Workouts.tsx`) are scheduled separately.
- `apps/server/src/**`, `apps/mobile/**`, and `packages/**` are out of scope (rationale documented in Hard Rule #18 and in the initiative).

## Governing Skill

- [`docs/initiatives/0001-module-decomposition.md`](docs/initiatives/0001-module-decomposition.md) — Phase 1 (lint guard + allowlist).

## Playbook

- Add a Hard Rule + ESLint guardrail with allowlist for legacy violations. Pattern based on the existing `sergeant-design/no-raw-local-storage` allowlist block in `eslint.config.js`.

## Verification

- `pnpm install --prefer-offline`
- `pnpm --filter @sergeant/web lint` — passes (legacy monoliths absorbed by allowlist; no new violations).
- `node scripts/check-hard-rules-registry.mjs` — `✅ Hard Rules registry OK — 18 rule(s) in sync with AGENTS.md and CONTRIBUTING.md.`
- `node scripts/check-governance-sync.mjs` — net delta vs `main`: 0 new dangling refs (the pre-existing 107 baseline is unchanged after fixing the one `apps/server/src/modules/chat/agent.ts` ref I introduced first).

## Docs and Governance

- [x] Hard Rules registry (`docs/governance/hard-rules.json`) updated to keep AGENTS.md ↔ registry ↔ CONTRIBUTING.md in lockstep (Hard Rule #15).
- [x] Tech-debt tracker (`docs/tech-debt/frontend.md`) status updated to **In progress (Initiative 0001)** with backlink to the initiative.
- [x] Initiative doc (`docs/initiatives/0001-module-decomposition.md`) is the canonical owner of the allowlist queue; dropping an entry = visible in `git blame` against this file.

## Risk and Rollout

- **Blast radius:** lint-only. No runtime code changes.
- **Rollback:** revert the `eslint.config.js` block (or move the file to the allowlist block if a legitimate large file lands).
- **CI cost:** negligible — `max-lines` is a built-in ESLint rule, no extra plugin loaded.
- **Sequence with Phase 2:** safe to merge first; each subsequent decomposition PR removes one allowlist entry, gradually tightening the surface from 16 → ≤2.

## Hard Rule #15

- [x] Read governance before coding (`AGENTS.md` Hard Rules § + initiative 0001 + tech-debt frontend §4).
- [x] Updated docs alongside code in this same PR (AGENTS.md, CONTRIBUTING.md, hard-rules registry, tech-debt frontend).
- [x] Internal docs (Hard Rule body, tech-debt status, initiative status block) authored in Ukrainian per Hard Rule #15.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an ESLint guard that enforces `max-lines: 600` for `apps/web/src/**/*.{ts,tsx}` (skipping blanks and comments) with an explicit allowlist for the 16 current >600 LOC files. This blocks any new large web TS/TSX files in CI and makes future decompositions incremental; no runtime changes.

- **New Features**
  - `eslint.config.js`: adds `max-lines: [error, { max: 600, skipBlankLines: true, skipComments: true }]` scoped to web TS/TSX; excludes tests and `apps/web/src/generated/**`.
  - Explicit allowlist turns the rule off for 16 legacy files; each entry will be removed in Phase 2 decomposition PRs.
  - Governance and docs updated: Hard Rule #18 in `AGENTS.md`, list in `CONTRIBUTING.md`, registry entry in `docs/governance/hard-rules.json`, and tech-debt status in `docs/tech-debt/frontend.md`.

<sup>Written for commit 2805b04311852766a899f3cd64be529699baaad2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established Hard Rule #18: a module-size discipline policy enforcing a 600 lines-of-code maximum for web TypeScript/JavaScript files, improving codebase maintainability and developer productivity.
  * Updated governance documentation, technical debt tracking, and development tool configurations to support enforcement of this new code quality standard across the team.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->