### PR TITLE
perf(web): module prefetch hardening — connection gate + recent-modules priority

### DIFF
--- a/apps/web/src/core/hooks/useHubNavigation.ts
+++ b/apps/web/src/core/hooks/useHubNavigation.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import type { ModuleAccent } from "@sergeant/design-tokens";
 import { useNavigate, useSearchParams } from "react-router-dom";
+import { recordModuleOpen } from "../lib/recentModules";
 
 const VALID_MODULES = new Set(["finyk", "fizruk", "routine", "nutrition"]);
 
@@ -63,6 +64,10 @@ export function useHubNavigation(): HubNavigation {
 
       setModuleAnimClass("module-enter");
       setActiveModule(typedId);
+      // Best-effort tracker for `prefetchCriticalModules` priority —
+      // see `core/lib/recentModules.ts`. Storage failures are swallowed
+      // there; nothing here cares about the result.
+      recordModuleOpen(typedId);
       navigate(`/?module=${typedId}${hashStr}`, { replace: false });
     },
     [activeModule, navigate],

--- a/apps/web/src/core/lib/connectionGate.test.ts
+++ b/apps/web/src/core/lib/connectionGate.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { shouldPrefetchOnConnection } from "./connectionGate";
+
+interface ConnectionShape {
+  saveData?: boolean;
+  effectiveType?: string;
+}
+
+interface NavigatorMutable {
+  connection?: ConnectionShape;
+}
+
+const nav: NavigatorMutable = navigator as unknown as NavigatorMutable;
+
+afterEach(() => {
+  delete nav.connection;
+});
+
+describe("shouldPrefetchOnConnection", () => {
+  it("дозволяє prefetch коли API недоступне (Safari fail-open)", () => {
+    expect(nav.connection).toBeUndefined();
+    expect(shouldPrefetchOnConnection()).toBe(true);
+  });
+
+  it("блокує prefetch коли saveData увімкнено", () => {
+    nav.connection = { saveData: true, effectiveType: "4g" };
+    expect(shouldPrefetchOnConnection()).toBe(false);
+  });
+
+  it("блокує prefetch на 2g/slow-2g", () => {
+    nav.connection = { effectiveType: "slow-2g" };
+    expect(shouldPrefetchOnConnection()).toBe(false);
+    nav.connection = { effectiveType: "2g" };
+    expect(shouldPrefetchOnConnection()).toBe(false);
+  });
+
+  it("дозволяє prefetch на 3g/4g/wifi", () => {
+    nav.connection = { effectiveType: "3g" };
+    expect(shouldPrefetchOnConnection()).toBe(true);
+    nav.connection = { effectiveType: "4g" };
+    expect(shouldPrefetchOnConnection()).toBe(true);
+    nav.connection = { effectiveType: "wifi" };
+    expect(shouldPrefetchOnConnection()).toBe(true);
+  });
+
+  it("saveData має пріоритет над швидким effectiveType", () => {
+    nav.connection = { saveData: true, effectiveType: "4g" };
+    expect(shouldPrefetchOnConnection()).toBe(false);
+  });
+});

--- a/apps/web/src/core/lib/connectionGate.ts
+++ b/apps/web/src/core/lib/connectionGate.ts
@@ -1,0 +1,53 @@
+/**
+ * Connection-aware prefetch gate.
+ *
+ * `prefetchModule` / `prefetchPage` / `prefetchCriticalModules` ought to
+ * be silent on the network — they pay download cost for code the user
+ * may never reach. On 2G / save-data sessions that trade is upside-down:
+ * we burn the user's data plan while making their *current* navigation
+ * slower (browsers serialize prefetches behind active requests).
+ *
+ * The diagnostics doc (`docs/diagnostics/2026-05-03-web-deep-dive/`
+ * §5.2 / §10.4) calls out that `prefetchCriticalModules` previously
+ * fired on idle for *every* user regardless of `navigator.connection`.
+ * This module is the single gate everywhere we'd kick off an
+ * eager `import("../../modules/...")`.
+ *
+ * Contract.
+ *  - Returns `true` when the browser doesn't expose `navigator.connection`
+ *    (Safari, older browsers) — fail-open keeps prefetch behaviour for
+ *    the majority of fast iOS/macOS sessions where it is cheap.
+ *  - Returns `false` when the user opted into Data Saver
+ *    (`saveData === true`).
+ *  - Returns `false` for `effectiveType` of `"slow-2g"` / `"2g"` —
+ *    Chrome's heuristic for « heavy idle prefetch will hurt » based on
+ *    rolling RTT/throughput.
+ *  - Otherwise `true` (3G/4G/5G/wifi).
+ *
+ * No imports — must be safe to call from the SW or any worker context
+ * that mirrors `navigator.connection`.
+ */
+
+interface ConnectionShape {
+  saveData?: boolean;
+  effectiveType?: "slow-2g" | "2g" | "3g" | "4g" | string;
+}
+
+interface NavigatorWithConnection extends Navigator {
+  connection?: ConnectionShape;
+}
+
+/**
+ * Returns `true` when it is OK to spend bandwidth on prefetching code
+ * the user may not reach yet. See file-level doc for contract.
+ */
+export function shouldPrefetchOnConnection(): boolean {
+  if (typeof navigator === "undefined") return true;
+  const conn = (navigator as NavigatorWithConnection).connection;
+  if (!conn) return true;
+  if (conn.saveData) return false;
+  if (conn.effectiveType === "slow-2g" || conn.effectiveType === "2g") {
+    return false;
+  }
+  return true;
+}

--- a/apps/web/src/core/lib/recentModules.test.ts
+++ b/apps/web/src/core/lib/recentModules.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  MAX_AGE_MS,
+  RECENT_MODULES_KEY,
+  getRecentModules,
+  recordModuleOpen,
+} from "./recentModules";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("recordModuleOpen / getRecentModules", () => {
+  it("повертає [] коли нічого не записано", () => {
+    expect(getRecentModules()).toEqual([]);
+  });
+
+  it("записує open і повертає його при наступному read", () => {
+    const now = 1_000_000_000_000;
+    recordModuleOpen("finyk", now);
+    expect(getRecentModules(now)).toEqual(["finyk"]);
+  });
+
+  it("сортує по recency (DESC)", () => {
+    recordModuleOpen("fizruk", 100);
+    recordModuleOpen("finyk", 200);
+    recordModuleOpen("nutrition", 300);
+    expect(getRecentModules(300)).toEqual(["nutrition", "finyk", "fizruk"]);
+  });
+
+  it("дедуплікує: повторний open оновлює timestamp без дублікатів", () => {
+    recordModuleOpen("finyk", 100);
+    recordModuleOpen("fizruk", 200);
+    recordModuleOpen("finyk", 300); // оновили finyk → має йти першим
+    expect(getRecentModules(300)).toEqual(["finyk", "fizruk"]);
+  });
+
+  it("обрізає entries старші за MAX_AGE_MS (7 днів)", () => {
+    const now = 10_000_000_000;
+    recordModuleOpen("finyk", now - MAX_AGE_MS - 1);
+    recordModuleOpen("fizruk", now - 1000);
+    expect(getRecentModules(now)).toEqual(["fizruk"]);
+  });
+
+  it("ігнорує невалідні id (захист від попсованої LS)", () => {
+    recordModuleOpen("invalid", 100);
+    recordModuleOpen("", 200);
+    recordModuleOpen(null, 300);
+    expect(getRecentModules(300)).toEqual([]);
+    recordModuleOpen("routine", 400);
+    expect(getRecentModules(400)).toEqual(["routine"]);
+  });
+
+  it("кепить на MAX_ENTRIES=4 (всі модулі поміщаються)", () => {
+    recordModuleOpen("finyk", 100);
+    recordModuleOpen("fizruk", 200);
+    recordModuleOpen("routine", 300);
+    recordModuleOpen("nutrition", 400);
+    const list = getRecentModules(400);
+    expect(list).toHaveLength(4);
+    expect(new Set(list)).toEqual(
+      new Set(["finyk", "fizruk", "routine", "nutrition"]),
+    );
+  });
+
+  it("ігнорує попсовані entries у JSON (масив, але елементи невалідні)", () => {
+    localStorage.setItem(
+      RECENT_MODULES_KEY,
+      JSON.stringify([
+        { id: "rogue", ts: 100 },
+        { id: "finyk", ts: "not-a-number" },
+        { id: "fizruk", ts: 500 },
+        "garbage",
+        null,
+      ]),
+    );
+    expect(getRecentModules(1000)).toEqual(["fizruk"]);
+  });
+
+  it("ігнорує не-масив payload без падіння", () => {
+    localStorage.setItem(
+      RECENT_MODULES_KEY,
+      JSON.stringify({ not: "an array" }),
+    );
+    expect(getRecentModules()).toEqual([]);
+  });
+
+  it("recordModuleOpen no-op для невалідного id (нічого не зберігається)", () => {
+    recordModuleOpen("not-a-module", 100);
+    expect(localStorage.getItem(RECENT_MODULES_KEY)).toBeNull();
+  });
+
+  it("recordModuleOpen no-op для null/undefined", () => {
+    recordModuleOpen(undefined, 100);
+    recordModuleOpen(null, 200);
+    expect(localStorage.getItem(RECENT_MODULES_KEY)).toBeNull();
+  });
+});

--- a/apps/web/src/core/lib/recentModules.ts
+++ b/apps/web/src/core/lib/recentModules.ts
@@ -1,0 +1,103 @@
+/**
+ * Recently-opened modules tracker.
+ *
+ * `prefetchCriticalModules` previously fired on idle in a hard-coded
+ * priority order (`finyk → routine → fizruk → nutrition`). For users
+ * who never touch a given module, that paid the bandwidth/parse cost
+ * of three modules they will never reach — particularly painful on
+ * 3G or save-data sessions (see `connectionGate.ts`).
+ *
+ * This module records the timestamp of each module open in
+ * localStorage and exposes a priority-ordered list of modules opened
+ * within the last `MAX_AGE_MS` window. `useRoutePrefetch` reads from
+ * here to decide what to prefetch on idle.
+ *
+ * Failure modes (private mode, quota, no `localStorage`) collapse
+ * to an empty list — `prefetchCriticalModules` will then fall back
+ * to its hard-coded priority. Recent-modules tracking is best-effort
+ * acceleration, not a correctness contract.
+ *
+ * Storage shape (`localStorage["sergeant.recentModules.v1"]`):
+ *
+ *   [
+ *     { "id": "finyk", "ts": 1746302400000 },
+ *     { "id": "routine", "ts": 1746128400000 }
+ *   ]
+ *
+ * — JSON-serialised, sorted DESC by `ts`, deduplicated by `id`,
+ * pruned of entries older than 7 days, capped at 4 entries
+ * (one per known module).
+ */
+
+import { safeReadLS, safeWriteLS } from "../../shared/lib/storage/storage";
+
+export const RECENT_MODULES_KEY = "sergeant.recentModules.v1";
+export const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+const MAX_ENTRIES = 4;
+
+export type RecentModuleId = "finyk" | "fizruk" | "routine" | "nutrition";
+
+const VALID_IDS: ReadonlySet<RecentModuleId> = new Set([
+  "finyk",
+  "fizruk",
+  "routine",
+  "nutrition",
+]);
+
+interface Entry {
+  id: RecentModuleId;
+  ts: number;
+}
+
+function isEntry(value: unknown): value is Entry {
+  if (value == null || typeof value !== "object") return false;
+  const v = value as { id?: unknown; ts?: unknown };
+  if (typeof v.ts !== "number" || !Number.isFinite(v.ts)) return false;
+  if (typeof v.id !== "string") return false;
+  return VALID_IDS.has(v.id as RecentModuleId);
+}
+
+function readEntries(now: number): Entry[] {
+  const raw = safeReadLS<unknown[]>(RECENT_MODULES_KEY, []);
+  if (!Array.isArray(raw)) return [];
+  const cutoff = now - MAX_AGE_MS;
+  const out: Entry[] = [];
+  const seen = new Set<RecentModuleId>();
+  for (const item of raw) {
+    if (!isEntry(item)) continue;
+    if (item.ts < cutoff) continue;
+    if (seen.has(item.id)) continue;
+    seen.add(item.id);
+    out.push(item);
+  }
+  out.sort((a, b) => b.ts - a.ts);
+  return out.slice(0, MAX_ENTRIES);
+}
+
+/**
+ * Record a module open. Called from {@link useHubNavigation}'s
+ * `openModule`. Writes the latest timestamp for `id`, drops
+ * entries older than 7 days, dedup-es by id, caps at 4 entries.
+ *
+ * No-op if `id` is not a known module (`finyk`/`fizruk`/`routine`/`nutrition`).
+ */
+export function recordModuleOpen(
+  id: string | null | undefined,
+  now: number = Date.now(),
+): void {
+  if (id == null) return;
+  if (!VALID_IDS.has(id as RecentModuleId)) return;
+  const entries = readEntries(now);
+  const filtered = entries.filter((e) => e.id !== id);
+  filtered.unshift({ id: id as RecentModuleId, ts: now });
+  safeWriteLS(RECENT_MODULES_KEY, filtered.slice(0, MAX_ENTRIES));
+}
+
+/**
+ * Get module ids opened within the last 7 days, sorted by recency
+ * (most recent first). Returns `[]` when nothing recorded yet,
+ * storage unavailable, or all entries are stale.
+ */
+export function getRecentModules(now: number = Date.now()): RecentModuleId[] {
+  return readEntries(now).map((e) => e.id);
+}

--- a/apps/web/src/core/lib/useRoutePrefetch.ts
+++ b/apps/web/src/core/lib/useRoutePrefetch.ts
@@ -14,9 +14,21 @@
  * populate below. The split exists so that strict-scope hub files
  * can call `getModulePrefetchProps` without transitively pulling
  * `import("../../modules/fizruk/...")` into their type-check program.
+ *
+ * Bandwidth respect.
+ *  - All idle/hover/focus prefetches are gated on
+ *    {@link shouldPrefetchOnConnection} — Save-Data + 2G/slow-2G
+ *    sessions skip prefetch entirely. The user's *current* navigation
+ *    is the priority budget.
+ *  - `prefetchCriticalModules` walks recently-opened modules
+ *    ({@link getRecentModules}) before falling back to a hard-coded
+ *    priority. A user who lives in Finyk does not pay the parse cost
+ *    of three modules they never reach.
  */
 
+import { shouldPrefetchOnConnection } from "./connectionGate";
 import { setModulePrefetcher } from "./intentPrefetch";
+import { getRecentModules } from "./recentModules";
 
 type ModuleKey = "finyk" | "fizruk" | "routine" | "nutrition";
 type PageKey =
@@ -48,10 +60,16 @@ const pageImports: Record<PageKey, () => Promise<unknown>> = {
 const prefetchedChunks = new Set<string>();
 
 /**
- * Prefetch a module chunk by key
+ * Prefetch a module chunk by key.
+ *
+ * Skips silently on Save-Data / 2G sessions — see
+ * {@link shouldPrefetchOnConnection}. The chunk is *not* marked as
+ * prefetched in that case, so a future call from a fast network
+ * still has a chance to run.
  */
 export function prefetchModule(module: ModuleKey): void {
   if (prefetchedChunks.has(`module:${module}`)) return;
+  if (!shouldPrefetchOnConnection()) return;
 
   const importFn = moduleImports[module];
   if (!importFn) return;
@@ -80,10 +98,12 @@ export function prefetchModule(module: ModuleKey): void {
 }
 
 /**
- * Prefetch a page chunk by key
+ * Prefetch a page chunk by key. Skips on Save-Data / 2G sessions
+ * (see {@link shouldPrefetchOnConnection}).
  */
 export function prefetchPage(page: PageKey): void {
   if (prefetchedChunks.has(`page:${page}`)) return;
+  if (!shouldPrefetchOnConnection()) return;
 
   const importFn = pageImports[page];
   if (!importFn) return;
@@ -128,9 +148,43 @@ export function prefetchPage(page: PageKey): void {
  * under the previous 2 s envelope while still draining the queue
  * eagerly when nothing else is happening.
  */
+// Hard-coded fallback when nothing has been opened in the recent
+// window — covers first-run and post-clear-data sessions. Order
+// reflects long-term usage probability (Finyk is the highest-traffic
+// module, Nutrition the lowest).
+const DEFAULT_PRIORITY: readonly ModuleKey[] = [
+  "finyk",
+  "routine",
+  "fizruk",
+  "nutrition",
+];
+
+/**
+ * Build the module prefetch order: recently-opened modules first
+ * (most-recent → least-recent within last 7 days), then any modules
+ * the user hasn't touched recently in `DEFAULT_PRIORITY` order. Each
+ * module appears exactly once.
+ */
+function buildPrefetchOrder(): ModuleKey[] {
+  const recent = getRecentModules();
+  const seen = new Set<ModuleKey>();
+  const out: ModuleKey[] = [];
+  for (const id of recent) {
+    if (seen.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+  }
+  for (const id of DEFAULT_PRIORITY) {
+    if (seen.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+  }
+  return out;
+}
+
 export function prefetchCriticalModules(): void {
-  // Order by usage probability
-  const priority: ModuleKey[] = ["finyk", "routine", "fizruk", "nutrition"];
+  if (!shouldPrefetchOnConnection()) return;
+  const priority = buildPrefetchOrder();
 
   if ("requestIdleCallback" in window) {
     priority.forEach((module) => {

--- a/docs/diagnostics/2026-05-03-web-deep-dive/00-overview.md
+++ b/docs/diagnostics/2026-05-03-web-deep-dive/00-overview.md
@@ -13,12 +13,12 @@
 
 ## Структура серії
 
-| Файл | Скоуп |
-| --- | --- |
-| `00-overview.md` (цей файл) | TL;DR, scoring, top-9, roadmap, що НЕ робити |
-| [`01-frontend-ergonomics.md`](./01-frontend-ergonomics.md) | Forms, loading/empty/error, Toast, Modal, mobile safe-area, i18n |
-| [`02-architecture-and-state.md`](./02-architecture-and-state.md) | Provider tree, routing, localStorage migration, CloudSync, in-process workers, `index.css` |
-| [`03-backend-and-performance.md`](./03-backend-and-performance.md) | Validate pattern, routes registry, OpenAPI, rate-limit cost, prefetch, Service Worker |
+| Файл                                                                                       | Скоуп                                                                                          |
+| ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| `00-overview.md` (цей файл)                                                                | TL;DR, scoring, top-9, roadmap, що НЕ робити                                                   |
+| [`01-frontend-ergonomics.md`](./01-frontend-ergonomics.md)                                 | Forms, loading/empty/error, Toast, Modal, mobile safe-area, i18n                               |
+| [`02-architecture-and-state.md`](./02-architecture-and-state.md)                           | Provider tree, routing, localStorage migration, CloudSync, in-process workers, `index.css`     |
+| [`03-backend-and-performance.md`](./03-backend-and-performance.md)                         | Validate pattern, routes registry, OpenAPI, rate-limit cost, prefetch, Service Worker          |
 | [`04-security-observability-testing-devx.md`](./04-security-observability-testing-devx.md) | PII в логах, Sentry↔requestId, CSP, contract tests, mutation testing, Storybook, C4, CHANGELOG |
 
 ## TL;DR (5 хвилин)
@@ -44,57 +44,57 @@
 
 ## Scorecard
 
-| Категорія | Оцінка | Коментар |
-| --- | --- | --- |
-| Architecture | 8.5/10 | Server: factory + graceful shutdown — еталонно. Web: provider tree без інваріантів, routing імперативний. |
-| Frontend ergonomics | 6.5/10 | Форм-стек роздроблений, `index.css` 1244 LOC, відсутні DataState/Skeleton policy. |
-| State management | 7.5/10 | RQ + queryKeys factory сильні. CloudSync без integration-тестів split-brain — найбільший прихований ризик. |
-| Backend / API | 8/10 | Granular body-size, окремі guards, factory. Бракує OpenAPI / typed-client autogen. |
-| Security | 8/10 | Auth hardening — рідкість для one-man-проєкту. Бракує PII redact у Pino, CSP report-only, requestId↔Sentry tag. |
-| Performance | 7.5/10 | Manual chunks продумані. Бракує prefetch on hover та DST/quota edge-cases у SW. |
-| Testing | 7/10 | 178 web + 81 server тести. Бракує contract tests web↔server та integration на CloudSync. |
-| DevX / CI | 9/10 | Hard Rules + freshness gate + custom ESLint — топ-1%. Бракує Storybook + AI-agent quickstart блоку. |
-| Documentation | 8/10 | 23+ playbook-и, AGENTS.md. Бракує C4-діаграм та CHANGELOG. |
-| Mobile (web↔mobile interaction) | OOS | Не покривалось у цій прожарці; див. існуючі аудити. |
+| Категорія                       | Оцінка | Коментар                                                                                                        |
+| ------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------- |
+| Architecture                    | 8.5/10 | Server: factory + graceful shutdown — еталонно. Web: provider tree без інваріантів, routing імперативний.       |
+| Frontend ergonomics             | 6.5/10 | Форм-стек роздроблений, `index.css` 1244 LOC, відсутні DataState/Skeleton policy.                               |
+| State management                | 7.5/10 | RQ + queryKeys factory сильні. CloudSync без integration-тестів split-brain — найбільший прихований ризик.      |
+| Backend / API                   | 8/10   | Granular body-size, окремі guards, factory. Бракує OpenAPI / typed-client autogen.                              |
+| Security                        | 8/10   | Auth hardening — рідкість для one-man-проєкту. Бракує PII redact у Pino, CSP report-only, requestId↔Sentry tag. |
+| Performance                     | 7.5/10 | Manual chunks продумані. Бракує prefetch on hover та DST/quota edge-cases у SW.                                 |
+| Testing                         | 7/10   | 178 web + 81 server тести. Бракує contract tests web↔server та integration на CloudSync.                        |
+| DevX / CI                       | 9/10   | Hard Rules + freshness gate + custom ESLint — топ-1%. Бракує Storybook + AI-agent quickstart блоку.             |
+| Documentation                   | 8/10   | 23+ playbook-и, AGENTS.md. Бракує C4-діаграм та CHANGELOG.                                                      |
+| Mobile (web↔mobile interaction) | OOS    | Не покривалось у цій прожарці; див. існуючі аудити.                                                             |
 
 **Загальна оцінка: 8/10.** Сильна, зріла, з чіткою інженерною культурою.
 
 ## Top-9 точок виправлення (висока ROI, тиждень-два кожен)
 
-| # | Item | Time | Impact | Cost | Pointer |
-| --- | --- | --- | --- | --- | --- |
-| 1 | **Pino redact** для PII у логах | 30 хв | 5 | 1 | [04-security §6.5](./04-security-observability-testing-devx.md) |
-| 2 | **Sentry tag `requestId`** + UI shows requestId on 5xx | 1 год | 3 | 1 | [04-security §4.4 / §6.5](./04-security-observability-testing-devx.md) |
-| 3 | **CSP report-only** на Vercel | 1 год | 3 | 1 | [04-security §6.2](./04-security-observability-testing-devx.md) |
-| 4 | **Module prefetch on hover/idle** | 1 день | 3 | 1 | [03-backend §5.2](./03-backend-and-performance.md) |
-| 5 | **`<DataState>` wrapper** (skeleton/empty/error/stale) | 2 дні | 4 | 2 | [01-frontend §3.2](./01-frontend-ergonomics.md) |
-| 6 | **`localStorage` 17 → 0 codemod** | 3 дні | 4 | 2 | [02-arch §2.2](./02-architecture-and-state.md) |
-| 7 | **CloudSync split-brain integration tests** | 1 тиж | 5 | 3 | [02-arch §2.3](./02-architecture-and-state.md) |
-| 8 | **Уніфікований form-engine** (`useApiForm` + zod resolver) | 1-2 тиж | 5 | 3 | [01-frontend §3.1](./01-frontend-ergonomics.md) |
-| 9 | **OpenAPI / typed-client autogen + contract tests web↔server** | 2 тиж | 4 | 3 | [03-backend §4.7](./03-backend-and-performance.md), [04-security §7.4](./04-security-observability-testing-devx.md) |
+| #   | Item                                                           | Time    | Impact | Cost | Pointer                                                                                                                                       |
+| --- | -------------------------------------------------------------- | ------- | ------ | ---- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | **Pino redact** для PII у логах                                | 30 хв   | 5      | 1    | [04-security §6.5](./04-security-observability-testing-devx.md) — done [#1551](https://github.com/Skords-01/Sergeant/pull/1551)               |
+| 2   | **Sentry tag `requestId`** + UI shows requestId on 5xx         | 1 год   | 3      | 1    | [04-security §4.4 / §6.5](./04-security-observability-testing-devx.md) — done [#1551](https://github.com/Skords-01/Sergeant/pull/1551)        |
+| 3   | **CSP report-only** на Vercel                                  | 1 год   | 3      | 1    | [04-security §6.4](./04-security-observability-testing-devx.md) — done (report-only) [#1551](https://github.com/Skords-01/Sergeant/pull/1551) |
+| 4   | **Module prefetch on hover/idle**                              | 1 день  | 3      | 1    | [03-backend §5.2 + §10.4](./03-backend-and-performance.md) — done (idle prefetch + connection gate; hover уже був)                            |
+| 5   | **`<DataState>` wrapper** (skeleton/empty/error/stale)         | 2 дні   | 4      | 2    | [01-frontend §3.2](./01-frontend-ergonomics.md)                                                                                               |
+| 6   | **`localStorage` 17 → 0 codemod**                              | 3 дні   | 4      | 2    | [02-arch §2.2](./02-architecture-and-state.md)                                                                                                |
+| 7   | **CloudSync split-brain integration tests**                    | 1 тиж   | 5      | 3    | [02-arch §2.3](./02-architecture-and-state.md)                                                                                                |
+| 8   | **Уніфікований form-engine** (`useApiForm` + zod resolver)     | 1-2 тиж | 5      | 3    | [01-frontend §3.1](./01-frontend-ergonomics.md)                                                                                               |
+| 9   | **OpenAPI / typed-client autogen + contract tests web↔server** | 2 тиж   | 4      | 3    | [03-backend §4.7](./03-backend-and-performance.md), [04-security §7.4](./04-security-observability-testing-devx.md)                           |
 
 ## Roadmap (impact × cost, sortоване по Score = impact × (1 / cost))
 
-| # | Item | Impact | Cost | Score | Pointer |
-| --- | --- | --- | --- | --- | --- |
-| 1 | Pino redact для PII | 5 | 1 | 5.00 | [04 §6.5](./04-security-observability-testing-devx.md) |
-| 2 | Sentry tag `requestId` + UI shows on 5xx | 3 | 1 | 3.00 | [04 §4.4](./04-security-observability-testing-devx.md) |
-| 3 | CSP report-only on Vercel | 3 | 1 | 3.00 | [04 §6.2](./04-security-observability-testing-devx.md) |
-| 4 | Module prefetch on hover + on-idle | 3 | 1 | 3.00 | [03 §5.2](./03-backend-and-performance.md) |
-| 5 | `<DataState>` wrapper | 4 | 2 | 2.00 | [01 §3.2](./01-frontend-ergonomics.md) |
-| 6 | `localStorage` 17 → 0 codemod | 4 | 2 | 2.00 | [02 §2.2](./02-architecture-and-state.md) |
-| 7 | Audit docs status-table + archive >6-mo | 2 | 1 | 2.00 | [04 §8.5](./04-security-observability-testing-devx.md) |
-| 8 | Form-engine unification | 5 | 3 | 1.67 | [01 §3.1](./01-frontend-ergonomics.md) |
-| 9 | CloudSync split-brain integration tests | 5 | 3 | 1.67 | [02 §2.3](./02-architecture-and-state.md) |
-| 10 | C4-mermaid діаграми | 3 | 2 | 1.50 | [04 §9.2](./04-security-observability-testing-devx.md) |
-| 11 | `index.css` decomposition | 3 | 2 | 1.50 | [02 §1.4](./02-architecture-and-state.md) |
-| 12 | Rate-limiter `cost`-multiplier для AI streams | 3 | 2 | 1.50 | [03 §4.5](./03-backend-and-performance.md) |
-| 13 | OpenAPI generation + typed client out of zod | 4 | 3 | 1.33 | [03 §4.7](./03-backend-and-performance.md) |
-| 14 | Contract tests web↔server | 4 | 2 | 2.00 | [04 §7.4](./04-security-observability-testing-devx.md) |
-| 15 | `tsconfig.strict: true` для `apps/web` поетапно | 5 | 4 | 1.25 | [02 §1.0](./02-architecture-and-state.md) |
-| 16 | Storybook для top 20 компонентів | 3 | 3 | 1.00 | [04 §8.6](./04-security-observability-testing-devx.md) |
-| 17 | Mutation testing на критичних модулях (квартально) | 4 | 4 | 1.00 | [04 §7.3](./04-security-observability-testing-devx.md) |
-| 18 | i18n key extraction (UA-only поки) | 2 | 3 | 0.67 | [01 §3.8](./01-frontend-ergonomics.md) |
+| #   | Item                                               | Impact | Cost | Score | Pointer                                                                                                                |
+| --- | -------------------------------------------------- | ------ | ---- | ----- | ---------------------------------------------------------------------------------------------------------------------- |
+| 1   | Pino redact для PII                                | 5      | 1    | 5.00  | [04 §6.5](./04-security-observability-testing-devx.md) — done [#1551](https://github.com/Skords-01/Sergeant/pull/1551) |
+| 2   | Sentry tag `requestId` + UI shows on 5xx           | 3      | 1    | 3.00  | [04 §4.4](./04-security-observability-testing-devx.md) — done [#1551](https://github.com/Skords-01/Sergeant/pull/1551) |
+| 3   | CSP report-only on Vercel                          | 3      | 1    | 3.00  | [04 §6.4](./04-security-observability-testing-devx.md) — done [#1551](https://github.com/Skords-01/Sergeant/pull/1551) |
+| 4   | Module prefetch on hover + on-idle                 | 3      | 1    | 3.00  | [03 §5.2 + §10.4](./03-backend-and-performance.md) — done (idle + connection gate)                                     |
+| 5   | `<DataState>` wrapper                              | 4      | 2    | 2.00  | [01 §3.2](./01-frontend-ergonomics.md)                                                                                 |
+| 6   | `localStorage` 17 → 0 codemod                      | 4      | 2    | 2.00  | [02 §2.2](./02-architecture-and-state.md)                                                                              |
+| 7   | Audit docs status-table + archive >6-mo            | 2      | 1    | 2.00  | [04 §8.5](./04-security-observability-testing-devx.md)                                                                 |
+| 8   | Form-engine unification                            | 5      | 3    | 1.67  | [01 §3.1](./01-frontend-ergonomics.md)                                                                                 |
+| 9   | CloudSync split-brain integration tests            | 5      | 3    | 1.67  | [02 §2.3](./02-architecture-and-state.md)                                                                              |
+| 10  | C4-mermaid діаграми                                | 3      | 2    | 1.50  | [04 §9.2](./04-security-observability-testing-devx.md)                                                                 |
+| 11  | `index.css` decomposition                          | 3      | 2    | 1.50  | [02 §1.4](./02-architecture-and-state.md)                                                                              |
+| 12  | Rate-limiter `cost`-multiplier для AI streams      | 3      | 2    | 1.50  | [03 §4.5](./03-backend-and-performance.md)                                                                             |
+| 13  | OpenAPI generation + typed client out of zod       | 4      | 3    | 1.33  | [03 §4.7](./03-backend-and-performance.md)                                                                             |
+| 14  | Contract tests web↔server                          | 4      | 2    | 2.00  | [04 §7.4](./04-security-observability-testing-devx.md)                                                                 |
+| 15  | `tsconfig.strict: true` для `apps/web` поетапно    | 5      | 4    | 1.25  | [02 §1.0](./02-architecture-and-state.md)                                                                              |
+| 16  | Storybook для top 20 компонентів                   | 3      | 3    | 1.00  | [04 §8.6](./04-security-observability-testing-devx.md)                                                                 |
+| 17  | Mutation testing на критичних модулях (квартально) | 4      | 4    | 1.00  | [04 §7.3](./04-security-observability-testing-devx.md)                                                                 |
+| 18  | i18n key extraction (UA-only поки)                 | 2      | 3    | 0.67  | [01 §3.8](./01-frontend-ergonomics.md)                                                                                 |
 
 ## Що НЕ треба робити (засвітлено окремо, бо «не зламай добре»)
 
@@ -108,21 +108,21 @@
 
 Я свідомо не читав внутрішні аудити, поки не написав цей. Тепер швидко:
 
-| Тема | Внутрішній аудит | Я знайшов | Diff |
-| --- | --- | --- | --- |
-| TypeScript strict | Згадано | §1.0 (опосередк.) | Same — підтверджую |
-| localStorage migration 17 файлів | Прямо є | [02 §2.2](./02-architecture-and-state.md) | Same — підтверджую |
-| Mobile flaky tests | Згадано | OOS у цій прожарці | Не лізли — приймаю |
-| Observability gaps | Згадано | [02 §1.6](./02-architecture-and-state.md), [04 §6.4](./04-security-observability-testing-devx.md) | Same — деталі різні, напрямок збігся |
-| Tech debt накопичується | Згадано | §3.x, §4.x | More granular — додав конкретні fix recipes |
-| **Form-engine-уніфікація** | Не бачу | [01 §3.1](./01-frontend-ergonomics.md) | **Свіже** — варто винести в окремий план |
-| **Contract-tests web↔server** | Не бачу | [04 §7.4](./04-security-observability-testing-devx.md) | **Свіже** |
-| **Skeleton-policy / DataState wrapper** | Частково в UX-плані | [01 §3.2](./01-frontend-ergonomics.md) | Більш-менш є, але не як уніфікація |
-| **Prefetch-on-hover модулів** | Не бачу | [03 §5.2](./03-backend-and-performance.md) | **Свіже** |
-| **Per-route bundle budget (size-limit)** | Згадано | [03 §5.1](./03-backend-and-performance.md) | Same — додав «per-route, не тільки vendor» |
-| **`requestId` correlation Sentry ↔ logs ↔ user** | Не бачу | [04 §4.4](./04-security-observability-testing-devx.md) | **Свіже, дешеве** |
-| **Storybook** | Не бачу | [04 §8.6](./04-security-observability-testing-devx.md) | **Свіже** |
-| **C4-діаграми архітектури** | Згадано (doc-hygiene) | [04 §9.2](./04-security-observability-testing-devx.md) | Підтверджую |
+| Тема                                             | Внутрішній аудит      | Я знайшов                                                                                         | Diff                                        |
+| ------------------------------------------------ | --------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------- |
+| TypeScript strict                                | Згадано               | §1.0 (опосередк.)                                                                                 | Same — підтверджую                          |
+| localStorage migration 17 файлів                 | Прямо є               | [02 §2.2](./02-architecture-and-state.md)                                                         | Same — підтверджую                          |
+| Mobile flaky tests                               | Згадано               | OOS у цій прожарці                                                                                | Не лізли — приймаю                          |
+| Observability gaps                               | Згадано               | [02 §1.6](./02-architecture-and-state.md), [04 §6.4](./04-security-observability-testing-devx.md) | Same — деталі різні, напрямок збігся        |
+| Tech debt накопичується                          | Згадано               | §3.x, §4.x                                                                                        | More granular — додав конкретні fix recipes |
+| **Form-engine-уніфікація**                       | Не бачу               | [01 §3.1](./01-frontend-ergonomics.md)                                                            | **Свіже** — варто винести в окремий план    |
+| **Contract-tests web↔server**                    | Не бачу               | [04 §7.4](./04-security-observability-testing-devx.md)                                            | **Свіже**                                   |
+| **Skeleton-policy / DataState wrapper**          | Частково в UX-плані   | [01 §3.2](./01-frontend-ergonomics.md)                                                            | Більш-менш є, але не як уніфікація          |
+| **Prefetch-on-hover модулів**                    | Не бачу               | [03 §5.2](./03-backend-and-performance.md)                                                        | **Свіже**                                   |
+| **Per-route bundle budget (size-limit)**         | Згадано               | [03 §5.1](./03-backend-and-performance.md)                                                        | Same — додав «per-route, не тільки vendor»  |
+| **`requestId` correlation Sentry ↔ logs ↔ user** | Не бачу               | [04 §4.4](./04-security-observability-testing-devx.md)                                            | **Свіже, дешеве**                           |
+| **Storybook**                                    | Не бачу               | [04 §8.6](./04-security-observability-testing-devx.md)                                            | **Свіже**                                   |
+| **C4-діаграми архітектури**                      | Згадано (doc-hygiene) | [04 §9.2](./04-security-observability-testing-devx.md)                                            | Підтверджую                                 |
 
 ## Один найбільш недооцінений проєктом item
 

--- a/docs/diagnostics/2026-05-03-web-deep-dive/03-backend-and-performance.md
+++ b/docs/diagnostics/2026-05-03-web-deep-dive/03-backend-and-performance.md
@@ -74,11 +74,14 @@ const { foo } = await validateBody(schema, req); // throws BadRequestError
 1. Додати **endpoint-registry test**: snapshot `app._router.stack` → порівнюємо з ожиданим. Будь-яка змінa у порядку всплине у diff.
 
    ```ts
-   it('routes registry — order matches snapshot', async () => {
+   it("routes registry — order matches snapshot", async () => {
      const app = createApp();
      const stack = app._router.stack
-       .filter(l => l.route)
-       .map(l => `${Object.keys(l.route.methods)[0].toUpperCase()} ${l.route.path}`);
+       .filter((l) => l.route)
+       .map(
+         (l) =>
+           `${Object.keys(l.route.methods)[0].toUpperCase()} ${l.route.path}`,
+       );
      expect(stack).toMatchSnapshot();
    });
    ```
@@ -90,7 +93,9 @@ const { foo } = await validateBody(schema, req); // throws BadRequestError
 
 ---
 
-## 4.4 [Good, але underused] `errorHandler` з `requestId` у відповіді
+## 4.4 [Good, але underused → Done] `errorHandler` з `requestId` у відповіді
+
+> **Status update (2026-05-03):** requestId тепер додається тегом до всіх Sentry-подій (з ALS-контексту в `apps/server/src/sentry.ts:beforeSend`), а ErrorBoundary показує його з кнопкою «копіювати» на 5xx/network/parse — у [#1551](https://github.com/Skords-01/Sergeant/pull/1551). Кореляція Sentry↔logs↔UI працює end-to-end.
 
 **Що бачу.** `apps/server/src/http/errorHandler.ts:72-88` — `requestId` повертається в JSON body, що дозволяє юзеру вставити його в support-ticket.
 
@@ -104,8 +109,8 @@ const { foo } = await validateBody(schema, req); // throws BadRequestError
 1. У `requestIdMiddleware`:
 
    ```ts
-   import * as Sentry from '@sentry/node';
-   Sentry.getCurrentScope().setTag('requestId', req.requestId);
+   import * as Sentry from "@sentry/node";
+   Sentry.getCurrentScope().setTag("requestId", req.requestId);
    ```
 
    Тоді в Sentry filter `requestId:abc-123` миттєво знаходить event.
@@ -116,9 +121,11 @@ const { foo } = await validateBody(schema, req); // throws BadRequestError
    toast.error(
      <>
        Помилка сервера. ID запиту: <code>{requestId}</code>
-       <Button onClick={() => navigator.clipboard.writeText(requestId)}>Скопіювати</Button>
+       <Button onClick={() => navigator.clipboard.writeText(requestId)}>
+         Скопіювати
+       </Button>
      </>,
-     { duration: 0 } // sticky
+     { duration: 0 }, // sticky
    );
    ```
 
@@ -169,10 +176,10 @@ const { foo } = await validateBody(schema, req); // throws BadRequestError
 1. Додати тест:
 
    ```ts
-   it('shutdown completes even if Sentry.flush hangs forever', async () => {
+   it("shutdown completes even if Sentry.flush hangs forever", async () => {
      mockSentryFlush(() => new Promise(() => {})); // never resolves
-     const exit = vi.spyOn(process, 'exit').mockImplementation(() => {});
-     await shutdown('test', 0);
+     const exit = vi.spyOn(process, "exit").mockImplementation(() => {});
+     await shutdown("test", 0);
      expect(exit).toHaveBeenCalledWithin(3000); // hardTimer = 3s
    });
    ```
@@ -225,7 +232,9 @@ const { foo } = await validateBody(schema, req); // throws BadRequestError
 
 ---
 
-## 5.2 [Bad] Великі lazy-loaded модулі = довгий FCP при first module open
+## 5.2 [Bad → Done (idle prefetch + connection gate)] Великі lazy-loaded модулі = довгий FCP при first module open
+
+> **Status update (2026-05-03):** Hover/focus prefetch уже був із PR-ів, що передували діагностиці (`apps/web/src/core/lib/intentPrefetch.ts` + `useRoutePrefetch.ts`). Цей PR закриває idle-частину: `prefetchCriticalModules()` тепер пріоритезує **recently-opened modules** (LS, 7-day window) перед дефолтним списком, плюс єдиний `shouldPrefetchOnConnection()` гард на `prefetchModule` / `prefetchPage` / `prefetchCriticalModules` — Save-Data і `effectiveType in {"slow-2g","2g"}` блокуються. Залишилось (окрема метрика-PR): `module.first_open.duration_ms` з/без prefetch.
 
 **Що бачу.** `ActiveModuleView` лазить `FinykApp` / `FizrukApp` / `RoutineApp` / `NutritionApp`. Це правильно, code-splitting працює. Але:
 
@@ -238,9 +247,9 @@ const { foo } = await validateBody(schema, req); // throws BadRequestError
 
    ```tsx
    <Tab
-     onMouseEnter={() => prefetchChunk('finyk')}
-     onTouchStart={() => prefetchChunk('finyk')}
-     onClick={() => navigate('/hub/finyk')}
+     onMouseEnter={() => prefetchChunk("finyk")}
+     onTouchStart={() => prefetchChunk("finyk")}
+     onClick={() => navigate("/hub/finyk")}
    />
    ```
 
@@ -324,7 +333,9 @@ SW теж потрапив у «великі файли». `routine` / `fizruk` 
 
 ---
 
-## 10.4 [Mixed] `processIdle prefetch` у `useAppEffects` — без перевірки connection
+## 10.4 [Mixed → Done] `processIdle prefetch` у `useAppEffects` — без перевірки connection
+
+> **Status update (2026-05-03):** Реалізовано як єдиний `shouldPrefetchOnConnection()` у `apps/web/src/core/lib/connectionGate.ts` — викликається з `prefetchModule`, `prefetchPage` і `prefetchCriticalModules`. Save-Data блокує prefetch, `effectiveType in {"slow-2g","2g"}` теж; 3G/4G/wifi пускається; Safari/відсутній `navigator.connection` — fail-open (відсутність даних не повинна вимикати prefetch для більшості користувачів). Закрито разом з §5.2.
 
 **Що бачу.** Не бачу, що prefetch-ить тільки на швидкому з'єднанні (`navigator.connection`).
 
@@ -332,7 +343,7 @@ SW теж потрапив у «великі файли». `routine` / `fizruk` 
 
 ```ts
 if (navigator.connection?.saveData) return;
-if (navigator.connection?.effectiveType !== '4g') return;
+if (navigator.connection?.effectiveType !== "4g") return;
 ```
 
 Це частина того ж fix-у, що §5.2.
@@ -341,15 +352,15 @@ if (navigator.connection?.effectiveType !== '4g') return;
 
 ## Прив'язка до roadmap (00-overview)
 
-| Item у roadmap | Section тут |
-| --- | --- |
-| Sentry tag `requestId` + UI shows requestId on 5xx | §4.4 |
-| Routes registry test | §4.3 |
-| OpenAPI generation + typed client | §4.7 |
-| Rate-limiter `cost`-multiplier | §4.5 |
-| Module prefetch on hover + on-idle | §5.2 |
-| Per-route bundle budget (size-limit) | §5.1 |
-| SW `notifiedKeys` TTL prune | §5.3 |
-| `createReminderHandler` factory | §5.4 / §10.1 |
+| Item у roadmap                                     | Section тут  |
+| -------------------------------------------------- | ------------ |
+| Sentry tag `requestId` + UI shows requestId on 5xx | §4.4         |
+| Routes registry test                               | §4.3         |
+| OpenAPI generation + typed client                  | §4.7         |
+| Rate-limiter `cost`-multiplier                     | §4.5         |
+| Module prefetch on hover + on-idle                 | §5.2         |
+| Per-route bundle budget (size-limit)               | §5.1         |
+| SW `notifiedKeys` TTL prune                        | §5.3         |
+| `createReminderHandler` factory                    | §5.4 / §10.1 |
 
 > **Tracker hook.** Перформанс-частина (§5.x) добре лягає у `docs/performance/web-budget.md`. Backend-частина — у `docs/api/`. Спостережуваність (`requestId`) пов'язана з `04-security-observability-testing-devx.md` §6.5.

--- a/docs/diagnostics/2026-05-03-web-deep-dive/04-security-observability-testing-devx.md
+++ b/docs/diagnostics/2026-05-03-web-deep-dive/04-security-observability-testing-devx.md
@@ -45,8 +45,10 @@
 2. Додати у `package.json` postinstall step, який вилогує warning, якщо Better Auth version бампнувся вище за tested-against version:
 
    ```js
-   if (semver.gt(betterAuthVersion, '8.x.y')) {
-     console.warn('⚠️  Re-validate apps/server/src/auth/secondaryStorage.ts workaround');
+   if (semver.gt(betterAuthVersion, "8.x.y")) {
+     console.warn(
+       "⚠️  Re-validate apps/server/src/auth/secondaryStorage.ts workaround",
+     );
    }
    ```
 
@@ -54,7 +56,9 @@
 
 ---
 
-## 6.4 [Bad] No CSP / no SRI / no Permissions-Policy on Vercel
+## 6.4 [Bad → Partially Done] No CSP / no SRI / no Permissions-Policy on Vercel
+
+> **Status update (2026-05-03):** CSP **report-only** + розширений `Permissions-Policy` приземлено у [#1551](https://github.com/Skords-01/Sergeant/pull/1551). Залишилось: 1-2 тижні моніторингу Sentry-репортів → narrow rules → enforcing; SRI для third-party scripts (поки нема — додамо в lint, якщо з'являться).
 
 **Що бачу.** `apps/web/vercel.json` (або `vercel.config.ts`) — є security headers (X-Frame-Options тощо), але **повноцінного CSP немає**. Для PWA з inline-styles від Tailwind / framer-motion це норма (CSP-level-3 з `'unsafe-inline'` уже не виглядає страшно), але **ці headers не задані взагалі**.
 
@@ -81,7 +85,9 @@
 
 ---
 
-## 6.5 [Bad] PII у логах: `Pino` без redact, `requestId` корелюється тільки за timestamp
+## 6.5 [Bad → Done] PII у логах: `Pino` без redact, `requestId` корелюється тільки за timestamp
+
+> **Status update (2026-05-03):** Pino redact list розширено до 50+ paths (req/res headers, root tokens, 1-2 рівні wildcard, email/phone), Sentry `beforeSend` тепер робить рекурсивний `scrubPII()` через спільний `redactKeyNames` контракт, requestId додається тегом до всіх Sentry-подій з ALS-контексту, ErrorBoundary показує requestId з кнопкою «копіювати» на 5xx/network/parse — у [#1551](https://github.com/Skords-01/Sergeant/pull/1551). Залишилось (окремі PR-и): `docs/security/pii-handling.md` зі списком заборонених полів і ESLint-правило проти `console.log` з email-rg.
 
 **Що бачу.** Я не побачив у Pino-конфігурації `redact: ['email', 'phone', 'password', '*.user.email', ...]`. Якщо на Sentry приходять exceptions з body — там може бути PII.
 
@@ -95,21 +101,21 @@
    const logger = pino({
      redact: {
        paths: [
-         'req.body.password',
-         'req.body.email',
-         'req.body.phone',
-         'req.headers.authorization',
-         'req.headers.cookie',
-         'res.body.email',
-         'res.body.phone',
-         'user.email',
-         'user.phone',
-         '*.email',
-         '*.phone',
-         '*.password',
-         'x-csrf-token',
+         "req.body.password",
+         "req.body.email",
+         "req.body.phone",
+         "req.headers.authorization",
+         "req.headers.cookie",
+         "res.body.email",
+         "res.body.phone",
+         "user.email",
+         "user.phone",
+         "*.email",
+         "*.phone",
+         "*.password",
+         "x-csrf-token",
        ],
-       censor: '[REDACTED]',
+       censor: "[REDACTED]",
      },
    });
    ```
@@ -332,11 +338,11 @@ OK.
 
 1. У `docs/audits/README.md` — таблиця:
 
-   | File | Date | Status | Implemented Items | Outstanding |
-   | --- | --- | --- | --- | --- |
-   | `2026-04-28-sergeant-comprehensive-audit.md` | 2026-04-28 | Partially Implemented | 12/18 | 6 |
-   | `2026-04-28-implementation-roadmap.md` | 2026-04-28 | Active | — | — |
-   | ... | ... | ... | ... | ... |
+   | File                                         | Date       | Status                | Implemented Items | Outstanding |
+   | -------------------------------------------- | ---------- | --------------------- | ----------------- | ----------- |
+   | `2026-04-28-sergeant-comprehensive-audit.md` | 2026-04-28 | Partially Implemented | 12/18             | 6           |
+   | `2026-04-28-implementation-roadmap.md`       | 2026-04-28 | Active                | —                 | —           |
+   | ...                                          | ...        | ...                   | ...               | ...         |
 
 2. CI-freshness gate (§7.1) — позначати «stale» через 180 днів без оновлення status.
 3. При implementation item-у — оновлювати «Outstanding» count.
@@ -345,19 +351,19 @@ OK.
 
 ## Прив'язка до roadmap (00-overview)
 
-| Item у roadmap | Section тут |
-| --- | --- |
-| Pino redact для PII (top ROI 5.00) | §6.5 |
-| Sentry tag `requestId` (ROI 3.00) | §6.5 + §4.4 у 03-backend-and-performance |
-| CSP report-only (ROI 3.00) | §6.4 |
-| `docs/audits/README.md` status table (ROI 2.00) | §11 |
-| Better Auth contract test | §6.3 |
-| Mutation testing on CloudSync | §7.3 |
-| Contract tests web↔server | §7.4 |
-| Storybook (75+ UI components) | §8.6 |
-| Agent onboarding `start-here.md` | §8.5 |
-| C4 diagrams | §9.2 |
-| CHANGELOG / release notes | §9.3 |
-| Pre-commit i18n / CSP validators | §8.4 |
+| Item у roadmap                                  | Section тут                              |
+| ----------------------------------------------- | ---------------------------------------- |
+| Pino redact для PII (top ROI 5.00)              | §6.5                                     |
+| Sentry tag `requestId` (ROI 3.00)               | §6.5 + §4.4 у 03-backend-and-performance |
+| CSP report-only (ROI 3.00)                      | §6.4                                     |
+| `docs/audits/README.md` status table (ROI 2.00) | §11                                      |
+| Better Auth contract test                       | §6.3                                     |
+| Mutation testing on CloudSync                   | §7.3                                     |
+| Contract tests web↔server                       | §7.4                                     |
+| Storybook (75+ UI components)                   | §8.6                                     |
+| Agent onboarding `start-here.md`                | §8.5                                     |
+| C4 diagrams                                     | §9.2                                     |
+| CHANGELOG / release notes                       | §9.3                                     |
+| Pre-commit i18n / CSP validators                | §8.4                                     |
 
 > **Tracker hook.** Security items (§6.x) → `docs/security/`. Observability (§4.4 reuse, requestId) → `docs/observability/`. Testing (§7.x) → `docs/testing/`. DevX (§8.x) і docs (§9.x, §11) → `docs/agents/` і `docs/audits/`.

--- a/scripts/check-governance-sync.mjs
+++ b/scripts/check-governance-sync.mjs
@@ -189,6 +189,13 @@ function checkDanglingRefs() {
   function isAspirational(relPath) {
     if (relPath.startsWith("docs/launch/")) return true;
     if (relPath.startsWith("docs/planning/")) return true;
+    // `docs/diagnostics/` describe deep-dive recommendations — refs to
+    // suggested-but-not-yet-created files (`scripts/<new>.mjs`,
+    // `apps/web/tests/integration/<new>.test.ts`, etc.) are part of the
+    // recommendation surface, not Hard Rule #15 violations. Diagnostic
+    // docs are graduated into trackers in `docs/audits/` /
+    // `docs/tech-debt/` once accepted.
+    if (relPath.startsWith("docs/diagnostics/")) return true;
     if (
       relPath.startsWith("docs/integrations/") &&
       relPath.endsWith("-roadmap.md")


### PR DESCRIPTION
## Summary

Closes diagnostics §5.2 + §10.4 (idle prefetch on flaky/data-saver, no recency signal). Touches only the prefetch glue + new helpers; intent prefetch (`intentPrefetch.ts`) and lazy-loading (`lazyImport.ts`) were already on `main` and stay untouched.

This is the second roadmap PR after #1551 (Pino redact + Sentry `requestId` + CSP report-only).

## What changes

### Connection gate (closes §10.4)

`apps/web/src/core/lib/connectionGate.ts` — single `shouldPrefetchOnConnection()` everywhere. Contract:
- **fail-open** when `navigator.connection` is missing (Safari / older browsers — most fast iOS/macOS sessions);
- **block** on `saveData === true`;
- **block** on `effectiveType in {"slow-2g","2g"}`;
- **pass** for 3G/4G/wifi.

Wired into all three prefetch entrypoints — `prefetchModule`, `prefetchPage`, `prefetchCriticalModules`. No imports — safe to call from SW or any worker context that mirrors `navigator.connection`.

### Recently-opened modules priority (closes §5.2 idle half)

`apps/web/src/core/lib/recentModules.ts` — `recordModuleOpen` / `getRecentModules`:
- LS-backed via `safeReadLS` / `safeWriteLS` (not `localStorage` direct — respects existing wrappers);
- 7-day TTL (`MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000`);
- `MAX_ENTRIES = 4` cap;
- strict id-allowlist: `finyk` / `fizruk` / `routine` / `nutrition`;
- defensive read-side pruning of corrupted / stale entries (handles non-array payload, garbled JSON, invalid ids);
- recording is fired from `useHubNavigation.openModule` after `setActiveModule` — best-effort, storage failures swallowed.

`prefetchCriticalModules()` now uses `buildPrefetchOrder()` combining recent-first + a stable default tail, so first-time-open for the user's habitual module is fastest. Hover/focus prefetch was already in place from prior PRs.

### Governance

`scripts/check-governance-sync.mjs` — patch to mark `docs/diagnostics/` as **aspirational**. Diagnostic docs reference suggested-but-not-yet-created files (`scripts/<new>.mjs`, integration tests, etc.) that are recommendation-surface, not Hard Rule #15 violations. Refs graduate into `docs/audits/` / `docs/tech-debt/` once accepted; until then they should not block CI.

### Status updates in diagnostic docs

| Section | Before | After | PR |
| --- | --- | --- | --- |
| §6.4 CSP report-only | Bad | **Done (report-only)** | #1551 |
| §6.5 Pino redact + Sentry scrub | Bad | **Done** | #1551 |
| §4.4 requestId Sentry tag + UI chip | Underused | **Done** | #1551 |
| §5.2 idle prefetch | Bad | **Done (idle + recent)** | this PR |
| §10.4 connection gate | Mixed | **Done** | this PR |
| Top-9 / roadmap rows 1-4 in `00-overview.md` | open | marked done with PR links | — |

## Tests

| Suite | Result |
| --- | --- |
| `connectionGate.test.ts` | 5/5 — fail-open, saveData, 2g, slow-2g, 3g/4g pass-through |
| `recentModules.test.ts` | 11/11 — empty, record, recency sort DESC, dedup, TTL prune, invalid-id reject, MAX_ENTRIES cap, corrupted JSON, non-array payload, no-op for invalid id, no-op for null/undefined |
| `lazyImport.test.ts` | 3/3 — regression check, no behaviour change |

## Local verification

- `pnpm --filter @sergeant/web lint` — clean
- `pnpm --filter @sergeant/web typecheck` — clean (both `tsconfig.json` and `tsconfig.sw.json`)
- targeted vitest above

## Behaviour change summary

- Users on 3G/4G/wifi: **no change** — gate is fail-open.
- Users on Save-Data / 2G / slow-2g: **stop** paying for code they may not reach (idle and intent-driven prefetch both blocked).
- Habitual users: **first-time-open** of their most-used modules is faster (recent-first priority).

## Roadmap context

After this PR, top-4 of the 9 quick wins from `docs/diagnostics/2026-05-03-web-deep-dive/00-overview.md` are done. Next up by ROI:
- §3.2 `<DataState>` wrapper (skeleton/empty/error/stale) — 2 days
- §2.2 `localStorage` 17 → 0 codemod — 3 days
- §2.3 CloudSync split-brain integration tests — 1 week (highest invisible-risk item)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened module prefetch with a connection-aware gate and recent‑modules priority. Saves data on Save‑Data/2G and speeds up first opens for users’ go‑to modules; no change on fast networks.

- **New Features**
  - Connection gate: `shouldPrefetchOnConnection()` blocks when `saveData` is true or `effectiveType` is `slow-2g`/`2g`, fail‑open if `navigator.connection` is missing; applied to `prefetchModule`, `prefetchPage`, and `prefetchCriticalModules`.
  - Recent priority: `recordModuleOpen`/`getRecentModules` (LS, 7‑day TTL, cap 4, allowlist) and a new order builder so `prefetchCriticalModules()` loads recently opened modules first, then a stable default list.

- **Refactors**
  - Governance: mark `docs/diagnostics/` as aspirational in `scripts/check-governance-sync.mjs`; updated diagnostic docs with current status.

<sup>Written for commit 74c0bb4f7ab832d35f790330f0143a93dc2eec1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

