### PR TITLE
feat(web): fire missing canonical FTUX events (S0.4)

### DIFF
--- a/apps/web/src/core/hints/HintsOrchestrator.tsx
+++ b/apps/web/src/core/hints/HintsOrchestrator.tsx
@@ -129,16 +129,27 @@ export function HintsOrchestrator({
 
       if (!msg) return;
 
+      // Track which hints the user actually engaged with vs. let
+      // time out. The flag is closed over by both callbacks so the
+      // dismiss-after-timeout fires only when no click happened.
+      let actionTaken = false;
+      const HINT_TIMEOUT_MS = 5000;
+
       const action =
         next === "ftux_open_chat"
           ? {
               label: "Відкрити чат",
               onClick: () => {
+                actionTaken = true;
                 try {
                   emitHubBus("openChat", {
                     message: "Що мені важливо сьогодні?",
                   });
                   trackEvent(ANALYTICS_EVENTS.HINT_CLICKED, { id: next });
+                  trackEvent(ANALYTICS_EVENTS.HINT_COMPLETED, {
+                    id: next,
+                    via: "action",
+                  });
                 } catch {
                   /* noop */
                 }
@@ -148,9 +159,14 @@ export function HintsOrchestrator({
             ? {
                 label: "Пошук",
                 onClick: () => {
+                  actionTaken = true;
                   try {
                     emitHubBus("openSearch", undefined);
                     trackEvent(ANALYTICS_EVENTS.HINT_CLICKED, { id: next });
+                    trackEvent(ANALYTICS_EVENTS.HINT_COMPLETED, {
+                      id: next,
+                      via: "action",
+                    });
                   } catch {
                     /* noop */
                   }
@@ -158,7 +174,19 @@ export function HintsOrchestrator({
               }
             : undefined;
 
-      toast.info(msg, 5000, action);
+      toast.info(msg, HINT_TIMEOUT_MS, action);
+
+      // A hint that times out without an action click counts as a
+      // passive dismissal — it surfaces in §3.5 of the dashboards
+      // doc as the «hint shown but never actioned» half of the
+      // hint-effectiveness ratio.
+      window.setTimeout(() => {
+        if (actionTaken) return;
+        trackEvent(ANALYTICS_EVENTS.HINT_DISMISSED, {
+          id: next,
+          via: "timeout",
+        });
+      }, HINT_TIMEOUT_MS);
     }
   }, [candidates, ctx, hasFirstRealEntry, showHints, toast]);
 

--- a/apps/web/src/core/hub/dashboard/dashboardCards.tsx
+++ b/apps/web/src/core/hub/dashboard/dashboardCards.tsx
@@ -1,12 +1,32 @@
-import { useMemo, type CSSProperties, type ReactNode } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
 import { cn } from "@shared/lib/ui/cn";
 import { Icon } from "@shared/components/ui/Icon";
 import { StreakBadge } from "@shared/components/ui/StreakFlame";
 import { safeReadLS, safeReadStringLS } from "@shared/lib/storage/storage";
 import { STORAGE_KEYS, countRealEntries } from "@sergeant/shared";
+import { ANALYTICS_EVENTS, trackEvent } from "../../observability/analytics";
 import { getWeekRange } from "../../insights/useWeeklyDigest";
 import { MODULE_CONFIGS, type ModuleId } from "./moduleConfigs";
 import { localStorageStore } from "./dashboardStore";
+
+const STREAK_MILESTONES = [7, 14, 21, 30, 60, 90, 100, 365] as const;
+
+function highestMilestoneCrossed(
+  current: number,
+  previous: number,
+): number | null {
+  for (let i = STREAK_MILESTONES.length - 1; i >= 0; i--) {
+    const m = STREAK_MILESTONES[i];
+    if (current >= m && previous < m) return m;
+  }
+  return null;
+}
 
 const PILL_MODULES: ModuleId[] = ["finyk", "routine", "nutrition", "fizruk"];
 
@@ -127,6 +147,38 @@ export function StreakIndicator() {
 
     return streaks[0]?.days ?? 0;
   }, []);
+
+  // Detect streak-milestone crossings on the hub itself rather than
+  // inside the (currently unused) `<StreakCelebration>` modal — that
+  // way the funnel sees `streak_milestone_reached` even when the
+  // celebration UI hasn't been wired into the dashboard yet. We seed
+  // `previousStreakRef` to `streak` on first mount so a returning user
+  // who already crossed a milestone doesn't get double-tracked.
+  const previousStreakRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (previousStreakRef.current === null) {
+      previousStreakRef.current = streak;
+      return;
+    }
+    const previous = previousStreakRef.current;
+    if (streak <= previous) {
+      previousStreakRef.current = streak;
+      return;
+    }
+    const crossed = highestMilestoneCrossed(streak, previous);
+    if (crossed !== null) {
+      trackEvent(ANALYTICS_EVENTS.STREAK_MILESTONE_REACHED, {
+        days: crossed,
+        // Hub renders a `<StreakBadge>` for every crossing; the modal
+        // (`<StreakCelebration>`) is a separate UI path that isn't
+        // mounted here yet. Keeping `type` on the payload lets PostHog
+        // segment by surface once the modal lands without a payload-
+        // shape change to chase.
+        type: "toast" as const,
+      });
+    }
+    previousStreakRef.current = streak;
+  }, [streak]);
 
   if (streak < 2) return null;
 

--- a/apps/web/src/core/onboarding/CelebrationModal.tsx
+++ b/apps/web/src/core/onboarding/CelebrationModal.tsx
@@ -10,6 +10,7 @@ import { cn } from "@shared/lib/ui/cn";
 import { Button } from "@shared/components/ui/Button";
 import { Icon } from "@shared/components/ui/Icon";
 import { hapticTap } from "@shared/lib/adapters/haptic";
+import { ANALYTICS_EVENTS, trackEvent } from "../observability/analytics";
 
 interface ConfettiParticle {
   id: number;
@@ -77,8 +78,12 @@ export function CelebrationModal({
       if (navigator.vibrate) {
         navigator.vibrate([50, 30, 50]);
       }
+      trackEvent(ANALYTICS_EVENTS.CELEBRATION_SHOWN, {
+        ttvMs,
+        source: "first_entry",
+      });
     }
-  }, [open]);
+  }, [open, ttvMs]);
 
   // Auto-dismiss after 10 seconds
   useEffect(() => {

--- a/apps/web/src/core/onboarding/ModuleChecklist.tsx
+++ b/apps/web/src/core/onboarding/ModuleChecklist.tsx
@@ -22,6 +22,7 @@ import {
   saveChecklistState,
   type DashboardModuleId,
 } from "@sergeant/shared";
+import { ANALYTICS_EVENTS, trackEvent } from "../observability/analytics";
 
 const MODULE_STYLES: Record<
   DashboardModuleId,
@@ -91,10 +92,15 @@ export function ModuleChecklist({
   const total = def.steps.length;
   const progress = total > 0 ? (completed / total) * 100 : 0;
 
-  // Mark as seen on first render
+  // Mark as seen on first render. Fire `module_checklist_shown` exactly
+  // once per (moduleId × mount) — `markChecklistSeen` is idempotent at
+  // the storage level but the analytics event is a true "first paint"
+  // signal for the funnel, so we tie it to the first time the effect
+  // fires for this module.
   useEffect(() => {
     if (!visible) return;
     markChecklistSeen(localStorageStore, moduleId);
+    trackEvent(ANALYTICS_EVENTS.MODULE_CHECKLIST_SHOWN, { module: moduleId });
   }, [visible, moduleId]);
 
   const handleStepDone = useCallback(
@@ -129,13 +135,27 @@ export function ModuleChecklist({
         onAction?.(action);
       }
 
+      const total = def.steps.length;
+      const completed = Math.min(
+        total,
+        getChecklistState(localStorageStore, moduleId).completedSteps.filter(
+          (s) => def.steps.some((step) => step.id === s),
+        ).length,
+      );
+      trackEvent(ANALYTICS_EVENTS.MODULE_CHECKLIST_STEP_DONE, {
+        module: moduleId,
+        stepId,
+        completed,
+        total,
+      });
+
       // Celebrate only on the transition to "all done"; auto-hide is handled
       // by the useEffect below so we don't double-fire setTimeout here.
       if (justCompleted) {
         toast.success(`${def.title}: перші кроки виконано! 🎉`, 4000);
       }
     },
-    [moduleId, onAction, def.steps.length, def.title, toast],
+    [moduleId, onAction, def.steps, def.title, toast],
   );
 
   useEffect(() => {
@@ -150,7 +170,12 @@ export function ModuleChecklist({
     hapticTap();
     dismissChecklist(localStorageStore, moduleId);
     setVisible(false);
-  }, [moduleId]);
+    trackEvent(ANALYTICS_EVENTS.MODULE_CHECKLIST_DISMISSED, {
+      module: moduleId,
+      completed,
+      total,
+    });
+  }, [moduleId, completed, total]);
 
   if (!visible) return null;
 

--- a/apps/web/src/core/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/core/onboarding/OnboardingWizard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "@shared/lib/ui/cn";
 import {
   safeReadStringLS,
@@ -351,8 +351,15 @@ export function OnboardingWizard({
     persistPicks(picks);
   }, [picks]);
 
+  // The wizard is a single-screen flow (welcome → finish), so the
+  // first paint counts as both `onboarding_started` and the welcome
+  // step's `onboarding_step_viewed`. Capture both in one effect so
+  // the funnel definition in `posthog-ftux-dashboards.md` stays a
+  // strict superset of `started`.
+  const startedAtRef = useRef(Date.now());
   useEffect(() => {
     trackEvent(ANALYTICS_EVENTS.ONBOARDING_STARTED);
+    trackEvent(ANALYTICS_EVENTS.ONBOARDING_STEP_VIEWED, { step: "welcome" });
   }, []);
 
   const togglePick = useCallback((id: string) => {
@@ -376,6 +383,10 @@ export function OnboardingWizard({
     trackEvent(ANALYTICS_EVENTS.ONBOARDING_VIBE_PICKED, {
       picks: chosen,
       picksCount: chosen.length,
+    });
+    trackEvent(ANALYTICS_EVENTS.ONBOARDING_STEP_COMPLETED, {
+      step: "welcome",
+      durationMs: Math.max(0, Date.now() - startedAtRef.current),
     });
     trackEvent(ANALYTICS_EVENTS.ONBOARDING_COMPLETED, {
       intent: hadEmptyPicks ? "vibe_empty" : "vibe_picked",

--- a/packages/shared/src/lib/firstRealEntry.ts
+++ b/packages/shared/src/lib/firstRealEntry.ts
@@ -19,6 +19,7 @@ import {
   markFirstRealEntryDone,
   saveTimeToValueMs,
 } from "./vibePicks";
+import { ANALYTICS_EVENTS } from "./analyticsEvents";
 import { readJSON, type KVStore } from "../storage/kv";
 
 // Storage keys inspected by `hasAnyRealEntry`. Centralised here so
@@ -168,10 +169,17 @@ export function countRealEntries(store: KVStore): number {
   return count;
 }
 
-/** Event names emitted by `detectFirstRealEntry` when the flag flips. */
+/**
+ * Event names emitted by `detectFirstRealEntry` when the flag flips.
+ *
+ * Re-export of the canonical names from `ANALYTICS_EVENTS` so call-sites
+ * that already import this module don't have to learn a second
+ * constant. Keeping the indirection prevents string drift between this
+ * file and `analyticsEvents.ts`.
+ */
 export const FIRST_REAL_ENTRY_EVENTS = {
-  FIRST_REAL_ENTRY: "first_real_entry",
-  FTUX_TIME_TO_VALUE: "ftux_time_to_value",
+  FIRST_REAL_ENTRY: ANALYTICS_EVENTS.FIRST_REAL_ENTRY,
+  FTUX_TIME_TO_VALUE: ANALYTICS_EVENTS.FTUX_TIME_TO_VALUE,
 } as const;
 
 export interface DetectFirstRealEntryOptions {


### PR DESCRIPTION
## Summary

Wires the **9 canonical analytics events** that the activation funnel defined in [`docs/observability/posthog-ftux-dashboards.md`](https://github.com/Skords-01/Sergeant/blob/main/docs/observability/posthog-ftux-dashboards.md) (S0.5, PR #1570) expects to consume but were missing on web. With S0.4 + S0.5 landed, **Sprint 0 from the FTUX audit (`docs/audits/2026-05-03-ftux-onboarding-roast.md`) is fully unblocked** — every step of the funnel now emits a real event with a documented payload.

> Не змінює UI, не додає залежностей. Усі події fire-and-forget через існуючий `trackEvent()` транспорт.

## Events wired (recommendation R5 від аудиту)

| Event | Surface | Payload | Source |
| --- | --- | --- | --- |
| `celebration_shown` | `<CelebrationModal/>` (onboarding) | `{ ttvMs, source: "first_entry" }` | `apps/web/src/core/onboarding/CelebrationModal.tsx` |
| `module_checklist_shown` | `<ModuleChecklist/>` | `{ module }` | `apps/web/src/core/onboarding/ModuleChecklist.tsx` |
| `module_checklist_step_done` | `<ModuleChecklist/>` | `{ module, stepId, completed, total }` | ↑ |
| `module_checklist_dismissed` | `<ModuleChecklist/>` | `{ module, completed, total }` | ↑ |
| `onboarding_step_viewed` | `<OnboardingWizard/>` | `{ step: "welcome" }` | `apps/web/src/core/onboarding/OnboardingWizard.tsx` |
| `onboarding_step_completed` | `<OnboardingWizard/>` | `{ step: "welcome", durationMs }` | ↑ |
| `hint_completed` | `HintsOrchestrator` | `{ id, via: "action" }` | `apps/web/src/core/hints/HintsOrchestrator.tsx` |
| `hint_dismissed` | `HintsOrchestrator` (5s timeout, no click) | `{ id, via: "timeout" }` | ↑ |
| `streak_milestone_reached` | `<StreakIndicator/>` (hub) | `{ days, type: "toast" }` | `apps/web/src/core/hub/dashboard/dashboardCards.tsx` |

### Funnel after this PR

```
onboarding_started
  └─ onboarding_step_viewed       ← NEW (welcome)
       └─ onboarding_step_completed ← NEW (durationMs)
            └─ onboarding_vibe_picked
                 └─ onboarding_first_action_picked
                      └─ ftux_preset_picked
                           └─ first_real_entry  (+ ftux_time_to_value)
                                └─ celebration_shown ← NEW
```

Жодних gap-ів між кроками. Дашборди, що описані у §3 `posthog-ftux-dashboards.md`, тепер мають усі вхідні події.

## Implementation notes

### `streak_milestone_reached` — детект перетину на хабі, а не в модалці

`<StreakCelebration>` як UI ще не змонтований у хабі (експорт з `shared/components/ui` без споживача). Щоб не блокувати трекінг до моменту, коли його реально приземлять, я детектю перетин у `<StreakIndicator/>` через `useRef(prevStreak)` та `highestMilestoneCrossed(current, previous)` для віх `[7, 14, 21, 30, 60, 90, 100, 365]`. На першому маунті `previousStreakRef` сідає в поточне значення — у returning-юзера, який уже перетнув віху, повторного fire не буде.

### `hint_dismissed` — таймаут без кліку, а не явний закрит

`<Toast>` API не має кнопки «закрити», лише auto-dismiss після `duration`. Чесний сигнал «юзер побачив, але не зробив дію» — це таймаут без кліку. Я запускаю `setTimeout(HINT_TIMEOUT_MS)` поруч з `toast.info(...)` і вистрелюю `hint_dismissed { via: "timeout" }`, якщо `actionTaken` лишається `false`. Коли користувач клікає action — `actionTaken = true` і `hint_completed { via: "action" }`.

### `firstRealEntry.ts` — дедуп FIRST_REAL_ENTRY_EVENTS

`FIRST_REAL_ENTRY_EVENTS.{FIRST_REAL_ENTRY,FTUX_TIME_TO_VALUE}` тепер re-export з `ANALYTICS_EVENTS` замість дубльованих рядків. Це усуває drift-ризик між двома константами в `packages/shared/src/lib/`.

## Tests

- `pnpm --filter @sergeant/web lint` — clean
- `pnpm --filter @sergeant/web typecheck` — нові помилки в торкнутих файлах = 0; решта — pre-existing з `@sergeant/db-schema/sqlite/migrations` (workspace-package не зібраний у dev) і не пов'язані з цим PR
- `pnpm --filter @sergeant/web test` — 1851/1851 unit-тестів проходять; 10 файлів падають на тому ж pre-existing `db-schema` issue (sqliteReader / dualWrite intern-tests)
- `pnpm --filter @sergeant/shared test` — 472/472 проходять
- Husky `lint-staged` (eslint --fix --max-warnings=0 + prettier) пройшов на коміт

## Залишилось поза скоупом цього PR (логічно для S1+)

- `onboarding_skipped` — поточний one-screen wizard (v3) не має skip-шляху; емітити фейкову подію через empty-picks некоректно. Залишаю на момент, коли в дизайні з'явиться явна "Skip" affordance.
- Wiring `<StreakCelebration>` модалки в hub — окремий S1 task (UI-зміна, цей PR — тільки трекінг).
- `<Toast>` UI з кнопкою закрити (тоді `hint_dismissed { via: "user" }` стане можливим окремо від таймауту).

## Refs

- `docs/audits/2026-05-03-ftux-onboarding-roast.md` (R5 — instrument missing canonical events)
- `docs/observability/posthog-ftux-dashboards.md` (PR #1570) — payload contracts
- Sprint plan: S0.4 (`docs/specs/ftux-sprint-plan.md` §2)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired nine missing FTUX analytics events across onboarding, hints, checklists, and streaks so the activation funnel is fully instrumented and dashboards have complete data. No UI changes or new deps; events use existing `trackEvent()`.

- **New Features**
  - Onboarding: `onboarding_step_viewed` and `onboarding_step_completed` for the welcome step; includes `durationMs`.
  - First entry: `celebration_shown` with `{ ttvMs, source: "first_entry" }`.
  - Hints: `hint_completed` on action click and `hint_dismissed` on 5s timeout.
  - Module checklist: `module_checklist_shown`, `module_checklist_step_done`, `module_checklist_dismissed` with `{ module, completed, total }`.
  - Streaks: `streak_milestone_reached` when crossing `[7, 14, 21, 30, 60, 90, 100, 365]` with `{ days, type: "toast" }`.

- **Refactors**
  - Deduped `FIRST_REAL_ENTRY_EVENTS` in `@sergeant/shared` by re-exporting from `ANALYTICS_EVENTS` to avoid string drift.

<sup>Written for commit 90b0665ce3270b955f7bb5268251ca630ddf7eaa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced analytics tracking for user engagement with hints, onboarding flows, and milestone achievements.
  * Standardized event tracking across the application for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->