### PR TITLE
feat(server): session fingerprint + revoke-on-password-change (h3)

### DIFF
--- a/apps/server/src/auth.test.ts
+++ b/apps/server/src/auth.test.ts
@@ -273,4 +273,135 @@ describe("auth config — bearer plugin інтегрований у Better Auth"
       expect(result.data.image).toBe(url);
     }
   });
+
+  /**
+   * H3 — `databaseHooks.session.create.before` ріже `ipAddress` до /24
+   * (IPv4) або /64 (IPv6) prefix-а. Без цього в `session.ipAddress` лежить
+   * повний IP, який для нас не несе додаткової інформації, але є PII у
+   * 30-денному запису. Закриває
+   * `docs/security/hardening/H3-session-revoke-and-binding.md`.
+   */
+  it("H3: databaseHooks.session.create.before truncates ipAddress to /24 (IPv4)", async () => {
+    const before = (
+      auth as unknown as {
+        options: {
+          databaseHooks?: {
+            session?: {
+              create?: {
+                before?: (
+                  data: Record<string, unknown>,
+                ) => Promise<{ data: Record<string, unknown> } | false | void>;
+              };
+            };
+          };
+        };
+      }
+    ).options.databaseHooks?.session?.create?.before;
+    expect(typeof before).toBe("function");
+    const result = await before!({
+      id: "s-1",
+      userId: "u-1",
+      token: "t-1",
+      ipAddress: "203.0.113.42",
+      userAgent: "Mozilla/5.0",
+    });
+    expect(result).toBeTruthy();
+    if (result && typeof result === "object" && "data" in result) {
+      expect(result.data.ipAddress).toBe("203.0.113.0/24");
+      // userAgent зберігаємо повністю — він не PII у тому ж сенсі, що IP,
+      // і потрібен буквально для UA-drift detection.
+      expect(result.data.userAgent).toBe("Mozilla/5.0");
+    }
+  });
+
+  it("H3: databaseHooks.session.create.before truncates ipAddress to /64 (IPv6)", async () => {
+    const before = (
+      auth as unknown as {
+        options: {
+          databaseHooks?: {
+            session?: {
+              create?: {
+                before?: (
+                  data: Record<string, unknown>,
+                ) => Promise<{ data: Record<string, unknown> } | false | void>;
+              };
+            };
+          };
+        };
+      }
+    ).options.databaseHooks?.session?.create?.before;
+    const result = await before!({
+      id: "s-1",
+      userId: "u-1",
+      token: "t-1",
+      ipAddress: "2001:db8::1",
+    });
+    expect(result).toBeTruthy();
+    if (result && typeof result === "object" && "data" in result) {
+      expect(result.data.ipAddress).toBe("2001:db8:0:0::/64");
+    }
+  });
+
+  it("H3: databaseHooks.session.create.before — no-op коли ipAddress вже prefix", async () => {
+    const before = (
+      auth as unknown as {
+        options: {
+          databaseHooks?: {
+            session?: {
+              create?: {
+                before?: (
+                  data: Record<string, unknown>,
+                ) => Promise<{ data: Record<string, unknown> } | false | void>;
+              };
+            };
+          };
+        };
+      }
+    ).options.databaseHooks?.session?.create?.before;
+    // Якщо повторно прогнати ту ж сесію (наприклад через update path, що
+    // інколи зачитує дані назад), не повинно бути розширення/пере-обрізки.
+    // Наша імплементація повертає `void` коли значення вже у фінальному
+    // вигляді — Better Auth тоді залишає payload як є.
+    const result = await before!({
+      id: "s-1",
+      userId: "u-1",
+      token: "t-1",
+      ipAddress: "203.0.113.0/24",
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("H3: hooks.before примусово додає revokeOtherSessions=true для /change-password", async () => {
+    const before = (
+      auth as unknown as {
+        options: { hooks?: { before?: unknown } };
+      }
+    ).options.hooks?.before;
+    expect(typeof before).toBe("function");
+    // Better Auth-міддлвара очікує MiddlewareInputContext. Передаємо
+    // мінімальну форму, яку наш handler читає (`path`, `body`).
+    const ctx = {
+      path: "/change-password",
+      body: { newPassword: "n", currentPassword: "c" } as Record<
+        string,
+        unknown
+      >,
+    };
+    await (before as (input: unknown) => Promise<unknown>)(ctx);
+    expect(ctx.body.revokeOtherSessions).toBe(true);
+  });
+
+  it("H3: hooks.before не чіпає інші endpoint-и", async () => {
+    const before = (
+      auth as unknown as {
+        options: { hooks?: { before?: unknown } };
+      }
+    ).options.hooks?.before;
+    const ctx = {
+      path: "/sign-in/email",
+      body: { email: "x@y.z", password: "p" } as Record<string, unknown>,
+    };
+    await (before as (input: unknown) => Promise<unknown>)(ctx);
+    expect(ctx.body.revokeOtherSessions).toBeUndefined();
+  });
 });

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 
 import { betterAuth } from "better-auth";
+import { createAuthMiddleware } from "better-auth/api";
 import { fromNodeHeaders } from "better-auth/node";
 import { bearer } from "better-auth/plugins";
 import { expo } from "@better-auth/expo";
@@ -10,6 +11,7 @@ import { createEncryptingAdapter } from "./auth/encryptingAdapter.js";
 import { drizzleAdapter } from "@better-auth/drizzle-adapter";
 import { db } from "./drizzle.js";
 import { sanitizeUserImage } from "./auth/sanitizeUserImage.js";
+import { detectFingerprintDrift, ipPrefix } from "./auth/sessionFingerprint.js";
 import { queueAuthTransactionalEmail } from "./email/authTransactionalMail.js";
 import { logger } from "./obs/logger.js";
 import {
@@ -244,6 +246,56 @@ export const auth = betterAuth({
         },
       },
     },
+    /**
+     * H3 — `databaseHooks.session.create.before` truncates `ipAddress` до
+     * privacy-friendly prefix (`/24` для IPv4, `/64` для IPv6) ДО запису у
+     * `session.ipAddress`. На цей момент Better Auth уже резолвив реальний
+     * client-IP з reverse-proxy ланцюга (з урахуванням `app.set('trust
+     * proxy', …)` на нашому Express), тож ми йдемо «вниз» по точності з
+     * максимальної до достатньої для drift-detection (24/64 біти ASN/підмережі).
+     *
+     * Чому prefix замість повного IP. Повний IP у `session` — це
+     * персональні дані (GDPR Art. 4(1)), що зберігаються 30 днів. Ми це
+     * не використовуємо ніде, окрім fingerprint-порівняння у
+     * `requireSession`, яке і так оперує prefix-ом. Звуження до /24 / /64
+     * виключає сесію як storage-layer для повних IP, не псуючи функціонал.
+     *
+     * Закриває: `docs/security/hardening/H3-session-revoke-and-binding.md`.
+     */
+    session: {
+      create: {
+        before: async (data) => {
+          if (!data.ipAddress) return;
+          const truncated = ipPrefix(data.ipAddress);
+          if (truncated && truncated !== data.ipAddress) {
+            return { data: { ...data, ipAddress: truncated } };
+          }
+        },
+      },
+    },
+  },
+  /**
+   * H3 — глобальний `hooks.before` забезпечує, що будь-який successful
+   * `POST /api/auth/change-password` ВЖЕ revoke-ає інші сесії того ж юзера,
+   * навіть якщо клієнт випадково забув передати `revokeOtherSessions: true`
+   * у тілі. Defense-in-depth: один скомпрометований cookie перестає бути
+   * валідним рівно у момент зміни пароля, не чекаючи 30-денного TTL.
+   *
+   * Реалізація мінімальна — тільки мутуємо `ctx.body`, нічого не запускаємо
+   * самостійно. Better Auth далі сам викликає вбудований
+   * `revokeOtherSessions` flow (див. `change-password` endpoint у
+   * `node_modules/better-auth/dist/api/routes/update-user.mjs`).
+   *
+   * Закриває: `docs/security/hardening/H3-session-revoke-and-binding.md`.
+   */
+  hooks: {
+    before: createAuthMiddleware(async (ctx) => {
+      if (ctx.path !== "/change-password") return;
+      const body = ctx.body;
+      if (body && typeof body === "object" && !Array.isArray(body)) {
+        (body as Record<string, unknown>).revokeOtherSessions = true;
+      }
+    }),
   },
   trustedOrigins: getTrustedOrigins(),
   /**
@@ -345,6 +397,43 @@ export async function getSessionUser(
     const user = (session?.user ?? null) as SessionUser | null;
     if (user?.id) {
       outcome = "hit";
+      // H3 — порівнюємо stored fingerprint (UA + IP-prefix) з поточним
+      // запитом. На drift кидаємо warn-лог `auth.session.ua_drift` —
+      // Sentry/Datadog alert-rule вже може на нього реагувати. Сесію не
+      // викидаємо: drift сам по собі не доказ компромісу (юзер міг
+      // переключити мережу / оновити браузер), але patterns у логах
+      // дають фундамент для майбутнього step-up flow для high-risk
+      // операцій (Mono connect, password change).
+      const stored = (session?.session ?? null) as {
+        id?: string;
+        ipAddress?: string | null;
+        userAgent?: string | null;
+      } | null;
+      if (stored) {
+        const drift = detectFingerprintDrift({
+          storedUserAgent: stored.userAgent ?? null,
+          storedIp: stored.ipAddress ?? null,
+          currentUserAgent:
+            typeof req.headers["user-agent"] === "string"
+              ? req.headers["user-agent"]
+              : null,
+          currentIp: typeof req.ip === "string" ? req.ip : null,
+        });
+        if (drift) {
+          logger.warn(
+            {
+              event: "auth.session.ua_drift",
+              session_id: stored.id,
+              user_id: user.id,
+              ua_changed: drift.ua,
+              ip_changed: drift.ip,
+              stored_ip_prefix: drift.storedIpPrefix,
+              current_ip_prefix: drift.currentIpPrefix,
+            },
+            "session fingerprint drift detected",
+          );
+        }
+      }
       // Ліниво прив'язуємо сесію до request-context і Sentry-scope. Завдяки
       // цьому будь-який log/Sentry-івент далі в ланцюжку знає, хто саме
       // виконує запит. Безпечно без сесії — просто no-op.

--- a/apps/server/src/auth/sessionFingerprint.test.ts
+++ b/apps/server/src/auth/sessionFingerprint.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+
+import { ipPrefix, detectFingerprintDrift } from "./sessionFingerprint.js";
+
+describe("ipPrefix", () => {
+  it("truncates IPv4 to /24", () => {
+    expect(ipPrefix("203.0.113.42")).toBe("203.0.113.0/24");
+    expect(ipPrefix("10.0.0.1")).toBe("10.0.0.0/24");
+  });
+
+  it("truncates IPv6 to /64 (first four groups)", () => {
+    expect(ipPrefix("2001:db8::1")).toBe("2001:db8:0:0::/64");
+    expect(ipPrefix("fd00::dead:beef")).toBe("fd00:0:0:0::/64");
+    expect(ipPrefix("2001:db8:1234:5678:abcd::1")).toBe(
+      "2001:db8:1234:5678::/64",
+    );
+  });
+
+  it("is idempotent on already-prefixed inputs", () => {
+    expect(ipPrefix("203.0.113.0/24")).toBe("203.0.113.0/24");
+    expect(ipPrefix("2001:db8:0:0::/64")).toBe("2001:db8:0:0::/64");
+  });
+
+  it("returns null for empty / invalid inputs", () => {
+    expect(ipPrefix(null)).toBeNull();
+    expect(ipPrefix(undefined)).toBeNull();
+    expect(ipPrefix("")).toBeNull();
+    expect(ipPrefix("   ")).toBeNull();
+    expect(ipPrefix("not-an-ip")).toBeNull();
+    expect(ipPrefix("999.999.999.999")).toBeNull();
+  });
+});
+
+describe("detectFingerprintDrift", () => {
+  it("returns null when stored fingerprint is empty (legacy session)", () => {
+    expect(
+      detectFingerprintDrift({
+        storedUserAgent: null,
+        storedIp: null,
+        currentUserAgent: "Mozilla/5.0",
+        currentIp: "203.0.113.42",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when nothing has drifted", () => {
+    expect(
+      detectFingerprintDrift({
+        storedUserAgent: "Mozilla/5.0",
+        storedIp: "203.0.113.42",
+        currentUserAgent: "Mozilla/5.0",
+        currentIp: "203.0.113.99", // same /24 prefix
+      }),
+    ).toBeNull();
+  });
+
+  it("flags UA drift only", () => {
+    const drift = detectFingerprintDrift({
+      storedUserAgent: "Mozilla/5.0 (orig)",
+      storedIp: "203.0.113.42",
+      currentUserAgent: "Curl/8.0",
+      currentIp: "203.0.113.42",
+    });
+    expect(drift).not.toBeNull();
+    expect(drift!.ua).toBe(true);
+    expect(drift!.ip).toBe(false);
+  });
+
+  it("flags IP-prefix drift only", () => {
+    const drift = detectFingerprintDrift({
+      storedUserAgent: "Mozilla/5.0",
+      storedIp: "203.0.113.42",
+      currentUserAgent: "Mozilla/5.0",
+      currentIp: "198.51.100.1",
+    });
+    expect(drift).not.toBeNull();
+    expect(drift!.ua).toBe(false);
+    expect(drift!.ip).toBe(true);
+    expect(drift!.storedIpPrefix).toBe("203.0.113.0/24");
+    expect(drift!.currentIpPrefix).toBe("198.51.100.0/24");
+  });
+
+  it("flags both axes when both differ", () => {
+    const drift = detectFingerprintDrift({
+      storedUserAgent: "Mozilla/5.0",
+      storedIp: "2001:db8::1",
+      currentUserAgent: "Curl/8.0",
+      currentIp: "2001:db9::1",
+    });
+    expect(drift).not.toBeNull();
+    expect(drift!.ua).toBe(true);
+    expect(drift!.ip).toBe(true);
+  });
+
+  it("does not flag drift when only one side has UA (skewed legacy data)", () => {
+    expect(
+      detectFingerprintDrift({
+        storedUserAgent: null,
+        storedIp: "203.0.113.42",
+        currentUserAgent: "Mozilla/5.0",
+        currentIp: "203.0.113.42",
+      }),
+    ).toBeNull();
+  });
+
+  it("matches stored prefix against current full IP gracefully", () => {
+    // Stored value has already been truncated; current is full IP.
+    // Both sides should normalise to /24 and compare equal.
+    expect(
+      detectFingerprintDrift({
+        storedUserAgent: "Mozilla/5.0",
+        storedIp: "203.0.113.0/24",
+        currentUserAgent: "Mozilla/5.0",
+        currentIp: "203.0.113.250",
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/server/src/auth/sessionFingerprint.ts
+++ b/apps/server/src/auth/sessionFingerprint.ts
@@ -1,0 +1,149 @@
+import { isIP } from "node:net";
+
+/**
+ * Privacy-friendly fingerprint helpers for Better Auth sessions.
+ *
+ * Closes hardening card H3
+ * (`docs/security/hardening/H3-session-revoke-and-binding.md`).
+ *
+ * Goals:
+ *  1. **Storage minimisation.** На запис у `session.ipAddress` ми кладемо
+ *     не повний IP, а **prefix** (`/24` для IPv4, `/64` для IPv6). Цього
+ *     достатньо, щоб виявити, що сесія раптом обслуговує запит з іншого
+ *     ASN/мобільного оператора, але не дозволяє корелювати юзера з точним
+ *     IP-у access-log-ах БД (зменшує blast-radius у разі експлуатації
+ *     SQLi або прямого ексфільтру з replicу).
+ *
+ *  2. **Drift detection.** На кожному `requireSession*` запиті ми
+ *     порівнюємо stored UA + IP-prefix із тими, що приходять з реквесту,
+ *     і кидаємо `auth.session.ua_drift` warn-лог при невідповідності.
+ *     Це сигнал на cookie/bearer hijack (інша вкладка, інша мережа) і
+ *     залогований запис, на який Sentry alert-rule вже може реагувати.
+ *
+ * Не залежить від Better Auth — pure helpers, тестується ізольовано.
+ */
+
+/**
+ * Truncate an IP to a privacy-friendly prefix.
+ *
+ * - IPv4 → `/24` (наприклад, `203.0.113.42` → `203.0.113.0/24`).
+ *   24 біти ховають хост у мережі провайдера, але зберігають достатньо
+ *   ентропії для drift-detection (сусідня мережа = інший /24).
+ *
+ * - IPv6 → `/64` (наприклад, `2001:db8::1` → `2001:db8:0:0::/64`).
+ *   /64 — стандартна subnet-розмірність у IPv6 (RFC 4291); рівно це
+ *   видно як «єдина мережа» з точки зору операторів.
+ *
+ * - Якщо інпут вже у формі prefix-нотації (містить `/`) — повертаємо
+ *   його як є, щоб функція була idempotent (важливо, бо порівнюємо
+ *   stored prefix vs. поточний IP, нормалізуючи обидві сторони).
+ *
+ * - Невалідні значення (порожня строка, не-IP) → `null`. Це означає
+ *   "fingerprint недоступний", і `detectFingerprintDrift` тоді не б'є
+ *   тривогу — false-positive з невалідних X-Forwarded-For хедерів
+ *   нікому не потрібен.
+ */
+export function ipPrefix(ip: string | null | undefined): string | null {
+  if (!ip) return null;
+  const trimmed = ip.trim();
+  if (!trimmed) return null;
+  if (trimmed.includes("/")) return trimmed;
+  const family = isIP(trimmed);
+  if (family === 4) {
+    const parts = trimmed.split(".");
+    if (parts.length !== 4) return null;
+    return `${parts[0]}.${parts[1]}.${parts[2]}.0/24`;
+  }
+  if (family === 6) {
+    return `${expandIpv6Prefix(trimmed)}/64`;
+  }
+  return null;
+}
+
+/**
+ * Expand the leading 4 groups (64 bits) of an IPv6 address.
+ *
+ * Працює з compressed (`::`) формою: розгортаємо до 8 груп через `::`,
+ * беремо перші 4. Не залежимо від зовнішніх IP-бібліотек (єдиний споживач
+ * — fingerprint-порівняння).
+ */
+function expandIpv6Prefix(addr: string): string {
+  const [head, tail = ""] = addr.split("::", 2);
+  const headParts = head ? head.split(":") : [];
+  const tailParts = tail ? tail.split(":") : [];
+  const fillCount = Math.max(0, 8 - headParts.length - tailParts.length);
+  const allGroups = [...headParts, ...Array(fillCount).fill("0"), ...tailParts];
+  const prefix = allGroups
+    .slice(0, 4)
+    .map((g) => g || "0")
+    .join(":");
+  return `${prefix}::`;
+}
+
+export interface FingerprintInputs {
+  storedUserAgent: string | null | undefined;
+  storedIp: string | null | undefined;
+  currentUserAgent: string | null | undefined;
+  currentIp: string | null | undefined;
+}
+
+export interface FingerprintDrift {
+  ua: boolean;
+  ip: boolean;
+  storedIpPrefix: string | null;
+  currentIpPrefix: string | null;
+}
+
+/**
+ * Detect drift between a stored session fingerprint and the current request.
+ *
+ * Returns `null`, коли:
+ *   - stored fingerprint порожній (legacy-сесія до introduction цієї фічі —
+ *     порівнювати немає з чим, тривога була б false-positive);
+ *   - не виявлено drift у жодній з двох осей.
+ *
+ * Інакше повертає об'єкт з прапорами `ua` / `ip` та обчисленими prefix-ами
+ * для логу (щоб Sentry-event і grep по логах одразу показували, що саме
+ * змінилось).
+ *
+ * Дизайн-вибори:
+ *  - "Drift" — це коли обидві сторони задані і не збігаються. Якщо одна
+ *    сторона `null` (наприклад, `storedUserAgent === null`), drift НЕ
+ *    реєструємо: це сигнал, що при створенні сесії UA не дійшов
+ *    (рідкісне, але буває з proxy-агентами), і ми не хочемо викидати юзера.
+ *  - Truncation IP робиться обом сторонам — навіть якщо stored вже
+ *    prefix, `ipPrefix()` ідемпотентна.
+ *  - UA порівнюється посимвольно. Браузерні bumps мінорних версій (123 →
+ *    124) дадуть drift, але це і є очікувана поведінка — auto-update міг
+ *    статись на тому самому пристрої, тому ми лише warn-лог, а не force
+ *    re-auth (rotation політика — окреме рішення на майбутнє).
+ */
+export function detectFingerprintDrift({
+  storedUserAgent,
+  storedIp,
+  currentUserAgent,
+  currentIp,
+}: FingerprintInputs): FingerprintDrift | null {
+  const storedIpPrefix = ipPrefix(storedIp);
+  const currentIpPrefix = ipPrefix(currentIp);
+
+  const haveStoredFingerprint = !!storedUserAgent || !!storedIpPrefix;
+  if (!haveStoredFingerprint) return null;
+
+  const uaDrift =
+    !!storedUserAgent &&
+    !!currentUserAgent &&
+    storedUserAgent !== currentUserAgent;
+
+  const ipDrift =
+    !!storedIpPrefix && !!currentIpPrefix && storedIpPrefix !== currentIpPrefix;
+
+  if (!uaDrift && !ipDrift) return null;
+
+  return {
+    ua: uaDrift,
+    ip: ipDrift,
+    storedIpPrefix,
+    currentIpPrefix,
+  };
+}


### PR DESCRIPTION
## Summary

Closes phase 1 of `docs/security/hardening/H3-session-revoke-and-binding.md`. Three layered changes inside `apps/server`:

1. **Privacy-friendly IP storage.** `databaseHooks.session.create.before` truncates `session.ipAddress` to `/24` (IPv4) or `/64` (IPv6) before the row is written.
2. **UA + IP-prefix drift detection.** `getSessionUser` compares the stored fingerprint with the current request and emits an `auth.session.ua_drift` warn-log on mismatch.
3. **Forced session revoke on password change.** A global `hooks.before` middleware injects `revokeOtherSessions: true` into any `POST /api/auth/change-password` body so a successful password change always invalidates sibling sessions.

New helper module `apps/server/src/auth/sessionFingerprint.ts` (pure, idempotent) holds prefix-truncation and drift-detection.

**Out of scope (stay on the H3 card as follow-ups):** Active sessions UI tile; mobile bearer TTL reduction; step-up re-auth on UA drift.

## Governing Skill

- Primary skill: `sergeant-server-api`
- Secondary skill: `better-auth-best-practices`

## Playbook

- Primary playbook: n/a
- Why this playbook: n/a
- If no playbook matched, why: pattern follows the existing `databaseHooks.user.{create,update}.before` precedent in the same `auth.ts`.

## Verification

```bash
pnpm lint
pnpm typecheck
pnpm --filter @sergeant/server vitest run src/auth/sessionFingerprint.test.ts
pnpm --filter @sergeant/server vitest run src/auth.test.ts
```

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs: H3 hardening card will be flipped to `Closed` in a separate docs-only PR after this lands (so the closure note can reference the merged PR #).

## Risk and Rollout

- User-visible risk: Low. The `hooks.before` middleware only mutates the body for `/change-password`. The `databaseHooks.session.create.before` only narrows what is stored in `session.ipAddress`; legacy rows with full IPs keep working because comparison normalises both sides.
- Rollout / deploy order: Single PR; no migration.
- Backout plan: Revert.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian (in-code comments).
- [x] I did not use `--no-verify`.

## Reviewer Notes

- Drift comparison runs on every session-resolving request but is constant-time and adds no DB roundtrip.
- `hooks.before` imports `createAuthMiddleware` from `better-auth/api` (stable subpath export).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds session fingerprinting (UA + IP-prefix) and forced revoke-on-password-change in `apps/server` to tighten session security and reduce stored PII. Aligns with the H3 session revoke and binding hardening card (phase 1).

- **New Features**
  - Truncate `session.ipAddress` to /24 (IPv4) or /64 (IPv6) via `databaseHooks.session.create.before`.
  - Detect UA + IP-prefix drift in `getSessionUser` and warn-log `auth.session.ua_drift` (no eviction yet).
  - Enforce `revokeOtherSessions: true` for `POST /api/auth/change-password` through a global `hooks.before` middleware.

<sup>Written for commit 1dd9ada199383f19349fb67d2845554ee4d463a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

