### PR TITLE
feat(shared): enable noUncheckedIndexedAccess + tighten array/regex access

### DIFF
--- a/packages/shared/src/lib/abTest.ts
+++ b/packages/shared/src/lib/abTest.ts
@@ -81,11 +81,9 @@ export function assignVariant(
 ): string {
   const assignments = getAssignments(store);
 
-  if (
-    assignments[experiment.id] &&
-    experiment.variants.includes(assignments[experiment.id])
-  ) {
-    return assignments[experiment.id];
+  const existing = assignments[experiment.id];
+  if (existing && experiment.variants.includes(existing)) {
+    return existing;
   }
 
   const fp = getOrCreateFingerprint(store);
@@ -95,11 +93,12 @@ export function assignVariant(
     experiment.variants.map(() => 1 / experiment.variants.length);
 
   let cumulative = 0;
-  let chosen = experiment.variants[0];
+  // Fallback to the first variant; experiments are required to declare ≥1.
+  let chosen = experiment.variants[0] ?? "control";
   for (let i = 0; i < experiment.variants.length; i++) {
-    cumulative += weights[i];
+    cumulative += weights[i] ?? 0;
     if (fraction < cumulative) {
-      chosen = experiment.variants[i];
+      chosen = experiment.variants[i] ?? chosen;
       break;
     }
   }

--- a/packages/shared/src/lib/animations.ts
+++ b/packages/shared/src/lib/animations.ts
@@ -229,6 +229,14 @@ export function cssTransitionMulti(
  * Mobile consumers should use `AccessibilityInfo.isReduceMotionEnabled()`.
  */
 export function prefersReducedMotion(): boolean {
-  if (typeof window === "undefined") return false;
-  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  // We avoid pulling DOM types into this package (it is shared web ↔ mobile
+  // ↔ server). The local cast keeps the runtime check while satisfying the
+  // type-checker without `lib: ["DOM"]`.
+  const w = (
+    globalThis as {
+      window?: { matchMedia?: (q: string) => { matches: boolean } };
+    }
+  ).window;
+  if (!w?.matchMedia) return false;
+  return w.matchMedia("(prefers-reduced-motion: reduce)").matches;
 }

--- a/packages/shared/src/lib/dashboard.ts
+++ b/packages/shared/src/lib/dashboard.ts
@@ -166,6 +166,7 @@ export function arrayMoveImmutable<T>(
   if (toIndex < 0 || toIndex >= list.length) return [...list];
   const next = [...list];
   const [moved] = next.splice(fromIndex, 1);
+  if (moved === undefined) return [...list];
   next.splice(toIndex, 0, moved);
   return next;
 }

--- a/packages/shared/src/lib/dashboardFocus.ts
+++ b/packages/shared/src/lib/dashboardFocus.ts
@@ -92,7 +92,7 @@ export interface FocusSelection<T> {
  */
 export function selectFocusAndRest<T>(recs: readonly T[]): FocusSelection<T> {
   if (recs.length === 0) return { focus: null, rest: [] };
-  return { focus: recs[0], rest: recs.slice(1) };
+  return { focus: recs[0] ?? null, rest: recs.slice(1) };
 }
 
 /**

--- a/packages/shared/src/lib/onboardingGoals.test.ts
+++ b/packages/shared/src/lib/onboardingGoals.test.ts
@@ -75,9 +75,9 @@ describe("onboardingGoals — getGoalQuestions", () => {
       "routine",
       "nutrition",
     ]);
-    expect(questions[0].module).toBe("routine");
-    expect(questions[1].module).toBe("finyk");
-    expect(questions[2].module).toBe("nutrition");
+    expect(questions[0]?.module).toBe("routine");
+    expect(questions[1]?.module).toBe("finyk");
+    expect(questions[2]?.module).toBe("nutrition");
   });
 
   it("caps at maxQuestions", () => {
@@ -91,7 +91,7 @@ describe("onboardingGoals — getGoalQuestions", () => {
   it("only returns questions for picked modules", () => {
     const questions = getGoalQuestions(["finyk"]);
     expect(questions).toHaveLength(1);
-    expect(questions[0].module).toBe("finyk");
+    expect(questions[0]?.module).toBe("finyk");
   });
 
   it("includes correct question types", () => {

--- a/packages/shared/src/lib/undoTombstone.ts
+++ b/packages/shared/src/lib/undoTombstone.ts
@@ -122,7 +122,8 @@ export function purgeExpiredTombstones(
   const nowMs = (now ?? new Date()).getTime();
   let dirty = false;
   for (const id of Object.keys(map)) {
-    if (map[id].expiresAt <= nowMs) {
+    const entry = map[id];
+    if (entry && entry.expiresAt <= nowMs) {
       delete map[id];
       dirty = true;
     }

--- a/packages/shared/src/schemas/mono.test.ts
+++ b/packages/shared/src/schemas/mono.test.ts
@@ -131,7 +131,7 @@ describe("MonoAccountsResponseSchema", () => {
       { ...VALID_ACCOUNT, monoAccountId: "acc2", currencyCode: 840 },
     ]);
     expect(parsed).toHaveLength(2);
-    expect(parsed[1].currencyCode).toBe(840);
+    expect(parsed[1]?.currencyCode).toBe(840);
   });
 
   it("rejects when one row is malformed", () => {

--- a/packages/shared/src/utils/speechParsers.ts
+++ b/packages/shared/src/utils/speechParsers.ts
@@ -138,9 +138,10 @@ export function normalizeUaNumbers(text: string): string {
   const PUNCT_BREAK = /[.,;:!?)»]$/;
   let i = 0;
   while (i < words.length) {
-    const clean = stripWordPunctuation(words[i]).toLowerCase();
+    const wi = words[i] ?? "";
+    const clean = stripWordPunctuation(wi).toLowerCase();
     if (UA_NUMBER_WORDS[clean] == null) {
-      out.push(words[i]);
+      out.push(wi);
       i++;
       continue;
     }
@@ -152,8 +153,9 @@ export function normalizeUaNumbers(text: string): string {
       // If the previous word ended with separator punctuation, stop the run
       // here so that "вісімдесят, вісім" produces 80 + 8 (two numbers) rather
       // than the merged "вісімдесят вісім" = 88.
-      if (PUNCT_BREAK.test(words[j - 1])) break;
-      const c = stripWordPunctuation(words[j]).toLowerCase();
+      const prev = words[j - 1] ?? "";
+      if (PUNCT_BREAK.test(prev)) break;
+      const c = stripWordPunctuation(words[j] ?? "").toLowerCase();
       if (UA_NUMBER_WORDS[c] == null) break;
       runWords.push(c);
       j++;
@@ -162,11 +164,11 @@ export function normalizeUaNumbers(text: string): string {
     if (n != null) {
       // Preserve trailing punctuation on the last word of the run
       // (e.g. "вісімдесят," → "80,").
-      const lastRaw = words[j - 1];
+      const lastRaw = words[j - 1] ?? "";
       const trailingPunct = lastRaw.match(/[.,!?;:)»]+$/)?.[0] ?? "";
       out.push(String(n) + trailingPunct);
     } else {
-      for (let k = i; k < j; k++) out.push(words[k]);
+      for (let k = i; k < j; k++) out.push(words[k] ?? "");
     }
     i = j;
   }
@@ -194,7 +196,7 @@ export function parseExpenseSpeech(text: string): ParsedExpense | null {
     ) || lower.match(/(\d+(?:\.\d+)?)/u);
 
   let amount: number | null = null;
-  if (amountMatch) {
+  if (amountMatch?.[1]) {
     amount = parseFloat(amountMatch[1]);
   }
 
@@ -267,17 +269,17 @@ export function parseWorkoutSetSpeech(text: string): ParsedWorkoutSet | null {
     lower.match(/(?:підхід|sets?)\s*(\d+)/iu);
 
   let weight: number | null = null;
-  if (weightMatch) {
+  if (weightMatch?.[1]) {
     weight = parseFloat(weightMatch[1].replace(",", "."));
     if (/lb|lbs|фунт/i.test(weightMatch[0]))
       weight = Math.round(weight * 0.453592);
   }
 
   let reps: number | null = null;
-  if (repsMatch) reps = parseInt(repsMatch[1] || repsMatch[2], 10);
+  if (repsMatch) reps = parseInt(repsMatch[1] ?? repsMatch[2] ?? "", 10);
 
   let sets: number | null = null;
-  if (setsMatch) sets = parseInt(setsMatch[1] || setsMatch[2], 10);
+  if (setsMatch) sets = parseInt(setsMatch[1] ?? setsMatch[2] ?? "", 10);
 
   let exerciseName: string | null = norm
     .replace(
@@ -343,13 +345,14 @@ export function parseMealSpeech(text: string): ParsedMeal | null {
 
   let kcal: number | null = null;
   if (kcalMatch)
-    kcal = parseFloat((kcalMatch[1] || kcalMatch[2]).replace(",", "."));
+    kcal = parseFloat((kcalMatch[1] ?? kcalMatch[2] ?? "").replace(",", "."));
 
   let grams: number | null = null;
-  if (gramsMatch) grams = parseFloat(gramsMatch[1].replace(",", "."));
+  if (gramsMatch?.[1]) grams = parseFloat(gramsMatch[1].replace(",", "."));
 
   let protein: number | null = null;
-  if (proteinMatch) protein = parseFloat(proteinMatch[1].replace(",", "."));
+  if (proteinMatch?.[1])
+    protein = parseFloat(proteinMatch[1].replace(",", "."));
 
   // Strip recognized number-units from the name. Same Cyrillic-aware
   // lookahead trick for "гр"/"г" so we don't munch food-name prefixes.

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "allowJs": false,
     "checkJs": false,
-    "noUncheckedIndexedAccess": false,
+    "noUncheckedIndexedAccess": true,
     "lib": ["ES2022"],
     "types": ["node"],
     "rootDir": "./src",


### PR DESCRIPTION
## Summary

Закриває foundation roadmap-item #15 з `docs/diagnostics/2026-05-03-web-deep-dive/00-overview.md` ("tsconfig.strict — `noUncheckedIndexedAccess`"). База ([`@sergeant/config/tsconfig.base.json`](packages/config/tsconfig.base.json)) вже має флаг увімкненим, але **9 з 13 пакетів** перевизначають його у `false`. Цей PR перемикає його у `true` для `@sergeant/shared` — найфундаментальніший пакет, від якого залежать всі інші. Майбутні PR-и зможуть вмикати флаг на consumer-пакетах (`api-client`, `insights`, `*-domain`) **без re-fix-у тих самих shared-помилок**, бо вони вже виправлені тут.

Чому це важливо: `noUncheckedIndexedAccess` ловить класичний клас bug-ів — `arr[i]` повертає `T | undefined`, але код вважає його `T`. У великому monorepo один забутий guard на регексі типу `match[1]` стає silent NaN у проді.

**What changed:**

- `packages/shared/tsconfig.json` — `noUncheckedIndexedAccess: false → true`.
- `packages/shared/src/lib/abTest.ts` — narrow `assignments[id]` перед повторним читанням; default `chosen` на `experiment.variants[0] ?? "control"`; `weights[i] ?? 0` у циклі.
- `packages/shared/src/lib/animations.ts` — `typeof window` guard через `globalThis` cast (не тягне DOM lib у shared).
- `packages/shared/src/lib/dashboard.ts` — guard на `splice()` result у `arrayMoveImmutable`.
- `packages/shared/src/lib/dashboardFocus.ts` — `recs[0] ?? null` у `selectFocusAndRest`.
- `packages/shared/src/lib/undoTombstone.ts` — narrow `map[id]` перед `.expiresAt` у `purgeExpiredTombstones`.
- `packages/shared/src/lib/onboardingGoals.test.ts` — `questions[0]?.module` у 4 `expect`.
- `packages/shared/src/schemas/mono.test.ts` — `parsed[1]?.currencyCode`.
- `packages/shared/src/utils/speechParsers.ts` — full pass, 13 NUIA-помилок виправлено через `?? ""` у regex `match[i]` і fallback у array iteration. Поведінка ідентична — додано лише захист на випадок, коли regex-групи опціональні `(?:а|б)(?:в|г)` і match може повернути undefined для конкретного індекса.

**Що НЕ зроблено (Phase 2 — окремий PR на пакет):**

- `apps/web`, `apps/server`, `apps/mobile` — кожен має свій окремий борг помилок (estimated 30-100+ each), які з'являться при увімкненні. Окремі PR-и для кожного.
- `packages/api-client`, `insights`, `*-domain` — мінімальний борг (5-7 помилок кожен), теж окремими PR-ами.

## Governing Skill

- Primary skill: `sergeant-monorepo-boundaries`
- Secondary skill (if truly needed): —

## Playbook

- Primary playbook: —
- Why this playbook: foundational tsconfig migration; немає specific playbook на NUIA rollout.
- If no playbook matched, why: scope обмежений одним пакетом + його helpers.

## Verification

```bash
pnpm --filter @sergeant/shared typecheck    # PASS (0 errors)
pnpm --filter @sergeant/shared test         # Test Files 35 passed (35) | Tests 485 passed (485)
pnpm --filter @sergeant/shared lint         # PASS

pnpm typecheck                              # 1 pre-existing error
# (apps/server/src/modules/mono/rotateSecret.test.ts:63 — НЕ пов'язано з shared,
#  існує на main незалежно від цього PR)
```

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed (всі 9 змінених файлів проходять lint + typecheck + tests)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout — N/A (поведінка ідентична, лише typing tightening).
- [x] I checked whether `AGENTS.md` needed an update — не потрібно.
- [x] I checked whether a playbook or skill needed an update — не потрібно.
- [x] I checked whether governance docs or review docs needed an update — не потрібно.

Updated docs:

- n/a

## Risk and Rollout

- User-visible risk: ніякого. Поведінка функцій ідентична — додано лише defensive guard-и на випадок, коли indexed access справді повернув би undefined (раніше — silent crash / NaN; тепер — graceful no-op).
- Rollout / deploy order: безпечно деплоїти коли завгодно.
- Backout plan: `git revert`. Поведінкових змін немає, лише narrowing.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

- Деякі fallback-и (`?? ""`, `?? "control"`) — захисні для контракту, який і раніше виконувався (наприклад, experiment.variants завжди має ≥1 елемент за zod-схемою). Але `noUncheckedIndexedAccess` не знає про runtime-інваріант, тому потрібен типовий guard.
- 2 помилки у `animations.ts` (`Cannot find name 'window'`) були **pre-existing** на main — у попередній prod CI вони пройшли, бо `pnpm typecheck` для shared не enforced. Цей PR їх теж виправив (через `globalThis` cast). Якщо raise concern — можу винести у окремий PR.
- 13 змін у `speechParsers.ts` зроблено через regex-match optional groups. Поведінка ідентична: де раніше `match[1]` міг бути undefined і `parseFloat(undefined)` повертав NaN, тепер `match?.[1]` явно guard-иться. Жоден тест не зламано.
- Майбутні PR-и Phase 2 (consumer-пакети) тепер не потребують торкатися shared — це і є foundation.

---

Requested by: Вася <steppupa@gmail.com>
Devin session: https://app.devin.ai/sessions/76cd6ba5cda7404dac5c87d7c3765059

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable `noUncheckedIndexedAccess` in `@sergeant/shared` and harden array/regex/DOM access to prevent undefined reads. This is a foundation for enabling the flag across consumers with no behavior changes.

- **Refactors**
  - Turn `noUncheckedIndexedAccess` on in `packages/shared/tsconfig.json`.
  - Add safe guards for indexed access and regex groups in `abTest.ts`, `dashboard*.ts`, `undoTombstone.ts`, `speechParsers.ts`; update tests with optional chaining.
  - Use a `globalThis.window?.matchMedia` check in `animations.ts` to avoid DOM typings.

<sup>Written for commit 0ace7282caba130a8054ab8f0a6edf03872f651f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

