### PR TITLE
refactor(web): decompose RoutineApp into thin composition root

### DIFF
--- a/apps/web/src/modules/routine/RoutineActions.tsx
+++ b/apps/web/src/modules/routine/RoutineActions.tsx
@@ -1,0 +1,53 @@
+/**
+ * Routine bottom actions: tab nav + the quick-add habit dialog.
+ *
+ * Split out of `RoutineApp.tsx` as part of the Phase 2 decomposition
+ * (initiative 0001). The bottom nav and the bottom-sheet dialog form
+ * a tight visual cluster — both anchor to the bottom of the viewport
+ * and react to the same "+ Add habit" affordance.
+ */
+
+import type { Dispatch, SetStateAction } from "react";
+import { HabitQuickCreateDialog } from "./components/HabitQuickCreateDialog";
+import { RoutineBottomNav } from "./components/RoutineBottomNav";
+import type { RoutineMainTab } from "./context/RoutineCalendarContext";
+import type { RoutineState } from "./lib/types";
+
+export interface RoutineActionsProps {
+  mainTab: RoutineMainTab;
+  setMainTab: Dispatch<SetStateAction<RoutineMainTab>>;
+  routine: RoutineState;
+  setRoutine: Dispatch<SetStateAction<RoutineState>>;
+  quickAddHabitOpen: boolean;
+  quickAddFocusTick: number;
+  onOpenQuickAddHabit: () => void;
+  onCloseQuickAddHabit: () => void;
+}
+
+export function RoutineActions({
+  mainTab,
+  setMainTab,
+  routine,
+  setRoutine,
+  quickAddHabitOpen,
+  quickAddFocusTick,
+  onOpenQuickAddHabit,
+  onCloseQuickAddHabit,
+}: RoutineActionsProps) {
+  return (
+    <>
+      <RoutineBottomNav
+        mainTab={mainTab}
+        onSelectTab={setMainTab}
+        onAddHabit={onOpenQuickAddHabit}
+      />
+      <HabitQuickCreateDialog
+        open={quickAddHabitOpen}
+        routine={routine}
+        setRoutine={setRoutine}
+        onClose={onCloseQuickAddHabit}
+        focusTick={quickAddFocusTick}
+      />
+    </>
+  );
+}

--- a/apps/web/src/modules/routine/RoutineApp.helpers.ts
+++ b/apps/web/src/modules/routine/RoutineApp.helpers.ts
@@ -1,0 +1,100 @@
+/**
+ * Pure helpers for the RoutineApp composition root.
+ *
+ * Split out as part of the Phase 2 decomposition (initiative 0001) so
+ * the composition root in `RoutineApp.tsx` stays under the 600-LOC
+ * lint guard. Nothing here depends on React — these are date math,
+ * grouping, and constant utilities that can be unit-tested without
+ * mounting a component tree.
+ */
+
+import {
+  dateKeyFromDate,
+  FIZRUK_GROUP_LABEL,
+} from "./lib/hubCalendarAggregate";
+import { FINYK_SUB_GROUP_LABEL } from "./lib/finykSubscriptionCalendar";
+import type { HubCalendarEvent } from "./lib/types";
+
+export interface MonthCursor {
+  y: number;
+  m: number;
+}
+
+export interface DateRange {
+  startKey: string;
+  endKey: string;
+}
+
+export const FIZRUK_PLAN_SYNC = "fizruk-storage-monthly-plan";
+
+export const HABIT_TIME_GROUPS = ["Ранок", "День", "Вечір", "Будь-коли"];
+
+export const GROUP_ORDER = [
+  ...HABIT_TIME_GROUPS,
+  FIZRUK_GROUP_LABEL,
+  FINYK_SUB_GROUP_LABEL,
+];
+
+export function todayDate(): Date {
+  const d = new Date();
+  d.setHours(12, 0, 0, 0);
+  return d;
+}
+
+export function monthBounds(y: number, m0: number): DateRange {
+  const start = new Date(y, m0, 1);
+  const end = new Date(y, m0 + 1, 0);
+  return {
+    startKey: dateKeyFromDate(start),
+    endKey: dateKeyFromDate(end),
+  };
+}
+
+export function monthGrid(
+  y: number,
+  monthIndex: number,
+): { cells: Array<number | null> } {
+  const last = new Date(y, monthIndex + 1, 0).getDate();
+  const firstWd = (new Date(y, monthIndex, 1).getDay() + 6) % 7;
+  const cells: Array<number | null> = [];
+  for (let i = 0; i < firstWd; i++) cells.push(null);
+  for (let d = 1; d <= last; d++) cells.push(d);
+  while (cells.length % 7 !== 0) cells.push(null);
+  return { cells };
+}
+
+export function timeOfDayBucket(hhmm: string | null | undefined): string {
+  const t = (hhmm || "").trim();
+  if (!t) return "Будь-коли";
+  const m = /^(\d{1,2}):(\d{2})$/.exec(t);
+  if (!m) return "Будь-коли";
+  const h = Number(m[1]);
+  if (!Number.isFinite(h)) return "Будь-коли";
+  if (h < 12) return "Ранок";
+  if (h <= 18) return "День";
+  return "Вечір";
+}
+
+export function groupEventsForList(
+  events: HubCalendarEvent[],
+): Array<[string, HubCalendarEvent[]]> {
+  const map = new Map<string, HubCalendarEvent[]>();
+  for (const e of events) {
+    let head: string;
+    if (e.fizruk) head = FIZRUK_GROUP_LABEL;
+    else if (e.finykSub) head = FINYK_SUB_GROUP_LABEL;
+    else if (e.sourceKind === "habit") head = timeOfDayBucket(e.timeOfDay);
+    else head = e.tagLabels[0] || "Інше";
+    const existing = map.get(head);
+    if (existing) existing.push(e);
+    else map.set(head, [e]);
+  }
+  return [...map.entries()].sort((a, b) => {
+    const ai = GROUP_ORDER.indexOf(a[0]);
+    const bi = GROUP_ORDER.indexOf(b[0]);
+    if (ai === -1 && bi === -1) return a[0].localeCompare(b[0], "uk");
+    if (ai === -1) return 1;
+    if (bi === -1) return -1;
+    return ai - bi;
+  });
+}

--- a/apps/web/src/modules/routine/RoutineApp.tsx
+++ b/apps/web/src/modules/routine/RoutineApp.tsx
@@ -1,164 +1,27 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-  useTransition,
-} from "react";
-import { cn } from "@shared/lib/ui/cn";
-import { Banner } from "@shared/components/ui/Banner";
-import { SkeletonHabitRow } from "@shared/components/ui/Skeleton";
-import { SectionErrorBoundary } from "@shared/components/ui/SectionErrorBoundary";
-import { PullToRefresh } from "@shared/components/ui/PullToRefresh";
-import { requestCloudPull } from "@shared/lib/modules/cloudPullRequest";
-import { useToast } from "@shared/hooks/useToast";
-import {
-  ModuleAccentProvider,
-  ModuleHeader,
-  ModuleHeaderAssistantButton,
-  ModuleHeaderBackButton,
-} from "@shared/components/layout";
-import { hapticTap, hapticSuccess } from "@shared/lib/adapters/haptic";
-import {
-  loadRoutineState,
-  toggleHabitCompletion,
-  markAllScheduledHabitsComplete,
-  ROUTINE_EVENT,
-  ROUTINE_STORAGE_ERROR,
-} from "./lib/routineStorage";
-import { useRoutineDualWriteBoot } from "./hooks/useRoutineDualWriteBoot";
-import { useSqliteReadBoot } from "./hooks/useSqliteReadBoot";
-import { addDays, startOfIsoWeek } from "./lib/weekUtils";
-import { maxActiveStreak, completionRateForRange } from "./lib/streaks";
-import { useRoutineReminders } from "./hooks/useRoutineReminders";
-import { useLocalStorageState } from "@shared/hooks/useLocalStorageState";
-import {
-  buildHubCalendarEvents,
-  countEventsByDate,
-  dateKeyFromDate,
-  FIZRUK_GROUP_LABEL,
-  parseDateKey,
-  habitScheduledOnDate,
-} from "./lib/hubCalendarAggregate";
-import { FINYK_SUB_GROUP_LABEL } from "./lib/finykSubscriptionCalendar";
-import { HUB_FINYK_ROUTINE_SYNC_EVENT } from "../finyk/hubRoutineSync";
-import { useFinykHubPreview } from "../../core/hub/useFinykHubPreview";
-import { ROUTINE_THEME as C } from "./lib/routineConstants";
-import { RoutineBottomNav } from "./components/RoutineBottomNav";
-import { RoutineCalendarPanel } from "./components/RoutineCalendarPanel";
-import { RoutineStatsPanel } from "./components/RoutineStatsPanel";
-import { HabitQuickCreateDialog } from "./components/HabitQuickCreateDialog";
-import { RoutineCalendarProvider } from "./context/RoutineCalendarContext";
-import type {
-  RoutineMainTab,
-  RoutineTimeMode,
-} from "./context/RoutineCalendarContext";
-import { STORAGE_KEYS } from "@sergeant/shared";
-import type { Dispatch, SetStateAction } from "react";
-import type { HubCalendarEvent, RoutineState } from "./lib/types";
+/**
+ * Routine module composition root.
+ *
+ * Phase 2 decomposition (initiative 0001) — the prior 745-LOC file
+ * has been split into:
+ *
+ *   - `RoutineApp.helpers.ts` — pure date/grouping utilities.
+ *   - `useRoutineAppState.ts` — orchestrator hook with the
+ *     time-state reducer, derived memos and effects.
+ *   - `RoutineHeader.tsx` — the standard module header bar.
+ *   - `RoutineTimeline.tsx` — the calendar/stats timeline body.
+ *   - `RoutineActions.tsx` — bottom nav + quick-add dialog.
+ *
+ * This root is intentionally thin: it wires the public props through
+ * the orchestrator hook and renders the three visual chunks inside
+ * the module's accent provider. No business logic lives here —
+ * adding a new behaviour means editing the matching shard above.
+ */
 
-interface MonthCursor {
-  y: number;
-  m: number;
-}
-
-interface DateRange {
-  startKey: string;
-  endKey: string;
-}
-
-const FIZRUK_PLAN_SYNC = "fizruk-storage-monthly-plan";
-
-function todayDate() {
-  const d = new Date();
-  d.setHours(12, 0, 0, 0);
-  return d;
-}
-
-function monthBounds(y: number, m0: number): DateRange {
-  const start = new Date(y, m0, 1);
-  const end = new Date(y, m0 + 1, 0);
-  return {
-    startKey: dateKeyFromDate(start),
-    endKey: dateKeyFromDate(end),
-  };
-}
-
-function monthGrid(
-  y: number,
-  monthIndex: number,
-): { cells: Array<number | null> } {
-  const last = new Date(y, monthIndex + 1, 0).getDate();
-  const firstWd = (new Date(y, monthIndex, 1).getDay() + 6) % 7;
-  const cells: Array<number | null> = [];
-  for (let i = 0; i < firstWd; i++) cells.push(null);
-  for (let d = 1; d <= last; d++) cells.push(d);
-  while (cells.length % 7 !== 0) cells.push(null);
-  return { cells };
-}
-
-function useRoutineState(): [
-  RoutineState,
-  Dispatch<SetStateAction<RoutineState>>,
-] {
-  const [state, setState] = useState<RoutineState>(() => loadRoutineState());
-  useEffect(() => {
-    const sync = () => setState(loadRoutineState());
-    window.addEventListener("storage", sync);
-    window.addEventListener(ROUTINE_EVENT, sync);
-    window.addEventListener(FIZRUK_PLAN_SYNC, sync);
-    return () => {
-      window.removeEventListener("storage", sync);
-      window.removeEventListener(ROUTINE_EVENT, sync);
-      window.removeEventListener(FIZRUK_PLAN_SYNC, sync);
-    };
-  }, []);
-
-  return [state, setState];
-}
-
-const HABIT_TIME_GROUPS = ["Ранок", "День", "Вечір", "Будь-коли"];
-const GROUP_ORDER = [
-  ...HABIT_TIME_GROUPS,
-  FIZRUK_GROUP_LABEL,
-  FINYK_SUB_GROUP_LABEL,
-];
-
-function timeOfDayBucket(hhmm: string | null | undefined): string {
-  const t = (hhmm || "").trim();
-  if (!t) return "Будь-коли";
-  const m = /^(\d{1,2}):(\d{2})$/.exec(t);
-  if (!m) return "Будь-коли";
-  const h = Number(m[1]);
-  if (!Number.isFinite(h)) return "Будь-коли";
-  if (h < 12) return "Ранок";
-  if (h <= 18) return "День";
-  return "Вечір";
-}
-
-function groupEventsForList(
-  events: HubCalendarEvent[],
-): Array<[string, HubCalendarEvent[]]> {
-  const map = new Map<string, HubCalendarEvent[]>();
-  for (const e of events) {
-    let head: string;
-    if (e.fizruk) head = FIZRUK_GROUP_LABEL;
-    else if (e.finykSub) head = FINYK_SUB_GROUP_LABEL;
-    else if (e.sourceKind === "habit") head = timeOfDayBucket(e.timeOfDay);
-    else head = e.tagLabels[0] || "Інше";
-    const existing = map.get(head);
-    if (existing) existing.push(e);
-    else map.set(head, [e]);
-  }
-  return [...map.entries()].sort((a, b) => {
-    const ai = GROUP_ORDER.indexOf(a[0]);
-    const bi = GROUP_ORDER.indexOf(b[0]);
-    if (ai === -1 && bi === -1) return a[0].localeCompare(b[0], "uk");
-    if (ai === -1) return 1;
-    if (bi === -1) return -1;
-    return ai - bi;
-  });
-}
+import { ModuleAccentProvider } from "@shared/components/layout";
+import { RoutineActions } from "./RoutineActions";
+import { RoutineHeader } from "./RoutineHeader";
+import { RoutineTimeline } from "./RoutineTimeline";
+import { useRoutineAppState } from "./useRoutineAppState";
 
 export interface RoutineAppProps {
   onBackToHub?: () => void;
@@ -173,572 +36,51 @@ export default function RoutineApp({
   pwaAction,
   onPwaActionConsumed,
 }: RoutineAppProps = {}) {
-  const toast = useToast();
-  useSqliteReadBoot();
-  useRoutineDualWriteBoot();
-  const [routine, setRoutine] = useRoutineState();
-  // Low-priority transition for habit toggles: the checkbox haptic fires
-  // instantly while React defers the heavier re-render (full list + persist)
-  // so the animation never feels janky on slower devices.
-  const [isHabitPending, startHabitTransition] = useTransition();
-  // Finyk calendar events depend on both the Finyk Monobank cache and the
-  // subscription calendar. The former now flows through React Query
-  // (`hubKeys.preview("finyk")`), the latter still uses a custom event
-  // because nothing else observes the subscription-only signal.
-  const finykPreview = useFinykHubPreview();
-  const [routineSyncBump, setRoutineSyncBump] = useState<number>(0);
-  useEffect(() => {
-    const bump = () => setRoutineSyncBump((n) => n + 1);
-    window.addEventListener(HUB_FINYK_ROUTINE_SYNC_EVENT, bump);
-    return () => {
-      window.removeEventListener(HUB_FINYK_ROUTINE_SYNC_EVENT, bump);
-    };
-  }, []);
-  const finykCalendarTick = finykPreview.dataUpdatedAt + routineSyncBump;
-
-  // Persistent storage-error banner: quota failures won't go away until the
-  // user frees space, so a 7s toast is too transient. Matches the pattern
-  // already used in Nutrition (`storageBanner`) and Finyk.
-  const [storageErrorMsg, setStorageErrorMsg] = useState<string | null>(null);
-  useEffect(() => {
-    const onErr = (ev: Event) => {
-      const detail = (ev as CustomEvent<{ message?: string }>).detail;
-      const msg = detail?.message || "невідома помилка";
-      setStorageErrorMsg(msg);
-    };
-    window.addEventListener(ROUTINE_STORAGE_ERROR, onErr);
-    return () => window.removeEventListener(ROUTINE_STORAGE_ERROR, onErr);
-  }, []);
-
-  useRoutineReminders(routine);
-
-  const [mainTab, setMainTab] = useLocalStorageState<RoutineMainTab>(
-    STORAGE_KEYS.ROUTINE_MAIN_TAB,
-    "calendar",
-    {
-      raw: true,
-      validate: (v): v is RoutineMainTab => v === "calendar" || v === "stats",
-    },
-  );
-
-  // Deep-link: коли модуль відкритий з hash `#calendar` чи `#stats`
-  // (напр. з Fizruk → «Запланувати тренування»), форсуємо вкладку
-  // незалежно від попередньо збереженої у localStorage. Прибираємо
-  // hash після застосування, щоб back-навігація / refresh не
-  // повторювали стрибок.
-  useEffect(() => {
-    let raw = "";
-    try {
-      raw = (window.location.hash || "").replace(/^#\/?/, "").toLowerCase();
-    } catch {
-      return;
-    }
-    if (raw !== "calendar" && raw !== "stats") return;
-    setMainTab(raw);
-    try {
-      const next = `${window.location.pathname}${window.location.search}`;
-      window.history.replaceState(null, "", next);
-    } catch {
-      /* noop */
-    }
-    // Один раз на mount — наступні переходи між вкладками — через
-    // RoutineBottomNav, без url hash.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-  const [timeMode, setTimeMode] = useState<RoutineTimeMode>("today");
-  const now = todayDate();
-  const [monthCursor, setMonthCursor] = useState<MonthCursor>(() => ({
-    y: now.getFullYear(),
-    m: now.getMonth(),
-  }));
-  const [selectedDay, setSelectedDay] = useState<string>(() =>
-    dateKeyFromDate(now),
-  );
-  const [tagFilter, setTagFilter] = useState<string | null>(null);
-  const [listQuery, setListQuery] = useState<string>("");
-
-  // Quick-create dialog state. The `add_habit` PWA action opens a
-  // bottom-sheet modal overlaid on whatever tab the user is already on
-  // (#S0.2). The tick is bumped each time so the dialog re-focuses its
-  // name input when reopened after a previous close.
-  const [quickAddHabitOpen, setQuickAddHabitOpen] = useState<boolean>(false);
-  const [quickAddFocusTick, setQuickAddFocusTick] = useState<number>(0);
-
-  useEffect(() => {
-    if (pwaAction !== "add_habit") return;
-    setQuickAddHabitOpen(true);
-    setQuickAddFocusTick((t) => t + 1);
-    onPwaActionConsumed?.();
-  }, [pwaAction, onPwaActionConsumed]);
-
-  useEffect(() => {
-    try {
-      const params = new URLSearchParams(window.location.search);
-      const q = params.get("routineDay");
-      if (q && /^\d{4}-\d{2}-\d{2}$/.test(q)) {
-        setSelectedDay(q);
-        setTimeMode("day");
-        // Видаляємо параметр після застосування, щоб back-навігація чи
-        // рефреш не запускали стрибок у "day"-режим повторно.
-        params.delete("routineDay");
-        const qs = params.toString();
-        const next = `${window.location.pathname}${qs ? `?${qs}` : ""}${window.location.hash}`;
-        window.history.replaceState(null, "", next);
-      }
-    } catch {
-      /* noop */
-    }
-  }, []);
-
-  useEffect(() => {
-    if (timeMode !== "month") return;
-    const { startKey, endKey } = monthBounds(monthCursor.y, monthCursor.m);
-    setSelectedDay((d) => (d < startKey || d > endKey ? startKey : d));
-  }, [monthCursor.y, monthCursor.m, timeMode]);
-
-  const range = useMemo<DateRange>(() => {
-    const t = todayDate();
-    const tk = dateKeyFromDate(t);
-    if (timeMode === "today") return { startKey: tk, endKey: tk };
-    if (timeMode === "tomorrow") {
-      const d = addDays(t, 1);
-      const k = dateKeyFromDate(d);
-      return { startKey: k, endKey: k };
-    }
-    if (timeMode === "day") {
-      return { startKey: selectedDay, endKey: selectedDay };
-    }
-    if (timeMode === "week") {
-      const anchor = parseDateKey(selectedDay);
-      const s = startOfIsoWeek(anchor);
-      const e = addDays(s, 6);
-      return { startKey: dateKeyFromDate(s), endKey: dateKeyFromDate(e) };
-    }
-    return monthBounds(monthCursor.y, monthCursor.m);
-  }, [timeMode, monthCursor.y, monthCursor.m, selectedDay]);
-
-  const events = useMemo(
-    () =>
-      buildHubCalendarEvents(routine, range, {
-        showFizruk: routine.prefs.showFizrukInCalendar !== false,
-        showFinykSubs: routine.prefs.showFinykSubscriptionsInCalendar !== false,
-      }),
-    /* finykCalendarTick лишаємо: оновлення подій Фініка без зміни routine */
-    [routine, range, finykCalendarTick], // eslint-disable-line react-hooks/exhaustive-deps
-  );
-
-  const filtered = useMemo(() => {
-    let ev = events;
-    if (tagFilter) {
-      if (tagFilter === "__fizruk") ev = ev.filter((e) => e.fizruk);
-      else if (tagFilter === "__finyk_sub") ev = ev.filter((e) => e.finykSub);
-      else ev = ev.filter((e) => e.tagLabels.includes(tagFilter));
-    }
-    const q = listQuery.trim().toLowerCase();
-    if (q) {
-      ev = ev.filter((e) => {
-        const hay =
-          `${e.title} ${e.subtitle} ${(e.tagLabels || []).join(" ")} ${e.note || ""}`.toLowerCase();
-        return hay.includes(q);
-      });
-    }
-    return ev;
-  }, [events, tagFilter, listQuery]);
-
-  const tagChips = useMemo<string[]>(() => {
-    const set = new Set<string>();
-    for (const t of routine.tags) set.add(t.name);
-    for (const e of events) {
-      for (const x of e.tagLabels) {
-        if (x !== FIZRUK_GROUP_LABEL && x !== FINYK_SUB_GROUP_LABEL) set.add(x);
-      }
-    }
-    return [...set].sort((a, b) => a.localeCompare(b, "uk"));
-  }, [routine.tags, events]);
-
-  const listEvents = useMemo(() => {
-    if (timeMode === "month")
-      return filtered.filter((e) => e.date === selectedDay);
-    return filtered;
-  }, [filtered, timeMode, selectedDay]);
-
-  const grouped = useMemo(() => groupEventsForList(listEvents), [listEvents]);
-
-  const dayCounts = useMemo(() => countEventsByDate(events), [events]);
-
-  const goMonth = useCallback((delta: number) => {
-    setMonthCursor((c) => {
-      let m = c.m + delta;
-      let y = c.y;
-      if (m > 11) {
-        m = 0;
-        y++;
-      }
-      if (m < 0) {
-        m = 11;
-        y--;
-      }
-      return { y, m };
-    });
-  }, []);
-
-  const goToToday = useCallback(() => {
-    const t = todayDate();
-    setMonthCursor({ y: t.getFullYear(), m: t.getMonth() });
-    setSelectedDay(dateKeyFromDate(t));
-  }, []);
-
-  const applyTimeMode = useCallback((id: RoutineTimeMode) => {
-    const t = todayDate();
-    const tk = dateKeyFromDate(t);
-    if (id === "today") {
-      setSelectedDay(tk);
-      setTimeMode("today");
-    } else if (id === "tomorrow") {
-      setSelectedDay(dateKeyFromDate(addDays(t, 1)));
-      setTimeMode("tomorrow");
-    } else if (id === "week") {
-      setSelectedDay(tk);
-      setTimeMode("week");
-    } else if (id === "month") {
-      setMonthCursor({ y: t.getFullYear(), m: t.getMonth() });
-      setSelectedDay(tk);
-      setTimeMode("month");
-    }
-  }, []);
-
-  const shiftWeekStrip = useCallback((deltaWeeks: number) => {
-    setSelectedDay((prev) => {
-      const d = parseDateKey(prev);
-      d.setDate(d.getDate() + 7 * deltaWeeks);
-      return dateKeyFromDate(d);
-    });
-    setTimeMode("day");
-  }, []);
-
-  const onToggleHabit = useCallback(
-    (habitId: string, dateKey: string) => {
-      // Легкий тап на ✓ — фізичне відчуття підтверджує дію до того, як
-      // око встигне відскакувати до heatmap-анімації. `hapticTap` —
-      // noop на desktop/iOS Safari і під prefers-reduced-motion.
-      hapticTap();
-      // Wrap in startTransition so React can commit the haptic + checkbox
-      // visual change at high priority while deferring the full list
-      // re-render + localStorage persist to a lower-priority lane.
-      startHabitTransition(() => {
-        setRoutine((prev) => toggleHabitCompletion(prev, habitId, dateKey));
-      });
-    },
-    [setRoutine, startHabitTransition],
-  );
-
-  const onBulkMarkDay = useCallback(() => {
-    const dk = range.startKey;
-    if (range.startKey !== range.endKey) return;
-    setRoutine((s) => markAllScheduledHabitsComplete(s, dk));
-    hapticSuccess();
-  }, [range.startKey, range.endKey, setRoutine]);
-
-  const canBulkMark = useMemo(() => {
-    if (range.startKey !== range.endKey) return false;
-    const dk = range.startKey;
-    for (const h of routine.habits) {
-      if (h.archived) continue;
-      if (!habitScheduledOnDate(h, dk)) continue;
-      if (!(routine.completions[h.id] || []).includes(dk)) return true;
-    }
-    return false;
-  }, [range.startKey, range.endKey, routine.habits, routine.completions]);
-
-  const monthTitle = new Date(
-    monthCursor.y,
-    monthCursor.m,
-    1,
-  ).toLocaleDateString("uk-UA", {
-    month: "long",
-    year: "numeric",
-  });
-
-  const { cells } = monthGrid(monthCursor.y, monthCursor.m);
-
-  const rangeLabel = useMemo(() => {
-    if (timeMode === "today") return "Сьогодні";
-    if (timeMode === "tomorrow") return "Завтра";
-    if (timeMode === "day") {
-      return parseDateKey(selectedDay).toLocaleDateString("uk-UA", {
-        weekday: "long",
-        day: "numeric",
-        month: "long",
-      });
-    }
-    if (timeMode === "week") return "Цей тиждень";
-    return monthTitle;
-  }, [timeMode, monthTitle, selectedDay]);
-
-  const fmtUk = (key: string) =>
-    parseDateKey(key).toLocaleDateString("uk-UA", {
-      weekday: "long",
-      day: "numeric",
-      month: "long",
-    });
-
-  const headlineDate = useMemo(() => {
-    const t0 = todayDate();
-    const tk = dateKeyFromDate(t0);
-    if (timeMode === "day") return fmtUk(selectedDay);
-    if (timeMode === "today") return fmtUk(tk);
-    if (timeMode === "tomorrow") return fmtUk(dateKeyFromDate(addDays(t0, 1)));
-    if (timeMode === "week") {
-      const a = fmtUk(range.startKey);
-      const b = fmtUk(range.endKey);
-      return range.startKey === range.endKey ? a : `${a} — ${b}`;
-    }
-    if (timeMode === "month") return fmtUk(selectedDay);
-    return fmtUk(tk);
-  }, [timeMode, selectedDay, range.startKey, range.endKey]);
-
-  const todayKey = dateKeyFromDate(todayDate());
-  const streakMax = useMemo(
-    () => maxActiveStreak(routine.habits, routine.completions, todayKey),
-    [routine.habits, routine.completions, todayKey],
-  );
-
-  const completionRateVal = useMemo(
-    () =>
-      completionRateForRange(
-        routine.habits,
-        routine.completions,
-        range.startKey,
-        range.endKey,
-      ),
-    [routine.habits, routine.completions, range.startKey, range.endKey],
-  );
-
-  const dayProgress = useMemo(
-    () =>
-      completionRateForRange(
-        routine.habits,
-        routine.completions,
-        todayKey,
-        todayKey,
-      ),
-    [routine.habits, routine.completions, todayKey],
-  );
-
-  const activeHabitsCount = routine.habits.filter((h) => !h.archived).length;
-  const hasNoHabits = activeHabitsCount === 0;
-  const hasListFilter = Boolean(tagFilter) || listQuery.trim().length > 0;
-  const listIsEmpty = grouped.length === 0;
-
-  // Routine is local-first (localStorage) and the visible state is
-  // recomputed from `routine` on each render, so PTR's only job is to
-  // ask the App-level cloud-sync engine for a pull. The `routine`
-  // listener (`ROUTINE_EVENT`) re-renders us when the engine writes new
-  // state into localStorage.
-  const handlePullRefresh = useCallback(() => requestCloudPull(2500), []);
-  const handlePullRefreshError = useCallback(() => {
-    toast.error("Не вдалося оновити дані. Перевір з'єднання.");
-  }, [toast]);
+  const {
+    routine,
+    setRoutine,
+    isHabitPending,
+    storageErrorMsg,
+    setStorageErrorMsg,
+    mainTab,
+    setMainTab,
+    quickAddHabitOpen,
+    quickAddFocusTick,
+    openQuickAddHabit,
+    closeQuickAddHabit,
+    streakMax,
+    calendarData,
+    calendarActions,
+    handlePullRefresh,
+    handlePullRefreshError,
+  } = useRoutineAppState({ pwaAction, onPwaActionConsumed, onOpenModule });
 
   return (
     <ModuleAccentProvider module="routine" asShellRoot>
-      <ModuleHeader
-        module="routine"
-        left={
-          typeof onBackToHub === "function" ? (
-            <ModuleHeaderBackButton onClick={onBackToHub} />
-          ) : (
-            <div
-              className={cn(
-                "shrink-0 w-10 h-10 rounded-xl flex items-center justify-center border",
-                C.iconBox,
-              )}
-              aria-hidden
-            >
-              <svg
-                width="20"
-                height="20"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.6"
-                aria-hidden
-              >
-                <rect x="3" y="4" width="18" height="18" rx="2" />
-                <path d="M8 14h.01M12 14h.01M16 14h.01" />
-              </svg>
-            </div>
-          )
-        }
-        title="РУТИНА"
-        subtitle="Звички · план Фізрука · один розклад"
-        right={<ModuleHeaderAssistantButton />}
-      />
+      <RoutineHeader onBackToHub={onBackToHub} />
 
-      <div className="flex-1 overflow-hidden flex flex-col min-h-0">
-        <PullToRefresh
-          as="main"
-          id="routine-main"
-          tabIndex={-1}
-          onRefresh={handlePullRefresh}
-          onError={handlePullRefreshError}
-          variant="routine"
-          contentClassName="page-tabbar-pad routine-main-pad"
-        >
-          <div className="max-w-4xl mx-auto w-full pt-4 space-y-4">
-            {storageErrorMsg && (
-              <Banner
-                variant="danger"
-                role="alert"
-                className="flex items-start justify-between gap-3"
-              >
-                <span>
-                  Не вдалося зберегти дані Рутини ({storageErrorMsg}). Можливо,
-                  браузер переповнив сховище — звільни місце або експортуй
-                  резервну копію.
-                </span>
-                <button
-                  type="button"
-                  onClick={() => setStorageErrorMsg(null)}
-                  className="shrink-0 text-xs font-semibold text-danger/80 hover:text-danger"
-                  aria-label="Закрити повідомлення"
-                >
-                  Закрити
-                </button>
-              </Banner>
-            )}
-            <RoutineCalendarProvider
-              data={useMemo(
-                () => ({
-                  rangeLabel,
-                  headlineDate,
-                  filtered,
-                  routine,
-                  currentStreak: streakMax,
-                  completionRate: completionRateVal,
-                  dayProgress,
-                  timeMode,
-                  selectedDay,
-                  todayKey,
-                  shiftWeekStrip,
-                  setSelectedDay,
-                  setTimeMode,
-                  listQuery,
-                  setListQuery,
-                  tagFilter,
-                  setTagFilter,
-                  tagChips,
-                  monthCursor,
-                  monthTitle,
-                  goMonth,
-                  goToToday,
-                  cells,
-                  dayCounts,
-                  listIsEmpty,
-                  hasListFilter,
-                  hasNoHabits,
-                  grouped,
-                  canBulkMark,
-                }),
-                [
-                  rangeLabel,
-                  headlineDate,
-                  filtered,
-                  routine,
-                  streakMax,
-                  completionRateVal,
-                  dayProgress,
-                  timeMode,
-                  selectedDay,
-                  todayKey,
-                  shiftWeekStrip,
-                  setSelectedDay,
-                  setTimeMode,
-                  listQuery,
-                  setListQuery,
-                  tagFilter,
-                  setTagFilter,
-                  tagChips,
-                  monthCursor,
-                  monthTitle,
-                  goMonth,
-                  goToToday,
-                  cells,
-                  dayCounts,
-                  listIsEmpty,
-                  hasListFilter,
-                  hasNoHabits,
-                  grouped,
-                  canBulkMark,
-                ],
-              )}
-              actions={useMemo(
-                () => ({
-                  applyTimeMode,
-                  onToggleHabit,
-                  setRoutine,
-                  setMainTab,
-                  onOpenModule,
-                  onBulkMarkDay,
-                  onOpenQuickAddHabit: () => {
-                    setQuickAddHabitOpen(true);
-                    setQuickAddFocusTick((t) => t + 1);
-                  },
-                }),
-                [
-                  applyTimeMode,
-                  onToggleHabit,
-                  setRoutine,
-                  setMainTab,
-                  onOpenModule,
-                  onBulkMarkDay,
-                ],
-              )}
-            >
-              <SectionErrorBoundary title="Не вдалось показати «Календар»">
-                {isHabitPending && mainTab === "calendar" ? (
-                  <div className="px-4 pt-2 space-y-2 motion-safe:animate-pulse">
-                    {[0, 1, 2, 3].map((i) => (
-                      <SkeletonHabitRow
-                        key={i}
-                        shimmer
-                        module="routine"
-                        style={{ animationDelay: `${i * 40}ms` }}
-                      />
-                    ))}
-                  </div>
-                ) : (
-                  <RoutineCalendarPanel hidden={mainTab !== "calendar"} />
-                )}
-              </SectionErrorBoundary>
-            </RoutineCalendarProvider>
-
-            <SectionErrorBoundary title="Не вдалось показати «Статистика»">
-              <RoutineStatsPanel
-                routine={routine}
-                currentStreak={streakMax}
-                hidden={mainTab !== "stats"}
-              />
-            </SectionErrorBoundary>
-          </div>
-        </PullToRefresh>
-      </div>
-
-      <RoutineBottomNav
+      <RoutineTimeline
+        storageErrorMsg={storageErrorMsg}
+        onDismissStorageError={() => setStorageErrorMsg(null)}
+        calendarData={calendarData}
+        calendarActions={calendarActions}
+        isHabitPending={isHabitPending}
         mainTab={mainTab}
-        onSelectTab={setMainTab}
-        onAddHabit={() => {
-          setQuickAddHabitOpen(true);
-          setQuickAddFocusTick((t) => t + 1);
-        }}
+        routine={routine}
+        streakMax={streakMax}
+        onPullRefresh={handlePullRefresh}
+        onPullRefreshError={handlePullRefreshError}
       />
 
-      <HabitQuickCreateDialog
-        open={quickAddHabitOpen}
+      <RoutineActions
+        mainTab={mainTab}
+        setMainTab={setMainTab}
         routine={routine}
         setRoutine={setRoutine}
-        onClose={() => setQuickAddHabitOpen(false)}
-        focusTick={quickAddFocusTick}
+        quickAddHabitOpen={quickAddHabitOpen}
+        quickAddFocusTick={quickAddFocusTick}
+        onOpenQuickAddHabit={openQuickAddHabit}
+        onCloseQuickAddHabit={closeQuickAddHabit}
       />
     </ModuleAccentProvider>
   );

--- a/apps/web/src/modules/routine/RoutineHeader.tsx
+++ b/apps/web/src/modules/routine/RoutineHeader.tsx
@@ -1,0 +1,57 @@
+/**
+ * Routine module header bar.
+ *
+ * Split out of `RoutineApp.tsx` as part of the Phase 2 decomposition
+ * (initiative 0001). Renders the standard `<ModuleHeader>` for the
+ * Routine module, with either a back-to-Hub button or the static
+ * Routine icon as the left slot.
+ */
+
+import {
+  ModuleHeader,
+  ModuleHeaderAssistantButton,
+  ModuleHeaderBackButton,
+} from "@shared/components/layout";
+import { cn } from "@shared/lib/ui/cn";
+import { ROUTINE_THEME as C } from "./lib/routineConstants";
+
+export interface RoutineHeaderProps {
+  onBackToHub?: () => void;
+}
+
+export function RoutineHeader({ onBackToHub }: RoutineHeaderProps) {
+  return (
+    <ModuleHeader
+      module="routine"
+      left={
+        typeof onBackToHub === "function" ? (
+          <ModuleHeaderBackButton onClick={onBackToHub} />
+        ) : (
+          <div
+            className={cn(
+              "shrink-0 w-10 h-10 rounded-xl flex items-center justify-center border",
+              C.iconBox,
+            )}
+            aria-hidden
+          >
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              aria-hidden
+            >
+              <rect x="3" y="4" width="18" height="18" rx="2" />
+              <path d="M8 14h.01M12 14h.01M16 14h.01" />
+            </svg>
+          </div>
+        )
+      }
+      title="РУТИНА"
+      subtitle="Звички · план Фізрука · один розклад"
+      right={<ModuleHeaderAssistantButton />}
+    />
+  );
+}

--- a/apps/web/src/modules/routine/RoutineTimeline.tsx
+++ b/apps/web/src/modules/routine/RoutineTimeline.tsx
@@ -1,0 +1,115 @@
+/**
+ * Routine module main timeline body.
+ *
+ * Renders the storage-error banner, the calendar/stats panels with
+ * their context provider, and the pull-to-refresh wrapper. Split out
+ * of `RoutineApp.tsx` as part of the Phase 2 decomposition
+ * (initiative 0001).
+ */
+
+import { Banner } from "@shared/components/ui/Banner";
+import { PullToRefresh } from "@shared/components/ui/PullToRefresh";
+import { SectionErrorBoundary } from "@shared/components/ui/SectionErrorBoundary";
+import { SkeletonHabitRow } from "@shared/components/ui/Skeleton";
+import { RoutineCalendarPanel } from "./components/RoutineCalendarPanel";
+import { RoutineStatsPanel } from "./components/RoutineStatsPanel";
+import {
+  RoutineCalendarProvider,
+  type RoutineCalendarActions,
+  type RoutineCalendarData,
+  type RoutineMainTab,
+} from "./context/RoutineCalendarContext";
+import type { RoutineState } from "./lib/types";
+
+export interface RoutineTimelineProps {
+  storageErrorMsg: string | null;
+  onDismissStorageError: () => void;
+  calendarData: RoutineCalendarData;
+  calendarActions: RoutineCalendarActions;
+  isHabitPending: boolean;
+  mainTab: RoutineMainTab;
+  routine: RoutineState;
+  streakMax: number;
+  onPullRefresh: () => Promise<void>;
+  onPullRefreshError: () => void;
+}
+
+export function RoutineTimeline({
+  storageErrorMsg,
+  onDismissStorageError,
+  calendarData,
+  calendarActions,
+  isHabitPending,
+  mainTab,
+  routine,
+  streakMax,
+  onPullRefresh,
+  onPullRefreshError,
+}: RoutineTimelineProps) {
+  return (
+    <div className="flex-1 overflow-hidden flex flex-col min-h-0">
+      <PullToRefresh
+        as="main"
+        id="routine-main"
+        tabIndex={-1}
+        onRefresh={onPullRefresh}
+        onError={onPullRefreshError}
+        variant="routine"
+        contentClassName="page-tabbar-pad routine-main-pad"
+      >
+        <div className="max-w-4xl mx-auto w-full pt-4 space-y-4">
+          {storageErrorMsg && (
+            <Banner
+              variant="danger"
+              role="alert"
+              className="flex items-start justify-between gap-3"
+            >
+              <span>
+                Не вдалося зберегти дані Рутини ({storageErrorMsg}). Можливо,
+                браузер переповнив сховище — звільни місце або експортуй
+                резервну копію.
+              </span>
+              <button
+                type="button"
+                onClick={onDismissStorageError}
+                className="shrink-0 text-xs font-semibold text-danger/80 hover:text-danger"
+                aria-label="Закрити повідомлення"
+              >
+                Закрити
+              </button>
+            </Banner>
+          )}
+          <RoutineCalendarProvider
+            data={calendarData}
+            actions={calendarActions}
+          >
+            <SectionErrorBoundary title="Не вдалось показати «Календар»">
+              {isHabitPending && mainTab === "calendar" ? (
+                <div className="px-4 pt-2 space-y-2 motion-safe:animate-pulse">
+                  {[0, 1, 2, 3].map((i) => (
+                    <SkeletonHabitRow
+                      key={i}
+                      shimmer
+                      module="routine"
+                      style={{ animationDelay: `${i * 40}ms` }}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <RoutineCalendarPanel hidden={mainTab !== "calendar"} />
+              )}
+            </SectionErrorBoundary>
+          </RoutineCalendarProvider>
+
+          <SectionErrorBoundary title="Не вдалось показати «Статистика»">
+            <RoutineStatsPanel
+              routine={routine}
+              currentStreak={streakMax}
+              hidden={mainTab !== "stats"}
+            />
+          </SectionErrorBoundary>
+        </div>
+      </PullToRefresh>
+    </div>
+  );
+}

--- a/apps/web/src/modules/routine/useRoutineAppState.ts
+++ b/apps/web/src/modules/routine/useRoutineAppState.ts
@@ -1,0 +1,350 @@
+/**
+ * Orchestrator hook for `RoutineApp`.
+ *
+ * Composes the smaller hooks introduced as part of the Phase 2
+ * decomposition (initiative 0001):
+ *
+ *   - `useRoutineTimeState` — the time-mode reducer.
+ *   - `useRoutineDerivedData` — pure-derived calendar/stats data.
+ *
+ * On top of those it owns the rest of the App-level state: the
+ * canonical routine state (LS-backed), the main tab, filter inputs,
+ * the quick-add dialog and the storage-error banner. It also wires
+ * the side effects that connect the module to the rest of the app
+ * (sqlite read boot, dual-write boot, Finyk preview, reminders,
+ * deep-link handling and the PWA `add_habit` action).
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useTransition,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
+import { STORAGE_KEYS } from "@sergeant/shared";
+import { requestCloudPull } from "@shared/lib/modules/cloudPullRequest";
+import { useToast } from "@shared/hooks/useToast";
+import { hapticTap, hapticSuccess } from "@shared/lib/adapters/haptic";
+import { useLocalStorageState } from "@shared/hooks/useLocalStorageState";
+import { useFinykHubPreview } from "../../core/hub/useFinykHubPreview";
+import {
+  loadRoutineState,
+  toggleHabitCompletion,
+  markAllScheduledHabitsComplete,
+  ROUTINE_EVENT,
+  ROUTINE_STORAGE_ERROR,
+} from "./lib/routineStorage";
+import { useRoutineDualWriteBoot } from "./hooks/useRoutineDualWriteBoot";
+import { useSqliteReadBoot } from "./hooks/useSqliteReadBoot";
+import { useRoutineReminders } from "./hooks/useRoutineReminders";
+import { HUB_FINYK_ROUTINE_SYNC_EVENT } from "../finyk/hubRoutineSync";
+import type {
+  RoutineCalendarActions,
+  RoutineCalendarData,
+  RoutineMainTab,
+} from "./context/RoutineCalendarContext";
+import type { RoutineState } from "./lib/types";
+import { FIZRUK_PLAN_SYNC } from "./RoutineApp.helpers";
+import { useRoutineTimeState } from "./useRoutineTimeState";
+import { useRoutineDerivedData } from "./useRoutineDerivedData";
+
+function useRoutineState(): [
+  RoutineState,
+  Dispatch<SetStateAction<RoutineState>>,
+] {
+  const [state, setState] = useState<RoutineState>(() => loadRoutineState());
+  useEffect(() => {
+    const sync = () => setState(loadRoutineState());
+    window.addEventListener("storage", sync);
+    window.addEventListener(ROUTINE_EVENT, sync);
+    window.addEventListener(FIZRUK_PLAN_SYNC, sync);
+    return () => {
+      window.removeEventListener("storage", sync);
+      window.removeEventListener(ROUTINE_EVENT, sync);
+      window.removeEventListener(FIZRUK_PLAN_SYNC, sync);
+    };
+  }, []);
+  return [state, setState];
+}
+
+export interface UseRoutineAppStateParams {
+  pwaAction?: string | null;
+  onPwaActionConsumed?: () => void;
+  onOpenModule?: (moduleId: string, opts?: { hash?: string }) => void;
+}
+
+export interface RoutineAppStateBundle {
+  routine: RoutineState;
+  setRoutine: Dispatch<SetStateAction<RoutineState>>;
+  isHabitPending: boolean;
+  storageErrorMsg: string | null;
+  setStorageErrorMsg: Dispatch<SetStateAction<string | null>>;
+  mainTab: RoutineMainTab;
+  setMainTab: Dispatch<SetStateAction<RoutineMainTab>>;
+  quickAddHabitOpen: boolean;
+  quickAddFocusTick: number;
+  openQuickAddHabit: () => void;
+  closeQuickAddHabit: () => void;
+  streakMax: number;
+  calendarData: RoutineCalendarData;
+  calendarActions: RoutineCalendarActions;
+  handlePullRefresh: () => Promise<void>;
+  handlePullRefreshError: () => void;
+}
+
+export function useRoutineAppState({
+  pwaAction,
+  onPwaActionConsumed,
+  onOpenModule,
+}: UseRoutineAppStateParams): RoutineAppStateBundle {
+  const toast = useToast();
+  useSqliteReadBoot();
+  useRoutineDualWriteBoot();
+  const [routine, setRoutine] = useRoutineState();
+  // Low-priority transition for habit toggles: the checkbox haptic fires
+  // instantly while React defers the heavier re-render (full list + persist)
+  // so the animation never feels janky on slower devices.
+  const [isHabitPending, startHabitTransition] = useTransition();
+  // Finyk calendar events depend on both the Finyk Monobank cache and the
+  // subscription calendar. The former now flows through React Query
+  // (`hubKeys.preview("finyk")`), the latter still uses a custom event
+  // because nothing else observes the subscription-only signal.
+  const finykPreview = useFinykHubPreview();
+  const [routineSyncBump, setRoutineSyncBump] = useState<number>(0);
+  useEffect(() => {
+    const bump = () => setRoutineSyncBump((n) => n + 1);
+    window.addEventListener(HUB_FINYK_ROUTINE_SYNC_EVENT, bump);
+    return () => {
+      window.removeEventListener(HUB_FINYK_ROUTINE_SYNC_EVENT, bump);
+    };
+  }, []);
+  const finykCalendarTick = finykPreview.dataUpdatedAt + routineSyncBump;
+
+  // Persistent storage-error banner: quota failures won't go away until the
+  // user frees space, so a 7s toast is too transient. Matches the pattern
+  // already used in Nutrition (`storageBanner`) and Finyk.
+  const [storageErrorMsg, setStorageErrorMsg] = useState<string | null>(null);
+  useEffect(() => {
+    const onErr = (ev: Event) => {
+      const detail = (ev as CustomEvent<{ message?: string }>).detail;
+      const msg = detail?.message || "невідома помилка";
+      setStorageErrorMsg(msg);
+    };
+    window.addEventListener(ROUTINE_STORAGE_ERROR, onErr);
+    return () => window.removeEventListener(ROUTINE_STORAGE_ERROR, onErr);
+  }, []);
+
+  useRoutineReminders(routine);
+
+  const [mainTab, setMainTab] = useLocalStorageState<RoutineMainTab>(
+    STORAGE_KEYS.ROUTINE_MAIN_TAB,
+    "calendar",
+    {
+      raw: true,
+      validate: (v): v is RoutineMainTab => v === "calendar" || v === "stats",
+    },
+  );
+
+  // Deep-link: коли модуль відкритий з hash `#calendar` чи `#stats`
+  // (напр. з Fizruk → «Запланувати тренування»), форсуємо вкладку
+  // незалежно від попередньо збереженої у localStorage. Прибираємо
+  // hash після застосування, щоб back-навігація / refresh не
+  // повторювали стрибок.
+  useEffect(() => {
+    let raw = "";
+    try {
+      raw = (window.location.hash || "").replace(/^#\/?/, "").toLowerCase();
+    } catch {
+      return;
+    }
+    if (raw !== "calendar" && raw !== "stats") return;
+    setMainTab(raw);
+    try {
+      const next = `${window.location.pathname}${window.location.search}`;
+      window.history.replaceState(null, "", next);
+    } catch {
+      /* noop */
+    }
+    // Один раз на mount — наступні переходи між вкладками — через
+    // RoutineBottomNav, без url hash.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const time = useRoutineTimeState();
+  const [tagFilter, setTagFilter] = useState<string | null>(null);
+  const [listQuery, setListQuery] = useState<string>("");
+
+  // Quick-create dialog state. The `add_habit` PWA action opens a
+  // bottom-sheet modal overlaid on whatever tab the user is already on
+  // (#S0.2). The tick is bumped each time so the dialog re-focuses its
+  // name input when reopened after a previous close.
+  const [quickAddHabitOpen, setQuickAddHabitOpen] = useState<boolean>(false);
+  const [quickAddFocusTick, setQuickAddFocusTick] = useState<number>(0);
+  const openQuickAddHabit = useCallback(() => {
+    setQuickAddHabitOpen(true);
+    setQuickAddFocusTick((t) => t + 1);
+  }, []);
+  const closeQuickAddHabit = useCallback(() => {
+    setQuickAddHabitOpen(false);
+  }, []);
+
+  // PWA shortcut entry: when the App-shell receives the
+  // `?pwa=add_habit` deep-link it sets `pwaAction` and we open the
+  // quick-add dialog once. The setStates here are an external-event
+  // adaptor (the OS opening the PWA), not a render derivation, so we
+  // suppress `react-hooks/set-state-in-effect` rather than restructure.
+  useEffect(() => {
+    if (pwaAction !== "add_habit") return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setQuickAddHabitOpen(true);
+    setQuickAddFocusTick((t) => t + 1);
+    onPwaActionConsumed?.();
+  }, [pwaAction, onPwaActionConsumed]);
+
+  useEffect(() => {
+    try {
+      const params = new URLSearchParams(window.location.search);
+      const q = params.get("routineDay");
+      if (q && /^\d{4}-\d{2}-\d{2}$/.test(q)) {
+        time.deepLinkDay(q);
+        // Видаляємо параметр після застосування, щоб back-навігація чи
+        // рефреш не запускали стрибок у "day"-режим повторно.
+        params.delete("routineDay");
+        const qs = params.toString();
+        const next = `${window.location.pathname}${qs ? `?${qs}` : ""}${window.location.hash}`;
+        window.history.replaceState(null, "", next);
+      }
+    } catch {
+      /* noop */
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const timeState = useMemo(
+    () => ({
+      timeMode: time.timeMode,
+      monthCursor: time.monthCursor,
+      selectedDay: time.selectedDay,
+    }),
+    [time.timeMode, time.monthCursor, time.selectedDay],
+  );
+
+  const derived = useRoutineDerivedData({
+    routine,
+    timeState,
+    tagFilter,
+    listQuery,
+    finykCalendarTick,
+  });
+
+  const onToggleHabit = useCallback(
+    (habitId: string, dateKey: string) => {
+      // Легкий тап на ✓ — фізичне відчуття підтверджує дію до того, як
+      // око встигне відскакувати до heatmap-анімації. `hapticTap` —
+      // noop на desktop/iOS Safari і під prefers-reduced-motion.
+      hapticTap();
+      // Wrap in startTransition so React can commit the haptic + checkbox
+      // visual change at high priority while deferring the full list
+      // re-render + localStorage persist to a lower-priority lane.
+      startHabitTransition(() => {
+        setRoutine((prev) => toggleHabitCompletion(prev, habitId, dateKey));
+      });
+    },
+    [setRoutine, startHabitTransition],
+  );
+
+  const onBulkMarkDay = useCallback(() => {
+    const dk = derived.range.startKey;
+    if (derived.range.startKey !== derived.range.endKey) return;
+    setRoutine((s) => markAllScheduledHabitsComplete(s, dk));
+    hapticSuccess();
+  }, [derived.range.startKey, derived.range.endKey, setRoutine]);
+
+  // Routine is local-first (localStorage) and the visible state is
+  // recomputed from `routine` on each render, so PTR's only job is to
+  // ask the App-level cloud-sync engine for a pull. The `routine`
+  // listener (`ROUTINE_EVENT`) re-renders us when the engine writes new
+  // state into localStorage.
+  const handlePullRefresh = useCallback(() => requestCloudPull(2500), []);
+  const handlePullRefreshError = useCallback(() => {
+    toast.error("Не вдалося оновити дані. Перевір з'єднання.");
+  }, [toast]);
+
+  const calendarData = useMemo<RoutineCalendarData>(
+    () => ({
+      rangeLabel: derived.rangeLabel,
+      headlineDate: derived.headlineDate,
+      filtered: derived.filtered,
+      routine,
+      currentStreak: derived.streakMax,
+      completionRate: derived.completionRateVal,
+      dayProgress: derived.dayProgress,
+      timeMode: time.timeMode,
+      selectedDay: time.selectedDay,
+      todayKey: derived.todayKey,
+      shiftWeekStrip: time.shiftWeekStrip,
+      setSelectedDay: time.setSelectedDay,
+      setTimeMode: time.setTimeMode,
+      listQuery,
+      setListQuery,
+      tagFilter,
+      setTagFilter,
+      tagChips: derived.tagChips,
+      monthCursor: time.monthCursor,
+      monthTitle: derived.monthTitle,
+      goMonth: time.goMonth,
+      goToToday: time.goToToday,
+      cells: derived.cells,
+      dayCounts: derived.dayCounts,
+      listIsEmpty: derived.listIsEmpty,
+      hasListFilter: derived.hasListFilter,
+      hasNoHabits: derived.hasNoHabits,
+      grouped: derived.grouped,
+      canBulkMark: derived.canBulkMark,
+    }),
+    [derived, routine, time, listQuery, tagFilter],
+  );
+
+  const calendarActions = useMemo<RoutineCalendarActions>(
+    () => ({
+      applyTimeMode: time.applyTimeMode,
+      onToggleHabit,
+      setRoutine,
+      setMainTab,
+      onOpenModule,
+      onBulkMarkDay,
+      onOpenQuickAddHabit: openQuickAddHabit,
+    }),
+    [
+      time.applyTimeMode,
+      onToggleHabit,
+      setRoutine,
+      setMainTab,
+      onOpenModule,
+      onBulkMarkDay,
+      openQuickAddHabit,
+    ],
+  );
+
+  return {
+    routine,
+    setRoutine,
+    isHabitPending,
+    storageErrorMsg,
+    setStorageErrorMsg,
+    mainTab,
+    setMainTab,
+    quickAddHabitOpen,
+    quickAddFocusTick,
+    openQuickAddHabit,
+    closeQuickAddHabit,
+    streakMax: derived.streakMax,
+    calendarData,
+    calendarActions,
+    handlePullRefresh,
+    handlePullRefreshError,
+  };
+}

--- a/apps/web/src/modules/routine/useRoutineDerivedData.ts
+++ b/apps/web/src/modules/routine/useRoutineDerivedData.ts
@@ -1,0 +1,267 @@
+/**
+ * Pure-derived view layer for the Routine calendar.
+ *
+ * Given the canonical routine state, the time-state (mode + cursor +
+ * selected day) and the active filters, derive everything the
+ * calendar/stats UI needs to render: the active date range, the
+ * filtered + grouped events, the day-count map, the localized labels
+ * and the metrics (streak, completion, day progress).
+ *
+ * Split out of `useRoutineAppState.ts` as part of the Phase 2
+ * decomposition (initiative 0001) so the orchestrator hook stays
+ * under the 600-LOC lint guard. Everything here is `useMemo`-based
+ * and contains no event listeners or side effects.
+ */
+
+import { useMemo } from "react";
+import {
+  buildHubCalendarEvents,
+  countEventsByDate,
+  dateKeyFromDate,
+  FIZRUK_GROUP_LABEL,
+  habitScheduledOnDate,
+  parseDateKey,
+} from "./lib/hubCalendarAggregate";
+import { FINYK_SUB_GROUP_LABEL } from "./lib/finykSubscriptionCalendar";
+import { addDays, startOfIsoWeek } from "./lib/weekUtils";
+import { completionRateForRange, maxActiveStreak } from "./lib/streaks";
+import {
+  groupEventsForList,
+  monthBounds,
+  monthGrid,
+  todayDate,
+  type DateRange,
+} from "./RoutineApp.helpers";
+import type {
+  RoutineCompletionRate,
+  RoutineDayProgress,
+} from "./context/RoutineCalendarContext";
+import type { HubCalendarEvent, RoutineState } from "./lib/types";
+import type { TimeState } from "./useRoutineTimeState";
+
+export interface UseRoutineDerivedDataParams {
+  routine: RoutineState;
+  timeState: TimeState;
+  tagFilter: string | null;
+  listQuery: string;
+  finykCalendarTick: number;
+}
+
+export interface RoutineDerivedData {
+  range: DateRange;
+  events: HubCalendarEvent[];
+  filtered: HubCalendarEvent[];
+  listEvents: HubCalendarEvent[];
+  grouped: Array<[string, HubCalendarEvent[]]>;
+  tagChips: string[];
+  dayCounts: Map<string, number>;
+  monthTitle: string;
+  cells: Array<number | null>;
+  rangeLabel: string;
+  headlineDate: string;
+  todayKey: string;
+  streakMax: number;
+  completionRateVal: RoutineCompletionRate;
+  dayProgress: RoutineDayProgress;
+  activeHabitsCount: number;
+  hasNoHabits: boolean;
+  hasListFilter: boolean;
+  listIsEmpty: boolean;
+  canBulkMark: boolean;
+}
+
+function fmtUk(key: string): string {
+  return parseDateKey(key).toLocaleDateString("uk-UA", {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+  });
+}
+
+export function useRoutineDerivedData({
+  routine,
+  timeState,
+  tagFilter,
+  listQuery,
+  finykCalendarTick,
+}: UseRoutineDerivedDataParams): RoutineDerivedData {
+  const { timeMode, monthCursor, selectedDay } = timeState;
+
+  const range = useMemo<DateRange>(() => {
+    const t = todayDate();
+    const tk = dateKeyFromDate(t);
+    if (timeMode === "today") return { startKey: tk, endKey: tk };
+    if (timeMode === "tomorrow") {
+      const d = addDays(t, 1);
+      const k = dateKeyFromDate(d);
+      return { startKey: k, endKey: k };
+    }
+    if (timeMode === "day") {
+      return { startKey: selectedDay, endKey: selectedDay };
+    }
+    if (timeMode === "week") {
+      const anchor = parseDateKey(selectedDay);
+      const s = startOfIsoWeek(anchor);
+      const e = addDays(s, 6);
+      return { startKey: dateKeyFromDate(s), endKey: dateKeyFromDate(e) };
+    }
+    return monthBounds(monthCursor.y, monthCursor.m);
+  }, [timeMode, monthCursor.y, monthCursor.m, selectedDay]);
+
+  const events = useMemo(
+    () =>
+      buildHubCalendarEvents(routine, range, {
+        showFizruk: routine.prefs.showFizrukInCalendar !== false,
+        showFinykSubs: routine.prefs.showFinykSubscriptionsInCalendar !== false,
+      }),
+    /* finykCalendarTick лишаємо: оновлення подій Фініка без зміни routine */
+    [routine, range, finykCalendarTick], // eslint-disable-line react-hooks/exhaustive-deps
+  );
+
+  const filtered = useMemo(() => {
+    let ev: HubCalendarEvent[] = events;
+    if (tagFilter) {
+      if (tagFilter === "__fizruk") ev = ev.filter((e) => e.fizruk);
+      else if (tagFilter === "__finyk_sub") ev = ev.filter((e) => e.finykSub);
+      else ev = ev.filter((e) => e.tagLabels.includes(tagFilter));
+    }
+    const q = listQuery.trim().toLowerCase();
+    if (q) {
+      ev = ev.filter((e) => {
+        const hay =
+          `${e.title} ${e.subtitle} ${(e.tagLabels || []).join(" ")} ${e.note || ""}`.toLowerCase();
+        return hay.includes(q);
+      });
+    }
+    return ev;
+  }, [events, tagFilter, listQuery]);
+
+  const tagChips = useMemo<string[]>(() => {
+    const set = new Set<string>();
+    for (const t of routine.tags) set.add(t.name);
+    for (const e of events) {
+      for (const x of e.tagLabels) {
+        if (x !== FIZRUK_GROUP_LABEL && x !== FINYK_SUB_GROUP_LABEL) set.add(x);
+      }
+    }
+    return [...set].sort((a, b) => a.localeCompare(b, "uk"));
+  }, [routine.tags, events]);
+
+  const listEvents = useMemo(() => {
+    if (timeMode === "month")
+      return filtered.filter((e) => e.date === selectedDay);
+    return filtered;
+  }, [filtered, timeMode, selectedDay]);
+
+  const grouped = useMemo(() => groupEventsForList(listEvents), [listEvents]);
+
+  const dayCounts = useMemo(() => countEventsByDate(events), [events]);
+
+  const monthTitle = new Date(
+    monthCursor.y,
+    monthCursor.m,
+    1,
+  ).toLocaleDateString("uk-UA", {
+    month: "long",
+    year: "numeric",
+  });
+
+  const { cells } = monthGrid(monthCursor.y, monthCursor.m);
+
+  const rangeLabel = useMemo(() => {
+    if (timeMode === "today") return "Сьогодні";
+    if (timeMode === "tomorrow") return "Завтра";
+    if (timeMode === "day") {
+      return parseDateKey(selectedDay).toLocaleDateString("uk-UA", {
+        weekday: "long",
+        day: "numeric",
+        month: "long",
+      });
+    }
+    if (timeMode === "week") return "Цей тиждень";
+    return monthTitle;
+  }, [timeMode, monthTitle, selectedDay]);
+
+  const headlineDate = useMemo(() => {
+    const t0 = todayDate();
+    const tk = dateKeyFromDate(t0);
+    if (timeMode === "day") return fmtUk(selectedDay);
+    if (timeMode === "today") return fmtUk(tk);
+    if (timeMode === "tomorrow") return fmtUk(dateKeyFromDate(addDays(t0, 1)));
+    if (timeMode === "week") {
+      const a = fmtUk(range.startKey);
+      const b = fmtUk(range.endKey);
+      return range.startKey === range.endKey ? a : `${a} — ${b}`;
+    }
+    if (timeMode === "month") return fmtUk(selectedDay);
+    return fmtUk(tk);
+  }, [timeMode, selectedDay, range.startKey, range.endKey]);
+
+  const todayKey = dateKeyFromDate(todayDate());
+
+  const streakMax = useMemo(
+    () => maxActiveStreak(routine.habits, routine.completions, todayKey),
+    [routine.habits, routine.completions, todayKey],
+  );
+
+  const completionRateVal = useMemo(
+    () =>
+      completionRateForRange(
+        routine.habits,
+        routine.completions,
+        range.startKey,
+        range.endKey,
+      ),
+    [routine.habits, routine.completions, range.startKey, range.endKey],
+  );
+
+  const dayProgress = useMemo(
+    () =>
+      completionRateForRange(
+        routine.habits,
+        routine.completions,
+        todayKey,
+        todayKey,
+      ),
+    [routine.habits, routine.completions, todayKey],
+  );
+
+  const canBulkMark = useMemo(() => {
+    if (range.startKey !== range.endKey) return false;
+    const dk = range.startKey;
+    for (const h of routine.habits) {
+      if (h.archived) continue;
+      if (!habitScheduledOnDate(h, dk)) continue;
+      if (!(routine.completions[h.id] || []).includes(dk)) return true;
+    }
+    return false;
+  }, [range.startKey, range.endKey, routine.habits, routine.completions]);
+
+  const activeHabitsCount = routine.habits.filter((h) => !h.archived).length;
+  const hasNoHabits = activeHabitsCount === 0;
+  const hasListFilter = Boolean(tagFilter) || listQuery.trim().length > 0;
+  const listIsEmpty = grouped.length === 0;
+
+  return {
+    range,
+    events,
+    filtered,
+    listEvents,
+    grouped,
+    tagChips,
+    dayCounts,
+    monthTitle,
+    cells,
+    rangeLabel,
+    headlineDate,
+    todayKey,
+    streakMax,
+    completionRateVal,
+    dayProgress,
+    activeHabitsCount,
+    hasNoHabits,
+    hasListFilter,
+    listIsEmpty,
+    canBulkMark,
+  };
+}

--- a/apps/web/src/modules/routine/useRoutineTimeState.test.ts
+++ b/apps/web/src/modules/routine/useRoutineTimeState.test.ts
@@ -1,0 +1,198 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import {
+  initialTimeState,
+  timeReducer,
+  useRoutineTimeState,
+} from "./useRoutineTimeState";
+
+/**
+ * Locks the time-state machine that powers the Routine calendar.
+ *
+ * The reducer encodes the previously-implicit transitions between
+ * `timeMode` ("today" / "tomorrow" / "day" / "week" / "month"),
+ * `monthCursor` and `selectedDay`. Each test below pins one of those
+ * transitions so future refactors can't silently drop a behaviour.
+ *
+ * `vi.setSystemTime` freezes "today" so the assertions are stable
+ * across local clocks.
+ */
+describe("timeReducer", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Wed 2025-06-04 — middle of the week, mid-month, mid-year so
+    // every branch (week start, month bounds, etc.) is exercised
+    // without crossing month / year boundaries unintentionally.
+    vi.setSystemTime(new Date(2025, 5, 4, 12, 0, 0));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("seeds the initial state to today/today/current-month", () => {
+    const s = initialTimeState();
+    expect(s.timeMode).toBe("today");
+    expect(s.selectedDay).toBe("2025-06-04");
+    expect(s.monthCursor).toEqual({ y: 2025, m: 5 });
+  });
+
+  it("applyMode=today snaps selectedDay back to today", () => {
+    const start = { ...initialTimeState(), selectedDay: "2024-01-01" };
+    const next = timeReducer(start, { type: "applyMode", mode: "today" });
+    expect(next.timeMode).toBe("today");
+    expect(next.selectedDay).toBe("2025-06-04");
+  });
+
+  it("applyMode=tomorrow advances selectedDay by one day", () => {
+    const next = timeReducer(initialTimeState(), {
+      type: "applyMode",
+      mode: "tomorrow",
+    });
+    expect(next.timeMode).toBe("tomorrow");
+    expect(next.selectedDay).toBe("2025-06-05");
+  });
+
+  it("applyMode=month resets monthCursor to current month", () => {
+    const start = { ...initialTimeState(), monthCursor: { y: 2024, m: 0 } };
+    const next = timeReducer(start, { type: "applyMode", mode: "month" });
+    expect(next.timeMode).toBe("month");
+    expect(next.monthCursor).toEqual({ y: 2025, m: 5 });
+  });
+
+  it("goMonth wraps over December → January (and back)", () => {
+    const dec = { ...initialTimeState(), monthCursor: { y: 2025, m: 11 } };
+    const jan = timeReducer(dec, { type: "goMonth", delta: 1 });
+    expect(jan.monthCursor).toEqual({ y: 2026, m: 0 });
+
+    const back = timeReducer(jan, { type: "goMonth", delta: -1 });
+    expect(back.monthCursor).toEqual({ y: 2025, m: 11 });
+  });
+
+  it("goToToday resets monthCursor and selectedDay simultaneously", () => {
+    const drift = {
+      timeMode: "month" as const,
+      monthCursor: { y: 2024, m: 0 },
+      selectedDay: "2024-01-15",
+    };
+    const next = timeReducer(drift, { type: "goToToday" });
+    expect(next.monthCursor).toEqual({ y: 2025, m: 5 });
+    expect(next.selectedDay).toBe("2025-06-04");
+  });
+
+  it("shiftWeekStrip jumps by 7 days and forces day-mode", () => {
+    const start = {
+      timeMode: "week" as const,
+      monthCursor: { y: 2025, m: 5 },
+      selectedDay: "2025-06-04",
+    };
+    const fwd = timeReducer(start, { type: "shiftWeekStrip", deltaWeeks: 1 });
+    expect(fwd.timeMode).toBe("day");
+    expect(fwd.selectedDay).toBe("2025-06-11");
+
+    const back = timeReducer(fwd, { type: "shiftWeekStrip", deltaWeeks: -2 });
+    expect(back.selectedDay).toBe("2025-05-28");
+  });
+
+  it("syncMonthRange clamps selectedDay back into the visible month", () => {
+    const drift = {
+      timeMode: "month" as const,
+      monthCursor: { y: 2025, m: 5 }, // June 2025 → 06-01..06-30
+      selectedDay: "2025-04-15", // outside the visible month
+    };
+    const next = timeReducer(drift, { type: "syncMonthRange" });
+    expect(next.selectedDay).toBe("2025-06-01");
+  });
+
+  it("syncMonthRange is a no-op when selectedDay is in range", () => {
+    const ok = {
+      timeMode: "month" as const,
+      monthCursor: { y: 2025, m: 5 },
+      selectedDay: "2025-06-15",
+    };
+    const next = timeReducer(ok, { type: "syncMonthRange" });
+    expect(next).toBe(ok);
+  });
+
+  it("deepLinkDay forces day-mode at the given key", () => {
+    const next = timeReducer(initialTimeState(), {
+      type: "deepLinkDay",
+      selectedDay: "2025-12-31",
+    });
+    expect(next.timeMode).toBe("day");
+    expect(next.selectedDay).toBe("2025-12-31");
+  });
+});
+
+describe("useRoutineTimeState", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2025, 5, 4, 12, 0, 0));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("exposes stable callback identities across re-renders", () => {
+    const { result, rerender } = renderHook(() => useRoutineTimeState());
+    const first = {
+      goMonth: result.current.goMonth,
+      goToToday: result.current.goToToday,
+      applyTimeMode: result.current.applyTimeMode,
+      deepLinkDay: result.current.deepLinkDay,
+    };
+
+    rerender();
+
+    expect(result.current.goMonth).toBe(first.goMonth);
+    expect(result.current.goToToday).toBe(first.goToToday);
+    expect(result.current.applyTimeMode).toBe(first.applyTimeMode);
+    expect(result.current.deepLinkDay).toBe(first.deepLinkDay);
+  });
+
+  it("syncMonthRange runs on monthCursor change to clamp selectedDay", () => {
+    const { result } = renderHook(() => useRoutineTimeState());
+
+    // Force month-mode + a selectedDay that won't be in May 2025
+    act(() => {
+      result.current.applyTimeMode("month");
+    });
+    act(() => {
+      result.current.setSelectedDay("2025-06-30");
+    });
+    act(() => {
+      result.current.goMonth(-1); // → May 2025 (01..31)
+    });
+
+    // After the goMonth dispatch fires, the syncMonthRange effect
+    // should clamp the day to the start of May since 06-30 falls
+    // outside that month's bounds.
+    expect(result.current.monthCursor).toEqual({ y: 2025, m: 4 });
+    expect(result.current.selectedDay).toBe("2025-05-01");
+  });
+
+  it("setSelectedDay accepts a function updater", () => {
+    const { result } = renderHook(() => useRoutineTimeState());
+    act(() => {
+      result.current.setSelectedDay("2025-06-04");
+    });
+    act(() => {
+      result.current.setSelectedDay((prev) => {
+        const d = new Date(prev);
+        d.setDate(d.getDate() + 3);
+        return d.toISOString().slice(0, 10);
+      });
+    });
+    expect(result.current.selectedDay).toBe("2025-06-07");
+  });
+
+  it("setTimeMode accepts a function updater", () => {
+    const { result } = renderHook(() => useRoutineTimeState());
+    act(() => {
+      result.current.setTimeMode((prev) => (prev === "today" ? "week" : prev));
+    });
+    expect(result.current.timeMode).toBe("week");
+  });
+});

--- a/apps/web/src/modules/routine/useRoutineTimeState.ts
+++ b/apps/web/src/modules/routine/useRoutineTimeState.ts
@@ -1,0 +1,201 @@
+/**
+ * Time-state machine for the Routine calendar.
+ *
+ * The trio (`timeMode`, `monthCursor`, `selectedDay`) used to live as
+ * three uncoupled `useState`s in `RoutineApp.tsx`, with several
+ * callbacks and effects keeping them in sync. The Phase 2
+ * decomposition (initiative 0001) moves them behind a `useReducer`
+ * so transitions are explicit and testable in one place.
+ */
+
+import { useCallback, useEffect, useReducer } from "react";
+import { dateKeyFromDate, parseDateKey } from "./lib/hubCalendarAggregate";
+import { addDays } from "./lib/weekUtils";
+import type { RoutineTimeMode } from "./context/RoutineCalendarContext";
+import { monthBounds, todayDate, type MonthCursor } from "./RoutineApp.helpers";
+
+export interface TimeState {
+  timeMode: RoutineTimeMode;
+  monthCursor: MonthCursor;
+  selectedDay: string;
+}
+
+export type TimeAction =
+  | { type: "applyMode"; mode: RoutineTimeMode }
+  | { type: "goMonth"; delta: number }
+  | { type: "goToToday" }
+  | { type: "shiftWeekStrip"; deltaWeeks: number }
+  | { type: "setSelectedDay"; selectedDay: string }
+  | { type: "setTimeMode"; mode: RoutineTimeMode }
+  | { type: "syncMonthRange" }
+  | { type: "deepLinkDay"; selectedDay: string };
+
+export function timeReducer(state: TimeState, action: TimeAction): TimeState {
+  switch (action.type) {
+    case "applyMode": {
+      const t = todayDate();
+      const tk = dateKeyFromDate(t);
+      if (action.mode === "today") {
+        return { ...state, timeMode: "today", selectedDay: tk };
+      }
+      if (action.mode === "tomorrow") {
+        return {
+          ...state,
+          timeMode: "tomorrow",
+          selectedDay: dateKeyFromDate(addDays(t, 1)),
+        };
+      }
+      if (action.mode === "week") {
+        return { ...state, timeMode: "week", selectedDay: tk };
+      }
+      if (action.mode === "month") {
+        return {
+          timeMode: "month",
+          monthCursor: { y: t.getFullYear(), m: t.getMonth() },
+          selectedDay: tk,
+        };
+      }
+      return { ...state, timeMode: action.mode };
+    }
+    case "goMonth": {
+      let m = state.monthCursor.m + action.delta;
+      let y = state.monthCursor.y;
+      if (m > 11) {
+        m = 0;
+        y++;
+      }
+      if (m < 0) {
+        m = 11;
+        y--;
+      }
+      return { ...state, monthCursor: { y, m } };
+    }
+    case "goToToday": {
+      const t = todayDate();
+      return {
+        ...state,
+        monthCursor: { y: t.getFullYear(), m: t.getMonth() },
+        selectedDay: dateKeyFromDate(t),
+      };
+    }
+    case "shiftWeekStrip": {
+      const d = parseDateKey(state.selectedDay);
+      d.setDate(d.getDate() + 7 * action.deltaWeeks);
+      return {
+        ...state,
+        timeMode: "day",
+        selectedDay: dateKeyFromDate(d),
+      };
+    }
+    case "setSelectedDay":
+      return { ...state, selectedDay: action.selectedDay };
+    case "setTimeMode":
+      return { ...state, timeMode: action.mode };
+    case "syncMonthRange": {
+      if (state.timeMode !== "month") return state;
+      const { startKey, endKey } = monthBounds(
+        state.monthCursor.y,
+        state.monthCursor.m,
+      );
+      if (state.selectedDay < startKey || state.selectedDay > endKey) {
+        return { ...state, selectedDay: startKey };
+      }
+      return state;
+    }
+    case "deepLinkDay":
+      return {
+        ...state,
+        timeMode: "day",
+        selectedDay: action.selectedDay,
+      };
+    default:
+      return state;
+  }
+}
+
+export function initialTimeState(): TimeState {
+  const t = todayDate();
+  return {
+    timeMode: "today",
+    monthCursor: { y: t.getFullYear(), m: t.getMonth() },
+    selectedDay: dateKeyFromDate(t),
+  };
+}
+
+export interface RoutineTimeStateBundle extends TimeState {
+  applyTimeMode: (mode: RoutineTimeMode) => void;
+  goMonth: (delta: number) => void;
+  goToToday: () => void;
+  shiftWeekStrip: (deltaWeeks: number) => void;
+  setSelectedDay: (next: string | ((prev: string) => string)) => void;
+  setTimeMode: (
+    next: RoutineTimeMode | ((prev: RoutineTimeMode) => RoutineTimeMode),
+  ) => void;
+  deepLinkDay: (selectedDay: string) => void;
+}
+
+export function useRoutineTimeState(): RoutineTimeStateBundle {
+  const [state, dispatch] = useReducer(timeReducer, initialTimeState());
+
+  // When the month cursor moves, clamp `selectedDay` so it stays
+  // inside the visible month — kept here (rather than in the parent)
+  // because both inputs come from this hook's reducer.
+  useEffect(() => {
+    dispatch({ type: "syncMonthRange" });
+  }, [state.monthCursor.y, state.monthCursor.m, state.timeMode]);
+
+  const applyTimeMode = useCallback((mode: RoutineTimeMode) => {
+    dispatch({ type: "applyMode", mode });
+  }, []);
+
+  const goMonth = useCallback((delta: number) => {
+    dispatch({ type: "goMonth", delta });
+  }, []);
+
+  const goToToday = useCallback(() => {
+    dispatch({ type: "goToToday" });
+  }, []);
+
+  const shiftWeekStrip = useCallback((deltaWeeks: number) => {
+    dispatch({ type: "shiftWeekStrip", deltaWeeks });
+  }, []);
+
+  const setSelectedDay = useCallback(
+    (next: string | ((prev: string) => string)) => {
+      const value =
+        typeof next === "function"
+          ? (next as (prev: string) => string)(state.selectedDay)
+          : next;
+      dispatch({ type: "setSelectedDay", selectedDay: value });
+    },
+    [state.selectedDay],
+  );
+
+  const setTimeMode = useCallback(
+    (next: RoutineTimeMode | ((prev: RoutineTimeMode) => RoutineTimeMode)) => {
+      const value =
+        typeof next === "function"
+          ? (next as (prev: RoutineTimeMode) => RoutineTimeMode)(state.timeMode)
+          : next;
+      dispatch({ type: "setTimeMode", mode: value });
+    },
+    [state.timeMode],
+  );
+
+  const deepLinkDay = useCallback((selectedDay: string) => {
+    dispatch({ type: "deepLinkDay", selectedDay });
+  }, []);
+
+  return {
+    timeMode: state.timeMode,
+    monthCursor: state.monthCursor,
+    selectedDay: state.selectedDay,
+    applyTimeMode,
+    goMonth,
+    goToToday,
+    shiftWeekStrip,
+    setSelectedDay,
+    setTimeMode,
+    deepLinkDay,
+  };
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -767,7 +767,6 @@ export default [
   // file shows up in `git blame` / `git log` against this rule.
   {
     files: [
-      "apps/web/src/modules/routine/RoutineApp.tsx",
       "apps/web/src/modules/nutrition/components/LogCard.tsx",
       "apps/web/src/modules/fizruk/pages/Workouts.tsx",
       "apps/web/src/modules/fizruk/pages/Progress.tsx",


### PR DESCRIPTION
## Summary

Initiative 0001 Phase 2 — splits `apps/web/src/modules/routine/RoutineApp.tsx` (745 LOC) into single-purpose shards under the 600-LOC lint guard, replacing the scattered `useState` calls for the calendar's time-state with an explicit `useReducer` machine.

This is the **last** Phase 2 file. After this merges, Phase 2 of the module-decomposition initiative is fully done; the only remaining work is `decomp-finalize` (close the initiative as Done).

Composition (every shard under the 600-LOC guard):

| File | LOC | Role |
| --- | ---: | --- |
| `RoutineApp.tsx` | 88 | Thin composition root — wires the orchestrator hook to the shards. |
| `RoutineApp.helpers.ts` | 100 | Pure date/grouping helpers (no React). |
| `useRoutineAppState.ts` | ~350 | Orchestrator: routine state, main tab, filters, quick-add, deep-link / PWA effects, callbacks. |
| `useRoutineTimeState.ts` | 212 | `useReducer` machine for `timeMode` + `monthCursor` + `selectedDay`. |
| `useRoutineDerivedData.ts` | 267 | Pure derived memos (range, events, filtered, listEvents, grouped, dayCounts, tagChips, monthTitle, cells, rangeLabel, headlineDate, streakMax, completionRateVal, dayProgress, canBulkMark). |
| `RoutineHeader.tsx` | 57 | Module header bar. |
| `RoutineTimeline.tsx` | 115 | Calendar/stats body + storage-error banner + pull-to-refresh. |
| `RoutineActions.tsx` | 53 | Bottom nav + quick-add dialog. |
| `useRoutineTimeState.test.ts` | 200 | New test fixture (14 cases) locking the time-state machine. |

Removed `apps/web/src/modules/routine/RoutineApp.tsx` from `eslint.config.js` `max-lines` allowlist — no allowlist entry remains for any file in `apps/web/src/modules/routine`.

Public API stability: `RoutineApp` default export and `RoutineAppProps` interface unchanged. No consumer needs to update its imports.

## Governing Skill

- Primary skill: `sergeant-web-ui`
- Secondary skill (if truly needed): `sergeant-monorepo-boundaries` (cross-module `routine ↔ finyk hub-preview` wiring stays in place)

## Playbook

- Primary playbook: `docs/initiatives/0001-module-decomposition.md`
- Why this playbook: Closes out Phase 2 (the last allowlist file in the routine module).
- If no playbook matched, why: n/a

## Verification

```bash
# in apps/web (with @sergeant/db-schema rebuilt — pre-existing requirement on main)
pnpm exec vitest run src/modules/routine --exclude '**/dualWrite/**'
# Test Files 5 passed (5) — Tests 61 passed (61)

pnpm exec vitest run src/modules/routine src/core/hub --exclude '**/dualWrite/**'
# Test Files 12 passed (12) — Tests 160 passed (160)

pnpm exec vitest run src/modules/routine/useRoutineTimeState.test.ts
# Tests 14 passed (14) — new state-machine fixture

pnpm lint   # apps/web — total errors 139 (main) → 136 (this PR), delta -3
pnpm build  # ../server/dist/assets/RoutineApp-*.js  53.32 kB (vs 53.56 kB on main)
```

Additional checks:

- [x] Local smoke / manual validation completed (`pnpm build` succeeds; `RoutineApp` chunk emits correctly)
- [x] Surface-specific checks completed (routine + hub + finyk hub-preview unit tests pass; reducer locked by new fixture)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. (Initiative 0001 status update is the next PR — `decomp-finalize`.)
- [x] I checked whether `AGENTS.md` needed an update. (No — public API and module ownership unchanged.)
- [x] I checked whether a playbook or skill needed an update. (No — the routine surface still maps cleanly to `sergeant-web-ui`.)
- [x] I checked whether governance docs or review docs needed an update. (No.)

Updated docs:

- n/a (Phase 2 outcome doc moves in `decomp-finalize`).

## Risk and Rollout

- User-visible risk: **Low.** Pure refactor — the composition root, orchestrator hook and pure derived hook all preserve the original hook call order, effect dependency arrays and memo deps. The new `useReducer` machine is a drop-in replacement for three previously-coupled `useState`s and is unit-tested. Public `RoutineApp` API is unchanged.
- Rollout / deploy order: Standard merge → main → Vercel preview → prod. No env, migration or feature-flag changes.
- Backout plan: Single-commit revert (`git revert <sha>` on main). The original 745-LOC `RoutineApp.tsx` is reproducible from history.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

- The `react-hooks/set-state-in-effect` rule fires on **3 patterns** that already existed in the original `RoutineApp.tsx` (visible on main with 139 lint errors). After the split, only 1 of those remains (in `useRoutineAppState.ts`, the PWA `add_habit` deep-link handler) and is suppressed inline with a rationale comment — `setQuickAddHabitOpen(true)` is an external-event adaptor, not a render derivation. Net project-wide: **3 fewer** lint errors than main.
- The `dualWrite` test suites (`adapter.test.ts`, `integration.test.ts`) fail with `Cannot find package '@sergeant/db-schema/sqlite/migrations'` — confirmed pre-existing on main; `pnpm --filter @sergeant/db-schema build` once before `pnpm build` is required for both branches.
- Followup: `decomp-finalize` will remove the (now empty for routine module) allowlist coverage assertions and close the initiative as Done.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the Routine module with improved component architecture and state management for better maintainability and performance.

* **Tests**
  * Added comprehensive test coverage for routine time state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->