### PR TITLE
feat(server): hard-block AI_QUOTA_DISABLED in production (H9)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,11 +56,18 @@ ANTHROPIC_API_KEY=sk-ant-api03-...
 # Copy the production webhook URL from workflow 20 after importing it into n8n.
 # N8N_AGENT_DISPATCHER_WEBHOOK_URL=https://n8n.your-domain.com/webhook/agent-dispatcher
 
-# Денні ліміти викликів AI (таблиця ai_usage_daily у Postgres). AI_QUOTA_DISABLED=1 — вимкнути.
+# Денні ліміти викликів AI (таблиця ai_usage_daily у Postgres).
 # Залогінений користувач: AI_DAILY_USER_LIMIT (за замовч. 120). Без сесії — по IP: AI_DAILY_ANON_LIMIT (за замовч. 40).
 # AI_DAILY_USER_LIMIT=120
 # AI_DAILY_ANON_LIMIT=40
 # AI_QUOTA_DISABLED=0
+#
+# AI_QUOTA_DISABLED=1 — вимкнути квоту повністю (no-op для assertAiQuota).
+# !!! ТІЛЬКИ для CI/test/dev. У production assertStartupEnv() хард-блокує
+# server-startup, якщо AI_QUOTA_DISABLED=true і NODE_ENV=production
+# (або RAILWAY_ENVIRONMENT/RAILWAY_SERVICE_NAME виставлені). Без цього
+# хард-блока випадковий copy-paste flag-а зі staging до prod дав би
+# unlimited Anthropic budget burn. Див. docs/security/ai-quota-kill-switch.md
 # Tool-use квота (окремий bucket у ai_usage_daily). Кожен виклик tool-а (наприклад
 # change_category, create_debt) коштує AI_QUOTA_TOOL_COST одиниць у власному
 # лічильнику tool:<name>. Ліміти на кожен tool задаються JSON-ом у AI_QUOTA_TOOL_LIMITS;

--- a/.github/workflows/extended-e2e.yml
+++ b/.github/workflows/extended-e2e.yml
@@ -50,6 +50,11 @@ jobs:
           --health-retries 5
 
     env:
+      # NODE_ENV=test is mandatory: the server hard-blocks startup if
+      # AI_QUOTA_DISABLED is truthy alongside NODE_ENV=production /
+      # RAILWAY_*. Without this var the workflow would fail to boot the
+      # API server (see assertStartupEnv in apps/server/src/env/env.ts).
+      NODE_ENV: test
       DATABASE_URL: postgresql://hub:hub@127.0.0.1:5432/hub
       BETTER_AUTH_SECRET: smoke_test_better_auth_secret_32_chars_min
       AI_QUOTA_DISABLED: "1"

--- a/apps/server/src/env.ts
+++ b/apps/server/src/env.ts
@@ -148,6 +148,25 @@ export const env = {
     30_000,
   ),
 
+  /**
+   * Killer-switch for AI-quota: when `true`, `assertAiQuota()` becomes a no-op
+   * and every AI route runs without decrementing the `ai_usage_daily` counter.
+   * Designed **exclusively** for CI/test environments where e2e tests hammer
+   * the real Anthropic API without burning user quota
+   * (see `.github/workflows/extended-e2e.yml`).
+   *
+   * In production this flag is a fail-open kill-switch on billing: a stray
+   * `AI_QUOTA_DISABLED=1` in Railway env (copy-paste from staging, helm typo)
+   * disables every per-user / per-IP cap and lets clients burn the entire
+   * Anthropic budget. `assertStartupEnv()` in `env/env.ts` hard-blocks
+   * production startup when this flag is truthy alongside `NODE_ENV=production`
+   * (or any RAILWAY_* env), so a misconfigured deploy refuses to boot rather
+   * than silently leak budget.
+   *
+   * Default: `false`.
+   */
+  AI_QUOTA_DISABLED: parseBoolEnv("AI_QUOTA_DISABLED", false),
+
   // ─────────────────────────────────────────────────────────────────────────
   // Rate Limiting
   // ─────────────────────────────────────────────────────────────────────────

--- a/apps/server/src/env/__tests__/assertStartupEnv.test.ts
+++ b/apps/server/src/env/__tests__/assertStartupEnv.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Re-imports `env/env.ts` from scratch each test so the zod schema reads the
+// current `process.env` snapshot. Without this every test would see whatever
+// state the first import froze.
+async function loadAssertStartupEnv(
+  envOverrides: Record<string, string> = {},
+): Promise<() => void> {
+  for (const [k, v] of Object.entries(envOverrides)) vi.stubEnv(k, v);
+  vi.resetModules();
+  const mod = await import("../env.js");
+  return mod.assertStartupEnv;
+}
+
+const PROD_BASELINE = {
+  // Minimum env that lets `assertStartupEnv()` proceed past the unrelated
+  // production checks (DATABASE_URL, BETTER_AUTH_TOKEN_ENC_KEY,
+  // NUTRITION_BACKUP_KEY_SECRET) before reaching the AI_QUOTA_DISABLED gate.
+  NODE_ENV: "production",
+  DATABASE_URL: "postgres://hub:hub@127.0.0.1:5432/hub",
+  BETTER_AUTH_TOKEN_ENC_KEY: "a".repeat(64),
+  NUTRITION_BACKUP_KEY_SECRET: "b".repeat(64),
+};
+
+describe("assertStartupEnv — AI_QUOTA_DISABLED hard-block (H9)", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("throws when NODE_ENV=production AND AI_QUOTA_DISABLED=true", async () => {
+    const assertStartupEnv = await loadAssertStartupEnv({
+      ...PROD_BASELINE,
+      AI_QUOTA_DISABLED: "true",
+    });
+    expect(() => assertStartupEnv()).toThrow(/AI_QUOTA_DISABLED/);
+  });
+
+  it("throws when NODE_ENV=production AND AI_QUOTA_DISABLED=1 (legacy spelling)", async () => {
+    const assertStartupEnv = await loadAssertStartupEnv({
+      ...PROD_BASELINE,
+      AI_QUOTA_DISABLED: "1",
+    });
+    expect(() => assertStartupEnv()).toThrow(/AI_QUOTA_DISABLED/);
+  });
+
+  it("throws when only RAILWAY_ENVIRONMENT is set (Railway prod without NODE_ENV)", async () => {
+    const assertStartupEnv = await loadAssertStartupEnv({
+      ...PROD_BASELINE,
+      NODE_ENV: "test",
+      RAILWAY_ENVIRONMENT: "production",
+      AI_QUOTA_DISABLED: "true",
+    });
+    expect(() => assertStartupEnv()).toThrow(/AI_QUOTA_DISABLED/);
+  });
+
+  it("throws when only RAILWAY_SERVICE_NAME is set", async () => {
+    const assertStartupEnv = await loadAssertStartupEnv({
+      ...PROD_BASELINE,
+      NODE_ENV: "test",
+      RAILWAY_SERVICE_NAME: "sergeant-api",
+      AI_QUOTA_DISABLED: "true",
+    });
+    expect(() => assertStartupEnv()).toThrow(/AI_QUOTA_DISABLED/);
+  });
+
+  it("does NOT throw in production when AI_QUOTA_DISABLED is unset (default)", async () => {
+    const assertStartupEnv = await loadAssertStartupEnv(PROD_BASELINE);
+    expect(() => assertStartupEnv()).not.toThrow();
+  });
+
+  it("does NOT throw in production when AI_QUOTA_DISABLED=false", async () => {
+    const assertStartupEnv = await loadAssertStartupEnv({
+      ...PROD_BASELINE,
+      AI_QUOTA_DISABLED: "false",
+    });
+    expect(() => assertStartupEnv()).not.toThrow();
+  });
+
+  it("does NOT throw in production when AI_QUOTA_DISABLED=0", async () => {
+    const assertStartupEnv = await loadAssertStartupEnv({
+      ...PROD_BASELINE,
+      AI_QUOTA_DISABLED: "0",
+    });
+    expect(() => assertStartupEnv()).not.toThrow();
+  });
+
+  it("allows AI_QUOTA_DISABLED=true in NODE_ENV=test (CI/e2e)", async () => {
+    const assertStartupEnv = await loadAssertStartupEnv({
+      NODE_ENV: "test",
+      AI_QUOTA_DISABLED: "true",
+    });
+    expect(() => assertStartupEnv()).not.toThrow();
+  });
+
+  it("allows AI_QUOTA_DISABLED=1 in NODE_ENV=development (local dev)", async () => {
+    const assertStartupEnv = await loadAssertStartupEnv({
+      NODE_ENV: "development",
+      AI_QUOTA_DISABLED: "1",
+    });
+    expect(() => assertStartupEnv()).not.toThrow();
+  });
+});

--- a/apps/server/src/env/env.ts
+++ b/apps/server/src/env/env.ts
@@ -116,8 +116,25 @@ const envSchema = z.object({
    * якістю українською. Альтернатива: `whisper-large-v3`.
    */
   GROQ_TRANSCRIBE_MODEL: z.string().default("whisper-large-v3-turbo"),
-  /** `"1"` — повністю вимкнути AI-квоту (fail-open без перевірки). */
-  AI_QUOTA_DISABLED: z.string().optional(),
+  /**
+   * Killer-switch для AI-квоти: при `true` `assertAiQuota()` стає no-op і всі
+   * AI-роути проходять без декременту лічильника `ai_usage_daily`. Призначений
+   * **виключно** для CI/test середовищ, де e2e ганяють реальний Anthropic API
+   * без burning-у user-quota (див. `.github/workflows/extended-e2e.yml`).
+   *
+   * У production цей flag є fail-open kill-switch для billing-а: якщо випадково
+   * виставити `1` у Railway env (copy-paste зі staging, або помилка у helm-у),
+   * жоден per-user / per-IP ліміт більше не працює — користувачі можуть
+   * burn-нути unlimited Anthropic budget. Тому `assertStartupEnv()` хард-блокує
+   * production-startup, якщо одночасно `NODE_ENV=production` (або Railway env)
+   * і цей flag truthy.
+   *
+   * Default: `false`. Приймається як `true|false|1|0`.
+   */
+  AI_QUOTA_DISABLED: z
+    .enum(["true", "false", "1", "0", ""])
+    .default("false")
+    .transform((v) => v === "true" || v === "1"),
   /** Денний ліміт AI-запитів для автентифікованого юзера. */
   AI_DAILY_USER_LIMIT: coerceInt.nonnegative().optional(),
   /** Денний ліміт AI-запитів для анонімного юзера. */
@@ -288,6 +305,18 @@ export function assertStartupEnv(): void {
   } else if (!env.NUTRITION_BACKUP_KEY_SECRET) {
     warnings.push(
       "NUTRITION_BACKUP_KEY_SECRET is not set — /api/nutrition/backup-{upload,download} will return 503.",
+    );
+  }
+
+  // H9: AI_QUOTA_DISABLED is a billing kill-switch — fine in CI/test where e2e
+  // hammers real Anthropic without burning user quota, catastrophic in
+  // production where it disables every per-user / per-IP cap. The advisory
+  // module-load `logger.warn` in aiQuota.ts was easy to miss; this fail-fast
+  // check refuses to start the server at all so the misconfig is caught at
+  // boot instead of at the next billing cycle.
+  if (isProduction && env.AI_QUOTA_DISABLED) {
+    throw new Error(
+      "AI_QUOTA_DISABLED MUST NOT be set in production. It disables every per-user / per-IP AI cap and lets clients burn the entire Anthropic budget. If you really need this in production (e.g. emergency disable of the quota subsystem itself), unset NODE_ENV / RAILWAY_ENVIRONMENT for that run, document the reason in the runbook, and remove the override immediately after.",
     );
   }
 

--- a/apps/server/src/modules/chat/aiQuota.ts
+++ b/apps/server/src/modules/chat/aiQuota.ts
@@ -86,16 +86,22 @@ function parseLimit<F extends number | null>(
   return Number.isFinite(n) && n >= 0 ? n : fallback;
 }
 
+/**
+ * `true` when the AI-quota subsystem is disabled wholesale (CI/test only).
+ *
+ * Reads `process.env` directly rather than the validated `env` module so that
+ * unit tests can flip the flag at runtime via `process.env.AI_QUOTA_DISABLED`
+ * without re-importing modules. Accepts the same truthy spellings as the typed
+ * env (`true|1`) so the two stay in sync.
+ *
+ * Production safety lives at startup — `assertStartupEnv()` in
+ * `apps/server/src/env/env.ts` hard-blocks server boot when this flag is
+ * truthy alongside `NODE_ENV=production` (or any RAILWAY_* env). The module
+ * here trusts the startup check and does not re-validate at runtime.
+ */
 export function isAiQuotaDisabled(): boolean {
-  return process.env.AI_QUOTA_DISABLED === "1";
-}
-
-// Runs once at module import — warns ops if quotas are bypassed in production.
-if (
-  process.env.AI_QUOTA_DISABLED === "1" &&
-  process.env.NODE_ENV === "production"
-) {
-  logger.warn({ msg: "ai_quota_disabled_in_production" });
+  const v = process.env.AI_QUOTA_DISABLED?.toLowerCase();
+  return v === "1" || v === "true";
 }
 
 function effectiveLimits(): EffectiveLimits {

--- a/docs/planning/stack-pulse-2026-05/pr-15-ai-quota-disabled-hardblock.md
+++ b/docs/planning/stack-pulse-2026-05/pr-15-ai-quota-disabled-hardblock.md
@@ -1,12 +1,12 @@
 # PR-15: `AI_QUOTA_DISABLED=1` hard-block у production
 
 > **Last validated:** 2026-05-03 by Devin. **Next review:** 2026-08-03.
-> **Status:** Planned
+> **Status:** In review (PR pending)
 
 |              |                                        |
 | ------------ | -------------------------------------- |
 | **Severity** | High (H9)                              |
-| **Owner**    | TBD                                    |
+| **Owner**    | Devin (security pass)                  |
 | **Effort**   | 0.5 дня                                |
 | **Risk**     | Low                                    |
 | **Touches**  | `apps/server/src/env*`, AI-quota guard |

--- a/docs/security/ai-quota-kill-switch.md
+++ b/docs/security/ai-quota-kill-switch.md
@@ -1,0 +1,150 @@
+# AI quota kill-switch policy
+
+> **Last validated:** 2026-05-03 by Devin. **Next review:** 2026-08-03.
+> **Status:** Active
+
+## TL;DR
+
+`AI_QUOTA_DISABLED=true` (or `=1`) globally disables `assertAiQuota()` —
+every per-user / per-IP daily limit becomes a no-op and the AI subsystem
+runs without consulting `ai_usage_daily`. **In production this is
+hard-blocked at startup.** The flag exists exclusively for CI/test
+environments where end-to-end suites need to call the real Anthropic API
+without burning real user quota.
+
+## Why a kill-switch exists
+
+Nightly Playwright e2e suites (`.github/workflows/extended-e2e.yml`,
+`visual-regression.yml`, `ci.yml`) talk to the real Anthropic API to
+exercise the full chat / coach / nutrition flows end-to-end. Counting
+those calls against the per-IP `AI_DAILY_ANON_LIMIT=40` would either:
+
+1. Make the tests flaky (they would 429 themselves after a few runs in
+   the same window), or
+2. Force the tests to share a real user account whose quota would be
+   trivially exhausted by repeated CI runs.
+
+The simplest fix is to wholesale disable the quota subsystem when the
+env reports `NODE_ENV=test`. The runtime check
+(`isAiQuotaDisabled()` in `apps/server/src/modules/chat/aiQuota.ts`)
+short-circuits before the `pool.query` UPSERT into `ai_usage_daily`, so
+the tests can hammer Anthropic without hitting any per-day cap.
+
+## Why production is hard-blocked
+
+`AI_QUOTA_DISABLED` in production is a fail-open kill-switch on billing.
+Once it's true, `effectiveLimits()` returns `{ user: null, anon: null }`,
+`assertAiQuota()` returns `true` unconditionally, no `ai_usage_daily`
+row gets touched, and there is **no other gate** between an authenticated
+user and Anthropic.
+
+A single misconfigured Railway secret (copy-pasted from the staging or
+test environment, dropped in by a helm-chart typo, or smuggled in via
+`RAILWAY_ENVIRONMENT=production` + a `.env.local` left over from local
+debugging) lets any client burn unlimited Anthropic budget. There is no
+per-user cost cap below the quota, and the upstream Anthropic budget
+guard is account-wide — by the time the alert fires, the damage is
+already done.
+
+The previous safeguard was an advisory `logger.warn` that fired once at
+module import. In practice that warning was indistinguishable from any
+of the dozens of legitimate "X is not configured" warnings during
+production boot, and nobody saw it on staging when it shipped. Replacing
+the advisory log with a startup throw means a misconfigured deploy
+**refuses to boot** rather than silently leaking budget — the misconfig
+is caught by the Railway crash-loop alert instead of by the next billing
+cycle.
+
+## Where the hard-block lives
+
+Source of truth: `apps/server/src/env/env.ts` → `assertStartupEnv()`.
+
+```ts
+// Validated env exposes AI_QUOTA_DISABLED as a boolean (default false).
+AI_QUOTA_DISABLED: z
+  .enum(["true", "false", "1", "0", ""])
+  .default("false")
+  .transform((v) => v === "true" || v === "1"),
+
+// In assertStartupEnv():
+if (isProduction && env.AI_QUOTA_DISABLED) {
+  throw new Error(
+    "AI_QUOTA_DISABLED MUST NOT be set in production. …",
+  );
+}
+```
+
+`isProduction` covers both `NODE_ENV=production` **and** any
+`RAILWAY_ENVIRONMENT` / `RAILWAY_SERVICE_NAME` value being set. The
+latter two cover the case where Railway boots the server without
+`NODE_ENV` explicitly set to production — which is the default for
+service deployments.
+
+`assertStartupEnv()` is invoked from `apps/server/src/index.ts` before
+the HTTP listener binds, so a tripped check produces an unrecoverable
+boot error and the process exits non-zero.
+
+## Allowed configurations
+
+| Environment                        | `AI_QUOTA_DISABLED` | Behaviour                               |
+| ---------------------------------- | ------------------- | --------------------------------------- |
+| Local dev (`NODE_ENV=development`) | `false` (default)   | Quota active, normal per-day limits     |
+| Local dev (`NODE_ENV=development`) | `true` / `1`        | Allowed — quota disabled                |
+| CI (`NODE_ENV=test`)               | `true` / `1`        | Allowed — quota disabled                |
+| Production (`NODE_ENV=production`) | `false` (default)   | Quota active, normal per-day limits     |
+| Production (`NODE_ENV=production`) | `true` / `1`        | **Hard-block** — server refuses to boot |
+| Railway (`RAILWAY_ENVIRONMENT=*`)  | `true` / `1`        | **Hard-block** — server refuses to boot |
+
+## Test coverage
+
+`apps/server/src/env/__tests__/assertStartupEnv.test.ts` — full matrix
+covering:
+
+- Production + truthy spelling (`true`, `1`) → throws.
+- Production via Railway env (`RAILWAY_ENVIRONMENT`,
+  `RAILWAY_SERVICE_NAME`) without `NODE_ENV=production` → throws.
+- Production + falsy spelling (`false`, `0`, unset) → does not throw.
+- `NODE_ENV=test` + `AI_QUOTA_DISABLED=true` → does not throw.
+- `NODE_ENV=development` + `AI_QUOTA_DISABLED=1` → does not throw.
+
+`apps/server/src/modules/chat/aiQuota.test.ts` — runtime behaviour of
+`assertAiQuota()` and `consumeToolQuota()` when the flag is set; these
+tests use `process.env.AI_QUOTA_DISABLED = "1"` directly so each case
+mutates the runtime state without re-importing `env.js`.
+
+## Operational guidance
+
+### When you need to disable the quota subsystem in a non-test env
+
+If something pathological is happening with `ai_usage_daily` (corrupt
+rows, stuck row-locks, runaway upsert errors) and you genuinely need to
+disable the quota subsystem in production while you fix it:
+
+1. Acknowledge that this exposes the Anthropic budget. Decide whether
+   to hard-pause AI routes at the gateway / feature flag instead — that
+   is the safer alternative.
+2. If you still need to flip the flag, **un-set** `RAILWAY_ENVIRONMENT`,
+   `RAILWAY_SERVICE_NAME`, **and** set `NODE_ENV=development` for the
+   affected service. The service will boot but will be visibly
+   misconfigured (Sentry / metrics / `BETTER_AUTH_TOKEN_ENC_KEY`
+   warnings will surface).
+3. Document the reason in an incident ticket and remove the override
+   immediately after.
+
+### What to monitor
+
+- Railway boot crash-loop alerts (`Error: AI_QUOTA_DISABLED MUST NOT be
+set in production`) — fires the moment the misconfig hits.
+- Anthropic billing dashboard daily spend — secondary signal if the
+  hard-block is somehow bypassed.
+- `ai_quota_blocks_total` (Prometheus counter) — sustained zero in
+  production while traffic is non-zero is a smoke signal.
+
+## Related docs
+
+- ADR-0042 — `docs/adr/0042-password-hashing-strategy.md` (similar
+  fail-closed pattern for bcrypt 72-byte cap).
+- `docs/security/rate-limit-failure-mode.md` — same fail-closed mental
+  model for `/api/auth/*`.
+- `docs/planning/stack-pulse-2026-05/pr-15-ai-quota-disabled-hardblock.md`
+  — original plan record.


### PR DESCRIPTION
## Summary

Implements **PR-15 / H9** from `docs/planning/stack-pulse-2026-05/`. `AI_QUOTA_DISABLED` is a fail-open kill-switch on the per-user / per-IP AI quota subsystem, intentionally true in CI so e2e suites can hammer the real Anthropic API without burning user quota. In production a stray copy-paste or helm-typo would let any client burn unlimited Anthropic budget. The previous safeguard was a single module-load `logger.warn` that was indistinguishable from dozens of other startup warnings and got missed.

This PR replaces the advisory log with a **fail-fast startup throw** so a misconfigured deploy refuses to boot rather than silently leaking budget.

## Changes

- `apps/server/src/env/env.ts` — `AI_QUOTA_DISABLED` is now a typed boolean (`enum(["true", "false", "1", "0", ""]).default("false").transform(...)`). `assertStartupEnv()` throws when `isProduction && env.AI_QUOTA_DISABLED`. `isProduction` covers `NODE_ENV=production` AND any `RAILWAY_ENVIRONMENT` / `RAILWAY_SERVICE_NAME` value.
- `apps/server/src/env.ts` — mirror with `parseBoolEnv` default `false` so the legacy and zod env modules stay in sync until PR-01 unify lands.
- `apps/server/src/modules/chat/aiQuota.ts` — `isAiQuotaDisabled()` now accepts both `1` and `true` (matches the typed env transform). The module-load `logger.warn` is dropped because the startup hard-block supersedes it.
- `apps/server/src/env/__tests__/assertStartupEnv.test.ts` (new) — 9-case matrix covering production + truthy/falsy spellings, Railway-env-without-`NODE_ENV`, and the test/development allow paths.
- `.github/workflows/extended-e2e.yml` — explicitly sets `NODE_ENV: test` in the job env so the workflow keeps booting after the hard-block ships.
- `.env.example` — extended `AI_QUOTA_DISABLED` comment to flag the prod hard-block and reference the new runbook.
- `docs/security/ai-quota-kill-switch.md` (new) — full runbook (why the kill-switch exists, why prod is hard-blocked, allowed-configurations matrix, test coverage, operational guidance, monitoring).
- `docs/planning/stack-pulse-2026-05/pr-15-ai-quota-disabled-hardblock.md` — `Status: Planned` -> `In review`, owner -> Devin.

## Allowed configurations

| Environment | `AI_QUOTA_DISABLED` | Behaviour |
|---|---|---|
| Local dev (`NODE_ENV=development`) | any | Allowed |
| CI (`NODE_ENV=test`) | any | Allowed |
| Production (`NODE_ENV=production`) | `false` / unset | Allowed (default) |
| Production (`NODE_ENV=production`) | `true` / `1` | **Hard-block** — server refuses to boot |
| Railway (`RAILWAY_ENVIRONMENT=*`) | `true` / `1` | **Hard-block** — server refuses to boot |

## Test plan

- New `assertStartupEnv.test.ts` — full matrix, see file.
- Existing `aiQuota.test.ts` — unchanged, still uses `process.env.AI_QUOTA_DISABLED` mutations at runtime; relaxed `isAiQuotaDisabled()` accepts both `1` and `true` and was verified against existing tests by inspection (no test mutates to `true` today).
- `extended-e2e.yml` will continue to boot because `NODE_ENV: test` is now set explicitly in the job env block.

## Risks & mitigations

- **CI workflows that set `AI_QUOTA_DISABLED=1` without `NODE_ENV=test` would crash.** Audited: `ci.yml` and `visual-regression.yml` already pass `NODE_ENV=test` via vitest / playwright defaults. `extended-e2e.yml` was the one outlier and is fixed in this PR.
- **Production rollback path**: setting `AI_QUOTA_DISABLED=false` or unsetting it removes the hard-block. There is no schema migration so rollback is a single env-var change.

## Out of scope

- The `cost_tracking` daily $-cap and Sentry / Slack alerting from the original plan acceptance criteria — those are a separate workstream owned by ops, tracked back to the planning doc.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hard-blocks server startup in production if `AI_QUOTA_DISABLED` is truthy to prevent unlimited Anthropic spend; the flag remains allowed in test/dev for e2e runs.

- **New Features**
  - Added fail-fast check in `assertStartupEnv()` that throws when in production (or any `RAILWAY_*` env) and `AI_QUOTA_DISABLED` is true/`1`.
  - Typed `AI_QUOTA_DISABLED` as a boolean in the validated env; accepts `true|1|false|0` (default `false`). Mirrored in legacy `env.ts`.
  - Updated `isAiQuotaDisabled()` to accept `true` and `1`; removed the old module-load warning.
  - New tests cover prod/test/dev and Railway cases.
  - Updated `.env.example`, added `docs/security/ai-quota-kill-switch.md`, and set `NODE_ENV: test` in `extended-e2e.yml`.

- **Migration**
  - Ensure CI/e2e jobs export `NODE_ENV=test` when using `AI_QUOTA_DISABLED=1`.
  - In production, unset `AI_QUOTA_DISABLED` or set it to `false` before deploy.

<sup>Written for commit fd64058616694420ac3affe0e27bd932c66629ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new environment variable for AI quota configuration management.
  * Enhanced environment validation with production startup safeguards.
  * Updated GitHub Actions workflow configuration.
  * Added comprehensive documentation for quota management policies.

* **Tests**
  * Added test coverage for environment startup validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->