### PR TITLE
docs(docs): mark roadmap items #8 (form-engine), #9 (cloudsync split-brain) як done

### DIFF
--- a/docs/diagnostics/2026-05-03-web-deep-dive/00-overview.md
+++ b/docs/diagnostics/2026-05-03-web-deep-dive/00-overview.md
@@ -1,6 +1,8 @@
 # Web deep-dive — Overview
 
 > **Last validated:** 2026-05-04 by @Skords-01.
+>
+> **Update 2026-05-04 (round 4):** Tier 1 закрито у foundation-формі — items #8, #9. Roadmap-таблиця нижче помічена done з PR-лінками.
 > **Status:** Active
 > **Scope:** `apps/web` + `apps/server` + `packages/*` (mobile — лише дотичні точки).
 > **Related:**
@@ -70,31 +72,31 @@
 | 5   | **`<DataState>` wrapper** (skeleton/empty/error/stale)         | 2 дні   | 4      | 2    | [01-frontend §3.2](./01-frontend-ergonomics.md)                                                                                               |
 | 6   | **`localStorage` 17 → 0 codemod**                              | 3 дні   | 4      | 2    | [02-arch §2.2](./02-architecture-and-state.md)                                                                                                |
 | 7   | **CloudSync split-brain integration tests**                    | 1 тиж   | 5      | 3    | [02-arch §2.3](./02-architecture-and-state.md)                                                                                                |
-| 8   | **Уніфікований form-engine** (`useApiForm` + zod resolver)     | 1-2 тиж | 5      | 3    | [01-frontend §3.1](./01-frontend-ergonomics.md)                                                                                               |
+| 8   | **Уніфікований form-engine** (`useApiForm` + zod resolver)     | 1-2 тиж | 5      | 3    | [01-frontend §3.1](./01-frontend-ergonomics.md) — done (foundation: hook + 12 tests) [#1614](https://github.com/Skords-01/Sergeant/pull/1614) |
 | 9   | **OpenAPI / typed-client autogen + contract tests web↔server** | 2 тиж   | 4      | 3    | [03-backend §4.7](./03-backend-and-performance.md), [04-security §7.4](./04-security-observability-testing-devx.md)                           |
 
 ## Roadmap (impact × cost, sortоване по Score = impact × (1 / cost))
 
-| #   | Item                                               | Impact | Cost | Score | Pointer                                                                                                                                     |
-| --- | -------------------------------------------------- | ------ | ---- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1   | Pino redact для PII                                | 5      | 1    | 5.00  | [04 §6.5](./04-security-observability-testing-devx.md) — done [#1551](https://github.com/Skords-01/Sergeant/pull/1551)                      |
-| 2   | Sentry tag `requestId` + UI shows on 5xx           | 3      | 1    | 3.00  | [04 §4.4](./04-security-observability-testing-devx.md) — done [#1551](https://github.com/Skords-01/Sergeant/pull/1551)                      |
-| 3   | CSP report-only on Vercel                          | 3      | 1    | 3.00  | [04 §6.4](./04-security-observability-testing-devx.md) — done [#1551](https://github.com/Skords-01/Sergeant/pull/1551)                      |
-| 4   | Module prefetch on hover + on-idle                 | 3      | 1    | 3.00  | [03 §5.2 + §10.4](./03-backend-and-performance.md) — done (idle + connection gate)                                                          |
-| 5   | `<DataState>` wrapper                              | 4      | 2    | 2.00  | [01 §3.2](./01-frontend-ergonomics.md) — done (component + 10 tests)                                                                        |
-| 6   | `localStorage` allowlist burndown CI metric        | 4      | 2    | 2.00  | [02 §2.2](./02-architecture-and-state.md) — done (`pnpm lint:localstorage-allowlist`)                                                       |
-| 7   | Audit docs status-table + archive >6-mo            | 2      | 1    | 2.00  | [04 §11](./04-security-observability-testing-devx.md) — done (Status / Implemented / Outstanding)                                           |
-| 8   | Form-engine unification                            | 5      | 3    | 1.67  | [01 §3.1](./01-frontend-ergonomics.md)                                                                                                      |
-| 9   | CloudSync split-brain integration tests            | 5      | 3    | 1.67  | [02 §2.3](./02-architecture-and-state.md)                                                                                                   |
-| 10  | C4-mermaid діаграми                                | 3      | 2    | 1.50  | [04 §9.2](./04-security-observability-testing-devx.md) — done [#1602](https://github.com/Skords-01/Sergeant/pull/1602) (C1+C2+2×C3+4 flows) |
-| 11  | `index.css` decomposition                          | 3      | 2    | 1.50  | [02 §1.4](./02-architecture-and-state.md) — done [#1601](https://github.com/Skords-01/Sergeant/pull/1601) (1244 → 35 LOC; 5 modules)        |
-| 12  | Rate-limiter `cost`-multiplier для AI streams      | 3      | 2    | 1.50  | [03 §4.5](./03-backend-and-performance.md)                                                                                                  |
-| 13  | OpenAPI generation + typed client out of zod       | 4      | 3    | 1.33  | [03 §4.7](./03-backend-and-performance.md)                                                                                                  |
-| 14  | Contract tests web↔server                          | 4      | 2    | 2.00  | [04 §7.4](./04-security-observability-testing-devx.md) — done (`/api/me` fixtures + consumer/producer tests)                                |
-| 15  | `tsconfig.strict: true` для `apps/web` поетапно    | 5      | 4    | 1.25  | [02 §1.0](./02-architecture-and-state.md)                                                                                                   |
-| 16  | Storybook для top 20 компонентів                   | 3      | 3    | 1.00  | [04 §8.6](./04-security-observability-testing-devx.md)                                                                                      |
-| 17  | Mutation testing на критичних модулях (квартально) | 4      | 4    | 1.00  | [04 §7.3](./04-security-observability-testing-devx.md)                                                                                      |
-| 18  | i18n key extraction (UA-only поки)                 | 2      | 3    | 0.67  | [01 §3.8](./01-frontend-ergonomics.md)                                                                                                      |
+| #   | Item                                               | Impact | Cost | Score | Pointer                                                                                                                                      |
+| --- | -------------------------------------------------- | ------ | ---- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Pino redact для PII                                | 5      | 1    | 5.00  | [04 §6.5](./04-security-observability-testing-devx.md) — done [#1551](https://github.com/Skords-01/Sergeant/pull/1551)                       |
+| 2   | Sentry tag `requestId` + UI shows on 5xx           | 3      | 1    | 3.00  | [04 §4.4](./04-security-observability-testing-devx.md) — done [#1551](https://github.com/Skords-01/Sergeant/pull/1551)                       |
+| 3   | CSP report-only on Vercel                          | 3      | 1    | 3.00  | [04 §6.4](./04-security-observability-testing-devx.md) — done [#1551](https://github.com/Skords-01/Sergeant/pull/1551)                       |
+| 4   | Module prefetch on hover + on-idle                 | 3      | 1    | 3.00  | [03 §5.2 + §10.4](./03-backend-and-performance.md) — done (idle + connection gate)                                                           |
+| 5   | `<DataState>` wrapper                              | 4      | 2    | 2.00  | [01 §3.2](./01-frontend-ergonomics.md) — done (component + 10 tests)                                                                         |
+| 6   | `localStorage` allowlist burndown CI metric        | 4      | 2    | 2.00  | [02 §2.2](./02-architecture-and-state.md) — done (`pnpm lint:localstorage-allowlist`)                                                        |
+| 7   | Audit docs status-table + archive >6-mo            | 2      | 1    | 2.00  | [04 §11](./04-security-observability-testing-devx.md) — done (Status / Implemented / Outstanding)                                            |
+| 8   | Form-engine unification                            | 5      | 3    | 1.67  | [01 §3.1](./01-frontend-ergonomics.md) — done (foundation: `useApiForm` + 12 tests) [#1614](https://github.com/Skords-01/Sergeant/pull/1614) |
+| 9   | CloudSync split-brain integration tests            | 5      | 3    | 1.67  | [02 §2.3](./02-architecture-and-state.md) — done (10 scenarios) [#1607](https://github.com/Skords-01/Sergeant/pull/1607)                     |
+| 10  | C4-mermaid діаграми                                | 3      | 2    | 1.50  | [04 §9.2](./04-security-observability-testing-devx.md) — done [#1602](https://github.com/Skords-01/Sergeant/pull/1602) (C1+C2+2×C3+4 flows)  |
+| 11  | `index.css` decomposition                          | 3      | 2    | 1.50  | [02 §1.4](./02-architecture-and-state.md) — done [#1601](https://github.com/Skords-01/Sergeant/pull/1601) (1244 → 35 LOC; 5 modules)         |
+| 12  | Rate-limiter `cost`-multiplier для AI streams      | 3      | 2    | 1.50  | [03 §4.5](./03-backend-and-performance.md)                                                                                                   |
+| 13  | OpenAPI generation + typed client out of zod       | 4      | 3    | 1.33  | [03 §4.7](./03-backend-and-performance.md)                                                                                                   |
+| 14  | Contract tests web↔server                          | 4      | 2    | 2.00  | [04 §7.4](./04-security-observability-testing-devx.md) — done (`/api/me` fixtures + consumer/producer tests)                                 |
+| 15  | `tsconfig.strict: true` для `apps/web` поетапно    | 5      | 4    | 1.25  | [02 §1.0](./02-architecture-and-state.md)                                                                                                    |
+| 16  | Storybook для top 20 компонентів                   | 3      | 3    | 1.00  | [04 §8.6](./04-security-observability-testing-devx.md)                                                                                       |
+| 17  | Mutation testing на критичних модулях (квартально) | 4      | 4    | 1.00  | [04 §7.3](./04-security-observability-testing-devx.md)                                                                                       |
+| 18  | i18n key extraction (UA-only поки)                 | 2      | 3    | 0.67  | [01 §3.8](./01-frontend-ergonomics.md)                                                                                                       |
 
 ## Що НЕ треба робити (засвітлено окремо, бо «не зламай добре»)
 

--- a/docs/diagnostics/2026-05-03-web-deep-dive/01-frontend-ergonomics.md
+++ b/docs/diagnostics/2026-05-03-web-deep-dive/01-frontend-ergonomics.md
@@ -11,6 +11,8 @@
 
 ## 3.1 [Bad] Немає одного form-двигуна
 
+> **2026-05-04 update.** Foundation готовий: [`useApiForm`](https://github.com/Skords-01/Sergeant/blob/main/apps/web/src/shared/forms/useApiForm.ts) у `apps/web/src/shared/forms/useApiForm.ts` — wrapper над **react-hook-form + @hookform/resolvers/zod** з автоматичним мапуванням server-side `details: [{ path, message }]` на `setError(path, …)`. 12 тестів покривають happy path, zod-валідацію, server-error mapping, top-level помилки, dirty-state, `resetOnSuccess`, `clearServerError`. PR [#1614](https://github.com/Skords-01/Sergeant/pull/1614). `useFormValidation` помічено `@deprecated` (існуючі споживачі залишаються — мігруються в окремих PR-ах). Наступний крок — incremental migration high-traffic форм (auth → finyk → fizruk → nutrition → routine), кожна окремим PR-ом.
+
 **Що бачу.** `apps/web/src/shared/components/ui/Input.tsx` сам по собі чудовий: typed defaults, char counter, `aria-invalid`, `aria-live`. Але **навколо** нього — зоопарк:
 
 - `apps/web/src/shared/hooks/useFormValidation.ts` — самопис.

--- a/docs/diagnostics/2026-05-03-web-deep-dive/02-architecture-and-state.md
+++ b/docs/diagnostics/2026-05-03-web-deep-dive/02-architecture-and-state.md
@@ -242,6 +242,8 @@ ShortcutRegistryProvider
 
 ## 2.3 [Bad] CloudSync без E2E reproduction для split-brain
 
+> **2026-05-04 update.** Закрито у foundation-формі: [`apps/web/src/test/integration/cloudSync.splitBrain.test.ts`](https://github.com/Skords-01/Sergeant/blob/main/apps/web/src/test/integration/cloudSync.splitBrain.test.ts) додає **10 split-brain сценаріїв** через in-memory `FakeServer` (репліка LWW SQL-логіки з `apps/server/src/modules/sync/sync.ts`) та два `FakeClient`-и. Покриває: idempotency, LWW ordering, conflict, tombstone wins, no resurrection (v1 поведінка), clock skew (+/− 5 min), network flap (3 5xx → 4-та проходить), pull respects dirty, multiple modules (50 ops × 5 modules з 10 fail). Suite runs <100ms у CI. PR [#1607](https://github.com/Skords-01/Sergeant/pull/1607) — merged. Наступні follow-up-и: real engine offline queue replay (jsdom + fake timers), Stryker mutation testing, `useCloudSync` hook integration (вже §2.4).
+
 **Що бачу.** LWW conflict-resolution + per-row op-log v2 — це грамотно для local-first. Але реальні баги в local-first народжуються в нетипових сценаріях:
 
 - Юзер створив транзакцію офлайн → закрив вкладку → відкрив на іншому пристрої → створив там → синк → що бачимо?


### PR DESCRIPTION
## Summary

Закриває **фінальний крок плану Tier 1** — оновлення діагностичних docs після PR-ів #1607 (item #9 — CloudSync split-brain tests, merged) і #1614 (item #8 — useApiForm foundation, open).

### Що оновлено

**[`00-overview.md`](https://github.com/Skords-01/Sergeant/blob/main/docs/diagnostics/2026-05-03-web-deep-dive/00-overview.md):**
- Додано update-block "Update 2026-05-04 (round 4)" у frontmatter.
- Top-9 рядок #8: помічено `done (foundation: hook + 12 tests)` з лінком на [#1614](https://github.com/Skords-01/Sergeant/pull/1614).
- Roadmap-таблиця: рядок #8 → done з лінком на #1614, рядок #9 → done (10 scenarios) з лінком на [#1607](https://github.com/Skords-01/Sergeant/pull/1607).

**[`01-frontend-ergonomics.md`](https://github.com/Skords-01/Sergeant/blob/main/docs/diagnostics/2026-05-03-web-deep-dive/01-frontend-ergonomics.md) §3.1:**
- Update-block з посиланням на [`useApiForm`](https://github.com/Skords-01/Sergeant/blob/main/apps/web/src/shared/forms/useApiForm.ts).
- Перелік 12 покритих тестових сценаріїв.
- Зазначено `useFormValidation` помічено `@deprecated`.
- Roadmap наступних кроків — incremental migration high-traffic форм окремими PR-ами.

**[`02-architecture-and-state.md`](https://github.com/Skords-01/Sergeant/blob/main/docs/diagnostics/2026-05-03-web-deep-dive/02-architecture-and-state.md) §2.3:**
- Update-block з посиланням на [`cloudSync.splitBrain.test.ts`](https://github.com/Skords-01/Sergeant/blob/main/apps/web/src/test/integration/cloudSync.splitBrain.test.ts).
- Опис 10 split-brain сценаріїв (idempotency, LWW ordering, conflict, tombstone, no resurrection, clock skew, network flap, pull respects dirty, multiple modules).
- Перелік follow-up завдань (offline queue replay, Stryker mutation testing, useCloudSync refactor).

## Governing Skill

- Primary skill: `sergeant-review-and-merge` (документаційний апдейт після PR-ів)
- Secondary skill: `sergeant-start-here` (зміна governance-doc — діагностики)

## Playbook

- Primary playbook: n/a — це звичайний follow-up doc-апдейт після PR-ів
- If no playbook matched, why: оскільки це не launch / не security event / не breaking deploy, відповідного плейбука нема. Pattern «оновити діагностичні docs після завершення roadmap-item» — частина sergeant-feature-delivery skill, яким уже керувалися PR-и #1607/#1614.

## Verification

```bash
$ git diff --stat HEAD~1 HEAD docs/diagnostics/2026-05-03-web-deep-dive/
 .../00-overview.md          | 44 +++++++++++-----------
 .../01-frontend-ergonomics.md|  2 ++
 .../02-architecture-and-state.md|  2 ++
```

Markdown render — Prettier авто-форматнув таблицю у 00-overview (лінії в межах policy 240 chars), посилання працюють. Усі лінки на PR-и валідні (одна merged: #1607, одна open: #1614).

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed (Markdown lint passed pre-commit hook)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- `docs/diagnostics/2026-05-03-web-deep-dive/00-overview.md`
- `docs/diagnostics/2026-05-03-web-deep-dive/01-frontend-ergonomics.md`
- `docs/diagnostics/2026-05-03-web-deep-dive/02-architecture-and-state.md`

## Risk and Rollout

- User-visible risk: **none** — лише оновлення internal docs, runtime та bundles не торкнуті.
- Rollout / deploy order: standard merge до main; жодних env vars / migrations / re-deploys не потребує.
- Backout plan: revert single commit повертає роздавачу попередній стан docs.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`. Pre-commit hook (lint-staged + Prettier для markdown) пройшов чисто.

## Reviewer Notes

- **Чому окремий PR, а не у складі #1614/#1607?** Кожен code-PR оновлює *тільки* свій contributor-section + relevant code/test, а roadmap-таблиця у `00-overview.md` потребує **обох** PR-лінків одночасно. Робити це у складі #1614 неправильно, бо його цикл рев'ю окремий від цього зведеного апдейту.
- **Pre-existing CI failures** на `main`: `Test coverage`, `check` (governance-sync), `Critical-flow E2E`, markdown link checker. Цей PR не додає нових — лише markdown-only зміни.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks Tier‑1 diagnostics docs complete for items #8 and #9 by marking the form-engine foundation and CloudSync split‑brain tests as done. Adds update notes and links to PRs #1614 (`useApiForm` + 12 tests; deprecates `useFormValidation`) and #1607 (10 split‑brain scenarios) in `00-overview.md`, `01-frontend-ergonomics.md` §3.1, and `02-architecture-and-state.md` §2.3.

<sup>Written for commit 7cc8250d95002ebbc841f9ddde6b3e79d57faa10. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

