### PR TITLE
refactor(web): декомпонувати chatActions/types.ts 672 LOC на 6 доменних шарів (initiative 0001)

### DIFF
--- a/apps/web/src/core/lib/chatActions/types.cross.ts
+++ b/apps/web/src/core/lib/chatActions/types.cross.ts
@@ -1,0 +1,116 @@
+/**
+ * Крос-модульні chat-action payload-и: briefing, summary, аналітика,
+ * notes/memory, утиліти, export/import. Виокремлено з `types.ts`
+ * (initiative 0001 Phase 2).
+ */
+
+import type { ModuleAccent } from "@sergeant/design-tokens";
+
+// ─── Briefing / weekly summary ─────────────────────────────────────────────
+
+export interface MorningBriefingAction {
+  name: "morning_briefing";
+  input: Record<string, never>;
+}
+
+export interface WeeklySummaryAction {
+  name: "weekly_summary";
+  input: { include_recommendations?: boolean };
+}
+
+// ─── Goal / progress ───────────────────────────────────────────────────────
+
+export interface SetGoalAction {
+  name: "set_goal";
+  input: {
+    description: string;
+    target_weight_kg?: number | string;
+    target_date?: string;
+    daily_kcal?: number | string;
+    workouts_per_week?: number | string;
+  };
+}
+
+// ─── Аналітика (cross-module dashboards) ───────────────────────────────────
+
+export interface SpendingTrendAction {
+  name: "spending_trend";
+  input: { period_days?: number | string };
+}
+
+export interface WeightChartAction {
+  name: "weight_chart";
+  input: { period_days?: number | string };
+}
+
+export interface CategoryBreakdownAction {
+  name: "category_breakdown";
+  input: { period_days?: number | string };
+}
+
+export interface DetectAnomaliesAction {
+  name: "detect_anomalies";
+  input: {
+    period_days?: number | string;
+    threshold_multiplier?: number | string;
+  };
+}
+
+export type CompareWeeksModule = ModuleAccent;
+
+export interface CompareWeeksAction {
+  name: "compare_weeks";
+  input: {
+    week_a?: string;
+    week_b?: string;
+    modules?: CompareWeeksModule[];
+  };
+}
+
+// ─── Утиліти ───────────────────────────────────────────────────────────────
+
+export interface ConvertUnitsAction {
+  name: "convert_units";
+  input: { value: number | string; from: string; to: string };
+}
+
+// ─── Notes / memory ────────────────────────────────────────────────────────
+
+export interface SaveNoteAction {
+  name: "save_note";
+  input: { text: string; tag?: string };
+}
+
+export interface ListNotesAction {
+  name: "list_notes";
+  input: { tag?: string; limit?: number | string };
+}
+
+export interface ExportModuleDataAction {
+  name: "export_module_data";
+  input: { module: string; format?: string };
+}
+
+export interface RememberAction {
+  name: "remember";
+  input: { fact: string; category?: string };
+}
+
+export interface ForgetAction {
+  name: "forget";
+  input: { fact_id: string };
+}
+
+export interface MyProfileAction {
+  name: "my_profile";
+  input: { category?: string };
+}
+
+export interface RecallMemoryAction {
+  name: "recall_memory";
+  input: {
+    query: string;
+    top_k?: number | string;
+    sources?: string[];
+  };
+}

--- a/apps/web/src/core/lib/chatActions/types.finyk.ts
+++ b/apps/web/src/core/lib/chatActions/types.finyk.ts
@@ -1,0 +1,188 @@
+/**
+ * Finyk-доменні chat-action payload-и + share-shape entities (Budget,
+ * Debt, Receivable, MonthlyPlan). Виокремлено з `types.ts` (initiative
+ * 0001 Phase 2). Імпортуються через barrel `./types` без зміни
+ * шляхів у consumer-ах.
+ */
+
+// ─── Action payload-и ──────────────────────────────────────────────────────
+
+export interface ChangeCategoryAction {
+  name: "change_category";
+  input: { tx_id: string; category_id: string };
+}
+
+export interface FindTransactionAction {
+  name: "find_transaction";
+  input: {
+    query?: string;
+    amount?: number | string;
+    amount_tolerance?: number | string;
+    date_from?: string;
+    date_to?: string;
+    limit?: number | string;
+  };
+}
+
+export interface BatchCategorizeAction {
+  name: "batch_categorize";
+  input: {
+    pattern: string;
+    category_id: string;
+    dry_run?: boolean;
+    amount?: number | string;
+    amount_tolerance?: number | string;
+    date_from?: string;
+    date_to?: string;
+    limit?: number | string;
+  };
+}
+
+export interface CreateDebtAction {
+  name: "create_debt";
+  input: {
+    name: string;
+    amount: number | string;
+    due_date?: string;
+    emoji?: string;
+  };
+}
+
+export interface CreateReceivableAction {
+  name: "create_receivable";
+  input: { name: string; amount: number | string };
+}
+
+export interface HideTransactionAction {
+  name: "hide_transaction";
+  input: { tx_id: string };
+}
+
+export interface SetBudgetLimitAction {
+  name: "set_budget_limit";
+  input: { category_id: string; limit: number | string };
+}
+
+export interface SetMonthlyPlanAction {
+  name: "set_monthly_plan";
+  input: {
+    income?: number | string | null;
+    expense?: number | string | null;
+    savings?: number | string | null;
+  };
+}
+
+export interface CreateTransactionAction {
+  name: "create_transaction";
+  input: {
+    type?: string;
+    amount: number | string;
+    category?: string;
+    description?: string;
+    date?: string;
+  };
+}
+
+export interface DeleteTransactionAction {
+  name: "delete_transaction";
+  input: { tx_id: string };
+}
+
+export interface UpdateBudgetAction {
+  name: "update_budget";
+  input: {
+    scope: "limit" | "goal";
+    category_id?: string;
+    limit?: number | string;
+    name?: string;
+    target_amount?: number | string;
+    saved_amount?: number | string;
+  };
+}
+
+export interface MarkDebtPaidAction {
+  name: "mark_debt_paid";
+  input: {
+    debt_id: string;
+    amount?: number | string;
+    note?: string;
+  };
+}
+
+export interface AddAssetAction {
+  name: "add_asset";
+  input: {
+    name: string;
+    amount: number | string;
+    currency?: string;
+  };
+}
+
+export interface ImportMonobankRangeAction {
+  name: "import_monobank_range";
+  input: { from: string; to: string };
+}
+
+export interface SplitTransactionAction {
+  name: "split_transaction";
+  input: {
+    tx_id: string;
+    parts: Array<{ category_id: string; amount: number | string }>;
+  };
+}
+
+export interface RecurringExpenseAction {
+  name: "recurring_expense";
+  input: {
+    name: string;
+    amount: number | string;
+    day_of_month?: number | string;
+    category?: string;
+  };
+}
+
+export interface ExportReportAction {
+  name: "export_report";
+  input: { period?: string; from?: string; to?: string };
+}
+
+// ─── Domain entities (зберігаються в localStorage та повертаються з handler-ів) ─
+
+export interface BudgetLimit {
+  id: string;
+  type: "limit";
+  categoryId: string;
+  limit: number;
+}
+
+export interface BudgetGoal {
+  id: string;
+  type: "goal";
+  name: string;
+  targetAmount: number;
+  savedAmount?: number;
+}
+
+export type Budget = BudgetLimit | BudgetGoal;
+
+export interface Debt {
+  id: string;
+  name: string;
+  totalAmount: number;
+  dueDate: string;
+  emoji: string;
+  linkedTxIds: string[];
+}
+
+export interface Receivable {
+  id: string;
+  name: string;
+  amount: number;
+  linkedTxIds: string[];
+}
+
+export interface MonthlyPlan {
+  income?: string;
+  expense?: string;
+  savings?: string;
+}

--- a/apps/web/src/core/lib/chatActions/types.fizruk.ts
+++ b/apps/web/src/core/lib/chatActions/types.fizruk.ts
@@ -1,0 +1,135 @@
+/**
+ * Fizruk-доменні chat-action payload-и + Workout/WorkoutItem/WorkoutSet.
+ * Виокремлено з `types.ts` (initiative 0001 Phase 2). Імпортуються
+ * через barrel `./types` без зміни шляхів у consumer-ах.
+ */
+
+// ─── Action payload-и ──────────────────────────────────────────────────────
+
+export interface PlanWorkoutAction {
+  name: "plan_workout";
+  input: {
+    date?: string;
+    time?: string;
+    note?: string;
+    exercises?: Array<{
+      name: string;
+      sets?: number | string;
+      reps?: number | string;
+      weight?: number | string;
+    }>;
+  };
+}
+
+export interface LogSetAction {
+  name: "log_set";
+  input: {
+    exercise_name: string;
+    weight_kg?: number | string;
+    reps: number | string;
+    sets?: number | string;
+  };
+}
+
+export interface StartWorkoutAction {
+  name: "start_workout";
+  input: { note?: string; date?: string; time?: string };
+}
+
+export interface FinishWorkoutAction {
+  name: "finish_workout";
+  input: { workout_id?: string };
+}
+
+export interface LogMeasurementAction {
+  name: "log_measurement";
+  input: Record<string, number | string | undefined>;
+}
+
+export interface AddProgramDayAction {
+  name: "add_program_day";
+  input: {
+    weekday: number | string;
+    name: string;
+    exercises?: Array<{
+      name: string;
+      sets?: number | string;
+      reps?: number | string;
+      weight?: number | string;
+    }>;
+  };
+}
+
+export interface LogWellbeingAction {
+  name: "log_wellbeing";
+  input: {
+    weight_kg?: number | string;
+    sleep_hours?: number | string;
+    energy_level?: number | string;
+    mood_score?: number | string;
+    note?: string;
+  };
+}
+
+export interface LogWeightAction {
+  name: "log_weight";
+  input: { weight_kg: number | string; note?: string };
+}
+
+export interface SuggestWorkoutAction {
+  name: "suggest_workout";
+  input: { focus?: string };
+}
+
+export interface CopyWorkoutAction {
+  name: "copy_workout";
+  input: { source_workout_id?: string; date?: string };
+}
+
+export interface CompareProgressAction {
+  name: "compare_progress";
+  input: {
+    exercise_name?: string;
+    muscle_group?: string;
+    period_days?: number | string;
+  };
+}
+
+export interface Calculate1rmAction {
+  name: "calculate_1rm";
+  input: {
+    weight_kg: number | string;
+    reps: number | string;
+    exercise_name?: string;
+  };
+}
+
+// ─── Domain entities (зберігаються в localStorage / cloudSync) ──────────────
+
+export interface WorkoutSet {
+  weightKg: number;
+  reps: number;
+}
+
+export interface WorkoutItem {
+  id: string;
+  nameUk: string;
+  type: "strength";
+  musclesPrimary: string[];
+  musclesSecondary: string[];
+  sets: WorkoutSet[];
+  durationSec: number;
+  distanceM: number;
+}
+
+export interface Workout {
+  id: string;
+  startedAt: string;
+  endedAt: string | null;
+  items: WorkoutItem[];
+  groups: unknown[];
+  warmup: unknown | null;
+  cooldown: unknown | null;
+  note: string;
+  planned: boolean;
+}

--- a/apps/web/src/core/lib/chatActions/types.nutrition.ts
+++ b/apps/web/src/core/lib/chatActions/types.nutrition.ts
@@ -1,0 +1,103 @@
+/**
+ * Nutrition-доменні chat-action payload-и + NutritionMeal/NutritionDay.
+ * Виокремлено з `types.ts` (initiative 0001 Phase 2).
+ */
+
+// ─── Action payload-и ──────────────────────────────────────────────────────
+
+export interface LogMealAction {
+  name: "log_meal";
+  input: {
+    name?: string;
+    kcal?: number | string;
+    protein_g?: number | string;
+    fat_g?: number | string;
+    carbs_g?: number | string;
+  };
+}
+
+export interface LogWaterAction {
+  name: "log_water";
+  input: {
+    amount_ml: number | string;
+    date?: string;
+  };
+}
+
+export interface AddRecipeAction {
+  name: "add_recipe";
+  input: {
+    title: string;
+    ingredients?: string[];
+    steps?: string[];
+    servings?: number | string;
+    time_minutes?: number | string;
+    kcal?: number | string;
+    protein_g?: number | string;
+    fat_g?: number | string;
+    carbs_g?: number | string;
+  };
+}
+
+export interface AddToShoppingListAction {
+  name: "add_to_shopping_list";
+  input: {
+    name: string;
+    quantity?: string;
+    note?: string;
+    category?: string;
+  };
+}
+
+export interface ConsumeFromPantryAction {
+  name: "consume_from_pantry";
+  input: { name: string };
+}
+
+export interface SetDailyPlanAction {
+  name: "set_daily_plan";
+  input: {
+    kcal?: number | string;
+    protein_g?: number | string;
+    fat_g?: number | string;
+    carbs_g?: number | string;
+    water_ml?: number | string;
+  };
+}
+
+export interface SuggestMealAction {
+  name: "suggest_meal";
+  input: { focus?: string; meal_type?: string };
+}
+
+export interface CopyMealFromDateAction {
+  name: "copy_meal_from_date";
+  input: { source_date: string; meal_index?: number | string };
+}
+
+export interface PlanMealsForDayAction {
+  name: "plan_meals_for_day";
+  input: {
+    target_kcal?: number | string;
+    meals_count?: number | string;
+    preferences?: string;
+  };
+}
+
+// ─── Domain entities (зберігаються в localStorage) ──────────────────────────
+
+export interface NutritionMeal {
+  id: string;
+  name: string;
+  macros: {
+    kcal: number;
+    protein_g: number;
+    fat_g: number;
+    carbs_g: number;
+  };
+  addedAt: string;
+}
+
+export interface NutritionDay {
+  meals: NutritionMeal[];
+}

--- a/apps/web/src/core/lib/chatActions/types.result.ts
+++ b/apps/web/src/core/lib/chatActions/types.result.ts
@@ -1,0 +1,34 @@
+/**
+ * Result-shape для HubChat tool handler-ів.
+ *
+ * Виокремлено з `types.ts` (initiative 0001 Phase 2) — ці два типи не
+ * змінюються між доменами і потрібні усім handler-ам незалежно від
+ * модуля, тому живуть окремо від action-payload-ів.
+ */
+
+/**
+ * Виконані mutator-handler-и можуть опційно повернути об'єкт з полем
+ * `undo`, яке HubChat сам пропустить через `showUndoToast`. Read-only
+ * tools (`find_transaction`, `weekly_summary`, …) залишаються
+ * `string` — там нема що реверсити. Це навмисно дискриміноване
+ * об'єднання, а не загальне `unknown`-розширення: тип дозволяє
+ * перевіряти `typeof out === "string"` як «не було undo» без додаткових
+ * runtime-перевірок.
+ */
+export interface ChatActionUndoableResult {
+  /** Текст для `tool_result` (та чату). Identical до того, що раніше було сам по собі `string`. */
+  result: string;
+  /**
+   * Реверсує мутацію handler-а. Викликається з обробника `showUndoToast`
+   * у HubChat, тож має бути ідемпотентним і не кидати на повторний клік
+   * (показ undo-toast гарантує максимум одне натискання, але safer is safer).
+   */
+  undo: () => void;
+}
+
+/**
+ * Уніфікований результат handler-а. Старі handler-и далі повертають
+ * `string` без жодних змін; нові mutator-и повертають
+ * `ChatActionUndoableResult` коли мають reverse-snapshot.
+ */
+export type ChatActionResult = string | ChatActionUndoableResult;

--- a/apps/web/src/core/lib/chatActions/types.routine.ts
+++ b/apps/web/src/core/lib/chatActions/types.routine.ts
@@ -1,0 +1,85 @@
+/**
+ * Routine-доменні chat-action payload-и (habits + calendar) + HabitState.
+ * Виокремлено з `types.ts` (initiative 0001 Phase 2).
+ */
+
+// ─── Action payload-и ──────────────────────────────────────────────────────
+
+export interface MarkHabitDoneAction {
+  name: "mark_habit_done";
+  input: { habit_id: string; date?: string };
+}
+
+export interface CreateHabitAction {
+  name: "create_habit";
+  input: {
+    name: string;
+    emoji?: string;
+    recurrence?: string;
+    weekdays?: number[];
+    time_of_day?: string;
+  };
+}
+
+export interface CreateReminderAction {
+  name: "create_reminder";
+  input: { habit_id: string; time: string };
+}
+
+export interface CompleteHabitForDateAction {
+  name: "complete_habit_for_date";
+  input: { habit_id: string; date: string; completed?: boolean };
+}
+
+export interface ArchiveHabitAction {
+  name: "archive_habit";
+  input: { habit_id: string; archived?: boolean };
+}
+
+export interface AddCalendarEventAction {
+  name: "add_calendar_event";
+  input: { name: string; date: string; time?: string; emoji?: string };
+}
+
+export interface EditHabitAction {
+  name: "edit_habit";
+  input: {
+    habit_id: string;
+    name?: string;
+    emoji?: string;
+    recurrence?: string;
+    weekdays?: number[];
+  };
+}
+
+export interface ReorderHabitsAction {
+  name: "reorder_habits";
+  input: { habit_ids: string[] };
+}
+
+export interface HabitStatsAction {
+  name: "habit_stats";
+  input: { habit_id: string; period_days?: number | string };
+}
+
+export interface SetHabitScheduleAction {
+  name: "set_habit_schedule";
+  input: { habit_id: string; days: string[] };
+}
+
+export interface PauseHabitAction {
+  name: "pause_habit";
+  input: { habit_id: string; paused?: boolean };
+}
+
+export interface HabitTrendAction {
+  name: "habit_trend";
+  input: { habit_id?: string; period_days?: number | string };
+}
+
+// ─── Domain entities (зберігаються в localStorage) ──────────────────────────
+
+export interface HabitState {
+  habits: Array<{ id: string; name?: string; emoji?: string }>;
+  completions: Record<string, string[]>;
+}

--- a/apps/web/src/core/lib/chatActions/types.ts
+++ b/apps/web/src/core/lib/chatActions/types.ts
@@ -1,520 +1,213 @@
-import type { ModuleAccent } from "@sergeant/design-tokens";
+/**
+ * HubChat action-types barrel.
+ *
+ * Чисті action-payload-и + share-shape entities тепер живуть у
+ * `types.<domain>.ts` (initiative 0001 Phase 2 — module-decomposition).
+ * Цей файл лишається публічним entry-point-ом, тому жоден consumer
+ * (`./serverActions`, `./crossActions`, `./finykActions`,
+ * `./routineActions`, `./nutritionActions`, `./fizrukActions`, …)
+ * не змінює свої імпорти.
+ *
+ * Тут зосереджено лише дві речі:
+ *   1. Re-export усіх payload-ів і entities з доменних файлів.
+ *   2. Дискримінований union `ChatAction`, який мусить бачити їх усіх,
+ *      бо handler dispatch і Anthropic tool-schema спираються саме на нього.
+ */
+
+import type {
+  ChangeCategoryAction,
+  FindTransactionAction,
+  BatchCategorizeAction,
+  CreateDebtAction,
+  CreateReceivableAction,
+  HideTransactionAction,
+  SetBudgetLimitAction,
+  SetMonthlyPlanAction,
+  CreateTransactionAction,
+  DeleteTransactionAction,
+  UpdateBudgetAction,
+  MarkDebtPaidAction,
+  AddAssetAction,
+  ImportMonobankRangeAction,
+  SplitTransactionAction,
+  RecurringExpenseAction,
+  ExportReportAction,
+} from "./types.finyk";
+import type {
+  PlanWorkoutAction,
+  LogSetAction,
+  StartWorkoutAction,
+  FinishWorkoutAction,
+  LogMeasurementAction,
+  AddProgramDayAction,
+  LogWellbeingAction,
+  LogWeightAction,
+  SuggestWorkoutAction,
+  CopyWorkoutAction,
+  CompareProgressAction,
+  Calculate1rmAction,
+} from "./types.fizruk";
+import type {
+  MarkHabitDoneAction,
+  CreateHabitAction,
+  CreateReminderAction,
+  CompleteHabitForDateAction,
+  ArchiveHabitAction,
+  AddCalendarEventAction,
+  EditHabitAction,
+  ReorderHabitsAction,
+  HabitStatsAction,
+  SetHabitScheduleAction,
+  PauseHabitAction,
+  HabitTrendAction,
+} from "./types.routine";
+import type {
+  LogMealAction,
+  LogWaterAction,
+  AddRecipeAction,
+  AddToShoppingListAction,
+  ConsumeFromPantryAction,
+  SetDailyPlanAction,
+  SuggestMealAction,
+  CopyMealFromDateAction,
+  PlanMealsForDayAction,
+} from "./types.nutrition";
+import type {
+  MorningBriefingAction,
+  WeeklySummaryAction,
+  SetGoalAction,
+  SpendingTrendAction,
+  WeightChartAction,
+  CategoryBreakdownAction,
+  DetectAnomaliesAction,
+  CompareWeeksAction,
+  ConvertUnitsAction,
+  SaveNoteAction,
+  ListNotesAction,
+  ExportModuleDataAction,
+  RememberAction,
+  ForgetAction,
+  MyProfileAction,
+  RecallMemoryAction,
+} from "./types.cross";
+
+// Result-shape для handler-ів.
+export type {
+  ChatActionResult,
+  ChatActionUndoableResult,
+} from "./types.result";
+
+// Доменні re-export-и (action payloads + share-shape entities).
+export type {
+  // Action payloads
+  ChangeCategoryAction,
+  FindTransactionAction,
+  BatchCategorizeAction,
+  CreateDebtAction,
+  CreateReceivableAction,
+  HideTransactionAction,
+  SetBudgetLimitAction,
+  SetMonthlyPlanAction,
+  CreateTransactionAction,
+  DeleteTransactionAction,
+  UpdateBudgetAction,
+  MarkDebtPaidAction,
+  AddAssetAction,
+  ImportMonobankRangeAction,
+  SplitTransactionAction,
+  RecurringExpenseAction,
+  ExportReportAction,
+  // Domain entities
+  BudgetLimit,
+  BudgetGoal,
+  Budget,
+  Debt,
+  Receivable,
+  MonthlyPlan,
+} from "./types.finyk";
+
+export type {
+  // Action payloads
+  PlanWorkoutAction,
+  LogSetAction,
+  StartWorkoutAction,
+  FinishWorkoutAction,
+  LogMeasurementAction,
+  AddProgramDayAction,
+  LogWellbeingAction,
+  LogWeightAction,
+  SuggestWorkoutAction,
+  CopyWorkoutAction,
+  CompareProgressAction,
+  Calculate1rmAction,
+  // Domain entities
+  WorkoutSet,
+  WorkoutItem,
+  Workout,
+} from "./types.fizruk";
+
+export type {
+  // Action payloads
+  MarkHabitDoneAction,
+  CreateHabitAction,
+  CreateReminderAction,
+  CompleteHabitForDateAction,
+  ArchiveHabitAction,
+  AddCalendarEventAction,
+  EditHabitAction,
+  ReorderHabitsAction,
+  HabitStatsAction,
+  SetHabitScheduleAction,
+  PauseHabitAction,
+  HabitTrendAction,
+  // Domain entities
+  HabitState,
+} from "./types.routine";
+
+export type {
+  // Action payloads
+  LogMealAction,
+  LogWaterAction,
+  AddRecipeAction,
+  AddToShoppingListAction,
+  ConsumeFromPantryAction,
+  SetDailyPlanAction,
+  SuggestMealAction,
+  CopyMealFromDateAction,
+  PlanMealsForDayAction,
+  // Domain entities
+  NutritionMeal,
+  NutritionDay,
+} from "./types.nutrition";
+
+export type {
+  MorningBriefingAction,
+  WeeklySummaryAction,
+  SetGoalAction,
+  SpendingTrendAction,
+  WeightChartAction,
+  CategoryBreakdownAction,
+  DetectAnomaliesAction,
+  CompareWeeksAction,
+  CompareWeeksModule,
+  ConvertUnitsAction,
+  SaveNoteAction,
+  ListNotesAction,
+  ExportModuleDataAction,
+  RememberAction,
+  ForgetAction,
+  MyProfileAction,
+  RecallMemoryAction,
+} from "./types.cross";
 
 /**
- * Виконані mutator-handler-и можуть опційно повернути об'єкт з полем
- * `undo`, яке HubChat сам пропустить через `showUndoToast`. Read-only
- * tools (`find_transaction`, `weekly_summary`, …) залишаються
- * `string` — там нема що реверсити. Це навмисно дискриміноване
- * об'єднання, а не загальне `unknown`-розширення: тип дозволяє
- * перевіряти `typeof out === "string"` як «не було undo» без додаткових
- * runtime-перевірок.
+ * Дискримінований union усіх HubChat tool-payload-ів. Останній варіант —
+ * `{ name: string; input: Record<string, unknown> }` — навмисно широкий
+ * fallback для невідомих/нових tool-name-ів, які можуть прийти з
+ * Anthropic API (forward-compat) до того, як ми додамо сюди типи.
  */
-export interface ChatActionUndoableResult {
-  /** Текст для `tool_result` (та чату). Identical до того, що раніше було сам по собі `string`. */
-  result: string;
-  /**
-   * Реверсує мутацію handler-а. Викликається з обробника `showUndoToast`
-   * у HubChat, тож має бути ідемпотентним і не кидати на повторний клік
-   * (показ undo-toast гарантує максимум одне натискання, але safer is safer).
-   */
-  undo: () => void;
-}
-
-/**
- * Уніфікований результат handler-а. Старі handler-и далі повертають
- * `string` без жодних змін; нові mutator-и повертають
- * `ChatActionUndoableResult` коли мають reverse-snapshot.
- */
-export type ChatActionResult = string | ChatActionUndoableResult;
-
-export interface ChangeCategoryAction {
-  name: "change_category";
-  input: { tx_id: string; category_id: string };
-}
-
-export interface FindTransactionAction {
-  name: "find_transaction";
-  input: {
-    query?: string;
-    amount?: number | string;
-    amount_tolerance?: number | string;
-    date_from?: string;
-    date_to?: string;
-    limit?: number | string;
-  };
-}
-
-export interface BatchCategorizeAction {
-  name: "batch_categorize";
-  input: {
-    pattern: string;
-    category_id: string;
-    dry_run?: boolean;
-    amount?: number | string;
-    amount_tolerance?: number | string;
-    date_from?: string;
-    date_to?: string;
-    limit?: number | string;
-  };
-}
-
-export interface CreateDebtAction {
-  name: "create_debt";
-  input: {
-    name: string;
-    amount: number | string;
-    due_date?: string;
-    emoji?: string;
-  };
-}
-
-export interface CreateReceivableAction {
-  name: "create_receivable";
-  input: { name: string; amount: number | string };
-}
-
-export interface HideTransactionAction {
-  name: "hide_transaction";
-  input: { tx_id: string };
-}
-
-export interface SetBudgetLimitAction {
-  name: "set_budget_limit";
-  input: { category_id: string; limit: number | string };
-}
-
-export interface SetMonthlyPlanAction {
-  name: "set_monthly_plan";
-  input: {
-    income?: number | string | null;
-    expense?: number | string | null;
-    savings?: number | string | null;
-  };
-}
-
-export interface MarkHabitDoneAction {
-  name: "mark_habit_done";
-  input: { habit_id: string; date?: string };
-}
-
-export interface PlanWorkoutAction {
-  name: "plan_workout";
-  input: {
-    date?: string;
-    time?: string;
-    note?: string;
-    exercises?: Array<{
-      name: string;
-      sets?: number | string;
-      reps?: number | string;
-      weight?: number | string;
-    }>;
-  };
-}
-
-export interface LogMealAction {
-  name: "log_meal";
-  input: {
-    name?: string;
-    kcal?: number | string;
-    protein_g?: number | string;
-    fat_g?: number | string;
-    carbs_g?: number | string;
-  };
-}
-
-export interface CreateHabitAction {
-  name: "create_habit";
-  input: {
-    name: string;
-    emoji?: string;
-    recurrence?: string;
-    weekdays?: number[];
-    time_of_day?: string;
-  };
-}
-
-export interface CreateTransactionAction {
-  name: "create_transaction";
-  input: {
-    type?: string;
-    amount: number | string;
-    category?: string;
-    description?: string;
-    date?: string;
-  };
-}
-
-export interface LogSetAction {
-  name: "log_set";
-  input: {
-    exercise_name: string;
-    weight_kg?: number | string;
-    reps: number | string;
-    sets?: number | string;
-  };
-}
-
-export interface LogWaterAction {
-  name: "log_water";
-  input: {
-    amount_ml: number | string;
-    date?: string;
-  };
-}
-
-export interface DeleteTransactionAction {
-  name: "delete_transaction";
-  input: { tx_id: string };
-}
-
-export interface UpdateBudgetAction {
-  name: "update_budget";
-  input: {
-    scope: "limit" | "goal";
-    category_id?: string;
-    limit?: number | string;
-    name?: string;
-    target_amount?: number | string;
-    saved_amount?: number | string;
-  };
-}
-
-export interface MarkDebtPaidAction {
-  name: "mark_debt_paid";
-  input: {
-    debt_id: string;
-    amount?: number | string;
-    note?: string;
-  };
-}
-
-export interface AddAssetAction {
-  name: "add_asset";
-  input: {
-    name: string;
-    amount: number | string;
-    currency?: string;
-  };
-}
-
-export interface ImportMonobankRangeAction {
-  name: "import_monobank_range";
-  input: { from: string; to: string };
-}
-
-export interface StartWorkoutAction {
-  name: "start_workout";
-  input: { note?: string; date?: string; time?: string };
-}
-
-export interface FinishWorkoutAction {
-  name: "finish_workout";
-  input: { workout_id?: string };
-}
-
-export interface LogMeasurementAction {
-  name: "log_measurement";
-  input: Record<string, number | string | undefined>;
-}
-
-export interface AddProgramDayAction {
-  name: "add_program_day";
-  input: {
-    weekday: number | string;
-    name: string;
-    exercises?: Array<{
-      name: string;
-      sets?: number | string;
-      reps?: number | string;
-      weight?: number | string;
-    }>;
-  };
-}
-
-export interface LogWellbeingAction {
-  name: "log_wellbeing";
-  input: {
-    weight_kg?: number | string;
-    sleep_hours?: number | string;
-    energy_level?: number | string;
-    mood_score?: number | string;
-    note?: string;
-  };
-}
-
-export interface CreateReminderAction {
-  name: "create_reminder";
-  input: { habit_id: string; time: string };
-}
-
-export interface CompleteHabitForDateAction {
-  name: "complete_habit_for_date";
-  input: { habit_id: string; date: string; completed?: boolean };
-}
-
-export interface ArchiveHabitAction {
-  name: "archive_habit";
-  input: { habit_id: string; archived?: boolean };
-}
-
-export interface AddCalendarEventAction {
-  name: "add_calendar_event";
-  input: { name: string; date: string; time?: string; emoji?: string };
-}
-
-export interface AddRecipeAction {
-  name: "add_recipe";
-  input: {
-    title: string;
-    ingredients?: string[];
-    steps?: string[];
-    servings?: number | string;
-    time_minutes?: number | string;
-    kcal?: number | string;
-    protein_g?: number | string;
-    fat_g?: number | string;
-    carbs_g?: number | string;
-  };
-}
-
-export interface AddToShoppingListAction {
-  name: "add_to_shopping_list";
-  input: {
-    name: string;
-    quantity?: string;
-    note?: string;
-    category?: string;
-  };
-}
-
-export interface ConsumeFromPantryAction {
-  name: "consume_from_pantry";
-  input: { name: string };
-}
-
-export interface SetDailyPlanAction {
-  name: "set_daily_plan";
-  input: {
-    kcal?: number | string;
-    protein_g?: number | string;
-    fat_g?: number | string;
-    carbs_g?: number | string;
-    water_ml?: number | string;
-  };
-}
-
-export interface LogWeightAction {
-  name: "log_weight";
-  input: { weight_kg: number | string; note?: string };
-}
-
-export interface SuggestWorkoutAction {
-  name: "suggest_workout";
-  input: { focus?: string };
-}
-
-export interface CopyWorkoutAction {
-  name: "copy_workout";
-  input: { source_workout_id?: string; date?: string };
-}
-
-export interface CompareProgressAction {
-  name: "compare_progress";
-  input: {
-    exercise_name?: string;
-    muscle_group?: string;
-    period_days?: number | string;
-  };
-}
-
-export interface SplitTransactionAction {
-  name: "split_transaction";
-  input: {
-    tx_id: string;
-    parts: Array<{ category_id: string; amount: number | string }>;
-  };
-}
-
-export interface RecurringExpenseAction {
-  name: "recurring_expense";
-  input: {
-    name: string;
-    amount: number | string;
-    day_of_month?: number | string;
-    category?: string;
-  };
-}
-
-export interface ExportReportAction {
-  name: "export_report";
-  input: { period?: string; from?: string; to?: string };
-}
-
-export interface EditHabitAction {
-  name: "edit_habit";
-  input: {
-    habit_id: string;
-    name?: string;
-    emoji?: string;
-    recurrence?: string;
-    weekdays?: number[];
-  };
-}
-
-export interface ReorderHabitsAction {
-  name: "reorder_habits";
-  input: { habit_ids: string[] };
-}
-
-export interface HabitStatsAction {
-  name: "habit_stats";
-  input: { habit_id: string; period_days?: number | string };
-}
-
-export interface SetHabitScheduleAction {
-  name: "set_habit_schedule";
-  input: { habit_id: string; days: string[] };
-}
-
-export interface PauseHabitAction {
-  name: "pause_habit";
-  input: { habit_id: string; paused?: boolean };
-}
-
-export interface SuggestMealAction {
-  name: "suggest_meal";
-  input: { focus?: string; meal_type?: string };
-}
-
-export interface CopyMealFromDateAction {
-  name: "copy_meal_from_date";
-  input: { source_date: string; meal_index?: number | string };
-}
-
-export interface PlanMealsForDayAction {
-  name: "plan_meals_for_day";
-  input: {
-    target_kcal?: number | string;
-    meals_count?: number | string;
-    preferences?: string;
-  };
-}
-
-export interface MorningBriefingAction {
-  name: "morning_briefing";
-  input: Record<string, never>;
-}
-
-export interface WeeklySummaryAction {
-  name: "weekly_summary";
-  input: { include_recommendations?: boolean };
-}
-
-export interface SetGoalAction {
-  name: "set_goal";
-  input: {
-    description: string;
-    target_weight_kg?: number | string;
-    target_date?: string;
-    daily_kcal?: number | string;
-    workouts_per_week?: number | string;
-  };
-}
-
-export interface SpendingTrendAction {
-  name: "spending_trend";
-  input: { period_days?: number | string };
-}
-
-export interface WeightChartAction {
-  name: "weight_chart";
-  input: { period_days?: number | string };
-}
-
-export interface CategoryBreakdownAction {
-  name: "category_breakdown";
-  input: { period_days?: number | string };
-}
-
-export interface DetectAnomaliesAction {
-  name: "detect_anomalies";
-  input: {
-    period_days?: number | string;
-    threshold_multiplier?: number | string;
-  };
-}
-
-export interface HabitTrendAction {
-  name: "habit_trend";
-  input: { habit_id?: string; period_days?: number | string };
-}
-
-export type CompareWeeksModule = ModuleAccent;
-
-export interface CompareWeeksAction {
-  name: "compare_weeks";
-  input: {
-    week_a?: string;
-    week_b?: string;
-    modules?: CompareWeeksModule[];
-  };
-}
-
-export interface Calculate1rmAction {
-  name: "calculate_1rm";
-  input: {
-    weight_kg: number | string;
-    reps: number | string;
-    exercise_name?: string;
-  };
-}
-
-export interface ConvertUnitsAction {
-  name: "convert_units";
-  input: { value: number | string; from: string; to: string };
-}
-
-export interface SaveNoteAction {
-  name: "save_note";
-  input: { text: string; tag?: string };
-}
-
-export interface ListNotesAction {
-  name: "list_notes";
-  input: { tag?: string; limit?: number | string };
-}
-
-export interface ExportModuleDataAction {
-  name: "export_module_data";
-  input: { module: string; format?: string };
-}
-
-export interface RememberAction {
-  name: "remember";
-  input: { fact: string; category?: string };
-}
-
-export interface ForgetAction {
-  name: "forget";
-  input: { fact_id: string };
-}
-
-export interface MyProfileAction {
-  name: "my_profile";
-  input: { category?: string };
-}
-
-export interface RecallMemoryAction {
-  name: "recall_memory";
-  input: {
-    query: string;
-    top_k?: number | string;
-    sources?: string[];
-  };
-}
-
 export type ChatAction =
+  // finyk
   | ChangeCategoryAction
   | FindTransactionAction
   | BatchCategorizeAction
@@ -523,46 +216,52 @@ export type ChatAction =
   | HideTransactionAction
   | SetBudgetLimitAction
   | SetMonthlyPlanAction
-  | MarkHabitDoneAction
-  | PlanWorkoutAction
-  | LogMealAction
-  | CreateHabitAction
   | CreateTransactionAction
-  | LogSetAction
-  | LogWaterAction
   | DeleteTransactionAction
   | UpdateBudgetAction
   | MarkDebtPaidAction
   | AddAssetAction
   | ImportMonobankRangeAction
+  | SplitTransactionAction
+  | RecurringExpenseAction
+  | ExportReportAction
+  // fizruk
+  | PlanWorkoutAction
+  | LogSetAction
   | StartWorkoutAction
   | FinishWorkoutAction
   | LogMeasurementAction
   | AddProgramDayAction
   | LogWellbeingAction
-  | CreateReminderAction
-  | CompleteHabitForDateAction
-  | ArchiveHabitAction
-  | AddCalendarEventAction
-  | AddRecipeAction
-  | AddToShoppingListAction
-  | ConsumeFromPantryAction
-  | SetDailyPlanAction
   | LogWeightAction
   | SuggestWorkoutAction
   | CopyWorkoutAction
   | CompareProgressAction
-  | SplitTransactionAction
-  | RecurringExpenseAction
-  | ExportReportAction
+  | Calculate1rmAction
+  // routine
+  | MarkHabitDoneAction
+  | CreateHabitAction
+  | CreateReminderAction
+  | CompleteHabitForDateAction
+  | ArchiveHabitAction
+  | AddCalendarEventAction
   | EditHabitAction
   | ReorderHabitsAction
   | HabitStatsAction
   | SetHabitScheduleAction
   | PauseHabitAction
+  | HabitTrendAction
+  // nutrition
+  | LogMealAction
+  | LogWaterAction
+  | AddRecipeAction
+  | AddToShoppingListAction
+  | ConsumeFromPantryAction
+  | SetDailyPlanAction
   | SuggestMealAction
   | CopyMealFromDateAction
   | PlanMealsForDayAction
+  // cross
   | MorningBriefingAction
   | WeeklySummaryAction
   | SetGoalAction
@@ -570,9 +269,7 @@ export type ChatAction =
   | WeightChartAction
   | CategoryBreakdownAction
   | DetectAnomaliesAction
-  | HabitTrendAction
   | CompareWeeksAction
-  | Calculate1rmAction
   | ConvertUnitsAction
   | SaveNoteAction
   | ListNotesAction
@@ -582,91 +279,3 @@ export type ChatAction =
   | MyProfileAction
   | RecallMemoryAction
   | { name: string; input: Record<string, unknown> };
-
-export interface BudgetLimit {
-  id: string;
-  type: "limit";
-  categoryId: string;
-  limit: number;
-}
-
-export interface BudgetGoal {
-  id: string;
-  type: "goal";
-  name: string;
-  targetAmount: number;
-  savedAmount?: number;
-}
-
-export type Budget = BudgetLimit | BudgetGoal;
-
-export interface Debt {
-  id: string;
-  name: string;
-  totalAmount: number;
-  dueDate: string;
-  emoji: string;
-  linkedTxIds: string[];
-}
-
-export interface Receivable {
-  id: string;
-  name: string;
-  amount: number;
-  linkedTxIds: string[];
-}
-
-export interface MonthlyPlan {
-  income?: string;
-  expense?: string;
-  savings?: string;
-}
-
-export interface HabitState {
-  habits: Array<{ id: string; name?: string; emoji?: string }>;
-  completions: Record<string, string[]>;
-}
-
-export interface WorkoutSet {
-  weightKg: number;
-  reps: number;
-}
-
-export interface WorkoutItem {
-  id: string;
-  nameUk: string;
-  type: "strength";
-  musclesPrimary: string[];
-  musclesSecondary: string[];
-  sets: WorkoutSet[];
-  durationSec: number;
-  distanceM: number;
-}
-
-export interface Workout {
-  id: string;
-  startedAt: string;
-  endedAt: string | null;
-  items: WorkoutItem[];
-  groups: unknown[];
-  warmup: unknown | null;
-  cooldown: unknown | null;
-  note: string;
-  planned: boolean;
-}
-
-export interface NutritionMeal {
-  id: string;
-  name: string;
-  macros: {
-    kcal: number;
-    protein_g: number;
-    fat_g: number;
-    carbs_g: number;
-  };
-  addedAt: string;
-}
-
-export interface NutritionDay {
-  meals: NutritionMeal[];
-}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -777,7 +777,6 @@ export default [
       "apps/web/src/core/lib/hubChatContext.ts",
       "apps/web/src/core/hub/HubDashboard.tsx",
       "apps/web/src/modules/nutrition/components/DailyPlanCard.tsx",
-      "apps/web/src/core/lib/chatActions/types.ts",
       "apps/web/src/core/lib/chatActions/fizrukActions.ts",
       "apps/web/src/modules/fizruk/pages/Exercise.tsx",
       "apps/web/src/modules/finyk/pages/AssetsTable.tsx",

--- a/package.json
+++ b/package.json
@@ -74,9 +74,9 @@
   "devDependencies": {
     "@commitlint/cli": "^20.5.3",
     "@commitlint/config-conventional": "^20.5.3",
-    "@eslint/js": "^10.0.1",
+    "@eslint/js": "^9.39.4",
     "depcheck": "^1.4.7",
-    "eslint": "^10.3.0",
+    "eslint": "^9.39.4",
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-import": "^2.32.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,32 +29,32 @@ importers:
         specifier: ^20.5.3
         version: 20.5.3
       '@eslint/js':
-        specifier: ^10.0.1
-        version: 10.0.1(eslint@10.3.0(jiti@2.6.1))
+        specifier: ^9.39.4
+        version: 9.39.4
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
       eslint:
-        specifier: ^10.3.0
-        version: 10.3.0(jiti@2.6.1)
+        specifier: ^9.39.4
+        version: 9.39.4(jiti@2.6.1)
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@10.3.0(jiti@2.6.1))
+        version: 10.1.8(eslint@9.39.4(jiti@2.6.1))
       eslint-import-resolver-typescript:
         specifier: ^4.4.4
-        version: 4.4.4(eslint-plugin-import@2.32.0)(eslint@10.3.0(jiti@2.6.1))
+        version: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@10.3.0(jiti@2.6.1))
+        version: 2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
-        version: 6.10.2(eslint@10.3.0(jiti@2.6.1))
+        version: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react:
         specifier: ^7.37.2
-        version: 7.37.5(eslint@10.3.0(jiti@2.6.1))
+        version: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks:
         specifier: ^7.1.1
-        version: 7.1.1(eslint@10.3.0(jiti@2.6.1))
+        version: 7.1.1(eslint@9.39.4(jiti@2.6.1))
       globals:
         specifier: ^17.6.0
         version: 17.6.0
@@ -87,7 +87,7 @@ importers:
         version: 6.0.3
       typescript-eslint:
         specifier: ^8.59.1
-        version: 8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3)
+        version: 8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
 
   apps/console:
     dependencies:
@@ -2656,34 +2656,33 @@ packages:
     resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  '@eslint/config-array@0.23.5':
-    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  '@eslint/config-array@0.21.2':
+    resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/config-helpers@0.5.5':
-    resolution: {integrity: sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  '@eslint/config-helpers@0.4.2':
+    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/core@1.2.1':
-    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  '@eslint/core@0.17.0':
+    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/js@10.0.1':
-    resolution: {integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-    peerDependencies:
-      eslint: ^10.0.0
-    peerDependenciesMeta:
-      eslint:
-        optional: true
+  '@eslint/eslintrc@3.3.5':
+    resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/object-schema@3.0.5':
-    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  '@eslint/js@9.39.4':
+    resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/plugin-kit@0.7.1':
-    resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  '@eslint/object-schema@2.1.7':
+    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.4.1':
+    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@exodus/bytes@1.15.0':
     resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
@@ -4734,9 +4733,6 @@ packages:
 
   '@types/eslint@9.6.1':
     resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
-
-  '@types/esrecurse@4.3.1':
-    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -7117,21 +7113,25 @@ packages:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
 
-  eslint-scope@9.1.2:
-    resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   eslint-visitor-keys@5.0.1:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  eslint@10.3.0:
-    resolution: {integrity: sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  eslint@9.39.4:
+    resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -7139,9 +7139,9 @@ packages:
       jiti:
         optional: true
 
-  espree@11.2.0:
-    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
@@ -7864,6 +7864,10 @@ packages:
   global-prefix@1.0.2:
     resolution: {integrity: sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==}
     engines: {node: '>=0.10.0'}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
 
   globals@17.6.0:
     resolution: {integrity: sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==}
@@ -14086,38 +14090,50 @@ snapshots:
   '@esbuild/win32-x64@0.28.0':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.3.0(jiti@2.6.1))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.6.1))':
     dependencies:
-      eslint: 10.3.0(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.23.5':
+  '@eslint/config-array@0.21.2':
     dependencies:
-      '@eslint/object-schema': 3.0.5
+      '@eslint/object-schema': 2.1.7
       debug: 4.4.3
-      minimatch: 10.2.5
+      minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-helpers@0.5.5':
+  '@eslint/config-helpers@0.4.2':
     dependencies:
-      '@eslint/core': 1.2.1
+      '@eslint/core': 0.17.0
 
-  '@eslint/core@1.2.1':
+  '@eslint/core@0.17.0':
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/js@10.0.1(eslint@10.3.0(jiti@2.6.1))':
-    optionalDependencies:
-      eslint: 10.3.0(jiti@2.6.1)
-
-  '@eslint/object-schema@3.0.5': {}
-
-  '@eslint/plugin-kit@0.7.1':
+  '@eslint/eslintrc@3.3.5':
     dependencies:
-      '@eslint/core': 1.2.1
+      ajv: 6.15.0
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      minimatch: 3.1.5
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.39.4': {}
+
+  '@eslint/object-schema@2.1.7': {}
+
+  '@eslint/plugin-kit@0.4.1':
+    dependencies:
+      '@eslint/core': 0.17.0
       levn: 0.4.1
 
   '@exodus/bytes@1.15.0(@noble/hashes@2.2.0)':
@@ -16618,8 +16634,6 @@ snapshots:
       '@types/json-schema': 7.0.15
     optional: true
 
-  '@types/esrecurse@4.3.1': {}
-
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.8
@@ -16845,15 +16859,15 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.59.1(@typescript-eslint/parser@8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3))(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.59.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.59.1
-      '@typescript-eslint/type-utils': 8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.59.1
-      eslint: 10.3.0(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.6.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -16861,14 +16875,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.59.1
       '@typescript-eslint/types': 8.59.1
       '@typescript-eslint/typescript-estree': 8.59.1(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.59.1
       debug: 4.4.3
-      eslint: 10.3.0(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.6.1)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -16891,13 +16905,13 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.59.1
       '@typescript-eslint/typescript-estree': 8.59.1(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       debug: 4.4.3
-      eslint: 10.3.0(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.6.1)
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -16920,13 +16934,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.3.0(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.59.1
       '@typescript-eslint/types': 8.59.1
       '@typescript-eslint/typescript-estree': 8.59.1(typescript@6.0.3)
-      eslint: 10.3.0(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.6.1)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -19121,9 +19135,9 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-prettier@10.1.8(eslint@10.3.0(jiti@2.6.1)):
+  eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
-      eslint: 10.3.0(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.6.1)
 
   eslint-import-context@0.1.9(unrs-resolver@1.11.1):
     dependencies:
@@ -19140,10 +19154,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@10.3.0(jiti@2.6.1)):
+  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 4.4.3
-      eslint: 10.3.0(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.6.1)
       eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
       get-tsconfig: 4.14.0
       is-bun-module: 2.0.0
@@ -19151,22 +19165,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@10.3.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.4)(eslint@10.3.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3)
-      eslint: 10.3.0(jiti@2.6.1)
+      '@typescript-eslint/parser': 8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
+      eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0)(eslint@10.3.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@10.3.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -19175,9 +19189,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 10.3.0(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.4)(eslint@10.3.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -19189,13 +19203,13 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jsx-a11y@6.10.2(eslint@10.3.0(jiti@2.6.1)):
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       aria-query: 5.3.2
       array-includes: 3.1.9
@@ -19205,7 +19219,7 @@ snapshots:
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 10.3.0(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.6.1)
       hasown: 2.0.3
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
@@ -19214,18 +19228,18 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-react-hooks@7.1.1(eslint@10.3.0(jiti@2.6.1)):
+  eslint-plugin-react-hooks@7.1.1(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/parser': 7.29.3
-      eslint: 10.3.0(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.6.1)
       hermes-parser: 0.25.1
       zod: 4.4.2
       zod-validation-error: 4.0.2(zod@4.4.2)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react@7.37.5(eslint@10.3.0(jiti@2.6.1)):
+  eslint-plugin-react@7.37.5(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
@@ -19233,7 +19247,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.3.2
-      eslint: 10.3.0(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.6.1)
       estraverse: 5.3.0
       hasown: 2.0.3
       jsx-ast-utils: 3.3.5
@@ -19253,36 +19267,39 @@ snapshots:
       estraverse: 4.3.0
     optional: true
 
-  eslint-scope@9.1.2:
+  eslint-scope@8.4.0:
     dependencies:
-      '@types/esrecurse': 4.3.1
-      '@types/estree': 1.0.8
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
   eslint-visitor-keys@3.4.3: {}
 
+  eslint-visitor-keys@4.2.1: {}
+
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.3.0(jiti@2.6.1):
+  eslint@9.39.4(jiti@2.6.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.3.0(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.5
-      '@eslint/config-helpers': 0.5.5
-      '@eslint/core': 1.2.1
-      '@eslint/plugin-kit': 0.7.1
+      '@eslint/config-array': 0.21.2
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.5
+      '@eslint/js': 9.39.4
+      '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.8
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
       '@types/estree': 1.0.8
       ajv: 6.15.0
+      chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.3
       escape-string-regexp: 4.0.0
-      eslint-scope: 9.1.2
-      eslint-visitor-keys: 5.0.1
-      espree: 11.2.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
       esquery: 1.7.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
@@ -19293,7 +19310,8 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
-      minimatch: 10.2.5
+      lodash.merge: 4.6.2
+      minimatch: 3.1.5
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
@@ -19301,11 +19319,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  espree@11.2.0:
+  espree@10.4.0:
     dependencies:
       acorn: 8.16.0
       acorn-jsx: 5.3.2(acorn@8.16.0)
-      eslint-visitor-keys: 5.0.1
+      eslint-visitor-keys: 4.2.1
 
   esprima@4.0.1: {}
 
@@ -20169,6 +20187,8 @@ snapshots:
       ini: 1.3.8
       is-windows: 1.0.2
       which: 1.3.1
+
+  globals@14.0.0: {}
 
   globals@17.6.0: {}
 
@@ -24805,13 +24825,13 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typescript-eslint@8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3):
+  typescript-eslint@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.59.1(@typescript-eslint/parser@8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3))(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.59.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       '@typescript-eslint/typescript-estree': 8.59.1(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3)
-      eslint: 10.3.0(jiti@2.6.1)
+      '@typescript-eslint/utils': 8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
+      eslint: 9.39.4(jiti@2.6.1)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
## Summary

Phase 2 PR з [initiative 0001 — module decomposition](../blob/main/docs/initiatives/0001-module-decomposition.md). Розбиваю `apps/web/src/core/lib/chatActions/types.ts` (672 LOC) на 6 доменних файлів-сусідів і тонкий barrel.

| Файл                  | LOC | Призначення                                                                        |
| --------------------- | --- | ---------------------------------------------------------------------------------- |
| `types.result.ts`     |  34 | `ChatActionResult` + `ChatActionUndoableResult`                                    |
| `types.finyk.ts`      | 188 | finyk payload-и + `Budget`/`Debt`/`Receivable`/`MonthlyPlan`                       |
| `types.fizruk.ts`     | 135 | fizruk payload-и + `WorkoutSet`/`WorkoutItem`/`Workout`                            |
| `types.routine.ts`    |  85 | routine payload-и + `HabitState`                                                   |
| `types.nutrition.ts`  | 103 | nutrition payload-и + `NutritionMeal`/`NutritionDay`                               |
| `types.cross.ts`      | 116 | крос-модульні (briefing, summary, goal, аналітика, notes, memory, utility)        |
| **`types.ts`**        | 281 | Barrel: re-export усього + discriminated union `ChatAction` для dispatch          |

Жоден consumer не змінює свої import-и: `./serverActions`, `./crossActions`, `./finykActions`, `./routineActions`, `./nutritionActions`, `./fizrukActions`, `./hubChatActionCards`, `./hubChatActions` усі далі резолвлять `./types` / `../types` як раніше.

`eslint.config.js`: знімаю файл з `max-lines` allowlist — найбільший новий файл 281 LOC, `max-lines: 600` тримає себе сам.

## Governing Skill

- Primary skill: `sergeant-feature-delivery`
- Secondary skill (if truly needed): `sergeant-monorepo-boundaries`

## Playbook

- Primary playbook: n/a — точкова декомпозиція по плану з `docs/initiatives/0001-module-decomposition.md`.
- Why this playbook: ініціатива явно визначає Phase 2 PR `decomp-chat-actions-types` з очікуваною формою (Core leaves only ChatAction-result types; per-domain types у sibling-файлах).
- If no playbook matched, why: для decomposition-PR немає окремого playbook у `docs/playbooks/`.

## Verification

```bash
$ . ~/.nvm/nvm.sh && nvm use 20.20.2

# Lint — clean
$ pnpm exec eslint --max-warnings=0 \
    apps/web/src/core/lib/chatActions/types.ts \
    apps/web/src/core/lib/chatActions/types.{result,finyk,fizruk,routine,nutrition,cross}.ts
# (no output, exit 0)

# Typecheck — без нових chatActions помилок
$ pnpm --filter @sergeant/web typecheck 2>&1 | grep "chatActions"
# (нічого)

# Vitest — усі 7 chatActions test-files зелені
$ cd apps/web && pnpm exec vitest run src/core/lib/chatActions/
Test Files  7 passed (7)
     Tests  293 passed (293)
```

LOC verification:

```bash
$ wc -l apps/web/src/core/lib/chatActions/types*.ts
  116 types.cross.ts
  188 types.finyk.ts
  135 types.fizruk.ts
  103 types.nutrition.ts
   34 types.result.ts
   85 types.routine.ts
  281 types.ts
  942 total
```

Усі 7 файлів < 600 LOC; правило `max-lines: 600` тепер застосовується без винятку.

Additional checks:

- [x] Local smoke / manual validation completed — всі 293 chatActions vitest-тести зелені.
- [x] Surface-specific checks completed — public barrel export сумісний; HubChat dispatch (через `ChatAction` union) бачить ті самі payload-и.

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update. (Не потребує — `apps/web/src/core/lib/chatActions/**` ownership stable, тестовий стек той самий.)
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a у цьому PR — окремий docs PR оновить status table в `docs/initiatives/README.md` і Outcome у `docs/initiatives/0001-module-decomposition.md` після всієї серії decomp-* PR-ів.

## Risk and Rollout

- User-visible risk: **none** — це лише `.d.ts`-рівневий рефакторинг; runtime код незмінний. `ChatAction` union того самого складу (15 + 12 + 12 + 9 + 16 + fallback = 65 варіантів — 1:1 з оригіналом).
- Rollout / deploy order: можна merge'ити одразу після #1592 (eslint pin). Без міграцій, без env, без feature-flag. Bundle-розмір не змінюється — тип-only код.
- Backout plan: revert цього PR; types.ts повертається у вигляді одного 672-LOC файлу і знов потрапляє у `max-lines` allowlist.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

- Base = `devin/1777867828-fix-eslint-10-revert` (#1592). Як тільки той PR мерджиться у `main`, GitHub автоматично перецілить цей PR на `main` і diff залишиться чистим (тільки декомпозиція).
- Класифікація action-ів по доменах субʼєктивна: я використав `name`-prefix (`mark_habit_*` → routine, `log_meal`/`log_water`/`add_recipe` → nutrition, тощо). `LogWeightAction` і `LogWellbeingAction` тримаю у fizruk, бо handler-и для них живуть саме в `fizrukActions.ts`. Якщо буде бажання — переїде окремим shuffle-PR.
- Залишок Phase 2 (RoutineApp 745, Icon 660, sw 643) — окремими PR-ами.

---
Requested by Вася (steppupa@gmail.com)
Devin session: https://app.devin.ai/sessions/e8e3c286f0b346dd9796f650e94679db


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split `chatActions/types.ts` (672 LOC) into six domain files and a thin barrel to improve maintainability, with no import or runtime changes. Part of initiative 0001 (Phase 2) — module decomposition.

- **Refactors**
  - Added `types.result.ts`, `types.finyk.ts`, `types.fizruk.ts`, `types.routine.ts`, `types.nutrition.ts`, `types.cross.ts`; kept `types.ts` as a barrel and the single `ChatAction` union.
  - All consumers continue importing from `./types`; no API changes.
  - Removed `apps/web/src/core/lib/chatActions/types.ts` from ESLint `max-lines` allowlist; each new file < 600 LOC.

<sup>Written for commit 92d0a8faf98025ab5a07e5b511eec46479f8109b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

