### PR TITLE
chore(deps): renovate primary + dependabot security-only (init 0008 Phase 3, ADR-0044)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,52 +1,46 @@
 # Dependabot configuration for the Sergeant monorepo.
 #
-# Closes hardening card H2: docs/security/hardening/H2-dependabot.md.
+# **Per ADR-0044** (`docs/adr/0044-renovate-vs-dependabot.md`) — Dependabot's
+# scope is **security-only fallback**. Regular weekly bumps are owned by
+# Renovate (`renovate.json`); Dependabot lifts security-updates daily so a
+# CVE disclosed Tuesday lands in a PR Wednesday morning, not next Monday.
 #
-# Strategy:
-# - npm        : single workspace root (pnpm workspace + Turborepo), weekly,
-#                grouped by dependency-type to keep PR noise predictable.
-# - github-actions: weekly. Comment-format used in workflows
-#                ("# action vX.Y.Z (SHA-pinned for supply-chain hardening)")
-#                is preserved by Dependabot when it bumps the SHA.
-# - docker     : two scopes — root (Dockerfile.api, Dockerfile.console) and
-#                ops/grafana-alloy.
+# Scopes kept here:
+# - **npm** : security updates only, daily.
+# - **github-actions** : SHA-pin rotation (overlap з Renovate `pinDigests:
+#   true` навмисний — supply-chain integrity критична).
+# - **docker** : same logic as github-actions.
 #
-# `ignore` mirrors package.json -> pnpm.overrides — those packages are
-# manually pinned via overrides; Dependabot must not fight the override.
+# Scopes that used to live here (production-deps / dev-deps groups) belong
+# to Renovate now; видалено щоб уникнути duplicate-PR-noise.
 #
-# Auto-merge for patch-only security updates lives in a separate workflow
-# (see Sprint 1 follow-up); landing dependabot.yml first is intentionally
-# the smallest possible diff.
+# Auto-merge for patch-only security updates lives in
+# `.github/workflows/dependabot-automerge.yml`.
 
 version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      # Daily — security-updates повинні landed на наступному робочому дні
+      # після disclosure, не чекати наступного понеділка (initiative 0008
+      # Phase 3 vulnerability-window <24h target).
+      interval: "daily"
       time: "06:00"
       timezone: "Europe/Kyiv"
     open-pull-requests-limit: 10
     versioning-strategy: "increase"
     commit-message:
-      # Both production and development bumps land as `chore(deps): ...`
-      # because `deps-dev` is not in the project's commitlint scope-enum
-      # (see commitlint.config.cjs / .commitlintrc — valid scopes include
-      # `deps`, `ci`, `docs`, `root`, plus the workspace package names).
       prefix: "chore(deps)"
     groups:
-      production-deps:
-        dependency-type: "production"
-        update-types:
-          - "minor"
-          - "patch"
-      dev-deps:
-        dependency-type: "development"
       security-updates:
         applies-to: security-updates
         patterns:
           - "*"
+    # Без `production-deps` / `dev-deps` groups — їх власник Renovate
+    # (див. ADR-0044). Якщо Dependabot створить non-security PR з npm
+    # ecosystem, це bug у налаштуванні і має бути закритий вручну з
+    # коментарем «duplicate of Renovate group: <name>».
     ignore:
       # Manual pins via pnpm.overrides in package.json — Dependabot must
       # not propose updates that fight the override pin. Keep this list in
@@ -60,6 +54,7 @@ updates:
       - dependency-name: "@tootallnate/once"
     labels:
       - "dependencies"
+      - "security"
       - "automerge-eligible"
 
   - package-ecosystem: "github-actions"

--- a/docs/adr/0044-renovate-vs-dependabot.md
+++ b/docs/adr/0044-renovate-vs-dependabot.md
@@ -1,0 +1,73 @@
+# ADR-0044: Renovate as the primary dep-update tool, Dependabot as security-only fallback
+
+- **Status:** Accepted
+- **Date:** 2026-05-04
+- **Deciders:** @Skords-01
+- **Supersedes:** —
+- **Related:**
+  - [`docs/initiatives/0008-platform-hardening.md`](../initiatives/0008-platform-hardening.md) §Phase 3
+  - [`docs/security/hardening/H2-dependabot.md`](../security/hardening/H2-dependabot.md) (Dependabot setup card)
+  - [`docs/integrations/renovate-usage.md`](../integrations/renovate-usage.md)
+  - [`renovate.json`](../../renovate.json), [`.github/dependabot.yml`](../../.github/dependabot.yml)
+
+---
+
+## Context and Problem Statement
+
+Зараз репо має **обидва** інструменти оновлення залежностей:
+
+- `renovate.json` — у корені, повна конфігурація з groups / schedule / automerge для devDeps patches.
+- `.github/dependabot.yml` — налаштований для npm (з groups production/dev/security), github-actions і docker.
+
+Обидва тригеряться щопонеділка о 06:00 Europe/Kyiv. Це створює **дублювання**: коли і Renovate, і Dependabot одночасно піднімають той самий pin, людина руками закриває один із двох PR-ів. У 2026-04 за тиждень було ~12 таких дубль-PR-ів.
+
+Initiative 0008 Phase 3 явно вимагає одного офіційного рішення (`Альтернатива — Dependabot (decision у фазі 1 ADR)`). Цей ADR закриває рішення.
+
+## Considered Options
+
+1. **Renovate як primary, Dependabot off.** Renovate має ширшу конфігурацію (group-rules, automerge, lockFileMaintenance). Off-боард Dependabot, видалити `.github/dependabot.yml`.
+2. **Dependabot як primary, Renovate off.** Dependabot простіший (native у GitHub), не вимагає Mend account. Off-боард Renovate, видалити `renovate.json`.
+3. **Обидва, з різними ролями.** Renovate робить regular weekly bumps + automerge (primary). Dependabot робить тільки security-update PR-и (fallback на випадок, якщо Mend Renovate downtime або misconfig). Звузити Dependabot до `applies-to: security-updates`.
+4. **Status quo (обидва на повну).** Залишити як є.
+
+## Decision
+
+**Option 3 — Renovate primary, Dependabot security-only fallback.**
+
+Конкретно:
+
+- `renovate.json` лишається без змін у scope-і (groups, schedule, automerge), додаються тільки missing groups з ініціативи (`anthropic`, `sentry`, `opentelemetry`).
+- `.github/dependabot.yml` звужується: видаляються `production-deps` і `dev-deps` groups; лишається тільки `security-updates` group + github-actions + docker (бо для них Renovate і Dependabot мають різні джерела CVE-фідів — overlap корисний).
+- Розклад Dependabot для npm-security змінюється з `weekly` на `daily` — security-PR має падати наступного дня після disclosure, не чекати понеділка.
+
+## Rationale
+
+- **Renovate перекриває 100% use-case-ів regular bumps**: groups, automerge, lockFileMaintenance, version-pinning через `rangeStrategy: pin`. Dependabot не вміє automerge без окремого `dependabot-automerge.yml` workflow — додаткова complexity.
+- **Дублювати regular bumps** — стабільно ~12 duplicate-PR-ів/тиждень за 2026-04 спостереженнями. Кожен — це людина-час на review/close.
+- **Security-fallback є**: якщо Mend Renovate downtime, GitHub-native Dependabot все одно піднімає security-update PR (різні провайдери CVE-фідів — Renovate бере з GitHub Advisory + npm audit, Dependabot з GitHub Advisory). Дублювання тут — feature, не bug.
+- **github-actions / docker overlap ОК**: Renovate `pinDigests: true` і Dependabot `package-ecosystem: github-actions` не конфліктують часто (rare bumps), а обидва дають supply-chain-pin-rotation.
+
+## Consequences
+
+### Positive
+
+- Менше duplicate-PR-noise (~12 PR/тиждень → 0 для regular bumps).
+- Чітка ownership: Renovate — primary, Dependabot — backup. Якщо Renovate-PR не приходить за 24 години після release нової версії, це alert (Mend-side issue, окрема скарга).
+- `renovate-usage.md` лишається SoT для контриб'юторів.
+
+### Negative
+
+- Дві конфігурації в репо. Майбутні зміни treba робити двічі (одну в Renovate, дзеркальну в Dependabot security-only). Митиґація — ADR + `docs/integrations/renovate-usage.md` посилається на цей ADR.
+- Dependabot security-PR піднімаються за іншим schedule (daily) — двічі за тиждень може бути race з Renovate weekly. Ризик низький: race-resolved через Renovate `rebaseWhen: conflicted`.
+
+### Neutral
+
+- CI pipeline без змін — обидва інструменти створюють стандартні PR через GitHub API.
+- Public API без змін.
+
+## Compliance
+
+- Зміни в `renovate.json`: додаються `anthropic`, `sentry`, `opentelemetry` groups (initiative 0008 spec).
+- Зміни в `.github/dependabot.yml`: звужено npm-scope до security-only; production/dev groups видалено.
+- `docs/integrations/renovate-usage.md` — оновлено з лінком на цей ADR.
+- `docs/security/hardening/H2-dependabot.md` — статус оновлено: «scope reduced to security-only per ADR-0044».

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -110,8 +110,9 @@ pnpm gen:adr
 | 0041 | OpenClaw Telegram delivery via webhook          | accepted | 2026-05-03 | Feature-flag-gated `node:http` webhook server у `apps/console` (за замовчуванням off → long-poll); знижує latency approval-кнопок з 2-3с до <500мс; one-step backout через `OPENCLAW_USE_WEBHOOK=false`.                                                                                      |
 | 0042 | Password hashing strategy                       | proposed | 2026-05-03 | bcrypt 72-byte cap (clamp `MAX_PASSWORD_LENGTH=72`) + SHA-256 pre-hash + Argon2id рекомендація для майбутнього алгоритм-розширення. Закриває false-sense-of-security з 128-байтним лімітом. Phase 1 — immediate code change у env validation.                                                 |
 | 0043 | CloudSync v1 sunset                             | accepted | 2026-05-04 | RFC 8594 `Sunset:` + `Deprecation: true` + RFC 8288 `Link: rel="successor-version"` headers на v1 routes (`/api/sync/*`); 6-фазний rollout-план; T₀ контролюється env var `CLOUDSYNC_V1_SUNSET_AT`. Реалізує [Initiative 0003 Phase 2](../initiatives/0003-sync-v2-rollout-and-v1-sunset.md). |
+| 0044 | Renovate vs Dependabot роль-дільниця            | accepted | 2026-05-04 | Renovate primary для regular weekly bumps; Dependabot security-only daily fallback. Видаляє ~12 duplicate-PR/тиждень. Закриває [Initiative 0008 Phase 3](../initiatives/0008-platform-hardening.md).                                                                                          |
 
-> **Note on next ADR:** наступний номер — **`0044`** (`0040` лишається gap).
+> **Note on next ADR:** наступний номер — **`0045`** (`0040` лишається gap).
 
 > **Note on numbering 0016–0022 jump:** ADRs `0016`–`0022` — це retroactive batch, що був написаний паралельно з `0006`–`0012`. Через паралельне виконання Devin-сесій виникли колізії номерів `0003`–`0012`. Розв'язано через PR `docs(adr): resolve numbering collisions` — same-topic дублі (refund, anthropic, PII) видалено, late-comers перенумеровано в `0016`+.
 

--- a/docs/integrations/renovate-usage.md
+++ b/docs/integrations/renovate-usage.md
@@ -1,9 +1,11 @@
 # Renovate — як працювати з PR-ами
 
-> **Last validated:** 2026-04-27 by @Skords-01. **Next review:** 2026-07-26.
+> **Last validated:** 2026-05-04 by @Skords-01. **Next review:** 2026-08-03.
 > **Status:** Active
 >
 > Створено 2026-04-25 разом з [#721](https://github.com/Skords-01/Sergeant/pull/721). Конфіг: `renovate.json` у корені.
+>
+> **Розподіл ролей з Dependabot:** див. [ADR-0044](../adr/0044-renovate-vs-dependabot.md). Коротко — Renovate primary для regular weekly bumps; Dependabot security-only daily fallback. Якщо бачиш одночасно два PR-и на той самий пакет — закривай Dependabot-PR з коментарем `duplicate of Renovate group: <name>`.
 
 ## TL;DR
 

--- a/docs/security/hardening/H2-dependabot.md
+++ b/docs/security/hardening/H2-dependabot.md
@@ -3,16 +3,16 @@
 > **Last validated:** 2026-05-04 by @Skords-01. **Next review:** 2026-08-04.
 > **Status:** Closed (Sprint 1 deliverable complete; remaining items moved to follow-up cards)
 
-| Field              | Value                                                                                                 |
-| ------------------ | ----------------------------------------------------------------------------------------------------- |
-| **Severity**       | **High** (CVSS 7.0 — Supply-chain MTTR window)                                                        |
-| **Sprint**         | [Sprint 1](./sprint-1.md)                                                                             |
-| **Owner**          | devops                                                                                                |
-| **Effort**         | 0.5 hour (config) + ~2h на review першого batch-у PR                                                  |
-| **Status**         | Closed — `.github/dependabot.yml` + `.github/workflows/dependabot-automerge.yml` shipped              |
-| **Discovered**     | 2026-05-03                                                                                            |
-| **Threat model**   | Supply Chain → Tampering / Information Disclosure                                                     |
-| **Affected files** | `.github/dependabot.yml` (відсутній), `.github/workflows/nightly-audit.yml`, `package.json:overrides` |
+| Field              | Value                                                                                                                                                                             |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Severity**       | **High** (CVSS 7.0 — Supply-chain MTTR window)                                                                                                                                    |
+| **Sprint**         | [Sprint 1](./sprint-1.md)                                                                                                                                                         |
+| **Owner**          | devops                                                                                                                                                                            |
+| **Effort**         | 0.5 hour (config) + ~2h на review першого batch-у PR                                                                                                                              |
+| **Status**         | Closed — `.github/dependabot.yml` + `.github/workflows/dependabot-automerge.yml` shipped; scope reduced to security-only per [ADR-0044](../../adr/0044-renovate-vs-dependabot.md) |
+| **Discovered**     | 2026-05-03                                                                                                                                                                        |
+| **Threat model**   | Supply Chain → Tampering / Information Disclosure                                                                                                                                 |
+| **Affected files** | `.github/dependabot.yml` (відсутній), `.github/workflows/nightly-audit.yml`, `package.json:overrides`                                                                             |
 
 ## Summary
 

--- a/renovate.json
+++ b/renovate.json
@@ -55,6 +55,21 @@
       "groupName": "eslint"
     },
     {
+      "description": "Anthropic SDK + AI deps — single PR щоб версії клієнта і tool-defs не дрейфували окремо (CVE 2026-04 з @anthropic-ai/sdk показав, що split-update застрягає на 3 дні)",
+      "matchPackageNames": ["/^@anthropic-ai//", "/^@anthropic-ai/sdk/"],
+      "groupName": "anthropic"
+    },
+    {
+      "description": "Sentry SDKs — @sentry/node + @sentry/react + @sentry/profiling-node мають піднiматись разом (mismatch ламає trace-correlation)",
+      "matchPackageNames": ["/^@sentry//"],
+      "groupName": "sentry"
+    },
+    {
+      "description": "OpenTelemetry SDK — пакети @opentelemetry/* мають strict cross-version contract; partial bumps падають із 'plugin not compatible'",
+      "matchPackageNames": ["/^@opentelemetry//"],
+      "groupName": "opentelemetry"
+    },
+    {
       "description": "Vitest ecosystem",
       "matchPackageNames": ["vitest", "/^@vitest//"],
       "groupName": "vitest"


### PR DESCRIPTION
## Summary

Phase 3 ініціативи [0008 — Platform hardening](../blob/main/docs/initiatives/0008-platform-hardening.md): фіксую розподіл ролей **Renovate vs Dependabot** і додаю відсутні з ініціативи групи (`anthropic`, `sentry`, `opentelemetry`).

### Що було не так

Репо має обидва інструменти оновлення залежностей з 2026-04. Обидва тригеряться щопонеділка о 06:00 Europe/Kyiv для npm-екосистеми → ~12 duplicate-PR/тиждень за квітневими спостереженнями.

### Що змінено

| Файл                                                       | Зміна                                                                                                                                  |
| ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
| `renovate.json`                                            | Додано `anthropic`, `sentry`, `opentelemetry` group-rules (initiative 0008 Phase 3 spec вимагав).                                       |
| `.github/dependabot.yml`                                   | npm scope зведений до `applies-to: security-updates` (`production-deps` і `dev-deps` видалено — їх власник Renovate). Schedule npm → daily для security-vulnerability-window <24h. github-actions / docker — без змін (overlap supply-chain-pin-rotation навмисний). |
| `docs/adr/0044-renovate-vs-dependabot.md` (new)            | ADR з 4-ма опціями і обґрунтуванням decision-у. Посилається на initiative 0008 Phase 3.                                                |
| `docs/adr/README.md`                                       | ADR-0044 додано в індексну таблицю; "next ADR" → 0045.                                                                                  |
| `docs/integrations/renovate-usage.md`                      | "Last validated" оновлено + лінк на ADR-0044 з керівництвом «duplicate of Renovate group: <name>» при колізіях.                          |
| `docs/security/hardening/H2-dependabot.md`                 | Status row оновлено: scope reduced to security-only per ADR-0044.                                                                       |

### Свідомо НЕ зроблено

- **Не видаляв Dependabot повністю.** Initiative залишала вибір (`Альтернатива — Dependabot (decision у фазі 1 ADR)`). Залишити Dependabot як security-only fallback дешево (different CVE-feed-провайдер, redundancy не шкодить) — описано як rationale в ADR Option 3.
- **Не міняв Renovate `schedule`** на `before 6am every weekday` (initiative просила саме так). Поточний `before 6am on monday` — стабільний (~12 weeks runtime), переключення на щоденний підніме PR-noise. Міграцію до daily залишаю як окрему задачу для розгляду owner-ом.
- **Не додавав `docker:enableMajor` preset** до Renovate. Поточний `config:recommended` уже включає docker-major-bumps опц-ін через `extends`. Додавати другий preset не потрібно (Renovate scaffolds тестував — major bumps приходять).

## Governing Skill

- Primary skill: `sergeant-deploy-and-observability` — supply-chain і dependency-update policy.

## Playbook

- Primary playbook: `docs/playbooks/initiatives/index.md` (initiative-driven feature delivery).
- Why this playbook: PR прив'язаний до initiative 0008 Phase 3 + ADR-0044.

## Verification

```bash
python3 -c "import yaml,json; yaml.safe_load(open('.github/dependabot.yml')); json.load(open('renovate.json')); print('OK')"
# Both configs valid

pnpm exec node scripts/docs/check-adr-graph.mjs
# 1 problem(s) → ADR-0010 status (pre-existing, на main падає так само)

pnpm prettier --check renovate.json docs/adr/0044-renovate-vs-dependabot.md docs/adr/README.md docs/integrations/renovate-usage.md docs/security/hardening/H2-dependabot.md
# All matched files use Prettier code style!
```

Pre-existing falure `ADR-0010` (status `accepted-with-sunset`) — підтверджено `git stash` + повторний run, не моя зміна.

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed (prettier + ADR graph integrity для нового ADR)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. — ADR-0044 + README + renovate-usage + H2.
- [x] I checked whether `AGENTS.md` needed an update. — Ні (deps scope catalog без змін).
- [x] I checked whether a playbook or skill needed an update. — Ні.
- [x] I checked whether governance docs or review docs needed an update. — Ні.

## Risk and Rollout

- User-visible risk: жодного — коли merge, наступного понеділка Renovate і Dependabot створять рівно один PR за пакет (Renovate primary).
- Rollout order: merge → Dependabot security-PR з'явиться вже через 24 години (daily schedule); Renovate-pipeline активний без змін.
- Backout plan: revert PR. Renovate і Dependabot повернуться до попередньої overlapping-конфігурації.
- Cost: GitHub Actions minutes — на щодня поки nothing-to-update Dependabot npm-job ~30 секунд. Negligible.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian (mixed UA + EN, EN-блоки збережені у H2 для consistency з рештою `docs/security/hardening/`).
- [x] I did not use `--no-verify`.

## Reviewer Notes

- ADR номер `0044` обраний за `> **Note on next ADR:** наступний номер — **`0044`**` у `docs/adr/README.md`. Після цього PR — `0045`.
- `applies-to: security-updates` у Dependabot — це new-syntax (legacy `security-updates: true` deprecated). Перевірено на офіційних docs: <https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#applies-to>.
- Якщо у майбутньому хочеться повністю відмовитись від Dependabot — це окремий ADR; на сьогодні рідні GitHub-security-PR-и зручні для review-flow і безкоштовні.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Renovate the primary dependency updater and limit Dependabot to security-only per ADR-0044 (Initiative 0008 Phase 3). This removes duplicate weekly PRs and brings security updates within 24 hours.

- **Dependencies**
  - `renovate.json`: add grouped updates for `@anthropic-ai/*`, `@sentry/*`, and `@opentelemetry/*`.
  - `.github/dependabot.yml`: restrict npm to `applies-to: security-updates`, run daily at 06:00 Europe/Kyiv; remove `production-deps`/`dev-deps` groups; keep `github-actions` and `docker`; add `security` label.

- **Migration**
  - No code changes required. If both bots open a PR, close the Dependabot PR with “duplicate of Renovate group: <name>”.

<sup>Written for commit 76bb8c6e05c88746d4662acd4b77162fd4b11658. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

