### PR TITLE
docs(docs): add posthog ftux dashboards runbook (S0.5)

### DIFF
--- a/docs/observability/posthog-ftux-dashboards.md
+++ b/docs/observability/posthog-ftux-dashboards.md
@@ -1,0 +1,331 @@
+# PostHog FTUX dashboards — runbook
+
+> **Last validated:** 2026-05-03 by @Skords-01. **Next review:** 2026-08-01.
+> **Status:** Active
+
+Operational runbook for PostHog (Cloud EU) dashboards that monitor the
+First-Time User Experience (FTUX) funnel. Owns the contracts that
+[`apps/web/src/core/observability/analytics.ts`](../../apps/web/src/core/observability/analytics.ts)
+must respect when firing canonical events — payload field names below
+are normative for all `trackEvent(...)` callsites.
+
+> **Cross-refs:**
+> [`docs/observability/frontend.md`](./frontend.md) — analytics
+> transport · [`docs/launch/ftux-sprint-plan.md` §2](../launch/ftux-sprint-plan.md#2-sprint-0--analytics-live-1-тиждень)
+> — Sprint 0 deliverable spec (this doc is **S0.5**) ·
+> [`docs/launch/01-monetization-and-pricing.md` §7](../launch/01-monetization-and-pricing.md)
+> — activation baseline · [`packages/shared/src/lib/analyticsEvents.ts`](../../packages/shared/src/lib/analyticsEvents.ts)
+> — canonical event names (single source of truth).
+
+---
+
+## 1. Where this lives in PostHog
+
+- **Account:** Sergeant Cloud EU (host `https://eu.i.posthog.com`).
+- **Project:** `sergeant-prod` (separate `sergeant-staging` project for
+  preview deployments — same dashboards, separate data).
+- **Folder:** `Dashboards → FTUX` — five insights below + one umbrella
+  dashboard `FTUX overview` that pins all five tiles in a 2×3 grid.
+- **Permissions:** founders + on-call SRE have `Dashboard collaborator`.
+  Anyone else with PostHog access can view but not edit.
+
+> **Founder-task:** create the five insights via PostHog UI (HogQL +
+> Insight builder), pin to `FTUX overview` dashboard, paste live links
+> back into the «Screenshot» column of §3 below. Until then the table
+> uses placeholder URLs — links are dead in this commit on purpose so
+> the diff is review-friendly.
+
+---
+
+## 2. Canonical events consumed
+
+Every insight in §3 reads from a subset of these canonical events.
+**All names are frozen** — see
+[`analyticsEvents.ts`](../../packages/shared/src/lib/analyticsEvents.ts).
+
+| Event                            | Fired by                                                           | Required payload                                                                    |
+| -------------------------------- | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| `onboarding_started`             | `OnboardingWizard.tsx` mount                                       | —                                                                                   |
+| `onboarding_step_viewed`         | `OnboardingWizard.tsx` step render                                 | `step: "welcome" \| "modules" \| "ready"`                                           |
+| `onboarding_step_completed`      | `OnboardingWizard.tsx` step exit                                   | `step`, `durationMs: number`                                                        |
+| `onboarding_skipped`             | `OnboardingWizard.tsx` early-exit                                  | `step`                                                                              |
+| `onboarding_vibe_picked`         | `OnboardingWizard.tsx#finish`                                      | `picks: string[]`, `picksCount: number`                                             |
+| `onboarding_completed`           | `OnboardingWizard.tsx#finish`                                      | `intent: "vibe_picked" \| "vibe_empty"`, `picksCount: number`                       |
+| `onboarding_first_action_shown`  | `FirstActionSheet.tsx` open                                        | `module: string`, `source: "auto" \| "user"`                                        |
+| `onboarding_first_action_picked` | `FirstActionSheet.tsx` choose                                      | `module: string`, `action: string`                                                  |
+| `ftux_preset_sheet_shown`        | `PresetSheet.tsx` open                                             | `module: string`                                                                    |
+| `ftux_preset_picked`             | `PresetSheet.tsx` choose preset                                    | `module: string`, `presetId: string`                                                |
+| `ftux_preset_custom`             | `PresetSheet.tsx` skip-presets path                                | `module: string`                                                                    |
+| `first_real_entry`               | `firstRealEntry.ts#detectFirstRealEntry` (web + mobile via shared) | —                                                                                   |
+| `ftux_time_to_value`             | `firstRealEntry.ts#detectFirstRealEntry` once when flag flips      | `durationMs: number`, `durationSec: number`                                         |
+| `celebration_shown`              | `CelebrationModal.tsx` open                                        | `ttvMs: number \| null`, `source: "first_entry" \| "streak" \| "milestone"`         |
+| `module_checklist_shown`         | `ModuleChecklist.tsx` first paint per module                       | `module: DashboardModuleId`                                                         |
+| `module_checklist_step_done`     | `ModuleChecklist.tsx#handleStepDone`                               | `module: DashboardModuleId`, `stepId: string`, `completed: number`, `total: number` |
+| `module_checklist_dismissed`     | `ModuleChecklist.tsx#handleDismiss`                                | `module: DashboardModuleId`, `completed: number`, `total: number`                   |
+| `streak_milestone_reached`       | `StreakCelebration.tsx` mount when crossing milestone              | `days: number`, `type: "toast" \| "modal"`                                          |
+| `hint_dismissed`                 | `HintsOrchestrator.tsx` user dismiss                               | `id: string`                                                                        |
+| `hint_completed`                 | `HintsOrchestrator.tsx` underlying action satisfied                | `id: string`                                                                        |
+| `budget_set`                     | `apps/web/src/modules/finyk/pages/budgets/Budgets.tsx`             | `bucket: string`, `amount: number`, `currency: string`                              |
+
+**Super-properties** (registered via `posthog.register`, set in
+[`apps/web/src/core/observability/posthog.ts`](../../apps/web/src/core/observability/posthog.ts)):
+
+- `platform: "web" | "ios" | "android"`
+- `is_capacitor: boolean`
+
+**Person-properties** (set via `identifyPostHogUser`, see
+[`apps/web/src/core/observability/identifyTraits.ts`](../../apps/web/src/core/observability/identifyTraits.ts)):
+
+- `vibe: string[]` — module picks
+- `plan: "free" | "plus" | "pro"`
+- `locale: string`
+- `signup_date: ISO8601`
+
+> **Contract rule:** the field names above are stable. Do **not** rename
+> them in payloads without bumping the dashboards in §3 — broken filters
+> silently zero out tiles for ≥7 days before someone notices.
+
+---
+
+## 3. The five saved insights
+
+All HogQL queries below assume the events table is `events` and that
+`person.properties` columns are populated by `identify`. Replace the
+placeholder screenshot URLs with live PostHog links once the insights
+are created.
+
+### 3.1 Activation funnel
+
+**Type:** Funnel (steps — strict sequence) · **Time range:** Last 28
+days · **Breakdown:** `vibe` (person property) · **Conversion window:**
+24 hours.
+
+**Steps (in order):**
+
+1. `onboarding_started`
+2. `onboarding_step_viewed` (any step)
+3. `onboarding_step_completed` (any step)
+4. `onboarding_vibe_picked`
+5. `onboarding_first_action_picked`
+6. `ftux_preset_picked` **OR** `ftux_preset_custom`
+7. `first_real_entry`
+8. `celebration_shown` (filter: `source = "first_entry"`)
+
+**Why:** end-to-end funnel from wizard mount to celebrated first real
+entry. **No gaps allowed** — if any step has 0 events the funnel
+short-circuits to 0% activation, which is the canary the entire FTUX
+sprint depends on.
+
+**Targets:** see [§5](#5-alert-thresholds).
+
+**Screenshot:** _TBD founder-task — paste PostHog `Dashboards → FTUX →
+Activation funnel` link here once created._
+
+### 3.2 TTV histogram
+
+**Type:** Trends (Distribution) · **Event:** `ftux_time_to_value` ·
+**Aggregation:** numeric histogram on `properties.durationSec` ·
+**Bucket size:** 30 seconds · **Time range:** Last 28 days.
+
+**HogQL:**
+
+```sql
+SELECT
+  toStartOfInterval(toFloat(properties.durationSec) / 30, INTERVAL 1 SECOND) AS bucket_30s,
+  count() AS users
+FROM events
+WHERE event = 'ftux_time_to_value'
+  AND timestamp > now() - INTERVAL 28 DAY
+  AND toFloat(properties.durationSec) BETWEEN 0 AND 1800
+GROUP BY bucket_30s
+ORDER BY bucket_30s
+```
+
+**Why:** TTV (time-to-value) p50 is the single number that summarizes
+"how long until the user gets to _their data_". Histogram shape is more
+informative than a single percentile — bimodal distribution means the
+preset path and the manual path are diverging.
+
+**Targets:** p50 < 90 sec (per
+[`ftux-sprint-plan.md` §8](../launch/ftux-sprint-plan.md#8-roll-up-success-metrics-dashboard)) ·
+p95 < 600 sec (10 min) — anything beyond is a stuck user, not a slow
+one.
+
+**Screenshot:** _TBD founder-task._
+
+### 3.3 Vibe → first-entry per module
+
+**Type:** Trends · **Series:** `first_real_entry` · **Breakdown:**
+person property `vibe` (array — PostHog flattens) · **Filter:** `event
+property module ∈ {finyk, fizruk, routine, nutrition}` (set by the
+emitting hook) · **Time range:** Last 28 days.
+
+**Why:** detects the audit's "vibe-blind primary action" failure mode.
+If a user picks `finyk` only and the first real entry overwhelmingly
+arrives in `nutrition`, the FTUX flow is suggesting the wrong primary
+action. We expect a strong correlation diagonal — most-picked vibe ==
+module of first entry.
+
+**Reads as:** matrix `vibe-pick × first-entry-module`. Off-diagonal mass
+
+> 30% means the recommendation engine is misaligned with intent.
+
+**HogQL (matrix-shaped):**
+
+```sql
+SELECT
+  arrayJoin(person.properties.vibe) AS vibe,
+  properties.module AS first_entry_module,
+  count() AS users
+FROM events
+WHERE event = 'first_real_entry'
+  AND timestamp > now() - INTERVAL 28 DAY
+GROUP BY vibe, first_entry_module
+ORDER BY users DESC
+```
+
+**Screenshot:** _TBD founder-task._
+
+### 3.4 D1/D7 retention by signup-cohort
+
+**Type:** Retention · **Cohortizing event:** `onboarding_started`
+(first event per user — cohort = `properties.signup_date` truncated to
+day) · **Returning event:** any event in `["first_real_entry",
+"expense_added", "module_checklist_step_done", "celebration_shown"]` ·
+**Granularity:** Day · **Period:** 30 days back, 7 days forward.
+
+**Why:** D1 + D7 retention are the load-bearing metrics for the entire
+FTUX sprint. D1 measures whether the user came back at all; D7 measures
+whether the FTUX promise sustained beyond a single session of curiosity.
+
+**Targets:** D1 ≥ 35% · D7 ≥ 15% (baseline TBD in
+[`ftux-sprint-plan.md` §8](../launch/ftux-sprint-plan.md#8-roll-up-success-metrics-dashboard) —
+update both files together when the first 28 days of data land).
+
+**Screenshot:** _TBD founder-task._
+
+### 3.5 Celebration drop-off
+
+**Type:** Funnel · **Time range:** Last 28 days · **Conversion window:**
+6 hours.
+
+**Steps (strict sequence):**
+
+1. `celebration_shown` (filter: `source = "first_entry"`)
+2. **EITHER** `module_checklist_shown` **OR** `ftux_preset_picked`
+   **OR** any module-specific add (e.g. `expense_added`,
+   `module_checklist_step_done`) — use OR-step in PostHog.
+
+**Why:** the audit identifies celebration as a **terminal** screen —
+users see confetti and then bounce. This funnel quantifies the bounce.
+If step-2 conversion < 50% within 6 hours, the celebration modal is the
+de-facto exit point of the FTUX flow and S3.1 (module-aware
+CelebrationModal headlines, see
+[`ftux-sprint-plan.md` §5](../launch/ftux-sprint-plan.md#5-sprint-3--reward-у-правильний-момент--value-progress-2-тижні))
+needs to ship.
+
+**Screenshot:** _TBD founder-task._
+
+---
+
+## 4. Umbrella dashboard
+
+`Dashboards → FTUX overview` pins:
+
+| Slot | Tile                                                                                                             |
+| ---- | ---------------------------------------------------------------------------------------------------------------- |
+| 1    | §3.1 Activation funnel — full width, last 28 days, breakdown by `vibe`                                           |
+| 2    | §3.2 TTV histogram — half width                                                                                  |
+| 3    | §3.4 D1/D7 retention — half width                                                                                |
+| 4    | §3.3 Vibe → first-entry per module — full width                                                                  |
+| 5    | §3.5 Celebration drop-off — half width                                                                           |
+| 6    | Daily counters (single-stats): `onboarding_started`, `first_real_entry`, `celebration_shown` (last 24h, last 7d) |
+
+**Refresh cadence:** PostHog default (30 min). On-call rotates through
+the umbrella dashboard during morning standup.
+
+---
+
+## 5. Alert thresholds
+
+PostHog → **Alerts** (subscriptions, Slack `#sergeant-ftux-alerts`):
+
+| Alert                     | Source           | Condition                                            | Severity                                                                        |
+| ------------------------- | ---------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Funnel collapse           | §3.1 step 1→8    | overall conversion < 15% (7-day rolling)             | P1 — page on-call. Likely missing-event regression (S0.4 contract drift).       |
+| Wizard floor              | §3.1 step 1→4    | drop-off step 1→4 > 60% (7-day rolling)              | P2 — file Linear ticket. Hero copy / module picks are scaring users away.       |
+| TTV blow-out              | §3.2 histogram   | p50 > 180 sec (28-day window)                        | P2 — first-action recommendation is too vague or PresetSheet is empty.          |
+| Celebration is a dead end | §3.5 step 1→2    | conversion < 40% within 6h (7-day rolling)           | P2 — schedule S3.1 (module-aware celebration headlines).                        |
+| D1 retention regression   | §3.4 D1 cohort   | D1 < baseline − 5pp for any signup-cohort            | P1 — page on-call. Likely a user-facing regression on the hub.                  |
+| Funnel ZEROES             | any step in §3.1 | events count = 0 over 24h (and > 0 in the 7d before) | P1 — page on-call. **Always** indicates a deploy that broke `trackEvent` calls. |
+| FTUX_TIME_TO_VALUE silent | §3.2 series      | event count = 0 over 7d while `first_real_entry` > 0 | P1 — `markFirstActionStartedAt()` regression; TTV measurement is broken.        |
+
+> **Why P1 for "funnel ZEROES":** every previous outage where canonical
+> events stopped firing took 3–9 days to detect through dashboards
+> alone. A naked zero-count alert on **each** funnel step is the
+> cheapest leading indicator.
+
+---
+
+## 6. Runbook — adding a new insight
+
+When a new event lands in
+[`analyticsEvents.ts`](../../packages/shared/src/lib/analyticsEvents.ts)
+and you need a dashboard to monitor it, follow this checklist:
+
+1. **Frame the question.** What user behaviour or product hypothesis is
+   the insight checking? Write it as a single sentence in the PR
+   description (e.g. "Users who hit `streak_milestone_reached` at day 7
+   are 2× more likely to log a real entry on day 8."). If the question
+   is mushy, the dashboard will be too.
+2. **Pick the chart type.** Funnels for ordered sequences; trends for
+   over-time counts; retention for cohort-based stickiness; histograms
+   for distribution shape.
+3. **Write the HogQL** in the PostHog **Data exploration → SQL editor**
+   first. Validate the schema with `LIMIT 100` queries. Only after the
+   query returns the right data, lift it into a saved insight.
+4. **Pin to the umbrella dashboard.** Either `FTUX overview` (if FTUX-
+   relevant) or create a new domain-scoped dashboard
+   (`Dashboards → <Domain>`). Never let an insight live as a personal
+   bookmark — they rot inside a quarter.
+5. **Document in this file.** Add a row to §2 (if a new event), an
+   entry in §3 (the insight itself), and an alert threshold in §5 if it
+   warrants paging. The doc and the dashboard ship in the same PR.
+6. **Set an alert** if it materially affects activation, retention, or
+   billing. Never add a "nice to track" alert — alert fatigue is real
+   and costs us the P1 ones.
+7. **Add a screenshot link** in §3 once the insight is saved. Anyone
+   reading this doc should be able to land on the live tile in two
+   clicks.
+
+**Hard rules:**
+
+- Insights are **owned by docs** here, not by individual editors.
+  Drift = stale dashboard. The PR that adds an insight must update §3.
+- Never add a derived insight that consumes events not declared in §2.
+  If you need a new event, file a separate PR that wires it in
+  [`analyticsEvents.ts`](../../packages/shared/src/lib/analyticsEvents.ts)
+  - the call-site, **then** the insight PR. This keeps the funnel
+    contract atomic.
+- Every breakdown property must be either a super-property or a
+  person-property registered via `identify`. Never break down by
+  ad-hoc event payload fields — that creates cardinality time-bombs.
+
+---
+
+## 7. Open questions / TODOs
+
+- **Mobile parity (S0.3).** Until `apps/mobile` writes to PostHog
+  (planned in
+  [`ftux-sprint-plan.md` §2](../launch/ftux-sprint-plan.md#2-sprint-0--analytics-live-1-тиждень)
+  S0.3), all five insights here represent **web-only** users. The
+  super-property `platform` is already registered, so insights will
+  start segmenting cleanly the moment mobile lands without dashboard
+  edits.
+- **`signup_date` cohort precision.** Person-property is set on
+  identify, which fires on first authenticated session. Anonymous-only
+  users never get a `signup_date` and fall out of §3.4 retention.
+  Acceptable trade-off until soft-auth conversion uplift kicks in.
+- **A/B testing.** Sprint 5 (goal-first wizard) introduces feature
+  flags. When that lands, add a §3.6 insight that breaks down §3.1 by
+  the active variant.


### PR DESCRIPTION
## Summary

Adds `docs/observability/posthog-ftux-dashboards.md` per **S0.5** from [`docs/launch/ftux-sprint-plan.md`](https://github.com/Skords-01/Sergeant/blob/main/docs/launch/ftux-sprint-plan.md). 1st of 2 PRs from the [FTUX onboarding audit](https://github.com/Skords-01/Sergeant/blob/main/docs/audits/2026-05-03-ftux-onboarding-roast.md).

Why first: Sprint 0 explicitly states *«S0.5 (docs) → S0.4 (web events) → S0.3 (mobile)»* — the dashboard contracts dictate exactly how the missing events should fire payload, so they need to land before S0.4 wires them.

## What this defines

### 5 saved insights

1. **Activation funnel** — strict 8-step funnel `onboarding_started → step_viewed → step_completed → vibe_picked → first_action_picked → ftux_preset_picked → first_real_entry → celebration_shown`. No gaps.
2. **TTV histogram** — distribution of `ftux_time_to_value.durationSec`, 30s buckets, p50/p95 targets.
3. **Vibe → first-entry per module** — matrix of person.properties.vibe × `first_real_entry.module`. Detects the audit's «vibe-blind primary action» failure.
4. **D1/D7 retention by signup-cohort** — cohorted by `onboarding_started` truncated to day, returning event = any FTUX-meaningful action.
5. **Celebration drop-off** — short funnel from `celebration_shown` to a follow-up action within 6h. Quantifies the audit's «celebration is a dead end» finding.

### Canonical payload contracts (§2)

All fields and field-names in the doc are **normative** for `trackEvent(...)` callsites — payload contracts for `CELEBRATION_SHOWN`, `MODULE_CHECKLIST_*`, `ONBOARDING_STEP_*`, `STREAK_MILESTONE_REACHED`, `HINT_DISMISSED/COMPLETED` are the contract S0.4 must implement.

### Alert thresholds (§5)

P1/P2 thresholds for: funnel collapse, wizard floor, TTV blow-out, celebration dead-end, D1 regression, **funnel ZEROES** (single most useful canary), and `FTUX_TIME_TO_VALUE` silent-failure.

### Runbook (§6)

Checklist + hard rules for adding new insights without rotting the doc. Single rule that matters: every breakdown property must be a registered super-property or a person-property — never break down by ad-hoc payload fields (cardinality time-bomb).

## Scope

- **Pure docs**: no code changes, no event-firing changes (those land in PR #2 / S0.4).
- 0 LOC of code; 331 LOC of markdown (per S0.5 spec which budgets `LOC: 0` since it's docs-only).
- The screenshot links in §3 are TBD founder-task — the file flags them as such on purpose so the diff is review-friendly.

## Pre-existing CI noise

`pnpm lint` fails on a pre-existing unused-var error in `apps/server/src/http/rateLimit.ts` (function `checkRateLimitPgWithFallback`, introduced in commit `2f05a6a9` on `main`). Unrelated to this PR.

## Test plan

- ✅ `pnpm lint` — no docs-related issues (only the pre-existing server lint noise above).
- ✅ Markdown links resolve to existing files (cross-refs verified).
- ✅ Conventional Commits scope (`docs`) accepted by commitlint.
- N/A — typecheck/tests (no code changes).

---

_Assisted by Devin: https://app.devin.ai/sessions/2f88974f103c40c9976549040b5576de_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a PostHog FTUX dashboards runbook that defines the five required insights, canonical event payload contracts, alert thresholds, and an umbrella dashboard to monitor activation and time-to-value. Establishes the analytics contract for S0.4 so event wiring can proceed without ambiguity.

- **New Features**
  - Runbook at docs/observability/posthog-ftux-dashboards.md covering:
    - Five insights: activation funnel, TTV histogram, vibe→first-entry, D1/D7 retention, celebration drop‑off.
    - Canonical event names and payload fields for `trackEvent(...)` callsites.
    - Alert thresholds (e.g., funnel collapse, TTV blow‑out, funnel zeroes) and FTUX overview dashboard layout.
    - Rules to add new insights and prevent dashboard drift.

- **Migration**
  - Create the five insights in PostHog, pin to FTUX overview, and replace §3 screenshot placeholders with live links.
  - In S0.4, fire events with the defined payload shapes and enable alerts to `#sergeant-ftux-alerts`.
  - Data is web-only until mobile instrumentation lands in S0.3.

<sup>Written for commit 1c86e3c236f8f94a0b3de44ef54695feb792b19c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive observability runbook for PostHog First Time User Experience analytics, including event definitions, dashboard configuration, retention metrics, and alert thresholds to guide operational monitoring and setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->