### PR TITLE
ci(ci): weekly shell-tax-report cron (initiative 0002 Phase 2)

### DIFF
--- a/.github/workflows/shell-tax-report.yml
+++ b/.github/workflows/shell-tax-report.yml
@@ -1,0 +1,167 @@
+name: Shell-tax weekly report
+
+# Phase 2 of initiative 0002 (mobile platform decision):
+#   docs/initiatives/0002-mobile-platform-decision.md § "Що далі (Phase 2+)".
+#
+# What it does:
+#   - Runs `node scripts/report-shell-tax.mjs --since 90 --json` weekly.
+#   - Publishes the snapshot as both a GitHub Step Summary (visible in the
+#     run page) and an upload artifact (machine-readable JSON, 90-day
+#     retention so consecutive weeks can be diff-ed).
+#   - Maintains a single tracking GitHub issue tagged `shell-tax-report`
+#     so the maintainer has *one* persistent place to see the cost
+#     trend instead of digging through cron-run logs.
+#
+# Why a tracking issue and not a Slack webhook:
+#   - The original initiative pencilled in a `#mobile-channel` webhook,
+#     but landing that requires a saved repo secret that does not yet
+#     exist. The tracking issue is webhook-free, uses the built-in
+#     `GITHUB_TOKEN`, and the message body is stable so notifications
+#     stay quiet (only the issue body is rewritten — no new comments).
+#   - When the team is ready to add Slack, swap the `update-issue` step
+#     for a curl-to-webhook one; the script output is already JSON.
+#
+# How to read the artifact:
+#   - shell-tax-report.json: the raw `--json` payload (see the script
+#     header for fields).
+#
+# Manual trigger:
+#   - "Run workflow" on the Actions tab uses the same defaults; pass
+#     `since` to override the 90-day window for ad-hoc baselines.
+
+on:
+  schedule:
+    # Weekly Monday at 06:00 UTC (≈ 09:00 Kyiv) — same slot as docs cron.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+    inputs:
+      since:
+        description: "Window for git log --since (e.g. '90.days.ago', '6.months')"
+        required: false
+        default: "90.days.ago"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: shell-tax-report
+  cancel-in-progress: true
+
+jobs:
+  report:
+    name: Run report-shell-tax.mjs and update tracking issue
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout v6.0.2 (SHA-pinned for supply-chain hardening)
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          # The script reads `git log` for the last 90 days; without
+          # full history a shallow clone underreports `shell_commits`.
+          fetch-depth: 0
+
+      # actions/setup-node v6.4.0 (SHA-pinned for supply-chain hardening)
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "20"
+
+      - name: Run shell-tax report
+        id: report
+        env:
+          SINCE: ${{ github.event.inputs.since || '90.days.ago' }}
+        run: |
+          set -e
+          node scripts/report-shell-tax.mjs --since "$SINCE" --json > shell-tax-report.json
+          node scripts/report-shell-tax.mjs --since "$SINCE" > shell-tax-report.txt
+
+          {
+            echo "### Shell-tax report (window: $SINCE)"
+            echo
+            echo '```'
+            cat shell-tax-report.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload report artifact
+        if: ${{ !cancelled() }}
+        # actions/upload-artifact v4.4.3 (SHA-pinned for supply-chain hardening)
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: shell-tax-report
+          path: |
+            shell-tax-report.json
+            shell-tax-report.txt
+          retention-days: 90
+
+      - name: Update tracking issue
+        if: ${{ !cancelled() && github.event_name == 'schedule' }}
+        # actions/github-script v8.0.0 (SHA-pinned for supply-chain hardening)
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        with:
+          script: |
+            const fs = require('node:fs');
+            const data = JSON.parse(fs.readFileSync('shell-tax-report.json', 'utf8'));
+            const txt = fs.readFileSync('shell-tax-report.txt', 'utf8');
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const today = new Date().toISOString().slice(0, 10);
+
+            const top = (data.top_files || []).slice(0, 10).map(
+              (f) => `- \`${f.file}\` — ${f.touches}`,
+            ).join('\n');
+
+            const body = [
+              '<!-- managed-by: .github/workflows/shell-tax-report.yml -->',
+              '',
+              `> **Last run:** ${today} (window: \`${data.since}\`).`,
+              '> **Initiative:** [0002 — mobile platform decision](../blob/main/docs/initiatives/0002-mobile-platform-decision.md).',
+              '> **ADR:** [0010 — mobile dual-track](../blob/main/docs/adr/0010-mobile-dual-track-capacitor-expo.md) (`accepted-with-sunset`, T₀ 2026-09-01).',
+              '',
+              '## Latest snapshot',
+              '',
+              '```',
+              txt.trim(),
+              '```',
+              '',
+              '## Top-10 hottest files',
+              '',
+              top || '_no shell touches in the window — celebrate quietly_',
+              '',
+              '## Sources',
+              '',
+              `- Workflow run: ${runUrl}`,
+              '- Artifact: `shell-tax-report` (json + txt)',
+              '- Script: `scripts/report-shell-tax.mjs`',
+              '',
+              '_This issue is auto-updated weekly. Do not edit the body — comments are fine._',
+            ].join('\n');
+
+            const title = 'Shell-tax weekly report';
+            const label = 'shell-tax-report';
+
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: label,
+              state: 'open',
+              per_page: 5,
+            });
+
+            if (existing.length > 0) {
+              const issue = existing[0];
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body,
+              });
+              core.notice(`Updated tracking issue #${issue.number}`);
+            } else {
+              const { data: created } = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: [label],
+              });
+              core.notice(`Opened tracking issue #${created.number}`);
+            }

--- a/docs/initiatives/0002-mobile-platform-decision.md
+++ b/docs/initiatives/0002-mobile-platform-decision.md
@@ -1,6 +1,6 @@
 # 0002 — Mobile platform decision: lock the deprecation deadline
 
-> **Status:** In progress (Phase 1 done — sunset locked, lint guard live, shell-tax script ready)
+> **Status:** In progress (Phase 1 done — sunset locked, lint guard live, shell-tax script ready; Phase 2 — weekly cron live)
 > **Priority:** P0 (Sprint 1)
 > **Owner:** `@Skords-01`
 > **ETA:** 2 weeks (рішення + 1 ADR + комунікація)
@@ -185,18 +185,43 @@ top_files:     README.md (16), package.json (13), AndroidManifest.xml (6), …
 | Feature-parity матриця <7 днів                 | ні                    | **так** (свіжа)                     | так                      |
 | RN feature-parity маяків зелених               | ? / 3                 | 1 / 3 (Detox 🟡)                    | 3 / 3 до T₀              |
 
+### Фаза 2 — `ci-shell-tax-report` cron (DONE — 2026-05-04)
+
+**PR:** `devin/0002-shell-tax-cron-…` (номер додам сюди після merge).
+
+`report-shell-tax.mjs` тепер ганяється автоматично:
+
+- **Workflow:** [`.github/workflows/shell-tax-report.yml`](../../.github/workflows/shell-tax-report.yml).
+- **Schedule:** weekly Monday 06:00 UTC (≈ 09:00 Kyiv) — той самий слот, що
+  й `docs-freshness`/`skill-freshness`, щоб не бити cron-слот.
+- **Manual trigger:** `workflow_dispatch` приймає `since` (default
+  `90.days.ago`) — для ad-hoc baseline переміряння.
+- **Output:**
+  - GitHub Step Summary з людським текстовим звітом.
+  - Артефакт `shell-tax-report` (json + txt, 90-денна retention) — щоб
+    diff-ити сусідні тижні machine-readable.
+  - Тікет з міткою `shell-tax-report` із body, який оновлюється кожного
+    запуску (один persistent issue, не новий тікет щотижня — щоб не
+    спамити maintainer-у).
+
+Чому tracking-issue замість Slack-webhook (як у початковому плані):
+вебхук вимагає окремий збережений секрет, якого ще нема. Тікет
+тримається на вбудованому `GITHUB_TOKEN` і має стабільний body, тому
+GitHub-нотифікації не вибухнуть. Коли команда зробить рішення про
+Slack — `update-issue` крок міняється на `curl` до webhook-у, JSON
+output вже придатний.
+
 Що далі (Phase 2+):
 
-1. **PR `ci-shell-tax-report`** — щотижневий cron у GH Actions, що ганяє
-   `report-shell-tax.mjs --json` і постить summary у `#mobile-channel`.
-2. **PR `mobile-feature-parity-refresh-2026-08`** — оновлення матриці на 2026-08-01
+1. **PR `mobile-feature-parity-refresh-2026-08`** — оновлення матриці на 2026-08-01
    (next-review, перед T₀).
-3. **Phase 4 — комунікація** — пост у `#mobile-channel` + in-app banner у shell-білді
+2. **Phase 4 — комунікація** — пост у `#mobile-channel` + in-app banner у shell-білді
    (зробити перед T₀ — 2026-09-01).
 
 Відхилення від плану:
 
 - Phase 4 (комунікація) перенесена на серпень — близько до T₀, щоб не «вистрелювати»
   банер у користувачів за 4 місяці до freeze.
-- `ci-shell-tax-report` (фаза 3) ще не land-ить разом з цим PR — окремий PR,
-  бо потребує webhook secret і не блокує decision gating.
+- Slack-webhook нотифікація з `ci-shell-tax-report` свідомо відкладена:
+  тікет з міткою `shell-tax-report` віддає той самий сигнал без секрета,
+  webhook додамо, коли команда вирішить, у який канал постити.


### PR DESCRIPTION
## Summary

Закриває Phase 2 ініціативи [0002 — Mobile platform decision](../blob/main/docs/initiatives/0002-mobile-platform-decision.md): тепер `scripts/report-shell-tax.mjs` ганяється автоматично щотижня, а не запускається вручну, як baseline 2026-05-03.

- Новий workflow `.github/workflows/shell-tax-report.yml`. Cron — Monday 06:00 UTC (≈ 09:00 Kyiv), той самий слот, що в `docs-freshness` / `skill-freshness`, щоб не бити cron-quota.
- `workflow_dispatch` приймає `since` (default `90.days.ago`) — для ad-hoc baseline-переміряння.
- Output:
  - GitHub Step Summary з людським текстовим звітом (видно у списку run-ів).
  - Артефакт `shell-tax-report` (json + txt, 90-денна retention) — для diff-у тиждень-за-тиждень.
  - Persistent tracking issue з міткою `shell-tax-report` (один тікет, body перезаписується щоразу — не спам comments).
- Webhook у `#mobile-channel` свідомо відкладено: вебхук вимагає окремий збережений секрет, а tracking-issue віддає той самий сигнал на вбудованому `GITHUB_TOKEN`. Коли команда вирішить, у який канал слати, `update-issue` крок змінюється на `curl` до webhook URL — JSON output вже придатний.

Outcome-секцію в `docs/initiatives/0002-mobile-platform-decision.md` оновлено: додав `### Фаза 2 — ci-shell-tax-report cron (DONE — 2026-05-04)` з обґрунтуванням tracking-issue замість Slack.

## Governing Skill

- Primary skill: `sergeant-deploy-and-observability` (workflow + cron-job на CI, без коду в апі).
- Secondary skill (if truly needed): n/a — initiative-driven, спирається на існуючий `report-shell-tax.mjs`.

## Playbook

- Primary playbook: n/a (це не feature delivery, а ops cron).
- Why this playbook: жоден з playbook-ів у `docs/playbooks/` не покриває «додай cron, який пише у tracking issue» — це стандартний GitHub Actions додаток.
- If no playbook matched, why: див. вище.

## Verification

```bash
# Локальний smoke — script працює, JSON виглядає коректно.
node scripts/report-shell-tax.mjs --since 30 --json | head -8

pnpm prettier --check .github/workflows/shell-tax-report.yml docs/initiatives/0002-mobile-platform-decision.md
# Checking formatting...
# All matched files use Prettier code style!
```

CI workflow validation сама-собою проганяється на push (workflow YAML parse-иться GH Actions). Перший cron run відбудеться у понеділок 06:00 UTC; до того можна тригернути вручну через "Run workflow" на сторінці Actions.

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed (lint-staged + prettier через pre-commit)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update. — Ні, governance/scope не змінився.
- [x] I checked whether a playbook or skill needed an update. — Ні, це разовий cron.
- [x] I checked whether governance docs or review docs needed an update. — Ні.

Updated docs:

- `docs/initiatives/0002-mobile-platform-decision.md` — Phase 2 Outcome section.

## Risk and Rollout

- User-visible risk: жодного (cron + tracking issue, не зачіпає prod).
- Rollout / deploy order: merge → cron активується автоматично у понеділок 06:00 UTC; перший artefact видно одразу при `workflow_dispatch`.
- Backout plan: видалити `.github/workflows/shell-tax-report.yml` (revert PR); tracking issue можна закрити вручну.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

- Якщо хочете замість tracking issue одразу Slack-webhook — додайте `MOBILE_CHANNEL_WEBHOOK_URL` repo secret і замініть `actions/github-script` крок на `curl -X POST -H 'Content-Type: application/json' -d @shell-tax-report.json "$MOBILE_CHANNEL_WEBHOOK_URL"`.
- Issue-body містить `<!-- managed-by: ... -->` маркер, щоб уникнути конфузу «хто це створив».
- Concurrency key — глобальний (`shell-tax-report`), щоб два запуски (manual + scheduled) не наклалися.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates the shell-tax report with a weekly GitHub Actions cron that publishes artifacts and updates a single tracking issue. Completes Phase 2 of initiative 0002 by removing the manual run.

- **New Features**
  - New workflow `.github/workflows/shell-tax-report.yml`: runs Mondays 06:00 UTC; supports `workflow_dispatch` with `since` (default `90.days.ago`); `concurrency: shell-tax-report`.
  - Outputs: step summary and artifact `shell-tax-report` (JSON + TXT, 90‑day retention) for week-to-week diffs.
  - Tracking: maintains one issue labeled `shell-tax-report` and replaces its body on scheduled runs; Slack webhook deferred until a repo secret is added.
  - Docs: updated `docs/initiatives/0002-mobile-platform-decision.md` to mark Phase 2 done and document the tracking-issue approach.

<sup>Written for commit a2f5493461a759384a5d76875a80798cbb7386dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

