### PR TITLE
feat(web): expand Storybook with 5 new stories (Item 16 follow-up)

### DIFF
--- a/apps/web/src/shared/components/ui/Banner.stories.tsx
+++ b/apps/web/src/shared/components/ui/Banner.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Banner } from "./Banner";
+
+/**
+ * `Banner` — info-strip всередині картки чи екрану. Чотири статуси
+ * (`info` / `success` / `warning` / `danger`) використовують
+ * status-soft tokens (`--c-{status}-soft` + `--c-{status}-strong`) щоб
+ * автоматично перемикатись між light / dark і тримати WCAG AA контраст
+ * (≥ 4.5:1 на 14 px). Фолбек `dark:text-{palette}-100` — для випадків,
+ * коли `-strong` відтінок занадто тьмяний на dark soft surface.
+ */
+const meta: Meta<typeof Banner> = {
+  title: "UI / Banner",
+  component: Banner,
+  parameters: { layout: "padded" },
+  tags: ["autodocs"],
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["info", "success", "warning", "danger"],
+    },
+  },
+  args: {
+    variant: "info",
+    children: "Дані синхронізовані з усіма пристроями.",
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Banner>;
+
+export const Info: Story = {};
+
+export const Success: Story = {
+  args: {
+    variant: "success",
+    children: "Тренування завершено! +180 ккал.",
+  },
+};
+
+export const Warning: Story = {
+  args: {
+    variant: "warning",
+    children:
+      "Бюджет на категорію «Кафе» добігає кінця: лишилось 18% на 11 днів.",
+  },
+};
+
+export const Danger: Story = {
+  args: {
+    variant: "danger",
+    children: "Помилка синхронізації Mono — перевір токен у налаштуваннях.",
+  },
+};
+
+/** Усі чотири варіанти поряд — для accessibility / contrast аудитів. */
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3 max-w-md">
+      <Banner variant="info">Info — нейтральне повідомлення.</Banner>
+      <Banner variant="success">Success — операція успішна.</Banner>
+      <Banner variant="warning">
+        Warning — попередження, але дія ще можлива.
+      </Banner>
+      <Banner variant="danger">Danger — потрібна реакція користувача.</Banner>
+    </div>
+  ),
+};

--- a/apps/web/src/shared/components/ui/DataState.stories.tsx
+++ b/apps/web/src/shared/components/ui/DataState.stories.tsx
@@ -1,0 +1,203 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { DataState } from "./DataState";
+import { Skeleton, SkeletonText } from "./Skeleton";
+
+/**
+ * `DataState<TData, TError>` — single-spot wrapper навколо чотирьох
+ * канонічних станів React-Query-подібного результату:
+ *
+ * - **loading** — є `<SkeletonCard />` за замовчуванням; передавай
+ *   shape-aware skeleton щоб transition skeleton → content
+ *   reflow-вився мінімально.
+ * - **error** — функціональний slot `(error, retry) => ReactNode`.
+ *   Default fallback показує `Помилка` + текст + `Спробувати ще`.
+ * - **empty** — рендериться тільки якщо `empty` slot переданий
+ *   (інакше fallthrough до `children(data)`).
+ * - **stale** — рендер альонгсайд `children(data)` коли вже є дані,
+ *   але бекграунд refetch — useful для непомітних "оновлюється…".
+ *
+ * `query` приймає мінімальний контракт: `{ data, isLoading?, isError?,
+ * error?, refetch? }`. Це навмисно — деякі legacy-хуки (e.g.
+ * `useMonoTransactions`) не повертають повну `UseQueryResult`-форму.
+ *
+ * **Цей компонент НЕ викликає `useQuery`.** Host-page далі володіє
+ * хуком + ключем; wrapper лише формалізує presentation contract.
+ */
+const meta: Meta<typeof DataState> = {
+  title: "UI / DataState",
+  component: DataState,
+  parameters: { layout: "padded" },
+  tags: ["autodocs"],
+};
+export default meta;
+
+type Story = StoryObj<typeof DataState>;
+
+interface Tx {
+  id: number;
+  title: string;
+  amount: number;
+}
+
+const SAMPLE: Tx[] = [
+  { id: 1, title: "Сільпо", amount: -428.5 },
+  { id: 2, title: "monobank cashback", amount: 87.3 },
+  { id: 3, title: "Sundownr", amount: -120 },
+];
+
+function TxList({ items }: { items: Tx[] }) {
+  return (
+    <ul className="flex flex-col gap-1.5">
+      {items.map((t) => (
+        <li
+          key={t.id}
+          className="flex items-center justify-between rounded-xl bg-panel px-3 py-2 text-sm"
+        >
+          <span>{t.title}</span>
+          <span
+            className={
+              t.amount < 0 ? "text-danger-strong" : "text-success-strong"
+            }
+          >
+            {t.amount.toFixed(2)} ₴
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/** Базовий happy-path: дані прийшли, рендеримо TxList. */
+export const Loaded: Story = {
+  render: () => (
+    <DataState<Tx[]>
+      query={{ data: SAMPLE, isLoading: false }}
+      empty={<div className="text-muted text-sm">Немає транзакцій.</div>}
+    >
+      {(data) => <TxList items={data} />}
+    </DataState>
+  ),
+};
+
+/** Loading-стан: дефолтний `SkeletonCard` (без overrides). */
+export const LoadingDefault: Story = {
+  render: () => (
+    <DataState<Tx[]>
+      query={{ data: undefined, isLoading: true }}
+      empty={<div className="text-muted text-sm">Немає транзакцій.</div>}
+    >
+      {(data) => <TxList items={data} />}
+    </DataState>
+  ),
+};
+
+/** Loading зі shape-aware skeleton — мінімальний reflow при переході. */
+export const LoadingShapeAware: Story = {
+  render: () => (
+    <DataState<Tx[]>
+      query={{ data: undefined, isLoading: true }}
+      skeleton={
+        <div className="flex flex-col gap-1.5">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div
+              key={i}
+              className="flex items-center justify-between rounded-xl bg-panel px-3 py-2"
+            >
+              <SkeletonText className="w-1/3" />
+              <Skeleton className="h-3 w-20" />
+            </div>
+          ))}
+        </div>
+      }
+      empty={<div className="text-muted text-sm">Немає транзакцій.</div>}
+    >
+      {(data) => <TxList items={data} />}
+    </DataState>
+  ),
+};
+
+/** Empty-стан: дані прийшли але порожні. */
+export const Empty: Story = {
+  render: () => (
+    <DataState<Tx[]>
+      query={{ data: [], isLoading: false }}
+      empty={
+        <div className="rounded-2xl border border-line bg-panel/40 px-4 py-6 text-center text-sm text-muted">
+          Немає транзакцій за вибраний період.
+        </div>
+      }
+    >
+      {(data) => <TxList items={data} />}
+    </DataState>
+  ),
+};
+
+/** Error-стан: дефолтний fallback з кнопкою «Спробувати ще». */
+export const ErrorDefault: Story = {
+  render: () => (
+    <DataState<Tx[]>
+      query={{
+        data: undefined,
+        isError: true,
+        error: new Error("Mono API: 503 Service Unavailable"),
+        refetch: () => undefined,
+      }}
+      empty={<div className="text-muted text-sm">Немає транзакцій.</div>}
+    >
+      {(data) => <TxList items={data} />}
+    </DataState>
+  ),
+};
+
+/** Error-стан з кастомним slot-функцією — отримує `(err, retry)`. */
+export const ErrorCustom: Story = {
+  render: () => (
+    <DataState<Tx[]>
+      query={{
+        data: undefined,
+        isError: true,
+        error: new Error("Тимчасова помилка мережі"),
+        refetch: () => undefined,
+      }}
+      error={(err, retry) => (
+        <div className="rounded-2xl border border-warning/40 bg-warning-soft px-4 py-3 text-sm text-warning-strong dark:text-amber-100">
+          <p className="font-semibold">Не вдалось оновити</p>
+          <p className="mt-1 text-xs opacity-90">
+            {err instanceof Error ? err.message : "Невідома помилка"}
+          </p>
+          <button
+            type="button"
+            onClick={retry}
+            className="mt-3 underline text-xs"
+          >
+            Повторити запит
+          </button>
+        </div>
+      )}
+      empty={<div className="text-muted text-sm">Немає транзакцій.</div>}
+    >
+      {(data) => <TxList items={data} />}
+    </DataState>
+  ),
+};
+
+/**
+ * Stale-стан: дані вже на екрані, фон-refetch у польоті —
+ * `stale` slot рендериться поруч із `children(data)`. Корисно для
+ * «оновлюється…» badge-у без блокування контенту.
+ */
+export const Stale: Story = {
+  render: () => (
+    <DataState<Tx[]>
+      query={{ data: SAMPLE, isFetching: true }}
+      stale={(_data, isStale) =>
+        isStale ? (
+          <div className="text-2xs text-muted mb-1.5 italic">оновлюється…</div>
+        ) : null
+      }
+      empty={<div className="text-muted text-sm">Немає транзакцій.</div>}
+    >
+      {(data) => <TxList items={data} />}
+    </DataState>
+  ),
+};

--- a/apps/web/src/shared/components/ui/Modal.stories.tsx
+++ b/apps/web/src/shared/components/ui/Modal.stories.tsx
@@ -1,0 +1,212 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import { Modal } from "./Modal";
+import { Button } from "./Button";
+
+/**
+ * `Modal` — centered dialog. Counterpart до `Sheet` (bottom-sheet).
+ *
+ * Використовується для коротких підтверджень, focused повідомлень і
+ * квік-промптів на tablet / desktop ширинах. На coarse-pointer
+ * пристроях (touch screens) wrapper автоматично делегує до `<Sheet>` —
+ * так UX залишається консистентним з іншими bottom-sheet-ами.
+ *
+ * Авто-вшивує:
+ *   - `role="dialog"` + `aria-modal` + `aria-labelledby`
+ *   - 44×44 close button (WCAG tap target) через shared `Button` iconOnly
+ *   - focus trap + Escape (`useDialogFocusTrap`)
+ *   - overlay-click dismiss (відключається через `dismissOnOverlayClick={false}`)
+ *   - body scroll lock while open
+ *
+ * Caller володіє: header content, body, optional footer actions.
+ */
+const meta: Meta<typeof Modal> = {
+  title: "UI / Modal",
+  component: Modal,
+  parameters: { layout: "padded" },
+  tags: ["autodocs"],
+  argTypes: {
+    size: { control: "select", options: ["sm", "md", "lg", "xl"] },
+    hideClose: { control: "boolean" },
+    dismissOnOverlayClick: { control: "boolean" },
+  },
+  args: {
+    size: "md",
+    title: "Підтвердити дію",
+    description: "Це не можна буде відмінити.",
+    hideClose: false,
+    dismissOnOverlayClick: true,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Modal>;
+
+/**
+ * Storybook stories використовують hooks щоб тримати локальний open-стан
+ * без зовнішнього controller-у. ESLint-rule `react-hooks/rules-of-hooks`
+ * вимагає, щоб виклики hooks жили у компонентах з PascalCase-ім'ям —
+ * тому кожен `render` делегує до окремого Demo-компонента, а не
+ * викликає `useState` всередині arrow-render-у.
+ */
+function DefaultDemo({
+  size,
+  title,
+  description,
+  hideClose,
+  dismissOnOverlayClick,
+}: {
+  size?: "sm" | "md" | "lg" | "xl";
+  title?: string;
+  description?: string;
+  hideClose?: boolean;
+  dismissOnOverlayClick?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="p-4">
+      <Button variant="primary" onClick={() => setOpen(true)}>
+        Відкрити модал
+      </Button>
+      <Modal
+        open={open}
+        onClose={() => setOpen(false)}
+        size={size}
+        title={title}
+        description={description}
+        hideClose={hideClose}
+        dismissOnOverlayClick={dismissOnOverlayClick}
+        footer={
+          <div className="flex justify-end gap-2">
+            <Button variant="ghost" onClick={() => setOpen(false)}>
+              Скасувати
+            </Button>
+            <Button variant="primary" onClick={() => setOpen(false)}>
+              Підтвердити
+            </Button>
+          </div>
+        }
+      >
+        <p className="text-sm">
+          Видалення транзакції «Сільпо — 428.50 ₴» — операція незворотна.
+        </p>
+      </Modal>
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: (args) => (
+    <DefaultDemo
+      size={args.size}
+      title={typeof args.title === "string" ? args.title : undefined}
+      description={
+        typeof args.description === "string" ? args.description : undefined
+      }
+      hideClose={args.hideClose}
+      dismissOnOverlayClick={args.dismissOnOverlayClick}
+    />
+  ),
+};
+
+function SizesDemo() {
+  const [size, setSize] = useState<"sm" | "md" | "lg" | "xl" | null>(null);
+  return (
+    <div className="flex flex-wrap gap-2 p-4">
+      {(["sm", "md", "lg", "xl"] as const).map((s) => (
+        <Button key={s} variant="secondary" onClick={() => setSize(s)}>
+          {s.toUpperCase()}
+        </Button>
+      ))}
+      <Modal
+        open={size !== null}
+        onClose={() => setSize(null)}
+        size={size ?? "md"}
+        title={`Modal size = ${size ?? ""}`}
+        description="Ширина обмежена `max-w-{size}`."
+      >
+        <p className="text-sm">
+          Усі чотири preset-и тримають однакові padding-и; різниця лише у
+          `max-width` обгортки.
+        </p>
+      </Modal>
+    </div>
+  );
+}
+
+/** Розміри `sm` / `md` / `lg` / `xl` — для адаптивних карточок. */
+export const Sizes: Story = {
+  render: () => <SizesDemo />,
+};
+
+function ForceConfirmDemo() {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="p-4">
+      <Button variant="danger" onClick={() => setOpen(true)}>
+        Видалити акаунт
+      </Button>
+      <Modal
+        open={open}
+        onClose={() => setOpen(false)}
+        title="Підтвердити видалення"
+        description="Усі дані на цьому пристрої буде видалено."
+        hideClose
+        dismissOnOverlayClick={false}
+        footer={
+          <div className="flex justify-end gap-2">
+            <Button variant="ghost" onClick={() => setOpen(false)}>
+              Скасувати
+            </Button>
+            <Button variant="danger" onClick={() => setOpen(false)}>
+              Так, видалити
+            </Button>
+          </div>
+        }
+      >
+        <p className="text-sm">
+          Ця дія незворотна. Cloud-sync синхронізує видалення на всіх пристроях
+          у наступні 60 секунд.
+        </p>
+      </Modal>
+    </div>
+  );
+}
+
+/**
+ * `hideClose` + `dismissOnOverlayClick={false}` — для модалів,
+ * які мають бути explicitly підтверджені (e.g. destructive flows
+ * без safe-cancel). `Escape` далі працює — це WCAG вимога.
+ */
+export const ForceConfirm: Story = {
+  render: () => <ForceConfirmDemo />,
+};
+
+function BodyOnlyDemo() {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="p-4">
+      <Button variant="ghost" onClick={() => setOpen(true)}>
+        Body only
+      </Button>
+      <Modal
+        open={open}
+        onClose={() => setOpen(false)}
+        size="sm"
+        panelClassName="bg-bg"
+      >
+        <div className="flex flex-col items-center gap-3 py-4">
+          <p className="text-sm">Мінімальний контейнер без chrome.</p>
+          <Button variant="secondary" onClick={() => setOpen(false)}>
+            Закрити
+          </Button>
+        </div>
+      </Modal>
+    </div>
+  );
+}
+
+/** Без header / footer — лише тіло (e.g. Stories controls). */
+export const BodyOnly: Story = {
+  render: () => <BodyOnlyDemo />,
+};

--- a/apps/web/src/shared/components/ui/Skeleton.stories.tsx
+++ b/apps/web/src/shared/components/ui/Skeleton.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Skeleton, SkeletonText } from "./Skeleton";
+
+/**
+ * `Skeleton` / `SkeletonText` — низькорівневі загрузчики, що зберігають
+ * розмітку місце контенту що приходить.
+ *
+ * - `motion-safe:animate-pulse` — респектує `prefers-reduced-motion: reduce`.
+ * - `shimmer` — преміум-альтернатива для довгих списків (1.6s sweep). Рендерить
+ *   gradient overlay і потребує `motion-safe:animate-shimmer`.
+ * - Висота-/ширина-классы передаються через `className` — Skeleton не
+ *   диктує форму; це робить host-компонент (е.g. SkeletonCard, SkeletonText).
+ */
+const meta: Meta<typeof Skeleton> = {
+  title: "UI / Skeleton",
+  component: Skeleton,
+  parameters: { layout: "padded" },
+  tags: ["autodocs"],
+  argTypes: {
+    shimmer: { control: "boolean" },
+    className: { control: "text" },
+  },
+  args: {
+    className: "h-12 w-64",
+    shimmer: false,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Skeleton>;
+
+export const Pulse: Story = {};
+
+export const Shimmer: Story = {
+  args: { shimmer: true },
+};
+
+/**
+ * Текстовий skeleton кращий для контенту-абзаців: низько-висока
+ * висота (`h-3`) і trailing-row на 60% ширини імітує
+ * "останній рядок параграфа" — користувач відчуває обсяг.
+ */
+export const TextLines: Story = {
+  render: () => (
+    <div className="flex flex-col gap-2 w-80">
+      <SkeletonText className="w-full" />
+      <SkeletonText className="w-11/12" />
+      <SkeletonText className="w-3/5" />
+    </div>
+  ),
+};
+
+/** Картка-плейсхолдер: avatar + 2 рядки тексту. */
+export const CardPlaceholder: Story = {
+  render: () => (
+    <div className="bg-panel rounded-2xl p-4 flex items-start gap-3 w-80">
+      <Skeleton className="h-12 w-12 rounded-full shrink-0" />
+      <div className="flex-1 flex flex-col gap-2 min-w-0">
+        <SkeletonText className="w-3/4" />
+        <SkeletonText className="w-1/2" />
+      </div>
+    </div>
+  ),
+};
+
+/** Список рядків зі staggered animation-delay для відчуття "хвилі". */
+export const StaggeredList: Story = {
+  render: () => (
+    <div className="flex flex-col gap-2 w-80">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <Skeleton
+          key={i}
+          className="h-10 w-full"
+          style={{ animationDelay: `${i * 80}ms` }}
+        />
+      ))}
+    </div>
+  ),
+};

--- a/apps/web/src/shared/components/ui/Tooltip.stories.tsx
+++ b/apps/web/src/shared/components/ui/Tooltip.stories.tsx
@@ -1,0 +1,104 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Tooltip } from "./Tooltip";
+import { Button } from "./Button";
+
+/**
+ * `Tooltip` — accessible alternative до native `title="..."` (який не
+ * читається screen-reader-ами і не keyboard-доступний). Заточений під
+ * sergeant primitives:
+ *
+ * - `aria-describedby` авто-вішається на trigger, `role="tooltip"` —
+ *   на floating panel.
+ * - `openDelay` 150 ms (default) уникає flicker-у при русі по toolbar-у.
+ * - `motion-safe:animate-fade-in` — респектує
+ *   `prefers-reduced-motion: reduce`.
+ * - Закривається на mouseleave / focusout / Escape.
+ *
+ * `children` — рівно ОДИН React-елемент. Trigger має forward-ити
+ * `onMouseEnter` / `onMouseLeave` / `onFocus` / `onBlur` /
+ * `aria-describedby`. Sergeant primitives (`Button`, `IconButton`,
+ * `Badge`) роблять це з коробки.
+ */
+const meta: Meta<typeof Tooltip> = {
+  title: "UI / Tooltip",
+  component: Tooltip,
+  parameters: { layout: "centered" },
+  tags: ["autodocs"],
+  argTypes: {
+    placement: {
+      control: "select",
+      options: [
+        "top",
+        "bottom",
+        "left",
+        "right",
+        "top-center",
+        "bottom-center",
+        "left-center",
+        "right-center",
+      ],
+    },
+    openDelay: { control: { type: "number", min: 0, max: 1000, step: 50 } },
+    disabled: { control: "boolean" },
+  },
+  args: {
+    content: "Зберегти зміни (Ctrl+S)",
+    placement: "top-center",
+    openDelay: 150,
+    disabled: false,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Tooltip>;
+
+export const Default: Story = {
+  render: (args) => (
+    <Tooltip {...args}>
+      <Button variant="primary">Hover or focus me</Button>
+    </Tooltip>
+  ),
+};
+
+/** Чотири основні позиції — для візуального audit-у. */
+export const Placements: Story = {
+  render: () => (
+    <div className="grid grid-cols-2 gap-12 p-12">
+      <Tooltip content="Підказка зверху" placement="top">
+        <Button variant="secondary">Top</Button>
+      </Tooltip>
+      <Tooltip content="Підказка справа" placement="right">
+        <Button variant="secondary">Right</Button>
+      </Tooltip>
+      <Tooltip content="Підказка зліва" placement="left">
+        <Button variant="secondary">Left</Button>
+      </Tooltip>
+      <Tooltip content="Підказка знизу" placement="bottom">
+        <Button variant="secondary">Bottom</Button>
+      </Tooltip>
+    </div>
+  ),
+};
+
+/** `disabled=true` — рендерить trigger, але tooltip ніколи не з'являється. */
+export const Disabled: Story = {
+  args: { disabled: true, content: "Цей tooltip не має з'являтись" },
+  render: (args) => (
+    <Tooltip {...args}>
+      <Button variant="ghost">Hover me — нічого не станеться</Button>
+    </Tooltip>
+  ),
+};
+
+/** Довгий контент wrap-иться у max-w; не має ламати макет. */
+export const LongContent: Story = {
+  args: {
+    content:
+      "Ця дія негайно синхронізує локальні зміни з сервером і чекає підтвердження від cloud-sync queue (типово < 200 мс на 4G).",
+  },
+  render: (args) => (
+    <Tooltip {...args}>
+      <Button variant="primary">Force sync</Button>
+    </Tooltip>
+  ),
+};


### PR DESCRIPTION
## Summary

Closes **Item 16 follow-up** з roadmap-таблиці у
`docs/diagnostics/2026-05-03-web-deep-dive/00-overview.md`. Збільшує
покриття дизайн-системи у Storybook з 3 → 8 компонентів (на шляху до
цілі ≥ 20 з `02-frontend-quality.md §16`).

### Додано 5 stories

* **Banner** — info / success / warning / danger через status-soft tokens.
  Окрема story `AllVariants` для contrast / a11y audit-у.

* **Skeleton + SkeletonText** — `Pulse` / `Shimmer` / `TextLines` /
  `CardPlaceholder` / `StaggeredList`. Демонструє staggered
  `animationDelay` для відчуття «хвилі» на списках.

* **Tooltip** — `Default` + `Placements` (4 corners) + `Disabled` +
  `LongContent`. Показує WCAG-приклад заміни native `title="..."`.

* **DataState** — усі 5 канонічних станів: `Loaded`, `LoadingDefault`
  (SkeletonCard fallback), `LoadingShapeAware` (custom skeleton),
  `Empty`, `ErrorDefault`, `ErrorCustom` (slot-функція з retry),
  `Stale` (фон-refetch alongside content).

* **Modal** — `Default` (з footer + 2 кнопки), `Sizes` (sm/md/lg/xl),
  `ForceConfirm` (`hideClose` + `dismissOnOverlayClick={false}`),
  `BodyOnly`. Кожен story делегує до named Demo-компонента щоб
  дотриматись `react-hooks/rules-of-hooks` (PascalCase для функції з
  hooks).

Усі stories — UA копія (Hard Rule #15) і використовують лише
існуючі design-tokens / primitives (без інлайн-стилів).

## Governing Skill

- Primary skill: `sergeant-web-ui` (Storybook 10 + дизайн-система web-only)
- Secondary skill: `sergeant-feature-delivery`

## Playbook

- Primary playbook: n/a (incremental documentation)

## Verification

```bash
pnpm --filter @sergeant/web typecheck                   # clean
pnpm --filter @sergeant/web exec eslint src/shared/components/ui/*.stories.tsx  # 0 errors
pnpm --filter @sergeant/web build-storybook             # built успішно (3.32s)
```

Additional checks:

- [x] Local smoke / manual validation completed (Storybook static build OK)
- [x] Surface-specific checks completed (web-only)

## Docs and Governance

- [ ] Окремий PR з оновленням roadmap-таблиці після всіх 4 follow-up'ів
- [x] AGENTS.md не змінений (Hard Rules не торкнуті)

## Risk and Rollout

- User-visible risk: **відсутній**. Stories — окремі artifact-и під
  `*.stories.tsx`, не імпортуються production bundle-ом (Vite tree-shake).
- Rollout: standard CI → merge → no deploy.
- Backout: revert.

## Hard Rule #15

- [x] Всі коментарі / story descriptions — UA.
- [x] Не використано `--no-verify`.

## Reviewer Notes

- Стори для `Modal` потребували **named Demo-компонентів**, бо
  `react-hooks/rules-of-hooks` v7 заборонив `useState` усередині
  arrow-`render` без PascalCase ім'я. Кожен `render` тепер просто
  `() => <SomeDemo />` — це pattern для майбутніх interactive stories.
- `Toast` навмисно НЕ додано: він залежить від глобального
  `useToast()` контексту і не має простого uncontrolled API. Окремий
  PR з провайдером для Storybook у `.storybook/preview.tsx`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds five new Storybook stories to grow design system coverage from 3 to 8 components. Moves us toward Item 16’s target (≥20 components) by documenting `Banner`, `Skeleton`/`SkeletonText`, `Tooltip`, `DataState`, and `Modal`.

- **New Features**
  - `Banner`: four variants (info/success/warning/danger); `AllVariants` for contrast/a11y checks.
  - `Skeleton`/`SkeletonText`: `Pulse`, `Shimmer`, `TextLines`, `CardPlaceholder`, `StaggeredList` (staggered delays).
  - `Tooltip`: `Default`, `Placements`, `Disabled`, `LongContent`; accessible replacement for native `title`.
  - `DataState`: `Loaded`, `LoadingDefault`, `LoadingShapeAware`, `Empty`, `ErrorDefault`, `ErrorCustom` (retry), `Stale`.
  - `Modal`: `Default` (footer), `Sizes` (sm–xl), `ForceConfirm` (`hideClose`, no overlay dismiss), `BodyOnly`; stories use named demo components to satisfy hooks rules.

<sup>Written for commit e7074d6c14cbf584920f8f7d9055be8b18e80b48. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

