### PR TITLE
feat(finyk-domain): finyk normalized schema + apply-fns (PR #035)

### DIFF
--- a/apps/mobile/src/modules/finyk/lib/clientMigrate.ts
+++ b/apps/mobile/src/modules/finyk/lib/clientMigrate.ts
@@ -1,0 +1,32 @@
+import {
+  FINYK_CLIENT_MIGRATIONS,
+  FINYK_MIGRATIONS_TABLE,
+} from "@sergeant/db-schema/sqlite/migrations";
+import { runMigrations } from "@sergeant/db-schema/migrate";
+import {
+  createSqliteAdapter,
+  type SqliteMigrationClient,
+} from "@sergeant/db-schema/migrate/sqlite";
+
+/**
+ * Run the Finyk SQLite client migrations.
+ *
+ * Idempotent: re-running over an already-migrated DB is a no-op
+ * thanks to the runner's `__finyk_migrations` ledger contract.
+ *
+ * Stage 4 PR #035 of `docs/planning/storage-roadmap.md` — schema-only.
+ * The seam this exports is wired into the write paths by PR #036
+ * (dual-write); PR #035 itself only ships the runner so PR #036 has
+ * the same shape as the nutrition dual-write entry-point.
+ */
+export async function migrateFinyk(
+  client: SqliteMigrationClient,
+): Promise<void> {
+  await runMigrations({
+    adapter: createSqliteAdapter(client),
+    files: FINYK_CLIENT_MIGRATIONS,
+    tableName: FINYK_MIGRATIONS_TABLE,
+  });
+}
+
+export type { SqliteMigrationClient };

--- a/apps/server/src/migrations/039_finyk_tables.down.sql
+++ b/apps/server/src/migrations/039_finyk_tables.down.sql
@@ -1,0 +1,40 @@
+-- Rollback for migration 039_finyk_tables.sql.
+--
+-- Local-only rollback — production never runs `down.sql` (rule #4 in
+-- AGENTS.md). Order: child indexes / per-tx mappings / per-row tables
+-- first, then the singleton (`finyk_prefs` last in case future
+-- migrations add FKs from per-row data into prefs). Each statement is
+-- `IF EXISTS`-guarded so the file stays idempotent (rule #4
+-- re-application invariant — the `035-nutrition-tables` round-trip
+-- harness asserts this).
+
+DROP INDEX IF EXISTS finyk_hidden_accounts_user_active_idx;
+DROP INDEX IF EXISTS finyk_hidden_transactions_user_active_idx;
+DROP INDEX IF EXISTS finyk_budgets_user_active_idx;
+DROP INDEX IF EXISTS finyk_subscriptions_user_active_idx;
+DROP INDEX IF EXISTS finyk_assets_user_active_idx;
+DROP INDEX IF EXISTS finyk_debts_user_active_idx;
+DROP INDEX IF EXISTS finyk_receivables_user_active_idx;
+DROP INDEX IF EXISTS finyk_tx_categories_user_idx;
+DROP INDEX IF EXISTS finyk_tx_splits_user_idx;
+DROP INDEX IF EXISTS finyk_mono_debt_links_user_idx;
+DROP INDEX IF EXISTS finyk_networth_history_user_month_idx;
+DROP INDEX IF EXISTS finyk_custom_categories_user_active_idx;
+DROP INDEX IF EXISTS finyk_manual_expenses_user_active_idx;
+DROP INDEX IF EXISTS finyk_tx_filters_user_active_idx;
+
+DROP TABLE IF EXISTS finyk_hidden_accounts;
+DROP TABLE IF EXISTS finyk_hidden_transactions;
+DROP TABLE IF EXISTS finyk_budgets;
+DROP TABLE IF EXISTS finyk_subscriptions;
+DROP TABLE IF EXISTS finyk_assets;
+DROP TABLE IF EXISTS finyk_debts;
+DROP TABLE IF EXISTS finyk_receivables;
+DROP TABLE IF EXISTS finyk_tx_categories;
+DROP TABLE IF EXISTS finyk_tx_splits;
+DROP TABLE IF EXISTS finyk_mono_debt_links;
+DROP TABLE IF EXISTS finyk_networth_history;
+DROP TABLE IF EXISTS finyk_custom_categories;
+DROP TABLE IF EXISTS finyk_manual_expenses;
+DROP TABLE IF EXISTS finyk_tx_filters;
+DROP TABLE IF EXISTS finyk_prefs;

--- a/apps/server/src/migrations/039_finyk_tables.sql
+++ b/apps/server/src/migrations/039_finyk_tables.sql
@@ -1,0 +1,354 @@
+-- 039: finyk_* normalized target tables — Stage 4 / PR #035 of
+-- `docs/planning/storage-roadmap.md`.
+--
+-- Context. Finyk state is the largest cross-platform LS/MMKV blob set
+-- left in the app: 16 user-edited keys (`finyk_hidden`, `finyk_budgets`,
+-- `finyk_subs`, `finyk_assets`, `finyk_debts`, `finyk_recv`,
+-- `finyk_hidden_txs`, `finyk_monthly_plan`, `finyk_tx_cats`,
+-- `finyk_tx_splits`, `finyk_mono_debt_linked`, `finyk_networth_history`,
+-- `finyk_custom_cats_v1`, `finyk_manual_expenses_v1`,
+-- `finyk_tx_filters_v1`, `finyk_show_balance_v1`) plus the three Mono
+-- caches (`finyk_tx_cache`, `finyk_info_cache`, `finyk_tx_cache_last_good`,
+-- handled separately in PR #038). Whole-blob LWW push/pull through
+-- `module_data.finyk` has the same scalability issues the routine
+-- (PRs #023–#026), fizruk (PRs #027–#030), and nutrition (PRs #031–#034)
+-- shed before us:
+--
+--   * no per-row sync (multi-device collisions on a single blob
+--     overwrite the opponent's fresh edits — particularly painful for
+--     `finyk_tx_cats` where every web tx click races mobile),
+--   * payload growth scales with feature count, not user activity
+--     (subscriptions+budgets+assets+debts+manual-expenses pile up
+--     unbounded),
+--   * per-tx data (`finyk_tx_cats`, `finyk_tx_splits`,
+--     `finyk_mono_debt_linked`) re-pushes the entire map on every edit.
+--
+-- This migration adds **tables only** — the server does not read from
+-- them yet (Stage 5 read cut-over is PR #037). Writes happen through
+-- the v2 sync apply path (`OP_LOG_TABLE_REGISTRY` in `syncV2.ts`); the
+-- companion server-side apply functions land in this same PR so
+-- inbound dual-write traffic from PR #036 can already round-trip
+-- before Stage 5 lights up.
+--
+-- Mirrors the structure of migration 035_nutrition_tables.sql (PR #031
+-- of the same roadmap) — same FK-on-user / soft-delete-tombstone /
+-- per-user-active-index pattern, same TIMESTAMPTZ defaults, same
+-- `_lite`-suffixed indexes on the SQLite parallel schema. Five table
+-- shapes are reused across the 15 tables:
+--
+--   1. **per-row + JSONB blob** (budgets, subscriptions, assets,
+--      debts, receivables, custom_categories, manual_expenses,
+--      tx_filters): `id UUID PK`, `user_id`, `data_json JSONB`,
+--      `created_at`/`updated_at`/`deleted_at`. Open-ended user-edited
+--      shapes that the UI reads as a whole — not worth column
+--      splitting.
+--   2. **composite-PK tombstone** (hidden_accounts,
+--      hidden_transactions): `(user_id, ext_id) PRIMARY KEY` with
+--      `updated_at`/`deleted_at` — natural key is the external Mono
+--      account/transaction id; no surrogate `id`. Soft-delete
+--      preserves LWW so an "unhide" on device A doesn't lose to a
+--      stale "hide" replay from device B.
+--   3. **per-tx mapping** (tx_categories, tx_splits,
+--      mono_debt_links): `(user_id, transaction_id) PRIMARY KEY`
+--      with `updated_at`. The natural key is the Mono transaction id
+--      — there is at most one mapping per (user, tx). `tx_categories`
+--      is a single TEXT column (`category_id`); the other two carry
+--      JSONB (split arrays / debt id arrays). No `deleted_at` —
+--      "no mapping" is the same as the mapping not existing, so the
+--      sync apply path treats `delete` as `DELETE FROM` (idempotent).
+--   4. **time-series** (networth_history): `(user_id, month)
+--      PRIMARY KEY` with monthly snapshots. `month` is a TEXT
+--      `YYYY-MM` to mirror the LS shape exactly — no
+--      string-to-date coercion at the API boundary, makes the LWW
+--      key trivially comparable.
+--   5. **per-user singleton prefs** (prefs): `user_id PRIMARY KEY`,
+--      JSONB blob for the open-ended shape, plus split-out
+--      `show_balance BOOLEAN` and `monthly_plan_json JSONB` columns
+--      so multi-device LWW on those individual sub-fields doesn't
+--      have to merge the open-ended JSONB.
+--
+-- Forward-only: `pnpm db:migrate` does not add DROPs here, so rule #4
+-- (two-phase DROP) does not apply. `.down.sql` is for local rollback only.
+
+-- finyk_hidden_accounts — set of Mono account ids the user has hidden
+-- from list/dashboard views. Composite PK on `(user_id, account_id)`
+-- so the natural external id (Mono's account ID, opaque TEXT) is the
+-- key — no surrogate UUID needed. Soft-delete with `deleted_at` so an
+-- "unhide" race correctly LWW-resolves against a stale "hide" from
+-- another device.
+CREATE TABLE IF NOT EXISTS finyk_hidden_accounts (
+  user_id     TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  account_id  TEXT NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at  TIMESTAMPTZ,
+  PRIMARY KEY (user_id, account_id)
+);
+
+CREATE INDEX IF NOT EXISTS finyk_hidden_accounts_user_active_idx
+  ON finyk_hidden_accounts (user_id)
+  WHERE deleted_at IS NULL;
+
+-- finyk_hidden_transactions — set of Mono transaction ids the user
+-- has hidden. Same shape as finyk_hidden_accounts but keyed on
+-- `transaction_id`.
+CREATE TABLE IF NOT EXISTS finyk_hidden_transactions (
+  user_id        TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  transaction_id TEXT NOT NULL,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at     TIMESTAMPTZ,
+  PRIMARY KEY (user_id, transaction_id)
+);
+
+CREATE INDEX IF NOT EXISTS finyk_hidden_transactions_user_active_idx
+  ON finyk_hidden_transactions (user_id)
+  WHERE deleted_at IS NULL;
+
+-- finyk_budgets — per-row budget entries (limit/goal). `data_json`
+-- carries the open-ended `Budget` shape (categoryId, type,
+-- targetAmount, period, etc.) — UI reads the whole row at once so
+-- column-splitting buys nothing.
+CREATE TABLE IF NOT EXISTS finyk_budgets (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  data_json   JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at  TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS finyk_budgets_user_active_idx
+  ON finyk_budgets (user_id, deleted_at)
+  WHERE deleted_at IS NULL;
+
+-- finyk_subscriptions — recurring-payment definitions. `data_json`
+-- holds the `Subscription` shape (name, emoji, billingDay, currency,
+-- linkedTxId, …).
+CREATE TABLE IF NOT EXISTS finyk_subscriptions (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  data_json   JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at  TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS finyk_subscriptions_user_active_idx
+  ON finyk_subscriptions (user_id, deleted_at)
+  WHERE deleted_at IS NULL;
+
+-- finyk_assets — manually tracked assets (cash, real estate, vehicles,
+-- linked-tx-augmented balances). `data_json` is the full `ManualAsset`
+-- shape (amount, name, currency, linkedTxIds, emoji, …).
+CREATE TABLE IF NOT EXISTS finyk_assets (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  data_json   JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at  TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS finyk_assets_user_active_idx
+  ON finyk_assets (user_id, deleted_at)
+  WHERE deleted_at IS NULL;
+
+-- finyk_debts — manually tracked debts the user owes. `data_json` is
+-- the full `Debt` shape from `@sergeant/finyk-domain/domain/debtEngine`
+-- (amount, currency, counterparty, dueDate, schedule, payments, …).
+CREATE TABLE IF NOT EXISTS finyk_debts (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  data_json   JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at  TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS finyk_debts_user_active_idx
+  ON finyk_debts (user_id, deleted_at)
+  WHERE deleted_at IS NULL;
+
+-- finyk_receivables — money owed TO the user. Same shape as
+-- finyk_debts but the direction is reversed at the domain layer.
+CREATE TABLE IF NOT EXISTS finyk_receivables (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  data_json   JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at  TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS finyk_receivables_user_active_idx
+  ON finyk_receivables (user_id, deleted_at)
+  WHERE deleted_at IS NULL;
+
+-- finyk_tx_categories — per-transaction category override. The LS
+-- shape is `Record<txId, categoryId>` with `undefined` values meaning
+-- "fall back to MCC default". Composite PK `(user_id, transaction_id)`;
+-- no `deleted_at` because the absence of a mapping is itself the
+-- "no override" state — sync `delete` ops just `DELETE FROM`.
+CREATE TABLE IF NOT EXISTS finyk_tx_categories (
+  user_id        TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  transaction_id TEXT NOT NULL,
+  category_id    TEXT NOT NULL,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (user_id, transaction_id)
+);
+
+CREATE INDEX IF NOT EXISTS finyk_tx_categories_user_idx
+  ON finyk_tx_categories (user_id);
+
+-- finyk_tx_splits — per-transaction split definitions (multi-category
+-- breakdown of a single Mono transaction). LS shape is
+-- `Record<txId, TxSplit[]>`. Composite PK `(user_id, transaction_id)`;
+-- the array of splits goes into `splits_json` JSONB.
+CREATE TABLE IF NOT EXISTS finyk_tx_splits (
+  user_id        TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  transaction_id TEXT NOT NULL,
+  splits_json    JSONB NOT NULL DEFAULT '[]'::jsonb,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (user_id, transaction_id)
+);
+
+CREATE INDEX IF NOT EXISTS finyk_tx_splits_user_idx
+  ON finyk_tx_splits (user_id);
+
+-- finyk_mono_debt_links — which manual debts a Mono transaction is
+-- linked to. LS shape is `Record<txId, debtId[]>`. Composite PK,
+-- `debt_ids_json` is the array of `finyk_debts.id` strings.
+CREATE TABLE IF NOT EXISTS finyk_mono_debt_links (
+  user_id        TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  transaction_id TEXT NOT NULL,
+  debt_ids_json  JSONB NOT NULL DEFAULT '[]'::jsonb,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (user_id, transaction_id)
+);
+
+CREATE INDEX IF NOT EXISTS finyk_mono_debt_links_user_idx
+  ON finyk_mono_debt_links (user_id);
+
+-- finyk_networth_history — monthly net-worth snapshots. LS shape is
+-- `NetworthEntry[]` with `{ month: 'YYYY-MM', networth: number }`.
+-- `month` stays TEXT (not DATE) so LWW comparisons / API round-trips
+-- match the LS shape byte-for-byte. `snapshot_json` reserves space
+-- for richer per-month payloads (per-asset breakdowns, FX rate at
+-- snapshot time) without a follow-up migration.
+CREATE TABLE IF NOT EXISTS finyk_networth_history (
+  user_id        TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  month          TEXT NOT NULL,
+  networth       REAL NOT NULL DEFAULT 0,
+  snapshot_json  JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (user_id, month)
+);
+
+CREATE INDEX IF NOT EXISTS finyk_networth_history_user_month_idx
+  ON finyk_networth_history (user_id, month DESC);
+
+-- finyk_custom_categories — user-defined transaction categories
+-- (`finyk_custom_cats_v1`). Per-row with `id` UUID PK; `data_json`
+-- holds the `CustomCategory` shape (label, color, icon, parentId).
+CREATE TABLE IF NOT EXISTS finyk_custom_categories (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  data_json   JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at  TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS finyk_custom_categories_user_active_idx
+  ON finyk_custom_categories (user_id, deleted_at)
+  WHERE deleted_at IS NULL;
+
+-- finyk_manual_expenses — user-entered cash expenses outside Mono
+-- (`finyk_manual_expenses_v1`). Per-row `ManualExpense` shape (date,
+-- description, amount, category) inside `data_json`.
+CREATE TABLE IF NOT EXISTS finyk_manual_expenses (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  data_json   JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at  TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS finyk_manual_expenses_user_active_idx
+  ON finyk_manual_expenses (user_id, deleted_at)
+  WHERE deleted_at IS NULL;
+
+-- finyk_tx_filters — saved transaction filter presets
+-- (`finyk_tx_filters_v1`). Open-ended filter shape (date range, accounts,
+-- categories, search) lives in `data_json`.
+CREATE TABLE IF NOT EXISTS finyk_tx_filters (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  data_json   JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at  TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS finyk_tx_filters_user_active_idx
+  ON finyk_tx_filters (user_id, deleted_at)
+  WHERE deleted_at IS NULL;
+
+-- finyk_prefs — per-user singleton row of finyk-side preferences.
+-- `monthly_plan_json` carries `MonthlyPlan` (income/expense/savings —
+-- all stored as TEXT/number-strings to match the LS shape verbatim).
+-- `show_balance` is split out of the open-ended `prefs_json` so
+-- multi-device LWW on the balance-visibility toggle doesn't have to
+-- merge the JSONB blob. `user_id` is the primary key — exactly one
+-- row per user.
+CREATE TABLE IF NOT EXISTS finyk_prefs (
+  user_id            TEXT PRIMARY KEY REFERENCES "user"(id) ON DELETE CASCADE,
+  prefs_json         JSONB NOT NULL DEFAULT '{}'::jsonb,
+  monthly_plan_json  JSONB NOT NULL DEFAULT '{}'::jsonb,
+  show_balance       BOOLEAN NOT NULL DEFAULT true,
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE finyk_hidden_accounts IS
+  'Per-user set of Mono account ids hidden from the UI. Soft-delete on (user_id, account_id) for LWW unhide-vs-hide races.';
+COMMENT ON TABLE finyk_hidden_transactions IS
+  'Per-user set of Mono transaction ids hidden from the UI. Same shape as finyk_hidden_accounts but on transaction_id.';
+COMMENT ON TABLE finyk_budgets IS
+  'Per-row budget entries (limit/goal). data_json holds the open-ended Budget shape; UI reads whole-row.';
+COMMENT ON TABLE finyk_subscriptions IS
+  'Per-row recurring-payment definitions (name, emoji, billingDay, currency, linkedTxId).';
+COMMENT ON TABLE finyk_assets IS
+  'Per-row manually tracked assets (cash, real estate, vehicles). data_json is the ManualAsset shape.';
+COMMENT ON TABLE finyk_debts IS
+  'Per-row manually tracked debts the user owes. data_json is the Debt shape (debtEngine).';
+COMMENT ON TABLE finyk_receivables IS
+  'Money owed TO the user. Same shape as finyk_debts; direction reversed at the domain layer.';
+COMMENT ON TABLE finyk_tx_categories IS
+  'Per-transaction category override. Composite PK (user_id, transaction_id); delete = DELETE FROM (no soft-delete).';
+COMMENT ON TABLE finyk_tx_splits IS
+  'Per-transaction split definitions. splits_json holds the TxSplit[] array.';
+COMMENT ON TABLE finyk_mono_debt_links IS
+  'Maps Mono transactions to manual debts. debt_ids_json is the array of finyk_debts.id strings.';
+COMMENT ON TABLE finyk_networth_history IS
+  'Monthly net-worth snapshots. month is TEXT YYYY-MM to match the LS NetworthEntry shape verbatim.';
+COMMENT ON COLUMN finyk_networth_history.month IS
+  'YYYY-MM string. TEXT (not DATE) so LWW + API round-trips match LS byte-for-byte.';
+COMMENT ON TABLE finyk_custom_categories IS
+  'User-defined transaction categories (label/color/icon/parentId).';
+COMMENT ON TABLE finyk_manual_expenses IS
+  'User-entered cash expenses outside Mono (date/description/amount/category).';
+COMMENT ON TABLE finyk_tx_filters IS
+  'Saved transaction filter presets — date range, accounts, categories, search query.';
+COMMENT ON TABLE finyk_prefs IS
+  'Per-user singleton row of finyk preferences. show_balance + monthly_plan split out so multi-device LWW does not merge the JSONB.';
+COMMENT ON COLUMN finyk_prefs.show_balance IS
+  'Hoisted out of prefs_json so balance-visibility toggle has its own LWW lane.';
+COMMENT ON COLUMN finyk_prefs.monthly_plan_json IS
+  'MonthlyPlan blob (income/expense/savings as the original LS string-or-number shape).';

--- a/apps/server/src/migrations/__tests__/039-finyk-tables.test.ts
+++ b/apps/server/src/migrations/__tests__/039-finyk-tables.test.ts
@@ -1,0 +1,433 @@
+// Migration 039 — focused round-trip for the Finyk tables
+// (Stage 4 / PR #035 of `docs/planning/storage-roadmap.md`).
+//
+// Mirrors `035-nutrition-tables.test.ts`: same Docker / pgvector
+// testcontainer harness, same soft-skip behaviour, same assertions
+// shape — the only thing that changes is the table list and the
+// per-table column checks. Keeping the harness identical means a
+// regression in the migration-runner shows up the same way for both
+// modules in CI logs.
+//
+// Asserts that:
+//   1. applying every forward migration leaves all 15 finyk tables
+//      present with the columns / indexes documented in
+//      `apps/server/src/migrations/039_finyk_tables.sql`,
+//   2. running `039_finyk_tables.down.sql` drops them all (and
+//      removes the explicit indexes),
+//   3. the down migration is idempotent (rule #4 invariant),
+//   4. down → re-up restores the schema fingerprint byte-for-byte.
+
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+import { fileURLToPath } from "url";
+import pg from "pg";
+import { GenericContainer, Wait } from "testcontainers";
+import type { StartedTestContainer } from "testcontainers";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MIGRATIONS_DIR = path.resolve(__dirname, "..");
+
+const TIMEOUT_MS = 180_000;
+
+const FINYK_TABLES = [
+  "finyk_assets",
+  "finyk_budgets",
+  "finyk_custom_categories",
+  "finyk_debts",
+  "finyk_hidden_accounts",
+  "finyk_hidden_transactions",
+  "finyk_manual_expenses",
+  "finyk_mono_debt_links",
+  "finyk_networth_history",
+  "finyk_prefs",
+  "finyk_receivables",
+  "finyk_subscriptions",
+  "finyk_tx_categories",
+  "finyk_tx_filters",
+  "finyk_tx_splits",
+] as const;
+
+const FINYK_INDEXES = [
+  "finyk_assets_user_active_idx",
+  "finyk_budgets_user_active_idx",
+  "finyk_custom_categories_user_active_idx",
+  "finyk_debts_user_active_idx",
+  "finyk_hidden_accounts_user_active_idx",
+  "finyk_hidden_transactions_user_active_idx",
+  "finyk_manual_expenses_user_active_idx",
+  "finyk_mono_debt_links_user_idx",
+  "finyk_networth_history_user_month_idx",
+  "finyk_receivables_user_active_idx",
+  "finyk_subscriptions_user_active_idx",
+  "finyk_tx_categories_user_idx",
+  "finyk_tx_filters_user_active_idx",
+  "finyk_tx_splits_user_idx",
+] as const;
+
+let container: StartedTestContainer | undefined;
+let pool: pg.Pool | undefined;
+let dockerAvailable = false;
+let skipReason: string | null = null;
+
+beforeAll(async () => {
+  try {
+    container = await new GenericContainer("pgvector/pgvector:pg16")
+      .withEnvironment({
+        POSTGRES_USER: "hub",
+        POSTGRES_PASSWORD: "hub",
+        POSTGRES_DB: "hub_test",
+      })
+      .withExposedPorts(5432)
+      .withWaitStrategy(
+        Wait.forLogMessage(/database system is ready to accept connections/, 2),
+      )
+      .start();
+
+    const host = container.getHost();
+    const port = container.getMappedPort(5432);
+    pool = new pg.Pool({
+      connectionString: `postgresql://hub:hub@${host}:${port}/hub_test`,
+      max: 4,
+    });
+    dockerAvailable = true;
+  } catch (e) {
+    skipReason = e instanceof Error ? e.message : String(e);
+    console.warn(
+      `[039-finyk-tables] Skipping: Testcontainers unavailable — ${skipReason}`,
+    );
+  }
+}, TIMEOUT_MS);
+
+afterAll(async () => {
+  if (pool) {
+    await pool.end().catch(() => {
+      /* noop */
+    });
+  }
+  if (container) {
+    await container.stop().catch(() => {
+      /* noop */
+    });
+  }
+}, TIMEOUT_MS);
+
+async function readMigrationFiles(): Promise<string[]> {
+  const files = await fs.readdir(MIGRATIONS_DIR);
+  return files
+    .filter((f) => /^\d{3}_.+\.sql$/.test(f) && !f.endsWith(".down.sql"))
+    .sort();
+}
+
+async function execSqlFile(p: pg.Pool, file: string): Promise<void> {
+  const sql = (
+    await fs.readFile(path.join(MIGRATIONS_DIR, file), "utf8")
+  ).trim();
+  if (!sql) return;
+  await p.query(sql);
+}
+
+async function resetSchema(p: pg.Pool): Promise<void> {
+  await p.query(`DROP SCHEMA public CASCADE; CREATE SCHEMA public;`);
+  await p.query(`GRANT ALL ON SCHEMA public TO public;`);
+}
+
+async function listTables(p: pg.Pool): Promise<string[]> {
+  const r = await p.query<{ tablename: string }>(
+    `SELECT tablename FROM pg_tables
+     WHERE schemaname = 'public' AND tablename LIKE 'finyk_%'
+     ORDER BY tablename`,
+  );
+  return r.rows.map((row) => row.tablename);
+}
+
+async function listFinykIndexes(p: pg.Pool): Promise<string[]> {
+  const r = await p.query<{ indexname: string }>(
+    `SELECT indexname FROM pg_indexes
+     WHERE schemaname = 'public' AND indexname LIKE 'finyk_%'
+     ORDER BY indexname`,
+  );
+  return r.rows.map((row) => row.indexname);
+}
+
+async function listColumns(
+  p: pg.Pool,
+  table: string,
+): Promise<{ name: string; type: string; nullable: string }[]> {
+  const r = await p.query<{
+    column_name: string;
+    data_type: string;
+    is_nullable: string;
+  }>(
+    `SELECT column_name, data_type, is_nullable
+     FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = $1
+     ORDER BY ordinal_position`,
+    [table],
+  );
+  return r.rows.map((row) => ({
+    name: row.column_name,
+    type: row.data_type,
+    nullable: row.is_nullable,
+  }));
+}
+
+describe("039_finyk_tables migration", () => {
+  it(
+    "creates all 15 finyk tables and their explicit indexes after forward migration",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+
+      const tables = await listTables(pool);
+      expect(tables).toEqual([...FINYK_TABLES].sort());
+
+      const indexes = await listFinykIndexes(pool);
+      // Filter `_pkey` and the auto-named composite-PK indexes that
+      // Postgres creates implicitly — only the explicit
+      // `CREATE INDEX` statements from 039_finyk_tables.sql are
+      // asserted.
+      const explicit = indexes.filter((i) => !i.endsWith("_pkey"));
+      expect(explicit).toEqual([...FINYK_INDEXES].sort());
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "finyk_budgets has the documented per-row + JSONB shape",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+
+      const cols = await listColumns(pool, "finyk_budgets");
+      expect(cols.map((c) => c.name)).toEqual([
+        "id",
+        "user_id",
+        "data_json",
+        "created_at",
+        "updated_at",
+        "deleted_at",
+      ]);
+
+      const byName = Object.fromEntries(cols.map((c) => [c.name, c]));
+      expect(byName["id"]!.type).toBe("uuid");
+      expect(byName["id"]!.nullable).toBe("NO");
+      expect(byName["user_id"]!.type).toBe("text");
+      expect(byName["data_json"]!.type).toBe("jsonb");
+      expect(byName["data_json"]!.nullable).toBe("NO");
+      expect(byName["deleted_at"]!.nullable).toBe("YES");
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "finyk_hidden_accounts is keyed on (user_id, account_id) with soft-delete",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+
+      const cols = await listColumns(pool, "finyk_hidden_accounts");
+      expect(cols.map((c) => c.name)).toEqual([
+        "user_id",
+        "account_id",
+        "created_at",
+        "updated_at",
+        "deleted_at",
+      ]);
+
+      const pkCheck = await pool.query<{ column_name: string }>(
+        `SELECT a.attname AS column_name
+         FROM   pg_index i
+         JOIN   pg_attribute a ON a.attrelid = i.indrelid
+                              AND a.attnum   = ANY(i.indkey)
+         WHERE  i.indrelid = 'public.finyk_hidden_accounts'::regclass
+           AND  i.indisprimary
+         ORDER BY a.attnum`,
+      );
+      expect(pkCheck.rows.map((r) => r.column_name)).toEqual([
+        "user_id",
+        "account_id",
+      ]);
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "finyk_tx_categories has no soft-delete column (delete = DELETE FROM)",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+
+      const cols = await listColumns(pool, "finyk_tx_categories");
+      expect(cols.map((c) => c.name)).toEqual([
+        "user_id",
+        "transaction_id",
+        "category_id",
+        "created_at",
+        "updated_at",
+      ]);
+      expect(cols.map((c) => c.name)).not.toContain("deleted_at");
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "finyk_networth_history keeps month as TEXT (not DATE) for LWW parity with LS",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+
+      const cols = await listColumns(pool, "finyk_networth_history");
+      const byName = Object.fromEntries(cols.map((c) => [c.name, c]));
+      expect(byName["month"]!.type).toBe("text");
+      expect(byName["month"]!.nullable).toBe("NO");
+      expect(byName["networth"]!.type).toBe("real");
+      expect(byName["snapshot_json"]!.type).toBe("jsonb");
+
+      const pkCheck = await pool.query<{ column_name: string }>(
+        `SELECT a.attname AS column_name
+         FROM   pg_index i
+         JOIN   pg_attribute a ON a.attrelid = i.indrelid
+                              AND a.attnum   = ANY(i.indkey)
+         WHERE  i.indrelid = 'public.finyk_networth_history'::regclass
+           AND  i.indisprimary
+         ORDER BY a.attnum`,
+      );
+      expect(pkCheck.rows.map((r) => r.column_name)).toEqual([
+        "user_id",
+        "month",
+      ]);
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "finyk_prefs is a per-user singleton (user_id PRIMARY KEY)",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+
+      const cols = await listColumns(pool, "finyk_prefs");
+      expect(cols.map((c) => c.name)).toEqual([
+        "user_id",
+        "prefs_json",
+        "monthly_plan_json",
+        "show_balance",
+        "created_at",
+        "updated_at",
+      ]);
+
+      const pkCheck = await pool.query<{ column_name: string }>(
+        `SELECT a.attname AS column_name
+         FROM   pg_index i
+         JOIN   pg_attribute a ON a.attrelid = i.indrelid
+                              AND a.attnum   = ANY(i.indkey)
+         WHERE  i.indrelid = 'public.finyk_prefs'::regclass
+           AND  i.indisprimary`,
+      );
+      expect(pkCheck.rows.map((r) => r.column_name)).toEqual(["user_id"]);
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "039_finyk_tables.down.sql drops every finyk_* table",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+      expect((await listTables(pool)).length).toBeGreaterThan(0);
+
+      await execSqlFile(pool, "039_finyk_tables.down.sql");
+      expect(await listTables(pool)).toEqual([]);
+      expect(await listFinykIndexes(pool)).toEqual([]);
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "039_finyk_tables.down.sql is idempotent",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+
+      await execSqlFile(pool, "039_finyk_tables.down.sql");
+      await execSqlFile(pool, "039_finyk_tables.down.sql");
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "down then re-up restores the same schema fingerprint",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+
+      const before = {
+        tables: await listTables(pool),
+        indexes: await listFinykIndexes(pool),
+        budgets: await listColumns(pool, "finyk_budgets"),
+        prefs: await listColumns(pool, "finyk_prefs"),
+        networthHistory: await listColumns(pool, "finyk_networth_history"),
+      };
+
+      await execSqlFile(pool, "039_finyk_tables.down.sql");
+      await execSqlFile(pool, "039_finyk_tables.sql");
+
+      const after = {
+        tables: await listTables(pool),
+        indexes: await listFinykIndexes(pool),
+        budgets: await listColumns(pool, "finyk_budgets"),
+        prefs: await listColumns(pool, "finyk_prefs"),
+        networthHistory: await listColumns(pool, "finyk_networth_history"),
+      };
+
+      expect(after).toEqual(before);
+    },
+    TIMEOUT_MS,
+  );
+});

--- a/apps/server/src/modules/sync/syncV2.integration.test.ts
+++ b/apps/server/src/modules/sync/syncV2.integration.test.ts
@@ -156,7 +156,14 @@ beforeEach(async () => {
               fizruk_workout_sets, fizruk_workout_items, fizruk_workouts,
               fizruk_custom_exercises, fizruk_measurements,
               nutrition_pantry_items, nutrition_pantries,
-              nutrition_meals, nutrition_prefs, nutrition_recipes
+              nutrition_meals, nutrition_prefs, nutrition_recipes,
+              finyk_hidden_accounts, finyk_hidden_transactions,
+              finyk_budgets, finyk_subscriptions, finyk_assets,
+              finyk_debts, finyk_receivables, finyk_custom_categories,
+              finyk_manual_expenses, finyk_tx_filters,
+              finyk_tx_categories, finyk_tx_splits,
+              finyk_mono_debt_links, finyk_networth_history,
+              finyk_prefs
               RESTART IDENTITY CASCADE`,
   );
 });
@@ -1681,6 +1688,445 @@ describe("syncV2Push — nutrition apply-функції (PR #031)", () => {
       ]);
       expect(row.rows[0].name).toBe("Борщ");
       expect(row.rows[0].deleted_at).not.toBeNull();
+    },
+    TIMEOUT_MS,
+  );
+});
+
+// ---------------------------------------------------------------------
+// Finyk apply-функції — Stage 4 PR #035.
+//
+// Один integration-тест на shape (5 shapes у total, див. коментар в
+// `apps/server/src/migrations/039_finyk_tables.sql` — composite-PK
+// tombstone, per-row+JSONB, per-tx mapping, time-series, singleton
+// prefs). Фокус — на унікальній логіці кожного shape, а не на
+// повторюванні стандартної LWW-перевірки (її вже покривають nutrition
+// інтеграційні тести вище — apply-фн поділяє ту саму інфраструктуру).
+// ---------------------------------------------------------------------
+describe("syncV2Push — finyk apply-функції (PR #035)", () => {
+  it(
+    "finyk_hidden_accounts: insert → soft-delete (composite-PK tombstone shape)",
+    async (ctx) => {
+      if (!dockerAvailable || !testPool) return ctx.skip();
+      await ensureUser("u-fha");
+
+      const t1 = isoNow(-2_000);
+      const t2 = isoNow();
+
+      const r1 = makeRes();
+      await syncV2Push(
+        makeReq({
+          userId: "u-fha",
+          body: {
+            ops: [
+              {
+                table: "finyk_hidden_accounts",
+                op: "insert" as const,
+                row: {
+                  user_id: "u-fha",
+                  account_id: "mono-acc-42",
+                },
+                client_ts: t1,
+                idempotency_key: "fha-insert",
+              },
+            ],
+          },
+        }),
+        r1,
+      );
+      expect((r1.body as { accepted: number }).accepted).toBe(1);
+
+      const r2 = makeRes();
+      await syncV2Push(
+        makeReq({
+          userId: "u-fha",
+          body: {
+            ops: [
+              {
+                table: "finyk_hidden_accounts",
+                op: "delete" as const,
+                row: { user_id: "u-fha", account_id: "mono-acc-42" },
+                client_ts: t2,
+                idempotency_key: "fha-delete",
+              },
+            ],
+          },
+        }),
+        r2,
+      );
+      expect((r2.body as { accepted: number }).accepted).toBe(1);
+
+      const row = await testPool.query<{ deleted_at: Date | null }>(
+        `SELECT deleted_at FROM finyk_hidden_accounts
+         WHERE user_id = $1 AND account_id = $2`,
+        ["u-fha", "mono-acc-42"],
+      );
+      expect(row.rows).toHaveLength(1);
+      expect(row.rows[0].deleted_at).not.toBeNull();
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "finyk_budgets: insert → update (per-row + JSONB blob shape, LWW honoured)",
+    async (ctx) => {
+      if (!dockerAvailable || !testPool) return ctx.skip();
+      await ensureUser("u-fb");
+
+      const budgetId = "50000000-0000-4000-8000-000000000001";
+      const t1 = isoNow(-2_000);
+      const t2 = isoNow();
+
+      const r1 = makeRes();
+      await syncV2Push(
+        makeReq({
+          userId: "u-fb",
+          body: {
+            ops: [
+              {
+                table: "finyk_budgets",
+                op: "insert" as const,
+                row: {
+                  id: budgetId,
+                  user_id: "u-fb",
+                  data_json: { categoryId: "food", limit: 1000 },
+                },
+                client_ts: t1,
+                idempotency_key: "fb-insert",
+              },
+            ],
+          },
+        }),
+        r1,
+      );
+      expect((r1.body as { accepted: number }).accepted).toBe(1);
+
+      const r2 = makeRes();
+      await syncV2Push(
+        makeReq({
+          userId: "u-fb",
+          body: {
+            ops: [
+              {
+                table: "finyk_budgets",
+                op: "update" as const,
+                row: {
+                  id: budgetId,
+                  user_id: "u-fb",
+                  data_json: { categoryId: "food", limit: 1500 },
+                },
+                client_ts: t2,
+                idempotency_key: "fb-update",
+              },
+            ],
+          },
+        }),
+        r2,
+      );
+      expect((r2.body as { accepted: number }).accepted).toBe(1);
+
+      const row = await testPool.query<{ data_json: { limit: number } }>(
+        `SELECT data_json FROM finyk_budgets WHERE id = $1`,
+        [budgetId],
+      );
+      expect(row.rows[0].data_json.limit).toBe(1500);
+
+      // Stale (t1) update must lose to the t2 row already on disk.
+      const r3 = makeRes();
+      await syncV2Push(
+        makeReq({
+          userId: "u-fb",
+          body: {
+            ops: [
+              {
+                table: "finyk_budgets",
+                op: "update" as const,
+                row: {
+                  id: budgetId,
+                  user_id: "u-fb",
+                  data_json: { categoryId: "food", limit: 9999 },
+                },
+                client_ts: t1,
+                idempotency_key: "fb-stale",
+              },
+            ],
+          },
+        }),
+        r3,
+      );
+      const body3 = r3.body as {
+        accepted: number;
+        results: Array<{ status: string; reason?: string }>;
+      };
+      expect(body3.accepted).toBe(0);
+      expect(body3.results[0].reason).toBe("lww_conflict");
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "finyk_tx_categories: insert → delete uses hard DELETE (no soft-delete column)",
+    async (ctx) => {
+      if (!dockerAvailable || !testPool) return ctx.skip();
+      await ensureUser("u-ftc");
+
+      const t1 = isoNow(-2_000);
+      const t2 = isoNow();
+
+      const r1 = makeRes();
+      await syncV2Push(
+        makeReq({
+          userId: "u-ftc",
+          body: {
+            ops: [
+              {
+                table: "finyk_tx_categories",
+                op: "insert" as const,
+                row: {
+                  user_id: "u-ftc",
+                  transaction_id: "mono-tx-1",
+                  category_id: "groceries",
+                },
+                client_ts: t1,
+                idempotency_key: "ftc-insert",
+              },
+            ],
+          },
+        }),
+        r1,
+      );
+      expect((r1.body as { accepted: number }).accepted).toBe(1);
+
+      const r2 = makeRes();
+      await syncV2Push(
+        makeReq({
+          userId: "u-ftc",
+          body: {
+            ops: [
+              {
+                table: "finyk_tx_categories",
+                op: "delete" as const,
+                row: { user_id: "u-ftc", transaction_id: "mono-tx-1" },
+                client_ts: t2,
+                idempotency_key: "ftc-delete",
+              },
+            ],
+          },
+        }),
+        r2,
+      );
+      expect((r2.body as { accepted: number }).accepted).toBe(1);
+
+      const rows = await testPool.query(
+        `SELECT 1 FROM finyk_tx_categories
+           WHERE user_id = $1 AND transaction_id = $2`,
+        ["u-ftc", "mono-tx-1"],
+      );
+      expect(rows.rows).toHaveLength(0);
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "finyk_networth_history: monthly upsert keeps month TEXT (composite (user_id, month) PK)",
+    async (ctx) => {
+      if (!dockerAvailable || !testPool) return ctx.skip();
+      await ensureUser("u-fnh");
+
+      const t1 = isoNow(-2_000);
+      const t2 = isoNow();
+
+      const r1 = makeRes();
+      await syncV2Push(
+        makeReq({
+          userId: "u-fnh",
+          body: {
+            ops: [
+              {
+                table: "finyk_networth_history",
+                op: "insert" as const,
+                row: {
+                  user_id: "u-fnh",
+                  month: "2026-04",
+                  networth: 1234.5,
+                },
+                client_ts: t1,
+                idempotency_key: "fnh-insert",
+              },
+            ],
+          },
+        }),
+        r1,
+      );
+      expect((r1.body as { accepted: number }).accepted).toBe(1);
+
+      const r2 = makeRes();
+      await syncV2Push(
+        makeReq({
+          userId: "u-fnh",
+          body: {
+            ops: [
+              {
+                table: "finyk_networth_history",
+                op: "update" as const,
+                row: {
+                  user_id: "u-fnh",
+                  month: "2026-04",
+                  networth: 1500,
+                },
+                client_ts: t2,
+                idempotency_key: "fnh-update",
+              },
+            ],
+          },
+        }),
+        r2,
+      );
+      expect((r2.body as { accepted: number }).accepted).toBe(1);
+
+      const row = await testPool.query<{ networth: number; month: string }>(
+        `SELECT month, networth FROM finyk_networth_history
+           WHERE user_id = $1 AND month = $2`,
+        ["u-fnh", "2026-04"],
+      );
+      expect(row.rows[0].month).toBe("2026-04");
+      expect(row.rows[0].networth).toBeCloseTo(1500, 5);
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "finyk_networth_history: invalid month string is rejected",
+    async (ctx) => {
+      if (!dockerAvailable || !testPool) return ctx.skip();
+      await ensureUser("u-fnh-bad");
+
+      const r = makeRes();
+      await syncV2Push(
+        makeReq({
+          userId: "u-fnh-bad",
+          body: {
+            ops: [
+              {
+                table: "finyk_networth_history",
+                op: "insert" as const,
+                row: {
+                  user_id: "u-fnh-bad",
+                  month: "April 2026",
+                  networth: 1,
+                },
+                client_ts: isoNow(),
+                idempotency_key: "fnh-bad",
+              },
+            ],
+          },
+        }),
+        r,
+      );
+      const body = r.body as {
+        accepted: number;
+        results: Array<{ status: string; reason?: string }>;
+      };
+      expect(body.accepted).toBe(0);
+      expect(body.results[0].reason).toBe("invalid_month");
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "finyk_prefs: singleton upsert — insert then update; delete rejected",
+    async (ctx) => {
+      if (!dockerAvailable || !testPool) return ctx.skip();
+      await ensureUser("u-fp");
+
+      const t1 = isoNow(-2_000);
+      const t2 = isoNow();
+      const t3 = isoNow(2_000);
+
+      const r1 = makeRes();
+      await syncV2Push(
+        makeReq({
+          userId: "u-fp",
+          body: {
+            ops: [
+              {
+                table: "finyk_prefs",
+                op: "insert" as const,
+                row: {
+                  user_id: "u-fp",
+                  prefs_json: { defaultCurrency: "UAH" },
+                  monthly_plan_json: { income: "50000", expense: "30000" },
+                  show_balance: true,
+                },
+                client_ts: t1,
+                idempotency_key: "fp-insert",
+              },
+            ],
+          },
+        }),
+        r1,
+      );
+      expect((r1.body as { accepted: number }).accepted).toBe(1);
+
+      const r2 = makeRes();
+      await syncV2Push(
+        makeReq({
+          userId: "u-fp",
+          body: {
+            ops: [
+              {
+                table: "finyk_prefs",
+                op: "update" as const,
+                row: {
+                  user_id: "u-fp",
+                  prefs_json: { defaultCurrency: "USD" },
+                  monthly_plan_json: { income: "60000", expense: "30000" },
+                  show_balance: false,
+                },
+                client_ts: t2,
+                idempotency_key: "fp-update",
+              },
+            ],
+          },
+        }),
+        r2,
+      );
+      expect((r2.body as { accepted: number }).accepted).toBe(1);
+
+      const row = await testPool.query<{
+        prefs_json: { defaultCurrency: string };
+        show_balance: boolean;
+      }>(
+        `SELECT prefs_json, show_balance FROM finyk_prefs WHERE user_id = $1`,
+        ["u-fp"],
+      );
+      expect(row.rows[0].prefs_json.defaultCurrency).toBe("USD");
+      expect(row.rows[0].show_balance).toBe(false);
+
+      const r3 = makeRes();
+      await syncV2Push(
+        makeReq({
+          userId: "u-fp",
+          body: {
+            ops: [
+              {
+                table: "finyk_prefs",
+                op: "delete" as const,
+                row: { user_id: "u-fp" },
+                client_ts: t3,
+                idempotency_key: "fp-delete",
+              },
+            ],
+          },
+        }),
+        r3,
+      );
+      const body3 = r3.body as {
+        accepted: number;
+        results: Array<{ status: string; reason?: string }>;
+      };
+      expect(body3.accepted).toBe(0);
+      expect(body3.results[0].reason).toBe("delete_not_supported");
     },
     TIMEOUT_MS,
   );

--- a/apps/server/src/modules/sync/syncV2.ts
+++ b/apps/server/src/modules/sync/syncV2.ts
@@ -123,6 +123,21 @@ const OP_LOG_TABLE_REGISTRY: Record<string, ApplyFn> = {
   nutrition_pantry_items: applyNutritionPantryItems,
   nutrition_prefs: applyNutritionPrefs,
   nutrition_recipes: applyNutritionRecipes,
+  finyk_hidden_accounts: applyFinykHiddenAccounts,
+  finyk_hidden_transactions: applyFinykHiddenTransactions,
+  finyk_budgets: applyFinykBudgets,
+  finyk_subscriptions: applyFinykSubscriptions,
+  finyk_assets: applyFinykAssets,
+  finyk_debts: applyFinykDebts,
+  finyk_receivables: applyFinykReceivables,
+  finyk_custom_categories: applyFinykCustomCategories,
+  finyk_manual_expenses: applyFinykManualExpenses,
+  finyk_tx_filters: applyFinykTxFilters,
+  finyk_tx_categories: applyFinykTxCategories,
+  finyk_tx_splits: applyFinykTxSplits,
+  finyk_mono_debt_links: applyFinykMonoDebtLinks,
+  finyk_networth_history: applyFinykNetworthHistory,
+  finyk_prefs: applyFinykPrefs,
 };
 
 /**
@@ -1616,6 +1631,594 @@ async function applyNutritionRecipes(
              deleted_at = $4
        WHERE id = $5 AND user_id = $6`,
       [name, dataJson, clientTs, deletedAt ?? null, id, userId],
+    );
+  }
+  return { status: "applied" };
+}
+
+// ---------------------------------------------------------------------
+// Finyk apply-функції — Stage 4 PR #035.
+//
+// 15 split-функцій по таблицях. Архітектурно повторюють nutrition та
+// fizruk: кожна функція робить LWW-guard, розрізняє op `delete` /
+// upsert, оперує `(user_id, …)` ключем і повертає `applied`/`rejected`
+// з причиною (`lww_conflict`, `missing_id`, `user_id_mismatch`,
+// `fk_violation`, `not_found`).
+//
+// Розподіл за shape-ами (див. коментар у міграції 039_finyk_tables.sql):
+//
+//   * **Composite-PK tombstone** (per-(user, ext_id) запис із soft-delete):
+//     - `finyk_hidden_accounts`        — ext_id = account_id
+//     - `finyk_hidden_transactions`    — ext_id = transaction_id
+//
+//   * **Per-row + JSONB blob** (UUID PK, soft-delete):
+//     - `finyk_budgets`, `finyk_subscriptions`, `finyk_assets`,
+//       `finyk_debts`, `finyk_receivables`,
+//       `finyk_custom_categories`, `finyk_manual_expenses`,
+//       `finyk_tx_filters`
+//
+//   * **Per-tx mapping** (composite PK на (user_id, transaction_id),
+//     без soft-delete — `delete` = жорсткий `DELETE FROM`):
+//     - `finyk_tx_categories` — поле `category_id TEXT`
+//     - `finyk_tx_splits`     — поле `splits_json JSONB`
+//     - `finyk_mono_debt_links` — поле `debt_ids_json JSONB`
+//
+//   * **Time-series** (`finyk_networth_history`): composite PK
+//     `(user_id, month)`; `month` — TEXT YYYY-MM.
+//
+//   * **Singleton prefs** (`finyk_prefs`): PK = `user_id`. `delete`
+//     відхиляється, тільки оновлення.
+// ---------------------------------------------------------------------
+
+/**
+ * Generic helper for "composite-PK tombstone" finyk таблиць:
+ * `finyk_hidden_accounts` (ext column = account_id) і
+ * `finyk_hidden_transactions` (ext column = transaction_id). Уся
+ * apply-логіка ідентична — різняться лише імена колонки і таблиці.
+ */
+async function applyFinykTombstone(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+  table: "finyk_hidden_accounts" | "finyk_hidden_transactions",
+  extColumn: "account_id" | "transaction_id",
+): Promise<AppliedStatus> {
+  const row = op.row;
+  const extId = typeof row[extColumn] === "string" ? row[extColumn] : null;
+  if (!extId) return { status: "rejected", reason: "missing_ext_id" };
+
+  if (row.user_id != null && row.user_id !== userId) {
+    return { status: "rejected", reason: "user_id_mismatch" };
+  }
+
+  const existing = await client.query<{ updated_at: Date }>(
+    `SELECT updated_at FROM ${table} WHERE user_id = $1 AND ${extColumn} = $2`,
+    [userId, extId],
+  );
+  if (existing.rows.length > 0) {
+    if (existing.rows[0].updated_at.getTime() >= clientTs.getTime()) {
+      return { status: "rejected", reason: "lww_conflict" };
+    }
+  }
+
+  if (op.op === "delete") {
+    if (existing.rows.length === 0) {
+      return { status: "rejected", reason: "not_found" };
+    }
+    await client.query(
+      `UPDATE ${table}
+         SET deleted_at = $1, updated_at = $1
+       WHERE user_id = $2 AND ${extColumn} = $3`,
+      [clientTs, userId, extId],
+    );
+    return { status: "applied" };
+  }
+
+  const createdAt = parseOptionalDate(row.created_at);
+  if (createdAt === "invalid") {
+    return { status: "rejected", reason: "invalid_created_at" };
+  }
+  const deletedAt = parseOptionalDate(row.deleted_at);
+  if (deletedAt === "invalid") {
+    return { status: "rejected", reason: "invalid_deleted_at" };
+  }
+
+  if (existing.rows.length === 0) {
+    await client.query(
+      `INSERT INTO ${table}
+         (user_id, ${extColumn}, created_at, updated_at, deleted_at)
+       VALUES ($1, $2, $3, $4, $5)`,
+      [userId, extId, createdAt ?? clientTs, clientTs, deletedAt ?? null],
+    );
+  } else {
+    await client.query(
+      `UPDATE ${table}
+         SET updated_at = $1, deleted_at = $2
+       WHERE user_id = $3 AND ${extColumn} = $4`,
+      [clientTs, deletedAt ?? null, userId, extId],
+    );
+  }
+  return { status: "applied" };
+}
+
+async function applyFinykHiddenAccounts(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+): Promise<AppliedStatus> {
+  return applyFinykTombstone(
+    client,
+    op,
+    userId,
+    clientTs,
+    "finyk_hidden_accounts",
+    "account_id",
+  );
+}
+
+async function applyFinykHiddenTransactions(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+): Promise<AppliedStatus> {
+  return applyFinykTombstone(
+    client,
+    op,
+    userId,
+    clientTs,
+    "finyk_hidden_transactions",
+    "transaction_id",
+  );
+}
+
+/**
+ * Generic helper for "per-row + JSONB blob" finyk таблиць
+ * (`finyk_budgets`, `finyk_subscriptions`, `finyk_assets`,
+ * `finyk_debts`, `finyk_receivables`, `finyk_custom_categories`,
+ * `finyk_manual_expenses`, `finyk_tx_filters`). Ідентична семантика —
+ * лише ім'я таблиці змінюється. Колонки фіксовані: `(id UUID PK,
+ * user_id, data_json JSONB, created_at, updated_at, deleted_at)`.
+ */
+async function applyFinykPerRowBlob(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+  table: string,
+): Promise<AppliedStatus> {
+  const row = op.row;
+  const id = typeof row.id === "string" ? row.id : null;
+  if (!id) return { status: "rejected", reason: "missing_id" };
+
+  if (row.user_id != null && row.user_id !== userId) {
+    return { status: "rejected", reason: "user_id_mismatch" };
+  }
+
+  const existing = await client.query<{ user_id: string; updated_at: Date }>(
+    `SELECT user_id, updated_at FROM ${table} WHERE id = $1`,
+    [id],
+  );
+  if (existing.rows.length > 0) {
+    if (existing.rows[0].user_id !== userId) {
+      return { status: "rejected", reason: "fk_violation" };
+    }
+    if (existing.rows[0].updated_at.getTime() >= clientTs.getTime()) {
+      return { status: "rejected", reason: "lww_conflict" };
+    }
+  }
+
+  if (op.op === "delete") {
+    if (existing.rows.length === 0) {
+      return { status: "rejected", reason: "not_found" };
+    }
+    await client.query(
+      `UPDATE ${table}
+         SET deleted_at = $1, updated_at = $1
+       WHERE id = $2 AND user_id = $3`,
+      [clientTs, id, userId],
+    );
+    return { status: "applied" };
+  }
+
+  const dataJson = toJsonbParam(row.data_json);
+  if (dataJson === null) {
+    return { status: "rejected", reason: "missing_data_json" };
+  }
+  const createdAt = parseOptionalDate(row.created_at);
+  if (createdAt === "invalid") {
+    return { status: "rejected", reason: "invalid_created_at" };
+  }
+  const deletedAt = parseOptionalDate(row.deleted_at);
+  if (deletedAt === "invalid") {
+    return { status: "rejected", reason: "invalid_deleted_at" };
+  }
+
+  if (existing.rows.length === 0) {
+    await client.query(
+      `INSERT INTO ${table}
+         (id, user_id, data_json, created_at, updated_at, deleted_at)
+       VALUES ($1, $2, $3::jsonb, $4, $5, $6)`,
+      [
+        id,
+        userId,
+        dataJson,
+        createdAt ?? clientTs,
+        clientTs,
+        deletedAt ?? null,
+      ],
+    );
+  } else {
+    await client.query(
+      `UPDATE ${table}
+         SET data_json  = $1::jsonb,
+             updated_at = $2,
+             deleted_at = $3
+       WHERE id = $4 AND user_id = $5`,
+      [dataJson, clientTs, deletedAt ?? null, id, userId],
+    );
+  }
+  return { status: "applied" };
+}
+
+async function applyFinykBudgets(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+): Promise<AppliedStatus> {
+  return applyFinykPerRowBlob(client, op, userId, clientTs, "finyk_budgets");
+}
+
+async function applyFinykSubscriptions(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+): Promise<AppliedStatus> {
+  return applyFinykPerRowBlob(
+    client,
+    op,
+    userId,
+    clientTs,
+    "finyk_subscriptions",
+  );
+}
+
+async function applyFinykAssets(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+): Promise<AppliedStatus> {
+  return applyFinykPerRowBlob(client, op, userId, clientTs, "finyk_assets");
+}
+
+async function applyFinykDebts(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+): Promise<AppliedStatus> {
+  return applyFinykPerRowBlob(client, op, userId, clientTs, "finyk_debts");
+}
+
+async function applyFinykReceivables(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+): Promise<AppliedStatus> {
+  return applyFinykPerRowBlob(
+    client,
+    op,
+    userId,
+    clientTs,
+    "finyk_receivables",
+  );
+}
+
+async function applyFinykCustomCategories(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+): Promise<AppliedStatus> {
+  return applyFinykPerRowBlob(
+    client,
+    op,
+    userId,
+    clientTs,
+    "finyk_custom_categories",
+  );
+}
+
+async function applyFinykManualExpenses(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+): Promise<AppliedStatus> {
+  return applyFinykPerRowBlob(
+    client,
+    op,
+    userId,
+    clientTs,
+    "finyk_manual_expenses",
+  );
+}
+
+async function applyFinykTxFilters(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+): Promise<AppliedStatus> {
+  return applyFinykPerRowBlob(client, op, userId, clientTs, "finyk_tx_filters");
+}
+
+/**
+ * Apply-шлях для `finyk_tx_categories` — per-tx mapping без
+ * soft-delete. `delete` op виконує `DELETE FROM` (idempotent).
+ */
+async function applyFinykTxCategories(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+): Promise<AppliedStatus> {
+  const row = op.row;
+  const transactionId =
+    typeof row.transaction_id === "string" ? row.transaction_id : null;
+  if (!transactionId) return { status: "rejected", reason: "missing_tx_id" };
+
+  if (row.user_id != null && row.user_id !== userId) {
+    return { status: "rejected", reason: "user_id_mismatch" };
+  }
+
+  const existing = await client.query<{ updated_at: Date }>(
+    `SELECT updated_at FROM finyk_tx_categories
+       WHERE user_id = $1 AND transaction_id = $2`,
+    [userId, transactionId],
+  );
+  if (existing.rows.length > 0) {
+    if (existing.rows[0].updated_at.getTime() >= clientTs.getTime()) {
+      return { status: "rejected", reason: "lww_conflict" };
+    }
+  }
+
+  if (op.op === "delete") {
+    await client.query(
+      `DELETE FROM finyk_tx_categories
+         WHERE user_id = $1 AND transaction_id = $2`,
+      [userId, transactionId],
+    );
+    return { status: "applied" };
+  }
+
+  const categoryId =
+    typeof row.category_id === "string" ? row.category_id : null;
+  if (!categoryId) {
+    return { status: "rejected", reason: "missing_category_id" };
+  }
+
+  await client.query(
+    `INSERT INTO finyk_tx_categories
+       (user_id, transaction_id, category_id, created_at, updated_at)
+     VALUES ($1, $2, $3, $4, $5)
+     ON CONFLICT (user_id, transaction_id) DO UPDATE
+       SET category_id = EXCLUDED.category_id,
+           updated_at  = EXCLUDED.updated_at`,
+    [userId, transactionId, categoryId, clientTs, clientTs],
+  );
+  return { status: "applied" };
+}
+
+/**
+ * Generic helper for `finyk_tx_splits` and `finyk_mono_debt_links` —
+ * per-tx JSONB-array mapping (composite PK на `(user_id,
+ * transaction_id)`, без soft-delete). Розрізняються лише ім'ям
+ * таблиці і JSONB-колонки. Default fallback значення для відсутнього
+ * payload-у — порожній масив `[]`.
+ */
+async function applyFinykPerTxJsonbArray(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+  table: "finyk_tx_splits" | "finyk_mono_debt_links",
+  jsonColumn: "splits_json" | "debt_ids_json",
+): Promise<AppliedStatus> {
+  const row = op.row;
+  const transactionId =
+    typeof row.transaction_id === "string" ? row.transaction_id : null;
+  if (!transactionId) return { status: "rejected", reason: "missing_tx_id" };
+
+  if (row.user_id != null && row.user_id !== userId) {
+    return { status: "rejected", reason: "user_id_mismatch" };
+  }
+
+  const existing = await client.query<{ updated_at: Date }>(
+    `SELECT updated_at FROM ${table}
+       WHERE user_id = $1 AND transaction_id = $2`,
+    [userId, transactionId],
+  );
+  if (existing.rows.length > 0) {
+    if (existing.rows[0].updated_at.getTime() >= clientTs.getTime()) {
+      return { status: "rejected", reason: "lww_conflict" };
+    }
+  }
+
+  if (op.op === "delete") {
+    await client.query(
+      `DELETE FROM ${table}
+         WHERE user_id = $1 AND transaction_id = $2`,
+      [userId, transactionId],
+    );
+    return { status: "applied" };
+  }
+
+  const jsonValue = toJsonbParam(row[jsonColumn]) ?? "[]";
+
+  await client.query(
+    `INSERT INTO ${table}
+       (user_id, transaction_id, ${jsonColumn}, created_at, updated_at)
+     VALUES ($1, $2, $3::jsonb, $4, $5)
+     ON CONFLICT (user_id, transaction_id) DO UPDATE
+       SET ${jsonColumn} = EXCLUDED.${jsonColumn},
+           updated_at    = EXCLUDED.updated_at`,
+    [userId, transactionId, jsonValue, clientTs, clientTs],
+  );
+  return { status: "applied" };
+}
+
+async function applyFinykTxSplits(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+): Promise<AppliedStatus> {
+  return applyFinykPerTxJsonbArray(
+    client,
+    op,
+    userId,
+    clientTs,
+    "finyk_tx_splits",
+    "splits_json",
+  );
+}
+
+async function applyFinykMonoDebtLinks(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+): Promise<AppliedStatus> {
+  return applyFinykPerTxJsonbArray(
+    client,
+    op,
+    userId,
+    clientTs,
+    "finyk_mono_debt_links",
+    "debt_ids_json",
+  );
+}
+
+/**
+ * Apply-шлях для `finyk_networth_history` — time-series, composite
+ * PK `(user_id, month)`. `month` — TEXT YYYY-MM (stored verbatim).
+ */
+async function applyFinykNetworthHistory(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+): Promise<AppliedStatus> {
+  const row = op.row;
+  const month = typeof row.month === "string" ? row.month : null;
+  if (!month || !/^\d{4}-\d{2}$/.test(month)) {
+    return { status: "rejected", reason: "invalid_month" };
+  }
+
+  if (row.user_id != null && row.user_id !== userId) {
+    return { status: "rejected", reason: "user_id_mismatch" };
+  }
+
+  const existing = await client.query<{ updated_at: Date }>(
+    `SELECT updated_at FROM finyk_networth_history
+       WHERE user_id = $1 AND month = $2`,
+    [userId, month],
+  );
+  if (existing.rows.length > 0) {
+    if (existing.rows[0].updated_at.getTime() >= clientTs.getTime()) {
+      return { status: "rejected", reason: "lww_conflict" };
+    }
+  }
+
+  if (op.op === "delete") {
+    await client.query(
+      `DELETE FROM finyk_networth_history
+         WHERE user_id = $1 AND month = $2`,
+      [userId, month],
+    );
+    return { status: "applied" };
+  }
+
+  const networth = parseOptionalNumber(row.networth);
+  if (networth === "invalid") {
+    return { status: "rejected", reason: "invalid_networth" };
+  }
+  const snapshotJson = toJsonbParam(row.snapshot_json) ?? "{}";
+
+  await client.query(
+    `INSERT INTO finyk_networth_history
+       (user_id, month, networth, snapshot_json, created_at, updated_at)
+     VALUES ($1, $2, $3, $4::jsonb, $5, $6)
+     ON CONFLICT (user_id, month) DO UPDATE
+       SET networth      = EXCLUDED.networth,
+           snapshot_json = EXCLUDED.snapshot_json,
+           updated_at    = EXCLUDED.updated_at`,
+    [userId, month, networth ?? 0, snapshotJson, clientTs, clientTs],
+  );
+  return { status: "applied" };
+}
+
+/**
+ * Apply-шлях для `finyk_prefs` — singleton per-user (PK = user_id).
+ *
+ * Структурно дзеркало `applyNutritionPrefs`: `delete` відхиляється,
+ * `prefs_json`/`monthly_plan_json` серіалізуються через `toJsonbParam`,
+ * `show_balance` приходить як boolean / 0|1.
+ */
+async function applyFinykPrefs(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+): Promise<AppliedStatus> {
+  if (op.op === "delete") {
+    return { status: "rejected", reason: "delete_not_supported" };
+  }
+
+  const row = op.row;
+  if (row.user_id != null && row.user_id !== userId) {
+    return { status: "rejected", reason: "user_id_mismatch" };
+  }
+
+  const existing = await client.query<{ updated_at: Date }>(
+    `SELECT updated_at FROM finyk_prefs WHERE user_id = $1`,
+    [userId],
+  );
+  if (existing.rows.length > 0) {
+    if (existing.rows[0].updated_at.getTime() >= clientTs.getTime()) {
+      return { status: "rejected", reason: "lww_conflict" };
+    }
+  }
+
+  const prefsJson = toJsonbParam(row.prefs_json) ?? "{}";
+  const monthlyPlanJson = toJsonbParam(row.monthly_plan_json) ?? "{}";
+  const showBalance =
+    row.show_balance === false || row.show_balance === 0 ? false : true;
+
+  if (existing.rows.length === 0) {
+    await client.query(
+      `INSERT INTO finyk_prefs
+         (user_id, prefs_json, monthly_plan_json, show_balance,
+          created_at, updated_at)
+       VALUES ($1, $2::jsonb, $3::jsonb, $4, $5, $6)`,
+      [userId, prefsJson, monthlyPlanJson, showBalance, clientTs, clientTs],
+    );
+  } else {
+    await client.query(
+      `UPDATE finyk_prefs
+         SET prefs_json        = $1::jsonb,
+             monthly_plan_json = $2::jsonb,
+             show_balance      = $3,
+             updated_at        = $4
+       WHERE user_id = $5`,
+      [prefsJson, monthlyPlanJson, showBalance, clientTs, userId],
     );
   }
   return { status: "applied" };

--- a/apps/web/src/modules/finyk/lib/clientMigrate.ts
+++ b/apps/web/src/modules/finyk/lib/clientMigrate.ts
@@ -1,0 +1,32 @@
+import {
+  FINYK_CLIENT_MIGRATIONS,
+  FINYK_MIGRATIONS_TABLE,
+} from "@sergeant/db-schema/sqlite/migrations";
+import { runMigrations } from "@sergeant/db-schema/migrate/runner";
+import {
+  createSqliteAdapter,
+  type SqliteMigrationClient,
+} from "@sergeant/db-schema/migrate/sqlite";
+
+/**
+ * Run the Finyk SQLite client migrations.
+ *
+ * Idempotent: re-running over an already-migrated DB is a no-op
+ * thanks to the runner's `__finyk_migrations` ledger contract.
+ *
+ * Stage 4 PR #035 of `docs/planning/storage-roadmap.md` — schema-only.
+ * The seam this exports is wired into the write paths by PR #036
+ * (dual-write); PR #035 itself only ships the runner so PR #036 has
+ * the same shape as the nutrition dual-write entry-point.
+ */
+export async function migrateFinyk(
+  client: SqliteMigrationClient,
+): Promise<void> {
+  await runMigrations({
+    adapter: createSqliteAdapter(client),
+    files: FINYK_CLIENT_MIGRATIONS,
+    tableName: FINYK_MIGRATIONS_TABLE,
+  });
+}
+
+export type { SqliteMigrationClient };

--- a/packages/db-schema/src/__tests__/pg-finyk-snapshot.test.ts
+++ b/packages/db-schema/src/__tests__/pg-finyk-snapshot.test.ts
@@ -1,0 +1,328 @@
+import { describe, expect, it } from "vitest";
+import { getTableConfig } from "drizzle-orm/pg-core";
+import {
+  finykHiddenAccounts,
+  finykHiddenTransactions,
+  finykBudgets,
+  finykSubscriptions,
+  finykAssets,
+  finykDebts,
+  finykReceivables,
+  finykCustomCategories,
+  finykManualExpenses,
+  finykTxFilters,
+  finykTxCategories,
+  finykTxSplits,
+  finykMonoDebtLinks,
+  finykNetworthHistory,
+  finykPrefs,
+} from "../pg/finyk.js";
+
+/**
+ * Snapshot tests for the Postgres Drizzle schemas under `pg/finyk.ts`,
+ * locking down the column ordering, types, nullability, indexes, and
+ * defaults that mirror migration 039_finyk_tables.sql.
+ *
+ * Stage 4 / PR #035 of `docs/planning/storage-roadmap.md`. Pattern
+ * mirrors `pg-nutrition-snapshot.test.ts` — same structure, but the
+ * 15 tables here split into five groups (see migration header for
+ * rationale). The five-group structure is the test's organising
+ * principle: one describe block per group of tables that share the
+ * same shape, so a regression in any single group surfaces as a
+ * focused failure rather than a blob of unrelated diffs.
+ */
+
+// ---------------------------------------------------------------------
+// Group 1 — composite-PK tombstone
+// ---------------------------------------------------------------------
+
+describe("pg/finykHiddenAccounts schema snapshot", () => {
+  const config = getTableConfig(finykHiddenAccounts);
+
+  it("has the canonical table name", () => {
+    expect(config.name).toBe("finyk_hidden_accounts");
+  });
+
+  it("declares all expected columns", () => {
+    expect(config.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "account_id",
+      "created_at",
+      "updated_at",
+      "deleted_at",
+    ]);
+  });
+
+  it("declares (user_id, account_id) as a composite primary key", () => {
+    expect(config.primaryKeys).toHaveLength(1);
+    expect(config.primaryKeys[0]!.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "account_id",
+    ]);
+  });
+
+  it("declares the soft-delete partial index", () => {
+    expect(config.indexes.map((i) => i.config.name)).toContain(
+      "finyk_hidden_accounts_user_active_idx",
+    );
+  });
+});
+
+describe("pg/finykHiddenTransactions schema snapshot", () => {
+  const config = getTableConfig(finykHiddenTransactions);
+
+  it("has the canonical table name", () => {
+    expect(config.name).toBe("finyk_hidden_transactions");
+  });
+
+  it("declares all expected columns", () => {
+    expect(config.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "transaction_id",
+      "created_at",
+      "updated_at",
+      "deleted_at",
+    ]);
+  });
+
+  it("declares (user_id, transaction_id) as a composite primary key", () => {
+    expect(config.primaryKeys).toHaveLength(1);
+    expect(config.primaryKeys[0]!.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "transaction_id",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------
+// Group 2 — per-row + JSONB
+// ---------------------------------------------------------------------
+
+const PER_ROW_JSONB_TABLES: ReadonlyArray<{
+  name: string;
+  table: ReturnType<typeof getTableConfig>;
+}> = [
+  { name: "finyk_budgets", table: getTableConfig(finykBudgets) },
+  { name: "finyk_subscriptions", table: getTableConfig(finykSubscriptions) },
+  { name: "finyk_assets", table: getTableConfig(finykAssets) },
+  { name: "finyk_debts", table: getTableConfig(finykDebts) },
+  { name: "finyk_receivables", table: getTableConfig(finykReceivables) },
+  {
+    name: "finyk_custom_categories",
+    table: getTableConfig(finykCustomCategories),
+  },
+  {
+    name: "finyk_manual_expenses",
+    table: getTableConfig(finykManualExpenses),
+  },
+  { name: "finyk_tx_filters", table: getTableConfig(finykTxFilters) },
+];
+
+describe.each(PER_ROW_JSONB_TABLES)(
+  "pg/$name (per-row + JSONB)",
+  ({ name, table }) => {
+    it("has the canonical table name", () => {
+      expect(table.name).toBe(name);
+    });
+
+    it("declares the canonical (id, user_id, data_json, created_at, updated_at, deleted_at) shape", () => {
+      expect(table.columns.map((c) => c.name)).toEqual([
+        "id",
+        "user_id",
+        "data_json",
+        "created_at",
+        "updated_at",
+        "deleted_at",
+      ]);
+    });
+
+    it("uses uuid() PK with default", () => {
+      const cols = Object.fromEntries(table.columns.map((c) => [c.name, c]));
+      expect(cols["id"]!.columnType).toBe("PgUUID");
+      expect(cols["id"]!.primary).toBe(true);
+      expect(cols["id"]!.hasDefault).toBe(true);
+      expect(cols["data_json"]!.columnType).toBe("PgJsonb");
+      expect(cols["data_json"]!.notNull).toBe(true);
+      expect(cols["data_json"]!.hasDefault).toBe(true);
+      expect(cols["deleted_at"]!.notNull).toBe(false);
+    });
+
+    it("declares the (user_id, deleted_at) soft-delete partial index", () => {
+      const idxNames = table.indexes.map((i) => i.config.name);
+      expect(idxNames).toContain(`${name}_user_active_idx`);
+      const idx = table.indexes.find(
+        (i) => i.config.name === `${name}_user_active_idx`,
+      )!;
+      expect(idx.config.where).toBeDefined();
+    });
+  },
+);
+
+// ---------------------------------------------------------------------
+// Group 3 — per-tx mapping (composite PK on (user_id, transaction_id))
+// ---------------------------------------------------------------------
+
+describe("pg/finykTxCategories schema snapshot", () => {
+  const config = getTableConfig(finykTxCategories);
+
+  it("declares the canonical column shape", () => {
+    expect(config.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "transaction_id",
+      "category_id",
+      "created_at",
+      "updated_at",
+    ]);
+  });
+
+  it("uses (user_id, transaction_id) composite PK", () => {
+    expect(config.primaryKeys[0]!.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "transaction_id",
+    ]);
+  });
+
+  it("declares no soft-delete column (delete = DELETE FROM)", () => {
+    expect(config.columns.map((c) => c.name)).not.toContain("deleted_at");
+  });
+
+  it("category_id is a NOT NULL TEXT", () => {
+    const cols = Object.fromEntries(config.columns.map((c) => [c.name, c]));
+    expect(cols["category_id"]!.dataType).toBe("string");
+    expect(cols["category_id"]!.notNull).toBe(true);
+  });
+});
+
+describe("pg/finykTxSplits schema snapshot", () => {
+  const config = getTableConfig(finykTxSplits);
+
+  it("declares the canonical column shape with splits_json", () => {
+    expect(config.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "transaction_id",
+      "splits_json",
+      "created_at",
+      "updated_at",
+    ]);
+  });
+
+  it("uses (user_id, transaction_id) composite PK", () => {
+    expect(config.primaryKeys[0]!.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "transaction_id",
+    ]);
+  });
+
+  it("splits_json is JSONB with default '[]'", () => {
+    const cols = Object.fromEntries(config.columns.map((c) => [c.name, c]));
+    expect(cols["splits_json"]!.columnType).toBe("PgJsonb");
+    expect(cols["splits_json"]!.notNull).toBe(true);
+    expect(cols["splits_json"]!.hasDefault).toBe(true);
+  });
+});
+
+describe("pg/finykMonoDebtLinks schema snapshot", () => {
+  const config = getTableConfig(finykMonoDebtLinks);
+
+  it("declares the canonical column shape with debt_ids_json", () => {
+    expect(config.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "transaction_id",
+      "debt_ids_json",
+      "created_at",
+      "updated_at",
+    ]);
+  });
+
+  it("uses (user_id, transaction_id) composite PK", () => {
+    expect(config.primaryKeys[0]!.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "transaction_id",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------
+// Group 4 — time-series networth history
+// ---------------------------------------------------------------------
+
+describe("pg/finykNetworthHistory schema snapshot", () => {
+  const config = getTableConfig(finykNetworthHistory);
+
+  it("declares the canonical (user_id, month, networth, snapshot_json, …) shape", () => {
+    expect(config.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "month",
+      "networth",
+      "snapshot_json",
+      "created_at",
+      "updated_at",
+    ]);
+  });
+
+  it("uses (user_id, month) composite PK", () => {
+    expect(config.primaryKeys[0]!.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "month",
+    ]);
+  });
+
+  it("month stays TEXT (not DATE) so LWW matches LS byte-for-byte", () => {
+    const cols = Object.fromEntries(config.columns.map((c) => [c.name, c]));
+    expect(cols["month"]!.columnType).toBe("PgText");
+    expect(cols["month"]!.notNull).toBe(true);
+  });
+
+  it("networth is REAL with default 0", () => {
+    const cols = Object.fromEntries(config.columns.map((c) => [c.name, c]));
+    expect(cols["networth"]!.columnType).toBe("PgReal");
+    expect(cols["networth"]!.notNull).toBe(true);
+    expect(cols["networth"]!.hasDefault).toBe(true);
+  });
+
+  it("snapshot_json is JSONB with default '{}'", () => {
+    const cols = Object.fromEntries(config.columns.map((c) => [c.name, c]));
+    expect(cols["snapshot_json"]!.columnType).toBe("PgJsonb");
+    expect(cols["snapshot_json"]!.notNull).toBe(true);
+    expect(cols["snapshot_json"]!.hasDefault).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------
+// Group 5 — singleton prefs
+// ---------------------------------------------------------------------
+
+describe("pg/finykPrefs schema snapshot", () => {
+  const config = getTableConfig(finykPrefs);
+
+  it("declares the canonical singleton column shape", () => {
+    expect(config.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "prefs_json",
+      "monthly_plan_json",
+      "show_balance",
+      "created_at",
+      "updated_at",
+    ]);
+  });
+
+  it("user_id is the primary key (singleton — exactly one row per user)", () => {
+    const cols = Object.fromEntries(config.columns.map((c) => [c.name, c]));
+    expect(cols["user_id"]!.primary).toBe(true);
+  });
+
+  it("show_balance is a NOT NULL boolean with default true", () => {
+    const cols = Object.fromEntries(config.columns.map((c) => [c.name, c]));
+    expect(cols["show_balance"]!.columnType).toBe("PgBoolean");
+    expect(cols["show_balance"]!.notNull).toBe(true);
+    expect(cols["show_balance"]!.hasDefault).toBe(true);
+  });
+
+  it("prefs_json + monthly_plan_json are both JSONB with object defaults", () => {
+    const cols = Object.fromEntries(config.columns.map((c) => [c.name, c]));
+    expect(cols["prefs_json"]!.columnType).toBe("PgJsonb");
+    expect(cols["prefs_json"]!.hasDefault).toBe(true);
+    expect(cols["monthly_plan_json"]!.columnType).toBe("PgJsonb");
+    expect(cols["monthly_plan_json"]!.hasDefault).toBe(true);
+  });
+});

--- a/packages/db-schema/src/__tests__/sqlite-finyk-snapshot.test.ts
+++ b/packages/db-schema/src/__tests__/sqlite-finyk-snapshot.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it } from "vitest";
+import { getTableConfig } from "drizzle-orm/sqlite-core";
+import {
+  finykHiddenAccounts,
+  finykHiddenTransactions,
+  finykBudgets,
+  finykSubscriptions,
+  finykAssets,
+  finykDebts,
+  finykReceivables,
+  finykCustomCategories,
+  finykManualExpenses,
+  finykTxFilters,
+  finykTxCategories,
+  finykTxSplits,
+  finykMonoDebtLinks,
+  finykNetworthHistory,
+  finykPrefs,
+} from "../sqlite/finyk.js";
+import {
+  FINYK_CLIENT_MIGRATIONS,
+  FINYK_MIGRATIONS_TABLE,
+} from "../sqlite/migrations/index.js";
+
+/**
+ * Snapshot tests for the SQLite Drizzle schemas under `sqlite/finyk.ts`,
+ * mirroring the structural lock-down that `pg-finyk-snapshot.test.ts`
+ * applies to the Postgres source-of-truth.
+ *
+ * Stage 4 / PR #035 of `docs/planning/storage-roadmap.md`. PG↔SQLite
+ * schemas must stay aligned so push/pull round-trips are symmetric.
+ *
+ * The five-group structure (composite-PK tombstone, per-row+JSONB,
+ * per-tx mapping, time-series, singleton prefs) is the test's
+ * organising principle — one describe block per group.
+ */
+
+// ---------------------------------------------------------------------
+// Group 1 — composite-PK tombstone
+// ---------------------------------------------------------------------
+
+describe("sqlite/finykHiddenAccounts schema snapshot", () => {
+  const config = getTableConfig(finykHiddenAccounts);
+
+  it("has the canonical table name", () => {
+    expect(config.name).toBe("finyk_hidden_accounts");
+  });
+
+  it("declares all expected columns", () => {
+    expect(config.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "account_id",
+      "created_at",
+      "updated_at",
+      "deleted_at",
+    ]);
+  });
+
+  it("uses (user_id, account_id) composite PK", () => {
+    expect(config.primaryKeys).toHaveLength(1);
+    expect(config.primaryKeys[0]!.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "account_id",
+    ]);
+  });
+
+  it("declares the `_lite`-suffixed soft-delete partial index", () => {
+    const idxNames = config.indexes.map((i) => i.config.name);
+    expect(idxNames).toContain("finyk_hidden_accounts_user_active_idx_lite");
+  });
+});
+
+describe("sqlite/finykHiddenTransactions schema snapshot", () => {
+  const config = getTableConfig(finykHiddenTransactions);
+
+  it("uses (user_id, transaction_id) composite PK", () => {
+    expect(config.primaryKeys[0]!.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "transaction_id",
+    ]);
+  });
+
+  it("`_lite`-suffixed soft-delete partial index is declared", () => {
+    expect(config.indexes.map((i) => i.config.name)).toContain(
+      "finyk_hidden_transactions_user_active_idx_lite",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------
+// Group 2 — per-row + JSONB→TEXT
+// ---------------------------------------------------------------------
+
+const PER_ROW_TABLES: ReadonlyArray<{
+  name: string;
+  table: ReturnType<typeof getTableConfig>;
+}> = [
+  { name: "finyk_budgets", table: getTableConfig(finykBudgets) },
+  { name: "finyk_subscriptions", table: getTableConfig(finykSubscriptions) },
+  { name: "finyk_assets", table: getTableConfig(finykAssets) },
+  { name: "finyk_debts", table: getTableConfig(finykDebts) },
+  { name: "finyk_receivables", table: getTableConfig(finykReceivables) },
+  {
+    name: "finyk_custom_categories",
+    table: getTableConfig(finykCustomCategories),
+  },
+  {
+    name: "finyk_manual_expenses",
+    table: getTableConfig(finykManualExpenses),
+  },
+  { name: "finyk_tx_filters", table: getTableConfig(finykTxFilters) },
+];
+
+describe.each(PER_ROW_TABLES)(
+  "sqlite/$name (per-row + data_json TEXT)",
+  ({ name, table }) => {
+    it("declares the canonical (id, user_id, data_json, created_at, updated_at, deleted_at) shape", () => {
+      expect(table.columns.map((c) => c.name)).toEqual([
+        "id",
+        "user_id",
+        "data_json",
+        "created_at",
+        "updated_at",
+        "deleted_at",
+      ]);
+    });
+
+    it("id is TEXT PK (UUID-as-string), data_json is TEXT NOT NULL DEFAULT '{}'", () => {
+      const cols = Object.fromEntries(table.columns.map((c) => [c.name, c]));
+      expect(cols["id"]!.dataType).toBe("string");
+      expect(cols["id"]!.primary).toBe(true);
+      expect(cols["data_json"]!.dataType).toBe("string");
+      expect(cols["data_json"]!.notNull).toBe(true);
+      expect(cols["data_json"]!.hasDefault).toBe(true);
+      expect(cols["deleted_at"]!.notNull).toBe(false);
+    });
+
+    it("declares the `_lite` soft-delete partial index", () => {
+      expect(table.indexes.map((i) => i.config.name)).toContain(
+        `${name}_user_active_idx_lite`,
+      );
+    });
+  },
+);
+
+// ---------------------------------------------------------------------
+// Group 3 — per-tx mapping
+// ---------------------------------------------------------------------
+
+describe("sqlite/finykTxCategories schema snapshot", () => {
+  const config = getTableConfig(finykTxCategories);
+
+  it("declares the canonical column shape", () => {
+    expect(config.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "transaction_id",
+      "category_id",
+      "created_at",
+      "updated_at",
+    ]);
+  });
+
+  it("uses (user_id, transaction_id) composite PK", () => {
+    expect(config.primaryKeys[0]!.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "transaction_id",
+    ]);
+  });
+
+  it("has no soft-delete column", () => {
+    expect(config.columns.map((c) => c.name)).not.toContain("deleted_at");
+  });
+});
+
+describe("sqlite/finykTxSplits schema snapshot", () => {
+  const config = getTableConfig(finykTxSplits);
+
+  it("declares splits_json TEXT NOT NULL DEFAULT '[]'", () => {
+    const cols = Object.fromEntries(config.columns.map((c) => [c.name, c]));
+    expect(cols["splits_json"]!.dataType).toBe("string");
+    expect(cols["splits_json"]!.notNull).toBe(true);
+    expect(cols["splits_json"]!.hasDefault).toBe(true);
+  });
+
+  it("uses (user_id, transaction_id) composite PK", () => {
+    expect(config.primaryKeys[0]!.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "transaction_id",
+    ]);
+  });
+});
+
+describe("sqlite/finykMonoDebtLinks schema snapshot", () => {
+  const config = getTableConfig(finykMonoDebtLinks);
+
+  it("declares debt_ids_json TEXT NOT NULL DEFAULT '[]'", () => {
+    const cols = Object.fromEntries(config.columns.map((c) => [c.name, c]));
+    expect(cols["debt_ids_json"]!.dataType).toBe("string");
+    expect(cols["debt_ids_json"]!.notNull).toBe(true);
+    expect(cols["debt_ids_json"]!.hasDefault).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------
+// Group 4 — time-series
+// ---------------------------------------------------------------------
+
+describe("sqlite/finykNetworthHistory schema snapshot", () => {
+  const config = getTableConfig(finykNetworthHistory);
+
+  it("declares the canonical column shape", () => {
+    expect(config.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "month",
+      "networth",
+      "snapshot_json",
+      "created_at",
+      "updated_at",
+    ]);
+  });
+
+  it("uses (user_id, month) composite PK", () => {
+    expect(config.primaryKeys[0]!.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "month",
+    ]);
+  });
+
+  it("month is TEXT, networth is REAL DEFAULT 0", () => {
+    const cols = Object.fromEntries(config.columns.map((c) => [c.name, c]));
+    expect(cols["month"]!.dataType).toBe("string");
+    expect(cols["networth"]!.dataType).toBe("number");
+    expect(cols["networth"]!.notNull).toBe(true);
+    expect(cols["networth"]!.hasDefault).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------
+// Group 5 — singleton prefs
+// ---------------------------------------------------------------------
+
+describe("sqlite/finykPrefs schema snapshot", () => {
+  const config = getTableConfig(finykPrefs);
+
+  it("declares the canonical singleton column shape", () => {
+    expect(config.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "prefs_json",
+      "monthly_plan_json",
+      "show_balance",
+      "created_at",
+      "updated_at",
+    ]);
+  });
+
+  it("user_id is the primary key", () => {
+    const cols = Object.fromEntries(config.columns.map((c) => [c.name, c]));
+    expect(cols["user_id"]!.primary).toBe(true);
+  });
+
+  it("show_balance is INTEGER (boolean → 0/1) NOT NULL DEFAULT 1", () => {
+    const cols = Object.fromEntries(config.columns.map((c) => [c.name, c]));
+    expect(cols["show_balance"]!.dataType).toBe("number");
+    expect(cols["show_balance"]!.notNull).toBe(true);
+    expect(cols["show_balance"]!.hasDefault).toBe(true);
+  });
+
+  it("prefs_json + monthly_plan_json are TEXT NOT NULL DEFAULT '{}'", () => {
+    const cols = Object.fromEntries(config.columns.map((c) => [c.name, c]));
+    expect(cols["prefs_json"]!.dataType).toBe("string");
+    expect(cols["prefs_json"]!.notNull).toBe(true);
+    expect(cols["prefs_json"]!.hasDefault).toBe(true);
+    expect(cols["monthly_plan_json"]!.dataType).toBe("string");
+    expect(cols["monthly_plan_json"]!.notNull).toBe(true);
+    expect(cols["monthly_plan_json"]!.hasDefault).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------
+// Migrations export contract
+// ---------------------------------------------------------------------
+
+describe("sqlite/finyk migrations exports", () => {
+  it("exports a single 001_finyk_tables.sql migration", () => {
+    expect(FINYK_CLIENT_MIGRATIONS).toHaveLength(1);
+    expect(FINYK_CLIENT_MIGRATIONS[0]!.name).toBe("001_finyk_tables.sql");
+  });
+
+  it("inline SQL contains every finyk_* table CREATE", () => {
+    const sql = FINYK_CLIENT_MIGRATIONS[0]!.sql;
+    for (const table of [
+      "finyk_hidden_accounts",
+      "finyk_hidden_transactions",
+      "finyk_budgets",
+      "finyk_subscriptions",
+      "finyk_assets",
+      "finyk_debts",
+      "finyk_receivables",
+      "finyk_tx_categories",
+      "finyk_tx_splits",
+      "finyk_mono_debt_links",
+      "finyk_networth_history",
+      "finyk_custom_categories",
+      "finyk_manual_expenses",
+      "finyk_tx_filters",
+      "finyk_prefs",
+    ]) {
+      expect(sql).toMatch(new RegExp(`CREATE TABLE IF NOT EXISTS ${table}\\b`));
+    }
+  });
+
+  it("uses a separate `__finyk_migrations` ledger table", () => {
+    expect(FINYK_MIGRATIONS_TABLE).toBe("__finyk_migrations");
+  });
+});

--- a/packages/db-schema/src/pg/finyk.ts
+++ b/packages/db-schema/src/pg/finyk.ts
@@ -1,0 +1,405 @@
+import {
+  boolean,
+  index,
+  jsonb,
+  pgTable,
+  primaryKey,
+  real,
+  text,
+  timestamp,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+
+/**
+ * Postgres Drizzle schemas for the Finyk module's normalized cloud-sync
+ * target tables.
+ *
+ * Stage 4 / PR #035 of `docs/planning/storage-roadmap.md` — mirrors
+ * `apps/server/src/migrations/039_finyk_tables.sql` byte-for-byte
+ * (column ordering, types, defaults, indexes). Snapshot tests under
+ * `packages/db-schema/src/__tests__/pg-finyk-snapshot.test.ts` lock
+ * the shape so accidental drift between this Drizzle schema and the
+ * raw migration trips CI before it lands on main.
+ *
+ * Pattern reuse: the same five table shapes appear across the 15 finyk
+ * tables (per-row+JSONB, composite-PK tombstone, per-tx mapping,
+ * time-series, singleton prefs). See the migration's header comment
+ * for the rationale; each individual table doc-comment below repeats
+ * just enough context to be self-contained.
+ */
+
+// ---------------------------------------------------------------------
+// Composite-PK tombstone tables — hidden_accounts / hidden_transactions
+// ---------------------------------------------------------------------
+
+/**
+ * Per-user set of Mono account ids the user has hidden from the UI.
+ * Composite PK on `(user_id, account_id)`; soft-delete tombstone via
+ * `deleted_at` keeps LWW honest when an "unhide" on device A races a
+ * stale "hide" replay from device B.
+ */
+export const finykHiddenAccounts = pgTable(
+  "finyk_hidden_accounts",
+  {
+    userId: text("user_id").notNull(),
+    accountId: text("account_id").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.accountId] }),
+    index("finyk_hidden_accounts_user_active_idx")
+      .on(table.userId)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+/**
+ * Per-user set of Mono transaction ids hidden from the UI. Same shape
+ * as `finykHiddenAccounts` but keyed on `transaction_id`.
+ */
+export const finykHiddenTransactions = pgTable(
+  "finyk_hidden_transactions",
+  {
+    userId: text("user_id").notNull(),
+    transactionId: text("transaction_id").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.transactionId] }),
+    index("finyk_hidden_transactions_user_active_idx")
+      .on(table.userId)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+// ---------------------------------------------------------------------
+// Per-row + JSONB tables — open-ended user-edited shapes
+// ---------------------------------------------------------------------
+
+/**
+ * Per-row budget entries. `data_json` holds the open-ended `Budget`
+ * shape (categoryId, type, targetAmount, period, …) — UI reads the
+ * whole row at once so column-splitting buys nothing.
+ */
+export const finykBudgets = pgTable(
+  "finyk_budgets",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    userId: text("user_id").notNull(),
+    dataJson: jsonb("data_json").notNull().default({}),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+  },
+  (table) => [
+    index("finyk_budgets_user_active_idx")
+      .on(table.userId, table.deletedAt)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+/** Per-row recurring-payment definitions (`Subscription` shape). */
+export const finykSubscriptions = pgTable(
+  "finyk_subscriptions",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    userId: text("user_id").notNull(),
+    dataJson: jsonb("data_json").notNull().default({}),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+  },
+  (table) => [
+    index("finyk_subscriptions_user_active_idx")
+      .on(table.userId, table.deletedAt)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+/** Per-row manually tracked assets (`ManualAsset` shape). */
+export const finykAssets = pgTable(
+  "finyk_assets",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    userId: text("user_id").notNull(),
+    dataJson: jsonb("data_json").notNull().default({}),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+  },
+  (table) => [
+    index("finyk_assets_user_active_idx")
+      .on(table.userId, table.deletedAt)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+/** Per-row manually tracked debts the user owes (`Debt` shape from `debtEngine`). */
+export const finykDebts = pgTable(
+  "finyk_debts",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    userId: text("user_id").notNull(),
+    dataJson: jsonb("data_json").notNull().default({}),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+  },
+  (table) => [
+    index("finyk_debts_user_active_idx")
+      .on(table.userId, table.deletedAt)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+/** Money owed TO the user (`Receivable` shape). Same DDL as `finykDebts`. */
+export const finykReceivables = pgTable(
+  "finyk_receivables",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    userId: text("user_id").notNull(),
+    dataJson: jsonb("data_json").notNull().default({}),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+  },
+  (table) => [
+    index("finyk_receivables_user_active_idx")
+      .on(table.userId, table.deletedAt)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+/** User-defined transaction categories (label/color/icon/parentId). */
+export const finykCustomCategories = pgTable(
+  "finyk_custom_categories",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    userId: text("user_id").notNull(),
+    dataJson: jsonb("data_json").notNull().default({}),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+  },
+  (table) => [
+    index("finyk_custom_categories_user_active_idx")
+      .on(table.userId, table.deletedAt)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+/** User-entered cash expenses outside Mono (`ManualExpense` shape). */
+export const finykManualExpenses = pgTable(
+  "finyk_manual_expenses",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    userId: text("user_id").notNull(),
+    dataJson: jsonb("data_json").notNull().default({}),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+  },
+  (table) => [
+    index("finyk_manual_expenses_user_active_idx")
+      .on(table.userId, table.deletedAt)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+/** Saved transaction filter presets (date range, accounts, categories). */
+export const finykTxFilters = pgTable(
+  "finyk_tx_filters",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    userId: text("user_id").notNull(),
+    dataJson: jsonb("data_json").notNull().default({}),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+  },
+  (table) => [
+    index("finyk_tx_filters_user_active_idx")
+      .on(table.userId, table.deletedAt)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+// ---------------------------------------------------------------------
+// Per-tx mapping tables — composite-PK on (user_id, transaction_id)
+// ---------------------------------------------------------------------
+
+/**
+ * Per-transaction category override. The LS shape is
+ * `Record<txId, categoryId>` with `undefined` values meaning "fall
+ * back to MCC default". No `deleted_at` — absence of a row is the
+ * "no override" state, so sync `delete` ops just `DELETE FROM`.
+ */
+export const finykTxCategories = pgTable(
+  "finyk_tx_categories",
+  {
+    userId: text("user_id").notNull(),
+    transactionId: text("transaction_id").notNull(),
+    categoryId: text("category_id").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.transactionId] }),
+    index("finyk_tx_categories_user_idx").on(table.userId),
+  ],
+);
+
+/**
+ * Per-transaction split definitions. LS shape is
+ * `Record<txId, TxSplit[]>`; the array goes into `splits_json`.
+ */
+export const finykTxSplits = pgTable(
+  "finyk_tx_splits",
+  {
+    userId: text("user_id").notNull(),
+    transactionId: text("transaction_id").notNull(),
+    splitsJson: jsonb("splits_json").notNull().default([]),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.transactionId] }),
+    index("finyk_tx_splits_user_idx").on(table.userId),
+  ],
+);
+
+/**
+ * Maps Mono transactions to manual debts. LS shape is
+ * `Record<txId, debtId[]>`; `debt_ids_json` is the array of
+ * `finyk_debts.id` strings.
+ */
+export const finykMonoDebtLinks = pgTable(
+  "finyk_mono_debt_links",
+  {
+    userId: text("user_id").notNull(),
+    transactionId: text("transaction_id").notNull(),
+    debtIdsJson: jsonb("debt_ids_json").notNull().default([]),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.transactionId] }),
+    index("finyk_mono_debt_links_user_idx").on(table.userId),
+  ],
+);
+
+// ---------------------------------------------------------------------
+// Time-series — networth_history (one row per (user, month))
+// ---------------------------------------------------------------------
+
+/**
+ * Monthly net-worth snapshots. `month` stays TEXT (`YYYY-MM`) so LWW
+ * comparisons / API round-trips match the LS `NetworthEntry` shape
+ * byte-for-byte. `snapshot_json` reserves space for richer per-month
+ * payloads (per-asset breakdowns, FX rate at snapshot time) without a
+ * follow-up migration.
+ */
+export const finykNetworthHistory = pgTable(
+  "finyk_networth_history",
+  {
+    userId: text("user_id").notNull(),
+    month: text().notNull(),
+    networth: real().notNull().default(0),
+    snapshotJson: jsonb("snapshot_json").notNull().default({}),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.month] }),
+    index("finyk_networth_history_user_month_idx").on(
+      table.userId,
+      sql`${table.month} DESC`,
+    ),
+  ],
+);
+
+// ---------------------------------------------------------------------
+// Singleton prefs — one row per user
+// ---------------------------------------------------------------------
+
+/**
+ * Per-user singleton row of finyk preferences. `monthly_plan_json`
+ * carries `MonthlyPlan` (income/expense/savings — kept as the original
+ * LS string-or-number shape). `show_balance` is split out of the
+ * open-ended `prefs_json` so multi-device LWW on the
+ * balance-visibility toggle doesn't have to merge the JSONB. `user_id`
+ * is the PK — exactly one row per user.
+ */
+export const finykPrefs = pgTable("finyk_prefs", {
+  userId: text("user_id").primaryKey(),
+  prefsJson: jsonb("prefs_json").notNull().default({}),
+  monthlyPlanJson: jsonb("monthly_plan_json").notNull().default({}),
+  showBalance: boolean("show_balance").notNull().default(true),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});

--- a/packages/db-schema/src/pg/index.ts
+++ b/packages/db-schema/src/pg/index.ts
@@ -19,3 +19,20 @@ export {
   nutritionPrefs,
   nutritionRecipes,
 } from "./nutrition.js";
+export {
+  finykHiddenAccounts,
+  finykHiddenTransactions,
+  finykBudgets,
+  finykSubscriptions,
+  finykAssets,
+  finykDebts,
+  finykReceivables,
+  finykCustomCategories,
+  finykManualExpenses,
+  finykTxFilters,
+  finykTxCategories,
+  finykTxSplits,
+  finykMonoDebtLinks,
+  finykNetworthHistory,
+  finykPrefs,
+} from "./finyk.js";

--- a/packages/db-schema/src/sqlite/finyk.ts
+++ b/packages/db-schema/src/sqlite/finyk.ts
@@ -1,0 +1,354 @@
+import {
+  index,
+  integer,
+  primaryKey,
+  real,
+  sqliteTable,
+  text,
+} from "drizzle-orm/sqlite-core";
+import { sql } from "drizzle-orm";
+
+/**
+ * SQLite Drizzle schemas for the Finyk module's normalized tables.
+ *
+ * Mirrors the Postgres counterpart at `packages/db-schema/src/pg/finyk.ts`
+ * (which itself mirrors `apps/server/src/migrations/039_finyk_tables.sql`).
+ * Hosts finyk state on SQLite for both web (sqlite-wasm via OPFS-SAH) and
+ * mobile (`expo-sqlite`).
+ *
+ * Stage 4 / PR #035 of `docs/planning/storage-roadmap.md`.
+ *
+ * Differences from Postgres (same as nutrition / fizruk SQLite mirrors):
+ * - `id` is TEXT (UUID stored as a string — SQLite has no native UUID).
+ *   Generation is the client's responsibility (`crypto.randomUUID()`).
+ * - All TIMESTAMPTZ columns are TEXT (ISO-8601 with offset).
+ * - JSONB → TEXT (JSON stored as string in SQLite).
+ * - BOOLEAN → INTEGER (`0` / `1`) — SQLite has no native boolean.
+ * - REAL stays REAL (SQLite stores as 8-byte float; matches Postgres `real`).
+ * - No FK to `"user"(id)` — the client SQLite database has no auth tables.
+ * - Index names are `_lite`-suffixed to spot drift between server and
+ *   client at code-review time.
+ */
+
+// ---------------------------------------------------------------------
+// Composite-PK tombstone tables
+// ---------------------------------------------------------------------
+
+export const finykHiddenAccounts = sqliteTable(
+  "finyk_hidden_accounts",
+  {
+    userId: text("user_id").notNull(),
+    accountId: text("account_id").notNull(),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    deletedAt: text("deleted_at"),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.accountId] }),
+    index("finyk_hidden_accounts_user_active_idx_lite")
+      .on(table.userId)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+export const finykHiddenTransactions = sqliteTable(
+  "finyk_hidden_transactions",
+  {
+    userId: text("user_id").notNull(),
+    transactionId: text("transaction_id").notNull(),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    deletedAt: text("deleted_at"),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.transactionId] }),
+    index("finyk_hidden_transactions_user_active_idx_lite")
+      .on(table.userId)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+// ---------------------------------------------------------------------
+// Per-row + JSONB tables
+// ---------------------------------------------------------------------
+
+export const finykBudgets = sqliteTable(
+  "finyk_budgets",
+  {
+    id: text().primaryKey(),
+    userId: text("user_id").notNull(),
+    dataJson: text("data_json").notNull().default("{}"),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    deletedAt: text("deleted_at"),
+  },
+  (table) => [
+    index("finyk_budgets_user_active_idx_lite")
+      .on(table.userId, table.deletedAt)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+export const finykSubscriptions = sqliteTable(
+  "finyk_subscriptions",
+  {
+    id: text().primaryKey(),
+    userId: text("user_id").notNull(),
+    dataJson: text("data_json").notNull().default("{}"),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    deletedAt: text("deleted_at"),
+  },
+  (table) => [
+    index("finyk_subscriptions_user_active_idx_lite")
+      .on(table.userId, table.deletedAt)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+export const finykAssets = sqliteTable(
+  "finyk_assets",
+  {
+    id: text().primaryKey(),
+    userId: text("user_id").notNull(),
+    dataJson: text("data_json").notNull().default("{}"),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    deletedAt: text("deleted_at"),
+  },
+  (table) => [
+    index("finyk_assets_user_active_idx_lite")
+      .on(table.userId, table.deletedAt)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+export const finykDebts = sqliteTable(
+  "finyk_debts",
+  {
+    id: text().primaryKey(),
+    userId: text("user_id").notNull(),
+    dataJson: text("data_json").notNull().default("{}"),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    deletedAt: text("deleted_at"),
+  },
+  (table) => [
+    index("finyk_debts_user_active_idx_lite")
+      .on(table.userId, table.deletedAt)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+export const finykReceivables = sqliteTable(
+  "finyk_receivables",
+  {
+    id: text().primaryKey(),
+    userId: text("user_id").notNull(),
+    dataJson: text("data_json").notNull().default("{}"),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    deletedAt: text("deleted_at"),
+  },
+  (table) => [
+    index("finyk_receivables_user_active_idx_lite")
+      .on(table.userId, table.deletedAt)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+export const finykCustomCategories = sqliteTable(
+  "finyk_custom_categories",
+  {
+    id: text().primaryKey(),
+    userId: text("user_id").notNull(),
+    dataJson: text("data_json").notNull().default("{}"),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    deletedAt: text("deleted_at"),
+  },
+  (table) => [
+    index("finyk_custom_categories_user_active_idx_lite")
+      .on(table.userId, table.deletedAt)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+export const finykManualExpenses = sqliteTable(
+  "finyk_manual_expenses",
+  {
+    id: text().primaryKey(),
+    userId: text("user_id").notNull(),
+    dataJson: text("data_json").notNull().default("{}"),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    deletedAt: text("deleted_at"),
+  },
+  (table) => [
+    index("finyk_manual_expenses_user_active_idx_lite")
+      .on(table.userId, table.deletedAt)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+export const finykTxFilters = sqliteTable(
+  "finyk_tx_filters",
+  {
+    id: text().primaryKey(),
+    userId: text("user_id").notNull(),
+    dataJson: text("data_json").notNull().default("{}"),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    deletedAt: text("deleted_at"),
+  },
+  (table) => [
+    index("finyk_tx_filters_user_active_idx_lite")
+      .on(table.userId, table.deletedAt)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+// ---------------------------------------------------------------------
+// Per-tx mapping tables
+// ---------------------------------------------------------------------
+
+export const finykTxCategories = sqliteTable(
+  "finyk_tx_categories",
+  {
+    userId: text("user_id").notNull(),
+    transactionId: text("transaction_id").notNull(),
+    categoryId: text("category_id").notNull(),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.transactionId] }),
+    index("finyk_tx_categories_user_idx_lite").on(table.userId),
+  ],
+);
+
+export const finykTxSplits = sqliteTable(
+  "finyk_tx_splits",
+  {
+    userId: text("user_id").notNull(),
+    transactionId: text("transaction_id").notNull(),
+    splitsJson: text("splits_json").notNull().default("[]"),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.transactionId] }),
+    index("finyk_tx_splits_user_idx_lite").on(table.userId),
+  ],
+);
+
+export const finykMonoDebtLinks = sqliteTable(
+  "finyk_mono_debt_links",
+  {
+    userId: text("user_id").notNull(),
+    transactionId: text("transaction_id").notNull(),
+    debtIdsJson: text("debt_ids_json").notNull().default("[]"),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.transactionId] }),
+    index("finyk_mono_debt_links_user_idx_lite").on(table.userId),
+  ],
+);
+
+// ---------------------------------------------------------------------
+// Time-series — networth_history
+// ---------------------------------------------------------------------
+
+export const finykNetworthHistory = sqliteTable(
+  "finyk_networth_history",
+  {
+    userId: text("user_id").notNull(),
+    month: text().notNull(),
+    networth: real().notNull().default(0),
+    snapshotJson: text("snapshot_json").notNull().default("{}"),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.month] }),
+    index("finyk_networth_history_user_month_idx_lite").on(
+      table.userId,
+      sql`${table.month} DESC`,
+    ),
+  ],
+);
+
+// ---------------------------------------------------------------------
+// Singleton prefs
+// ---------------------------------------------------------------------
+
+export const finykPrefs = sqliteTable("finyk_prefs", {
+  userId: text("user_id").primaryKey(),
+  prefsJson: text("prefs_json").notNull().default("{}"),
+  monthlyPlanJson: text("monthly_plan_json").notNull().default("{}"),
+  showBalance: integer("show_balance").notNull().default(1),
+  createdAt: text("created_at")
+    .notNull()
+    .default(sql`(datetime('now'))`),
+  updatedAt: text("updated_at")
+    .notNull()
+    .default(sql`(datetime('now'))`),
+});

--- a/packages/db-schema/src/sqlite/index.ts
+++ b/packages/db-schema/src/sqlite/index.ts
@@ -22,6 +22,8 @@ export {
   FIZRUK_MIGRATIONS_TABLE,
   NUTRITION_CLIENT_MIGRATIONS,
   NUTRITION_MIGRATIONS_TABLE,
+  FINYK_CLIENT_MIGRATIONS,
+  FINYK_MIGRATIONS_TABLE,
 } from "./migrations/index.js";
 export {
   fizrukWorkouts,
@@ -37,3 +39,20 @@ export {
   nutritionPrefs,
   nutritionRecipes,
 } from "./nutrition.js";
+export {
+  finykHiddenAccounts,
+  finykHiddenTransactions,
+  finykBudgets,
+  finykSubscriptions,
+  finykAssets,
+  finykDebts,
+  finykReceivables,
+  finykCustomCategories,
+  finykManualExpenses,
+  finykTxFilters,
+  finykTxCategories,
+  finykTxSplits,
+  finykMonoDebtLinks,
+  finykNetworthHistory,
+  finykPrefs,
+} from "./finyk.js";

--- a/packages/db-schema/src/sqlite/migrations/index.ts
+++ b/packages/db-schema/src/sqlite/migrations/index.ts
@@ -369,3 +369,220 @@ export const NUTRITION_CLIENT_MIGRATIONS: readonly MigrationFile[] = [
  * (fizruk) so the three modules' migration histories don't collide.
  */
 export const NUTRITION_MIGRATIONS_TABLE = "__nutrition_migrations";
+
+// ---------------------------------------------------------------------------
+// Finyk module — Stage 4 / PR #035
+// ---------------------------------------------------------------------------
+
+const FINYK_001_SQL = `
+CREATE TABLE IF NOT EXISTS finyk_hidden_accounts (
+  user_id     TEXT NOT NULL,
+  account_id  TEXT NOT NULL,
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  deleted_at  TEXT,
+  PRIMARY KEY (user_id, account_id)
+);
+
+CREATE INDEX IF NOT EXISTS finyk_hidden_accounts_user_active_idx_lite
+  ON finyk_hidden_accounts (user_id)
+  WHERE deleted_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS finyk_hidden_transactions (
+  user_id        TEXT NOT NULL,
+  transaction_id TEXT NOT NULL,
+  created_at     TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at     TEXT NOT NULL DEFAULT (datetime('now')),
+  deleted_at     TEXT,
+  PRIMARY KEY (user_id, transaction_id)
+);
+
+CREATE INDEX IF NOT EXISTS finyk_hidden_transactions_user_active_idx_lite
+  ON finyk_hidden_transactions (user_id)
+  WHERE deleted_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS finyk_budgets (
+  id          TEXT PRIMARY KEY,
+  user_id     TEXT NOT NULL,
+  data_json   TEXT NOT NULL DEFAULT '{}',
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  deleted_at  TEXT
+);
+
+CREATE INDEX IF NOT EXISTS finyk_budgets_user_active_idx_lite
+  ON finyk_budgets (user_id, deleted_at)
+  WHERE deleted_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS finyk_subscriptions (
+  id          TEXT PRIMARY KEY,
+  user_id     TEXT NOT NULL,
+  data_json   TEXT NOT NULL DEFAULT '{}',
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  deleted_at  TEXT
+);
+
+CREATE INDEX IF NOT EXISTS finyk_subscriptions_user_active_idx_lite
+  ON finyk_subscriptions (user_id, deleted_at)
+  WHERE deleted_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS finyk_assets (
+  id          TEXT PRIMARY KEY,
+  user_id     TEXT NOT NULL,
+  data_json   TEXT NOT NULL DEFAULT '{}',
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  deleted_at  TEXT
+);
+
+CREATE INDEX IF NOT EXISTS finyk_assets_user_active_idx_lite
+  ON finyk_assets (user_id, deleted_at)
+  WHERE deleted_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS finyk_debts (
+  id          TEXT PRIMARY KEY,
+  user_id     TEXT NOT NULL,
+  data_json   TEXT NOT NULL DEFAULT '{}',
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  deleted_at  TEXT
+);
+
+CREATE INDEX IF NOT EXISTS finyk_debts_user_active_idx_lite
+  ON finyk_debts (user_id, deleted_at)
+  WHERE deleted_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS finyk_receivables (
+  id          TEXT PRIMARY KEY,
+  user_id     TEXT NOT NULL,
+  data_json   TEXT NOT NULL DEFAULT '{}',
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  deleted_at  TEXT
+);
+
+CREATE INDEX IF NOT EXISTS finyk_receivables_user_active_idx_lite
+  ON finyk_receivables (user_id, deleted_at)
+  WHERE deleted_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS finyk_tx_categories (
+  user_id        TEXT NOT NULL,
+  transaction_id TEXT NOT NULL,
+  category_id    TEXT NOT NULL,
+  created_at     TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at     TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (user_id, transaction_id)
+);
+
+CREATE INDEX IF NOT EXISTS finyk_tx_categories_user_idx_lite
+  ON finyk_tx_categories (user_id);
+
+CREATE TABLE IF NOT EXISTS finyk_tx_splits (
+  user_id        TEXT NOT NULL,
+  transaction_id TEXT NOT NULL,
+  splits_json    TEXT NOT NULL DEFAULT '[]',
+  created_at     TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at     TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (user_id, transaction_id)
+);
+
+CREATE INDEX IF NOT EXISTS finyk_tx_splits_user_idx_lite
+  ON finyk_tx_splits (user_id);
+
+CREATE TABLE IF NOT EXISTS finyk_mono_debt_links (
+  user_id        TEXT NOT NULL,
+  transaction_id TEXT NOT NULL,
+  debt_ids_json  TEXT NOT NULL DEFAULT '[]',
+  created_at     TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at     TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (user_id, transaction_id)
+);
+
+CREATE INDEX IF NOT EXISTS finyk_mono_debt_links_user_idx_lite
+  ON finyk_mono_debt_links (user_id);
+
+CREATE TABLE IF NOT EXISTS finyk_networth_history (
+  user_id        TEXT NOT NULL,
+  month          TEXT NOT NULL,
+  networth       REAL NOT NULL DEFAULT 0,
+  snapshot_json  TEXT NOT NULL DEFAULT '{}',
+  created_at     TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at     TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (user_id, month)
+);
+
+CREATE INDEX IF NOT EXISTS finyk_networth_history_user_month_idx_lite
+  ON finyk_networth_history (user_id, month DESC);
+
+CREATE TABLE IF NOT EXISTS finyk_custom_categories (
+  id          TEXT PRIMARY KEY,
+  user_id     TEXT NOT NULL,
+  data_json   TEXT NOT NULL DEFAULT '{}',
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  deleted_at  TEXT
+);
+
+CREATE INDEX IF NOT EXISTS finyk_custom_categories_user_active_idx_lite
+  ON finyk_custom_categories (user_id, deleted_at)
+  WHERE deleted_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS finyk_manual_expenses (
+  id          TEXT PRIMARY KEY,
+  user_id     TEXT NOT NULL,
+  data_json   TEXT NOT NULL DEFAULT '{}',
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  deleted_at  TEXT
+);
+
+CREATE INDEX IF NOT EXISTS finyk_manual_expenses_user_active_idx_lite
+  ON finyk_manual_expenses (user_id, deleted_at)
+  WHERE deleted_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS finyk_tx_filters (
+  id          TEXT PRIMARY KEY,
+  user_id     TEXT NOT NULL,
+  data_json   TEXT NOT NULL DEFAULT '{}',
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  deleted_at  TEXT
+);
+
+CREATE INDEX IF NOT EXISTS finyk_tx_filters_user_active_idx_lite
+  ON finyk_tx_filters (user_id, deleted_at)
+  WHERE deleted_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS finyk_prefs (
+  user_id            TEXT PRIMARY KEY,
+  prefs_json         TEXT NOT NULL DEFAULT '{}',
+  monthly_plan_json  TEXT NOT NULL DEFAULT '{}',
+  show_balance       INTEGER NOT NULL DEFAULT 1,
+  created_at         TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at         TEXT NOT NULL DEFAULT (datetime('now'))
+);
+`;
+
+/**
+ * Ordered list of bundled client migrations for the Finyk module on
+ * SQLite. Pass this directly to `runMigrations` from
+ * `@sergeant/db-schema/migrate`.
+ *
+ * The Finyk module uses a separate ledger table
+ * (`__finyk_migrations`) so that routine, fizruk, nutrition, and
+ * finyk migrations are independent — each module can be migrated,
+ * rolled out, and rolled back without affecting the others. Same
+ * rationale as nutrition's split from fizruk in PR #031.
+ */
+export const FINYK_CLIENT_MIGRATIONS: readonly MigrationFile[] = [
+  { name: "001_finyk_tables.sql", sql: FINYK_001_SQL },
+] as const;
+
+/**
+ * Stable ledger table name used by the Finyk SQLite module.
+ * Separate from `__migrations` (routine), `__fizruk_migrations`
+ * (fizruk), and `__nutrition_migrations` (nutrition) so all four
+ * modules' migration histories stay independent.
+ */
+export const FINYK_MIGRATIONS_TABLE = "__finyk_migrations";


### PR DESCRIPTION
## Summary

Stage 4 / PR #035 from `docs/planning/storage-roadmap.md` — schema-only landing of the Finyk normalized storage tables and their server-side apply-fns. Mirrors the nutrition rollout (PR #031). Default-off: nothing reads or writes these tables until PR #036 ships dual-write behind `feature.finyk.sqlite_v2.dual_write`.

What lands:

- **Migration `039_finyk_tables.sql` + `.down.sql`** — 15 tables across 5 shape patterns:
  - composite-PK tombstone — `finyk_hidden_accounts`, `finyk_hidden_transactions`
  - per-row + JSONB blob — `finyk_budgets`, `finyk_subscriptions`, `finyk_assets`, `finyk_debts`, `finyk_receivables`, `finyk_custom_categories`, `finyk_manual_expenses`, `finyk_tx_filters`
  - per-tx mapping — `finyk_tx_categories`, `finyk_tx_splits`, `finyk_mono_debt_links`
  - time-series — `finyk_networth_history` (month TEXT YYYY-MM)
  - singleton prefs — `finyk_prefs` (PK = `user_id`; absorbs `FINYK_MONTHLY_PLAN` + `FINYK_SHOW_BALANCE`)
- **Drizzle schemas** mirroring the migration verbatim: `packages/db-schema/src/pg/finyk.ts` and `packages/db-schema/src/sqlite/finyk.ts`. Snapshot tests in `packages/db-schema/src/__tests__/{pg,sqlite}-finyk-snapshot.test.ts` guard PG↔SQLite drift and shape patterns.
- **`FINYK_001_SQL` + `FINYK_CLIENT_MIGRATIONS` + `FINYK_MIGRATIONS_TABLE`** in `packages/db-schema/src/sqlite/migrations/index.ts` — own ledger `__finyk_migrations`, separate from routine/fizruk/nutrition.
- **`apps/{web,mobile}/src/modules/finyk/lib/clientMigrate.ts`** — callable seam wired up by PR #036's boot hook.
- **15 split apply-fns** added to `OP_LOG_TABLE_REGISTRY` in `apps/server/src/modules/sync/syncV2.ts`. Implementation uses three reusable helpers (`applyFinykTombstone`, `applyFinykPerRowBlob`, `applyFinykPerTxJsonbArray`) plus four bespoke ones (`applyFinykTxCategories`, `applyFinykNetworthHistory`, `applyFinykPrefs`). LWW guard, soft-delete semantics, `user_id` ownership and FK validation match nutrition's template.
- **Migration round-trip test** `apps/server/src/migrations/__tests__/039-finyk-tables.test.ts` — forward → down → re-up restores a byte-identical schema fingerprint; down-script idempotency asserted explicitly.
- **Integration tests** in `apps/server/src/modules/sync/syncV2.integration.test.ts` cover one shape per pattern: composite-PK tombstone, per-row blob LWW, per-tx hard `DELETE`, time-series month TEXT validation, singleton prefs delete-rejected.

## Governing Skill

- Primary skill: `sergeant-data-and-migrations`
- Secondary skill (if truly needed): `sergeant-server-api`

## Playbook

- Primary playbook: pattern from nutrition Stage 4 PR #031 (`feat(migrations): add Nutrition Drizzle schema + SQLite migration`) — same shape: migration + Drizzle pair + snapshot tests + apply-fns + integration tests.
- Why this playbook: it's the canonical Stage-4-per-module recipe documented in `docs/planning/storage-roadmap.md` and already followed by routine, fizruk and nutrition. Finyk extends it with two extra shape patterns (per-tx mapping + time-series) but the workflow is identical.
- If no playbook matched, why: n/a — followed nutrition's recipe.

## Verification

```bash
pnpm --filter @sergeant/db-schema test       # 247 tests pass (incl. 50+ new finyk snapshot assertions)
pnpm --filter @sergeant/server test src/modules/sync   # 86 tests pass (Docker-gated integration tests skip locally)
pnpm --filter @sergeant/server lint
pnpm --filter @sergeant/db-schema lint
pnpm --filter @sergeant/db-schema build
```

Pre-existing typecheck errors on `main` (`apps/server/src/modules/mono/rotateSecret.test.ts`, `apps/web/src/sync/__tests__/useSyncedStorage.test.tsx`, `apps/mobile/src/shared/lib/modules/hubNav.test.ts`) reproduce identically off this branch — out of scope for this PR.

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- `docs/planning/storage-roadmap.md` — will move PR #035 to LANDED and PR #036 to IN PROGRESS as part of PR #036 (paired update so the doc and the dual-write code land together).

## Risk and Rollout

- **User-visible risk:** none. New tables are unused. No code path reads or writes them until PR #036 lands and a dual-write feature flag is flipped.
- **Rollout / deploy order:** Railway pre-deploy applies `039_finyk_tables.sql` before the new server boots; old server keeps running with the old code path. Tables sit empty until PR #036 starts dual-writing.
- **Backout plan:** revert this PR; run `039_finyk_tables.down.sql` locally to drop everything (production never runs `down.sql` per AGENTS rule #4 — but an explicit `040_drop_finyk_tables.sql` would be the forward-only rollback).

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

- **Migration numbering.** `039_` is sequential — `038_rename_035_rate_limit_buckets.sql` was the last on `main`.
- **No `bigint` columns.** All numeric finyk fields use `REAL` / `INTEGER`. Rule #1 doesn't apply, but it stays in mind for future Mono columns where amount-in-minor will land as `BIGINT` — the Stage 4 cut-over PR (#037 read overlay) is when serializers are introduced.
- **`finyk_networth_history.month` is `TEXT`** (not `DATE`) intentionally — keeps verbatim parity with the LS-stored `YYYY-MM` strings the client already produces. The apply-fn validates the format with a regex.
- **`finyk_prefs` as singleton** — same shape as `nutrition_prefs`. Delete is rejected by design; any client-side "reset" goes through an upsert with empty JSON.
- **No new `STORAGE_KEYS` ESLint guard.** That's PR #039's scope.

Stack: PR #036 (dual-write web + mobile) is the immediate follow-up.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce the Finyk normalized storage schema (15 tables on Postgres and SQLite) plus server-side apply functions and the client migration seam. Default-off; no Finyk reads/writes until PR #036 enables dual-write behind a feature flag.

- **New Features**
  - Added `039_finyk_tables.sql` (+ `.down.sql`) defining 5 table patterns: composite-PK tombstones, per-row JSON blob, per-transaction mappings, time-series, and singleton prefs.
  - Added Drizzle schemas for PG and SQLite in `packages/db-schema/src/{pg,sqlite}/finyk.ts` with snapshot tests to prevent PG↔SQLite drift.
  - Introduced Finyk SQLite client migrations: `FINYK_CLIENT_MIGRATIONS` and `FINYK_MIGRATIONS_TABLE` in `@sergeant/db-schema/sqlite/migrations`, with `migrateFinyk` seams for web and mobile.
  - Registered 15 apply-fns in `apps/server/src/modules/sync/syncV2.ts`, using reusable helpers and guards (LWW, soft-delete, `user_id` ownership).

- **Migration**
  - Added forward/down round-trip test for migration 039; down script is idempotent.
  - Extended `syncV2` integration tests to cover each table pattern and key validations.
  - Safe rollout: Railway applies the migration before boot; dual-write is gated by `feature.finyk.sqlite_v2.dual_write` in PR #036.

<sup>Written for commit 7fa8e9f29f96e500c515e370e1db32e1bd2345b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Finyk financial management data infrastructure across server and client platforms.
  * Introduced database synchronization support for Finyk data across multiple devices and platforms.
  * Implemented automated migration tooling to manage Finyk schema updates on both server and client databases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->