### PR TITLE
feat(web): tour-mode replay for onboarding wizard

### DIFF
--- a/apps/web/src/core/onboarding/OnboardingWizard.tour.test.tsx
+++ b/apps/web/src/core/onboarding/OnboardingWizard.tour.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { OnboardingWizard } from "./OnboardingWizard";
+
+/**
+ * Tour mode (S4.5) covers the read-only replay launched from
+ * Settings → "Подивитись tour". The contract is that the wizard
+ * never touches the user's onboarding / first-action / vibe-picks
+ * state and never fires the FTUX-funnel events.
+ */
+describe("OnboardingWizard — tour mode (read-only replay)", () => {
+  // The repo's vitest setup does not auto-cleanup RTL renders; mount
+  // hygiene is handled per-file (see NoBankBanner.test.tsx).
+  afterEach(cleanup);
+
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("does not persist picks to localStorage", () => {
+    const setItem = vi.spyOn(Storage.prototype, "setItem");
+    render(<OnboardingWizard mode="tour" onDone={() => {}} />);
+    // The wizard should not write any of the FTUX persistence keys
+    // while running in tour mode.
+    const writtenKeys = setItem.mock.calls.map(([k]) => String(k));
+    expect(writtenKeys).not.toContain("sergeant.onboarding.wizardState.v2");
+    expect(writtenKeys).not.toContain("hub_onboarding_done_v1");
+    expect(writtenKeys.some((k) => k.startsWith("sergeant.vibePicks"))).toBe(
+      false,
+    );
+  });
+
+  it("does not mark onboarding done or change first-action state on close", () => {
+    const onDone = vi.fn();
+    render(<OnboardingWizard mode="tour" onDone={onDone} />);
+    fireEvent.click(screen.getByRole("button", { name: /Закрити/i }));
+    expect(onDone).toHaveBeenCalledTimes(1);
+    // Critical: tour finish must hand back `null` start module + intent
+    // tagged as `tour_replay`, never `vibe_picked` / `vibe_empty` (those
+    // labels feed the real activation funnel).
+    expect(onDone).toHaveBeenCalledWith(null, {
+      intent: "tour_replay",
+      picks: [],
+    });
+    expect(localStorage.getItem("hub_onboarding_done_v1")).toBeNull();
+    expect(
+      localStorage.getItem("sergeant.onboarding.wizardState.v2"),
+    ).toBeNull();
+  });
+
+  it("renders the «Закрити» CTA instead of «Відкрити Sergeant»", () => {
+    render(<OnboardingWizard mode="tour" onDone={() => {}} />);
+    expect(
+      screen.getByRole("button", { name: /Закрити/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Відкрити Sergeant/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("default mode still renders «Відкрити Sergeant» CTA", () => {
+    render(<OnboardingWizard onDone={() => {}} />);
+    expect(
+      screen.getByRole("button", { name: /Відкрити Sergeant/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/core/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/core/onboarding/OnboardingWizard.tsx
@@ -224,12 +224,15 @@ function WelcomeOneScreen({
   onOpen,
   expanded,
   onToggleExpanded,
+  ctaLabel = "Відкрити Sergeant",
 }: {
   picks: string[];
   togglePick: (id: string) => void;
   onOpen: () => void;
   expanded: boolean;
   onToggleExpanded: () => void;
+  /** Override label for the primary CTA (e.g. tour replay shows "Закрити"). */
+  ctaLabel?: string;
 }) {
   return (
     <div className="flex flex-col items-center text-center space-y-5">
@@ -293,7 +296,7 @@ function WelcomeOneScreen({
         size="lg"
         className="w-full"
       >
-        Відкрити Sergeant
+        {ctaLabel}
         <Icon name="chevron-right" size={16} />
       </Button>
 
@@ -332,36 +335,53 @@ function WelcomeOneScreen({
 export function OnboardingWizard({
   onDone,
   variant = "modal",
+  mode = "real",
 }: {
   onDone: (
     startModuleId: string | null,
     opts?: { intent: string; picks: string[] },
   ) => void;
   variant?: "modal" | "fullPage";
+  /**
+   * "real" (default) — first-run wizard: persists picks, fires the FTUX
+   * funnel events, and marks onboarding done on finish.
+   *
+   * "tour" — read-only replay launched from Settings → "Подивитись tour".
+   * Skips all storage writes and FTUX-funnel events, fires
+   * `onboarding_replay_*` instead, and `finish` simply closes the
+   * wizard without touching the user's onboarding / first-action state.
+   */
+  mode?: "real" | "tour";
 }) {
-  const [picks, setPicks] = useState<string[]>(loadPersistedPicks);
+  const isTour = mode === "tour";
+  const [picks, setPicks] = useState<string[]>(() =>
+    isTour ? [...ALL_MODULES] : loadPersistedPicks(),
+  );
   const [expanded, setExpanded] = useState(false);
 
   // Persist picks on every change. Payload is tiny (≤4 strings) so
   // unconditional writes are cheap and keep the resume-after-refresh
-  // story trivial.
+  // story trivial. Tour mode is throwaway state — never persists.
   useEffect(() => {
+    if (isTour) return;
     persistPicks(picks);
-  }, [picks]);
+  }, [picks, isTour]);
 
-  // The wizard is a single-screen flow (welcome → finish), so the
-  // first paint counts as both `onboarding_started` and the welcome
-  // step's `onboarding_step_viewed`. Capture both in one effect so
-  // the funnel definition in `posthog-ftux-dashboards.md` stays a
-  // strict superset of `started`. `startedAt` is initialised inside
-  // the effect so the render body stays pure (`Date.now()` is impure
-  // per react-hooks/purity).
+  // Real wizard: first paint counts as both `onboarding_started` and the
+  // welcome step's `onboarding_step_viewed` so the funnel definition in
+  // `posthog-ftux-dashboards.md` stays a strict superset of `started`.
+  // Tour replay fires its own events instead so it never inflates the
+  // FTUX funnel.
   const startedAtRef = useRef<number | null>(null);
   useEffect(() => {
     startedAtRef.current = Date.now();
+    if (isTour) {
+      trackEvent(ANALYTICS_EVENTS.ONBOARDING_REPLAY_VIEWED);
+      return;
+    }
     trackEvent(ANALYTICS_EVENTS.ONBOARDING_STARTED);
     trackEvent(ANALYTICS_EVENTS.ONBOARDING_STEP_VIEWED, { step: "welcome" });
-  }, []);
+  }, [isTour]);
 
   const togglePick = useCallback((id: string) => {
     setPicks((prev) =>
@@ -374,6 +394,21 @@ export function OnboardingWizard({
   }, []);
 
   const finish = useCallback(() => {
+    if (isTour) {
+      // Tour replay: no side effects on user state. Just emit the
+      // dismissal event with a duration so PostHog can show "how long
+      // does the user spend in replay" without polluting the FTUX
+      // funnel.
+      trackEvent(ANALYTICS_EVENTS.ONBOARDING_REPLAY_DISMISSED, {
+        durationMs: Math.max(
+          0,
+          Date.now() - (startedAtRef.current ?? Date.now()),
+        ),
+      });
+      onDone(null, { intent: "tour_replay", picks: [] });
+      return;
+    }
+
     // Empty selection falls back to all modules: the lazy "tap-through"
     // path leaves every module visible on the hub instead of producing
     // a useless dashboard.
@@ -410,7 +445,7 @@ export function OnboardingWizard({
       intent: hadEmptyPicks ? "vibe_empty" : "vibe_picked",
       picks: chosen,
     });
-  }, [picks, onDone]);
+  }, [picks, onDone, isTour]);
 
   const content = useMemo(
     () => (
@@ -420,9 +455,10 @@ export function OnboardingWizard({
         onOpen={finish}
         expanded={expanded}
         onToggleExpanded={toggleExpanded}
+        ctaLabel={isTour ? "Закрити" : "Відкрити Sergeant"}
       />
     ),
-    [picks, togglePick, finish, expanded, toggleExpanded],
+    [picks, togglePick, finish, expanded, toggleExpanded, isTour],
   );
 
   if (variant === "fullPage") {

--- a/apps/web/src/core/settings/GeneralSection.tsx
+++ b/apps/web/src/core/settings/GeneralSection.tsx
@@ -6,6 +6,7 @@ import { useToast } from "@shared/hooks/useToast";
 import { webKVStore } from "@shared/lib/storage/storage";
 import { resetOnboardingState, type User } from "@sergeant/shared";
 import { useAuth } from "../auth/AuthContext";
+import { OnboardingWizard } from "../onboarding/OnboardingWizard";
 import { SettingsGroup, SettingsSubGroup } from "./SettingsPrimitives";
 
 export interface GeneralSectionProps {
@@ -25,6 +26,11 @@ export function GeneralSection({
   const navigate = useNavigate();
   const { logout } = useAuth();
   const [loggingOut, setLoggingOut] = useState(false);
+  // Tour replay (S4.5): show the welcome wizard in read-only mode so
+  // users can re-watch the FTUX without resetting their state.
+  // Distinct from "Перезапустити онбординг", which wipes vibe picks +
+  // first-action flags and routes to /welcome.
+  const [tourOpen, setTourOpen] = useState(false);
 
   const handleLogout = async () => {
     if (loggingOut) return;
@@ -44,9 +50,20 @@ export function GeneralSection({
     <SettingsGroup title="Загальні" emoji="⚙️">
       <SettingsSubGroup title="Онбординг">
         <p className="text-xs text-subtle leading-snug">
-          Перезапуск не видаляє твої дані — лише повертає вітальний екран та
+          Подивитись tour — побачити вітальний екран ще раз без скидання твого
+          стану. Перезапуск не видаляє твої дані — повертає вітальний екран і
           підказки першого запуску.
         </p>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-10 w-full justify-center gap-2"
+          onClick={() => setTourOpen(true)}
+        >
+          <Icon name="compass" size={16} />
+          Подивитись tour
+        </Button>
         <Button
           type="button"
           variant="ghost"
@@ -112,6 +129,9 @@ export function GeneralSection({
             {loggingOut ? "Виходимо…" : "Вийти"}
           </Button>
         </SettingsSubGroup>
+      )}
+      {tourOpen && (
+        <OnboardingWizard mode="tour" onDone={() => setTourOpen(false)} />
       )}
     </SettingsGroup>
   );

--- a/apps/web/src/shared/components/ui/Icon.paths.system.tsx
+++ b/apps/web/src/shared/components/ui/Icon.paths.system.tsx
@@ -138,4 +138,10 @@ export const SYSTEM_PATHS: Record<string, ReactNode> = {
       <line x1="1" y1="1" x2="23" y2="23" />
     </>
   ),
+  compass: (
+    <>
+      <circle cx="12" cy="12" r="10" />
+      <polygon points="16.24 7.76 14.12 14.12 7.76 16.24 9.88 9.88 16.24 7.76" />
+    </>
+  ),
 };

--- a/packages/shared/src/lib/analyticsEvents.ts
+++ b/packages/shared/src/lib/analyticsEvents.ts
@@ -14,6 +14,13 @@ export const ANALYTICS_EVENTS = Object.freeze({
   ONBOARDING_GOAL_SET: "onboarding_goal_set",
   ONBOARDING_SKIPPED: "onboarding_skipped",
 
+  // Onboarding replay (Settings → "Подивитись tour" — read-only mode).
+  // Distinguished from `ONBOARDING_STARTED` / `ONBOARDING_COMPLETED` so
+  // re-runs do not inflate the FTUX funnel — see S4.5 in
+  // `docs/launch/ftux-sprint-plan.md`.
+  ONBOARDING_REPLAY_VIEWED: "onboarding_replay_viewed",
+  ONBOARDING_REPLAY_DISMISSED: "onboarding_replay_dismissed",
+
   // Finyk / activation
   EXPENSE_ADDED: "expense_added",
   EXPENSE_DELETED: "expense_deleted",


### PR DESCRIPTION
## Summary

S4.5 of `docs/launch/ftux-sprint-plan.md`. Adds a "Подивитись tour" entry under **Settings → Загальні → Онбординг** that replays the welcome wizard in a strictly read-only mode — users can re-watch FTUX without touching their onboarding / first-action / vibe-picks state.

- New `mode: "real" | "tour"` prop on `OnboardingWizard`. Tour mode skips:
  - picks persistence (`sergeant.onboarding.wizardState.v2`),
  - all FTUX funnel events (`onboarding_started` / `_step_viewed` / `_step_completed` / `_completed`, `onboarding_vibe_picked`),
  - `saveVibePicks`, `markFirstActionStartedAt`, `markFirstActionPending`, `markOnboardingDone`, `clearPersistedPicks`.
- Adds two analytics events to the canonical registry: `onboarding_replay_viewed` (on mount) and `onboarding_replay_dismissed` (on close, with `durationMs`). They sit outside the FTUX funnel so dashboards in `docs/observability/posthog-ftux-dashboards.md` stay clean.
- Adds a `compass` icon path so the new button can carry the icon called for in the sprint plan.
- `WelcomeOneScreen` accepts an optional `ctaLabel` override; tour mode shows **«Закрити»** instead of **«Відкрити Sergeant»** so the existing finish-style button reads correctly without forking the screen.
- `GeneralSection` mounts the wizard inline with `mode="tour"`. The wizard's fixed-position modal escapes the collapsible parent, so DOM placement is intentional and minimal.

LOC: 71 prod + 69 test (≤ 300 cap from sprint plan §0).

## Governing Skill

- Primary skill: `.agents/skills/sergeant-web-ui/SKILL.md`
- Secondary skill (if truly needed): `.agents/skills/sergeant-feature-delivery/SKILL.md`

## Playbook

- Primary playbook: `docs/playbooks/playbook-catalog.md` — feature-delivery (FTUX surface). The `add-onboarding-step.md` playbook is for **adding** a step to the wizard; this PR is a **mode switch**, not a step addition, so the broader feature-delivery playbook applies.
- Why this playbook: small, isolated FTUX surface change scoped to web + the analytics-events registry.
- If no playbook matched, why: n/a

## Verification

```bash
pnpm exec eslint apps/web/src/core/onboarding/OnboardingWizard.tsx \
  apps/web/src/core/onboarding/OnboardingWizard.tour.test.tsx \
  apps/web/src/core/settings/GeneralSection.tsx \
  apps/web/src/shared/components/ui/Icon.paths.system.tsx \
  packages/shared/src/lib/analyticsEvents.ts
# → clean

pnpm exec prettier --check (same files)
# → clean

pnpm --filter @sergeant/web exec vitest run src/core/onboarding src/core/settings
# → 4 files / 15 tests passed (4 new in OnboardingWizard.tour.test.tsx)

pnpm --filter @sergeant/shared exec vitest run src/lib/analyticsEvents.test.ts
# → 1 file / 5 tests passed (new replay events covered by the
#   "snake_case", "frozen", "unique" registry assertions)

pnpm --filter @sergeant/web exec vite build
# → built successfully
```

`pnpm typecheck` shows the same pre-existing failures present on `main` (db-schema-related test files, `HubDashboard.tsx`, `useStoryGestures.test.tsx`); this PR does not add any new typecheck errors.

Additional checks:

- [x] Local smoke / manual validation completed (`vite build` + targeted vitest)
- [x] Surface-specific checks completed (`pnpm lint:imports`, `lint:localstorage-allowlist`)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- `docs/launch/ftux-sprint-plan.md` — status row for S4.5 (and S4.4 from the companion PR) will be flipped to "DONE" in the doc-update commit that lands once both PRs are green (single docs sweep, per the task brief).

The two new events (`onboarding_replay_viewed`, `onboarding_replay_dismissed`) are documented inline next to the canonical registry. Their inclusion in `docs/observability/frontend.md` and the FTUX-dashboards spec is **not** required because they are explicitly out of the FTUX funnel — flagged in the registry comment for the next observability sweep.

## Risk and Rollout

- User-visible risk: low. Tour mode is purely additive — it never writes to localStorage, never flips onboarding flags, and never fires the funnel events. The only user-visible change to the existing wizard is a single new optional prop with a default that preserves the previous behaviour exactly.
- Rollout / deploy order: ship as a normal web release; no server / migration coupling.
- Backout plan: revert this commit. The new icon path and analytics events are forward-compatible — leaving them in place after a revert is also safe (they'd simply have zero callsites).

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

- The `mode="tour"` switch deliberately stays inside the existing wizard rather than forking a new component: the welcome screen layout is the contract under test, and any drift between "real onboarding" and "tour replay" would defeat the point of replay.
- Mobile parity (`apps/mobile`) is intentionally out of scope — mobile does not yet host an Onboarding wizard equivalent. When the mobile FTUX lands, the same canonical events (`onboarding_replay_*`) will be reused via the shared `ANALYTICS_EVENTS` registry.
- New `compass` icon path follows the lucide-style 24×24 outline convention used by the rest of `Icon.paths.system.tsx`.


---

Devin session: https://app.devin.ai/sessions/d4632d99514942cbadf0ed0da32968d3
Requested by: Андрій (andrijvigrav@gmail.com)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read‑only “tour” mode for the onboarding wizard and a “Подивитись tour” button in Settings so users can rewatch the welcome flow without changing their state. Default onboarding stays the same; replay analytics are kept out of the FTUX funnel.

- **New Features**
  - Added `mode: "real" | "tour"` to the onboarding wizard (default is `"real"`). Tour mode does not write to storage and does not fire FTUX funnel events.
  - Settings → Загальні → Онбординг now has “Подивитись tour” with a `compass` icon that opens the wizard in tour mode.
  - New analytics: `onboarding_replay_viewed` (on open) and `onboarding_replay_dismissed` (on close, with `durationMs`). These are separate from the FTUX funnel.
  - `WelcomeOneScreen` supports a `ctaLabel` override; tour shows “Закрити” instead of “Відкрити Sergeant”.

<sup>Written for commit 3e6c2f7fdd50558a1c5fa739043fa0aed0db5807. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Onboarding wizard now supports read-only tour mode for replaying the onboarding experience without persisting changes.
  * Added "View tour" option in General settings to replay the onboarding wizard at any time.
  * Added compass icon to the UI system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->