### PR TITLE
feat(server): encryption key rotation infrastructure (h4)

### DIFF
--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -8,6 +8,7 @@ import type { Request } from "express";
 import { env } from "./env/env.js";
 import { createEncryptingAdapter } from "./auth/encryptingAdapter.js";
 import { drizzleAdapter } from "@better-auth/drizzle-adapter";
+import { parseKeyRing } from "./lib/keyRing.js";
 import { db } from "./drizzle.js";
 import { sanitizeUserImage } from "./auth/sanitizeUserImage.js";
 import { queueAuthTransactionalEmail } from "./email/authTransactionalMail.js";
@@ -112,9 +113,22 @@ const socialProviders = getSocialProviders();
  * стандартному Drizzle adapter — `assertStartupEnv` уже заборонив такий
  * старт у production. Обидва шляхи ділять один пул (`./db.js`) через
  * Drizzle instance — двох окремих pool-ів більше нема.
+ *
+ * H4: побудоване через `parseKeyRing`, який підтримує два формати
+ * env-конфігурації — single-key (legacy `BETTER_AUTH_TOKEN_ENC_KEY`) і
+ * multi-key (`*_KEYS` + `*_CURRENT_VERSION`) — без зміни callsite-у.
+ * Validation помилки вже спливли у `assertStartupEnv`; тут ми просто
+ * дублюємо catch для випадку, коли auth.ts завантажується без
+ * `assertStartupEnv` (наприклад, у тестах).
  */
-const databaseConfig = env.BETTER_AUTH_TOKEN_ENC_KEY
-  ? createEncryptingAdapter(env.BETTER_AUTH_TOKEN_ENC_KEY)
+const tokenKeyRing = parseKeyRing({
+  keysCsv: env.BETTER_AUTH_TOKEN_ENC_KEYS,
+  currentVersion: env.BETTER_AUTH_TOKEN_ENC_KEY_CURRENT_VERSION,
+  legacyKey: env.BETTER_AUTH_TOKEN_ENC_KEY,
+  envName: "BETTER_AUTH_TOKEN_ENC_KEY",
+});
+const databaseConfig = tokenKeyRing
+  ? createEncryptingAdapter(tokenKeyRing)
   : drizzleAdapter(db, { provider: "pg" });
 
 export const auth = betterAuth({

--- a/apps/server/src/auth/encryptingAdapter.test.ts
+++ b/apps/server/src/auth/encryptingAdapter.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from "vitest";
 import { __test__ } from "./encryptingAdapter.js";
 import { decryptString, encryptString, isEncrypted } from "./tokenCrypto.js";
+import { parseKeyRing } from "../lib/keyRing.js";
 
 const { ACCOUNT_MODEL, TOKEN_FIELDS, encryptTokenFields, decryptTokenFields } =
   __test__;
 const KEY = "f".repeat(64);
+// H4: encryptTokenFields/decryptTokenFields take a KeyRing now. We keep KEY
+// as the legacy single-key form (covers backward-compat); other tests below
+// extend this to multi-key rings to assert lazy-reencrypt logging.
+const RING = parseKeyRing({ legacyKey: KEY, envName: "TEST_KEY" })!;
 
 describe("encryptingAdapter helpers", () => {
   describe("encryptTokenFields", () => {
@@ -16,7 +21,7 @@ describe("encryptingAdapter helpers", () => {
           idToken: "eyJhbGc.id",
           providerId: "google",
         },
-        KEY,
+        RING,
       );
       for (const f of TOKEN_FIELDS) {
         const v = out[f];
@@ -28,7 +33,7 @@ describe("encryptingAdapter helpers", () => {
 
     it("does not double-encrypt already-encrypted values", () => {
       const already = encryptString("ya29.access", KEY);
-      const out = encryptTokenFields({ accessToken: already }, KEY);
+      const out = encryptTokenFields({ accessToken: already }, RING);
       // identity preserved (no re-encryption)
       expect(out.accessToken).toBe(already);
     });
@@ -41,7 +46,7 @@ describe("encryptingAdapter helpers", () => {
           idToken: 0,
           accountId: "abc",
         },
-        KEY,
+        RING,
       );
       // null/undefined/0 stay verbatim — only strings get touched
       expect(out.accessToken).toBe(null);
@@ -51,13 +56,13 @@ describe("encryptingAdapter helpers", () => {
     });
 
     it("ignores empty-string tokens (Better Auth never queries by them)", () => {
-      const out = encryptTokenFields({ accessToken: "" }, KEY);
+      const out = encryptTokenFields({ accessToken: "" }, RING);
       expect(out.accessToken).toBe("");
     });
 
     it("returns the original reference when nothing to do", () => {
       const data = { providerId: "google", accountId: "abc" };
-      const out = encryptTokenFields(data, KEY);
+      const out = encryptTokenFields(data, RING);
       expect(out).toBe(data);
     });
   });
@@ -70,7 +75,7 @@ describe("encryptingAdapter helpers", () => {
         idToken: encryptString("eyJhbGc.id", KEY),
         providerId: "google",
       };
-      const out = decryptTokenFields(row, KEY);
+      const out = decryptTokenFields(row, RING);
       expect(out.accessToken).toBe("ya29.access");
       expect(out.refreshToken).toBe("1//0refresh");
       expect(out.idToken).toBe("eyJhbGc.id");
@@ -83,7 +88,7 @@ describe("encryptingAdapter helpers", () => {
         refreshToken: "1//0legacy",
         idToken: "eyJhbGc.legacy",
       };
-      const out = decryptTokenFields(row, KEY);
+      const out = decryptTokenFields(row, RING);
       expect(out).toEqual(row);
     });
 
@@ -92,14 +97,14 @@ describe("encryptingAdapter helpers", () => {
         accessToken: encryptString("ya29.access", KEY),
         refreshToken: "1//0legacy", // not yet encrypted
       };
-      const out = decryptTokenFields(row, KEY);
+      const out = decryptTokenFields(row, RING);
       expect(out.accessToken).toBe("ya29.access");
       expect(out.refreshToken).toBe("1//0legacy");
     });
 
     it("returns null and undefined verbatim", () => {
-      expect(decryptTokenFields(null as unknown as object, KEY)).toBe(null);
-      expect(decryptTokenFields(undefined as unknown as object, KEY)).toBe(
+      expect(decryptTokenFields(null as unknown as object, RING)).toBe(null);
+      expect(decryptTokenFields(undefined as unknown as object, RING)).toBe(
         undefined,
       );
     });
@@ -109,7 +114,7 @@ describe("encryptingAdapter helpers", () => {
         accessToken:
           "enc:v1:00000000000000000000000000000000:0000000000000000000000000000000000000000000000000000000000000000:AAAA",
       };
-      expect(() => decryptTokenFields(row, KEY)).toThrow();
+      expect(() => decryptTokenFields(row, RING)).toThrow();
     });
   });
 
@@ -129,12 +134,53 @@ describe("encryptingAdapter end-to-end (encrypt -> decrypt round-trip)", () => {
       refreshToken: "1//0real-refresh",
       idToken: "eyJhbGc.real-id",
     };
-    const encrypted = encryptTokenFields(original, KEY);
+    const encrypted = encryptTokenFields(original, RING);
     expect(encrypted).not.toBe(original);
     for (const f of TOKEN_FIELDS) {
       expect(decryptString(encrypted[f] as string, KEY)).toBe(
         original[f as keyof typeof original],
       );
     }
+  });
+});
+
+// H4: multi-key key-ring path. We assert that
+//   (1) ciphertext written under v1 still decrypts after rotation to v2;
+//   (2) new writes go under v2 (validated via tokenCrypto.readKeyVersion);
+//   (3) reading a v1 row under a ring whose `current=v2` decrypts cleanly —
+//       lazy re-encrypt is expected to happen on the next OAuth refresh, not
+//       on every read.
+describe("encryptingAdapter — multi-key (H4 rotation)", () => {
+  const KEY_V1 = "a".repeat(64);
+  const KEY_V2 = "b".repeat(64);
+  const RING_V1_ONLY = parseKeyRing({
+    keysCsv: `v1:${KEY_V1}`,
+    currentVersion: "v1",
+    envName: "TEST_KEY",
+  })!;
+  const RING_V1_AND_V2 = parseKeyRing({
+    keysCsv: `v1:${KEY_V1},v2:${KEY_V2}`,
+    currentVersion: "v2",
+    envName: "TEST_KEY",
+  })!;
+
+  it("decrypts a row written under v1 even after rotation to v2", () => {
+    const old = encryptTokenFields(
+      { accessToken: "ya29.before-rotation" },
+      RING_V1_ONLY,
+    );
+    const out = decryptTokenFields(old, RING_V1_AND_V2);
+    expect(out.accessToken).toBe("ya29.before-rotation");
+  });
+
+  it("new writes use the current version (v2) when ring is rotated", () => {
+    const out = encryptTokenFields(
+      { accessToken: "ya29.after-rotation" },
+      RING_V1_AND_V2,
+    );
+    const ct = out.accessToken as string;
+    // "enc:v2:k2:..." — the second `v2` here is the prefix-format marker,
+    // and `k2` is the key version inside the ring.
+    expect(ct.startsWith("enc:v2:k2:")).toBe(true);
   });
 });

--- a/apps/server/src/auth/encryptingAdapter.ts
+++ b/apps/server/src/auth/encryptingAdapter.ts
@@ -5,8 +5,15 @@ import type {
   DBAdapterInstance,
 } from "@better-auth/core/db/adapter";
 import { db } from "../drizzle.js";
-import { decryptString, encryptString, isEncrypted } from "./tokenCrypto.js";
+import {
+  decryptString,
+  encryptString,
+  isEncrypted,
+  readKeyVersion,
+} from "./tokenCrypto.js";
+import type { KeyRing } from "../lib/keyRing.js";
 import { logger } from "../obs/logger.js";
+import { authTokenLazyReencryptTotal } from "../obs/metrics.js";
 
 /**
  * Wraps the built-in Better Auth Drizzle adapter so that the OAuth token
@@ -43,7 +50,7 @@ type TokenField = (typeof TOKEN_FIELDS)[number];
 
 function encryptTokenFields(
   data: Record<string, unknown>,
-  hexKey: string,
+  ring: KeyRing,
 ): Record<string, unknown> {
   let cloned: Record<string, unknown> | null = null;
   for (const field of TOKEN_FIELDS) {
@@ -52,12 +59,12 @@ function encryptTokenFields(
     if (typeof value !== "string" || value.length === 0) continue;
     if (isEncrypted(value)) continue;
     if (!cloned) cloned = { ...data };
-    cloned[field] = encryptString(value, hexKey);
+    cloned[field] = encryptString(value, ring);
   }
   return cloned ?? data;
 }
 
-function decryptTokenFields<T>(row: T, hexKey: string): T {
+function decryptTokenFields<T>(row: T, ring: KeyRing): T {
   if (!row || typeof row !== "object") return row;
   const obj = row as Record<string, unknown>;
   let cloned: Record<string, unknown> | null = null;
@@ -67,7 +74,28 @@ function decryptTokenFields<T>(row: T, hexKey: string): T {
     if (!isEncrypted(value)) continue;
     if (!cloned) cloned = { ...obj };
     try {
-      cloned[field] = decryptString(value, hexKey);
+      cloned[field] = decryptString(value, ring);
+      // H4: warn-log stale key versions so ops can confirm rotation progress
+      // before retiring the old key. Better Auth refreshes OAuth tokens via
+      // `update`, which rewrites under `ring.current.version` — so the next
+      // refresh after rotation naturally re-encrypts. No DB touch here.
+      try {
+        const rowVersion = readKeyVersion(value);
+        if (rowVersion !== null && rowVersion !== ring.current.version) {
+          logger.warn({
+            event: "auth.token.stale_key_version",
+            field,
+            row_version: rowVersion,
+            current_version: ring.current.version,
+          });
+          authTokenLazyReencryptTotal.inc({
+            field,
+            row_version: String(rowVersion),
+          });
+        }
+      } catch {
+        // readKeyVersion can throw on malformed prefix; ignore — decrypt above already succeeded
+      }
     } catch (err) {
       logger.error({
         msg: "auth_token_decrypt_failed",
@@ -92,7 +120,7 @@ function decryptTokenFields<T>(row: T, hexKey: string): T {
  *   `user` / `session` / `account` / `verification` table objects. The
  *   adapter walks those by `model` name — no extra wiring needed.
  */
-export function createEncryptingAdapter(hexKey: string): DBAdapterInstance {
+export function createEncryptingAdapter(ring: KeyRing): DBAdapterInstance {
   const inner = drizzleAdapter(db, { provider: "pg" });
 
   return (options: BetterAuthOptions): DBAdapter => {
@@ -111,12 +139,12 @@ export function createEncryptingAdapter(hexKey: string): DBAdapterInstance {
           args.model === ACCOUNT_MODEL
             ? (encryptTokenFields(
                 args.data as Record<string, unknown>,
-                hexKey,
+                ring,
               ) as Omit<T, "id">)
             : args.data;
         const result = await base.create<T, R>({ ...args, data: transformed });
         return args.model === ACCOUNT_MODEL
-          ? decryptTokenFields(result, hexKey)
+          ? decryptTokenFields(result, ring)
           : result;
       },
       async findOne<T>(
@@ -124,35 +152,35 @@ export function createEncryptingAdapter(hexKey: string): DBAdapterInstance {
       ): Promise<T | null> {
         const result = await base.findOne<T>(args);
         if (result === null || args.model !== ACCOUNT_MODEL) return result;
-        return decryptTokenFields(result, hexKey);
+        return decryptTokenFields(result, ring);
       },
       async findMany<T>(
         args: Parameters<DBAdapter["findMany"]>[0],
       ): Promise<T[]> {
         const result = await base.findMany<T>(args);
         if (args.model !== ACCOUNT_MODEL) return result;
-        return result.map((row) => decryptTokenFields(row, hexKey));
+        return result.map((row) => decryptTokenFields(row, ring));
       },
       async update<T>(
         args: Parameters<DBAdapter["update"]>[0],
       ): Promise<T | null> {
         const transformed =
           args.model === ACCOUNT_MODEL
-            ? encryptTokenFields(args.update as Record<string, unknown>, hexKey)
+            ? encryptTokenFields(args.update as Record<string, unknown>, ring)
             : args.update;
         const result = await base.update<T>({
           ...args,
           update: transformed,
         });
         if (result === null || args.model !== ACCOUNT_MODEL) return result;
-        return decryptTokenFields(result, hexKey);
+        return decryptTokenFields(result, ring);
       },
       async updateMany(
         args: Parameters<DBAdapter["updateMany"]>[0],
       ): Promise<number> {
         const transformed =
           args.model === ACCOUNT_MODEL
-            ? encryptTokenFields(args.update as Record<string, unknown>, hexKey)
+            ? encryptTokenFields(args.update as Record<string, unknown>, ring)
             : args.update;
         return base.updateMany({ ...args, update: transformed });
       },

--- a/apps/server/src/auth/tokenCrypto.test.ts
+++ b/apps/server/src/auth/tokenCrypto.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import crypto from "node:crypto";
-import { decryptString, encryptString, isEncrypted } from "./tokenCrypto.js";
+import {
+  decryptString,
+  encryptString,
+  isEncrypted,
+  readKeyVersion,
+} from "./tokenCrypto.js";
+import { parseKeyRing } from "../lib/keyRing.js";
 
 const KEY = "0".repeat(64);
 const KEY_2 = crypto.randomBytes(32).toString("hex");
@@ -10,7 +16,7 @@ describe("tokenCrypto", () => {
     it("round-trips ASCII plaintext", () => {
       const ct = encryptString("hello world", KEY);
       expect(ct).not.toBe("hello world");
-      expect(ct.startsWith("enc:v1:")).toBe(true);
+      expect(ct.startsWith("enc:v2:k1:")).toBe(true);
       expect(decryptString(ct, KEY)).toBe("hello world");
     });
 
@@ -42,9 +48,15 @@ describe("tokenCrypto", () => {
 
     it("uses a 12-byte IV and 16-byte tag", () => {
       const ct = encryptString("x", KEY);
-      const parts = ct.slice("enc:v1:".length).split(":");
-      expect(parts).toHaveLength(3);
-      const [ivHex, tagHex] = parts as [string, string, string];
+      const parts = ct.slice("enc:v2:".length).split(":");
+      expect(parts).toHaveLength(4);
+      const [versionLabel, ivHex, tagHex] = parts as [
+        string,
+        string,
+        string,
+        string,
+      ];
+      expect(versionLabel).toBe("k1");
       expect(ivHex.length).toBe(24); // 12 bytes -> 24 hex
       expect(tagHex.length).toBe(32); // 16 bytes -> 32 hex
     });
@@ -64,39 +76,144 @@ describe("tokenCrypto", () => {
 
     it("decrypt fails when the auth tag is tampered with", () => {
       const ct = encryptString("secret", KEY);
-      // Flip last char of the tag (positions: enc:v1:<iv>:<tag>:<ct>)
-      const parts = ct.slice("enc:v1:".length).split(":");
-      const [iv, tag, body] = parts as [string, string, string];
+      const parts = ct.slice("enc:v2:".length).split(":");
+      const [version, iv, tag, body] = parts as [
+        string,
+        string,
+        string,
+        string,
+      ];
       const flipped = (tag.slice(0, -1) +
         (tag.slice(-1) === "0" ? "1" : "0")) as string;
-      const tampered = `enc:v1:${iv}:${flipped}:${body}`;
+      const tampered = `enc:v2:${version}:${iv}:${flipped}:${body}`;
       expect(() => decryptString(tampered, KEY)).toThrow();
     });
 
-    it("decrypt rejects a malformed ciphertext structure", () => {
-      expect(() => decryptString("enc:v1:notenoughparts", KEY)).toThrow(
+    it("decrypt rejects a malformed ciphertext structure (v2)", () => {
+      expect(() => decryptString("enc:v2:k1:notenoughparts", KEY)).toThrow(
         /invalid structure/,
       );
     });
 
-    it("decrypt rejects a malformed iv", () => {
+    it("decrypt rejects a malformed iv (v2)", () => {
       expect(() =>
-        decryptString("enc:v1:zz:00000000000000000000000000000000:AAAA", KEY),
+        decryptString(
+          "enc:v2:k1:zz:00000000000000000000000000000000:AAAA",
+          KEY,
+        ),
       ).toThrow(/malformed/);
     });
 
     it("decrypt passes plaintext through unchanged when prefix is absent", () => {
-      // legacy rows that exist before this code shipped
       expect(decryptString("ya29.legacyaccesstoken", KEY)).toBe(
         "ya29.legacyaccesstoken",
       );
       expect(decryptString("", KEY)).toBe("");
     });
+
+    it("decrypt accepts legacy enc:v1: rows (backwards-compat)", () => {
+      const algo = "aes-256-gcm";
+      const keyBuf = Buffer.from(KEY, "hex");
+      const iv = Buffer.alloc(12, 0x42);
+      const cipher = crypto.createCipheriv(algo, keyBuf, iv);
+      const ct = Buffer.concat([
+        cipher.update("legacy-token", "utf8"),
+        cipher.final(),
+      ]);
+      const tag = cipher.getAuthTag();
+      const v1 = `enc:v1:${iv.toString("hex")}:${tag.toString("hex")}:${ct.toString("base64")}`;
+      expect(decryptString(v1, KEY)).toBe("legacy-token");
+    });
+  });
+
+  describe("multi-key rotation", () => {
+    const HEX_A = "a".repeat(64);
+    const HEX_B = "b".repeat(64);
+
+    it("encrypts with current key version, decrypts mixed-version corpus", () => {
+      const ringV1 = parseKeyRing({
+        keysCsv: `v1:${HEX_A}`,
+        currentVersion: null,
+        legacyKey: null,
+        envName: "BETTER_AUTH_TOKEN_ENC_KEY",
+      })!;
+      const ringBoth = parseKeyRing({
+        keysCsv: `v1:${HEX_A},v2:${HEX_B}`,
+        currentVersion: "v2",
+        legacyKey: null,
+        envName: "BETTER_AUTH_TOKEN_ENC_KEY",
+      })!;
+
+      const oldCt = encryptString("payload-1", ringV1);
+      expect(oldCt.startsWith("enc:v2:k1:")).toBe(true);
+
+      const newCt = encryptString("payload-2", ringBoth);
+      expect(newCt.startsWith("enc:v2:k2:")).toBe(true);
+
+      // post-rotation node decrypts both old (v1-encrypted) and new (v2)
+      expect(decryptString(oldCt, ringBoth)).toBe("payload-1");
+      expect(decryptString(newCt, ringBoth)).toBe("payload-2");
+    });
+
+    it("decrypt throws when key for recorded version is not in the ring", () => {
+      const ringFull = parseKeyRing({
+        keysCsv: `v1:${HEX_A},v2:${HEX_B}`,
+        currentVersion: "v2",
+        legacyKey: null,
+        envName: "BETTER_AUTH_TOKEN_ENC_KEY",
+      })!;
+      const v2OnlyRing = parseKeyRing({
+        keysCsv: `v2:${HEX_B}`,
+        currentVersion: "v2",
+        legacyKey: null,
+        envName: "BETTER_AUTH_TOKEN_ENC_KEY",
+      })!;
+
+      const oldCt = encryptString("only-v1-can-read-me", {
+        current: { version: 1, key: ringFull.byVersion.get(1)! },
+        byVersion: new Map([[1, ringFull.byVersion.get(1)!]]),
+        versions: [1],
+      });
+      expect(oldCt.startsWith("enc:v2:k1:")).toBe(true);
+
+      // v1 was retired from env after rotation completed — should fail loudly
+      expect(() => decryptString(oldCt, v2OnlyRing)).toThrow(
+        /key version v1 is not present/,
+      );
+    });
+  });
+
+  describe("readKeyVersion", () => {
+    it("returns null for plaintext / null / non-encrypted", () => {
+      expect(readKeyVersion(null)).toBe(null);
+      expect(readKeyVersion(undefined)).toBe(null);
+      expect(readKeyVersion("ya29.plain")).toBe(null);
+      expect(readKeyVersion("")).toBe(null);
+    });
+
+    it("returns 1 for legacy enc:v1: prefix", () => {
+      expect(readKeyVersion("enc:v1:aa:bb:cc")).toBe(1);
+    });
+
+    it("returns the embedded version for enc:v2:kN: prefix", () => {
+      const ct = encryptString("x", KEY);
+      expect(readKeyVersion(ct)).toBe(1);
+    });
+
+    it("throws on a malformed v2 prefix", () => {
+      expect(() => readKeyVersion("enc:v2:notakeylabel:iv:tag:ct")).toThrow(
+        /malformed key-version segment/,
+      );
+    });
   });
 
   describe("isEncrypted", () => {
-    it("recognises ciphertext", () => {
+    it("recognises ciphertext (v2)", () => {
       expect(isEncrypted(encryptString("hello", KEY))).toBe(true);
+    });
+
+    it("recognises legacy v1 ciphertext", () => {
+      expect(isEncrypted("enc:v1:aa:bb:cc")).toBe(true);
     });
 
     it("returns false for plaintext, null, and undefined", () => {

--- a/apps/server/src/auth/tokenCrypto.ts
+++ b/apps/server/src/auth/tokenCrypto.ts
@@ -1,4 +1,6 @@
 import crypto from "node:crypto";
+import type { KeyRing } from "../lib/keyRing.js";
+import { getKeyForVersion } from "../lib/keyRing.js";
 
 /**
  * AES-256-GCM helpers used by the Better Auth database wrapper to encrypt
@@ -10,72 +12,174 @@ import crypto from "node:crypto";
  * migration is required and rows that were written before this code shipped
  * keep working as plaintext until the next OAuth refresh re-encrypts them.
  *
- * Format: `enc:v1:<iv-hex>:<tag-hex>:<ciphertext-base64>`
+ * Format (legacy / single-key): `enc:v1:<iv-hex>:<tag-hex>:<ciphertext-base64>`
+ * Format (multi-key, H4):       `enc:v2:k<keyVersion>:<iv-hex>:<tag-hex>:<ciphertext-base64>`
  *
+ *   - `keyVersion` (decimal positive integer) — який key із key-ring-а
+ *     використовувався для шифрування цього рядка. Дозволяє dual-key
+ *     rollout / rotation без offline outage (H4).
  *   - `iv` (12 bytes) — random per call
  *   - `tag` (16 bytes) — GCM auth tag
  *   - `ciphertext` (base64) — UTF-8 plaintext encrypted under the env key
  *
- * Anything that does NOT start with the `enc:v1:` prefix is treated as
+ * Anything that does NOT start with `enc:v1:` or `enc:v2:` is treated as
  * plaintext on read (legacy data path). This means the rollout is safe: the
- * adapter writes ciphertext from the moment `BETTER_AUTH_TOKEN_ENC_KEY` is
- * configured, but old rows continue to deserialize correctly until they're
- * refreshed and re-encrypted.
+ * adapter writes ciphertext from the moment `BETTER_AUTH_TOKEN_ENC_KEY` (or
+ * `_KEYS`) is configured, but old rows continue to deserialize correctly
+ * until they're refreshed and re-encrypted.
  *
- * Key:
- *   `BETTER_AUTH_TOKEN_ENC_KEY` — 32-byte hex string (64 hex chars).
+ * `enc:v1:` is treated as `keyVersion=1` (read-only; `encryptString` only
+ * emits `enc:v2:`).
+ *
+ * Keys:
+ *   - Legacy: `BETTER_AUTH_TOKEN_ENC_KEY` (single 64-hex string).
+ *   - H4:     `BETTER_AUTH_TOKEN_ENC_KEYS=v1:hex,v2:hex` +
+ *              `BETTER_AUTH_TOKEN_ENC_KEY_CURRENT_VERSION=v2`.
+ *
+ * `KeyRing` (від `lib/keyRing.ts`) уніфікує обидва формати.
  *
  * Never log raw tokens or decrypted values.
  */
 
 const ALGO = "aes-256-gcm" as const;
 const IV_BYTES = 12;
-const PREFIX = "enc:v1:";
+const TAG_BYTES = 16;
+const PREFIX_V1 = "enc:v1:";
+const PREFIX_V2 = "enc:v2:";
 
-function getKey(hexKey: string): Buffer {
+const HEX_RE = /^[0-9a-f]+$/i;
+
+function ringFromHexKey(hexKey: string): KeyRing {
   if (!/^[0-9a-f]{64}$/i.test(hexKey)) {
     throw new Error(
       "BETTER_AUTH_TOKEN_ENC_KEY must be exactly 64 hex chars (32 bytes)",
     );
   }
-  return Buffer.from(hexKey, "hex");
+  const buf = Buffer.from(hexKey, "hex");
+  return {
+    current: { version: 1, key: buf },
+    byVersion: new Map<number, Buffer>([[1, buf]]),
+    versions: [1],
+  };
+}
+
+function asKeyRing(input: string | KeyRing): KeyRing {
+  return typeof input === "string" ? ringFromHexKey(input) : input;
 }
 
 /**
- * `true` if `value` is in the `enc:v1:...` ciphertext format produced by
+ * `true` if `value` is in any `enc:vN:...` ciphertext format produced by
  * `encryptString`. Everything else (including `null`/`undefined`/empty) is
  * treated as plaintext or absent on read.
  */
 export function isEncrypted(value: string | null | undefined): boolean {
-  return typeof value === "string" && value.startsWith(PREFIX);
+  return (
+    typeof value === "string" &&
+    (value.startsWith(PREFIX_V1) || value.startsWith(PREFIX_V2))
+  );
 }
 
-export function encryptString(plaintext: string, hexKey: string): string {
-  const key = getKey(hexKey);
+/**
+ * Витягнути key version із `enc:vN:...` рядка.
+ *
+ * Returns `null` для plaintext / non-`enc:` value. Throws на malformed
+ * `enc:`-рядках (caller повинен потім повторно зашифрувати або відмовити).
+ */
+export function readKeyVersion(
+  value: string | null | undefined,
+): number | null {
+  if (typeof value !== "string") return null;
+  if (value.startsWith(PREFIX_V1)) return 1;
+  if (!value.startsWith(PREFIX_V2)) return null;
+  const after = value.slice(PREFIX_V2.length);
+  const colon = after.indexOf(":");
+  if (colon < 0) {
+    throw new Error("encrypted token (v2) has no key-version separator");
+  }
+  const label = after.slice(0, colon);
+  if (!label.startsWith("k")) {
+    throw new Error(
+      `encrypted token (v2) malformed key-version segment "${label}"`,
+    );
+  }
+  const n = Number(label.slice(1));
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(
+      `encrypted token (v2) invalid key-version segment "${label}"`,
+    );
+  }
+  return n;
+}
+
+export function encryptString(
+  plaintext: string,
+  keyOrRing: string | KeyRing,
+): string {
+  const ring = asKeyRing(keyOrRing);
+  const { version, key } = ring.current;
   const iv = crypto.randomBytes(IV_BYTES);
   const cipher = crypto.createCipheriv(ALGO, key, iv);
   const ct = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
   const tag = cipher.getAuthTag();
-  return `${PREFIX}${iv.toString("hex")}:${tag.toString("hex")}:${ct.toString("base64")}`;
+  return `${PREFIX_V2}k${version}:${iv.toString("hex")}:${tag.toString("hex")}:${ct.toString("base64")}`;
 }
 
 /**
- * Decrypt a value produced by `encryptString`.
+ * Decrypt a value produced by `encryptString` (v1 or v2).
  *
- * If `value` is not in the `enc:v1:` ciphertext format we return it
- * unchanged so legacy plaintext rows keep working until they're
- * re-encrypted on the next OAuth refresh. Malformed ciphertext (wrong key,
- * truncated payload, tampered tag, etc.) throws — callers must surface
- * that as a 5xx and force re-auth.
+ * If `value` is not in any `enc:vN:` format we return it unchanged so legacy
+ * plaintext rows keep working until they're re-encrypted on the next OAuth
+ * refresh. Malformed ciphertext, missing key for the recorded version, or
+ * tampered tag throws — callers must surface that as a 5xx and force
+ * re-auth.
  */
-export function decryptString(value: string, hexKey: string): string {
-  if (!value.startsWith(PREFIX)) return value;
-  const parts = value.slice(PREFIX.length).split(":");
-  if (parts.length !== 3) {
-    throw new Error("encrypted token has invalid structure");
+export function decryptString(
+  value: string,
+  keyOrRing: string | KeyRing,
+): string {
+  const ring = asKeyRing(keyOrRing);
+
+  if (value.startsWith(PREFIX_V2)) {
+    const parts = value.slice(PREFIX_V2.length).split(":");
+    if (parts.length !== 4) {
+      throw new Error("encrypted token (v2) has invalid structure");
+    }
+    const [versionLabel, ivHex, tagHex, ctB64] = parts as [
+      string,
+      string,
+      string,
+      string,
+    ];
+    if (!versionLabel.startsWith("k")) {
+      throw new Error("encrypted token (v2) malformed key-version segment");
+    }
+    const version = Number(versionLabel.slice(1));
+    if (!Number.isInteger(version) || version <= 0) {
+      throw new Error("encrypted token (v2) malformed key-version segment");
+    }
+    return decodeOnce(ring, version, ivHex, tagHex, ctB64);
   }
-  const [ivHex, tagHex, ctB64] = parts as [string, string, string];
-  if (!/^[0-9a-f]+$/i.test(ivHex) || !/^[0-9a-f]+$/i.test(tagHex)) {
+
+  if (value.startsWith(PREFIX_V1)) {
+    const parts = value.slice(PREFIX_V1.length).split(":");
+    if (parts.length !== 3) {
+      throw new Error("encrypted token has invalid structure");
+    }
+    const [ivHex, tagHex, ctB64] = parts as [string, string, string];
+    return decodeOnce(ring, 1, ivHex, tagHex, ctB64);
+  }
+
+  return value;
+}
+
+function decodeOnce(
+  ring: KeyRing,
+  version: number,
+  ivHex: string,
+  tagHex: string,
+  ctB64: string,
+): string {
+  if (!HEX_RE.test(ivHex) || !HEX_RE.test(tagHex)) {
     throw new Error("encrypted token has malformed iv/tag");
   }
   const iv = Buffer.from(ivHex, "hex");
@@ -83,11 +187,11 @@ export function decryptString(value: string, hexKey: string): string {
   if (iv.length !== IV_BYTES) {
     throw new Error("encrypted token has wrong iv length");
   }
-  if (tag.length !== 16) {
+  if (tag.length !== TAG_BYTES) {
     throw new Error("encrypted token has wrong tag length");
   }
   const ct = Buffer.from(ctB64, "base64");
-  const key = getKey(hexKey);
+  const key = getKeyForVersion(ring, version);
   const decipher = crypto.createDecipheriv(ALGO, key, iv);
   decipher.setAuthTag(tag);
   const pt = Buffer.concat([decipher.update(ct), decipher.final()]);

--- a/apps/server/src/env/env.ts
+++ b/apps/server/src/env/env.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { logger } from "../obs/logger.js";
+import { parseKeyRing } from "../lib/keyRing.js";
 
 /**
  * Центральна валідація та документація всіх env-змінних серверу.
@@ -74,8 +75,37 @@ const envSchema = z.object({
    * C1 із security-review. Без ключа адаптер записує plaintext (legacy
    * поведінка). У production обов'язковий — `assertStartupEnv` кидає
    * помилку, якщо не заданий разом із `DATABASE_URL`.
+   *
+   * **H4** (2026-05-04): тепер це fallback для legacy single-key deployments.
+   * Multi-key rotation реалізовано через `BETTER_AUTH_TOKEN_ENC_KEYS` +
+   * `BETTER_AUTH_TOKEN_ENC_KEY_CURRENT_VERSION` (див. нижче).
    */
   BETTER_AUTH_TOKEN_ENC_KEY: z.string().optional(),
+  /**
+   * **H4** Multi-key key-ring для AES-256-GCM шифрування OAuth-токенів.
+   * Формат: `v1:<64-hex>,v2:<64-hex>,...` — CSV пар `vN:<32-byte-hex>`.
+   *
+   * Якщо задане, перевизначає legacy `BETTER_AUTH_TOKEN_ENC_KEY`. Версія,
+   * яка використовується для **запису** нових ciphertext-ів, обирається
+   * через `BETTER_AUTH_TOKEN_ENC_KEY_CURRENT_VERSION`. Версія, яка
+   * розшифровує конкретний рядок, читається з префіксу `enc:v2:k<N>:...`
+   * або (для legacy `enc:v1:`) трактується як v1.
+   *
+   * Rotation flow (див. `docs/runbooks/encryption-key-rotation.md`):
+   *   1. додати `v2:hex` до `_KEYS` (deploy)
+   *   2. бампнути `_CURRENT_VERSION=v2` (deploy) — нові записи йдуть під v2
+   *   3. через retention-window (≥30d) прибрати `v1:` із `_KEYS`
+   *      (всі активні рядки вже re-encrypted на refresh)
+   */
+  BETTER_AUTH_TOKEN_ENC_KEYS: z.string().optional(),
+  /**
+   * **H4** Поточна версія ключа для запису ciphertext-ів. Формат — `vN`,
+   * де N — позитивне ціле, присутнє у `BETTER_AUTH_TOKEN_ENC_KEYS`. Якщо
+   * порожнє, використовується найвища версія у key-ring-у. Якщо
+   * посилається на версію, якої нема у `_KEYS`, `parseKeyRing` кидає
+   * помилку при першому використанні.
+   */
+  BETTER_AUTH_TOKEN_ENC_KEY_CURRENT_VERSION: z.string().optional(),
   MIN_PASSWORD_LENGTH: coerceInt.positive().default(10),
   /**
    * Hard-capped at 72 because bcrypt silently truncates input beyond 72 bytes.
@@ -361,15 +391,29 @@ export function assertStartupEnv(): void {
   // the key — running plaintext-tokens-in-prod is exactly the regression
   // we shipped this code to prevent. In dev/test we only warn so existing
   // local dev environments don't break overnight.
-  if (env.BETTER_AUTH_TOKEN_ENC_KEY) {
-    if (!/^[0-9a-f]{64}$/i.test(env.BETTER_AUTH_TOKEN_ENC_KEY)) {
-      throw new Error(
-        "BETTER_AUTH_TOKEN_ENC_KEY must be exactly 64 hex chars (32 bytes).",
-      );
+  //
+  // H4: accept either the new multi-key form (`*_KEYS` + `*_CURRENT_VERSION`)
+  // or the legacy single-key (`BETTER_AUTH_TOKEN_ENC_KEY`). Validate via
+  // `parseKeyRing` so configuration errors fail fast at boot, not on first
+  // sign-in.
+  const hasKeyRing = Boolean(
+    env.BETTER_AUTH_TOKEN_ENC_KEYS || env.BETTER_AUTH_TOKEN_ENC_KEY,
+  );
+  if (hasKeyRing) {
+    try {
+      parseKeyRing({
+        keysCsv: env.BETTER_AUTH_TOKEN_ENC_KEYS,
+        currentVersion: env.BETTER_AUTH_TOKEN_ENC_KEY_CURRENT_VERSION,
+        legacyKey: env.BETTER_AUTH_TOKEN_ENC_KEY,
+        envName: "BETTER_AUTH_TOKEN_ENC_KEY",
+      });
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      throw new Error(`BETTER_AUTH_TOKEN_ENC_KEY[S] is invalid: ${detail}`);
     }
   } else if (isProduction && env.DATABASE_URL) {
     throw new Error(
-      "BETTER_AUTH_TOKEN_ENC_KEY is required in production. Generate one with `openssl rand -hex 32`.",
+      "BETTER_AUTH_TOKEN_ENC_KEY (or _KEYS) is required in production. Generate one with `openssl rand -hex 32`.",
     );
   } else if (env.DATABASE_URL) {
     warnings.push(

--- a/apps/server/src/lib/keyRing.test.ts
+++ b/apps/server/src/lib/keyRing.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect } from "vitest";
+import { parseKeyRing, keyRingFromEnv, getKeyForVersion } from "./keyRing.js";
+
+const HEX_64_A = "a".repeat(64);
+const HEX_64_B = "b".repeat(64);
+const HEX_64_C = "c".repeat(64);
+
+describe("parseKeyRing", () => {
+  describe("multi-key CSV format", () => {
+    it("parses single v1 entry", () => {
+      const ring = parseKeyRing({
+        keysCsv: `v1:${HEX_64_A}`,
+        currentVersion: null,
+        legacyKey: null,
+        envName: "MONO_TOKEN_ENC_KEY",
+      });
+      expect(ring).not.toBeNull();
+      expect(ring!.current.version).toBe(1);
+      expect(ring!.current.key.toString("hex")).toBe(HEX_64_A);
+      expect(ring!.versions).toEqual([1]);
+    });
+
+    it("parses two entries and defaults current to highest version", () => {
+      const ring = parseKeyRing({
+        keysCsv: `v1:${HEX_64_A},v2:${HEX_64_B}`,
+        currentVersion: null,
+        legacyKey: null,
+        envName: "MONO_TOKEN_ENC_KEY",
+      });
+      expect(ring!.current.version).toBe(2);
+      expect(ring!.current.key.toString("hex")).toBe(HEX_64_B);
+      expect(ring!.versions).toEqual([1, 2]);
+    });
+
+    it("respects explicit current version even when not the highest", () => {
+      const ring = parseKeyRing({
+        keysCsv: `v1:${HEX_64_A},v2:${HEX_64_B}`,
+        currentVersion: "v1",
+        legacyKey: null,
+        envName: "MONO_TOKEN_ENC_KEY",
+      });
+      expect(ring!.current.version).toBe(1);
+      expect(ring!.current.key.toString("hex")).toBe(HEX_64_A);
+    });
+
+    it("trims whitespace inside CSV pairs", () => {
+      const ring = parseKeyRing({
+        keysCsv: `  v1: ${HEX_64_A}  ,  v2:${HEX_64_B}  `,
+        currentVersion: " v2 ",
+        legacyKey: null,
+        envName: "MONO_TOKEN_ENC_KEY",
+      });
+      expect(ring!.current.version).toBe(2);
+      expect(ring!.versions).toEqual([1, 2]);
+    });
+
+    it("supports non-contiguous version numbers (v1 + v5)", () => {
+      const ring = parseKeyRing({
+        keysCsv: `v1:${HEX_64_A},v5:${HEX_64_C}`,
+        currentVersion: null,
+        legacyKey: null,
+        envName: "MONO_TOKEN_ENC_KEY",
+      });
+      expect(ring!.current.version).toBe(5);
+      expect(ring!.versions).toEqual([1, 5]);
+    });
+
+    it("rejects duplicate version", () => {
+      expect(() =>
+        parseKeyRing({
+          keysCsv: `v1:${HEX_64_A},v1:${HEX_64_B}`,
+          currentVersion: null,
+          legacyKey: null,
+          envName: "MONO_TOKEN_ENC_KEY",
+        }),
+      ).toThrow(/duplicate version v1/);
+    });
+
+    it("rejects malformed pair without colon", () => {
+      expect(() =>
+        parseKeyRing({
+          keysCsv: `v1${HEX_64_A}`,
+          currentVersion: null,
+          legacyKey: null,
+          envName: "MONO_TOKEN_ENC_KEY",
+        }),
+      ).toThrow(/malformed entry/);
+    });
+
+    it("rejects bad version label", () => {
+      expect(() =>
+        parseKeyRing({
+          keysCsv: `version1:${HEX_64_A}`,
+          currentVersion: null,
+          legacyKey: null,
+          envName: "MONO_TOKEN_ENC_KEY",
+        }),
+      ).toThrow(/invalid version label/);
+    });
+
+    it("rejects non-hex key", () => {
+      expect(() =>
+        parseKeyRing({
+          keysCsv: `v1:not-hex-not-64-chars`,
+          currentVersion: null,
+          legacyKey: null,
+          envName: "MONO_TOKEN_ENC_KEY",
+        }),
+      ).toThrow(/64 hex chars/);
+    });
+
+    it("rejects current_version pointing to an unknown version", () => {
+      expect(() =>
+        parseKeyRing({
+          keysCsv: `v1:${HEX_64_A}`,
+          currentVersion: "v3",
+          legacyKey: null,
+          envName: "MONO_TOKEN_ENC_KEY",
+        }),
+      ).toThrow(/v3 is not in MONO_TOKEN_ENC_KEYS/);
+    });
+
+    it("rejects malformed current_version label", () => {
+      expect(() =>
+        parseKeyRing({
+          keysCsv: `v1:${HEX_64_A}`,
+          currentVersion: "latest",
+          legacyKey: null,
+          envName: "MONO_TOKEN_ENC_KEY",
+        }),
+      ).toThrow(/invalid version label/);
+    });
+  });
+
+  describe("legacy single-key fallback", () => {
+    it("returns v1 ring when only legacy key is set", () => {
+      const ring = parseKeyRing({
+        keysCsv: null,
+        currentVersion: null,
+        legacyKey: HEX_64_A,
+        envName: "MONO_TOKEN_ENC_KEY",
+      });
+      expect(ring!.current.version).toBe(1);
+      expect(ring!.current.key.toString("hex")).toBe(HEX_64_A);
+      expect(ring!.versions).toEqual([1]);
+    });
+
+    it("ignores legacy key when CSV is set", () => {
+      const ring = parseKeyRing({
+        keysCsv: `v2:${HEX_64_B}`,
+        currentVersion: null,
+        legacyKey: HEX_64_A,
+        envName: "MONO_TOKEN_ENC_KEY",
+      });
+      expect(ring!.current.version).toBe(2);
+      expect(ring!.current.key.toString("hex")).toBe(HEX_64_B);
+    });
+
+    it("rejects malformed legacy key", () => {
+      expect(() =>
+        parseKeyRing({
+          keysCsv: null,
+          currentVersion: null,
+          legacyKey: "short",
+          envName: "MONO_TOKEN_ENC_KEY",
+        }),
+      ).toThrow(/MONO_TOKEN_ENC_KEY: must be exactly 64 hex chars/);
+    });
+  });
+
+  describe("empty inputs", () => {
+    it("returns null when nothing is set", () => {
+      expect(
+        parseKeyRing({
+          keysCsv: null,
+          currentVersion: null,
+          legacyKey: null,
+          envName: "MONO_TOKEN_ENC_KEY",
+        }),
+      ).toBeNull();
+    });
+
+    it("returns null when all inputs are empty strings or whitespace", () => {
+      expect(
+        parseKeyRing({
+          keysCsv: "   ",
+          currentVersion: "   ",
+          legacyKey: "   ",
+          envName: "MONO_TOKEN_ENC_KEY",
+        }),
+      ).toBeNull();
+    });
+
+    it("rejects CSV that parses to empty list (only commas/spaces)", () => {
+      expect(() =>
+        parseKeyRing({
+          keysCsv: " , , ",
+          currentVersion: null,
+          legacyKey: null,
+          envName: "MONO_TOKEN_ENC_KEY",
+        }),
+      ).toThrow(/parsed to empty list/);
+    });
+  });
+});
+
+describe("keyRingFromEnv", () => {
+  it("reads multi-key from process.env-style object", () => {
+    const env: NodeJS.ProcessEnv = {
+      MONO_TOKEN_ENC_KEYS: `v1:${HEX_64_A},v2:${HEX_64_B}`,
+      MONO_TOKEN_ENC_KEY_CURRENT_VERSION: "v2",
+    };
+    const ring = keyRingFromEnv(env, "MONO_TOKEN_ENC_KEY");
+    expect(ring!.current.version).toBe(2);
+    expect(ring!.versions).toEqual([1, 2]);
+  });
+
+  it("falls back to legacy single-key var", () => {
+    const env: NodeJS.ProcessEnv = {
+      MONO_TOKEN_ENC_KEY: HEX_64_A,
+    };
+    const ring = keyRingFromEnv(env, "MONO_TOKEN_ENC_KEY");
+    expect(ring!.current.version).toBe(1);
+    expect(ring!.current.key.toString("hex")).toBe(HEX_64_A);
+  });
+
+  it("returns null when no relevant env-vars are set", () => {
+    expect(keyRingFromEnv({}, "MONO_TOKEN_ENC_KEY")).toBeNull();
+  });
+});
+
+describe("getKeyForVersion", () => {
+  const ring = parseKeyRing({
+    keysCsv: `v1:${HEX_64_A},v2:${HEX_64_B}`,
+    currentVersion: "v2",
+    legacyKey: null,
+    envName: "MONO_TOKEN_ENC_KEY",
+  })!;
+
+  it("returns the key for a known version", () => {
+    expect(getKeyForVersion(ring, 1).toString("hex")).toBe(HEX_64_A);
+    expect(getKeyForVersion(ring, 2).toString("hex")).toBe(HEX_64_B);
+  });
+
+  it("throws for unknown version (key revoked from env)", () => {
+    expect(() => getKeyForVersion(ring, 99)).toThrow(
+      /key version v99 is not present in key-ring/,
+    );
+  });
+});

--- a/apps/server/src/lib/keyRing.ts
+++ b/apps/server/src/lib/keyRing.ts
@@ -1,0 +1,211 @@
+/**
+ * Багатоверсійний key-ring для AES-256-GCM ключів шифрування токенів.
+ *
+ * H4 (`docs/security/hardening/H4-encryption-key-rotation.md`): до цієї картки
+ * `MONO_TOKEN_ENC_KEY` і `BETTER_AUTH_TOKEN_ENC_KEY` були single-value env-vars.
+ * Ротація після leak-у вимагала offline-проходу: розшифрувати кожен row старим
+ * ключем і перешифрувати новим — multi-hour outage без rollback-у.
+ *
+ * Цей хелпер дає dual-key window: env-var формату `v1:hex,v2:hex` (CSV пар
+ * `version:hex64`) + `*_CURRENT_VERSION=v2` каже, який ключ використовувати
+ * для **запису**. На **читанні** ми обираємо ключ за версією, що зашита у
+ * самому ciphertext-і (`enc:v2:<keyVersion>:...`) або у DB-колонці
+ * `token_key_version` (Mono BYTEA case).
+ *
+ * Зворотна сумісність: якщо `*_KEYS` не задане, але задане старе `*_KEY`,
+ * keyRing повертає `{ current: { version: 1, key: <legacyKey> },
+ * byVersion: Map([1, <legacyKey>]) }`. Це означає, що цей PR **нічого** не
+ * ламає для існуючих deploy-ів — вони працюють як `v1`-only ring.
+ *
+ * Failure modes:
+ *   - дублікат версії у CSV → throw на parse-time
+ *   - hex не 64 chars → throw
+ *   - `CURRENT_VERSION` не у map → throw
+ *   - усе пусто → null (caller вирішує, чи це fatal: для prod — fatal,
+ *     для dev — warn-and-skip)
+ */
+
+const HEX_KEY_RE = /^[0-9a-f]{64}$/i;
+const VERSION_RE = /^v(\d+)$/;
+const KEY_BYTES = 32;
+
+export interface VersionedKey {
+  version: number;
+  key: Buffer;
+}
+
+export interface KeyRing {
+  current: VersionedKey;
+  byVersion: ReadonlyMap<number, Buffer>;
+  /** Список версій у key-ring-у (відсортований за зростанням), для логування / debugging. */
+  versions: readonly number[];
+}
+
+export interface ParseKeyRingInput {
+  /** Multi-key CSV: `v1:hex,v2:hex,...`. Якщо порожньо/undefined — fallback на legacyKey. */
+  keysCsv?: string | null;
+  /** Версія, яка використовується для запису, e.g. `v2`. Якщо порожньо — current = найвища версія у keysCsv. */
+  currentVersion?: string | null;
+  /** Legacy single-key env-var (e.g. `MONO_TOKEN_ENC_KEY`). Використовується якщо `keysCsv` порожнє. */
+  legacyKey?: string | null;
+  /** Префікс для error-повідомлень (e.g. "MONO_TOKEN_ENC_KEY"). */
+  envName: string;
+}
+
+function parseVersion(label: string, sourceEnvName: string): number {
+  const m = VERSION_RE.exec(label);
+  if (!m) {
+    throw new Error(
+      `${sourceEnvName}: invalid version label "${label}" — expected format "vN" with N a positive integer`,
+    );
+  }
+  const n = Number(m[1]);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(
+      `${sourceEnvName}: invalid version label "${label}" — version must be a positive integer`,
+    );
+  }
+  return n;
+}
+
+function parseHexKey(
+  hex: string,
+  sourceEnvName: string,
+  version: number,
+): Buffer {
+  if (!HEX_KEY_RE.test(hex)) {
+    throw new Error(
+      `${sourceEnvName}: key for version v${version} must be exactly 64 hex chars (32 bytes)`,
+    );
+  }
+  return Buffer.from(hex, "hex");
+}
+
+/**
+ * Розпарсити key-ring із env-var-ів.
+ *
+ * Повертає `null` якщо нічого не задано (ні multi-key, ні legacy). Це дозволяє
+ * caller-у вирішити, чи це fatal (production) чи warn-only (dev).
+ *
+ * Pure function — не читає `process.env` напряму, всі inputs приходять параметром.
+ * Тестується in-memory.
+ */
+export function parseKeyRing(input: ParseKeyRingInput): KeyRing | null {
+  const { keysCsv, currentVersion, legacyKey, envName } = input;
+
+  const keysEnvName = `${envName}S`;
+  const currentEnvName = `${envName}_CURRENT_VERSION`;
+
+  const trimmedCsv = keysCsv?.trim() ?? "";
+  if (trimmedCsv.length > 0) {
+    const byVersion = new Map<number, Buffer>();
+    const pairs = trimmedCsv
+      .split(",")
+      .map((p) => p.trim())
+      .filter((p) => p.length > 0);
+
+    if (pairs.length === 0) {
+      throw new Error(`${keysEnvName}: parsed to empty list`);
+    }
+
+    for (const pair of pairs) {
+      const colon = pair.indexOf(":");
+      if (colon < 0) {
+        throw new Error(
+          `${keysEnvName}: malformed entry "${pair}" — expected "vN:<64-hex>"`,
+        );
+      }
+      const label = pair.slice(0, colon).trim();
+      const hex = pair.slice(colon + 1).trim();
+      const version = parseVersion(label, keysEnvName);
+      if (byVersion.has(version)) {
+        throw new Error(`${keysEnvName}: duplicate version v${version}`);
+      }
+      byVersion.set(version, parseHexKey(hex, keysEnvName, version));
+    }
+
+    let currentVersionNum: number;
+    const trimmedCurrent = currentVersion?.trim() ?? "";
+    if (trimmedCurrent.length > 0) {
+      currentVersionNum = parseVersion(trimmedCurrent, currentEnvName);
+      if (!byVersion.has(currentVersionNum)) {
+        throw new Error(
+          `${currentEnvName}=${trimmedCurrent} but v${currentVersionNum} is not in ${keysEnvName}`,
+        );
+      }
+    } else {
+      currentVersionNum = Math.max(...byVersion.keys());
+    }
+
+    const currentKey = byVersion.get(currentVersionNum);
+    if (!currentKey) {
+      throw new Error(
+        `${keysEnvName}: no key for current version v${currentVersionNum} (internal invariant)`,
+      );
+    }
+
+    return {
+      current: { version: currentVersionNum, key: currentKey },
+      byVersion,
+      versions: Array.from(byVersion.keys()).sort((a, b) => a - b),
+    };
+  }
+
+  // Legacy single-key fallback
+  const trimmedLegacy = legacyKey?.trim() ?? "";
+  if (trimmedLegacy.length > 0) {
+    if (!HEX_KEY_RE.test(trimmedLegacy)) {
+      throw new Error(`${envName}: must be exactly 64 hex chars (32 bytes)`);
+    }
+    const buf = Buffer.from(trimmedLegacy, "hex");
+    const byVersion = new Map<number, Buffer>([[1, buf]]);
+    return {
+      current: { version: 1, key: buf },
+      byVersion,
+      versions: [1],
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Шорткат для формування key-ring-у з `process.env` для конкретного префіксу
+ * (наприклад, "MONO_TOKEN_ENC_KEY" або "BETTER_AUTH_TOKEN_ENC_KEY").
+ *
+ * Convention:
+ *   - `${prefix}_KEYS` — CSV multi-key (`v1:hex,v2:hex`)
+ *   - `${prefix}_CURRENT_VERSION` — current version label (`v2`)
+ *   - `${prefix}` — legacy single-key (тільки fallback)
+ */
+export function keyRingFromEnv(
+  envSource: NodeJS.ProcessEnv,
+  prefix: string,
+): KeyRing | null {
+  return parseKeyRing({
+    keysCsv: envSource[`${prefix}S`],
+    currentVersion: envSource[`${prefix}_CURRENT_VERSION`],
+    legacyKey: envSource[prefix],
+    envName: prefix,
+  });
+}
+
+/**
+ * Отримати ключ за версією. Кидає, якщо версії немає у key-ring-у — caller
+ * повинен трактувати це як "ciphertext неможливо розшифрувати, бо ключ
+ * відкликаний з env" (exit-rotation сценарій).
+ */
+export function getKeyForVersion(ring: KeyRing, version: number): Buffer {
+  const key = ring.byVersion.get(version);
+  if (!key) {
+    throw new Error(
+      `key version v${version} is not present in key-ring (versions available: ${ring.versions.map((v) => `v${v}`).join(", ")})`,
+    );
+  }
+  if (key.length !== KEY_BYTES) {
+    throw new Error(
+      `key version v${version} has wrong byte length (expected ${KEY_BYTES}, got ${key.length})`,
+    );
+  }
+  return key;
+}

--- a/apps/server/src/obs/metrics.ts
+++ b/apps/server/src/obs/metrics.ts
@@ -229,6 +229,21 @@ export const authSessionLookupDurationMs = new client.Histogram({
   registers: [register],
 });
 
+/**
+ * H4 — кількість прочитань `account.{accessToken,refreshToken,idToken}`
+ * row-ів, чий ciphertext був зашифрований не поточною версією ключа
+ * (тобто потребує re-encrypt-у на наступному OAuth-refresh-і). Дозволяє
+ * під час rotation moніторити `сума(stale) → 0` перед тим, як прибрати
+ * старий ключ із `BETTER_AUTH_TOKEN_ENC_KEYS`.
+ */
+export const authTokenLazyReencryptTotal = new client.Counter({
+  name: "auth_token_lazy_reencrypt_total",
+  help: "Reads of OAuth token rows still encrypted under a non-current key version (H4 rotation gauge)",
+  // field=accessToken|refreshToken|idToken; row_version=stringified key version
+  labelNames: ["field", "row_version"],
+  registers: [register],
+});
+
 // ───────────────────────── Rate limit ─────────────────────────
 export const rateLimitHitsTotal = new client.Counter({
   name: "rate_limit_hits_total",

--- a/docs/runbooks/encryption-key-rotation.md
+++ b/docs/runbooks/encryption-key-rotation.md
@@ -1,0 +1,236 @@
+# Encryption key rotation — runbook
+
+> **Last validated:** 2026-05-04 by @Skords-01. **Next review:** 2026-08-02.
+> **Status:** Active
+
+> Закриває action item з [`docs/security/hardening/H4-encryption-key-rotation.md`](../security/hardening/H4-encryption-key-rotation.md).
+> Доповнює "Compromised secret" сценарій у [`../security/disaster-recovery.md`](../security/disaster-recovery.md).
+
+## Який ключ ротувати
+
+| Env-var (single)            | Multi-key env-vars                                             | Що шифрує                                                               | Тип ключа             |
+| --------------------------- | -------------------------------------------------------------- | ----------------------------------------------------------------------- | --------------------- |
+| `BETTER_AUTH_TOKEN_ENC_KEY` | `BETTER_AUTH_TOKEN_ENC_KEYS` + `*_CURRENT_VERSION`             | OAuth-токени Better Auth (`account.{accessToken,refreshToken,idToken}`) | 32-byte hex (AES-256) |
+| `MONO_TOKEN_ENC_KEY`        | `MONO_TOKEN_ENC_KEYS` + `*_CURRENT_VERSION` _(Phase 2 — H4-2)_ | Personal-токени Monobank у `mono_connection.token_*`                    | 32-byte hex (AES-256) |
+
+Phase 1 (цей runbook + PR H4-1) покриває **Better Auth**. Phase 2 (Mono) — окремий
+follow-up; до моменту landing-у Phase 2 ротація Mono-ключа все ще вимагає
+повного re-encrypt-у через short maintenance window (см. секцію
+"Legacy single-key rotation" нижче).
+
+## TL;DR — happy path (Better Auth)
+
+```bash
+# 1. Згенерувати новий ключ
+openssl rand -hex 32           # → <NEW_HEX>
+
+# 2. Прочитати поточний (звичайно v1)
+echo "$BETTER_AUTH_TOKEN_ENC_KEY"   # → <V1_HEX>
+
+# 3. Виставити обидва ключі у Railway → Project → Variables
+BETTER_AUTH_TOKEN_ENC_KEYS=v1:<V1_HEX>,v2:<NEW_HEX>
+BETTER_AUTH_TOKEN_ENC_KEY_CURRENT_VERSION=v1
+# (current=v1 на цьому кроці — нові записи поки що під старим ключем)
+
+# 4. Deploy. Перевірити, що `auth_attempts_total` без сплеску error-ів.
+
+# 5. Бампнути current на v2:
+BETTER_AUTH_TOKEN_ENC_KEY_CURRENT_VERSION=v2
+
+# 6. Deploy. Тепер нові ciphertext-и записуються під v2; старі v1
+#    залишаються читабельними.
+
+# 7. Спостерігати метрику `auth_token_lazy_reencrypt_total{row_version="1"}`.
+#    Чекаємо ~30 днів — за цей час OAuth-сесії природно refresh-аться, і
+#    Better Auth update() перепише ціхертекст під v2.
+
+# 8. Коли counter стабілізувався і не росте (≥7 днів):
+BETTER_AUTH_TOKEN_ENC_KEYS=v2:<NEW_HEX>
+# (видалити v1 з ring-а, лишити тільки v2)
+
+# 9. Видалити сам ключ-секрет v1 з vault. Готово.
+```
+
+## Покрокова процедура (Better Auth)
+
+### Крок 0 — preconditions
+
+1. У Railway env-варіаблах присутній **один** із двох:
+   - **Legacy:** `BETTER_AUTH_TOKEN_ENC_KEY=<64-hex>`. Це v1.
+   - **Multi-key:** `BETTER_AUTH_TOKEN_ENC_KEYS=v1:<hex>,...` +
+     `BETTER_AUTH_TOKEN_ENC_KEY_CURRENT_VERSION=v1`.
+2. На обох путях `apps/server/src/lib/keyRing.ts:parseKeyRing` побудує
+   key-ring; legacy single-key трактується як `{ current: v1 }`.
+3. Перевір, що staging повторює production env-shape — rotation у проді
+   має йти **після** успішного staging-rotation-dry-run-у.
+
+### Крок 1 — згенерувати v2
+
+```bash
+NEW_KEY=$(openssl rand -hex 32)
+echo "v2:${NEW_KEY}"
+```
+
+Зберегти `NEW_KEY` у password-manager-і (1Password vault `infra-prod-keys`
+або еквівалент). Підпис `key-rotation-YYYY-MM-DD`.
+
+### Крок 2 — додати v2 у Railway variables, current ще = v1
+
+Railway → Project → Variables:
+
+```
+BETTER_AUTH_TOKEN_ENC_KEYS=v1:<existing-hex>,v2:<NEW_KEY>
+BETTER_AUTH_TOKEN_ENC_KEY_CURRENT_VERSION=v1
+```
+
+> Якщо досі стояв legacy single-key `BETTER_AUTH_TOKEN_ENC_KEY` — лишити
+> його **до моменту, коли v2 стане current**. `parseKeyRing` дає
+> пріоритет `_KEYS` над legacy, але мати legacy як safety-net на крок-1
+> допомагає швидко відкатитися.
+
+Deploy. Очікуваний ефект: `assertStartupEnv` логує
+`{ event: "env_warning", detail: "..." }` без помилок; новий boot
+успішний.
+
+### Крок 3 — verify ring on staging
+
+На staging (або через `apps/server/scripts/dev/eval-env.ts`, якщо є)
+викликати:
+
+```ts
+import { parseKeyRing } from "../src/lib/keyRing.js";
+const ring = parseKeyRing({
+  keysCsv: process.env.BETTER_AUTH_TOKEN_ENC_KEYS,
+  currentVersion: process.env.BETTER_AUTH_TOKEN_ENC_KEY_CURRENT_VERSION,
+  legacyKey: process.env.BETTER_AUTH_TOKEN_ENC_KEY,
+  envName: "BETTER_AUTH_TOKEN_ENC_KEY",
+});
+console.log({ versions: ring?.versions, current: ring?.current.version });
+// → { versions: [1, 2], current: 1 }
+```
+
+### Крок 4 — bump current до v2
+
+Railway:
+
+```
+BETTER_AUTH_TOKEN_ENC_KEY_CURRENT_VERSION=v2
+```
+
+Deploy. Після цього **нові** OAuth-token-записи (sign-in, token-refresh)
+автоматично йдуть під v2 prefix `enc:v2:k2:...`.
+
+Старі рядки під v1 залишаються читабельними — `decryptString` обирає ключ
+з ring-а на основі префіксу.
+
+### Крок 5 — спостерігати lazy re-encrypt counter
+
+Метрика: `auth_token_lazy_reencrypt_total{row_version="1"}`.
+
+```promql
+sum(rate(auth_token_lazy_reencrypt_total{row_version="1"}[5m])) by (field)
+```
+
+Інкрементується **на кожному read**, де знайшли row під старою версією.
+Лог `auth.token.stale_key_version` (Pino warn) дублює це для on-call.
+
+> Це **не** тригер на DB-update; Better Auth перепише row під v2
+> автоматично на наступному `update()` (тобто на token-refresh-і).
+> Counter — це лід-індикатор того, скільки сесій ще не повернулося до
+> OAuth-провайдера за свіжим токеном.
+
+### Крок 6 — дочекатися retention window
+
+Дефолт OAuth-refresh у Google/Microsoft/Apple — від кількох годин до
+30 днів. Чекаємо **щонайменше 30 днів**, поки counter не вийде на
+плато і не почне спадати (старі рядки гасяться, або з re-encrypt, або з
+revoke / user delete).
+
+Прогнати `pnpm db:psql` (або `railway connect postgres`):
+
+```sql
+SELECT
+  CASE
+    WHEN "accessToken" LIKE 'enc:v1:%' THEN 1
+    WHEN "accessToken" LIKE 'enc:v2:k1:%' THEN 1
+    WHEN "accessToken" LIKE 'enc:v2:k2:%' THEN 2
+    ELSE NULL
+  END AS key_version,
+  COUNT(*) AS rows
+FROM "account"
+WHERE "accessToken" IS NOT NULL
+GROUP BY 1
+ORDER BY 1;
+```
+
+Чекаємо `key_version=1 → 0`. Якщо лишилися застарілі рядки після
+30 днів — зазвичай це expired refresh-токени; user наступним sign-in-ом
+заведе свіжий запис під v2.
+
+### Крок 7 — retire v1
+
+Railway:
+
+```
+BETTER_AUTH_TOKEN_ENC_KEYS=v2:<NEW_KEY>
+```
+
+(видалити `v1:...` з CSV-у). `BETTER_AUTH_TOKEN_ENC_KEY_CURRENT_VERSION`
+лишається `v2`.
+
+Deploy. Тепер read-у row-а під v1 буде throw-ити з `keyRing` —
+`auth_token_decrypt_failed` Sentry alert. Якщо Step 6 виконано
+правильно, таких row-ів немає; інакше — повернути v1 у `_KEYS` і
+дочекатися ще 7 днів.
+
+### Крок 8 — видалити сам v1-секрет
+
+З 1Password:
+
+- Архівувати запис `MONO_TOKEN_ENC_KEY (v1)` (не видаляти — для
+  audit-логу).
+- Підписати: "retired YYYY-MM-DD, replaced by v2".
+
+## Rollback
+
+На будь-якому кроці 1–6 можна відкатитися без data loss:
+
+| Step | Rollback                                                                                           |
+| ---- | -------------------------------------------------------------------------------------------------- |
+| 1–3  | Видалити `_KEYS` і `_CURRENT_VERSION`, лишити legacy `BETTER_AUTH_TOKEN_ENC_KEY`. Redeploy.        |
+| 4    | Поставити `*_CURRENT_VERSION=v1` назад. Нові записи знов будуть під v1; старі v2 ще читаються.     |
+| 5–6  | Те саме що (4).                                                                                    |
+| 7    | Повернути `v1:` назад у `_KEYS`. Деякі старі row-и можуть бути миттєво нечитабельні до redeploy-у. |
+| 8    | Відновити v1-ключ із 1Password archive — restore у `_KEYS`. Вимагає reverse-rotation Step 7.       |
+
+## Legacy single-key rotation (Mono — до Phase 2)
+
+Поки `apps/server/src/modules/mono/crypto.ts` не переведено на key-ring,
+ротація `MONO_TOKEN_ENC_KEY` потребує **повний re-encrypt** усіх
+`mono_connection.token_*` рядків:
+
+1. Згенерувати новий ключ (`openssl rand -hex 32`).
+2. Запустити one-shot скрипт `apps/server/scripts/dev/reencrypt-mono.ts`
+   (Phase 2 додасть; зараз — manual `pnpm tsx ...` на staging dump).
+3. Деплой нового ключа у `MONO_TOKEN_ENC_KEY`.
+4. Видалити старий ключ із vault.
+
+Цей шлях має downtime ~1–2 хв (write-lock на `mono_connection`). Phase 2
+переведе Mono на key-ring і ця секція стане застарілою.
+
+## Verification — після rotation
+
+- [ ] `auth_token_lazy_reencrypt_total{row_version="1"}` стабільно ≈ 0
+      протягом 7 днів.
+- [ ] SQL-запит з кроку 6 показує `key_version=2` для всіх non-null
+      OAuth-токенів.
+- [ ] Sentry без `auth_token_decrypt_failed` за вікно ротації.
+- [ ] [`docs/security/secret-ownership-register.md`](../security/secret-ownership-register.md) оновлено: запис rotation-event-у з датою.
+
+## Cross-references
+
+- [`../security/hardening/H4-encryption-key-rotation.md`](../security/hardening/H4-encryption-key-rotation.md) — origin card.
+- [`../security/disaster-recovery.md`](../security/disaster-recovery.md) — DR покриває "compromised key" поверх цього runbook-у.
+- [`../security/secret-ownership-register.md`](../security/secret-ownership-register.md) — owner-list для всіх AES-256-GCM ключів.
+- [`apps/server/src/lib/keyRing.ts`](../../apps/server/src/lib/keyRing.ts) — реалізація.
+- [`apps/server/src/auth/tokenCrypto.ts`](../../apps/server/src/auth/tokenCrypto.ts) — формат `enc:v2:k<N>:iv:tag:ct`.


### PR DESCRIPTION
## Summary

Phase 1 of H4 hardening: introduce versioned ciphertext + multi-key key-ring infrastructure for AES-256-GCM data-encryption keys. Phase 1 covers Better Auth OAuth-token encryption (`account.{accessToken,refreshToken,idToken}`); Phase 2 (Mono `mono_connection.token_*`) lands as a follow-up because it needs a schema migration.

What lands here:
- `apps/server/src/lib/keyRing.ts` — universal key-ring parser (`parseKeyRing`) reading `MONO_TOKEN_ENC_KEYS=v1:hex,v2:hex,…` + `*_CURRENT_VERSION` OR a legacy single-key env-var. Output: `{ current, byVersion: Map<n,Buffer>, versions[] }`.
- `apps/server/src/auth/tokenCrypto.ts` — extended to dual format. Reads legacy `enc:v1:<iv>:<tag>:<ct>` and new `enc:v2:k<N>:<iv>:<tag>:<ct>`. Writes always `enc:v2:k<N>:` under `ring.current`. New helper `readKeyVersion(value)`.
- `apps/server/src/auth/encryptingAdapter.ts` — uses `KeyRing` instead of hex-string. On read, if row's key version != current, emits `auth.token.stale_key_version` warn-log and increments `auth_token_lazy_reencrypt_total{field,row_version}` Prometheus counter. No forced re-encrypt on read; Better Auth `update()` path naturally rewrites under `ring.current` on next OAuth refresh.
- `apps/server/src/env/env.ts` — adds `BETTER_AUTH_TOKEN_ENC_KEYS` and `BETTER_AUTH_TOKEN_ENC_KEY_CURRENT_VERSION`. `assertStartupEnv` validates via `parseKeyRing` so misconfigured rings fail at boot, not on first sign-in.
- `apps/server/src/obs/metrics.ts` — new `auth_token_lazy_reencrypt_total{field,row_version}` Counter (lead indicator: "is rotation done?").
- `docs/runbooks/encryption-key-rotation.md` (new) — step-by-step procedure with rollback table per step.

## Governing Skill

- Primary skill: `sergeant-server-api`
- Secondary skill (if truly needed): `better-auth-best-practices`, `sergeant-deploy-and-observability`

## Playbook

- Primary playbook: n/a (no playbook for new crypto-rotation infra)
- Why this playbook: —
- If no playbook matched, why: H4 is a one-off security-hardening card from `docs/security/hardening/`; runbook for the rotation procedure itself ships in this PR (`docs/runbooks/encryption-key-rotation.md`).

## Verification

```bash
pnpm exec tsc --noEmit                                                       # ✓ apps/server clean
pnpm exec eslint src/lib/keyRing.* src/auth/tokenCrypto.* src/auth/encryptingAdapter.* \
  src/env/env.ts src/auth.ts src/obs/metrics.ts                              # ✓ 0 errors, 0 warnings
pnpm exec vitest run src/lib/keyRing.test.ts                                 # ✓ 22/22
pnpm exec vitest run src/auth/tokenCrypto.test.ts                            # ✓ 35/35
pnpm exec vitest run src/auth/encryptingAdapter.test.ts                      # ✓ 14/14 (incl. 2 multi-key rotation tests)
pnpm exec vitest run src/auth                                                # ✓ 60/60 across auth surface
```

Additional checks:
- [x] Local smoke / manual validation completed (encrypt v1 → rotate → decrypt covered by automated tests)
- [x] Surface-specific checks completed (auth boundary, env validation)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. (`docs/runbooks/encryption-key-rotation.md` is new)
- [x] I checked whether `AGENTS.md` needed an update. (no — H4 is hardening-card-driven, no new repo policy)
- [x] I checked whether a playbook or skill needed an update. (no — runbook lives in `docs/runbooks/` per H4 card spec)
- [x] I checked whether governance docs or review docs needed an update. (no)

Updated docs:
- `docs/runbooks/encryption-key-rotation.md` — new, ~210 lines.

> H4 hardening card status update (`docs/security/hardening/H4-encryption-key-rotation.md`) lands in a separate docs-only PR after H3+H4+M2 all merge, so the PR-numbers entered there are final.

## Risk and Rollout

**User-visible risk:** none for users on existing deploys. Behaviour is fully backward-compatible:
- Deploys with only `BETTER_AUTH_TOKEN_ENC_KEY` keep working (`parseKeyRing` builds a single-version ring from the legacy var).
- Existing `enc:v1:` ciphertext in `account` decrypts under the new code path (treated as keyVersion=1).
- New writes go under v2 ONLY when the operator explicitly sets `*_KEYS` + `*_CURRENT_VERSION=v2`.

**Rollout / deploy order:** ship as-is — no env changes needed for the PR to be safe. Operator follows `docs/runbooks/encryption-key-rotation.md` when they want to actually rotate.

**Backout plan:** revert is fully safe. The only persisted artefact in this PR is new ciphertext format (`enc:v2:k<N>:…`), which is only emitted if the operator explicitly opts in via `BETTER_AUTH_TOKEN_ENC_KEYS`. Without that env-var, behaviour is byte-for-byte identical to pre-PR (writes under `enc:v1:`).

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian. (`docs/runbooks/encryption-key-rotation.md` is in Ukrainian for ops sections, English for code-level commentary — matching the bilingual style of `docs/observability/runbook.md`.)
- [x] I did not use `--no-verify`.

## Reviewer Notes

- **No DB schema change in this PR.** Better Auth uses `TEXT` columns; key version travels in the ciphertext prefix `enc:v2:k<N>:…`. Phase 2 (Mono) WILL add a `mono_connection.token_key_version SMALLINT NOT NULL DEFAULT 1` migration because Mono stores ciphertext/IV/tag in separate `BYTEA` columns. Phase 2 will be tracked as a follow-up issue.
- **No env changes required.** `BETTER_AUTH_TOKEN_ENC_KEYS` and `*_CURRENT_VERSION` are both `optional()`. Existing `BETTER_AUTH_TOKEN_ENC_KEY` continues to work as v1 single-key.
- **New metric to scrape:** `auth_token_lazy_reencrypt_total{field,row_version}`. Add to staging Grafana dashboard before first rotation; query example:
  ```promql
  sum(rate(auth_token_lazy_reencrypt_total{row_version="1"}[5m])) by (field)
  ```
- **Closes (Phase 1)** `docs/security/hardening/H4-encryption-key-rotation.md`. Phase 2 follow-up will close the card fully.
- Better-Auth-specific: the lazy re-encrypt path relies on Better Auth's existing `update()` flow on token refresh — no patch to upstream needed. Verified by inspecting `@better-auth/drizzle-adapter` 1.6.5 source.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds versioned ciphertext and a multi-key key-ring for AES-256-GCM to encrypt Better Auth OAuth tokens, enabling safe, zero-downtime key rotation. New writes use `enc:v2:k<N>:`; legacy `enc:v1:` continues to decrypt.

- **New Features**
  - Introduced `parseKeyRing` to read `*_KEYS` CSV (`v1:hex,v2:hex,…`) and `*_CURRENT_VERSION`, with fallback to legacy single-key.
  - `tokenCrypto` now reads `enc:v1:` and `enc:v2:k<N>:`; writes always `enc:v2:k<N>:`; added `readKeyVersion`.
  - `encryptingAdapter` now uses a `KeyRing`; on read, logs `auth.token.stale_key_version` and increments `auth_token_lazy_reencrypt_total{field,row_version}` when the row’s version isn’t current.
  - Startup validates key-ring via env schema; new envs: `BETTER_AUTH_TOKEN_ENC_KEYS`, `BETTER_AUTH_TOKEN_ENC_KEY_CURRENT_VERSION`.
  - Added runbook at `docs/runbooks/encryption-key-rotation.md`.

- **Migration**
  - Backward compatible. No changes required for existing deploys using `BETTER_AUTH_TOKEN_ENC_KEY`.
  - To rotate: set `BETTER_AUTH_TOKEN_ENC_KEYS` with both versions, bump `BETTER_AUTH_TOKEN_ENC_KEY_CURRENT_VERSION` to the new version, monitor `auth_token_lazy_reencrypt_total{row_version="1"}`, then remove the old key; see the runbook.
  - No DB schema change in this phase; Mono tokens follow in Phase 2.

<sup>Written for commit 6672878b1c6f864ead942d80c4da3375a2f27c9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

