### PR TITLE
refactor(web): strict single-hero rule on ModuleChecklist (S3.5)

### DIFF
--- a/apps/web/src/core/hub/HubDashboard.test.tsx
+++ b/apps/web/src/core/hub/HubDashboard.test.tsx
@@ -194,6 +194,21 @@ vi.mock("../onboarding/FirstActionSheet", () => ({
   ),
 }));
 
+// Stub `ModuleChecklist` — its rendered «Фінік: Перші кроки» heading and
+// per-step buttons collided with the bento «Фінік» button under
+// `getByRole("button", { name: /Фінік/i })`. The post-S3.5 single-hero
+// rule shows the checklist whenever `hasRealEntry && sessionDays <= 7`,
+// which is the default beforeEach state. The dedicated S3.5 test below
+// asserts the checklist appears via its own title selector — other tests
+// only need to know it does not pollute the bento buttons.
+vi.mock("../onboarding/ModuleChecklist", () => ({
+  ModuleChecklist: ({ moduleId }: { moduleId: string }) => (
+    <div data-testid={`module-checklist-${moduleId}`}>
+      {MODULE_CHECKLISTS[moduleId as keyof typeof MODULE_CHECKLISTS]?.title}
+    </div>
+  ),
+}));
+
 vi.mock("../onboarding/SoftAuthPromptCard", () => ({
   SoftAuthPromptCard: ({ onOpenAuth }: { onOpenAuth: () => void }) => (
     <button type="button" onClick={onOpenAuth}>
@@ -319,14 +334,27 @@ describe("HubDashboard", () => {
 
     renderDashboard();
 
-    // Hero slot is empty when there is no focus rec — the bento module
-    // grid handles the FTUX entry points, so a chip fallback would only
-    // duplicate the per-module quick-add affordances below.
+    // Single-hero rule (S3.5): pre-FTUX (no real entry) `ModuleChecklist`
+    // is suppressed — `FirstActionHeroCard` / `TodayFocusCard` is the
+    // sole next-steps surface and the bento module grid handles ad-hoc
+    // entry points. Stacking the checklist on top would split user
+    // attention into two competing «do these N steps» surfaces.
     expect(screen.queryByTestId("today-focus-card")).toBeNull();
-    expect(screen.getByText(MODULE_CHECKLISTS.finyk.title)).toBeInTheDocument();
+    expect(screen.queryByText(MODULE_CHECKLISTS.finyk.title)).toBeNull();
     expect(screen.queryByTestId("assistant-advice-card")).toBeNull();
     expect(screen.queryByTestId("hub-insights-panel")).toBeNull();
     expect(screen.queryByTestId("weekly-digest-footer")).toBeNull();
+  });
+
+  it("renders module checklist post-FTUX within first week (single-hero S3.5)", () => {
+    // Past the FTUX gate (default beforeEach state): `hasRealEntry` true,
+    // `firstActionVisible` false, `sessionDays <= 7`. The checklist now
+    // takes over as the post-celebration guide toward 2nd/3rd entry.
+    localStorage.setItem(VIBE_PICKS_KEY, JSON.stringify(["finyk"]));
+
+    renderDashboard();
+
+    expect(screen.getByText(MODULE_CHECKLISTS.finyk.title)).toBeInTheDocument();
   });
 
   it("opens module cards and keeps quick-add actions scoped to active modules with recommendation signal", () => {

--- a/apps/web/src/core/hub/HubDashboard.tsx
+++ b/apps/web/src/core/hub/HubDashboard.tsx
@@ -179,7 +179,12 @@ export function HubDashboard({
   const hasRealEntry = detectFirstRealEntry();
   const celebration = useFirstEntryCelebration(hasRealEntry);
   const [sessionDays, setSessionDays] = useState(-1);
+  // `recordSessionDay()` has a side effect (writes today into the
+  // session-day ledger) — must run in effect, not render. The `-1`
+  // sentinel keeps FTUX gates closed during the first render so we
+  // don't flash post-FTUX surfaces before the value resolves.
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setSessionDays(recordSessionDay() || getSessionDays());
   }, []);
   const SOFT_AUTH_SESSION_DAYS_THRESHOLD = 3;
@@ -402,10 +407,15 @@ export function HubDashboard({
   const isMondayOrTuesday = now.getDay() === 1 || now.getDay() === 2;
   const showDigestFooter = digestFresh || isMondayOrTuesday;
 
-  // Show checklist for first active module (only if user has no real entry yet).
-  // Suppressed while `FirstActionHeroCard` is the hero — both surfaces enumerate
-  // module-specific next steps, so stacking them split user attention 1:1 and
-  // the FTUX hero already covers the same ground with a single primary CTA.
+  // Show checklist for first active module — strict single-hero rule:
+  // pre-FTUX (no real entry) FirstActionHeroCard / TodayFocusCard alone
+  // is the hero; ModuleChecklist would split attention into two
+  // module-specific next-steps surfaces. Post-FTUX, within the first
+  // 7 session-days, the checklist is the **post-celebration** guide
+  // toward second / third entry, while FirstActionHeroCard is gone.
+  // After 7 days the user is past activation; the checklist gracefully
+  // disappears so the dashboard does not carry a perpetual onboarding
+  // chrome above the bento grid.
   const primaryModule = activeModules[0] as
     | "finyk"
     | "fizruk"
@@ -413,7 +423,7 @@ export function HubDashboard({
     | "nutrition"
     | undefined;
   const showChecklist =
-    primaryModule && !hasRealEntry && !firstActionVisible && sessionDays <= 7;
+    primaryModule && hasRealEntry && !firstActionVisible && sessionDays <= 7;
 
   // ONE-HERO RULE
   let hero: React.ReactNode;


### PR DESCRIPTION
## Summary

Strict single-hero rule на `ModuleChecklist` у `HubDashboard`: до першого real entry — лише `FirstActionHeroCard` / `TodayFocusCard`; після — `ModuleChecklist` як post-celebration guide до 2-го / 3-го запису, поки `sessionDays <= 7`.

Закриває **S3.5** з `docs/launch/ftux-sprint-plan.md` §5: «ModuleChecklist рендериться **тільки** якщо `hasRealEntry && sessionDays <= 7` · до 1st entry — лише FirstAction».

## Чому

Раніше умова була `!hasRealEntry && !firstActionVisible && sessionDays <= 7` — checklist з'являвся pre-FTUX як guidance. Це конфліктувало з `FirstActionHeroCard` / `TodayFocusCard` (обидві — module-specific next-steps surfaces) і порушувало single-hero rule, який валідується у §5 audit-у. Після інверсії checklist живе лише там, де він справді корисний — після першого real entry, як post-celebration guide. Bento module grid сам по собі обслуговує ad-hoc entry points pre-FTUX.

## Зміни

- `apps/web/src/core/hub/HubDashboard.tsx`:
  - `showChecklist`: `!hasRealEntry` → `hasRealEntry`. Інші частини умови (`primaryModule`, `!firstActionVisible`, `sessionDays <= 7`) не зачеплені.
  - Розширено блок коментарів вище, щоб пояснити нову семантику (post-celebration guide vs. pre-FTUX guidance).
  - Inline-фікс `react-hooks/set-state-in-effect` на `setSessionDays(...)` — `recordSessionDay()` side-effect-ний (пише сьогоднішній день в session-day ledger), мусить лишатися в `useEffect`. Додано `eslint-disable-next-line` з обґрунтуванням, як у `apps/web/src/modules/routine/useRoutineAppState.ts:201`. Без цього lint-staged блокує staged-файл (rule додано після нещодавнього eslint-upgrade).
- `apps/web/src/core/hub/HubDashboard.test.tsx`:
  - Mock `ModuleChecklist` як простий `<div data-testid="module-checklist-{id}">{title}</div>` стуб. У дефолтному `beforeEach` state (`hasRealEntry=true`, `sessionDays<=7`) checklist тепер видно — і його повноцінний рендер з кнопкою «Додати першу витрату» (aria-label з «Фінік») колайдив з bento «Фінік» кнопкою під `getByRole({ name: /Фінік/i })` у двох інших тестах.
  - Тест `keeps the pre-FTUX dashboard focused on first-entry guidance` оновлений: `getByText(MODULE_CHECKLISTS.finyk.title)` → `queryByText(...)).toBeNull()`. Коментар пояснює, що pre-FTUX вже не показує checklist.
  - Доданий новий тест `renders module checklist post-FTUX within first week (single-hero S3.5)` — фіксує позитивну гілку нової умови.

## Mobile parity

`apps/mobile/src/core/HubScreen.tsx` не використовує `ModuleChecklist`. Mobile FTUX-flow інший (single-hero вже — `FirstActionHeroCard`-equivalent + bento grid), parity тримається.

## Аналітика

Без змін. `MODULE_CHECKLIST_*` events продовжують fire-и́тися лише коли checklist реально рендериться → у пост-FTUX вікні — це і є цільова cohort. Pre-FTUX events взагалі не очікуються (юзер ще нічого не зробив).

## Risks & rollout

- Risk: тимчасово зникає одна з guidance-карток pre-FTUX — навіть якщо `FirstActionHeroCard` не активний (наприклад, dismissed), нічого не підставиться. Це навмисно: bento + module-specific quick-actions достатні; додатковий checklist там був data-light і відволікав.
- Без feature-flag — diff детермінований і малий, behavior-зміна локальна (один компонент). Backout = revert single commit.
- Lint-disable додано лише для pre-existing main-error-у — не нова задовженість, копія вже існуючого pattern-у в `useRoutineAppState.ts:201`.

## Verification

- `pnpm --filter @sergeant/web exec eslint src/core/hub/HubDashboard.tsx src/core/hub/HubDashboard.test.tsx --max-warnings=0` — зелено.
- `pnpm --filter @sergeant/web exec vitest run src/core/hub` — 86 tests pass (6 файлів).

## Hard rules / governance

- [x] `AGENTS.md` rule #5 (Conventional Commits scope `web`) — OK.
- [x] `AGENTS.md` rule #7 (Husky pre-commit) — пройшло без `--no-verify`.
- [x] `AGENTS.md` rule #8 (Tailwind colour-opacity) — N/A, без CSS-changes.
- [x] Tests оновлені свідомо для нового contract-у (S3.5 AC), не для bypass-у (rule "Never modify tests to make them pass").

## Reviewer notes

- `firstActionVisible` clause зберігся у `showChecklist` навмисно як defensive guard — у нормі `firstActionVisible` clear-ається до того, як `hasRealEntry=true`, але якщо колись flow зміниться, цей `&&` запобігає overlap-у двох hero-equivalent surfaces.
- Якщо хочеш переконатися візуально pre-FTUX vs post-FTUX — у DevTools localStorage тогглей `hub_first_real_entry_done_v1` між `null` і `"1"` і дивись на верхній блок дашборду.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces the single-hero rule on the HubDashboard. `ModuleChecklist` now shows only after the first real entry and within the first 7 session days; pre-FTUX shows only `FirstActionHeroCard`/`TodayFocusCard` (S3.5).

- **Refactors**
  - In `HubDashboard.tsx`, inverted `showChecklist` to `primaryModule && hasRealEntry && !firstActionVisible && sessionDays <= 7`.
  - Kept `firstActionVisible` as a guard to avoid overlapping hero surfaces; expanded inline docs.
  - Added `eslint-disable-next-line react-hooks/set-state-in-effect` for `setSessionDays(recordSessionDay() || getSessionDays())` with rationale.
  - Tests: stubbed `ModuleChecklist` to avoid button name collisions, updated pre-FTUX test to expect no checklist, and added a post-FTUX (≤7 days) positive test.

<sup>Written for commit 75988f60aadd2c14b2678767dc34cdb795035599. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

