### PR TITLE
feat(web): demo-mode CTA on welcome + banner in hub

### DIFF
--- a/apps/web/src/core/app/WelcomeScreen.tsx
+++ b/apps/web/src/core/app/WelcomeScreen.tsx
@@ -1,6 +1,8 @@
 import { Icon } from "@shared/components/ui/Icon";
 import { cn } from "@shared/lib/ui/cn";
 import { OnboardingWizard } from "../onboarding/OnboardingWizard";
+import { seedDemoData } from "../onboarding/seedDemoData";
+import { trackEvent, ANALYTICS_EVENTS } from "../observability/analytics";
 
 // Static preview of the populated hub that sits behind the splash card on
 // `/welcome`. Renders a 2×2 bento grid matching `HubDashboard`'s module
@@ -168,6 +170,23 @@ interface WelcomeScreenProps {
  * backdrop and delegates the splash card to `OnboardingWizard` in
  * `fullPage` mode.
  */
+/**
+ * S4.1 "Подивитись приклад" handler. Seeds a synthetic hub payload
+ * across all four modules and reloads onto `/` so the demo state is
+ * visible immediately. Tracking is fired before the redirect so the
+ * `demo_started` event lands even if the new page mounts before the
+ * old PostHog buffer flushes (the SDK persists pending events).
+ */
+function startDemoAndGoHome(): void {
+  trackEvent(ANALYTICS_EVENTS.DEMO_STARTED, { source: "welcome" });
+  seedDemoData();
+  try {
+    window.location.assign("/");
+  } catch {
+    /* noop */
+  }
+}
+
 export function WelcomeScreen({ onDone, onOpenAuth }: WelcomeScreenProps) {
   return (
     <div className="relative min-h-dvh bg-bg text-text overflow-hidden page-enter">
@@ -175,6 +194,24 @@ export function WelcomeScreen({ onDone, onOpenAuth }: WelcomeScreenProps) {
       <div className="relative min-h-dvh flex items-end sm:items-center justify-center p-4 pb-safe">
         <div className="w-full max-w-sm space-y-3">
           <OnboardingWizard onDone={onDone} variant="fullPage" />
+          {/* Demo-first CTA (S4.1). Lower visual weight than the
+              wizard primary, but above the returning-user entry so
+              the "просто подивитись" cohort doesn't have to scan past
+              an account-prompt to find it. */}
+          <button
+            type="button"
+            onClick={startDemoAndGoHome}
+            className={cn(
+              "w-full flex items-center justify-center gap-2",
+              "h-11 min-h-[44px] rounded-2xl border border-brand-500/35 bg-brand-500/5",
+              "text-style-label text-brand-strong dark:text-brand",
+              "hover:bg-brand-500/10 hover:border-brand-500/55 transition-colors",
+              "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45",
+            )}
+          >
+            <Icon name="sparkles" size={16} strokeWidth={2} aria-hidden />
+            <span>Подивитись приклад</span>
+          </button>
           {/* Returning-user entry. The previous text-xs muted underline was
               almost invisible on a fresh device — users who already had an
               account were dropped into onboarding. Promoted to a secondary

--- a/apps/web/src/core/hub/HubDashboard.tsx
+++ b/apps/web/src/core/hub/HubDashboard.tsx
@@ -35,6 +35,7 @@ import {
 import { useCoachInsight } from "../insights/useCoachInsight";
 import { AssistantAdviceCard } from "../insights/AssistantAdviceCard";
 import { SoftAuthPromptCard } from "../onboarding/SoftAuthPromptCard";
+import { DemoModeBanner } from "../onboarding/DemoModeBanner";
 import { FirstActionHeroCard } from "../onboarding/FirstActionSheet";
 import { detectFirstRealEntry } from "../onboarding/firstRealEntry";
 import {
@@ -471,6 +472,11 @@ export function HubDashboard({
   // Stable group indices keep the reveal under ~250ms and predictable.
   return (
     <div className={DENSITY_OUTER_SPACE[density]}>
+      {/* S4.1 demo banner — only renders when localStorage holds a
+          seeded demo payload (`hub_demo_seeded_social_v1`). Sits above
+          the hero block so the «Це приклад» framing precedes any of
+          the metric cards below. */}
+      <DemoModeBanner />
       {/* GROUP 0 — Hero block (re-engagement OR streak + hero + checklist) */}
       <StaggerChild index={0}>
         <div className="space-y-4">

--- a/apps/web/src/core/onboarding/DemoModeBanner.test.tsx
+++ b/apps/web/src/core/onboarding/DemoModeBanner.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { DemoModeBanner } from "./DemoModeBanner";
+
+vi.mock("../observability/analytics", async () => {
+  const actual = await vi.importActual<
+    typeof import("../observability/analytics")
+  >("../observability/analytics");
+  return {
+    ...actual,
+    trackEvent: vi.fn(),
+  };
+});
+
+import { trackEvent, ANALYTICS_EVENTS } from "../observability/analytics";
+
+const DEMO_FLAG_KEY = "hub_demo_seeded_social_v1";
+const SESSION_DISMISS_KEY = "hub_demo_banner_dismissed_session";
+
+describe("DemoModeBanner (S4.1)", () => {
+  // The repo's vitest setup does not auto-cleanup RTL renders.
+  afterEach(cleanup);
+
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    vi.mocked(trackEvent).mockClear();
+    // jsdom's `location.assign` throws when the URL navigates away.
+    // Stub it for the «Створити свій» test.
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, assign: vi.fn() },
+    });
+  });
+
+  it("renders nothing when demo flag is not set", () => {
+    const { container } = render(<DemoModeBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders banner with CTA when demo flag is set", () => {
+    localStorage.setItem(DEMO_FLAG_KEY, "1");
+    render(<DemoModeBanner />);
+    expect(screen.getByText("Це приклад")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Створити свій/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides banner for the rest of the session when X is clicked", () => {
+    localStorage.setItem(DEMO_FLAG_KEY, "1");
+    render(<DemoModeBanner />);
+    fireEvent.click(screen.getByRole("button", { name: /Сховати/i }));
+
+    expect(screen.queryByText("Це приклад")).not.toBeInTheDocument();
+    expect(sessionStorage.getItem(SESSION_DISMISS_KEY)).toBe("1");
+    expect(vi.mocked(trackEvent)).toHaveBeenCalledWith(
+      ANALYTICS_EVENTS.DEMO_DISMISSED,
+    );
+  });
+
+  it("does not render when sessionStorage already has the dismiss flag", () => {
+    localStorage.setItem(DEMO_FLAG_KEY, "1");
+    sessionStorage.setItem(SESSION_DISMISS_KEY, "1");
+    const { container } = render(<DemoModeBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("«Створити свій» wipes the demo payload, fires event, and navigates to /welcome", () => {
+    localStorage.setItem(DEMO_FLAG_KEY, "1");
+    // Seed a couple of the keys the banner is supposed to reset on confirm.
+    localStorage.setItem("finyk_manual_expenses_v1", "[]");
+    localStorage.setItem("hub_onboarding_done_v1", "1");
+    render(<DemoModeBanner />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Створити свій/i }));
+
+    expect(vi.mocked(trackEvent)).toHaveBeenCalledWith(
+      ANALYTICS_EVENTS.DEMO_TO_WIZARD_CONFIRMED,
+    );
+    // resetDemoData() removes every SEEDED_KEYS entry; spot-check two.
+    expect(localStorage.getItem(DEMO_FLAG_KEY)).toBeNull();
+    expect(localStorage.getItem("hub_onboarding_done_v1")).toBeNull();
+    expect(window.location.assign).toHaveBeenCalledWith("/welcome");
+  });
+});

--- a/apps/web/src/core/onboarding/DemoModeBanner.tsx
+++ b/apps/web/src/core/onboarding/DemoModeBanner.tsx
@@ -1,0 +1,113 @@
+import { useState } from "react";
+import { Button } from "@shared/components/ui/Button";
+import { Icon } from "@shared/components/ui/Icon";
+import { trackEvent, ANALYTICS_EVENTS } from "../observability/analytics";
+import { isDemoMode, resetDemoData } from "./seedDemoData";
+
+const SESSION_DISMISS_KEY = "hub_demo_banner_dismissed_session";
+
+/**
+ * S4.1 retention banner. Surfaces inside the populated hub whenever
+ * the local store holds a demo payload (see `isDemoMode()` /
+ * `seedDemoData()`), nudging the user toward the real wizard.
+ *
+ * - "Створити свій" → `resetDemoData()` + redirect to `/welcome` so
+ *   the regular onboarding flow takes over against an empty store.
+ * - Close (X) → hide for the rest of the session (sessionStorage key
+ *   is cleared on the next cold start; the demo flag itself stays).
+ *
+ * Analytics:
+ *   `demo_to_wizard_confirmed` on CTA, `demo_dismissed` on close.
+ *   Kept outside the `onboarding_*` funnel so demo browsing doesn't
+ *   pollute activation cohorts.
+ */
+export function DemoModeBanner() {
+  // Synchronous reads so the banner can fork on first render without
+  // waiting for an effect. Both checks tolerate `localStorage` /
+  // `sessionStorage` being unavailable (incognito, hardened browsers,
+  // SSR pre-hydrate).
+  const [demo] = useState<boolean>(() => isDemoMode());
+  const [dismissed, setDismissed] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    try {
+      return window.sessionStorage.getItem(SESSION_DISMISS_KEY) === "1";
+    } catch {
+      return false;
+    }
+  });
+
+  if (!demo || dismissed) return null;
+
+  const dismiss = () => {
+    trackEvent(ANALYTICS_EVENTS.DEMO_DISMISSED);
+    try {
+      window.sessionStorage.setItem(SESSION_DISMISS_KEY, "1");
+    } catch {
+      /* sessionStorage unavailable — banner just stays hidden in-memory. */
+    }
+    setDismissed(true);
+  };
+
+  const goToWizard = () => {
+    trackEvent(ANALYTICS_EVENTS.DEMO_TO_WIZARD_CONFIRMED);
+    resetDemoData();
+    try {
+      window.sessionStorage.removeItem(SESSION_DISMISS_KEY);
+    } catch {
+      /* noop */
+    }
+    // Hard navigation: the empty-store assumptions across React
+    // Query caches, MMKV-web, and PWA prefetch are easier to reset
+    // by reloading onto `/welcome` than by tearing them down in JS.
+    try {
+      window.location.assign("/welcome");
+    } catch {
+      /* noop */
+    }
+  };
+
+  return (
+    <div
+      role="region"
+      aria-label="Демо-режим"
+      className="rounded-2xl border border-brand-500/40 bg-brand-500/5 p-4 shadow-card"
+    >
+      <div className="flex items-start gap-3">
+        <span
+          className="shrink-0 w-9 h-9 rounded-xl bg-brand-500/15 text-brand-strong dark:text-brand flex items-center justify-center"
+          aria-hidden
+        >
+          <Icon name="sparkles" size={18} />
+        </span>
+        <div className="min-w-0 flex-1">
+          <h3 className="text-style-label text-text">Це приклад</h3>
+          <p className="text-xs text-muted mt-1 leading-snug">
+            Цифри й категорії — для демонстрації. Натисни «Створити свій», щоб
+            почати з чистого аркуша.
+          </p>
+        </div>
+        <Button
+          variant="ghost"
+          size="xs"
+          iconOnly
+          onClick={dismiss}
+          aria-label="Сховати"
+          className="shrink-0 -mt-1 -mr-1 text-muted hover:text-text"
+        >
+          <Icon name="close" size={16} />
+        </Button>
+      </div>
+      <div className="mt-3 flex flex-col gap-2 sm:flex-row">
+        <Button
+          type="button"
+          variant="primary"
+          size="sm"
+          className="flex-1 min-h-[40px]"
+          onClick={goToWizard}
+        >
+          Створити свій
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/core/onboarding/seedDemoData.ts
+++ b/apps/web/src/core/onboarding/seedDemoData.ts
@@ -44,6 +44,7 @@ import { seedHubQuickStats } from "./seedDemoData/seedHubQuickStats";
 import { seedNutrition } from "./seedDemoData/seedNutrition";
 import { seedRoutine } from "./seedDemoData/seedRoutine";
 import { removeKey, writeRaw } from "./seedDemoData/utils";
+import { safeReadStringLS } from "@shared/lib/storage/storage";
 
 const SEEDED_KEYS = [
   DEMO_FLAG_KEY,
@@ -90,6 +91,18 @@ export function seedDemoData(): void {
 /** Wipe everything the seeder writes. */
 export function resetDemoData(): void {
   for (const k of SEEDED_KEYS) removeKey(k);
+}
+
+/**
+ * `true` when the local store currently holds a demo payload. Read
+ * synchronously from localStorage so the boot path can fork before
+ * React mounts. Used by the FTUX-banner (S4.1) to surface the
+ * "Це приклад. Створити свій?" CTA. Goes through the boundary helper
+ * so private-mode / corrupted-quota errors degrade to "no demo" the
+ * same way every other storage read does.
+ */
+export function isDemoMode(): boolean {
+  return safeReadStringLS(DEMO_FLAG_KEY) === "1";
 }
 
 /**

--- a/packages/shared/src/lib/analyticsEvents.ts
+++ b/packages/shared/src/lib/analyticsEvents.ts
@@ -150,6 +150,20 @@ export const ANALYTICS_EVENTS = Object.freeze({
   PRICING_VIEWED: "pricing_viewed",
   PRICING_CTA_CLICKED: "pricing_cta_clicked",
   WAITLIST_SUBMITTED: "waitlist_submitted",
+
+  // Demo mode (S4.1 of `docs/launch/ftux-sprint-plan.md`). The welcome
+  // screen ships a "Подивитись приклад" CTA that seeds a fake hub
+  // payload in localStorage; once the user lands inside the hub, a
+  // banner offers them a one-tap path back to the real onboarding
+  // wizard. Events are kept off the FTUX funnel so demo browsing
+  // doesn't inflate `onboarding_started` cohorts. Expected payloads:
+  //
+  //   DEMO_STARTED                { source: "welcome" | "deeplink" }
+  //   DEMO_DISMISSED              {}  // banner X
+  //   DEMO_TO_WIZARD_CONFIRMED    {}  // banner CTA → /welcome
+  DEMO_STARTED: "demo_started",
+  DEMO_DISMISSED: "demo_dismissed",
+  DEMO_TO_WIZARD_CONFIRMED: "demo_to_wizard_confirmed",
 } as const);
 
 export type AnalyticsEventName =


### PR DESCRIPTION
## Summary

S4.1 of `docs/launch/ftux-sprint-plan.md`. The welcome screen now ships a third CTA («Подивитись приклад») that seeds a demo payload in localStorage and redirects onto `/`. Once the user lands inside the populated hub, a new `DemoModeBanner` surfaces the «Це приклад. Створити свій?» prompt, which clears the seed and routes back to `/welcome` so the real onboarding flow takes over.

- New CTA in `WelcomeScreen.tsx`, slotted between the wizard splash and the returning-user entry. Its visual weight is intentionally lower than the primary, but higher than the secondary, so the "просто подивитись" cohort doesn't have to scan past an account prompt.
- New `DemoModeBanner` in `core/onboarding/` mounted at the top of `HubDashboard` (above `StaggerChild index=0`). Reads its visibility synchronously via a new `isDemoMode()` helper that goes through `safeReadStringLS` so private-mode / quota errors degrade cleanly.
- Sprite of three new canonical analytics events (`DEMO_STARTED { source }`, `DEMO_DISMISSED`, `DEMO_TO_WIZARD_CONFIRMED`) kept **outside** the FTUX `onboarding_*` funnel so demo browsing does not inflate activation cohorts. PostHog can still compute demo→wizard% as `count(DEMO_TO_WIZARD_CONFIRMED) / count(DEMO_STARTED)`.

LOC: 157 prod + 113 test (≤ 300 cap from sprint plan §0).

## Governing Skill

- Primary skill: `.agents/skills/sergeant-feature-delivery/SKILL.md` — wires together UI (`apps/web/src/core/app`, `apps/web/src/core/onboarding`), analytics in `packages/shared`, and an existing module-data seeder.
- Secondary skill: `.agents/skills/sergeant-web-ui/SKILL.md` for the WelcomeScreen / HubDashboard shells.

## Playbook

- Primary playbook: `docs/playbooks/playbook-catalog.md` — feature-delivery (FTUX surface).
- Why this playbook: matches the cross-package shape (web UI + shared analytics enum), with no schema/migration coupling.
- If no playbook matched, why: n/a.

## Verification

```bash
pnpm exec eslint apps/web/src/core/onboarding/DemoModeBanner.tsx \
  apps/web/src/core/onboarding/DemoModeBanner.test.tsx \
  apps/web/src/core/onboarding/seedDemoData.ts \
  apps/web/src/core/app/WelcomeScreen.tsx \
  apps/web/src/core/hub/HubDashboard.tsx \
  packages/shared/src/lib/analyticsEvents.ts
# → clean

pnpm exec prettier --check (same files)
# → clean

pnpm --filter @sergeant/web exec vitest run src/core/onboarding
# → 4 files / 16 tests passed (incl. new DemoModeBanner suite, 5 cases)

pnpm --filter @sergeant/shared exec vitest run src/lib/analyticsEvents.test.ts
# → 1 file / 5 tests passed (registry stays uniquely keyed)

node scripts/check-imports.mjs
node scripts/check-localstorage-allowlist.mjs
# → both green; new code only uses keys already in the allowlist
#   (`hub_demo_seeded_social_v1` is part of the existing seedDemoData
#   surface; `hub_demo_banner_dismissed_session` lives in
#   sessionStorage which the allowlist doesn't track)

pnpm --filter @sergeant/web exec vite build
# → built successfully
```

`pnpm typecheck` shows the same pre-existing failures present on `main`; this PR adds no new typecheck errors.

Additional checks:

- [x] Local smoke / manual validation completed (`vite build` + targeted vitest)
- [x] Surface-specific checks completed (`pnpm lint:imports`, `lint:localstorage-allowlist` — green)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- `docs/launch/ftux-sprint-plan.md` — status row for S4.1 will be flipped to "DONE" in the doc-update commit that lands once both PRs in this batch are green (single docs sweep, paired with S2.3).

The new analytics events are documented inline in `packages/shared/src/lib/analyticsEvents.ts` with their expected payload shapes; PostHog dashboards can wire to the strings directly.

## Risk and Rollout

- User-visible risk: low. The third CTA is additive on `/welcome` and the banner only renders when the seed flag is present (default = absent on real users). Existing demo-via-URL handshake (`?demo=1`) is untouched.
- Rollout / deploy order: ship as a normal web release; no server / migration coupling.
- Backout plan: revert this commit. Demo seed itself stays available via the URL handshake.
- Storage: writes to one new sessionStorage key (`hub_demo_banner_dismissed_session`) — session-scoped, cleared on tab close, no cross-session implications.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

- The `goToWizard` handler hard-navigates with `window.location.assign("/welcome")`. Empty-store assumptions across React Query caches, MMKV-web, and PWA prefetch are easier to reset by reloading than by tearing them down in JS — same pattern as `runDemoSeedFromUrl()`.
- The banner sits above `StaggerChild index=0`, so it is not part of the staggered hero reveal animation — it appears immediately, then the hero cards fade in. This is intentional: the «Це приклад» framing has to land before any of the metric cards do.
- Mobile parity is intentionally out of scope; tracked via `docs/launch/ftux-sprint-plan.md` cross-cutting notes.


---

Devin session: https://app.devin.ai/sessions/d4632d99514942cbadf0ed0da32968d3
Requested by: Андрій (andrijvigrav@gmail.com)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “View demo” CTA on the welcome screen that seeds demo data and opens the hub, plus a demo banner in the hub that offers “Create your own” and returns to onboarding.

- **New Features**
  - `apps/web/src/core/app/WelcomeScreen.tsx`: Adds “Подивитись приклад” button that calls `seedDemoData()` and navigates to `/` (tracks `DEMO_STARTED`).
  - `apps/web/src/core/hub/HubDashboard.tsx`: Mounts `DemoModeBanner` above the hero to show when demo data is present; close hides for the session; “Створити свій” clears demo data and navigates to `/welcome` (tracks `DEMO_DISMISSED` and `DEMO_TO_WIZARD_CONFIRMED`).
  - `apps/web/src/core/onboarding/seedDemoData.ts`: Adds `isDemoMode()` for sync visibility checks; `resetDemoData()` used by the banner.
  - `packages/shared/src/lib/analyticsEvents.ts`: Adds `DEMO_STARTED`, `DEMO_DISMISSED`, `DEMO_TO_WIZARD_CONFIRMED` (kept separate from `onboarding_*`).

<sup>Written for commit 632ed3e39f3b45ae90aa7b5ccf671bd75ad17bcd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Demo mode: Explore the full app experience with pre-populated sample data, accessible via a new button on the welcome screen
  * Dashboard now displays a demo-mode banner with options to dismiss the banner or reset and return to the welcome screen to start fresh
  * New analytics events to track demo usage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->