### PR TITLE
feat(server): sync v1 legacy-clients survey counter (initiative 0003 phase 1)

### DIFF
--- a/apps/server/src/modules/sync/clientSurvey.test.ts
+++ b/apps/server/src/modules/sync/clientSurvey.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../../obs/metrics.js", () => ({
+  syncV1LegacyClientsTotal: { inc: vi.fn() },
+}));
+
+import { syncV1LegacyClientsTotal } from "../../obs/metrics.js";
+import {
+  __resetKnownVersionsForTest,
+  classifyUserAgent,
+  classifyV1SyncOp,
+  extractAppVersion,
+  v1ClientSurveyMiddleware,
+} from "./clientSurvey.js";
+
+const incMock = syncV1LegacyClientsTotal.inc as unknown as ReturnType<
+  typeof vi.fn
+>;
+
+beforeEach(() => {
+  incMock.mockClear();
+  __resetKnownVersionsForTest();
+});
+
+describe("classifyUserAgent", () => {
+  it.each([
+    [
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+      "web",
+    ],
+    [
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Firefox/120.0",
+      "web",
+    ],
+    ["okhttp/4.12.0", "mobile-rn"],
+    ["Sergeant/1.4.2 CFNetwork/1492.0.1 Darwin/22.6.0", "mobile-rn"],
+    [
+      "Mozilla/5.0 (Linux; Android 14; SM-G991B; wv) AppleWebKit/537.36 Chrome/120.0 Capacitor/6.0",
+      "mobile-shell-android",
+    ],
+    [
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 Capacitor/6.0",
+      "mobile-shell-ios",
+    ],
+    ["curl/8.4.0", "other"],
+    [undefined, "other"],
+    [null, "other"],
+    ["", "other"],
+  ])("%s → %s", (ua, expected) => {
+    expect(classifyUserAgent(ua)).toBe(expected);
+  });
+
+  it("safari without cfnetwork is NOT mobile-rn (false-positive guard)", () => {
+    // Desktop Safari has CFNetwork but also "Safari" — must classify as web.
+    const ua =
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
+    expect(classifyUserAgent(ua)).toBe("web");
+  });
+});
+
+describe("extractAppVersion", () => {
+  it("normalizes major.minor.patch → major.minor", () => {
+    expect(extractAppVersion({ headers: { "x-app-version": "1.4.2" } })).toBe(
+      "1.4",
+    );
+  });
+
+  it("accepts major.minor without patch", () => {
+    expect(extractAppVersion({ headers: { "x-app-version": "2.0" } })).toBe(
+      "2.0",
+    );
+  });
+
+  it("strips pre-release / build suffix", () => {
+    expect(
+      extractAppVersion({ headers: { "x-app-version": "1.4.2-beta.1" } }),
+    ).toBe("1.4");
+    expect(
+      extractAppVersion({ headers: { "x-app-version": "1.4.2+build.42" } }),
+    ).toBe("1.4");
+  });
+
+  it("returns 'unknown' when header missing or not a semver", () => {
+    expect(extractAppVersion({ headers: {} })).toBe("unknown");
+    expect(extractAppVersion({ headers: { "x-app-version": "v1.4" } })).toBe(
+      "unknown",
+    );
+    expect(extractAppVersion({ headers: { "x-app-version": "garbage" } })).toBe(
+      "unknown",
+    );
+  });
+
+  it("treats array-valued header as the first element", () => {
+    expect(
+      extractAppVersion({
+        headers: {
+          "x-app-version": ["1.5.0", "2.0.0"] as unknown as string,
+        },
+      }),
+    ).toBe("1.5");
+  });
+
+  it("caps cardinality at KNOWN_VERSION_LIMIT (20)", () => {
+    for (let i = 0; i < 20; i++) {
+      const major = Math.floor(i / 10) + 1;
+      const minor = i % 10;
+      expect(
+        extractAppVersion({
+          headers: { "x-app-version": `${major}.${minor}.0` },
+        }),
+      ).toBe(`${major}.${minor}`);
+    }
+    // 21st distinct version goes to "old" bucket
+    expect(extractAppVersion({ headers: { "x-app-version": "9.9.9" } })).toBe(
+      "old",
+    );
+    // Already-seen version still resolves normally
+    expect(extractAppVersion({ headers: { "x-app-version": "1.0.42" } })).toBe(
+      "1.0",
+    );
+  });
+});
+
+describe("classifyV1SyncOp", () => {
+  it.each([
+    ["/api/sync/push", "push"],
+    ["/api/sync/pull", "pull"],
+    ["/api/sync/push-all", "push_all"],
+    ["/api/sync/pull-all", "pull_all"],
+    ["/api/sync/audit", null],
+    ["/api/v2/sync/push", null],
+    ["/api/healthz", null],
+  ])("%s → %s", (path, expected) => {
+    expect(classifyV1SyncOp(path)).toBe(expected);
+  });
+});
+
+type FakeReq = {
+  path: string;
+  headers: Record<string, string | undefined>;
+};
+
+function fakeReq(path: string, headers: Record<string, string> = {}): FakeReq {
+  return { path, headers };
+}
+
+describe("v1ClientSurveyMiddleware", () => {
+  it("emits one inc per matching v1 op with correct labels", () => {
+    const mw = v1ClientSurveyMiddleware();
+    const next = vi.fn();
+    mw(
+      fakeReq("/api/sync/push", {
+        "user-agent": "okhttp/4.12.0",
+        "x-app-version": "2.1.0",
+      }) as unknown as Parameters<typeof mw>[0],
+      {} as unknown as Parameters<typeof mw>[1],
+      next,
+    );
+    expect(next).toHaveBeenCalledOnce();
+    expect(incMock).toHaveBeenCalledWith({
+      user_agent_class: "mobile-rn",
+      app_version: "2.1",
+      op: "push",
+    });
+  });
+
+  it("does NOT inc for /api/sync/audit (read-only, not a sync op)", () => {
+    const mw = v1ClientSurveyMiddleware();
+    const next = vi.fn();
+    mw(
+      fakeReq("/api/sync/audit", {
+        "user-agent": "Mozilla/5.0 Chrome/120.0",
+      }) as unknown as Parameters<typeof mw>[0],
+      {} as unknown as Parameters<typeof mw>[1],
+      next,
+    );
+    expect(next).toHaveBeenCalledOnce();
+    expect(incMock).not.toHaveBeenCalled();
+  });
+
+  it("uses 'unknown' app_version when header is missing", () => {
+    const mw = v1ClientSurveyMiddleware();
+    const next = vi.fn();
+    mw(
+      fakeReq("/api/sync/pull", {
+        "user-agent":
+          "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/120.0",
+      }) as unknown as Parameters<typeof mw>[0],
+      {} as unknown as Parameters<typeof mw>[1],
+      next,
+    );
+    expect(incMock).toHaveBeenCalledWith({
+      user_agent_class: "web",
+      app_version: "unknown",
+      op: "pull",
+    });
+  });
+
+  it("survives metric throws without breaking the request", () => {
+    incMock.mockImplementationOnce(() => {
+      throw new Error("metric backend down");
+    });
+    const mw = v1ClientSurveyMiddleware();
+    const next = vi.fn();
+    mw(
+      fakeReq("/api/sync/push", {
+        "user-agent": "okhttp/4.12.0",
+        "x-app-version": "1.0.0",
+      }) as unknown as Parameters<typeof mw>[0],
+      {} as unknown as Parameters<typeof mw>[1],
+      next,
+    );
+    // Even though inc threw, next() still ran exactly once.
+    expect(next).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/server/src/modules/sync/clientSurvey.ts
+++ b/apps/server/src/modules/sync/clientSurvey.ts
@@ -1,0 +1,168 @@
+import type { Request, Response, NextFunction } from "express";
+
+import { syncV1LegacyClientsTotal } from "../../obs/metrics.js";
+
+/**
+ * Pre-sunset measurement layer для CloudSync v1 (`/api/sync/*`). Гілку v1 не
+ * розширюємо — тільки на read-час фіксуємо, **хто саме** ще викликає v1, щоб
+ * до T₀ (CloudSync v1 sunset, [Initiative
+ * 0003](../../../../../docs/initiatives/0003-sync-v2-rollout-and-v1-sunset.md))
+ * можна було адресно push-ити update-нагадування у застарілі клієнти.
+ *
+ * Чому окремий counter, а не нові label-и на `sync_operations_total`?
+ *
+ * - `sync_operations_total{op,module,outcome}` уже існує і має ~30 series
+ *   (4 op × 5 module × ~7 outcome). Додавання `user_agent_class` і
+ *   `app_version` сюди підняло б cardinality на × ~100 → vmagent backpressure.
+ * - Цей counter **тільки v1** (на v2 ми не вимірюємо клієнтів — там немає
+ *   sunset-плану). Природна границя кардинальності.
+ *
+ * **Cardinality cap**:
+ *
+ * - `user_agent_class` — whitelist 5 значень (`web`, `mobile-rn`,
+ *   `mobile-shell-ios`, `mobile-shell-android`, `other`).
+ * - `app_version` — нормалізовано до `major.minor` (skipping patch); `unknown`
+ *   якщо `x-app-version` header відсутній або не парситься.
+ * - `op` — 4 значення (`push`, `pull`, `push_all`, `pull_all`).
+ *
+ * Worst-case cardinality: `5 × N × 4` де `N` — кількість унікальних
+ * `major.minor` що ще ходять у production. Очікуємо `N ≤ 20` (active versions
+ * у двох sprint-ах). Понад 20 — кладемо в `old` bucket.
+ */
+
+export type UserAgentClass =
+  | "web"
+  | "mobile-rn"
+  | "mobile-shell-ios"
+  | "mobile-shell-android"
+  | "other";
+
+const KNOWN_VERSION_LIMIT = 20;
+const knownVersions = new Set<string>();
+
+/**
+ * Класифікація `user-agent` у фіксований набір. Список побудовано з огляду на:
+ *
+ * - Browser-based web SPA (`apps/web` через Vite) — генерує стандартні
+ *   `Mozilla/5.0 ... Chrome/... Safari/...` headers.
+ * - React Native (Expo) — `okhttp/...` (Android) / `CFNetwork/...` (iOS) —
+ *   див. [Expo network docs](https://docs.expo.dev/versions/latest/sdk/network/).
+ * - Capacitor mobile-shell — додає `wv` (WebView) до Chrome UA на Android, та
+ *   `Mobile/...` варіант Safari на iOS.
+ *
+ * Класифікація **best-effort**: ми не намагаємось 100% точно розпізнати усі
+ * клієнти. Мета — побачити агрегатну тенденцію перед T₀.
+ */
+export function classifyUserAgent(
+  ua: string | null | undefined,
+): UserAgentClass {
+  if (!ua || typeof ua !== "string") return "other";
+  const lower = ua.toLowerCase();
+  if (lower.includes("okhttp") || lower.includes("expo/")) {
+    return "mobile-rn";
+  }
+  if (lower.includes("cfnetwork") && !lower.includes("safari")) {
+    return "mobile-rn";
+  }
+  if (lower.includes("capacitor") || lower.includes(" wv)")) {
+    if (lower.includes("iphone") || lower.includes("ipad")) {
+      return "mobile-shell-ios";
+    }
+    if (lower.includes("android")) {
+      return "mobile-shell-android";
+    }
+  }
+  if (
+    lower.includes("mozilla") &&
+    (lower.includes("chrome") ||
+      lower.includes("safari") ||
+      lower.includes("firefox"))
+  ) {
+    return "web";
+  }
+  return "other";
+}
+
+const SEMVER_RE = /^(\d{1,4})\.(\d{1,4})(?:\.\d{1,4})?(?:[-+].*)?$/;
+
+/**
+ * Витягує `x-app-version` header і нормалізує до `major.minor` (drop patch і
+ * pre-release suffix). Якщо header відсутній або не парситься — повертає
+ * `"unknown"`.
+ *
+ * `KNOWN_VERSION_LIMIT` зберігає тільки 20 перших побачених `major.minor`
+ * як hot-set; решта kладеться в `"old"`. Це anti-cardinality захист на
+ * випадок incident-у з спам-header-ами.
+ */
+export function extractAppVersion(req: Pick<Request, "headers">): string {
+  const raw = req.headers["x-app-version"];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (!value || typeof value !== "string") return "unknown";
+  const match = SEMVER_RE.exec(value.trim());
+  if (!match) return "unknown";
+  const major = match[1];
+  const minor = match[2];
+  const normalized = `${major}.${minor}`;
+  if (knownVersions.has(normalized)) return normalized;
+  if (knownVersions.size >= KNOWN_VERSION_LIMIT) return "old";
+  knownVersions.add(normalized);
+  return normalized;
+}
+
+/**
+ * Map URL path → metric `op` label. Виконано окремою функцією, бо роутінг
+ * v1-handler-ів живе у `routes/sync.ts`, а survey-middleware
+ * монтується раніше за handler і не має доступу до Express route-pattern-у.
+ *
+ * Невідомий path (theoretically — нові v1 routes у майбутньому, що ми не
+ * сповістили цьому module-у) повертає `null` — counter не інкрементиться.
+ */
+export function classifyV1SyncOp(
+  path: string,
+): "push" | "pull" | "push_all" | "pull_all" | null {
+  if (path.endsWith("/api/sync/push")) return "push";
+  if (path.endsWith("/api/sync/pull")) return "pull";
+  if (path.endsWith("/api/sync/push-all")) return "push_all";
+  if (path.endsWith("/api/sync/pull-all")) return "pull_all";
+  return null;
+}
+
+/**
+ * Express middleware. Має бути змонтований **до** authMiddleware у
+ * `/api/sync/*` chain, але це не обов'язково — `req.headers["user-agent"]` і
+ * `req.headers["x-app-version"]` доступні незалежно від auth-стану.
+ *
+ * Counter інкрементиться **на entry** в handler (не на response). Це означає,
+ * що ми міряємо traffic-arrival (включаючи 4xx/5xx), а не успішні sync-и.
+ * Outcome-breakdown лишається у `sync_operations_total{outcome=...}`.
+ */
+export function v1ClientSurveyMiddleware() {
+  return (req: Request, _res: Response, next: NextFunction): void => {
+    const op = classifyV1SyncOp(req.path);
+    if (!op) {
+      next();
+      return;
+    }
+    try {
+      const userAgentClass = classifyUserAgent(req.headers["user-agent"]);
+      const appVersion = extractAppVersion(req);
+      syncV1LegacyClientsTotal.inc({
+        user_agent_class: userAgentClass,
+        app_version: appVersion,
+        op,
+      });
+    } catch {
+      /* survey must never break a request */
+    }
+    next();
+  };
+}
+
+/**
+ * Test-only: clear the in-memory `knownVersions` cache. **Не використовувати у
+ * production** — counter sample-и persisted у `prom-client` registry, які
+ * необхідно reset-ити окремо через `resetCounter()` на стороні тестів.
+ */
+export function __resetKnownVersionsForTest(): void {
+  knownVersions.clear();
+}

--- a/apps/server/src/obs/metrics.ts
+++ b/apps/server/src/obs/metrics.ts
@@ -285,6 +285,25 @@ export const syncPayloadBytes = new client.Histogram({
   registers: [register],
 });
 
+/**
+ * Pre-sunset measurement для CloudSync v1 (Initiative 0003 Phase 1).
+ *
+ * Окремий counter (а не label-extension на `sync_operations_total`), бо:
+ *   - інкрементиться **тільки на v1**-routes (`/api/sync/*`);
+ *   - дозволяє pull-ити топ user-agent-classes / app-versions, що ще ходять
+ *     у v1 → адресно push-ити update-нагадування перед T₀ (sunset date).
+ *
+ * Кардинальність: 5 (`user_agent_class`) × ≤20 (`app_version`) × 4 (`op`) =
+ * ≤400 series. Logic у `apps/server/src/modules/sync/clientSurvey.ts` накладає
+ * hard cap.
+ */
+export const syncV1LegacyClientsTotal = new client.Counter({
+  name: "sync_v1_legacy_clients_total",
+  help: "CloudSync v1 (LWW-blob) clients by UA-class and app-version (sunset survey)",
+  labelNames: ["user_agent_class", "app_version", "op"],
+  registers: [register],
+});
+
 // ───────────────────────── Application errors ─────────────────
 export const appErrorsTotal = new client.Counter({
   name: "app_errors_total",

--- a/apps/server/src/routes/sync.ts
+++ b/apps/server/src/routes/sync.ts
@@ -6,6 +6,7 @@ import {
   setModule,
 } from "../http/index.js";
 import { listSyncAudit } from "../modules/sync/audit.js";
+import { v1ClientSurveyMiddleware } from "../modules/sync/clientSurvey.js";
 import {
   syncPull,
   syncPullAll,
@@ -38,6 +39,9 @@ export function createSyncRouter(): Router {
     rateLimitExpress({ key: "api:sync", limit: 30, windowMs: 60_000 }),
   );
   r.use("/api/sync", requireSession());
+  // v1 sunset survey: emit `sync_v1_legacy_clients_total` per push/pull.
+  // Initiative 0003 Phase 1 — see `clientSurvey.ts`.
+  r.use("/api/sync", v1ClientSurveyMiddleware());
   r.post("/api/sync/push", asyncHandler(syncPush));
   r.post("/api/sync/pull", asyncHandler(syncPull));
   r.get("/api/sync/pull-all", asyncHandler(syncPullAll));

--- a/docs/observability/dashboards/sync.json
+++ b/docs/observability/dashboards/sync.json
@@ -362,6 +362,144 @@
           "refId": "E"
         }
       ]
+    },
+    {
+      "title": "V1 vs V2 traffic split (5m rate)",
+      "type": "timeseries",
+      "description": "Initiative 0003 Phase 1 — pre-sunset baseline. v1 = `module=sync` legacy LWW-blob; v2 = `module=syncV2` op-log. Target: v1 → 0 by T₀.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 6,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "stacking": {
+              "mode": "normal"
+            },
+            "lineWidth": 1
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["sum", "lastNotNull"]
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (module) (rate(sync_operations_total{module=~\"sync|syncV2\"}[5m]))",
+          "legendFormat": "{{module}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "V1 legacy clients by user-agent class (5m rate)",
+      "type": "timeseries",
+      "description": "Initiative 0003 Phase 1 survey. Тільки v1 (`/api/sync/*`); UA buckets: web, mobile-rn, mobile-shell-ios/-android, other. Counter живе у `apps/server/src/modules/sync/clientSurvey.ts`.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 7,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "stacking": {
+              "mode": "normal"
+            },
+            "lineWidth": 1
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["sum"]
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (user_agent_class) (rate(sync_v1_legacy_clients_total[5m]))",
+          "legendFormat": "{{user_agent_class}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "V1 legacy clients by app version (1h rate, top 5)",
+      "type": "timeseries",
+      "description": "Initiative 0003 Phase 1 survey. `app_version` = `major.minor` з `x-app-version` header (cap=20). Перед T₀ — push-апдейт топ-2 версій що ще ходять у v1.",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "id": 8,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 1
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["sum", "lastNotNull"]
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "topk(5, sum by (app_version) (rate(sync_v1_legacy_clients_total[1h])))",
+          "legendFormat": "v{{app_version}}",
+          "refId": "A"
+        }
+      ]
     }
   ],
   "refresh": "30s",

--- a/docs/observability/prometheus/recording_rules.yml
+++ b/docs/observability/prometheus/recording_rules.yml
@@ -82,6 +82,20 @@ groups:
           /
           clamp_min(sum(rate(sync_operations_total{op=~"push|push_all"}[1h])), 1)
 
+      # Initiative 0003 Phase 1 — sunset baseline. v1 (`module=sync` legacy
+      # LWW-blob) vs v2 (`module=syncV2` op-log) per-version split. Target:
+      # `sli:sync_v1:rate5m` → 0 by T₀; legacy survey counter каже, хто саме
+      # ще ходить.
+      - record: sli:sync_v1:rate5m
+        expr: |
+          sum(rate(sync_operations_total{module="sync"}[5m]))
+      - record: sli:sync_v2:rate5m
+        expr: |
+          sum(rate(sync_operations_total{module="syncV2"}[5m]))
+      - record: sli:sync_v1_legacy:rate1h_by_appversion
+        expr: |
+          sum by (app_version) (rate(sync_v1_legacy_clients_total[1h]))
+
   # ──────────────────────────── Auth ────────────────────────────
   - name: sli_auth
     interval: 30s


### PR DESCRIPTION
## Summary

Initiative 0003 Phase 1 — pre-sunset baseline для CloudSync v1. Окремий counter `sync_v1_legacy_clients_total{user_agent_class, app_version, op}` через Express middleware на `/api/sync/*` (НЕ на `/api/v2/sync/*`), щоб адресно знати, які саме клієнти ще ходять у v1, перед T₀ (sunset date — TBD у Phase 2 ADR).

Зміни:
- `apps/server/src/modules/sync/clientSurvey.ts` (новий, 158 LOC) — `classifyUserAgent`, `extractAppVersion`, `classifyV1SyncOp`, `v1ClientSurveyMiddleware`. Survey НЕ ламає request: try/catch; throw → next() все одно викликає.
- `apps/server/src/obs/metrics.ts` — новий counter export.
- `apps/server/src/routes/sync.ts` — `r.use('/api/sync', v1ClientSurveyMiddleware())` після `requireSession()`.
- `apps/server/src/modules/sync/clientSurvey.test.ts` — 28 кейсів (UA classification ×10, version extraction + cap ×7, path classification ×7, middleware ×4 включно з throw-recovery).
- `docs/observability/dashboards/sync.json` — +3 panels (id 6/7/8): V1 vs V2 traffic split, V1 legacy clients by UA-class, V1 legacy clients by app-version (top 5).
- `docs/observability/prometheus/recording_rules.yml` — `sli:sync_v1:rate5m`, `sli:sync_v2:rate5m`, `sli:sync_v1_legacy:rate1h_by_appversion`.

**Чому окремий counter, а не label-extension на `sync_operations_total`:**
- `sync_operations_total{op,module,outcome}` уже має ~30 series. Додавання `user_agent_class+app_version` туди підняло б cardinality на × ~100 → vmagent backpressure.
- Новий counter **тільки v1** (на v2 sunset нема) — природна границя.

**Cardinality cap:**
- `user_agent_class` — 5 buckets (`web`, `mobile-rn`, `mobile-shell-ios`, `mobile-shell-android`, `other`).
- `app_version` — `x-app-version` header, нормалізовано до `major.minor`; hard cap 20 hot versions, далі `old` bucket; `unknown` якщо header відсутній.
- `op` — 4 значення. `/api/sync/audit` і `/api/v2/sync/*` skip-аються.
- Worst-case: 5 × 20 × 4 = 400 series.

Out of scope (Phase 2+ — окремі PR-и):
- Sunset/Deprecation/Link HTTP headers per RFC 8594 — Phase 2.
- ADR-0043 cloudsync-v1-sunset.
- `cloudSyncMode` feature-flag + shadow mode — Phase 3.
- Backfill `module_data` → `sync_op_log` script — Phase 4.
- T₀ → 410 Gone — Phase 5.
- Cleanup of v1 handlers — Phase 6.

## Governing Skill

- Primary skill: `sergeant-deploy-and-observability` (Prom counter + Grafana dashboard + recording rules + sunset rollout strategy).
- Secondary skill (if truly needed): `sergeant-server-api` (touches `apps/server/src/modules/sync/` + `routes/sync.ts`).

## Playbook

- Primary playbook: n/a — це Phase 1 з [Initiative 0003](../blob/main/docs/initiatives/0003-sync-v2-rollout-and-v1-sunset.md), сам ініціатива-документ і є playbook-ом.
- Why this playbook: фази розписані в самій ініціативі; Phase 1 = observability baseline.
- If no playbook matched, why: фазно-розбиваний rollout більший за один playbook; кожна фаза — окремий PR із власним scope.

## Verification

```bash
cd apps/server && pnpm test src/modules/sync/clientSurvey.test.ts
# 28 passed (28); 299ms

cd apps/server && pnpm test src/modules/sync/
# 66 passed (66) — всі sync tests, не тільки нові

cd apps/server && pnpm lint
# 1 error: src/http/rateLimit.ts:329 'checkRateLimitPgWithFallback' unused — pre-existing on main, не від цього PR
# Мої файли — clean.

python3 -c "import json; json.load(open('docs/observability/dashboards/sync.json'))"
# JSON valid; 8 panels (5 → 8).
```

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed (sync module tests, dashboard JSON valid, recording rules YAML valid)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. — Grafana dashboard + recording rules + counter docstring у самому файлі.
- [x] I checked whether `AGENTS.md` needed an update. — Ні: hard-rules не змінюються.
- [x] I checked whether a playbook or skill needed an update. — Ні: `sergeant-deploy-and-observability` уже описує Prom counter + dashboard pattern.
- [x] I checked whether governance docs or review docs needed an update. — Ні.

Updated docs:

- `docs/observability/dashboards/sync.json` (+3 panels)
- `docs/observability/prometheus/recording_rules.yml` (+3 recording rules)

Initiative `0003-sync-v2-rollout-and-v1-sunset.md` сам status оновиться в окремому doc-PR-і після того, як landing Phase 2 (ADR-0043 + sunset headers).

## Risk and Rollout

- User-visible risk: **none**. Counter — pure observability, не змінює HTTP-семантику. Survey middleware має try/catch навколо `inc()` — throw → next() все одно викликає.
- Rollout / deploy order: безпечно деплоїти будь-якою чергою. Існуючий `sync_operations_total` не чіпається.
- Backout plan: revert PR. Counter новий — registry/Prom не зламаються від його зникнення.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian. — Counter docstring + dashboard panel descriptions + recording-rule comment — ua.
- [x] I did not use `--no-verify`.

## Reviewer Notes

- **Cardinality**: hard cap у `clientSurvey.ts:KNOWN_VERSION_LIMIT = 20`. Збільшення → треба переоцінити vmagent навантаження.
- **UA classification**: `classifyUserAgent` best-effort. Edge case з desktop Safari (CFNetwork + Safari) розв'язаний (тест `safari without cfnetwork is NOT mobile-rn`).
- **Pre-existing test failures на main**: `apps/server/src/lib/jobs/authMail.test.ts` — `BullMQ Queue is not a constructor`. Підтверджено `git stash` на чистому main HEAD-і. НЕ моя регресія.
- **Pre-existing typecheck failures на main**: `packages/shared/src/lib/animations.ts` (window not found), `apps/server/src/modules/mono/rotateSecret.test.ts` (vitest mock type). НЕ моя регресія.
- **Phase 2 next**: ADR-0043 cloudsync-v1-sunset + RFC 8594 Sunset/Deprecation/Link headers на v1 routes — окремий PR після цього.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a v1 legacy-client survey to identify who still uses CloudSync v1 ahead of the sunset (Initiative 0003, Phase 1). Instruments `/api/sync/*` via middleware and does not change API behavior.

- **New Features**
  - Adds `sync_v1_legacy_clients_total{user_agent_class, app_version, op}` and mounts `v1ClientSurveyMiddleware` on `/api/sync/*` (not `/api/v2/sync/*`).
  - UA buckets: `web`, `mobile-rn`, `mobile-shell-ios`, `mobile-shell-android`, `other`. App versions normalized to `major.minor` with a cap of 20; `unknown`/`old` fallbacks. Skips `/api/sync/audit`.
  - Updates Grafana dashboard (+3 panels) and Prometheus recording rules (`sli:sync_v1:rate5m`, `sli:sync_v2:rate5m`, `sli:sync_v1_legacy:rate1h_by_appversion`).
  - Tests cover UA/version/path classification and middleware error-safety; metric errors never block requests.

<sup>Written for commit a478fe06316ecf43c922fabf4d60429c4304bc74. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

