### PR TITLE
feat(finyk-domain): dual-write LS/MMKV<->SQLite with LWW (PR #036)

### DIFF
--- a/apps/mobile/src/core/lib/featureFlags.ts
+++ b/apps/mobile/src/core/lib/featureFlags.ts
@@ -96,6 +96,13 @@ export const EXPERIMENTAL_FLAGS: readonly FlagDefinition[] = [
       "Meals / pantries / prefs / recipes читаються з локальної SQLite (`nutrition_*` таблиці) замість MMKV blob. MMKV-write залишається як safety net. Stage 4 PR #033 storage-roadmap. Потребує увімкненого dual-write. Default: off.",
     defaultValue: false,
   },
+  {
+    id: "feature.finyk.sqlite_v2.dual_write",
+    label: "Finyk — dual-write MMKV↔SQLite",
+    description:
+      "Кожен write у MMKV Finyk-у додатково мирорить у локальну SQLite (`finyk_*` таблиці: hidden_accounts, hidden_transactions, budgets, subscriptions, assets, debts, receivables, custom_categories, manual_expenses, tx_categories, tx_splits, mono_debt_links, networth_history, prefs). Reads ще беруться з MMKV. Stage 4 PR #036 storage-roadmap. Best-effort: помилка SQLite-запису не ламає MMKV. Default: off.",
+    defaultValue: false,
+  },
 ] as const;
 
 const DEFAULTS: FlagValues = Object.freeze(

--- a/apps/mobile/src/modules/finyk/FinykApp.tsx
+++ b/apps/mobile/src/modules/finyk/FinykApp.tsx
@@ -19,8 +19,15 @@ import { SafeAreaView } from "react-native-safe-area-context";
 
 import { Overview } from "./pages/Overview";
 import type { OverviewNavRoute } from "./pages/Overview";
+import { useFinykDualWriteBoot } from "./hooks/useFinykDualWriteBoot";
 
 export function FinykApp() {
+  // Stage 4 PR #036: install the dual-write context once the user is
+  // known and the flag is on. Without this the `triggerFinykDualWrite`
+  // calls in `assetsStore.ts` and friends early-out at the
+  // `isFinykDualWriteRegistered()` gate, leaving SQLite empty.
+  useFinykDualWriteBoot();
+
   const router = useRouter();
   const handleNavigate = useCallback(
     (route: OverviewNavRoute) => {

--- a/apps/mobile/src/modules/finyk/hooks/useFinykDualWriteBoot.ts
+++ b/apps/mobile/src/modules/finyk/hooks/useFinykDualWriteBoot.ts
@@ -1,0 +1,49 @@
+/**
+ * React hook that installs the mobile Finyk dual-write context.
+ *
+ * Stage 4 PR #036 of `docs/planning/storage-roadmap.md`. Mirror of
+ * `useNutritionDualWriteBoot`.
+ */
+
+import { useEffect } from "react";
+
+import { useUser } from "@sergeant/api-client/react";
+import {
+  EXPERIMENTAL_FLAGS,
+  FLAGS_KEY,
+  useFlag,
+  type FlagValues,
+} from "@/core/lib/featureFlags";
+import { safeReadLS } from "@/lib/storage";
+
+import { bootFinykDualWrite } from "../lib/dualWriteBoot";
+
+const FLAG_ID = "feature.finyk.sqlite_v2.dual_write";
+
+function readFlagFromStorage(): boolean {
+  const stored = safeReadLS<FlagValues>(FLAGS_KEY, null);
+  if (stored && typeof stored === "object") {
+    const v = stored[FLAG_ID];
+    if (typeof v === "boolean") return v;
+  }
+  const def = EXPERIMENTAL_FLAGS.find((f) => f.id === FLAG_ID);
+  return def ? def.defaultValue : false;
+}
+
+export function useFinykDualWriteBoot(): void {
+  const { data: user } = useUser({
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+  const userId = user?.user?.id ?? null;
+  const flagOn = useFlag(FLAG_ID);
+
+  useEffect(() => {
+    if (!userId || !flagOn) return;
+    const teardown = bootFinykDualWrite({
+      getUserId: () => userId,
+      isFlagEnabled: () => readFlagFromStorage(),
+    });
+    return teardown;
+  }, [userId, flagOn]);
+}

--- a/apps/mobile/src/modules/finyk/lib/assetsStore.ts
+++ b/apps/mobile/src/modules/finyk/lib/assetsStore.ts
@@ -27,6 +27,12 @@ import type {
 
 import { _getMMKVInstance, safeReadLS, safeWriteLS } from "@/lib/storage";
 import { enqueueChange } from "@/sync/enqueue";
+import { isFinykDualWriteRegistered, triggerFinykDualWrite } from "./dualWrite";
+import {
+  blobsFromArray,
+  idsFromArray,
+  stateWithSlice,
+} from "./dualWrite/extract";
 
 const KEY_ASSETS = FINYK_BACKUP_STORAGE_KEYS.manualAssets;
 const KEY_DEBTS = FINYK_BACKUP_STORAGE_KEYS.manualDebts;
@@ -124,26 +130,66 @@ export function useFinykAssetsStore(
     return () => sub.remove();
   }, []);
 
-  const setManualAssets = useCallback((next: ManualAsset[]) => {
-    setAssetsState(next);
-    safeWriteLS(KEY_ASSETS, next);
-    enqueueChange(KEY_ASSETS);
-  }, []);
-  const setManualDebts = useCallback((next: AssetsDebt[]) => {
-    setDebtsState(next);
-    safeWriteLS(KEY_DEBTS, next);
-    enqueueChange(KEY_DEBTS);
-  }, []);
-  const setReceivables = useCallback((next: AssetsReceivable[]) => {
-    setRecvState(next);
-    safeWriteLS(KEY_RECV, next);
-    enqueueChange(KEY_RECV);
-  }, []);
-  const setHiddenAccounts = useCallback((next: string[]) => {
-    setHiddenState(next);
-    safeWriteLS(KEY_HIDDEN, next);
-    enqueueChange(KEY_HIDDEN);
-  }, []);
+  const setManualAssets = useCallback(
+    (next: ManualAsset[]) => {
+      const prev = manualAssets;
+      setAssetsState(next);
+      safeWriteLS(KEY_ASSETS, next);
+      enqueueChange(KEY_ASSETS);
+      if (isFinykDualWriteRegistered()) {
+        triggerFinykDualWrite(
+          stateWithSlice("assets", blobsFromArray(prev)),
+          stateWithSlice("assets", blobsFromArray(next)),
+        );
+      }
+    },
+    [manualAssets],
+  );
+  const setManualDebts = useCallback(
+    (next: AssetsDebt[]) => {
+      const prev = manualDebts;
+      setDebtsState(next);
+      safeWriteLS(KEY_DEBTS, next);
+      enqueueChange(KEY_DEBTS);
+      if (isFinykDualWriteRegistered()) {
+        triggerFinykDualWrite(
+          stateWithSlice("debts", blobsFromArray(prev)),
+          stateWithSlice("debts", blobsFromArray(next)),
+        );
+      }
+    },
+    [manualDebts],
+  );
+  const setReceivables = useCallback(
+    (next: AssetsReceivable[]) => {
+      const prev = receivables;
+      setRecvState(next);
+      safeWriteLS(KEY_RECV, next);
+      enqueueChange(KEY_RECV);
+      if (isFinykDualWriteRegistered()) {
+        triggerFinykDualWrite(
+          stateWithSlice("receivables", blobsFromArray(prev)),
+          stateWithSlice("receivables", blobsFromArray(next)),
+        );
+      }
+    },
+    [receivables],
+  );
+  const setHiddenAccounts = useCallback(
+    (next: string[]) => {
+      const prev = hiddenAccounts;
+      setHiddenState(next);
+      safeWriteLS(KEY_HIDDEN, next);
+      enqueueChange(KEY_HIDDEN);
+      if (isFinykDualWriteRegistered()) {
+        triggerFinykDualWrite(
+          stateWithSlice("hiddenAccounts", idsFromArray(prev)),
+          stateWithSlice("hiddenAccounts", idsFromArray(next)),
+        );
+      }
+    },
+    [hiddenAccounts],
+  );
 
   // Mono accounts + transactions are not persisted here — they come
   // from the network layer (to be wired in a follow-up PR). For now we

--- a/apps/mobile/src/modules/finyk/lib/budgetsStore.ts
+++ b/apps/mobile/src/modules/finyk/lib/budgetsStore.ts
@@ -23,9 +23,30 @@ import { STORAGE_KEYS } from "@sergeant/shared";
 import { _getMMKVInstance, safeReadLS, safeWriteLS } from "@/lib/storage";
 import { enqueueChange } from "@/sync/enqueue";
 
+import { isFinykDualWriteRegistered, triggerFinykDualWrite } from "./dualWrite";
+import { EMPTY_FINYK_STATE, type FinykPrefsSnapshot } from "./dualWrite/diff";
+import { blobsFromArray, stateWithSlice } from "./dualWrite/extract";
+
 const KEY_BUDGETS = STORAGE_KEYS.FINYK_BUDGETS;
 const KEY_MONTHLY_PLAN = STORAGE_KEYS.FINYK_MONTHLY_PLAN;
 const KEY_SUBS = STORAGE_KEYS.FINYK_SUBS;
+
+const SHOW_BALANCE_KEY = STORAGE_KEYS.FINYK_SHOW_BALANCE;
+
+function readShowBalance(): boolean {
+  const v = safeReadLS<unknown>(SHOW_BALANCE_KEY, true);
+  return typeof v === "boolean" ? v : true;
+}
+
+function prefsFrom(plan: MonthlyPlanInput): FinykPrefsSnapshot {
+  let monthlyPlanJson = "{}";
+  try {
+    monthlyPlanJson = JSON.stringify(plan ?? {});
+  } catch {
+    monthlyPlanJson = "{}";
+  }
+  return { monthlyPlanJson, showBalance: readShowBalance() };
+}
 
 /**
  * Subscription record persisted under FINYK_SUBS. Shape mirrors the
@@ -151,6 +172,12 @@ export function useFinykBudgetsStore(
             : next;
         safeWriteLS(KEY_BUDGETS, value);
         enqueueChange(KEY_BUDGETS);
+        if (isFinykDualWriteRegistered()) {
+          triggerFinykDualWrite(
+            stateWithSlice("budgets", blobsFromArray(prev)),
+            stateWithSlice("budgets", blobsFromArray(value)),
+          );
+        }
         return value;
       });
     },
@@ -167,6 +194,12 @@ export function useFinykBudgetsStore(
           : next;
       safeWriteLS(KEY_MONTHLY_PLAN, value);
       enqueueChange(KEY_MONTHLY_PLAN);
+      if (isFinykDualWriteRegistered()) {
+        triggerFinykDualWrite(
+          { ...EMPTY_FINYK_STATE, prefs: prefsFrom(prev) },
+          { ...EMPTY_FINYK_STATE, prefs: prefsFrom(value) },
+        );
+      }
       return value;
     });
   }, []);
@@ -181,6 +214,12 @@ export function useFinykBudgetsStore(
           : next;
       safeWriteLS(KEY_SUBS, value);
       enqueueChange(KEY_SUBS);
+      if (isFinykDualWriteRegistered()) {
+        triggerFinykDualWrite(
+          stateWithSlice("subscriptions", blobsFromArray(prev)),
+          stateWithSlice("subscriptions", blobsFromArray(value)),
+        );
+      }
       return value;
     });
   }, []);

--- a/apps/mobile/src/modules/finyk/lib/clientMigrate.ts
+++ b/apps/mobile/src/modules/finyk/lib/clientMigrate.ts
@@ -1,0 +1,32 @@
+import {
+  FINYK_CLIENT_MIGRATIONS,
+  FINYK_MIGRATIONS_TABLE,
+} from "@sergeant/db-schema/sqlite/migrations";
+import { runMigrations } from "@sergeant/db-schema/migrate";
+import {
+  createSqliteAdapter,
+  type SqliteMigrationClient,
+} from "@sergeant/db-schema/migrate/sqlite";
+
+/**
+ * Run the Finyk SQLite client migrations.
+ *
+ * Idempotent: re-running over an already-migrated DB is a no-op
+ * thanks to the runner's `__finyk_migrations` ledger contract.
+ *
+ * Stage 4 PR #035 of `docs/planning/storage-roadmap.md` — schema-only.
+ * The seam this exports is wired into the write paths by PR #036
+ * (dual-write); PR #035 itself only ships the runner so PR #036 has
+ * the same shape as the nutrition dual-write entry-point.
+ */
+export async function migrateFinyk(
+  client: SqliteMigrationClient,
+): Promise<void> {
+  await runMigrations({
+    adapter: createSqliteAdapter(client),
+    files: FINYK_CLIENT_MIGRATIONS,
+    tableName: FINYK_MIGRATIONS_TABLE,
+  });
+}
+
+export type { SqliteMigrationClient };

--- a/apps/mobile/src/modules/finyk/lib/dualWrite/adapter.ts
+++ b/apps/mobile/src/modules/finyk/lib/dualWrite/adapter.ts
@@ -1,0 +1,395 @@
+import type { SqliteMigrationClient } from "@sergeant/db-schema/migrate/sqlite";
+
+import type {
+  FinykBlobEntry,
+  FinykBlobTable,
+  FinykDualWriteOp,
+  FinykIdEntry,
+  FinykIdTable,
+  FinykMonoDebtLinkEntry,
+  FinykNetworthEntry,
+  FinykPrefsSnapshot,
+  FinykTxCategoryEntry,
+  FinykTxSplitsEntry,
+} from "./diff.js";
+
+/**
+ * Async SQLite-side adapter for the Finyk dual-write layer.
+ *
+ * Stage 4 PR #036 of `docs/planning/storage-roadmap.md`. Mirror of
+ * `apps/web/src/modules/nutrition/lib/dualWrite/adapter.ts` with the
+ * finyk entity types / table names. Takes the `FinykDualWriteOp[]`
+ * produced by `diffFinykDualWriteOps` and writes them to the local
+ * `finyk_*` tables defined by migration `039_finyk_tables.sql` and the
+ * SQLite parallel in `packages/db-schema/src/sqlite/finyk.ts`.
+ *
+ * Design notes (same as nutrition adapter):
+ *
+ * - Best-effort: every op is wrapped in try/catch. A single failed op
+ *   does NOT abort the rest.
+ * - Idempotent: upserts use ON CONFLICT(...) DO UPDATE with LWW guard.
+ * - LWW guard: updates only apply when the incoming `clientTs` is
+ *   strictly newer than the local `updated_at`.
+ * - Soft-delete on tables that have `deleted_at`; hard `DELETE` on
+ *   per-tx mappings (no soft-delete column there — absence is the
+ *   "no override" state, by design).
+ */
+
+export interface ApplyDualWriteOptions {
+  readonly userId: string;
+  readonly clientTs: string;
+  readonly logger?: DualWriteLogger;
+}
+
+export type DualWriteLogger = (
+  level: "warn" | "info",
+  message: string,
+  meta?: Record<string, unknown>,
+) => void;
+
+export interface ApplyDualWriteResult {
+  readonly applied: number;
+  readonly errored: number;
+  readonly skipped: number;
+}
+
+const DEFAULT_LOGGER: DualWriteLogger = (level, message, meta) => {
+  if (level === "warn") {
+    console.warn(`[finyk.dualWrite] ${message}`, meta ?? {});
+  }
+};
+
+export async function applyFinykDualWriteOps(
+  client: SqliteMigrationClient,
+  ops: readonly FinykDualWriteOp[],
+  options: ApplyDualWriteOptions,
+): Promise<ApplyDualWriteResult> {
+  if (ops.length === 0) {
+    return { applied: 0, errored: 0, skipped: 0 };
+  }
+  const logger = options.logger ?? DEFAULT_LOGGER;
+  let applied = 0;
+  let errored = 0;
+  let skipped = 0;
+
+  for (const op of ops) {
+    try {
+      const outcome = await applyOne(client, op, options);
+      if (outcome === "applied") applied += 1;
+      else skipped += 1;
+    } catch (err) {
+      errored += 1;
+      logger("warn", "dual-write op failed", {
+        op: op.kind,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return { applied, errored, skipped };
+}
+
+type ApplyOutcome = "applied" | "skipped";
+
+async function applyOne(
+  client: SqliteMigrationClient,
+  op: FinykDualWriteOp,
+  options: ApplyDualWriteOptions,
+): Promise<ApplyOutcome> {
+  const { userId, clientTs } = options;
+  switch (op.kind) {
+    case "id-upsert":
+      await upsertIdEntry(client, op.table, op.entry, userId, clientTs);
+      return "applied";
+
+    case "id-delete":
+      await softDeleteIdEntry(client, op.table, op.id, userId, clientTs);
+      return "applied";
+
+    case "blob-upsert":
+      await upsertBlobEntry(client, op.table, op.entry, userId, clientTs);
+      return "applied";
+
+    case "blob-delete":
+      await softDeleteBlobEntry(client, op.table, op.id, userId, clientTs);
+      return "applied";
+
+    case "tx-category-upsert":
+      await upsertTxCategory(client, op.entry, userId, clientTs);
+      return "applied";
+
+    case "tx-category-delete":
+      await deleteTxCategory(client, op.transactionId, userId);
+      return "applied";
+
+    case "tx-splits-upsert":
+      await upsertTxSplits(client, op.entry, userId, clientTs);
+      return "applied";
+
+    case "tx-splits-delete":
+      await deleteTxSplits(client, op.transactionId, userId);
+      return "applied";
+
+    case "mono-debt-link-upsert":
+      await upsertMonoDebtLink(client, op.entry, userId, clientTs);
+      return "applied";
+
+    case "mono-debt-link-delete":
+      await deleteMonoDebtLink(client, op.transactionId, userId);
+      return "applied";
+
+    case "networth-upsert":
+      await upsertNetworth(client, op.entry, userId, clientTs);
+      return "applied";
+
+    case "prefs-upsert":
+      await upsertPrefs(client, op.prefs, userId, clientTs);
+      return "applied";
+
+    default: {
+      const _exhaustive: never = op;
+      void _exhaustive;
+      return "skipped";
+    }
+  }
+}
+
+// -----------------------------------------------------------------------
+// Composite-PK tombstones (id-tables)
+// -----------------------------------------------------------------------
+
+const ID_COLUMN: Record<FinykIdTable, "account_id" | "transaction_id"> = {
+  finyk_hidden_accounts: "account_id",
+  finyk_hidden_transactions: "transaction_id",
+};
+
+async function upsertIdEntry(
+  client: SqliteMigrationClient,
+  table: FinykIdTable,
+  entry: FinykIdEntry,
+  userId: string,
+  clientTs: string,
+): Promise<void> {
+  const col = ID_COLUMN[table];
+  await client.run(
+    `INSERT INTO ${table}
+       (user_id, ${col}, created_at, updated_at, deleted_at)
+     VALUES (?, ?, ?, ?, NULL)
+     ON CONFLICT(user_id, ${col}) DO UPDATE SET
+       updated_at = excluded.updated_at,
+       deleted_at = NULL
+     WHERE excluded.updated_at > ${table}.updated_at`,
+    [userId, entry.id, clientTs, clientTs],
+  );
+}
+
+async function softDeleteIdEntry(
+  client: SqliteMigrationClient,
+  table: FinykIdTable,
+  id: string,
+  userId: string,
+  clientTs: string,
+): Promise<void> {
+  const col = ID_COLUMN[table];
+  await client.run(
+    `UPDATE ${table}
+        SET deleted_at = ?, updated_at = ?
+      WHERE user_id = ? AND ${col} = ? AND updated_at < ?`,
+    [clientTs, clientTs, userId, id, clientTs],
+  );
+}
+
+// -----------------------------------------------------------------------
+// Per-row + JSONB blobs
+// -----------------------------------------------------------------------
+
+async function upsertBlobEntry(
+  client: SqliteMigrationClient,
+  table: FinykBlobTable,
+  entry: FinykBlobEntry,
+  userId: string,
+  clientTs: string,
+): Promise<void> {
+  await client.run(
+    `INSERT INTO ${table}
+       (id, user_id, data_json, created_at, updated_at, deleted_at)
+     VALUES (?, ?, ?, ?, ?, NULL)
+     ON CONFLICT(id) DO UPDATE SET
+       data_json  = excluded.data_json,
+       updated_at = excluded.updated_at,
+       deleted_at = NULL
+     WHERE excluded.updated_at > ${table}.updated_at`,
+    [entry.id, userId, entry.dataJson ?? "{}", clientTs, clientTs],
+  );
+}
+
+async function softDeleteBlobEntry(
+  client: SqliteMigrationClient,
+  table: FinykBlobTable,
+  id: string,
+  userId: string,
+  clientTs: string,
+): Promise<void> {
+  await client.run(
+    `UPDATE ${table}
+        SET deleted_at = ?, updated_at = ?
+      WHERE id = ? AND user_id = ? AND updated_at < ?`,
+    [clientTs, clientTs, id, userId, clientTs],
+  );
+}
+
+// -----------------------------------------------------------------------
+// Per-tx mappings (no soft-delete — absence is the "no override" state)
+// -----------------------------------------------------------------------
+
+async function upsertTxCategory(
+  client: SqliteMigrationClient,
+  entry: FinykTxCategoryEntry,
+  userId: string,
+  clientTs: string,
+): Promise<void> {
+  await client.run(
+    `INSERT INTO finyk_tx_categories
+       (user_id, transaction_id, category_id, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(user_id, transaction_id) DO UPDATE SET
+       category_id = excluded.category_id,
+       updated_at  = excluded.updated_at
+     WHERE excluded.updated_at > finyk_tx_categories.updated_at`,
+    [userId, entry.transactionId, entry.categoryId, clientTs, clientTs],
+  );
+}
+
+async function deleteTxCategory(
+  client: SqliteMigrationClient,
+  transactionId: string,
+  userId: string,
+): Promise<void> {
+  await client.run(
+    `DELETE FROM finyk_tx_categories
+      WHERE user_id = ? AND transaction_id = ?`,
+    [userId, transactionId],
+  );
+}
+
+async function upsertTxSplits(
+  client: SqliteMigrationClient,
+  entry: FinykTxSplitsEntry,
+  userId: string,
+  clientTs: string,
+): Promise<void> {
+  await client.run(
+    `INSERT INTO finyk_tx_splits
+       (user_id, transaction_id, splits_json, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(user_id, transaction_id) DO UPDATE SET
+       splits_json = excluded.splits_json,
+       updated_at  = excluded.updated_at
+     WHERE excluded.updated_at > finyk_tx_splits.updated_at`,
+    [userId, entry.transactionId, entry.splitsJson ?? "[]", clientTs, clientTs],
+  );
+}
+
+async function deleteTxSplits(
+  client: SqliteMigrationClient,
+  transactionId: string,
+  userId: string,
+): Promise<void> {
+  await client.run(
+    `DELETE FROM finyk_tx_splits
+      WHERE user_id = ? AND transaction_id = ?`,
+    [userId, transactionId],
+  );
+}
+
+async function upsertMonoDebtLink(
+  client: SqliteMigrationClient,
+  entry: FinykMonoDebtLinkEntry,
+  userId: string,
+  clientTs: string,
+): Promise<void> {
+  await client.run(
+    `INSERT INTO finyk_mono_debt_links
+       (user_id, transaction_id, debt_ids_json, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(user_id, transaction_id) DO UPDATE SET
+       debt_ids_json = excluded.debt_ids_json,
+       updated_at    = excluded.updated_at
+     WHERE excluded.updated_at > finyk_mono_debt_links.updated_at`,
+    [
+      userId,
+      entry.transactionId,
+      entry.debtIdsJson ?? "[]",
+      clientTs,
+      clientTs,
+    ],
+  );
+}
+
+async function deleteMonoDebtLink(
+  client: SqliteMigrationClient,
+  transactionId: string,
+  userId: string,
+): Promise<void> {
+  await client.run(
+    `DELETE FROM finyk_mono_debt_links
+      WHERE user_id = ? AND transaction_id = ?`,
+    [userId, transactionId],
+  );
+}
+
+// -----------------------------------------------------------------------
+// Time-series: networth_history (composite PK (user_id, month))
+// -----------------------------------------------------------------------
+
+async function upsertNetworth(
+  client: SqliteMigrationClient,
+  entry: FinykNetworthEntry,
+  userId: string,
+  clientTs: string,
+): Promise<void> {
+  // Defensive: the apply-fn server-side validates the YYYY-MM format
+  // with a regex; mirror that here so a corrupt LS row doesn't poison
+  // the local table.
+  if (!/^\d{4}-\d{2}$/.test(entry.month)) return;
+  const networth = Number.isFinite(entry.networth) ? entry.networth : 0;
+  await client.run(
+    `INSERT INTO finyk_networth_history
+       (user_id, month, networth, snapshot_json, created_at, updated_at)
+     VALUES (?, ?, ?, '{}', ?, ?)
+     ON CONFLICT(user_id, month) DO UPDATE SET
+       networth   = excluded.networth,
+       updated_at = excluded.updated_at
+     WHERE excluded.updated_at > finyk_networth_history.updated_at`,
+    [userId, entry.month, networth, clientTs, clientTs],
+  );
+}
+
+// -----------------------------------------------------------------------
+// Singleton prefs (per-user)
+// -----------------------------------------------------------------------
+
+async function upsertPrefs(
+  client: SqliteMigrationClient,
+  prefs: FinykPrefsSnapshot,
+  userId: string,
+  clientTs: string,
+): Promise<void> {
+  await client.run(
+    `INSERT INTO finyk_prefs
+       (user_id, monthly_plan_json, show_balance, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(user_id) DO UPDATE SET
+       monthly_plan_json = excluded.monthly_plan_json,
+       show_balance      = excluded.show_balance,
+       updated_at        = excluded.updated_at
+     WHERE excluded.updated_at > finyk_prefs.updated_at`,
+    [
+      userId,
+      prefs.monthlyPlanJson ?? "{}",
+      prefs.showBalance ? 1 : 0,
+      clientTs,
+      clientTs,
+    ],
+  );
+}

--- a/apps/mobile/src/modules/finyk/lib/dualWrite/diff.ts
+++ b/apps/mobile/src/modules/finyk/lib/dualWrite/diff.ts
@@ -1,0 +1,448 @@
+/**
+ * Pure-function diff between two Finyk LS-state snapshots, producing
+ * the list of operations the dual-write layer must mirror to local
+ * SQLite.
+ *
+ * Stage 4 PR #036 of `docs/planning/storage-roadmap.md`. Mirrors the
+ * nutrition dual-write diff layer (PR #032) — same shape, same
+ * semantics, separate types because the entity surface is different.
+ *
+ * Five entity classes are tracked across 14 LS keys. The mapping to
+ * SQLite tables (created by PR #035 migration `039_finyk_tables.sql`):
+ *
+ *   - composite-PK tombstones (set membership)
+ *     - `finyk_hidden`            → `finyk_hidden_accounts`
+ *     - `finyk_hidden_txs`        → `finyk_hidden_transactions`
+ *
+ *   - per-row + JSONB blob (CRUD over arrays)
+ *     - `finyk_budgets`           → `finyk_budgets`
+ *     - `finyk_subs`              → `finyk_subscriptions`
+ *     - `finyk_assets`            → `finyk_assets`
+ *     - `finyk_debts`             → `finyk_debts`
+ *     - `finyk_recv`              → `finyk_receivables`
+ *     - `finyk_custom_cats_v1`    → `finyk_custom_categories`
+ *     - `finyk_manual_expenses_v1`→ `finyk_manual_expenses`
+ *
+ *   - per-tx mapping (composite (user_id, transaction_id) PK)
+ *     - `finyk_tx_cats`           → `finyk_tx_categories`     (string value)
+ *     - `finyk_tx_splits`         → `finyk_tx_splits`         (jsonb array)
+ *     - `finyk_mono_debt_linked`  → `finyk_mono_debt_links`   (jsonb array)
+ *
+ *   - time-series
+ *     - `finyk_networth_history`  → `finyk_networth_history`  (composite (user_id, month))
+ *
+ *   - singleton prefs (per-user)
+ *     - `finyk_monthly_plan` + `finyk_show_balance_v1` → `finyk_prefs`
+ *
+ * `finyk_tx_filters_v1` is intentionally NOT yet wired here — there is
+ * no LS source on `main` today; the table waits for the future filter
+ * persistence work. The diff layer omits it entirely until the LS
+ * shape lands.
+ */
+
+// -----------------------------------------------------------------------
+// Snapshot shapes — loose mirrors of the domain types, kept minimal so
+// the diff layer doesn't pull in the full domain package. The adapter
+// reads these to produce SQL statements.
+// -----------------------------------------------------------------------
+
+/** Set-membership entry for the composite-PK tombstone tables. */
+export interface FinykIdEntry {
+  /** Stable external id (account id / Mono transaction id). */
+  readonly id: string;
+}
+
+/**
+ * Per-row blob entry. `dataJson` is the verbatim JSON serialisation of
+ * the LS shape — the adapter writes it to `data_json` unchanged so
+ * future schema evolution doesn't require re-shaping at the dual-write
+ * boundary.
+ */
+export interface FinykBlobEntry {
+  readonly id: string;
+  readonly dataJson: string;
+}
+
+/** Per-tx category override (`finyk_tx_cats`). */
+export interface FinykTxCategoryEntry {
+  readonly transactionId: string;
+  readonly categoryId: string;
+}
+
+/** Per-tx splits (`finyk_tx_splits`). */
+export interface FinykTxSplitsEntry {
+  readonly transactionId: string;
+  readonly splitsJson: string;
+}
+
+/** Per-tx mono-debt links (`finyk_mono_debt_linked`). */
+export interface FinykMonoDebtLinkEntry {
+  readonly transactionId: string;
+  readonly debtIdsJson: string;
+}
+
+/** Time-series networth row (`finyk_networth_history`). */
+export interface FinykNetworthEntry {
+  readonly month: string;
+  readonly networth: number;
+}
+
+/** Singleton per-user prefs (`finyk_prefs`). */
+export interface FinykPrefsSnapshot {
+  /** Whole MonthlyPlan blob serialised to JSON. */
+  readonly monthlyPlanJson: string;
+  /** `finyk_show_balance_v1` raw boolean state. */
+  readonly showBalance: boolean;
+}
+
+// -----------------------------------------------------------------------
+// State — loose mirror of useFinykStorageSlots() across all LS keys
+// -----------------------------------------------------------------------
+
+export interface FinykDualWriteState {
+  readonly hiddenAccounts: readonly FinykIdEntry[];
+  readonly hiddenTransactions: readonly FinykIdEntry[];
+  readonly budgets: readonly FinykBlobEntry[];
+  readonly subscriptions: readonly FinykBlobEntry[];
+  readonly assets: readonly FinykBlobEntry[];
+  readonly debts: readonly FinykBlobEntry[];
+  readonly receivables: readonly FinykBlobEntry[];
+  readonly customCategories: readonly FinykBlobEntry[];
+  readonly manualExpenses: readonly FinykBlobEntry[];
+  readonly txCategories: readonly FinykTxCategoryEntry[];
+  readonly txSplits: readonly FinykTxSplitsEntry[];
+  readonly monoDebtLinks: readonly FinykMonoDebtLinkEntry[];
+  readonly networthHistory: readonly FinykNetworthEntry[];
+  readonly prefs: FinykPrefsSnapshot | null;
+}
+
+export const EMPTY_FINYK_STATE: FinykDualWriteState = {
+  hiddenAccounts: [],
+  hiddenTransactions: [],
+  budgets: [],
+  subscriptions: [],
+  assets: [],
+  debts: [],
+  receivables: [],
+  customCategories: [],
+  manualExpenses: [],
+  txCategories: [],
+  txSplits: [],
+  monoDebtLinks: [],
+  networthHistory: [],
+  prefs: null,
+};
+
+// -----------------------------------------------------------------------
+// Op types
+// -----------------------------------------------------------------------
+
+export type FinykIdTable =
+  | "finyk_hidden_accounts"
+  | "finyk_hidden_transactions";
+
+export type FinykBlobTable =
+  | "finyk_budgets"
+  | "finyk_subscriptions"
+  | "finyk_assets"
+  | "finyk_debts"
+  | "finyk_receivables"
+  | "finyk_custom_categories"
+  | "finyk_manual_expenses";
+
+export interface IdUpsertOp {
+  readonly kind: "id-upsert";
+  readonly table: FinykIdTable;
+  readonly entry: FinykIdEntry;
+}
+
+export interface IdDeleteOp {
+  readonly kind: "id-delete";
+  readonly table: FinykIdTable;
+  readonly id: string;
+}
+
+export interface BlobUpsertOp {
+  readonly kind: "blob-upsert";
+  readonly table: FinykBlobTable;
+  readonly entry: FinykBlobEntry;
+}
+
+export interface BlobDeleteOp {
+  readonly kind: "blob-delete";
+  readonly table: FinykBlobTable;
+  readonly id: string;
+}
+
+export interface TxCategoryUpsertOp {
+  readonly kind: "tx-category-upsert";
+  readonly entry: FinykTxCategoryEntry;
+}
+
+export interface TxCategoryDeleteOp {
+  readonly kind: "tx-category-delete";
+  readonly transactionId: string;
+}
+
+export interface TxSplitsUpsertOp {
+  readonly kind: "tx-splits-upsert";
+  readonly entry: FinykTxSplitsEntry;
+}
+
+export interface TxSplitsDeleteOp {
+  readonly kind: "tx-splits-delete";
+  readonly transactionId: string;
+}
+
+export interface MonoDebtLinkUpsertOp {
+  readonly kind: "mono-debt-link-upsert";
+  readonly entry: FinykMonoDebtLinkEntry;
+}
+
+export interface MonoDebtLinkDeleteOp {
+  readonly kind: "mono-debt-link-delete";
+  readonly transactionId: string;
+}
+
+export interface NetworthUpsertOp {
+  readonly kind: "networth-upsert";
+  readonly entry: FinykNetworthEntry;
+}
+
+export interface PrefsUpsertOp {
+  readonly kind: "prefs-upsert";
+  readonly prefs: FinykPrefsSnapshot;
+}
+
+export type FinykDualWriteOp =
+  | IdUpsertOp
+  | IdDeleteOp
+  | BlobUpsertOp
+  | BlobDeleteOp
+  | TxCategoryUpsertOp
+  | TxCategoryDeleteOp
+  | TxSplitsUpsertOp
+  | TxSplitsDeleteOp
+  | MonoDebtLinkUpsertOp
+  | MonoDebtLinkDeleteOp
+  | NetworthUpsertOp
+  | PrefsUpsertOp;
+
+// -----------------------------------------------------------------------
+// Diff
+// -----------------------------------------------------------------------
+
+/**
+ * Compute the dual-write operation list for the transition `prev → next`.
+ *
+ * Stable iteration order:
+ *   1. id-tables (`finyk_hidden_accounts`, `finyk_hidden_transactions`)
+ *   2. blob-tables in declaration order (budgets → subs → assets → …)
+ *   3. tx-categories / tx-splits / mono-debt-links (id asc)
+ *   4. networth-history (month asc)
+ *   5. prefs-upsert (singleton, last)
+ */
+export function diffFinykDualWriteOps(
+  prev: FinykDualWriteState,
+  next: FinykDualWriteState,
+): FinykDualWriteOp[] {
+  const ops: FinykDualWriteOp[] = [];
+
+  // --- ID tables ---
+  diffById(
+    prev.hiddenAccounts,
+    next.hiddenAccounts,
+    () => false, // no payload — set membership only
+    (entry) =>
+      ops.push({ kind: "id-upsert", table: "finyk_hidden_accounts", entry }),
+    (id) => ops.push({ kind: "id-delete", table: "finyk_hidden_accounts", id }),
+  );
+
+  diffById(
+    prev.hiddenTransactions,
+    next.hiddenTransactions,
+    () => false,
+    (entry) =>
+      ops.push({
+        kind: "id-upsert",
+        table: "finyk_hidden_transactions",
+        entry,
+      }),
+    (id) =>
+      ops.push({ kind: "id-delete", table: "finyk_hidden_transactions", id }),
+  );
+
+  // --- Per-row blobs ---
+  diffBlobs(prev.budgets, next.budgets, "finyk_budgets", ops);
+  diffBlobs(prev.subscriptions, next.subscriptions, "finyk_subscriptions", ops);
+  diffBlobs(prev.assets, next.assets, "finyk_assets", ops);
+  diffBlobs(prev.debts, next.debts, "finyk_debts", ops);
+  diffBlobs(prev.receivables, next.receivables, "finyk_receivables", ops);
+  diffBlobs(
+    prev.customCategories,
+    next.customCategories,
+    "finyk_custom_categories",
+    ops,
+  );
+  diffBlobs(
+    prev.manualExpenses,
+    next.manualExpenses,
+    "finyk_manual_expenses",
+    ops,
+  );
+
+  // --- Per-tx category overrides ---
+  diffByKey(
+    prev.txCategories,
+    next.txCategories,
+    (e) => e.transactionId,
+    (a, b) => a.categoryId !== b.categoryId,
+    (entry) => ops.push({ kind: "tx-category-upsert", entry }),
+    (transactionId) => ops.push({ kind: "tx-category-delete", transactionId }),
+  );
+
+  // --- Per-tx splits ---
+  diffByKey(
+    prev.txSplits,
+    next.txSplits,
+    (e) => e.transactionId,
+    (a, b) => a.splitsJson !== b.splitsJson,
+    (entry) => ops.push({ kind: "tx-splits-upsert", entry }),
+    (transactionId) => ops.push({ kind: "tx-splits-delete", transactionId }),
+  );
+
+  // --- Per-tx mono-debt links ---
+  diffByKey(
+    prev.monoDebtLinks,
+    next.monoDebtLinks,
+    (e) => e.transactionId,
+    (a, b) => a.debtIdsJson !== b.debtIdsJson,
+    (entry) => ops.push({ kind: "mono-debt-link-upsert", entry }),
+    (transactionId) =>
+      ops.push({ kind: "mono-debt-link-delete", transactionId }),
+  );
+
+  // --- Time-series: networth_history ---
+  // No deletes — history is append/replace-only per month.
+  diffByKey(
+    prev.networthHistory,
+    next.networthHistory,
+    (e) => e.month,
+    (a, b) => a.networth !== b.networth,
+    (entry) => ops.push({ kind: "networth-upsert", entry }),
+    () => {
+      /* no delete op for time-series */
+    },
+  );
+
+  // --- Singleton prefs ---
+  if (prefsChanged(prev.prefs, next.prefs) && next.prefs) {
+    ops.push({ kind: "prefs-upsert", prefs: next.prefs });
+  }
+
+  return ops;
+}
+
+// -----------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------
+
+function diffById(
+  prev: readonly FinykIdEntry[],
+  next: readonly FinykIdEntry[],
+  hasChanged: (a: FinykIdEntry, b: FinykIdEntry) => boolean,
+  onUpsert: (entry: FinykIdEntry) => void,
+  onDelete: (id: string) => void,
+): void {
+  const prevMap = new Map<string, FinykIdEntry>();
+  for (const item of prev) prevMap.set(item.id, item);
+  const nextMap = new Map<string, FinykIdEntry>();
+  for (const item of next) nextMap.set(item.id, item);
+
+  const sortedNextIds = [...nextMap.keys()].sort();
+  for (const id of sortedNextIds) {
+    const nextItem = nextMap.get(id)!;
+    const prevItem = prevMap.get(id);
+    if (!prevItem) onUpsert(nextItem);
+    else if (prevItem !== nextItem && hasChanged(prevItem, nextItem))
+      onUpsert(nextItem);
+  }
+
+  const sortedPrevIds = [...prevMap.keys()].sort();
+  for (const id of sortedPrevIds) {
+    if (!nextMap.has(id)) onDelete(id);
+  }
+}
+
+function diffBlobs(
+  prev: readonly FinykBlobEntry[],
+  next: readonly FinykBlobEntry[],
+  table: FinykBlobTable,
+  ops: FinykDualWriteOp[],
+): void {
+  const prevMap = new Map<string, FinykBlobEntry>();
+  for (const item of prev) prevMap.set(item.id, item);
+  const nextMap = new Map<string, FinykBlobEntry>();
+  for (const item of next) nextMap.set(item.id, item);
+
+  const sortedNextIds = [...nextMap.keys()].sort();
+  for (const id of sortedNextIds) {
+    const nextItem = nextMap.get(id)!;
+    const prevItem = prevMap.get(id);
+    if (!prevItem) {
+      ops.push({ kind: "blob-upsert", table, entry: nextItem });
+    } else if (
+      prevItem !== nextItem &&
+      prevItem.dataJson !== nextItem.dataJson
+    ) {
+      ops.push({ kind: "blob-upsert", table, entry: nextItem });
+    }
+  }
+
+  const sortedPrevIds = [...prevMap.keys()].sort();
+  for (const id of sortedPrevIds) {
+    if (!nextMap.has(id)) {
+      ops.push({ kind: "blob-delete", table, id });
+    }
+  }
+}
+
+function diffByKey<T>(
+  prev: readonly T[],
+  next: readonly T[],
+  getKey: (entry: T) => string,
+  hasChanged: (prev: T, next: T) => boolean,
+  onUpsert: (entry: T) => void,
+  onDelete: (key: string) => void,
+): void {
+  const prevMap = new Map<string, T>();
+  for (const item of prev) prevMap.set(getKey(item), item);
+  const nextMap = new Map<string, T>();
+  for (const item of next) nextMap.set(getKey(item), item);
+
+  const sortedNextKeys = [...nextMap.keys()].sort();
+  for (const key of sortedNextKeys) {
+    const nextItem = nextMap.get(key)!;
+    const prevItem = prevMap.get(key);
+    if (!prevItem) onUpsert(nextItem);
+    else if (prevItem !== nextItem && hasChanged(prevItem, nextItem))
+      onUpsert(nextItem);
+  }
+
+  const sortedPrevKeys = [...prevMap.keys()].sort();
+  for (const key of sortedPrevKeys) {
+    if (!nextMap.has(key)) onDelete(key);
+  }
+}
+
+function prefsChanged(
+  prev: FinykPrefsSnapshot | null,
+  next: FinykPrefsSnapshot | null,
+): boolean {
+  if (prev === next) return false;
+  if (!prev || !next) return prev !== next;
+  return (
+    prev.monthlyPlanJson !== next.monthlyPlanJson ||
+    prev.showBalance !== next.showBalance
+  );
+}

--- a/apps/mobile/src/modules/finyk/lib/dualWrite/extract.ts
+++ b/apps/mobile/src/modules/finyk/lib/dualWrite/extract.ts
@@ -1,0 +1,149 @@
+/**
+ * Tiny helpers that take a single LS-key value (e.g. `manualAssets[]`)
+ * and produce the partial FinykDualWriteState slice the diff layer
+ * expects. Used by the mobile MMKV stores after each write so the
+ * dual-write trigger can be called with a `prev`/`next` pair that
+ * differs only in the key being mutated.
+ *
+ * Stage 4 PR #036 of `docs/planning/storage-roadmap.md`.
+ */
+
+import {
+  EMPTY_FINYK_STATE,
+  type FinykBlobEntry,
+  type FinykDualWriteState,
+  type FinykIdEntry,
+  type FinykMonoDebtLinkEntry,
+  type FinykNetworthEntry,
+  type FinykTxCategoryEntry,
+  type FinykTxSplitsEntry,
+} from "./diff";
+
+/** Convert a per-row array (rows with `id`) into FinykBlobEntry[]. */
+export function blobsFromArray(
+  arr: readonly unknown[] | null | undefined,
+): FinykBlobEntry[] {
+  if (!Array.isArray(arr)) return [];
+  const out: FinykBlobEntry[] = [];
+  for (const row of arr) {
+    if (!row || typeof row !== "object") continue;
+    const r = row as { id?: unknown };
+    const id = typeof r.id === "string" ? r.id : null;
+    if (!id) continue;
+    let dataJson: string;
+    try {
+      dataJson = JSON.stringify(row);
+    } catch {
+      continue;
+    }
+    out.push({ id, dataJson });
+  }
+  return out;
+}
+
+/** Convert a string-array LS key into FinykIdEntry[]. */
+export function idsFromArray(
+  arr: readonly string[] | null | undefined,
+): FinykIdEntry[] {
+  if (!Array.isArray(arr)) return [];
+  const out: FinykIdEntry[] = [];
+  for (const v of arr) {
+    if (typeof v === "string" && v.length > 0) out.push({ id: v });
+  }
+  return out;
+}
+
+/** Convert a tx-id → categoryId map into FinykTxCategoryEntry[]. */
+export function txCatsFromMap(
+  map: Record<string, string | undefined> | null | undefined,
+): FinykTxCategoryEntry[] {
+  if (!map || typeof map !== "object") return [];
+  const out: FinykTxCategoryEntry[] = [];
+  for (const [transactionId, categoryId] of Object.entries(map)) {
+    if (typeof categoryId !== "string" || categoryId.length === 0) continue;
+    if (typeof transactionId !== "string" || transactionId.length === 0)
+      continue;
+    out.push({ transactionId, categoryId });
+  }
+  return out;
+}
+
+/** Convert a tx-id → splits[] map into FinykTxSplitsEntry[]. */
+export function txSplitsFromMap(
+  map: Record<string, unknown> | null | undefined,
+): FinykTxSplitsEntry[] {
+  if (!map || typeof map !== "object") return [];
+  const out: FinykTxSplitsEntry[] = [];
+  for (const [transactionId, splits] of Object.entries(map)) {
+    if (!Array.isArray(splits) || splits.length === 0) continue;
+    if (typeof transactionId !== "string" || transactionId.length === 0)
+      continue;
+    let splitsJson: string;
+    try {
+      splitsJson = JSON.stringify(splits);
+    } catch {
+      continue;
+    }
+    out.push({ transactionId, splitsJson });
+  }
+  return out;
+}
+
+/** Convert a tx-id → debtIds[] map into FinykMonoDebtLinkEntry[]. */
+export function monoDebtLinksFromMap(
+  map: Record<string, string[]> | null | undefined,
+): FinykMonoDebtLinkEntry[] {
+  if (!map || typeof map !== "object") return [];
+  const out: FinykMonoDebtLinkEntry[] = [];
+  for (const [transactionId, debtIds] of Object.entries(map)) {
+    if (!Array.isArray(debtIds) || debtIds.length === 0) continue;
+    if (typeof transactionId !== "string" || transactionId.length === 0)
+      continue;
+    let debtIdsJson: string;
+    try {
+      debtIdsJson = JSON.stringify(debtIds);
+    } catch {
+      continue;
+    }
+    out.push({ transactionId, debtIdsJson });
+  }
+  return out;
+}
+
+/** Convert a NetworthEntry[] LS array into FinykNetworthEntry[]. */
+export function networthHistoryFrom(
+  arr:
+    | ReadonlyArray<{ month?: unknown; networth?: unknown }>
+    | null
+    | undefined,
+): FinykNetworthEntry[] {
+  if (!Array.isArray(arr)) return [];
+  const out: FinykNetworthEntry[] = [];
+  for (const row of arr) {
+    if (!row || typeof row !== "object") continue;
+    const month =
+      typeof row.month === "string" && /^\d{4}-\d{2}$/.test(row.month)
+        ? row.month
+        : null;
+    const networth =
+      typeof row.networth === "number" && Number.isFinite(row.networth)
+        ? row.networth
+        : null;
+    if (!month || networth === null) continue;
+    out.push({ month, networth });
+  }
+  return out;
+}
+
+/**
+ * Build a FinykDualWriteState that contains ONLY the given slice. Used
+ * by mobile MMKV stores so each write fires a per-key trigger
+ * (`prev → next`) without paying the cost of reading every other LS
+ * key after every mutation.
+ */
+export function stateWithSlice<K extends keyof FinykDualWriteState>(
+  key: K,
+  value: FinykDualWriteState[K],
+): FinykDualWriteState {
+  return { ...EMPTY_FINYK_STATE, [key]: value };
+}

--- a/apps/mobile/src/modules/finyk/lib/dualWrite/index.ts
+++ b/apps/mobile/src/modules/finyk/lib/dualWrite/index.ts
@@ -1,0 +1,131 @@
+import type { SqliteMigrationClient } from "@sergeant/db-schema/migrate/sqlite";
+
+import {
+  applyFinykDualWriteOps,
+  type ApplyDualWriteResult,
+  type DualWriteLogger,
+} from "./adapter";
+import {
+  diffFinykDualWriteOps,
+  EMPTY_FINYK_STATE,
+  type FinykDualWriteState,
+} from "./diff";
+
+/**
+ * Orchestrator for the mobile Finyk dual-write layer.
+ *
+ * Stage 4 PR #036 of `docs/planning/storage-roadmap.md`. Mirror of
+ * `apps/web/src/modules/finyk/lib/dualWrite/index.ts` and of the
+ * mobile nutrition orchestrator (PR #032).
+ */
+
+export interface FinykDualWriteContext {
+  isEnabled(): boolean;
+  getUserId(): string | null;
+  getMigrationClient(): Promise<SqliteMigrationClient | null>;
+  getNow(): string;
+  logger?: DualWriteLogger;
+}
+
+let registeredContext: FinykDualWriteContext | null = null;
+
+export function registerFinykDualWriteContext(
+  ctx: FinykDualWriteContext,
+): () => void {
+  registeredContext = ctx;
+  return () => {
+    if (registeredContext === ctx) registeredContext = null;
+  };
+}
+
+export function __clearFinykDualWriteContextForTests(): void {
+  registeredContext = null;
+}
+
+export function isFinykDualWriteRegistered(): boolean {
+  return registeredContext !== null;
+}
+
+export async function dualWriteFinykState(
+  prev: FinykDualWriteState,
+  next: FinykDualWriteState,
+): Promise<DualWriteOutcome> {
+  const ctx = registeredContext;
+  if (!ctx) return { status: "skipped", reason: "context-unset" };
+  if (!ctx.isEnabled()) return { status: "skipped", reason: "flag-off" };
+
+  const ops = diffFinykDualWriteOps(prev, next);
+  if (ops.length === 0) return { status: "skipped", reason: "no-ops" };
+
+  const userId = ctx.getUserId();
+  if (!userId) {
+    logSafe(ctx, "warn", "dual-write skipped: user id unavailable", {
+      ops: ops.length,
+    });
+    return { status: "skipped", reason: "user-id-missing" };
+  }
+
+  let client: SqliteMigrationClient | null = null;
+  try {
+    client = await ctx.getMigrationClient();
+  } catch (err) {
+    logSafe(ctx, "warn", "dual-write skipped: sqlite unavailable", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return { status: "skipped", reason: "sqlite-unavailable" };
+  }
+  if (!client) {
+    logSafe(ctx, "warn", "dual-write skipped: sqlite returned null", {});
+    return { status: "skipped", reason: "sqlite-unavailable" };
+  }
+
+  const result = await applyFinykDualWriteOps(client, ops, {
+    userId,
+    clientTs: ctx.getNow(),
+    logger: ctx.logger,
+  });
+  return { status: "applied", result };
+}
+
+export function triggerFinykDualWrite(
+  prev: FinykDualWriteState,
+  next: FinykDualWriteState,
+): void {
+  if (!registeredContext) return;
+  void Promise.resolve().then(() => dualWriteFinykState(prev, next));
+}
+
+export type DualWriteOutcome =
+  | { status: "applied"; result: ApplyDualWriteResult }
+  | {
+      status: "skipped";
+      reason:
+        | "context-unset"
+        | "flag-off"
+        | "no-ops"
+        | "user-id-missing"
+        | "sqlite-unavailable";
+    };
+
+function logSafe(
+  ctx: FinykDualWriteContext,
+  level: "warn" | "info",
+  msg: string,
+  meta: Record<string, unknown>,
+): void {
+  try {
+    if (ctx.logger) ctx.logger(level, msg, meta);
+    else if (level === "warn") console.warn(`[finyk.dualWrite] ${msg}`, meta);
+  } catch {
+    /* noop — logging must never throw */
+  }
+}
+
+export {
+  applyFinykDualWriteOps,
+  diffFinykDualWriteOps,
+  EMPTY_FINYK_STATE,
+  type ApplyDualWriteResult,
+  type DualWriteLogger,
+  type FinykDualWriteState,
+};

--- a/apps/mobile/src/modules/finyk/lib/dualWriteBoot.ts
+++ b/apps/mobile/src/modules/finyk/lib/dualWriteBoot.ts
@@ -1,0 +1,44 @@
+/**
+ * Boot wiring for the mobile Finyk dual-write context.
+ *
+ * Stage 4 PR #036 of `docs/planning/storage-roadmap.md`. Mirror of
+ * `apps/mobile/src/modules/nutrition/lib/dualWriteBoot.ts`.
+ */
+
+import type { SqliteMigrationClient } from "@sergeant/db-schema/migrate/sqlite";
+import { getSqliteMigrationClient } from "@/core/db/sqlite";
+
+import { migrateFinyk } from "./clientMigrate";
+import {
+  registerFinykDualWriteContext,
+  type FinykDualWriteContext,
+} from "./dualWrite";
+
+export interface BootFinykDualWriteInput {
+  getUserId(): string | null;
+  isFlagEnabled(): boolean;
+}
+
+let migrationsApplied = false;
+
+export function bootFinykDualWrite(input: BootFinykDualWriteInput): () => void {
+  const ctx: FinykDualWriteContext = {
+    isEnabled: () => input.isFlagEnabled(),
+    getUserId: () => input.getUserId(),
+    getMigrationClient: async (): Promise<SqliteMigrationClient | null> => {
+      const client = await getSqliteMigrationClient();
+      if (!migrationsApplied) {
+        await migrateFinyk(client);
+        migrationsApplied = true;
+      }
+      return client;
+    },
+    getNow: () => new Date().toISOString(),
+  };
+  return registerFinykDualWriteContext(ctx);
+}
+
+/** Test-only escape hatch — clears the migrations-applied flag. */
+export function __resetFinykDualWriteBootForTests(): void {
+  migrationsApplied = false;
+}

--- a/apps/mobile/src/modules/finyk/lib/transactionsStore.ts
+++ b/apps/mobile/src/modules/finyk/lib/transactionsStore.ts
@@ -28,6 +28,14 @@ import type { MonoAccount, Transaction } from "@sergeant/finyk-domain/domain";
 import { STORAGE_KEYS } from "@sergeant/shared";
 
 import { _getMMKVInstance, safeReadLS, safeWriteLS } from "@/lib/storage";
+import { isFinykDualWriteRegistered, triggerFinykDualWrite } from "./dualWrite";
+import {
+  blobsFromArray,
+  idsFromArray,
+  stateWithSlice,
+  txCatsFromMap,
+  txSplitsFromMap,
+} from "./dualWrite/extract";
 import { enqueueChange } from "@/sync/enqueue";
 
 import type { ManualExpensePayload } from "../components/ManualExpenseSheet";
@@ -281,9 +289,16 @@ export function useFinykTransactionsStore(
   }, []);
 
   const writeManual = useCallback((next: ManualExpenseRecord[]) => {
+    const prev = read<ManualExpenseRecord[]>(KEY_MANUAL, []);
     setManualState(next);
     safeWriteLS(KEY_MANUAL, next);
     enqueueChange(KEY_MANUAL);
+    if (isFinykDualWriteRegistered()) {
+      triggerFinykDualWrite(
+        stateWithSlice("manualExpenses", blobsFromArray(prev)),
+        stateWithSlice("manualExpenses", blobsFromArray(next)),
+      );
+    }
   }, []);
 
   const addManualExpense = useCallback(
@@ -339,6 +354,12 @@ export function useFinykTransactionsStore(
     setHiddenState(next);
     safeWriteLS(KEY_HIDDEN_TXS, next);
     enqueueChange(KEY_HIDDEN_TXS);
+    if (isFinykDualWriteRegistered()) {
+      triggerFinykDualWrite(
+        stateWithSlice("hiddenTransactions", idsFromArray(current)),
+        stateWithSlice("hiddenTransactions", idsFromArray(next)),
+      );
+    }
   }, []);
 
   const unhideTx = useCallback((id: string) => {
@@ -348,6 +369,12 @@ export function useFinykTransactionsStore(
     setHiddenState(next);
     safeWriteLS(KEY_HIDDEN_TXS, next);
     enqueueChange(KEY_HIDDEN_TXS);
+    if (isFinykDualWriteRegistered()) {
+      triggerFinykDualWrite(
+        stateWithSlice("hiddenTransactions", idsFromArray(current)),
+        stateWithSlice("hiddenTransactions", idsFromArray(next)),
+      );
+    }
   }, []);
 
   const overrideCategory = useCallback(
@@ -362,6 +389,12 @@ export function useFinykTransactionsStore(
       setTxCatsState(next);
       safeWriteLS(KEY_TX_CATS, next);
       enqueueChange(KEY_TX_CATS);
+      if (isFinykDualWriteRegistered()) {
+        triggerFinykDualWrite(
+          stateWithSlice("txCategories", txCatsFromMap(current)),
+          stateWithSlice("txCategories", txCatsFromMap(next)),
+        );
+      }
     },
     [],
   );
@@ -377,6 +410,12 @@ export function useFinykTransactionsStore(
     setTxSplitsState(next);
     safeWriteLS(KEY_TX_SPLITS, next);
     enqueueChange(KEY_TX_SPLITS);
+    if (isFinykDualWriteRegistered()) {
+      triggerFinykDualWrite(
+        stateWithSlice("txSplits", txSplitsFromMap(current)),
+        stateWithSlice("txSplits", txSplitsFromMap(next)),
+      );
+    }
   }, []);
 
   const refresh = useCallback(() => {

--- a/apps/server/src/migrations/039_finyk_tables.down.sql
+++ b/apps/server/src/migrations/039_finyk_tables.down.sql
@@ -1,0 +1,40 @@
+-- Rollback for migration 039_finyk_tables.sql.
+--
+-- Local-only rollback — production never runs `down.sql` (rule #4 in
+-- AGENTS.md). Order: child indexes / per-tx mappings / per-row tables
+-- first, then the singleton (`finyk_prefs` last in case future
+-- migrations add FKs from per-row data into prefs). Each statement is
+-- `IF EXISTS`-guarded so the file stays idempotent (rule #4
+-- re-application invariant — the `035-nutrition-tables` round-trip
+-- harness asserts this).
+
+DROP INDEX IF EXISTS finyk_hidden_accounts_user_active_idx;
+DROP INDEX IF EXISTS finyk_hidden_transactions_user_active_idx;
+DROP INDEX IF EXISTS finyk_budgets_user_active_idx;
+DROP INDEX IF EXISTS finyk_subscriptions_user_active_idx;
+DROP INDEX IF EXISTS finyk_assets_user_active_idx;
+DROP INDEX IF EXISTS finyk_debts_user_active_idx;
+DROP INDEX IF EXISTS finyk_receivables_user_active_idx;
+DROP INDEX IF EXISTS finyk_tx_categories_user_idx;
+DROP INDEX IF EXISTS finyk_tx_splits_user_idx;
+DROP INDEX IF EXISTS finyk_mono_debt_links_user_idx;
+DROP INDEX IF EXISTS finyk_networth_history_user_month_idx;
+DROP INDEX IF EXISTS finyk_custom_categories_user_active_idx;
+DROP INDEX IF EXISTS finyk_manual_expenses_user_active_idx;
+DROP INDEX IF EXISTS finyk_tx_filters_user_active_idx;
+
+DROP TABLE IF EXISTS finyk_hidden_accounts;
+DROP TABLE IF EXISTS finyk_hidden_transactions;
+DROP TABLE IF EXISTS finyk_budgets;
+DROP TABLE IF EXISTS finyk_subscriptions;
+DROP TABLE IF EXISTS finyk_assets;
+DROP TABLE IF EXISTS finyk_debts;
+DROP TABLE IF EXISTS finyk_receivables;
+DROP TABLE IF EXISTS finyk_tx_categories;
+DROP TABLE IF EXISTS finyk_tx_splits;
+DROP TABLE IF EXISTS finyk_mono_debt_links;
+DROP TABLE IF EXISTS finyk_networth_history;
+DROP TABLE IF EXISTS finyk_custom_categories;
+DROP TABLE IF EXISTS finyk_manual_expenses;
+DROP TABLE IF EXISTS finyk_tx_filters;
+DROP TABLE IF EXISTS finyk_prefs;

--- a/apps/server/src/migrations/039_finyk_tables.sql
+++ b/apps/server/src/migrations/039_finyk_tables.sql
@@ -1,0 +1,354 @@
+-- 039: finyk_* normalized target tables — Stage 4 / PR #035 of
+-- `docs/planning/storage-roadmap.md`.
+--
+-- Context. Finyk state is the largest cross-platform LS/MMKV blob set
+-- left in the app: 16 user-edited keys (`finyk_hidden`, `finyk_budgets`,
+-- `finyk_subs`, `finyk_assets`, `finyk_debts`, `finyk_recv`,
+-- `finyk_hidden_txs`, `finyk_monthly_plan`, `finyk_tx_cats`,
+-- `finyk_tx_splits`, `finyk_mono_debt_linked`, `finyk_networth_history`,
+-- `finyk_custom_cats_v1`, `finyk_manual_expenses_v1`,
+-- `finyk_tx_filters_v1`, `finyk_show_balance_v1`) plus the three Mono
+-- caches (`finyk_tx_cache`, `finyk_info_cache`, `finyk_tx_cache_last_good`,
+-- handled separately in PR #038). Whole-blob LWW push/pull through
+-- `module_data.finyk` has the same scalability issues the routine
+-- (PRs #023–#026), fizruk (PRs #027–#030), and nutrition (PRs #031–#034)
+-- shed before us:
+--
+--   * no per-row sync (multi-device collisions on a single blob
+--     overwrite the opponent's fresh edits — particularly painful for
+--     `finyk_tx_cats` where every web tx click races mobile),
+--   * payload growth scales with feature count, not user activity
+--     (subscriptions+budgets+assets+debts+manual-expenses pile up
+--     unbounded),
+--   * per-tx data (`finyk_tx_cats`, `finyk_tx_splits`,
+--     `finyk_mono_debt_linked`) re-pushes the entire map on every edit.
+--
+-- This migration adds **tables only** — the server does not read from
+-- them yet (Stage 5 read cut-over is PR #037). Writes happen through
+-- the v2 sync apply path (`OP_LOG_TABLE_REGISTRY` in `syncV2.ts`); the
+-- companion server-side apply functions land in this same PR so
+-- inbound dual-write traffic from PR #036 can already round-trip
+-- before Stage 5 lights up.
+--
+-- Mirrors the structure of migration 035_nutrition_tables.sql (PR #031
+-- of the same roadmap) — same FK-on-user / soft-delete-tombstone /
+-- per-user-active-index pattern, same TIMESTAMPTZ defaults, same
+-- `_lite`-suffixed indexes on the SQLite parallel schema. Five table
+-- shapes are reused across the 15 tables:
+--
+--   1. **per-row + JSONB blob** (budgets, subscriptions, assets,
+--      debts, receivables, custom_categories, manual_expenses,
+--      tx_filters): `id UUID PK`, `user_id`, `data_json JSONB`,
+--      `created_at`/`updated_at`/`deleted_at`. Open-ended user-edited
+--      shapes that the UI reads as a whole — not worth column
+--      splitting.
+--   2. **composite-PK tombstone** (hidden_accounts,
+--      hidden_transactions): `(user_id, ext_id) PRIMARY KEY` with
+--      `updated_at`/`deleted_at` — natural key is the external Mono
+--      account/transaction id; no surrogate `id`. Soft-delete
+--      preserves LWW so an "unhide" on device A doesn't lose to a
+--      stale "hide" replay from device B.
+--   3. **per-tx mapping** (tx_categories, tx_splits,
+--      mono_debt_links): `(user_id, transaction_id) PRIMARY KEY`
+--      with `updated_at`. The natural key is the Mono transaction id
+--      — there is at most one mapping per (user, tx). `tx_categories`
+--      is a single TEXT column (`category_id`); the other two carry
+--      JSONB (split arrays / debt id arrays). No `deleted_at` —
+--      "no mapping" is the same as the mapping not existing, so the
+--      sync apply path treats `delete` as `DELETE FROM` (idempotent).
+--   4. **time-series** (networth_history): `(user_id, month)
+--      PRIMARY KEY` with monthly snapshots. `month` is a TEXT
+--      `YYYY-MM` to mirror the LS shape exactly — no
+--      string-to-date coercion at the API boundary, makes the LWW
+--      key trivially comparable.
+--   5. **per-user singleton prefs** (prefs): `user_id PRIMARY KEY`,
+--      JSONB blob for the open-ended shape, plus split-out
+--      `show_balance BOOLEAN` and `monthly_plan_json JSONB` columns
+--      so multi-device LWW on those individual sub-fields doesn't
+--      have to merge the open-ended JSONB.
+--
+-- Forward-only: `pnpm db:migrate` does not add DROPs here, so rule #4
+-- (two-phase DROP) does not apply. `.down.sql` is for local rollback only.
+
+-- finyk_hidden_accounts — set of Mono account ids the user has hidden
+-- from list/dashboard views. Composite PK on `(user_id, account_id)`
+-- so the natural external id (Mono's account ID, opaque TEXT) is the
+-- key — no surrogate UUID needed. Soft-delete with `deleted_at` so an
+-- "unhide" race correctly LWW-resolves against a stale "hide" from
+-- another device.
+CREATE TABLE IF NOT EXISTS finyk_hidden_accounts (
+  user_id     TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  account_id  TEXT NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at  TIMESTAMPTZ,
+  PRIMARY KEY (user_id, account_id)
+);
+
+CREATE INDEX IF NOT EXISTS finyk_hidden_accounts_user_active_idx
+  ON finyk_hidden_accounts (user_id)
+  WHERE deleted_at IS NULL;
+
+-- finyk_hidden_transactions — set of Mono transaction ids the user
+-- has hidden. Same shape as finyk_hidden_accounts but keyed on
+-- `transaction_id`.
+CREATE TABLE IF NOT EXISTS finyk_hidden_transactions (
+  user_id        TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  transaction_id TEXT NOT NULL,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at     TIMESTAMPTZ,
+  PRIMARY KEY (user_id, transaction_id)
+);
+
+CREATE INDEX IF NOT EXISTS finyk_hidden_transactions_user_active_idx
+  ON finyk_hidden_transactions (user_id)
+  WHERE deleted_at IS NULL;
+
+-- finyk_budgets — per-row budget entries (limit/goal). `data_json`
+-- carries the open-ended `Budget` shape (categoryId, type,
+-- targetAmount, period, etc.) — UI reads the whole row at once so
+-- column-splitting buys nothing.
+CREATE TABLE IF NOT EXISTS finyk_budgets (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  data_json   JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at  TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS finyk_budgets_user_active_idx
+  ON finyk_budgets (user_id, deleted_at)
+  WHERE deleted_at IS NULL;
+
+-- finyk_subscriptions — recurring-payment definitions. `data_json`
+-- holds the `Subscription` shape (name, emoji, billingDay, currency,
+-- linkedTxId, …).
+CREATE TABLE IF NOT EXISTS finyk_subscriptions (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  data_json   JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at  TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS finyk_subscriptions_user_active_idx
+  ON finyk_subscriptions (user_id, deleted_at)
+  WHERE deleted_at IS NULL;
+
+-- finyk_assets — manually tracked assets (cash, real estate, vehicles,
+-- linked-tx-augmented balances). `data_json` is the full `ManualAsset`
+-- shape (amount, name, currency, linkedTxIds, emoji, …).
+CREATE TABLE IF NOT EXISTS finyk_assets (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  data_json   JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at  TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS finyk_assets_user_active_idx
+  ON finyk_assets (user_id, deleted_at)
+  WHERE deleted_at IS NULL;
+
+-- finyk_debts — manually tracked debts the user owes. `data_json` is
+-- the full `Debt` shape from `@sergeant/finyk-domain/domain/debtEngine`
+-- (amount, currency, counterparty, dueDate, schedule, payments, …).
+CREATE TABLE IF NOT EXISTS finyk_debts (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  data_json   JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at  TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS finyk_debts_user_active_idx
+  ON finyk_debts (user_id, deleted_at)
+  WHERE deleted_at IS NULL;
+
+-- finyk_receivables — money owed TO the user. Same shape as
+-- finyk_debts but the direction is reversed at the domain layer.
+CREATE TABLE IF NOT EXISTS finyk_receivables (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  data_json   JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at  TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS finyk_receivables_user_active_idx
+  ON finyk_receivables (user_id, deleted_at)
+  WHERE deleted_at IS NULL;
+
+-- finyk_tx_categories — per-transaction category override. The LS
+-- shape is `Record<txId, categoryId>` with `undefined` values meaning
+-- "fall back to MCC default". Composite PK `(user_id, transaction_id)`;
+-- no `deleted_at` because the absence of a mapping is itself the
+-- "no override" state — sync `delete` ops just `DELETE FROM`.
+CREATE TABLE IF NOT EXISTS finyk_tx_categories (
+  user_id        TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  transaction_id TEXT NOT NULL,
+  category_id    TEXT NOT NULL,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (user_id, transaction_id)
+);
+
+CREATE INDEX IF NOT EXISTS finyk_tx_categories_user_idx
+  ON finyk_tx_categories (user_id);
+
+-- finyk_tx_splits — per-transaction split definitions (multi-category
+-- breakdown of a single Mono transaction). LS shape is
+-- `Record<txId, TxSplit[]>`. Composite PK `(user_id, transaction_id)`;
+-- the array of splits goes into `splits_json` JSONB.
+CREATE TABLE IF NOT EXISTS finyk_tx_splits (
+  user_id        TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  transaction_id TEXT NOT NULL,
+  splits_json    JSONB NOT NULL DEFAULT '[]'::jsonb,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (user_id, transaction_id)
+);
+
+CREATE INDEX IF NOT EXISTS finyk_tx_splits_user_idx
+  ON finyk_tx_splits (user_id);
+
+-- finyk_mono_debt_links — which manual debts a Mono transaction is
+-- linked to. LS shape is `Record<txId, debtId[]>`. Composite PK,
+-- `debt_ids_json` is the array of `finyk_debts.id` strings.
+CREATE TABLE IF NOT EXISTS finyk_mono_debt_links (
+  user_id        TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  transaction_id TEXT NOT NULL,
+  debt_ids_json  JSONB NOT NULL DEFAULT '[]'::jsonb,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (user_id, transaction_id)
+);
+
+CREATE INDEX IF NOT EXISTS finyk_mono_debt_links_user_idx
+  ON finyk_mono_debt_links (user_id);
+
+-- finyk_networth_history — monthly net-worth snapshots. LS shape is
+-- `NetworthEntry[]` with `{ month: 'YYYY-MM', networth: number }`.
+-- `month` stays TEXT (not DATE) so LWW comparisons / API round-trips
+-- match the LS shape byte-for-byte. `snapshot_json` reserves space
+-- for richer per-month payloads (per-asset breakdowns, FX rate at
+-- snapshot time) without a follow-up migration.
+CREATE TABLE IF NOT EXISTS finyk_networth_history (
+  user_id        TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  month          TEXT NOT NULL,
+  networth       REAL NOT NULL DEFAULT 0,
+  snapshot_json  JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (user_id, month)
+);
+
+CREATE INDEX IF NOT EXISTS finyk_networth_history_user_month_idx
+  ON finyk_networth_history (user_id, month DESC);
+
+-- finyk_custom_categories — user-defined transaction categories
+-- (`finyk_custom_cats_v1`). Per-row with `id` UUID PK; `data_json`
+-- holds the `CustomCategory` shape (label, color, icon, parentId).
+CREATE TABLE IF NOT EXISTS finyk_custom_categories (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  data_json   JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at  TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS finyk_custom_categories_user_active_idx
+  ON finyk_custom_categories (user_id, deleted_at)
+  WHERE deleted_at IS NULL;
+
+-- finyk_manual_expenses — user-entered cash expenses outside Mono
+-- (`finyk_manual_expenses_v1`). Per-row `ManualExpense` shape (date,
+-- description, amount, category) inside `data_json`.
+CREATE TABLE IF NOT EXISTS finyk_manual_expenses (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  data_json   JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at  TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS finyk_manual_expenses_user_active_idx
+  ON finyk_manual_expenses (user_id, deleted_at)
+  WHERE deleted_at IS NULL;
+
+-- finyk_tx_filters — saved transaction filter presets
+-- (`finyk_tx_filters_v1`). Open-ended filter shape (date range, accounts,
+-- categories, search) lives in `data_json`.
+CREATE TABLE IF NOT EXISTS finyk_tx_filters (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  data_json   JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at  TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS finyk_tx_filters_user_active_idx
+  ON finyk_tx_filters (user_id, deleted_at)
+  WHERE deleted_at IS NULL;
+
+-- finyk_prefs — per-user singleton row of finyk-side preferences.
+-- `monthly_plan_json` carries `MonthlyPlan` (income/expense/savings —
+-- all stored as TEXT/number-strings to match the LS shape verbatim).
+-- `show_balance` is split out of the open-ended `prefs_json` so
+-- multi-device LWW on the balance-visibility toggle doesn't have to
+-- merge the JSONB blob. `user_id` is the primary key — exactly one
+-- row per user.
+CREATE TABLE IF NOT EXISTS finyk_prefs (
+  user_id            TEXT PRIMARY KEY REFERENCES "user"(id) ON DELETE CASCADE,
+  prefs_json         JSONB NOT NULL DEFAULT '{}'::jsonb,
+  monthly_plan_json  JSONB NOT NULL DEFAULT '{}'::jsonb,
+  show_balance       BOOLEAN NOT NULL DEFAULT true,
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE finyk_hidden_accounts IS
+  'Per-user set of Mono account ids hidden from the UI. Soft-delete on (user_id, account_id) for LWW unhide-vs-hide races.';
+COMMENT ON TABLE finyk_hidden_transactions IS
+  'Per-user set of Mono transaction ids hidden from the UI. Same shape as finyk_hidden_accounts but on transaction_id.';
+COMMENT ON TABLE finyk_budgets IS
+  'Per-row budget entries (limit/goal). data_json holds the open-ended Budget shape; UI reads whole-row.';
+COMMENT ON TABLE finyk_subscriptions IS
+  'Per-row recurring-payment definitions (name, emoji, billingDay, currency, linkedTxId).';
+COMMENT ON TABLE finyk_assets IS
+  'Per-row manually tracked assets (cash, real estate, vehicles). data_json is the ManualAsset shape.';
+COMMENT ON TABLE finyk_debts IS
+  'Per-row manually tracked debts the user owes. data_json is the Debt shape (debtEngine).';
+COMMENT ON TABLE finyk_receivables IS
+  'Money owed TO the user. Same shape as finyk_debts; direction reversed at the domain layer.';
+COMMENT ON TABLE finyk_tx_categories IS
+  'Per-transaction category override. Composite PK (user_id, transaction_id); delete = DELETE FROM (no soft-delete).';
+COMMENT ON TABLE finyk_tx_splits IS
+  'Per-transaction split definitions. splits_json holds the TxSplit[] array.';
+COMMENT ON TABLE finyk_mono_debt_links IS
+  'Maps Mono transactions to manual debts. debt_ids_json is the array of finyk_debts.id strings.';
+COMMENT ON TABLE finyk_networth_history IS
+  'Monthly net-worth snapshots. month is TEXT YYYY-MM to match the LS NetworthEntry shape verbatim.';
+COMMENT ON COLUMN finyk_networth_history.month IS
+  'YYYY-MM string. TEXT (not DATE) so LWW + API round-trips match LS byte-for-byte.';
+COMMENT ON TABLE finyk_custom_categories IS
+  'User-defined transaction categories (label/color/icon/parentId).';
+COMMENT ON TABLE finyk_manual_expenses IS
+  'User-entered cash expenses outside Mono (date/description/amount/category).';
+COMMENT ON TABLE finyk_tx_filters IS
+  'Saved transaction filter presets — date range, accounts, categories, search query.';
+COMMENT ON TABLE finyk_prefs IS
+  'Per-user singleton row of finyk preferences. show_balance + monthly_plan split out so multi-device LWW does not merge the JSONB.';
+COMMENT ON COLUMN finyk_prefs.show_balance IS
+  'Hoisted out of prefs_json so balance-visibility toggle has its own LWW lane.';
+COMMENT ON COLUMN finyk_prefs.monthly_plan_json IS
+  'MonthlyPlan blob (income/expense/savings as the original LS string-or-number shape).';

--- a/apps/server/src/migrations/__tests__/039-finyk-tables.test.ts
+++ b/apps/server/src/migrations/__tests__/039-finyk-tables.test.ts
@@ -1,0 +1,433 @@
+// Migration 039 — focused round-trip for the Finyk tables
+// (Stage 4 / PR #035 of `docs/planning/storage-roadmap.md`).
+//
+// Mirrors `035-nutrition-tables.test.ts`: same Docker / pgvector
+// testcontainer harness, same soft-skip behaviour, same assertions
+// shape — the only thing that changes is the table list and the
+// per-table column checks. Keeping the harness identical means a
+// regression in the migration-runner shows up the same way for both
+// modules in CI logs.
+//
+// Asserts that:
+//   1. applying every forward migration leaves all 15 finyk tables
+//      present with the columns / indexes documented in
+//      `apps/server/src/migrations/039_finyk_tables.sql`,
+//   2. running `039_finyk_tables.down.sql` drops them all (and
+//      removes the explicit indexes),
+//   3. the down migration is idempotent (rule #4 invariant),
+//   4. down → re-up restores the schema fingerprint byte-for-byte.
+
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+import { fileURLToPath } from "url";
+import pg from "pg";
+import { GenericContainer, Wait } from "testcontainers";
+import type { StartedTestContainer } from "testcontainers";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MIGRATIONS_DIR = path.resolve(__dirname, "..");
+
+const TIMEOUT_MS = 180_000;
+
+const FINYK_TABLES = [
+  "finyk_assets",
+  "finyk_budgets",
+  "finyk_custom_categories",
+  "finyk_debts",
+  "finyk_hidden_accounts",
+  "finyk_hidden_transactions",
+  "finyk_manual_expenses",
+  "finyk_mono_debt_links",
+  "finyk_networth_history",
+  "finyk_prefs",
+  "finyk_receivables",
+  "finyk_subscriptions",
+  "finyk_tx_categories",
+  "finyk_tx_filters",
+  "finyk_tx_splits",
+] as const;
+
+const FINYK_INDEXES = [
+  "finyk_assets_user_active_idx",
+  "finyk_budgets_user_active_idx",
+  "finyk_custom_categories_user_active_idx",
+  "finyk_debts_user_active_idx",
+  "finyk_hidden_accounts_user_active_idx",
+  "finyk_hidden_transactions_user_active_idx",
+  "finyk_manual_expenses_user_active_idx",
+  "finyk_mono_debt_links_user_idx",
+  "finyk_networth_history_user_month_idx",
+  "finyk_receivables_user_active_idx",
+  "finyk_subscriptions_user_active_idx",
+  "finyk_tx_categories_user_idx",
+  "finyk_tx_filters_user_active_idx",
+  "finyk_tx_splits_user_idx",
+] as const;
+
+let container: StartedTestContainer | undefined;
+let pool: pg.Pool | undefined;
+let dockerAvailable = false;
+let skipReason: string | null = null;
+
+beforeAll(async () => {
+  try {
+    container = await new GenericContainer("pgvector/pgvector:pg16")
+      .withEnvironment({
+        POSTGRES_USER: "hub",
+        POSTGRES_PASSWORD: "hub",
+        POSTGRES_DB: "hub_test",
+      })
+      .withExposedPorts(5432)
+      .withWaitStrategy(
+        Wait.forLogMessage(/database system is ready to accept connections/, 2),
+      )
+      .start();
+
+    const host = container.getHost();
+    const port = container.getMappedPort(5432);
+    pool = new pg.Pool({
+      connectionString: `postgresql://hub:hub@${host}:${port}/hub_test`,
+      max: 4,
+    });
+    dockerAvailable = true;
+  } catch (e) {
+    skipReason = e instanceof Error ? e.message : String(e);
+    console.warn(
+      `[039-finyk-tables] Skipping: Testcontainers unavailable — ${skipReason}`,
+    );
+  }
+}, TIMEOUT_MS);
+
+afterAll(async () => {
+  if (pool) {
+    await pool.end().catch(() => {
+      /* noop */
+    });
+  }
+  if (container) {
+    await container.stop().catch(() => {
+      /* noop */
+    });
+  }
+}, TIMEOUT_MS);
+
+async function readMigrationFiles(): Promise<string[]> {
+  const files = await fs.readdir(MIGRATIONS_DIR);
+  return files
+    .filter((f) => /^\d{3}_.+\.sql$/.test(f) && !f.endsWith(".down.sql"))
+    .sort();
+}
+
+async function execSqlFile(p: pg.Pool, file: string): Promise<void> {
+  const sql = (
+    await fs.readFile(path.join(MIGRATIONS_DIR, file), "utf8")
+  ).trim();
+  if (!sql) return;
+  await p.query(sql);
+}
+
+async function resetSchema(p: pg.Pool): Promise<void> {
+  await p.query(`DROP SCHEMA public CASCADE; CREATE SCHEMA public;`);
+  await p.query(`GRANT ALL ON SCHEMA public TO public;`);
+}
+
+async function listTables(p: pg.Pool): Promise<string[]> {
+  const r = await p.query<{ tablename: string }>(
+    `SELECT tablename FROM pg_tables
+     WHERE schemaname = 'public' AND tablename LIKE 'finyk_%'
+     ORDER BY tablename`,
+  );
+  return r.rows.map((row) => row.tablename);
+}
+
+async function listFinykIndexes(p: pg.Pool): Promise<string[]> {
+  const r = await p.query<{ indexname: string }>(
+    `SELECT indexname FROM pg_indexes
+     WHERE schemaname = 'public' AND indexname LIKE 'finyk_%'
+     ORDER BY indexname`,
+  );
+  return r.rows.map((row) => row.indexname);
+}
+
+async function listColumns(
+  p: pg.Pool,
+  table: string,
+): Promise<{ name: string; type: string; nullable: string }[]> {
+  const r = await p.query<{
+    column_name: string;
+    data_type: string;
+    is_nullable: string;
+  }>(
+    `SELECT column_name, data_type, is_nullable
+     FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = $1
+     ORDER BY ordinal_position`,
+    [table],
+  );
+  return r.rows.map((row) => ({
+    name: row.column_name,
+    type: row.data_type,
+    nullable: row.is_nullable,
+  }));
+}
+
+describe("039_finyk_tables migration", () => {
+  it(
+    "creates all 15 finyk tables and their explicit indexes after forward migration",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+
+      const tables = await listTables(pool);
+      expect(tables).toEqual([...FINYK_TABLES].sort());
+
+      const indexes = await listFinykIndexes(pool);
+      // Filter `_pkey` and the auto-named composite-PK indexes that
+      // Postgres creates implicitly — only the explicit
+      // `CREATE INDEX` statements from 039_finyk_tables.sql are
+      // asserted.
+      const explicit = indexes.filter((i) => !i.endsWith("_pkey"));
+      expect(explicit).toEqual([...FINYK_INDEXES].sort());
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "finyk_budgets has the documented per-row + JSONB shape",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+
+      const cols = await listColumns(pool, "finyk_budgets");
+      expect(cols.map((c) => c.name)).toEqual([
+        "id",
+        "user_id",
+        "data_json",
+        "created_at",
+        "updated_at",
+        "deleted_at",
+      ]);
+
+      const byName = Object.fromEntries(cols.map((c) => [c.name, c]));
+      expect(byName["id"]!.type).toBe("uuid");
+      expect(byName["id"]!.nullable).toBe("NO");
+      expect(byName["user_id"]!.type).toBe("text");
+      expect(byName["data_json"]!.type).toBe("jsonb");
+      expect(byName["data_json"]!.nullable).toBe("NO");
+      expect(byName["deleted_at"]!.nullable).toBe("YES");
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "finyk_hidden_accounts is keyed on (user_id, account_id) with soft-delete",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+
+      const cols = await listColumns(pool, "finyk_hidden_accounts");
+      expect(cols.map((c) => c.name)).toEqual([
+        "user_id",
+        "account_id",
+        "created_at",
+        "updated_at",
+        "deleted_at",
+      ]);
+
+      const pkCheck = await pool.query<{ column_name: string }>(
+        `SELECT a.attname AS column_name
+         FROM   pg_index i
+         JOIN   pg_attribute a ON a.attrelid = i.indrelid
+                              AND a.attnum   = ANY(i.indkey)
+         WHERE  i.indrelid = 'public.finyk_hidden_accounts'::regclass
+           AND  i.indisprimary
+         ORDER BY a.attnum`,
+      );
+      expect(pkCheck.rows.map((r) => r.column_name)).toEqual([
+        "user_id",
+        "account_id",
+      ]);
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "finyk_tx_categories has no soft-delete column (delete = DELETE FROM)",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+
+      const cols = await listColumns(pool, "finyk_tx_categories");
+      expect(cols.map((c) => c.name)).toEqual([
+        "user_id",
+        "transaction_id",
+        "category_id",
+        "created_at",
+        "updated_at",
+      ]);
+      expect(cols.map((c) => c.name)).not.toContain("deleted_at");
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "finyk_networth_history keeps month as TEXT (not DATE) for LWW parity with LS",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+
+      const cols = await listColumns(pool, "finyk_networth_history");
+      const byName = Object.fromEntries(cols.map((c) => [c.name, c]));
+      expect(byName["month"]!.type).toBe("text");
+      expect(byName["month"]!.nullable).toBe("NO");
+      expect(byName["networth"]!.type).toBe("real");
+      expect(byName["snapshot_json"]!.type).toBe("jsonb");
+
+      const pkCheck = await pool.query<{ column_name: string }>(
+        `SELECT a.attname AS column_name
+         FROM   pg_index i
+         JOIN   pg_attribute a ON a.attrelid = i.indrelid
+                              AND a.attnum   = ANY(i.indkey)
+         WHERE  i.indrelid = 'public.finyk_networth_history'::regclass
+           AND  i.indisprimary
+         ORDER BY a.attnum`,
+      );
+      expect(pkCheck.rows.map((r) => r.column_name)).toEqual([
+        "user_id",
+        "month",
+      ]);
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "finyk_prefs is a per-user singleton (user_id PRIMARY KEY)",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+
+      const cols = await listColumns(pool, "finyk_prefs");
+      expect(cols.map((c) => c.name)).toEqual([
+        "user_id",
+        "prefs_json",
+        "monthly_plan_json",
+        "show_balance",
+        "created_at",
+        "updated_at",
+      ]);
+
+      const pkCheck = await pool.query<{ column_name: string }>(
+        `SELECT a.attname AS column_name
+         FROM   pg_index i
+         JOIN   pg_attribute a ON a.attrelid = i.indrelid
+                              AND a.attnum   = ANY(i.indkey)
+         WHERE  i.indrelid = 'public.finyk_prefs'::regclass
+           AND  i.indisprimary`,
+      );
+      expect(pkCheck.rows.map((r) => r.column_name)).toEqual(["user_id"]);
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "039_finyk_tables.down.sql drops every finyk_* table",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+      expect((await listTables(pool)).length).toBeGreaterThan(0);
+
+      await execSqlFile(pool, "039_finyk_tables.down.sql");
+      expect(await listTables(pool)).toEqual([]);
+      expect(await listFinykIndexes(pool)).toEqual([]);
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "039_finyk_tables.down.sql is idempotent",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+
+      await execSqlFile(pool, "039_finyk_tables.down.sql");
+      await execSqlFile(pool, "039_finyk_tables.down.sql");
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "down then re-up restores the same schema fingerprint",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+
+      const before = {
+        tables: await listTables(pool),
+        indexes: await listFinykIndexes(pool),
+        budgets: await listColumns(pool, "finyk_budgets"),
+        prefs: await listColumns(pool, "finyk_prefs"),
+        networthHistory: await listColumns(pool, "finyk_networth_history"),
+      };
+
+      await execSqlFile(pool, "039_finyk_tables.down.sql");
+      await execSqlFile(pool, "039_finyk_tables.sql");
+
+      const after = {
+        tables: await listTables(pool),
+        indexes: await listFinykIndexes(pool),
+        budgets: await listColumns(pool, "finyk_budgets"),
+        prefs: await listColumns(pool, "finyk_prefs"),
+        networthHistory: await listColumns(pool, "finyk_networth_history"),
+      };
+
+      expect(after).toEqual(before);
+    },
+    TIMEOUT_MS,
+  );
+});

--- a/apps/server/src/modules/sync/syncV2.integration.test.ts
+++ b/apps/server/src/modules/sync/syncV2.integration.test.ts
@@ -156,7 +156,14 @@ beforeEach(async () => {
               fizruk_workout_sets, fizruk_workout_items, fizruk_workouts,
               fizruk_custom_exercises, fizruk_measurements,
               nutrition_pantry_items, nutrition_pantries,
-              nutrition_meals, nutrition_prefs, nutrition_recipes
+              nutrition_meals, nutrition_prefs, nutrition_recipes,
+              finyk_hidden_accounts, finyk_hidden_transactions,
+              finyk_budgets, finyk_subscriptions, finyk_assets,
+              finyk_debts, finyk_receivables, finyk_custom_categories,
+              finyk_manual_expenses, finyk_tx_filters,
+              finyk_tx_categories, finyk_tx_splits,
+              finyk_mono_debt_links, finyk_networth_history,
+              finyk_prefs
               RESTART IDENTITY CASCADE`,
   );
 });
@@ -1681,6 +1688,445 @@ describe("syncV2Push — nutrition apply-функції (PR #031)", () => {
       ]);
       expect(row.rows[0].name).toBe("Борщ");
       expect(row.rows[0].deleted_at).not.toBeNull();
+    },
+    TIMEOUT_MS,
+  );
+});
+
+// ---------------------------------------------------------------------
+// Finyk apply-функції — Stage 4 PR #035.
+//
+// Один integration-тест на shape (5 shapes у total, див. коментар в
+// `apps/server/src/migrations/039_finyk_tables.sql` — composite-PK
+// tombstone, per-row+JSONB, per-tx mapping, time-series, singleton
+// prefs). Фокус — на унікальній логіці кожного shape, а не на
+// повторюванні стандартної LWW-перевірки (її вже покривають nutrition
+// інтеграційні тести вище — apply-фн поділяє ту саму інфраструктуру).
+// ---------------------------------------------------------------------
+describe("syncV2Push — finyk apply-функції (PR #035)", () => {
+  it(
+    "finyk_hidden_accounts: insert → soft-delete (composite-PK tombstone shape)",
+    async (ctx) => {
+      if (!dockerAvailable || !testPool) return ctx.skip();
+      await ensureUser("u-fha");
+
+      const t1 = isoNow(-2_000);
+      const t2 = isoNow();
+
+      const r1 = makeRes();
+      await syncV2Push(
+        makeReq({
+          userId: "u-fha",
+          body: {
+            ops: [
+              {
+                table: "finyk_hidden_accounts",
+                op: "insert" as const,
+                row: {
+                  user_id: "u-fha",
+                  account_id: "mono-acc-42",
+                },
+                client_ts: t1,
+                idempotency_key: "fha-insert",
+              },
+            ],
+          },
+        }),
+        r1,
+      );
+      expect((r1.body as { accepted: number }).accepted).toBe(1);
+
+      const r2 = makeRes();
+      await syncV2Push(
+        makeReq({
+          userId: "u-fha",
+          body: {
+            ops: [
+              {
+                table: "finyk_hidden_accounts",
+                op: "delete" as const,
+                row: { user_id: "u-fha", account_id: "mono-acc-42" },
+                client_ts: t2,
+                idempotency_key: "fha-delete",
+              },
+            ],
+          },
+        }),
+        r2,
+      );
+      expect((r2.body as { accepted: number }).accepted).toBe(1);
+
+      const row = await testPool.query<{ deleted_at: Date | null }>(
+        `SELECT deleted_at FROM finyk_hidden_accounts
+         WHERE user_id = $1 AND account_id = $2`,
+        ["u-fha", "mono-acc-42"],
+      );
+      expect(row.rows).toHaveLength(1);
+      expect(row.rows[0].deleted_at).not.toBeNull();
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "finyk_budgets: insert → update (per-row + JSONB blob shape, LWW honoured)",
+    async (ctx) => {
+      if (!dockerAvailable || !testPool) return ctx.skip();
+      await ensureUser("u-fb");
+
+      const budgetId = "50000000-0000-4000-8000-000000000001";
+      const t1 = isoNow(-2_000);
+      const t2 = isoNow();
+
+      const r1 = makeRes();
+      await syncV2Push(
+        makeReq({
+          userId: "u-fb",
+          body: {
+            ops: [
+              {
+                table: "finyk_budgets",
+                op: "insert" as const,
+                row: {
+                  id: budgetId,
+                  user_id: "u-fb",
+                  data_json: { categoryId: "food", limit: 1000 },
+                },
+                client_ts: t1,
+                idempotency_key: "fb-insert",
+              },
+            ],
+          },
+        }),
+        r1,
+      );
+      expect((r1.body as { accepted: number }).accepted).toBe(1);
+
+      const r2 = makeRes();
+      await syncV2Push(
+        makeReq({
+          userId: "u-fb",
+          body: {
+            ops: [
+              {
+                table: "finyk_budgets",
+                op: "update" as const,
+                row: {
+                  id: budgetId,
+                  user_id: "u-fb",
+                  data_json: { categoryId: "food", limit: 1500 },
+                },
+                client_ts: t2,
+                idempotency_key: "fb-update",
+              },
+            ],
+          },
+        }),
+        r2,
+      );
+      expect((r2.body as { accepted: number }).accepted).toBe(1);
+
+      const row = await testPool.query<{ data_json: { limit: number } }>(
+        `SELECT data_json FROM finyk_budgets WHERE id = $1`,
+        [budgetId],
+      );
+      expect(row.rows[0].data_json.limit).toBe(1500);
+
+      // Stale (t1) update must lose to the t2 row already on disk.
+      const r3 = makeRes();
+      await syncV2Push(
+        makeReq({
+          userId: "u-fb",
+          body: {
+            ops: [
+              {
+                table: "finyk_budgets",
+                op: "update" as const,
+                row: {
+                  id: budgetId,
+                  user_id: "u-fb",
+                  data_json: { categoryId: "food", limit: 9999 },
+                },
+                client_ts: t1,
+                idempotency_key: "fb-stale",
+              },
+            ],
+          },
+        }),
+        r3,
+      );
+      const body3 = r3.body as {
+        accepted: number;
+        results: Array<{ status: string; reason?: string }>;
+      };
+      expect(body3.accepted).toBe(0);
+      expect(body3.results[0].reason).toBe("lww_conflict");
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "finyk_tx_categories: insert → delete uses hard DELETE (no soft-delete column)",
+    async (ctx) => {
+      if (!dockerAvailable || !testPool) return ctx.skip();
+      await ensureUser("u-ftc");
+
+      const t1 = isoNow(-2_000);
+      const t2 = isoNow();
+
+      const r1 = makeRes();
+      await syncV2Push(
+        makeReq({
+          userId: "u-ftc",
+          body: {
+            ops: [
+              {
+                table: "finyk_tx_categories",
+                op: "insert" as const,
+                row: {
+                  user_id: "u-ftc",
+                  transaction_id: "mono-tx-1",
+                  category_id: "groceries",
+                },
+                client_ts: t1,
+                idempotency_key: "ftc-insert",
+              },
+            ],
+          },
+        }),
+        r1,
+      );
+      expect((r1.body as { accepted: number }).accepted).toBe(1);
+
+      const r2 = makeRes();
+      await syncV2Push(
+        makeReq({
+          userId: "u-ftc",
+          body: {
+            ops: [
+              {
+                table: "finyk_tx_categories",
+                op: "delete" as const,
+                row: { user_id: "u-ftc", transaction_id: "mono-tx-1" },
+                client_ts: t2,
+                idempotency_key: "ftc-delete",
+              },
+            ],
+          },
+        }),
+        r2,
+      );
+      expect((r2.body as { accepted: number }).accepted).toBe(1);
+
+      const rows = await testPool.query(
+        `SELECT 1 FROM finyk_tx_categories
+           WHERE user_id = $1 AND transaction_id = $2`,
+        ["u-ftc", "mono-tx-1"],
+      );
+      expect(rows.rows).toHaveLength(0);
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "finyk_networth_history: monthly upsert keeps month TEXT (composite (user_id, month) PK)",
+    async (ctx) => {
+      if (!dockerAvailable || !testPool) return ctx.skip();
+      await ensureUser("u-fnh");
+
+      const t1 = isoNow(-2_000);
+      const t2 = isoNow();
+
+      const r1 = makeRes();
+      await syncV2Push(
+        makeReq({
+          userId: "u-fnh",
+          body: {
+            ops: [
+              {
+                table: "finyk_networth_history",
+                op: "insert" as const,
+                row: {
+                  user_id: "u-fnh",
+                  month: "2026-04",
+                  networth: 1234.5,
+                },
+                client_ts: t1,
+                idempotency_key: "fnh-insert",
+              },
+            ],
+          },
+        }),
+        r1,
+      );
+      expect((r1.body as { accepted: number }).accepted).toBe(1);
+
+      const r2 = makeRes();
+      await syncV2Push(
+        makeReq({
+          userId: "u-fnh",
+          body: {
+            ops: [
+              {
+                table: "finyk_networth_history",
+                op: "update" as const,
+                row: {
+                  user_id: "u-fnh",
+                  month: "2026-04",
+                  networth: 1500,
+                },
+                client_ts: t2,
+                idempotency_key: "fnh-update",
+              },
+            ],
+          },
+        }),
+        r2,
+      );
+      expect((r2.body as { accepted: number }).accepted).toBe(1);
+
+      const row = await testPool.query<{ networth: number; month: string }>(
+        `SELECT month, networth FROM finyk_networth_history
+           WHERE user_id = $1 AND month = $2`,
+        ["u-fnh", "2026-04"],
+      );
+      expect(row.rows[0].month).toBe("2026-04");
+      expect(row.rows[0].networth).toBeCloseTo(1500, 5);
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "finyk_networth_history: invalid month string is rejected",
+    async (ctx) => {
+      if (!dockerAvailable || !testPool) return ctx.skip();
+      await ensureUser("u-fnh-bad");
+
+      const r = makeRes();
+      await syncV2Push(
+        makeReq({
+          userId: "u-fnh-bad",
+          body: {
+            ops: [
+              {
+                table: "finyk_networth_history",
+                op: "insert" as const,
+                row: {
+                  user_id: "u-fnh-bad",
+                  month: "April 2026",
+                  networth: 1,
+                },
+                client_ts: isoNow(),
+                idempotency_key: "fnh-bad",
+              },
+            ],
+          },
+        }),
+        r,
+      );
+      const body = r.body as {
+        accepted: number;
+        results: Array<{ status: string; reason?: string }>;
+      };
+      expect(body.accepted).toBe(0);
+      expect(body.results[0].reason).toBe("invalid_month");
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "finyk_prefs: singleton upsert — insert then update; delete rejected",
+    async (ctx) => {
+      if (!dockerAvailable || !testPool) return ctx.skip();
+      await ensureUser("u-fp");
+
+      const t1 = isoNow(-2_000);
+      const t2 = isoNow();
+      const t3 = isoNow(2_000);
+
+      const r1 = makeRes();
+      await syncV2Push(
+        makeReq({
+          userId: "u-fp",
+          body: {
+            ops: [
+              {
+                table: "finyk_prefs",
+                op: "insert" as const,
+                row: {
+                  user_id: "u-fp",
+                  prefs_json: { defaultCurrency: "UAH" },
+                  monthly_plan_json: { income: "50000", expense: "30000" },
+                  show_balance: true,
+                },
+                client_ts: t1,
+                idempotency_key: "fp-insert",
+              },
+            ],
+          },
+        }),
+        r1,
+      );
+      expect((r1.body as { accepted: number }).accepted).toBe(1);
+
+      const r2 = makeRes();
+      await syncV2Push(
+        makeReq({
+          userId: "u-fp",
+          body: {
+            ops: [
+              {
+                table: "finyk_prefs",
+                op: "update" as const,
+                row: {
+                  user_id: "u-fp",
+                  prefs_json: { defaultCurrency: "USD" },
+                  monthly_plan_json: { income: "60000", expense: "30000" },
+                  show_balance: false,
+                },
+                client_ts: t2,
+                idempotency_key: "fp-update",
+              },
+            ],
+          },
+        }),
+        r2,
+      );
+      expect((r2.body as { accepted: number }).accepted).toBe(1);
+
+      const row = await testPool.query<{
+        prefs_json: { defaultCurrency: string };
+        show_balance: boolean;
+      }>(
+        `SELECT prefs_json, show_balance FROM finyk_prefs WHERE user_id = $1`,
+        ["u-fp"],
+      );
+      expect(row.rows[0].prefs_json.defaultCurrency).toBe("USD");
+      expect(row.rows[0].show_balance).toBe(false);
+
+      const r3 = makeRes();
+      await syncV2Push(
+        makeReq({
+          userId: "u-fp",
+          body: {
+            ops: [
+              {
+                table: "finyk_prefs",
+                op: "delete" as const,
+                row: { user_id: "u-fp" },
+                client_ts: t3,
+                idempotency_key: "fp-delete",
+              },
+            ],
+          },
+        }),
+        r3,
+      );
+      const body3 = r3.body as {
+        accepted: number;
+        results: Array<{ status: string; reason?: string }>;
+      };
+      expect(body3.accepted).toBe(0);
+      expect(body3.results[0].reason).toBe("delete_not_supported");
     },
     TIMEOUT_MS,
   );

--- a/apps/server/src/modules/sync/syncV2.ts
+++ b/apps/server/src/modules/sync/syncV2.ts
@@ -123,6 +123,21 @@ const OP_LOG_TABLE_REGISTRY: Record<string, ApplyFn> = {
   nutrition_pantry_items: applyNutritionPantryItems,
   nutrition_prefs: applyNutritionPrefs,
   nutrition_recipes: applyNutritionRecipes,
+  finyk_hidden_accounts: applyFinykHiddenAccounts,
+  finyk_hidden_transactions: applyFinykHiddenTransactions,
+  finyk_budgets: applyFinykBudgets,
+  finyk_subscriptions: applyFinykSubscriptions,
+  finyk_assets: applyFinykAssets,
+  finyk_debts: applyFinykDebts,
+  finyk_receivables: applyFinykReceivables,
+  finyk_custom_categories: applyFinykCustomCategories,
+  finyk_manual_expenses: applyFinykManualExpenses,
+  finyk_tx_filters: applyFinykTxFilters,
+  finyk_tx_categories: applyFinykTxCategories,
+  finyk_tx_splits: applyFinykTxSplits,
+  finyk_mono_debt_links: applyFinykMonoDebtLinks,
+  finyk_networth_history: applyFinykNetworthHistory,
+  finyk_prefs: applyFinykPrefs,
 };
 
 /**
@@ -1616,6 +1631,594 @@ async function applyNutritionRecipes(
              deleted_at = $4
        WHERE id = $5 AND user_id = $6`,
       [name, dataJson, clientTs, deletedAt ?? null, id, userId],
+    );
+  }
+  return { status: "applied" };
+}
+
+// ---------------------------------------------------------------------
+// Finyk apply-функції — Stage 4 PR #035.
+//
+// 15 split-функцій по таблицях. Архітектурно повторюють nutrition та
+// fizruk: кожна функція робить LWW-guard, розрізняє op `delete` /
+// upsert, оперує `(user_id, …)` ключем і повертає `applied`/`rejected`
+// з причиною (`lww_conflict`, `missing_id`, `user_id_mismatch`,
+// `fk_violation`, `not_found`).
+//
+// Розподіл за shape-ами (див. коментар у міграції 039_finyk_tables.sql):
+//
+//   * **Composite-PK tombstone** (per-(user, ext_id) запис із soft-delete):
+//     - `finyk_hidden_accounts`        — ext_id = account_id
+//     - `finyk_hidden_transactions`    — ext_id = transaction_id
+//
+//   * **Per-row + JSONB blob** (UUID PK, soft-delete):
+//     - `finyk_budgets`, `finyk_subscriptions`, `finyk_assets`,
+//       `finyk_debts`, `finyk_receivables`,
+//       `finyk_custom_categories`, `finyk_manual_expenses`,
+//       `finyk_tx_filters`
+//
+//   * **Per-tx mapping** (composite PK на (user_id, transaction_id),
+//     без soft-delete — `delete` = жорсткий `DELETE FROM`):
+//     - `finyk_tx_categories` — поле `category_id TEXT`
+//     - `finyk_tx_splits`     — поле `splits_json JSONB`
+//     - `finyk_mono_debt_links` — поле `debt_ids_json JSONB`
+//
+//   * **Time-series** (`finyk_networth_history`): composite PK
+//     `(user_id, month)`; `month` — TEXT YYYY-MM.
+//
+//   * **Singleton prefs** (`finyk_prefs`): PK = `user_id`. `delete`
+//     відхиляється, тільки оновлення.
+// ---------------------------------------------------------------------
+
+/**
+ * Generic helper for "composite-PK tombstone" finyk таблиць:
+ * `finyk_hidden_accounts` (ext column = account_id) і
+ * `finyk_hidden_transactions` (ext column = transaction_id). Уся
+ * apply-логіка ідентична — різняться лише імена колонки і таблиці.
+ */
+async function applyFinykTombstone(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+  table: "finyk_hidden_accounts" | "finyk_hidden_transactions",
+  extColumn: "account_id" | "transaction_id",
+): Promise<AppliedStatus> {
+  const row = op.row;
+  const extId = typeof row[extColumn] === "string" ? row[extColumn] : null;
+  if (!extId) return { status: "rejected", reason: "missing_ext_id" };
+
+  if (row.user_id != null && row.user_id !== userId) {
+    return { status: "rejected", reason: "user_id_mismatch" };
+  }
+
+  const existing = await client.query<{ updated_at: Date }>(
+    `SELECT updated_at FROM ${table} WHERE user_id = $1 AND ${extColumn} = $2`,
+    [userId, extId],
+  );
+  if (existing.rows.length > 0) {
+    if (existing.rows[0].updated_at.getTime() >= clientTs.getTime()) {
+      return { status: "rejected", reason: "lww_conflict" };
+    }
+  }
+
+  if (op.op === "delete") {
+    if (existing.rows.length === 0) {
+      return { status: "rejected", reason: "not_found" };
+    }
+    await client.query(
+      `UPDATE ${table}
+         SET deleted_at = $1, updated_at = $1
+       WHERE user_id = $2 AND ${extColumn} = $3`,
+      [clientTs, userId, extId],
+    );
+    return { status: "applied" };
+  }
+
+  const createdAt = parseOptionalDate(row.created_at);
+  if (createdAt === "invalid") {
+    return { status: "rejected", reason: "invalid_created_at" };
+  }
+  const deletedAt = parseOptionalDate(row.deleted_at);
+  if (deletedAt === "invalid") {
+    return { status: "rejected", reason: "invalid_deleted_at" };
+  }
+
+  if (existing.rows.length === 0) {
+    await client.query(
+      `INSERT INTO ${table}
+         (user_id, ${extColumn}, created_at, updated_at, deleted_at)
+       VALUES ($1, $2, $3, $4, $5)`,
+      [userId, extId, createdAt ?? clientTs, clientTs, deletedAt ?? null],
+    );
+  } else {
+    await client.query(
+      `UPDATE ${table}
+         SET updated_at = $1, deleted_at = $2
+       WHERE user_id = $3 AND ${extColumn} = $4`,
+      [clientTs, deletedAt ?? null, userId, extId],
+    );
+  }
+  return { status: "applied" };
+}
+
+async function applyFinykHiddenAccounts(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+): Promise<AppliedStatus> {
+  return applyFinykTombstone(
+    client,
+    op,
+    userId,
+    clientTs,
+    "finyk_hidden_accounts",
+    "account_id",
+  );
+}
+
+async function applyFinykHiddenTransactions(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+): Promise<AppliedStatus> {
+  return applyFinykTombstone(
+    client,
+    op,
+    userId,
+    clientTs,
+    "finyk_hidden_transactions",
+    "transaction_id",
+  );
+}
+
+/**
+ * Generic helper for "per-row + JSONB blob" finyk таблиць
+ * (`finyk_budgets`, `finyk_subscriptions`, `finyk_assets`,
+ * `finyk_debts`, `finyk_receivables`, `finyk_custom_categories`,
+ * `finyk_manual_expenses`, `finyk_tx_filters`). Ідентична семантика —
+ * лише ім'я таблиці змінюється. Колонки фіксовані: `(id UUID PK,
+ * user_id, data_json JSONB, created_at, updated_at, deleted_at)`.
+ */
+async function applyFinykPerRowBlob(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+  table: string,
+): Promise<AppliedStatus> {
+  const row = op.row;
+  const id = typeof row.id === "string" ? row.id : null;
+  if (!id) return { status: "rejected", reason: "missing_id" };
+
+  if (row.user_id != null && row.user_id !== userId) {
+    return { status: "rejected", reason: "user_id_mismatch" };
+  }
+
+  const existing = await client.query<{ user_id: string; updated_at: Date }>(
+    `SELECT user_id, updated_at FROM ${table} WHERE id = $1`,
+    [id],
+  );
+  if (existing.rows.length > 0) {
+    if (existing.rows[0].user_id !== userId) {
+      return { status: "rejected", reason: "fk_violation" };
+    }
+    if (existing.rows[0].updated_at.getTime() >= clientTs.getTime()) {
+      return { status: "rejected", reason: "lww_conflict" };
+    }
+  }
+
+  if (op.op === "delete") {
+    if (existing.rows.length === 0) {
+      return { status: "rejected", reason: "not_found" };
+    }
+    await client.query(
+      `UPDATE ${table}
+         SET deleted_at = $1, updated_at = $1
+       WHERE id = $2 AND user_id = $3`,
+      [clientTs, id, userId],
+    );
+    return { status: "applied" };
+  }
+
+  const dataJson = toJsonbParam(row.data_json);
+  if (dataJson === null) {
+    return { status: "rejected", reason: "missing_data_json" };
+  }
+  const createdAt = parseOptionalDate(row.created_at);
+  if (createdAt === "invalid") {
+    return { status: "rejected", reason: "invalid_created_at" };
+  }
+  const deletedAt = parseOptionalDate(row.deleted_at);
+  if (deletedAt === "invalid") {
+    return { status: "rejected", reason: "invalid_deleted_at" };
+  }
+
+  if (existing.rows.length === 0) {
+    await client.query(
+      `INSERT INTO ${table}
+         (id, user_id, data_json, created_at, updated_at, deleted_at)
+       VALUES ($1, $2, $3::jsonb, $4, $5, $6)`,
+      [
+        id,
+        userId,
+        dataJson,
+        createdAt ?? clientTs,
+        clientTs,
+        deletedAt ?? null,
+      ],
+    );
+  } else {
+    await client.query(
+      `UPDATE ${table}
+         SET data_json  = $1::jsonb,
+             updated_at = $2,
+             deleted_at = $3
+       WHERE id = $4 AND user_id = $5`,
+      [dataJson, clientTs, deletedAt ?? null, id, userId],
+    );
+  }
+  return { status: "applied" };
+}
+
+async function applyFinykBudgets(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+): Promise<AppliedStatus> {
+  return applyFinykPerRowBlob(client, op, userId, clientTs, "finyk_budgets");
+}
+
+async function applyFinykSubscriptions(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+): Promise<AppliedStatus> {
+  return applyFinykPerRowBlob(
+    client,
+    op,
+    userId,
+    clientTs,
+    "finyk_subscriptions",
+  );
+}
+
+async function applyFinykAssets(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+): Promise<AppliedStatus> {
+  return applyFinykPerRowBlob(client, op, userId, clientTs, "finyk_assets");
+}
+
+async function applyFinykDebts(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+): Promise<AppliedStatus> {
+  return applyFinykPerRowBlob(client, op, userId, clientTs, "finyk_debts");
+}
+
+async function applyFinykReceivables(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+): Promise<AppliedStatus> {
+  return applyFinykPerRowBlob(
+    client,
+    op,
+    userId,
+    clientTs,
+    "finyk_receivables",
+  );
+}
+
+async function applyFinykCustomCategories(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+): Promise<AppliedStatus> {
+  return applyFinykPerRowBlob(
+    client,
+    op,
+    userId,
+    clientTs,
+    "finyk_custom_categories",
+  );
+}
+
+async function applyFinykManualExpenses(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+): Promise<AppliedStatus> {
+  return applyFinykPerRowBlob(
+    client,
+    op,
+    userId,
+    clientTs,
+    "finyk_manual_expenses",
+  );
+}
+
+async function applyFinykTxFilters(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+): Promise<AppliedStatus> {
+  return applyFinykPerRowBlob(client, op, userId, clientTs, "finyk_tx_filters");
+}
+
+/**
+ * Apply-шлях для `finyk_tx_categories` — per-tx mapping без
+ * soft-delete. `delete` op виконує `DELETE FROM` (idempotent).
+ */
+async function applyFinykTxCategories(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+): Promise<AppliedStatus> {
+  const row = op.row;
+  const transactionId =
+    typeof row.transaction_id === "string" ? row.transaction_id : null;
+  if (!transactionId) return { status: "rejected", reason: "missing_tx_id" };
+
+  if (row.user_id != null && row.user_id !== userId) {
+    return { status: "rejected", reason: "user_id_mismatch" };
+  }
+
+  const existing = await client.query<{ updated_at: Date }>(
+    `SELECT updated_at FROM finyk_tx_categories
+       WHERE user_id = $1 AND transaction_id = $2`,
+    [userId, transactionId],
+  );
+  if (existing.rows.length > 0) {
+    if (existing.rows[0].updated_at.getTime() >= clientTs.getTime()) {
+      return { status: "rejected", reason: "lww_conflict" };
+    }
+  }
+
+  if (op.op === "delete") {
+    await client.query(
+      `DELETE FROM finyk_tx_categories
+         WHERE user_id = $1 AND transaction_id = $2`,
+      [userId, transactionId],
+    );
+    return { status: "applied" };
+  }
+
+  const categoryId =
+    typeof row.category_id === "string" ? row.category_id : null;
+  if (!categoryId) {
+    return { status: "rejected", reason: "missing_category_id" };
+  }
+
+  await client.query(
+    `INSERT INTO finyk_tx_categories
+       (user_id, transaction_id, category_id, created_at, updated_at)
+     VALUES ($1, $2, $3, $4, $5)
+     ON CONFLICT (user_id, transaction_id) DO UPDATE
+       SET category_id = EXCLUDED.category_id,
+           updated_at  = EXCLUDED.updated_at`,
+    [userId, transactionId, categoryId, clientTs, clientTs],
+  );
+  return { status: "applied" };
+}
+
+/**
+ * Generic helper for `finyk_tx_splits` and `finyk_mono_debt_links` —
+ * per-tx JSONB-array mapping (composite PK на `(user_id,
+ * transaction_id)`, без soft-delete). Розрізняються лише ім'ям
+ * таблиці і JSONB-колонки. Default fallback значення для відсутнього
+ * payload-у — порожній масив `[]`.
+ */
+async function applyFinykPerTxJsonbArray(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+  table: "finyk_tx_splits" | "finyk_mono_debt_links",
+  jsonColumn: "splits_json" | "debt_ids_json",
+): Promise<AppliedStatus> {
+  const row = op.row;
+  const transactionId =
+    typeof row.transaction_id === "string" ? row.transaction_id : null;
+  if (!transactionId) return { status: "rejected", reason: "missing_tx_id" };
+
+  if (row.user_id != null && row.user_id !== userId) {
+    return { status: "rejected", reason: "user_id_mismatch" };
+  }
+
+  const existing = await client.query<{ updated_at: Date }>(
+    `SELECT updated_at FROM ${table}
+       WHERE user_id = $1 AND transaction_id = $2`,
+    [userId, transactionId],
+  );
+  if (existing.rows.length > 0) {
+    if (existing.rows[0].updated_at.getTime() >= clientTs.getTime()) {
+      return { status: "rejected", reason: "lww_conflict" };
+    }
+  }
+
+  if (op.op === "delete") {
+    await client.query(
+      `DELETE FROM ${table}
+         WHERE user_id = $1 AND transaction_id = $2`,
+      [userId, transactionId],
+    );
+    return { status: "applied" };
+  }
+
+  const jsonValue = toJsonbParam(row[jsonColumn]) ?? "[]";
+
+  await client.query(
+    `INSERT INTO ${table}
+       (user_id, transaction_id, ${jsonColumn}, created_at, updated_at)
+     VALUES ($1, $2, $3::jsonb, $4, $5)
+     ON CONFLICT (user_id, transaction_id) DO UPDATE
+       SET ${jsonColumn} = EXCLUDED.${jsonColumn},
+           updated_at    = EXCLUDED.updated_at`,
+    [userId, transactionId, jsonValue, clientTs, clientTs],
+  );
+  return { status: "applied" };
+}
+
+async function applyFinykTxSplits(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+): Promise<AppliedStatus> {
+  return applyFinykPerTxJsonbArray(
+    client,
+    op,
+    userId,
+    clientTs,
+    "finyk_tx_splits",
+    "splits_json",
+  );
+}
+
+async function applyFinykMonoDebtLinks(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+): Promise<AppliedStatus> {
+  return applyFinykPerTxJsonbArray(
+    client,
+    op,
+    userId,
+    clientTs,
+    "finyk_mono_debt_links",
+    "debt_ids_json",
+  );
+}
+
+/**
+ * Apply-шлях для `finyk_networth_history` — time-series, composite
+ * PK `(user_id, month)`. `month` — TEXT YYYY-MM (stored verbatim).
+ */
+async function applyFinykNetworthHistory(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+): Promise<AppliedStatus> {
+  const row = op.row;
+  const month = typeof row.month === "string" ? row.month : null;
+  if (!month || !/^\d{4}-\d{2}$/.test(month)) {
+    return { status: "rejected", reason: "invalid_month" };
+  }
+
+  if (row.user_id != null && row.user_id !== userId) {
+    return { status: "rejected", reason: "user_id_mismatch" };
+  }
+
+  const existing = await client.query<{ updated_at: Date }>(
+    `SELECT updated_at FROM finyk_networth_history
+       WHERE user_id = $1 AND month = $2`,
+    [userId, month],
+  );
+  if (existing.rows.length > 0) {
+    if (existing.rows[0].updated_at.getTime() >= clientTs.getTime()) {
+      return { status: "rejected", reason: "lww_conflict" };
+    }
+  }
+
+  if (op.op === "delete") {
+    await client.query(
+      `DELETE FROM finyk_networth_history
+         WHERE user_id = $1 AND month = $2`,
+      [userId, month],
+    );
+    return { status: "applied" };
+  }
+
+  const networth = parseOptionalNumber(row.networth);
+  if (networth === "invalid") {
+    return { status: "rejected", reason: "invalid_networth" };
+  }
+  const snapshotJson = toJsonbParam(row.snapshot_json) ?? "{}";
+
+  await client.query(
+    `INSERT INTO finyk_networth_history
+       (user_id, month, networth, snapshot_json, created_at, updated_at)
+     VALUES ($1, $2, $3, $4::jsonb, $5, $6)
+     ON CONFLICT (user_id, month) DO UPDATE
+       SET networth      = EXCLUDED.networth,
+           snapshot_json = EXCLUDED.snapshot_json,
+           updated_at    = EXCLUDED.updated_at`,
+    [userId, month, networth ?? 0, snapshotJson, clientTs, clientTs],
+  );
+  return { status: "applied" };
+}
+
+/**
+ * Apply-шлях для `finyk_prefs` — singleton per-user (PK = user_id).
+ *
+ * Структурно дзеркало `applyNutritionPrefs`: `delete` відхиляється,
+ * `prefs_json`/`monthly_plan_json` серіалізуються через `toJsonbParam`,
+ * `show_balance` приходить як boolean / 0|1.
+ */
+async function applyFinykPrefs(
+  client: PoolClient,
+  op: SyncV2Op,
+  userId: string,
+  clientTs: Date,
+): Promise<AppliedStatus> {
+  if (op.op === "delete") {
+    return { status: "rejected", reason: "delete_not_supported" };
+  }
+
+  const row = op.row;
+  if (row.user_id != null && row.user_id !== userId) {
+    return { status: "rejected", reason: "user_id_mismatch" };
+  }
+
+  const existing = await client.query<{ updated_at: Date }>(
+    `SELECT updated_at FROM finyk_prefs WHERE user_id = $1`,
+    [userId],
+  );
+  if (existing.rows.length > 0) {
+    if (existing.rows[0].updated_at.getTime() >= clientTs.getTime()) {
+      return { status: "rejected", reason: "lww_conflict" };
+    }
+  }
+
+  const prefsJson = toJsonbParam(row.prefs_json) ?? "{}";
+  const monthlyPlanJson = toJsonbParam(row.monthly_plan_json) ?? "{}";
+  const showBalance =
+    row.show_balance === false || row.show_balance === 0 ? false : true;
+
+  if (existing.rows.length === 0) {
+    await client.query(
+      `INSERT INTO finyk_prefs
+         (user_id, prefs_json, monthly_plan_json, show_balance,
+          created_at, updated_at)
+       VALUES ($1, $2::jsonb, $3::jsonb, $4, $5, $6)`,
+      [userId, prefsJson, monthlyPlanJson, showBalance, clientTs, clientTs],
+    );
+  } else {
+    await client.query(
+      `UPDATE finyk_prefs
+         SET prefs_json        = $1::jsonb,
+             monthly_plan_json = $2::jsonb,
+             show_balance      = $3,
+             updated_at        = $4
+       WHERE user_id = $5`,
+      [prefsJson, monthlyPlanJson, showBalance, clientTs, userId],
     );
   }
   return { status: "applied" };

--- a/apps/web/src/core/lib/featureFlags.ts
+++ b/apps/web/src/core/lib/featureFlags.ts
@@ -99,6 +99,14 @@ export const FLAG_REGISTRY: readonly FlagDefinition[] = [
     defaultValue: false,
     experimental: true,
   },
+  {
+    id: "feature.finyk.sqlite_v2.dual_write",
+    label: "Finyk — dual-write LS↔SQLite",
+    description:
+      "Кожен write у localStorage Finyk-у додатково мирорить у локальну SQLite (`finyk_hidden_accounts`, `finyk_hidden_transactions`, `finyk_budgets`, `finyk_subscriptions`, `finyk_assets`, `finyk_debts`, `finyk_receivables`, `finyk_custom_categories`, `finyk_manual_expenses`, `finyk_tx_categories`, `finyk_tx_splits`, `finyk_mono_debt_links`, `finyk_networth_history`, `finyk_prefs`). Reads ще беруться з LS. Stage 4 PR #036 storage-roadmap. Best-effort: помилка SQLite-запису не ламає LS. Default: off.",
+    defaultValue: false,
+    experimental: true,
+  },
 ] as const;
 
 export type FlagId = (typeof FLAG_REGISTRY)[number]["id"];

--- a/apps/web/src/modules/finyk/hooks/useFinykDualWriteBoot.ts
+++ b/apps/web/src/modules/finyk/hooks/useFinykDualWriteBoot.ts
@@ -1,0 +1,28 @@
+/**
+ * React hook that installs the Finyk dual-write context.
+ *
+ * Stage 4 PR #036 of `docs/planning/storage-roadmap.md`. Mirror of
+ * `useNutritionDualWriteBoot`.
+ */
+
+import { useEffect } from "react";
+import { useAuth } from "../../../core/auth/AuthContext";
+import { useFlag, getFlag } from "../../../core/lib/featureFlags.js";
+import { bootFinykDualWrite } from "../lib/dualWriteBoot.js";
+
+const FLAG_ID = "feature.finyk.sqlite_v2.dual_write";
+
+export function useFinykDualWriteBoot(): void {
+  const { user } = useAuth();
+  const userId = user?.id ?? null;
+  const flagOn = useFlag(FLAG_ID);
+
+  useEffect(() => {
+    if (!userId || !flagOn) return;
+    const teardown = bootFinykDualWrite({
+      getUserId: () => userId,
+      isFlagEnabled: () => getFlag(FLAG_ID),
+    });
+    return teardown;
+  }, [userId, flagOn]);
+}

--- a/apps/web/src/modules/finyk/hooks/useFinykDualWriteSync.ts
+++ b/apps/web/src/modules/finyk/hooks/useFinykDualWriteSync.ts
@@ -1,0 +1,67 @@
+/**
+ * Watches the bundle returned by `useFinykStorageSlots` and fires
+ * `triggerFinykDualWrite(prev, next)` after every React-state change
+ * (which is exactly when `usePersist` schedules a debounced LS write).
+ *
+ * Stage 4 PR #036 of `docs/planning/storage-roadmap.md`.
+ *
+ * Why a single watcher hook instead of inline triggers:
+ *  - Finyk's storage layer is generic (`usePersist<T>`), reused for 14
+ *    LS keys via `useFinykStorageSlots`. Inlining the trigger into
+ *    `usePersist` would require threading the dual-write state
+ *    extractor through the generic, coupling shared infra to the
+ *    finyk diff shape.
+ *  - The `useFinykStorageSlots` bundle is the natural seam — every
+ *    LS key the dual-write layer cares about is already exposed there
+ *    as React state, so we can compute the prev/next snapshots from
+ *    the slot bundle alone.
+ *
+ * The hook is a no-op until {@link useFinykDualWriteBoot} has
+ * registered a context (the gate `isFinykDualWriteRegistered()` in
+ * `triggerFinykDualWrite` short-circuits otherwise).
+ */
+
+import { useEffect, useRef } from "react";
+
+import {
+  EMPTY_FINYK_STATE,
+  isFinykDualWriteRegistered,
+  triggerFinykDualWrite,
+  type FinykDualWriteState,
+} from "../lib/dualWrite/index.js";
+import { extractFinykDualWriteState } from "../lib/dualWrite/extract.js";
+import { readRaw } from "../lib/finykStorage";
+import type { FinykStorageSlots } from "./useFinykStorageSlots";
+
+function readShowBalance(): boolean {
+  return readRaw("finyk_show_balance_v1", "1") !== "0";
+}
+
+export function useFinykDualWriteSync(slots: FinykStorageSlots): void {
+  const showBalance = readShowBalance();
+  const prevRef = useRef<FinykDualWriteState>(EMPTY_FINYK_STATE);
+  const initialisedRef = useRef(false);
+
+  useEffect(() => {
+    if (!isFinykDualWriteRegistered()) {
+      // No context — keep prev snapshot in sync but skip the trigger
+      // so that the first write after the user enables the flag still
+      // produces a meaningful diff (against the actual current state).
+      prevRef.current = extractFinykDualWriteState(slots, showBalance);
+      initialisedRef.current = true;
+      return;
+    }
+    const next = extractFinykDualWriteState(slots, showBalance);
+    if (!initialisedRef.current) {
+      // First render after the context is registered: snapshot the
+      // initial state and rely on the SQLite layer being empty (or
+      // already populated by a previous boot). Skipping the trigger
+      // here avoids spamming a full re-upsert on every page load.
+      prevRef.current = next;
+      initialisedRef.current = true;
+      return;
+    }
+    triggerFinykDualWrite(prevRef.current, next);
+    prevRef.current = next;
+  }, [slots, showBalance]);
+}

--- a/apps/web/src/modules/finyk/hooks/useStorage.ts
+++ b/apps/web/src/modules/finyk/hooks/useStorage.ts
@@ -4,6 +4,8 @@ import { toLocalISODate } from "@sergeant/shared";
 import { useFinykStorageSlots } from "./useFinykStorageSlots";
 import { useFinykStorageMutations } from "./useFinykStorageMutations";
 import { useFinykBackupSync } from "./useFinykBackupSync";
+import { useFinykDualWriteBoot } from "./useFinykDualWriteBoot";
+import { useFinykDualWriteSync } from "./useFinykDualWriteSync";
 
 // Public type re-exports — стабільний import path для зовнішніх consumer-ів
 // (`AssetsForm.tsx`, `Overview.tsx`, тощо). Декомпозиція внутрішнього коду
@@ -50,6 +52,12 @@ export function useStorage({
   const slots = useFinykStorageSlots();
   const mutations = useFinykStorageMutations(slots);
   const backupSync = useFinykBackupSync(slots, toast);
+
+  // Stage 4 PR #036 — install dual-write context once auth + flag are
+  // available, then mirror every slot mutation into SQLite (best-effort,
+  // gated by `feature.finyk.sqlite_v2.dual_write`).
+  useFinykDualWriteBoot();
+  useFinykDualWriteSync(slots);
 
   const {
     hiddenAccounts,

--- a/apps/web/src/modules/finyk/lib/clientMigrate.ts
+++ b/apps/web/src/modules/finyk/lib/clientMigrate.ts
@@ -1,0 +1,32 @@
+import {
+  FINYK_CLIENT_MIGRATIONS,
+  FINYK_MIGRATIONS_TABLE,
+} from "@sergeant/db-schema/sqlite/migrations";
+import { runMigrations } from "@sergeant/db-schema/migrate/runner";
+import {
+  createSqliteAdapter,
+  type SqliteMigrationClient,
+} from "@sergeant/db-schema/migrate/sqlite";
+
+/**
+ * Run the Finyk SQLite client migrations.
+ *
+ * Idempotent: re-running over an already-migrated DB is a no-op
+ * thanks to the runner's `__finyk_migrations` ledger contract.
+ *
+ * Stage 4 PR #035 of `docs/planning/storage-roadmap.md` — schema-only.
+ * The seam this exports is wired into the write paths by PR #036
+ * (dual-write); PR #035 itself only ships the runner so PR #036 has
+ * the same shape as the nutrition dual-write entry-point.
+ */
+export async function migrateFinyk(
+  client: SqliteMigrationClient,
+): Promise<void> {
+  await runMigrations({
+    adapter: createSqliteAdapter(client),
+    files: FINYK_CLIENT_MIGRATIONS,
+    tableName: FINYK_MIGRATIONS_TABLE,
+  });
+}
+
+export type { SqliteMigrationClient };

--- a/apps/web/src/modules/finyk/lib/dualWrite/__tests__/diff.test.ts
+++ b/apps/web/src/modules/finyk/lib/dualWrite/__tests__/diff.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  diffFinykDualWriteOps,
+  EMPTY_FINYK_STATE,
+  type FinykDualWriteState,
+} from "../diff.js";
+
+function blob(id: string, payload: Record<string, unknown> = {}) {
+  return { id, dataJson: JSON.stringify({ id, ...payload }) };
+}
+
+describe("diffFinykDualWriteOps", () => {
+  it("returns no ops when prev === next (identity case)", () => {
+    expect(diffFinykDualWriteOps(EMPTY_FINYK_STATE, EMPTY_FINYK_STATE)).toEqual(
+      [],
+    );
+  });
+
+  it("emits id-upsert ops for new hidden accounts", () => {
+    const next: FinykDualWriteState = {
+      ...EMPTY_FINYK_STATE,
+      hiddenAccounts: [{ id: "acc-1" }, { id: "acc-2" }],
+    };
+    const ops = diffFinykDualWriteOps(EMPTY_FINYK_STATE, next);
+    expect(ops).toEqual([
+      {
+        kind: "id-upsert",
+        table: "finyk_hidden_accounts",
+        entry: { id: "acc-1" },
+      },
+      {
+        kind: "id-upsert",
+        table: "finyk_hidden_accounts",
+        entry: { id: "acc-2" },
+      },
+    ]);
+  });
+
+  it("emits id-delete ops for removed hidden transactions", () => {
+    const prev: FinykDualWriteState = {
+      ...EMPTY_FINYK_STATE,
+      hiddenTransactions: [{ id: "tx-a" }, { id: "tx-b" }],
+    };
+    const next: FinykDualWriteState = {
+      ...EMPTY_FINYK_STATE,
+      hiddenTransactions: [{ id: "tx-a" }],
+    };
+    const ops = diffFinykDualWriteOps(prev, next);
+    expect(ops).toEqual([
+      {
+        kind: "id-delete",
+        table: "finyk_hidden_transactions",
+        id: "tx-b",
+      },
+    ]);
+  });
+
+  it("emits blob-upsert when budget data changes (json string differs)", () => {
+    const prev: FinykDualWriteState = {
+      ...EMPTY_FINYK_STATE,
+      budgets: [blob("b1", { amount: 100 })],
+    };
+    const next: FinykDualWriteState = {
+      ...EMPTY_FINYK_STATE,
+      budgets: [blob("b1", { amount: 200 })],
+    };
+    const ops = diffFinykDualWriteOps(prev, next);
+    expect(ops).toHaveLength(1);
+    expect(ops[0]).toMatchObject({
+      kind: "blob-upsert",
+      table: "finyk_budgets",
+      entry: { id: "b1" },
+    });
+  });
+
+  it("emits blob-delete when a budget is removed", () => {
+    const prev: FinykDualWriteState = {
+      ...EMPTY_FINYK_STATE,
+      budgets: [blob("b1"), blob("b2")],
+    };
+    const next: FinykDualWriteState = {
+      ...EMPTY_FINYK_STATE,
+      budgets: [blob("b1")],
+    };
+    const ops = diffFinykDualWriteOps(prev, next);
+    expect(ops).toEqual([
+      { kind: "blob-delete", table: "finyk_budgets", id: "b2" },
+    ]);
+  });
+
+  it("ignores rows whose dataJson is unchanged (deep-equal blobs do not retrigger)", () => {
+    const prev: FinykDualWriteState = {
+      ...EMPTY_FINYK_STATE,
+      subscriptions: [blob("s1", { name: "Spotify" })],
+    };
+    // Same id + same JSON payload -> no op.
+    const next: FinykDualWriteState = {
+      ...EMPTY_FINYK_STATE,
+      subscriptions: [blob("s1", { name: "Spotify" })],
+    };
+    expect(diffFinykDualWriteOps(prev, next)).toEqual([]);
+  });
+
+  it("emits tx-category-upsert / tx-category-delete on per-tx mapping diff", () => {
+    const prev: FinykDualWriteState = {
+      ...EMPTY_FINYK_STATE,
+      txCategories: [
+        { transactionId: "tx-1", categoryId: "cat-old" },
+        { transactionId: "tx-2", categoryId: "cat-other" },
+      ],
+    };
+    const next: FinykDualWriteState = {
+      ...EMPTY_FINYK_STATE,
+      txCategories: [
+        { transactionId: "tx-1", categoryId: "cat-new" },
+        // tx-2 removed
+        { transactionId: "tx-3", categoryId: "cat-third" },
+      ],
+    };
+    const ops = diffFinykDualWriteOps(prev, next);
+    expect(ops).toEqual([
+      {
+        kind: "tx-category-upsert",
+        entry: { transactionId: "tx-1", categoryId: "cat-new" },
+      },
+      {
+        kind: "tx-category-upsert",
+        entry: { transactionId: "tx-3", categoryId: "cat-third" },
+      },
+      { kind: "tx-category-delete", transactionId: "tx-2" },
+    ]);
+  });
+
+  it("emits tx-splits-upsert / tx-splits-delete on per-tx splits diff", () => {
+    const prev: FinykDualWriteState = {
+      ...EMPTY_FINYK_STATE,
+      txSplits: [{ transactionId: "tx-1", splitsJson: "[{}]" }],
+    };
+    const next: FinykDualWriteState = {
+      ...EMPTY_FINYK_STATE,
+      txSplits: [{ transactionId: "tx-2", splitsJson: "[{}]" }],
+    };
+    const ops = diffFinykDualWriteOps(prev, next);
+    expect(ops).toEqual([
+      {
+        kind: "tx-splits-upsert",
+        entry: { transactionId: "tx-2", splitsJson: "[{}]" },
+      },
+      { kind: "tx-splits-delete", transactionId: "tx-1" },
+    ]);
+  });
+
+  it("emits networth-upsert (no delete op for time-series)", () => {
+    const prev: FinykDualWriteState = {
+      ...EMPTY_FINYK_STATE,
+      networthHistory: [
+        { month: "2026-04", networth: 100 },
+        { month: "2026-03", networth: 50 },
+      ],
+    };
+    const next: FinykDualWriteState = {
+      ...EMPTY_FINYK_STATE,
+      networthHistory: [
+        { month: "2026-04", networth: 200 }, // changed
+        // 2026-03 removed — no delete op should be emitted
+      ],
+    };
+    const ops = diffFinykDualWriteOps(prev, next);
+    expect(ops).toEqual([
+      {
+        kind: "networth-upsert",
+        entry: { month: "2026-04", networth: 200 },
+      },
+    ]);
+  });
+
+  it("emits prefs-upsert when monthlyPlanJson or showBalance change", () => {
+    const prev: FinykDualWriteState = {
+      ...EMPTY_FINYK_STATE,
+      prefs: { monthlyPlanJson: '{"income":1}', showBalance: true },
+    };
+    const next: FinykDualWriteState = {
+      ...EMPTY_FINYK_STATE,
+      prefs: { monthlyPlanJson: '{"income":1}', showBalance: false },
+    };
+    const ops = diffFinykDualWriteOps(prev, next);
+    expect(ops).toEqual([
+      {
+        kind: "prefs-upsert",
+        prefs: { monthlyPlanJson: '{"income":1}', showBalance: false },
+      },
+    ]);
+  });
+
+  it("does not emit prefs-upsert when prefs are byte-identical", () => {
+    const prefs = { monthlyPlanJson: "{}", showBalance: true };
+    const prev: FinykDualWriteState = { ...EMPTY_FINYK_STATE, prefs };
+    const next: FinykDualWriteState = { ...EMPTY_FINYK_STATE, prefs };
+    expect(diffFinykDualWriteOps(prev, next)).toEqual([]);
+  });
+
+  it("emits ops in deterministic order (id-tables → blobs → per-tx → networth → prefs)", () => {
+    const prev = EMPTY_FINYK_STATE;
+    const next: FinykDualWriteState = {
+      ...EMPTY_FINYK_STATE,
+      hiddenAccounts: [{ id: "ha-1" }],
+      hiddenTransactions: [{ id: "ht-1" }],
+      budgets: [blob("bud")],
+      subscriptions: [blob("sub")],
+      assets: [blob("ast")],
+      debts: [blob("dbt")],
+      receivables: [blob("rcv")],
+      customCategories: [blob("cat")],
+      manualExpenses: [blob("exp")],
+      txCategories: [{ transactionId: "tx-1", categoryId: "c1" }],
+      txSplits: [{ transactionId: "tx-2", splitsJson: "[]" }],
+      monoDebtLinks: [{ transactionId: "tx-3", debtIdsJson: "[]" }],
+      networthHistory: [{ month: "2026-04", networth: 1 }],
+      prefs: { monthlyPlanJson: "{}", showBalance: true },
+    };
+    const ops = diffFinykDualWriteOps(prev, next);
+    const kinds = ops.map((o) => o.kind);
+    expect(kinds).toEqual([
+      "id-upsert",
+      "id-upsert",
+      "blob-upsert",
+      "blob-upsert",
+      "blob-upsert",
+      "blob-upsert",
+      "blob-upsert",
+      "blob-upsert",
+      "blob-upsert",
+      "tx-category-upsert",
+      "tx-splits-upsert",
+      "mono-debt-link-upsert",
+      "networth-upsert",
+      "prefs-upsert",
+    ]);
+  });
+});

--- a/apps/web/src/modules/finyk/lib/dualWrite/__tests__/integration.test.ts
+++ b/apps/web/src/modules/finyk/lib/dualWrite/__tests__/integration.test.ts
@@ -1,0 +1,296 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  __clearFinykDualWriteContextForTests,
+  applyFinykDualWriteOps,
+  dualWriteFinykState,
+  isFinykDualWriteRegistered,
+  registerFinykDualWriteContext,
+  triggerFinykDualWrite,
+  type FinykDualWriteContext,
+  type FinykDualWriteState,
+} from "../index.js";
+import { EMPTY_FINYK_STATE } from "../diff.js";
+import { createTestSqlite, type TestSqliteHandle } from "./testSqlite.js";
+
+const USER_ID = "u-1";
+const NOW = "2026-05-04T00:00:00.000Z";
+const LATER = "2026-05-05T00:00:00.000Z";
+
+let handle: TestSqliteHandle;
+
+beforeEach(async () => {
+  handle = await createTestSqlite();
+  __clearFinykDualWriteContextForTests();
+});
+
+afterEach(() => {
+  handle.close();
+  __clearFinykDualWriteContextForTests();
+});
+
+function makeCtx(
+  overrides: Partial<FinykDualWriteContext> = {},
+): FinykDualWriteContext {
+  return {
+    isEnabled: () => true,
+    getUserId: () => USER_ID,
+    getMigrationClient: async () => handle.client,
+    getNow: () => NOW,
+    ...overrides,
+  };
+}
+
+describe("Finyk dual-write — applyFinykDualWriteOps", () => {
+  it("inserts hidden_accounts row on id-upsert", async () => {
+    await applyFinykDualWriteOps(
+      handle.client,
+      [
+        {
+          kind: "id-upsert",
+          table: "finyk_hidden_accounts",
+          entry: { id: "acc-1" },
+        },
+      ],
+      { userId: USER_ID, clientTs: NOW },
+    );
+    const rows = await handle.client.all<{
+      user_id: string;
+      account_id: string;
+      deleted_at: string | null;
+    }>("SELECT user_id, account_id, deleted_at FROM finyk_hidden_accounts");
+    expect(rows).toEqual([
+      { user_id: USER_ID, account_id: "acc-1", deleted_at: null },
+    ]);
+  });
+
+  it("soft-deletes hidden_accounts row on id-delete (LWW)", async () => {
+    await applyFinykDualWriteOps(
+      handle.client,
+      [
+        {
+          kind: "id-upsert",
+          table: "finyk_hidden_accounts",
+          entry: { id: "acc-1" },
+        },
+      ],
+      { userId: USER_ID, clientTs: NOW },
+    );
+    await applyFinykDualWriteOps(
+      handle.client,
+      [{ kind: "id-delete", table: "finyk_hidden_accounts", id: "acc-1" }],
+      { userId: USER_ID, clientTs: LATER },
+    );
+    const rows = await handle.client.all<{ deleted_at: string | null }>(
+      "SELECT deleted_at FROM finyk_hidden_accounts WHERE account_id = ?",
+      ["acc-1"],
+    );
+    expect(rows[0]?.deleted_at).not.toBeNull();
+  });
+
+  it("upserts per-row blob with data_json (finyk_budgets)", async () => {
+    await applyFinykDualWriteOps(
+      handle.client,
+      [
+        {
+          kind: "blob-upsert",
+          table: "finyk_budgets",
+          entry: {
+            id: "11111111-1111-1111-1111-111111111111",
+            dataJson:
+              '{"id":"11111111-1111-1111-1111-111111111111","amount":100}',
+          },
+        },
+      ],
+      { userId: USER_ID, clientTs: NOW },
+    );
+    const rows = await handle.client.all<{
+      id: string;
+      data_json: string;
+    }>("SELECT id, data_json FROM finyk_budgets");
+    expect(rows).toHaveLength(1);
+    expect(JSON.parse(rows[0]!.data_json)).toEqual({
+      id: "11111111-1111-1111-1111-111111111111",
+      amount: 100,
+    });
+  });
+
+  it("hard-deletes per-tx category mapping on tx-category-delete", async () => {
+    await applyFinykDualWriteOps(
+      handle.client,
+      [
+        {
+          kind: "tx-category-upsert",
+          entry: { transactionId: "tx-1", categoryId: "c-1" },
+        },
+      ],
+      { userId: USER_ID, clientTs: NOW },
+    );
+    await applyFinykDualWriteOps(
+      handle.client,
+      [{ kind: "tx-category-delete", transactionId: "tx-1" }],
+      { userId: USER_ID, clientTs: LATER },
+    );
+    const rows = await handle.client.all<Record<string, unknown>>(
+      "SELECT * FROM finyk_tx_categories",
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  it("rejects invalid networth month silently (no row inserted)", async () => {
+    await applyFinykDualWriteOps(
+      handle.client,
+      [
+        {
+          kind: "networth-upsert",
+          entry: { month: "not-a-month", networth: 100 },
+        },
+      ],
+      { userId: USER_ID, clientTs: NOW },
+    );
+    const rows = await handle.client.all<Record<string, unknown>>(
+      "SELECT * FROM finyk_networth_history",
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  it("upserts singleton prefs row (one per user)", async () => {
+    await applyFinykDualWriteOps(
+      handle.client,
+      [
+        {
+          kind: "prefs-upsert",
+          prefs: { monthlyPlanJson: '{"income":"10"}', showBalance: false },
+        },
+      ],
+      { userId: USER_ID, clientTs: NOW },
+    );
+    const rows = await handle.client.all<{
+      user_id: string;
+      monthly_plan_json: string;
+      show_balance: number;
+    }>("SELECT user_id, monthly_plan_json, show_balance FROM finyk_prefs");
+    expect(rows).toEqual([
+      {
+        user_id: USER_ID,
+        monthly_plan_json: '{"income":"10"}',
+        show_balance: 0,
+      },
+    ]);
+  });
+
+  it("LWW: stale clientTs does NOT overwrite a newer row", async () => {
+    await applyFinykDualWriteOps(
+      handle.client,
+      [
+        {
+          kind: "blob-upsert",
+          table: "finyk_assets",
+          entry: {
+            id: "22222222-2222-2222-2222-222222222222",
+            dataJson: '{"amount":500}',
+          },
+        },
+      ],
+      { userId: USER_ID, clientTs: LATER },
+    );
+    // Stale write
+    await applyFinykDualWriteOps(
+      handle.client,
+      [
+        {
+          kind: "blob-upsert",
+          table: "finyk_assets",
+          entry: {
+            id: "22222222-2222-2222-2222-222222222222",
+            dataJson: '{"amount":1}',
+          },
+        },
+      ],
+      { userId: USER_ID, clientTs: NOW },
+    );
+    const rows = await handle.client.all<{ data_json: string }>(
+      "SELECT data_json FROM finyk_assets WHERE id = ?",
+      ["22222222-2222-2222-2222-222222222222"],
+    );
+    expect(JSON.parse(rows[0]!.data_json)).toEqual({ amount: 500 });
+  });
+});
+
+describe("Finyk dual-write — orchestrator (registerFinykDualWriteContext)", () => {
+  it("dualWriteFinykState applies ops when context is registered + flag on", async () => {
+    registerFinykDualWriteContext(makeCtx());
+    expect(isFinykDualWriteRegistered()).toBe(true);
+
+    const next: FinykDualWriteState = {
+      ...EMPTY_FINYK_STATE,
+      hiddenAccounts: [{ id: "acc-1" }],
+    };
+    const out = await dualWriteFinykState(EMPTY_FINYK_STATE, next);
+    expect(out.status).toBe("applied");
+
+    const rows = await handle.client.all<Record<string, unknown>>(
+      "SELECT * FROM finyk_hidden_accounts",
+    );
+    expect(rows).toHaveLength(1);
+  });
+
+  it("dualWriteFinykState skips when flag is off", async () => {
+    registerFinykDualWriteContext(makeCtx({ isEnabled: () => false }));
+    const out = await dualWriteFinykState(EMPTY_FINYK_STATE, {
+      ...EMPTY_FINYK_STATE,
+      hiddenAccounts: [{ id: "acc-1" }],
+    });
+    expect(out).toEqual({ status: "skipped", reason: "flag-off" });
+  });
+
+  it("dualWriteFinykState skips when no ops are diffed", async () => {
+    registerFinykDualWriteContext(makeCtx());
+    const out = await dualWriteFinykState(EMPTY_FINYK_STATE, EMPTY_FINYK_STATE);
+    expect(out).toEqual({ status: "skipped", reason: "no-ops" });
+  });
+
+  it("dualWriteFinykState skips when user id is missing", async () => {
+    registerFinykDualWriteContext(makeCtx({ getUserId: () => null }));
+    const out = await dualWriteFinykState(EMPTY_FINYK_STATE, {
+      ...EMPTY_FINYK_STATE,
+      hiddenAccounts: [{ id: "acc-1" }],
+    });
+    expect(out).toEqual({ status: "skipped", reason: "user-id-missing" });
+  });
+
+  it("triggerFinykDualWrite is fire-and-forget (resolves immediately)", async () => {
+    registerFinykDualWriteContext(makeCtx());
+    triggerFinykDualWrite(EMPTY_FINYK_STATE, {
+      ...EMPTY_FINYK_STATE,
+      budgets: [
+        {
+          id: "33333333-3333-3333-3333-333333333333",
+          dataJson: '{"amount":42}',
+        },
+      ],
+    });
+    // synchronous — row not yet present
+    let rows = await handle.client.all<Record<string, unknown>>(
+      "SELECT * FROM finyk_budgets WHERE id = ?",
+      ["33333333-3333-3333-3333-333333333333"],
+    );
+    expect(rows).toHaveLength(0);
+
+    // microtask flushed
+    await Promise.resolve();
+    await Promise.resolve();
+
+    rows = await handle.client.all<Record<string, unknown>>(
+      "SELECT * FROM finyk_budgets WHERE id = ?",
+      ["33333333-3333-3333-3333-333333333333"],
+    );
+    expect(rows).toHaveLength(1);
+  });
+
+  it("triggerFinykDualWrite no-ops with no context registered", () => {
+    expect(() =>
+      triggerFinykDualWrite(EMPTY_FINYK_STATE, EMPTY_FINYK_STATE),
+    ).not.toThrow();
+  });
+});

--- a/apps/web/src/modules/finyk/lib/dualWrite/__tests__/testSqlite.ts
+++ b/apps/web/src/modules/finyk/lib/dualWrite/__tests__/testSqlite.ts
@@ -1,0 +1,66 @@
+/**
+ * Shared test helper: in-memory SQLite with finyk migrations applied.
+ *
+ * Wraps `better-sqlite3` in a `SqliteMigrationClient` and runs the
+ * bundled Finyk migrations. The result is a freshly-migrated SQLite
+ * database ready for dual-write / adapter assertions.
+ *
+ * Mirror of
+ * `apps/web/src/modules/nutrition/lib/dualWrite/__tests__/testSqlite.ts`.
+ */
+
+import { createRequire } from "node:module";
+import type { SqliteMigrationClient } from "@sergeant/db-schema/migrate/sqlite";
+
+import { migrateFinyk } from "../../clientMigrate.js";
+
+const require = createRequire(import.meta.url);
+type BetterSqliteCtor = new (filename: string) => BetterSqliteDatabase;
+interface BetterSqliteDatabase {
+  exec(sql: string): unknown;
+  prepare(sql: string): {
+    run(...args: unknown[]): unknown;
+    all(...args: unknown[]): unknown[];
+    get(...args: unknown[]): unknown;
+  };
+  close(): unknown;
+}
+const Database = require("better-sqlite3") as BetterSqliteCtor;
+
+export interface TestSqliteHandle {
+  db: BetterSqliteDatabase;
+  client: SqliteMigrationClient;
+  close(): void;
+}
+
+/**
+ * Open an in-memory SQLite engine, wrap it as a `SqliteMigrationClient`,
+ * and apply the Finyk migrations.
+ */
+export async function createTestSqlite(): Promise<TestSqliteHandle> {
+  const db = new Database(":memory:");
+  const client: SqliteMigrationClient = {
+    exec(sql) {
+      db.exec(sql);
+    },
+    run(sql, params) {
+      db.prepare(sql).run(...((params ?? []) as unknown[]));
+    },
+    all<R extends Record<string, unknown>>(
+      sql: string,
+      params?: readonly unknown[],
+    ): R[] {
+      const stmt = db.prepare(sql);
+      const result = params ? stmt.all(...(params as unknown[])) : stmt.all();
+      return result as R[];
+    },
+  };
+  await migrateFinyk(client);
+  return {
+    db,
+    client,
+    close() {
+      db.close();
+    },
+  };
+}

--- a/apps/web/src/modules/finyk/lib/dualWrite/adapter.ts
+++ b/apps/web/src/modules/finyk/lib/dualWrite/adapter.ts
@@ -1,0 +1,395 @@
+import type { SqliteMigrationClient } from "@sergeant/db-schema/migrate/sqlite";
+
+import type {
+  FinykBlobEntry,
+  FinykBlobTable,
+  FinykDualWriteOp,
+  FinykIdEntry,
+  FinykIdTable,
+  FinykMonoDebtLinkEntry,
+  FinykNetworthEntry,
+  FinykPrefsSnapshot,
+  FinykTxCategoryEntry,
+  FinykTxSplitsEntry,
+} from "./diff.js";
+
+/**
+ * Async SQLite-side adapter for the Finyk dual-write layer.
+ *
+ * Stage 4 PR #036 of `docs/planning/storage-roadmap.md`. Mirror of
+ * `apps/web/src/modules/nutrition/lib/dualWrite/adapter.ts` with the
+ * finyk entity types / table names. Takes the `FinykDualWriteOp[]`
+ * produced by `diffFinykDualWriteOps` and writes them to the local
+ * `finyk_*` tables defined by migration `039_finyk_tables.sql` and the
+ * SQLite parallel in `packages/db-schema/src/sqlite/finyk.ts`.
+ *
+ * Design notes (same as nutrition adapter):
+ *
+ * - Best-effort: every op is wrapped in try/catch. A single failed op
+ *   does NOT abort the rest.
+ * - Idempotent: upserts use ON CONFLICT(...) DO UPDATE with LWW guard.
+ * - LWW guard: updates only apply when the incoming `clientTs` is
+ *   strictly newer than the local `updated_at`.
+ * - Soft-delete on tables that have `deleted_at`; hard `DELETE` on
+ *   per-tx mappings (no soft-delete column there — absence is the
+ *   "no override" state, by design).
+ */
+
+export interface ApplyDualWriteOptions {
+  readonly userId: string;
+  readonly clientTs: string;
+  readonly logger?: DualWriteLogger;
+}
+
+export type DualWriteLogger = (
+  level: "warn" | "info",
+  message: string,
+  meta?: Record<string, unknown>,
+) => void;
+
+export interface ApplyDualWriteResult {
+  readonly applied: number;
+  readonly errored: number;
+  readonly skipped: number;
+}
+
+const DEFAULT_LOGGER: DualWriteLogger = (level, message, meta) => {
+  if (level === "warn") {
+    console.warn(`[finyk.dualWrite] ${message}`, meta ?? {});
+  }
+};
+
+export async function applyFinykDualWriteOps(
+  client: SqliteMigrationClient,
+  ops: readonly FinykDualWriteOp[],
+  options: ApplyDualWriteOptions,
+): Promise<ApplyDualWriteResult> {
+  if (ops.length === 0) {
+    return { applied: 0, errored: 0, skipped: 0 };
+  }
+  const logger = options.logger ?? DEFAULT_LOGGER;
+  let applied = 0;
+  let errored = 0;
+  let skipped = 0;
+
+  for (const op of ops) {
+    try {
+      const outcome = await applyOne(client, op, options);
+      if (outcome === "applied") applied += 1;
+      else skipped += 1;
+    } catch (err) {
+      errored += 1;
+      logger("warn", "dual-write op failed", {
+        op: op.kind,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return { applied, errored, skipped };
+}
+
+type ApplyOutcome = "applied" | "skipped";
+
+async function applyOne(
+  client: SqliteMigrationClient,
+  op: FinykDualWriteOp,
+  options: ApplyDualWriteOptions,
+): Promise<ApplyOutcome> {
+  const { userId, clientTs } = options;
+  switch (op.kind) {
+    case "id-upsert":
+      await upsertIdEntry(client, op.table, op.entry, userId, clientTs);
+      return "applied";
+
+    case "id-delete":
+      await softDeleteIdEntry(client, op.table, op.id, userId, clientTs);
+      return "applied";
+
+    case "blob-upsert":
+      await upsertBlobEntry(client, op.table, op.entry, userId, clientTs);
+      return "applied";
+
+    case "blob-delete":
+      await softDeleteBlobEntry(client, op.table, op.id, userId, clientTs);
+      return "applied";
+
+    case "tx-category-upsert":
+      await upsertTxCategory(client, op.entry, userId, clientTs);
+      return "applied";
+
+    case "tx-category-delete":
+      await deleteTxCategory(client, op.transactionId, userId);
+      return "applied";
+
+    case "tx-splits-upsert":
+      await upsertTxSplits(client, op.entry, userId, clientTs);
+      return "applied";
+
+    case "tx-splits-delete":
+      await deleteTxSplits(client, op.transactionId, userId);
+      return "applied";
+
+    case "mono-debt-link-upsert":
+      await upsertMonoDebtLink(client, op.entry, userId, clientTs);
+      return "applied";
+
+    case "mono-debt-link-delete":
+      await deleteMonoDebtLink(client, op.transactionId, userId);
+      return "applied";
+
+    case "networth-upsert":
+      await upsertNetworth(client, op.entry, userId, clientTs);
+      return "applied";
+
+    case "prefs-upsert":
+      await upsertPrefs(client, op.prefs, userId, clientTs);
+      return "applied";
+
+    default: {
+      const _exhaustive: never = op;
+      void _exhaustive;
+      return "skipped";
+    }
+  }
+}
+
+// -----------------------------------------------------------------------
+// Composite-PK tombstones (id-tables)
+// -----------------------------------------------------------------------
+
+const ID_COLUMN: Record<FinykIdTable, "account_id" | "transaction_id"> = {
+  finyk_hidden_accounts: "account_id",
+  finyk_hidden_transactions: "transaction_id",
+};
+
+async function upsertIdEntry(
+  client: SqliteMigrationClient,
+  table: FinykIdTable,
+  entry: FinykIdEntry,
+  userId: string,
+  clientTs: string,
+): Promise<void> {
+  const col = ID_COLUMN[table];
+  await client.run(
+    `INSERT INTO ${table}
+       (user_id, ${col}, created_at, updated_at, deleted_at)
+     VALUES (?, ?, ?, ?, NULL)
+     ON CONFLICT(user_id, ${col}) DO UPDATE SET
+       updated_at = excluded.updated_at,
+       deleted_at = NULL
+     WHERE excluded.updated_at > ${table}.updated_at`,
+    [userId, entry.id, clientTs, clientTs],
+  );
+}
+
+async function softDeleteIdEntry(
+  client: SqliteMigrationClient,
+  table: FinykIdTable,
+  id: string,
+  userId: string,
+  clientTs: string,
+): Promise<void> {
+  const col = ID_COLUMN[table];
+  await client.run(
+    `UPDATE ${table}
+        SET deleted_at = ?, updated_at = ?
+      WHERE user_id = ? AND ${col} = ? AND updated_at < ?`,
+    [clientTs, clientTs, userId, id, clientTs],
+  );
+}
+
+// -----------------------------------------------------------------------
+// Per-row + JSONB blobs
+// -----------------------------------------------------------------------
+
+async function upsertBlobEntry(
+  client: SqliteMigrationClient,
+  table: FinykBlobTable,
+  entry: FinykBlobEntry,
+  userId: string,
+  clientTs: string,
+): Promise<void> {
+  await client.run(
+    `INSERT INTO ${table}
+       (id, user_id, data_json, created_at, updated_at, deleted_at)
+     VALUES (?, ?, ?, ?, ?, NULL)
+     ON CONFLICT(id) DO UPDATE SET
+       data_json  = excluded.data_json,
+       updated_at = excluded.updated_at,
+       deleted_at = NULL
+     WHERE excluded.updated_at > ${table}.updated_at`,
+    [entry.id, userId, entry.dataJson ?? "{}", clientTs, clientTs],
+  );
+}
+
+async function softDeleteBlobEntry(
+  client: SqliteMigrationClient,
+  table: FinykBlobTable,
+  id: string,
+  userId: string,
+  clientTs: string,
+): Promise<void> {
+  await client.run(
+    `UPDATE ${table}
+        SET deleted_at = ?, updated_at = ?
+      WHERE id = ? AND user_id = ? AND updated_at < ?`,
+    [clientTs, clientTs, id, userId, clientTs],
+  );
+}
+
+// -----------------------------------------------------------------------
+// Per-tx mappings (no soft-delete — absence is the "no override" state)
+// -----------------------------------------------------------------------
+
+async function upsertTxCategory(
+  client: SqliteMigrationClient,
+  entry: FinykTxCategoryEntry,
+  userId: string,
+  clientTs: string,
+): Promise<void> {
+  await client.run(
+    `INSERT INTO finyk_tx_categories
+       (user_id, transaction_id, category_id, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(user_id, transaction_id) DO UPDATE SET
+       category_id = excluded.category_id,
+       updated_at  = excluded.updated_at
+     WHERE excluded.updated_at > finyk_tx_categories.updated_at`,
+    [userId, entry.transactionId, entry.categoryId, clientTs, clientTs],
+  );
+}
+
+async function deleteTxCategory(
+  client: SqliteMigrationClient,
+  transactionId: string,
+  userId: string,
+): Promise<void> {
+  await client.run(
+    `DELETE FROM finyk_tx_categories
+      WHERE user_id = ? AND transaction_id = ?`,
+    [userId, transactionId],
+  );
+}
+
+async function upsertTxSplits(
+  client: SqliteMigrationClient,
+  entry: FinykTxSplitsEntry,
+  userId: string,
+  clientTs: string,
+): Promise<void> {
+  await client.run(
+    `INSERT INTO finyk_tx_splits
+       (user_id, transaction_id, splits_json, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(user_id, transaction_id) DO UPDATE SET
+       splits_json = excluded.splits_json,
+       updated_at  = excluded.updated_at
+     WHERE excluded.updated_at > finyk_tx_splits.updated_at`,
+    [userId, entry.transactionId, entry.splitsJson ?? "[]", clientTs, clientTs],
+  );
+}
+
+async function deleteTxSplits(
+  client: SqliteMigrationClient,
+  transactionId: string,
+  userId: string,
+): Promise<void> {
+  await client.run(
+    `DELETE FROM finyk_tx_splits
+      WHERE user_id = ? AND transaction_id = ?`,
+    [userId, transactionId],
+  );
+}
+
+async function upsertMonoDebtLink(
+  client: SqliteMigrationClient,
+  entry: FinykMonoDebtLinkEntry,
+  userId: string,
+  clientTs: string,
+): Promise<void> {
+  await client.run(
+    `INSERT INTO finyk_mono_debt_links
+       (user_id, transaction_id, debt_ids_json, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(user_id, transaction_id) DO UPDATE SET
+       debt_ids_json = excluded.debt_ids_json,
+       updated_at    = excluded.updated_at
+     WHERE excluded.updated_at > finyk_mono_debt_links.updated_at`,
+    [
+      userId,
+      entry.transactionId,
+      entry.debtIdsJson ?? "[]",
+      clientTs,
+      clientTs,
+    ],
+  );
+}
+
+async function deleteMonoDebtLink(
+  client: SqliteMigrationClient,
+  transactionId: string,
+  userId: string,
+): Promise<void> {
+  await client.run(
+    `DELETE FROM finyk_mono_debt_links
+      WHERE user_id = ? AND transaction_id = ?`,
+    [userId, transactionId],
+  );
+}
+
+// -----------------------------------------------------------------------
+// Time-series: networth_history (composite PK (user_id, month))
+// -----------------------------------------------------------------------
+
+async function upsertNetworth(
+  client: SqliteMigrationClient,
+  entry: FinykNetworthEntry,
+  userId: string,
+  clientTs: string,
+): Promise<void> {
+  // Defensive: the apply-fn server-side validates the YYYY-MM format
+  // with a regex; mirror that here so a corrupt LS row doesn't poison
+  // the local table.
+  if (!/^\d{4}-\d{2}$/.test(entry.month)) return;
+  const networth = Number.isFinite(entry.networth) ? entry.networth : 0;
+  await client.run(
+    `INSERT INTO finyk_networth_history
+       (user_id, month, networth, snapshot_json, created_at, updated_at)
+     VALUES (?, ?, ?, '{}', ?, ?)
+     ON CONFLICT(user_id, month) DO UPDATE SET
+       networth   = excluded.networth,
+       updated_at = excluded.updated_at
+     WHERE excluded.updated_at > finyk_networth_history.updated_at`,
+    [userId, entry.month, networth, clientTs, clientTs],
+  );
+}
+
+// -----------------------------------------------------------------------
+// Singleton prefs (per-user)
+// -----------------------------------------------------------------------
+
+async function upsertPrefs(
+  client: SqliteMigrationClient,
+  prefs: FinykPrefsSnapshot,
+  userId: string,
+  clientTs: string,
+): Promise<void> {
+  await client.run(
+    `INSERT INTO finyk_prefs
+       (user_id, monthly_plan_json, show_balance, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(user_id) DO UPDATE SET
+       monthly_plan_json = excluded.monthly_plan_json,
+       show_balance      = excluded.show_balance,
+       updated_at        = excluded.updated_at
+     WHERE excluded.updated_at > finyk_prefs.updated_at`,
+    [
+      userId,
+      prefs.monthlyPlanJson ?? "{}",
+      prefs.showBalance ? 1 : 0,
+      clientTs,
+      clientTs,
+    ],
+  );
+}

--- a/apps/web/src/modules/finyk/lib/dualWrite/diff.ts
+++ b/apps/web/src/modules/finyk/lib/dualWrite/diff.ts
@@ -1,0 +1,448 @@
+/**
+ * Pure-function diff between two Finyk LS-state snapshots, producing
+ * the list of operations the dual-write layer must mirror to local
+ * SQLite.
+ *
+ * Stage 4 PR #036 of `docs/planning/storage-roadmap.md`. Mirrors the
+ * nutrition dual-write diff layer (PR #032) — same shape, same
+ * semantics, separate types because the entity surface is different.
+ *
+ * Five entity classes are tracked across 14 LS keys. The mapping to
+ * SQLite tables (created by PR #035 migration `039_finyk_tables.sql`):
+ *
+ *   - composite-PK tombstones (set membership)
+ *     - `finyk_hidden`            → `finyk_hidden_accounts`
+ *     - `finyk_hidden_txs`        → `finyk_hidden_transactions`
+ *
+ *   - per-row + JSONB blob (CRUD over arrays)
+ *     - `finyk_budgets`           → `finyk_budgets`
+ *     - `finyk_subs`              → `finyk_subscriptions`
+ *     - `finyk_assets`            → `finyk_assets`
+ *     - `finyk_debts`             → `finyk_debts`
+ *     - `finyk_recv`              → `finyk_receivables`
+ *     - `finyk_custom_cats_v1`    → `finyk_custom_categories`
+ *     - `finyk_manual_expenses_v1`→ `finyk_manual_expenses`
+ *
+ *   - per-tx mapping (composite (user_id, transaction_id) PK)
+ *     - `finyk_tx_cats`           → `finyk_tx_categories`     (string value)
+ *     - `finyk_tx_splits`         → `finyk_tx_splits`         (jsonb array)
+ *     - `finyk_mono_debt_linked`  → `finyk_mono_debt_links`   (jsonb array)
+ *
+ *   - time-series
+ *     - `finyk_networth_history`  → `finyk_networth_history`  (composite (user_id, month))
+ *
+ *   - singleton prefs (per-user)
+ *     - `finyk_monthly_plan` + `finyk_show_balance_v1` → `finyk_prefs`
+ *
+ * `finyk_tx_filters_v1` is intentionally NOT yet wired here — there is
+ * no LS source on `main` today; the table waits for the future filter
+ * persistence work. The diff layer omits it entirely until the LS
+ * shape lands.
+ */
+
+// -----------------------------------------------------------------------
+// Snapshot shapes — loose mirrors of the domain types, kept minimal so
+// the diff layer doesn't pull in the full domain package. The adapter
+// reads these to produce SQL statements.
+// -----------------------------------------------------------------------
+
+/** Set-membership entry for the composite-PK tombstone tables. */
+export interface FinykIdEntry {
+  /** Stable external id (account id / Mono transaction id). */
+  readonly id: string;
+}
+
+/**
+ * Per-row blob entry. `dataJson` is the verbatim JSON serialisation of
+ * the LS shape — the adapter writes it to `data_json` unchanged so
+ * future schema evolution doesn't require re-shaping at the dual-write
+ * boundary.
+ */
+export interface FinykBlobEntry {
+  readonly id: string;
+  readonly dataJson: string;
+}
+
+/** Per-tx category override (`finyk_tx_cats`). */
+export interface FinykTxCategoryEntry {
+  readonly transactionId: string;
+  readonly categoryId: string;
+}
+
+/** Per-tx splits (`finyk_tx_splits`). */
+export interface FinykTxSplitsEntry {
+  readonly transactionId: string;
+  readonly splitsJson: string;
+}
+
+/** Per-tx mono-debt links (`finyk_mono_debt_linked`). */
+export interface FinykMonoDebtLinkEntry {
+  readonly transactionId: string;
+  readonly debtIdsJson: string;
+}
+
+/** Time-series networth row (`finyk_networth_history`). */
+export interface FinykNetworthEntry {
+  readonly month: string;
+  readonly networth: number;
+}
+
+/** Singleton per-user prefs (`finyk_prefs`). */
+export interface FinykPrefsSnapshot {
+  /** Whole MonthlyPlan blob serialised to JSON. */
+  readonly monthlyPlanJson: string;
+  /** `finyk_show_balance_v1` raw boolean state. */
+  readonly showBalance: boolean;
+}
+
+// -----------------------------------------------------------------------
+// State — loose mirror of useFinykStorageSlots() across all LS keys
+// -----------------------------------------------------------------------
+
+export interface FinykDualWriteState {
+  readonly hiddenAccounts: readonly FinykIdEntry[];
+  readonly hiddenTransactions: readonly FinykIdEntry[];
+  readonly budgets: readonly FinykBlobEntry[];
+  readonly subscriptions: readonly FinykBlobEntry[];
+  readonly assets: readonly FinykBlobEntry[];
+  readonly debts: readonly FinykBlobEntry[];
+  readonly receivables: readonly FinykBlobEntry[];
+  readonly customCategories: readonly FinykBlobEntry[];
+  readonly manualExpenses: readonly FinykBlobEntry[];
+  readonly txCategories: readonly FinykTxCategoryEntry[];
+  readonly txSplits: readonly FinykTxSplitsEntry[];
+  readonly monoDebtLinks: readonly FinykMonoDebtLinkEntry[];
+  readonly networthHistory: readonly FinykNetworthEntry[];
+  readonly prefs: FinykPrefsSnapshot | null;
+}
+
+export const EMPTY_FINYK_STATE: FinykDualWriteState = {
+  hiddenAccounts: [],
+  hiddenTransactions: [],
+  budgets: [],
+  subscriptions: [],
+  assets: [],
+  debts: [],
+  receivables: [],
+  customCategories: [],
+  manualExpenses: [],
+  txCategories: [],
+  txSplits: [],
+  monoDebtLinks: [],
+  networthHistory: [],
+  prefs: null,
+};
+
+// -----------------------------------------------------------------------
+// Op types
+// -----------------------------------------------------------------------
+
+export type FinykIdTable =
+  | "finyk_hidden_accounts"
+  | "finyk_hidden_transactions";
+
+export type FinykBlobTable =
+  | "finyk_budgets"
+  | "finyk_subscriptions"
+  | "finyk_assets"
+  | "finyk_debts"
+  | "finyk_receivables"
+  | "finyk_custom_categories"
+  | "finyk_manual_expenses";
+
+export interface IdUpsertOp {
+  readonly kind: "id-upsert";
+  readonly table: FinykIdTable;
+  readonly entry: FinykIdEntry;
+}
+
+export interface IdDeleteOp {
+  readonly kind: "id-delete";
+  readonly table: FinykIdTable;
+  readonly id: string;
+}
+
+export interface BlobUpsertOp {
+  readonly kind: "blob-upsert";
+  readonly table: FinykBlobTable;
+  readonly entry: FinykBlobEntry;
+}
+
+export interface BlobDeleteOp {
+  readonly kind: "blob-delete";
+  readonly table: FinykBlobTable;
+  readonly id: string;
+}
+
+export interface TxCategoryUpsertOp {
+  readonly kind: "tx-category-upsert";
+  readonly entry: FinykTxCategoryEntry;
+}
+
+export interface TxCategoryDeleteOp {
+  readonly kind: "tx-category-delete";
+  readonly transactionId: string;
+}
+
+export interface TxSplitsUpsertOp {
+  readonly kind: "tx-splits-upsert";
+  readonly entry: FinykTxSplitsEntry;
+}
+
+export interface TxSplitsDeleteOp {
+  readonly kind: "tx-splits-delete";
+  readonly transactionId: string;
+}
+
+export interface MonoDebtLinkUpsertOp {
+  readonly kind: "mono-debt-link-upsert";
+  readonly entry: FinykMonoDebtLinkEntry;
+}
+
+export interface MonoDebtLinkDeleteOp {
+  readonly kind: "mono-debt-link-delete";
+  readonly transactionId: string;
+}
+
+export interface NetworthUpsertOp {
+  readonly kind: "networth-upsert";
+  readonly entry: FinykNetworthEntry;
+}
+
+export interface PrefsUpsertOp {
+  readonly kind: "prefs-upsert";
+  readonly prefs: FinykPrefsSnapshot;
+}
+
+export type FinykDualWriteOp =
+  | IdUpsertOp
+  | IdDeleteOp
+  | BlobUpsertOp
+  | BlobDeleteOp
+  | TxCategoryUpsertOp
+  | TxCategoryDeleteOp
+  | TxSplitsUpsertOp
+  | TxSplitsDeleteOp
+  | MonoDebtLinkUpsertOp
+  | MonoDebtLinkDeleteOp
+  | NetworthUpsertOp
+  | PrefsUpsertOp;
+
+// -----------------------------------------------------------------------
+// Diff
+// -----------------------------------------------------------------------
+
+/**
+ * Compute the dual-write operation list for the transition `prev → next`.
+ *
+ * Stable iteration order:
+ *   1. id-tables (`finyk_hidden_accounts`, `finyk_hidden_transactions`)
+ *   2. blob-tables in declaration order (budgets → subs → assets → …)
+ *   3. tx-categories / tx-splits / mono-debt-links (id asc)
+ *   4. networth-history (month asc)
+ *   5. prefs-upsert (singleton, last)
+ */
+export function diffFinykDualWriteOps(
+  prev: FinykDualWriteState,
+  next: FinykDualWriteState,
+): FinykDualWriteOp[] {
+  const ops: FinykDualWriteOp[] = [];
+
+  // --- ID tables ---
+  diffById(
+    prev.hiddenAccounts,
+    next.hiddenAccounts,
+    () => false, // no payload — set membership only
+    (entry) =>
+      ops.push({ kind: "id-upsert", table: "finyk_hidden_accounts", entry }),
+    (id) => ops.push({ kind: "id-delete", table: "finyk_hidden_accounts", id }),
+  );
+
+  diffById(
+    prev.hiddenTransactions,
+    next.hiddenTransactions,
+    () => false,
+    (entry) =>
+      ops.push({
+        kind: "id-upsert",
+        table: "finyk_hidden_transactions",
+        entry,
+      }),
+    (id) =>
+      ops.push({ kind: "id-delete", table: "finyk_hidden_transactions", id }),
+  );
+
+  // --- Per-row blobs ---
+  diffBlobs(prev.budgets, next.budgets, "finyk_budgets", ops);
+  diffBlobs(prev.subscriptions, next.subscriptions, "finyk_subscriptions", ops);
+  diffBlobs(prev.assets, next.assets, "finyk_assets", ops);
+  diffBlobs(prev.debts, next.debts, "finyk_debts", ops);
+  diffBlobs(prev.receivables, next.receivables, "finyk_receivables", ops);
+  diffBlobs(
+    prev.customCategories,
+    next.customCategories,
+    "finyk_custom_categories",
+    ops,
+  );
+  diffBlobs(
+    prev.manualExpenses,
+    next.manualExpenses,
+    "finyk_manual_expenses",
+    ops,
+  );
+
+  // --- Per-tx category overrides ---
+  diffByKey(
+    prev.txCategories,
+    next.txCategories,
+    (e) => e.transactionId,
+    (a, b) => a.categoryId !== b.categoryId,
+    (entry) => ops.push({ kind: "tx-category-upsert", entry }),
+    (transactionId) => ops.push({ kind: "tx-category-delete", transactionId }),
+  );
+
+  // --- Per-tx splits ---
+  diffByKey(
+    prev.txSplits,
+    next.txSplits,
+    (e) => e.transactionId,
+    (a, b) => a.splitsJson !== b.splitsJson,
+    (entry) => ops.push({ kind: "tx-splits-upsert", entry }),
+    (transactionId) => ops.push({ kind: "tx-splits-delete", transactionId }),
+  );
+
+  // --- Per-tx mono-debt links ---
+  diffByKey(
+    prev.monoDebtLinks,
+    next.monoDebtLinks,
+    (e) => e.transactionId,
+    (a, b) => a.debtIdsJson !== b.debtIdsJson,
+    (entry) => ops.push({ kind: "mono-debt-link-upsert", entry }),
+    (transactionId) =>
+      ops.push({ kind: "mono-debt-link-delete", transactionId }),
+  );
+
+  // --- Time-series: networth_history ---
+  // No deletes — history is append/replace-only per month.
+  diffByKey(
+    prev.networthHistory,
+    next.networthHistory,
+    (e) => e.month,
+    (a, b) => a.networth !== b.networth,
+    (entry) => ops.push({ kind: "networth-upsert", entry }),
+    () => {
+      /* no delete op for time-series */
+    },
+  );
+
+  // --- Singleton prefs ---
+  if (prefsChanged(prev.prefs, next.prefs) && next.prefs) {
+    ops.push({ kind: "prefs-upsert", prefs: next.prefs });
+  }
+
+  return ops;
+}
+
+// -----------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------
+
+function diffById(
+  prev: readonly FinykIdEntry[],
+  next: readonly FinykIdEntry[],
+  hasChanged: (a: FinykIdEntry, b: FinykIdEntry) => boolean,
+  onUpsert: (entry: FinykIdEntry) => void,
+  onDelete: (id: string) => void,
+): void {
+  const prevMap = new Map<string, FinykIdEntry>();
+  for (const item of prev) prevMap.set(item.id, item);
+  const nextMap = new Map<string, FinykIdEntry>();
+  for (const item of next) nextMap.set(item.id, item);
+
+  const sortedNextIds = [...nextMap.keys()].sort();
+  for (const id of sortedNextIds) {
+    const nextItem = nextMap.get(id)!;
+    const prevItem = prevMap.get(id);
+    if (!prevItem) onUpsert(nextItem);
+    else if (prevItem !== nextItem && hasChanged(prevItem, nextItem))
+      onUpsert(nextItem);
+  }
+
+  const sortedPrevIds = [...prevMap.keys()].sort();
+  for (const id of sortedPrevIds) {
+    if (!nextMap.has(id)) onDelete(id);
+  }
+}
+
+function diffBlobs(
+  prev: readonly FinykBlobEntry[],
+  next: readonly FinykBlobEntry[],
+  table: FinykBlobTable,
+  ops: FinykDualWriteOp[],
+): void {
+  const prevMap = new Map<string, FinykBlobEntry>();
+  for (const item of prev) prevMap.set(item.id, item);
+  const nextMap = new Map<string, FinykBlobEntry>();
+  for (const item of next) nextMap.set(item.id, item);
+
+  const sortedNextIds = [...nextMap.keys()].sort();
+  for (const id of sortedNextIds) {
+    const nextItem = nextMap.get(id)!;
+    const prevItem = prevMap.get(id);
+    if (!prevItem) {
+      ops.push({ kind: "blob-upsert", table, entry: nextItem });
+    } else if (
+      prevItem !== nextItem &&
+      prevItem.dataJson !== nextItem.dataJson
+    ) {
+      ops.push({ kind: "blob-upsert", table, entry: nextItem });
+    }
+  }
+
+  const sortedPrevIds = [...prevMap.keys()].sort();
+  for (const id of sortedPrevIds) {
+    if (!nextMap.has(id)) {
+      ops.push({ kind: "blob-delete", table, id });
+    }
+  }
+}
+
+function diffByKey<T>(
+  prev: readonly T[],
+  next: readonly T[],
+  getKey: (entry: T) => string,
+  hasChanged: (prev: T, next: T) => boolean,
+  onUpsert: (entry: T) => void,
+  onDelete: (key: string) => void,
+): void {
+  const prevMap = new Map<string, T>();
+  for (const item of prev) prevMap.set(getKey(item), item);
+  const nextMap = new Map<string, T>();
+  for (const item of next) nextMap.set(getKey(item), item);
+
+  const sortedNextKeys = [...nextMap.keys()].sort();
+  for (const key of sortedNextKeys) {
+    const nextItem = nextMap.get(key)!;
+    const prevItem = prevMap.get(key);
+    if (!prevItem) onUpsert(nextItem);
+    else if (prevItem !== nextItem && hasChanged(prevItem, nextItem))
+      onUpsert(nextItem);
+  }
+
+  const sortedPrevKeys = [...prevMap.keys()].sort();
+  for (const key of sortedPrevKeys) {
+    if (!nextMap.has(key)) onDelete(key);
+  }
+}
+
+function prefsChanged(
+  prev: FinykPrefsSnapshot | null,
+  next: FinykPrefsSnapshot | null,
+): boolean {
+  if (prev === next) return false;
+  if (!prev || !next) return prev !== next;
+  return (
+    prev.monthlyPlanJson !== next.monthlyPlanJson ||
+    prev.showBalance !== next.showBalance
+  );
+}

--- a/apps/web/src/modules/finyk/lib/dualWrite/extract.ts
+++ b/apps/web/src/modules/finyk/lib/dualWrite/extract.ts
@@ -1,0 +1,200 @@
+/**
+ * Pure extractor: maps a `FinykStorageSlots` bundle (output of
+ * `useFinykStorageSlots`) into the `FinykDualWriteState` shape the
+ * diff layer consumes.
+ *
+ * Stage 4 PR #036 of `docs/planning/storage-roadmap.md`.
+ *
+ * The extractor is intentionally stupid — it does NOT mutate, deeply
+ * clone, or normalise data. The slot bundle already holds the LS
+ * shape verbatim (it's what `usePersist` reads/writes), so the only
+ * thing this layer does is:
+ *
+ *   - flatten record-shaped LS keys (`finyk_tx_cats`,
+ *     `finyk_tx_splits`, `finyk_mono_debt_linked`) into entry arrays
+ *     keyed by `transactionId`,
+ *   - synthesise a stable `id` for the `id-table` rows from the raw
+ *     string-array LS keys (`finyk_hidden`, `finyk_hidden_txs`),
+ *   - JSON-encode the per-row blobs once (the diff layer compares
+ *     `dataJson` strings to detect changes — comparing serialised
+ *     blobs avoids paying for deep equality and matches how the
+ *     server-side apply-fns store the row).
+ */
+
+import type { FinykStorageSlots } from "../../hooks/useFinykStorageSlots";
+import {
+  EMPTY_FINYK_STATE,
+  type FinykBlobEntry,
+  type FinykDualWriteState,
+  type FinykIdEntry,
+  type FinykMonoDebtLinkEntry,
+  type FinykNetworthEntry,
+  type FinykTxCategoryEntry,
+  type FinykTxSplitsEntry,
+} from "./diff.js";
+
+interface FinykIdLike {
+  id?: unknown;
+}
+
+function blobsFromArray(
+  arr: ReadonlyArray<FinykIdLike & Record<string, unknown>> | undefined,
+): FinykBlobEntry[] {
+  if (!Array.isArray(arr)) return [];
+  const out: FinykBlobEntry[] = [];
+  for (const row of arr) {
+    if (!row || typeof row !== "object") continue;
+    const id = typeof row.id === "string" ? row.id : null;
+    if (!id) continue;
+    let dataJson: string;
+    try {
+      dataJson = JSON.stringify(row);
+    } catch {
+      // Circular / non-serialisable rows are skipped — the LS layer
+      // can't have written them anyway, so this is just defensive.
+      continue;
+    }
+    out.push({ id, dataJson });
+  }
+  return out;
+}
+
+function idsFromArray(arr: readonly string[] | undefined): FinykIdEntry[] {
+  if (!Array.isArray(arr)) return [];
+  const out: FinykIdEntry[] = [];
+  for (const v of arr) {
+    if (typeof v === "string" && v.length > 0) out.push({ id: v });
+  }
+  return out;
+}
+
+function txCatsFromMap(
+  map: Record<string, string | undefined> | undefined,
+): FinykTxCategoryEntry[] {
+  if (!map || typeof map !== "object") return [];
+  const out: FinykTxCategoryEntry[] = [];
+  for (const [transactionId, categoryId] of Object.entries(map)) {
+    if (typeof categoryId !== "string" || categoryId.length === 0) continue;
+    if (typeof transactionId !== "string" || transactionId.length === 0)
+      continue;
+    out.push({ transactionId, categoryId });
+  }
+  return out;
+}
+
+function txSplitsFromMap(
+  map: Record<string, unknown> | undefined,
+): FinykTxSplitsEntry[] {
+  if (!map || typeof map !== "object") return [];
+  const out: FinykTxSplitsEntry[] = [];
+  for (const [transactionId, splits] of Object.entries(map)) {
+    if (!Array.isArray(splits) || splits.length === 0) continue;
+    if (typeof transactionId !== "string" || transactionId.length === 0)
+      continue;
+    let splitsJson: string;
+    try {
+      splitsJson = JSON.stringify(splits);
+    } catch {
+      continue;
+    }
+    out.push({ transactionId, splitsJson });
+  }
+  return out;
+}
+
+function monoDebtLinksFromMap(
+  map: Record<string, string[]> | undefined,
+): FinykMonoDebtLinkEntry[] {
+  if (!map || typeof map !== "object") return [];
+  const out: FinykMonoDebtLinkEntry[] = [];
+  for (const [transactionId, debtIds] of Object.entries(map)) {
+    if (!Array.isArray(debtIds) || debtIds.length === 0) continue;
+    if (typeof transactionId !== "string" || transactionId.length === 0)
+      continue;
+    let debtIdsJson: string;
+    try {
+      debtIdsJson = JSON.stringify(debtIds);
+    } catch {
+      continue;
+    }
+    out.push({ transactionId, debtIdsJson });
+  }
+  return out;
+}
+
+function networthHistoryFrom(
+  arr: ReadonlyArray<{ month?: unknown; networth?: unknown }> | undefined,
+): FinykNetworthEntry[] {
+  if (!Array.isArray(arr)) return [];
+  const out: FinykNetworthEntry[] = [];
+  for (const row of arr) {
+    if (!row || typeof row !== "object") continue;
+    const month =
+      typeof row.month === "string" && /^\d{4}-\d{2}$/.test(row.month)
+        ? row.month
+        : null;
+    const networth =
+      typeof row.networth === "number" && Number.isFinite(row.networth)
+        ? row.networth
+        : null;
+    if (!month || networth === null) continue;
+    out.push({ month, networth });
+  }
+  return out;
+}
+
+export function extractFinykDualWriteState(
+  slots: FinykStorageSlots,
+  showBalance: boolean,
+): FinykDualWriteState {
+  if (!slots) return EMPTY_FINYK_STATE;
+
+  let monthlyPlanJson: string;
+  try {
+    monthlyPlanJson = JSON.stringify(slots.monthlyPlan ?? {});
+  } catch {
+    monthlyPlanJson = "{}";
+  }
+
+  return {
+    hiddenAccounts: idsFromArray(slots.hiddenAccounts),
+    hiddenTransactions: idsFromArray(slots.hiddenTxIds),
+    budgets: blobsFromArray(
+      slots.budgets as ReadonlyArray<FinykIdLike & Record<string, unknown>>,
+    ),
+    subscriptions: blobsFromArray(
+      slots.subscriptions as ReadonlyArray<
+        FinykIdLike & Record<string, unknown>
+      >,
+    ),
+    assets: blobsFromArray(
+      slots.manualAssets as ReadonlyArray<
+        FinykIdLike & Record<string, unknown>
+      >,
+    ),
+    debts: blobsFromArray(
+      slots.manualDebts as ReadonlyArray<FinykIdLike & Record<string, unknown>>,
+    ),
+    receivables: blobsFromArray(
+      slots.receivables as ReadonlyArray<FinykIdLike & Record<string, unknown>>,
+    ),
+    customCategories: blobsFromArray(
+      slots.customCategories as ReadonlyArray<
+        FinykIdLike & Record<string, unknown>
+      >,
+    ),
+    manualExpenses: blobsFromArray(
+      slots.manualExpenses as ReadonlyArray<
+        FinykIdLike & Record<string, unknown>
+      >,
+    ),
+    txCategories: txCatsFromMap(slots.txCategories),
+    txSplits: txSplitsFromMap(slots.txSplits as Record<string, unknown>),
+    monoDebtLinks: monoDebtLinksFromMap(slots.monoDebtLinkedTxIds),
+    networthHistory: networthHistoryFrom(slots.networthHistory),
+    prefs: {
+      monthlyPlanJson,
+      showBalance,
+    },
+  };
+}

--- a/apps/web/src/modules/finyk/lib/dualWrite/index.ts
+++ b/apps/web/src/modules/finyk/lib/dualWrite/index.ts
@@ -1,0 +1,173 @@
+import type { SqliteMigrationClient } from "@sergeant/db-schema/migrate/sqlite";
+
+import {
+  applyFinykDualWriteOps,
+  type ApplyDualWriteResult,
+  type DualWriteLogger,
+} from "./adapter.js";
+import {
+  diffFinykDualWriteOps,
+  EMPTY_FINYK_STATE,
+  type FinykDualWriteState,
+} from "./diff.js";
+
+/**
+ * Orchestrator for the Finyk dual-write layer.
+ *
+ * Stage 4 PR #036 of `docs/planning/storage-roadmap.md`. Mirrors the
+ * nutrition dual-write orchestrator pattern from PR #032.
+ *
+ * Glues together:
+ *
+ *  - the **gating** check (`feature.finyk.sqlite_v2.dual_write` flag,
+ *    default off);
+ *  - the **identity** resolver (`getUserId()`);
+ *  - the **SQLite** resolver (`getMigrationClient()`);
+ *  - and the **adapter** (`applyFinykDualWriteOps`).
+ *
+ * Registration pattern: the hooks that write to localStorage sit below
+ * the auth + sqlite singletons in the dependency graph. Pulling those
+ * in directly creates a cycle. The registration pattern lets the boot
+ * wiring file install the dependencies once.
+ *
+ * Best-effort guarantees:
+ *
+ *  - The orchestrator's promise NEVER rejects.
+ *  - When the flag is off, no resolver is called and no diff is
+ *    computed (zero per-write overhead).
+ *  - When `getUserId()` or `getMigrationClient()` return null the
+ *    call is a no-op.
+ */
+
+export interface FinykDualWriteContext {
+  isEnabled(): boolean;
+  getUserId(): string | null;
+  getMigrationClient(): Promise<SqliteMigrationClient | null>;
+  getNow(): string;
+  logger?: DualWriteLogger;
+}
+
+let registeredContext: FinykDualWriteContext | null = null;
+
+/**
+ * Install the dual-write context. Call from the platform bootstrap
+ * file when the React Query client and sqlite singletons are available.
+ *
+ * Returns a teardown function that clears the registration.
+ */
+export function registerFinykDualWriteContext(
+  ctx: FinykDualWriteContext,
+): () => void {
+  registeredContext = ctx;
+  return () => {
+    if (registeredContext === ctx) registeredContext = null;
+  };
+}
+
+/** Test-only escape hatch — clears any registered context. */
+export function __clearFinykDualWriteContextForTests(): void {
+  registeredContext = null;
+}
+
+/**
+ * Returns `true` while a context is currently registered. Used by
+ * the LS write layer to decide whether to read the previous state.
+ */
+export function isFinykDualWriteRegistered(): boolean {
+  return registeredContext !== null;
+}
+
+/**
+ * Run the dual-write pipeline for a `prev → next` LS-state transition.
+ *
+ * The function is `async` but the LS-write call site fires it
+ * fire-and-forget through {@link triggerFinykDualWrite}.
+ */
+export async function dualWriteFinykState(
+  prev: FinykDualWriteState,
+  next: FinykDualWriteState,
+): Promise<DualWriteOutcome> {
+  const ctx = registeredContext;
+  if (!ctx) return { status: "skipped", reason: "context-unset" };
+  if (!ctx.isEnabled()) return { status: "skipped", reason: "flag-off" };
+
+  const ops = diffFinykDualWriteOps(prev, next);
+  if (ops.length === 0) return { status: "skipped", reason: "no-ops" };
+
+  const userId = ctx.getUserId();
+  if (!userId) {
+    logSafe(ctx, "warn", "dual-write skipped: user id unavailable", {
+      ops: ops.length,
+    });
+    return { status: "skipped", reason: "user-id-missing" };
+  }
+
+  let client: SqliteMigrationClient | null = null;
+  try {
+    client = await ctx.getMigrationClient();
+  } catch (err) {
+    logSafe(ctx, "warn", "dual-write skipped: sqlite unavailable", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return { status: "skipped", reason: "sqlite-unavailable" };
+  }
+  if (!client) {
+    logSafe(ctx, "warn", "dual-write skipped: sqlite returned null", {});
+    return { status: "skipped", reason: "sqlite-unavailable" };
+  }
+
+  const result = await applyFinykDualWriteOps(client, ops, {
+    userId,
+    clientTs: ctx.getNow(),
+    logger: ctx.logger,
+  });
+  return { status: "applied", result };
+}
+
+/**
+ * Fire-and-forget entry point used by Finyk LS-write hooks.
+ * Resolves immediately so the LS-write call site doesn't pay any
+ * latency on the happy path.
+ */
+export function triggerFinykDualWrite(
+  prev: FinykDualWriteState,
+  next: FinykDualWriteState,
+): void {
+  if (!registeredContext) return;
+  void Promise.resolve().then(() => dualWriteFinykState(prev, next));
+}
+
+export type DualWriteOutcome =
+  | { status: "applied"; result: ApplyDualWriteResult }
+  | {
+      status: "skipped";
+      reason:
+        | "context-unset"
+        | "flag-off"
+        | "no-ops"
+        | "user-id-missing"
+        | "sqlite-unavailable";
+    };
+
+function logSafe(
+  ctx: FinykDualWriteContext,
+  level: "warn" | "info",
+  msg: string,
+  meta: Record<string, unknown>,
+): void {
+  try {
+    if (ctx.logger) ctx.logger(level, msg, meta);
+    else if (level === "warn") console.warn(`[finyk.dualWrite] ${msg}`, meta);
+  } catch {
+    /* noop — logging must never throw */
+  }
+}
+
+export {
+  applyFinykDualWriteOps,
+  diffFinykDualWriteOps,
+  EMPTY_FINYK_STATE,
+  type ApplyDualWriteResult,
+  type DualWriteLogger,
+  type FinykDualWriteState,
+};

--- a/apps/web/src/modules/finyk/lib/dualWriteBoot.ts
+++ b/apps/web/src/modules/finyk/lib/dualWriteBoot.ts
@@ -1,0 +1,47 @@
+/**
+ * Boot wiring for the Finyk dual-write context.
+ *
+ * Stage 4 PR #036 of `docs/planning/storage-roadmap.md`. Mirror of
+ * `apps/web/src/modules/nutrition/lib/dualWriteBoot.ts`.
+ */
+
+import type { SqliteMigrationClient } from "@sergeant/db-schema/migrate/sqlite";
+import { getSqliteDb } from "../../../core/db/sqlite.js";
+import {
+  registerFinykDualWriteContext,
+  type FinykDualWriteContext,
+} from "./dualWrite/index.js";
+import { migrateFinyk } from "./clientMigrate.js";
+
+export interface BootFinykDualWriteInput {
+  getUserId(): string | null;
+  isFlagEnabled(): boolean;
+}
+
+let migrationsApplied = false;
+
+/**
+ * Install the Finyk dual-write context. Returns a teardown function.
+ */
+export function bootFinykDualWrite(input: BootFinykDualWriteInput): () => void {
+  const ctx: FinykDualWriteContext = {
+    isEnabled: () => input.isFlagEnabled(),
+    getUserId: () => input.getUserId(),
+    getMigrationClient: async (): Promise<SqliteMigrationClient | null> => {
+      const handle = await getSqliteDb();
+      const client = handle.migrationClient();
+      if (!migrationsApplied) {
+        await migrateFinyk(client);
+        migrationsApplied = true;
+      }
+      return client;
+    },
+    getNow: () => new Date().toISOString(),
+  };
+  return registerFinykDualWriteContext(ctx);
+}
+
+/** Test-only escape hatch — clears the migrations-applied flag. */
+export function __resetFinykDualWriteBootForTests(): void {
+  migrationsApplied = false;
+}

--- a/docs/planning/storage-roadmap.md
+++ b/docs/planning/storage-roadmap.md
@@ -1,6 +1,6 @@
 # Storage & Sync — Roadmap до production-ready
 
-> **Last validated:** 2026-05-03 by Devin — **Stage 1 COMPLETE, Stage 4 Nutrition in progress.** Stage 1: all 8/8 PRs landed (PR #008 `ff217246`, PR #010 [#1543](https://github.com/Skords-01/Sergeant/pull/1543), PR #013 via 4 sub-PRs). Stage 4 Fizruk: 5/5 PRs merged (PR #027–#030 + #029a). Stage 4 Nutrition: PR #031 LANDED (schema `17644bef` + server apply-fns in `OP_LOG_TABLE_REGISTRY`), PR #032 LANDED ([#1528](https://github.com/Skords-01/Sergeant/pull/1528) dual-write), PR #033 IN PROGRESS (read-overlay files implemented for web + mobile in [#1574](https://github.com/Skords-01/Sergeant/pull/1574), UI overlay hooks pending). Boot-wiring follow-up для `register{Routine,Fizruk,Nutrition}DualWriteContext` ще не залендили. **Next review:** 2026-08-01.
+> **Last validated:** 2026-05-04 by Devin — **Stage 1 COMPLETE, Stage 4 Finyk in progress.** Stage 1: all 8/8 PRs landed (PR #008 `ff217246`, PR #010 [#1543](https://github.com/Skords-01/Sergeant/pull/1543), PR #013 via 4 sub-PRs). Stage 4 Fizruk: 5/5 PRs merged (PR #027–#030 + #029a). Stage 4 Nutrition: PR #031 LANDED (schema `17644bef` + server apply-fns in `OP_LOG_TABLE_REGISTRY`), PR #032 LANDED ([#1528](https://github.com/Skords-01/Sergeant/pull/1528) dual-write), PR #033 IN PROGRESS (read-overlay files implemented for web + mobile in [#1574](https://github.com/Skords-01/Sergeant/pull/1574), UI overlay hooks pending). Stage 4 Finyk: PR #035 IN CI ([#1667](https://github.com/Skords-01/Sergeant/pull/1667) — schema + apply-fns), PR #036 IN PROGRESS (dual-write web + mobile, boot-hook wired in `FinykApp.tsx`). Boot-wiring follow-up для `register{Routine,Fizruk,Nutrition}DualWriteContext` ще не залендили. **Next review:** 2026-08-01.
 > **Status:** Active
 
 > Зріз: 2026-05-02. Базується на storage-аудиті + поточний стек:
@@ -945,7 +945,7 @@ userId)` запитує 5 SQLite таблиць (`nutrition_meals`,
 > - ESLint guard (PR #039). Усі дзеркалять відповідні fizruk PR
 >   #027–#030 і nutrition PR #031–#034.
 
-##### **PR #035 — `feat(finyk-domain): Drizzle SQLite + Postgres normalized tables + server apply-fns`** ⏳ DRAFT
+##### **PR #035 — `feat(finyk-domain): Drizzle SQLite + Postgres normalized tables + server apply-fns`** ⏳ DRAFT (in CI — [#1667](https://github.com/Skords-01/Sergeant/pull/1667))
 
 - **Scope.** Створити нормалізовані таблиці на PG і SQLite під 16
   user-edited cloud-sync ключів модуля (`FINYK_HIDDEN`, `FINYK_HIDDEN_TXS`,
@@ -1038,7 +1038,7 @@ show_balance, updated_at, deleted_at)` — об'єднує
   жорсткого зв'язку між Drizzle schema і domain types — refactoring
   у `useStorage.types.ts` не повинен ламати DB.
 
-##### **PR #036 — `feat(finyk-domain): dual-write LS/MMKV↔SQLite`** ⏳ DRAFT
+##### **PR #036 — `feat(finyk-domain): dual-write LS/MMKV↔SQLite`** ⏳ DRAFT (in CI — TBD)
 
 - Mirror PR #028 (fizruk dual-write) і PR #032 (nutrition dual-write)
   для finyk. Feature flag `feature.finyk.sqlite_v2.dual_write`,
@@ -1054,11 +1054,23 @@ show_balance, updated_at, deleted_at)` — об'єднує
   LWW-guardом на `updated_at`. `index.ts` — orchestrator з
   registration-pattern-ом (gating через
   `feature.finyk.sqlite_v2.dual_write`, fail-soft на no-userId /
-  sqlite-unavailable). Mirror у
-  `apps/mobile/src/modules/finyk/lib/dualWrite/` для expo-sqlite.
+  sqlite-unavailable). `extract.ts` — пара мапперів LS-shape →
+  diff-state. `dualWriteBoot.ts` + `useFinykDualWriteBoot()` —
+  boot-wiring (mirror nutrition). `useFinykDualWriteSync()` —
+  per-`useFinykStorageSlots`-render snapshot diff trigger; шлях
+  включається тільки коли flag і userId відомі.
+- **Реалізовано (mobile).** `apps/mobile/src/modules/finyk/lib/dualWrite/`
+  diff/adapter/index/extract з тим самим shape-ом. Boot-hook
+  `useFinykDualWriteBoot` встановлюється у `FinykApp.tsx`.
+  `assetsStore.ts`, `budgetsStore.ts`, `transactionsStore.ts`
+  додатково викликають `triggerFinykDualWrite(prev, next)` після
+  `safeWriteLS` per-key (через `stateWithSlice` helper для
+  ізольованого diff-у — інші ключі лишаються `EMPTY_FINYK_STATE` і
+  не випльовують операцій).
 - **Реєстрація.** Через registration-pattern як у routine / fizruk /
-  nutrition. Boot-wiring follow-up за тим же шаблоном як
-  `register{Routine,Fizruk,Nutrition}DualWriteContext`.
+  nutrition. `bootFinykDualWrite()` + `registerFinykDualWriteContext()`
+  у `lib/dualWriteBoot.ts` встановлюється з `useFinykDualWriteBoot`
+  у `FinykApp.tsx` (web + mobile).
 - **Не входить.** Outbox / `/v2/sync/push` для `finyk_*` (server
   apply-fns ландять у PR #035). Reads з SQLite — PR #037.
 - **Dep.** PR #035 (schema + client migration runner).

--- a/packages/db-schema/src/__tests__/pg-finyk-snapshot.test.ts
+++ b/packages/db-schema/src/__tests__/pg-finyk-snapshot.test.ts
@@ -1,0 +1,328 @@
+import { describe, expect, it } from "vitest";
+import { getTableConfig } from "drizzle-orm/pg-core";
+import {
+  finykHiddenAccounts,
+  finykHiddenTransactions,
+  finykBudgets,
+  finykSubscriptions,
+  finykAssets,
+  finykDebts,
+  finykReceivables,
+  finykCustomCategories,
+  finykManualExpenses,
+  finykTxFilters,
+  finykTxCategories,
+  finykTxSplits,
+  finykMonoDebtLinks,
+  finykNetworthHistory,
+  finykPrefs,
+} from "../pg/finyk.js";
+
+/**
+ * Snapshot tests for the Postgres Drizzle schemas under `pg/finyk.ts`,
+ * locking down the column ordering, types, nullability, indexes, and
+ * defaults that mirror migration 039_finyk_tables.sql.
+ *
+ * Stage 4 / PR #035 of `docs/planning/storage-roadmap.md`. Pattern
+ * mirrors `pg-nutrition-snapshot.test.ts` — same structure, but the
+ * 15 tables here split into five groups (see migration header for
+ * rationale). The five-group structure is the test's organising
+ * principle: one describe block per group of tables that share the
+ * same shape, so a regression in any single group surfaces as a
+ * focused failure rather than a blob of unrelated diffs.
+ */
+
+// ---------------------------------------------------------------------
+// Group 1 — composite-PK tombstone
+// ---------------------------------------------------------------------
+
+describe("pg/finykHiddenAccounts schema snapshot", () => {
+  const config = getTableConfig(finykHiddenAccounts);
+
+  it("has the canonical table name", () => {
+    expect(config.name).toBe("finyk_hidden_accounts");
+  });
+
+  it("declares all expected columns", () => {
+    expect(config.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "account_id",
+      "created_at",
+      "updated_at",
+      "deleted_at",
+    ]);
+  });
+
+  it("declares (user_id, account_id) as a composite primary key", () => {
+    expect(config.primaryKeys).toHaveLength(1);
+    expect(config.primaryKeys[0]!.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "account_id",
+    ]);
+  });
+
+  it("declares the soft-delete partial index", () => {
+    expect(config.indexes.map((i) => i.config.name)).toContain(
+      "finyk_hidden_accounts_user_active_idx",
+    );
+  });
+});
+
+describe("pg/finykHiddenTransactions schema snapshot", () => {
+  const config = getTableConfig(finykHiddenTransactions);
+
+  it("has the canonical table name", () => {
+    expect(config.name).toBe("finyk_hidden_transactions");
+  });
+
+  it("declares all expected columns", () => {
+    expect(config.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "transaction_id",
+      "created_at",
+      "updated_at",
+      "deleted_at",
+    ]);
+  });
+
+  it("declares (user_id, transaction_id) as a composite primary key", () => {
+    expect(config.primaryKeys).toHaveLength(1);
+    expect(config.primaryKeys[0]!.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "transaction_id",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------
+// Group 2 — per-row + JSONB
+// ---------------------------------------------------------------------
+
+const PER_ROW_JSONB_TABLES: ReadonlyArray<{
+  name: string;
+  table: ReturnType<typeof getTableConfig>;
+}> = [
+  { name: "finyk_budgets", table: getTableConfig(finykBudgets) },
+  { name: "finyk_subscriptions", table: getTableConfig(finykSubscriptions) },
+  { name: "finyk_assets", table: getTableConfig(finykAssets) },
+  { name: "finyk_debts", table: getTableConfig(finykDebts) },
+  { name: "finyk_receivables", table: getTableConfig(finykReceivables) },
+  {
+    name: "finyk_custom_categories",
+    table: getTableConfig(finykCustomCategories),
+  },
+  {
+    name: "finyk_manual_expenses",
+    table: getTableConfig(finykManualExpenses),
+  },
+  { name: "finyk_tx_filters", table: getTableConfig(finykTxFilters) },
+];
+
+describe.each(PER_ROW_JSONB_TABLES)(
+  "pg/$name (per-row + JSONB)",
+  ({ name, table }) => {
+    it("has the canonical table name", () => {
+      expect(table.name).toBe(name);
+    });
+
+    it("declares the canonical (id, user_id, data_json, created_at, updated_at, deleted_at) shape", () => {
+      expect(table.columns.map((c) => c.name)).toEqual([
+        "id",
+        "user_id",
+        "data_json",
+        "created_at",
+        "updated_at",
+        "deleted_at",
+      ]);
+    });
+
+    it("uses uuid() PK with default", () => {
+      const cols = Object.fromEntries(table.columns.map((c) => [c.name, c]));
+      expect(cols["id"]!.columnType).toBe("PgUUID");
+      expect(cols["id"]!.primary).toBe(true);
+      expect(cols["id"]!.hasDefault).toBe(true);
+      expect(cols["data_json"]!.columnType).toBe("PgJsonb");
+      expect(cols["data_json"]!.notNull).toBe(true);
+      expect(cols["data_json"]!.hasDefault).toBe(true);
+      expect(cols["deleted_at"]!.notNull).toBe(false);
+    });
+
+    it("declares the (user_id, deleted_at) soft-delete partial index", () => {
+      const idxNames = table.indexes.map((i) => i.config.name);
+      expect(idxNames).toContain(`${name}_user_active_idx`);
+      const idx = table.indexes.find(
+        (i) => i.config.name === `${name}_user_active_idx`,
+      )!;
+      expect(idx.config.where).toBeDefined();
+    });
+  },
+);
+
+// ---------------------------------------------------------------------
+// Group 3 — per-tx mapping (composite PK on (user_id, transaction_id))
+// ---------------------------------------------------------------------
+
+describe("pg/finykTxCategories schema snapshot", () => {
+  const config = getTableConfig(finykTxCategories);
+
+  it("declares the canonical column shape", () => {
+    expect(config.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "transaction_id",
+      "category_id",
+      "created_at",
+      "updated_at",
+    ]);
+  });
+
+  it("uses (user_id, transaction_id) composite PK", () => {
+    expect(config.primaryKeys[0]!.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "transaction_id",
+    ]);
+  });
+
+  it("declares no soft-delete column (delete = DELETE FROM)", () => {
+    expect(config.columns.map((c) => c.name)).not.toContain("deleted_at");
+  });
+
+  it("category_id is a NOT NULL TEXT", () => {
+    const cols = Object.fromEntries(config.columns.map((c) => [c.name, c]));
+    expect(cols["category_id"]!.dataType).toBe("string");
+    expect(cols["category_id"]!.notNull).toBe(true);
+  });
+});
+
+describe("pg/finykTxSplits schema snapshot", () => {
+  const config = getTableConfig(finykTxSplits);
+
+  it("declares the canonical column shape with splits_json", () => {
+    expect(config.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "transaction_id",
+      "splits_json",
+      "created_at",
+      "updated_at",
+    ]);
+  });
+
+  it("uses (user_id, transaction_id) composite PK", () => {
+    expect(config.primaryKeys[0]!.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "transaction_id",
+    ]);
+  });
+
+  it("splits_json is JSONB with default '[]'", () => {
+    const cols = Object.fromEntries(config.columns.map((c) => [c.name, c]));
+    expect(cols["splits_json"]!.columnType).toBe("PgJsonb");
+    expect(cols["splits_json"]!.notNull).toBe(true);
+    expect(cols["splits_json"]!.hasDefault).toBe(true);
+  });
+});
+
+describe("pg/finykMonoDebtLinks schema snapshot", () => {
+  const config = getTableConfig(finykMonoDebtLinks);
+
+  it("declares the canonical column shape with debt_ids_json", () => {
+    expect(config.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "transaction_id",
+      "debt_ids_json",
+      "created_at",
+      "updated_at",
+    ]);
+  });
+
+  it("uses (user_id, transaction_id) composite PK", () => {
+    expect(config.primaryKeys[0]!.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "transaction_id",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------
+// Group 4 — time-series networth history
+// ---------------------------------------------------------------------
+
+describe("pg/finykNetworthHistory schema snapshot", () => {
+  const config = getTableConfig(finykNetworthHistory);
+
+  it("declares the canonical (user_id, month, networth, snapshot_json, …) shape", () => {
+    expect(config.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "month",
+      "networth",
+      "snapshot_json",
+      "created_at",
+      "updated_at",
+    ]);
+  });
+
+  it("uses (user_id, month) composite PK", () => {
+    expect(config.primaryKeys[0]!.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "month",
+    ]);
+  });
+
+  it("month stays TEXT (not DATE) so LWW matches LS byte-for-byte", () => {
+    const cols = Object.fromEntries(config.columns.map((c) => [c.name, c]));
+    expect(cols["month"]!.columnType).toBe("PgText");
+    expect(cols["month"]!.notNull).toBe(true);
+  });
+
+  it("networth is REAL with default 0", () => {
+    const cols = Object.fromEntries(config.columns.map((c) => [c.name, c]));
+    expect(cols["networth"]!.columnType).toBe("PgReal");
+    expect(cols["networth"]!.notNull).toBe(true);
+    expect(cols["networth"]!.hasDefault).toBe(true);
+  });
+
+  it("snapshot_json is JSONB with default '{}'", () => {
+    const cols = Object.fromEntries(config.columns.map((c) => [c.name, c]));
+    expect(cols["snapshot_json"]!.columnType).toBe("PgJsonb");
+    expect(cols["snapshot_json"]!.notNull).toBe(true);
+    expect(cols["snapshot_json"]!.hasDefault).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------
+// Group 5 — singleton prefs
+// ---------------------------------------------------------------------
+
+describe("pg/finykPrefs schema snapshot", () => {
+  const config = getTableConfig(finykPrefs);
+
+  it("declares the canonical singleton column shape", () => {
+    expect(config.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "prefs_json",
+      "monthly_plan_json",
+      "show_balance",
+      "created_at",
+      "updated_at",
+    ]);
+  });
+
+  it("user_id is the primary key (singleton — exactly one row per user)", () => {
+    const cols = Object.fromEntries(config.columns.map((c) => [c.name, c]));
+    expect(cols["user_id"]!.primary).toBe(true);
+  });
+
+  it("show_balance is a NOT NULL boolean with default true", () => {
+    const cols = Object.fromEntries(config.columns.map((c) => [c.name, c]));
+    expect(cols["show_balance"]!.columnType).toBe("PgBoolean");
+    expect(cols["show_balance"]!.notNull).toBe(true);
+    expect(cols["show_balance"]!.hasDefault).toBe(true);
+  });
+
+  it("prefs_json + monthly_plan_json are both JSONB with object defaults", () => {
+    const cols = Object.fromEntries(config.columns.map((c) => [c.name, c]));
+    expect(cols["prefs_json"]!.columnType).toBe("PgJsonb");
+    expect(cols["prefs_json"]!.hasDefault).toBe(true);
+    expect(cols["monthly_plan_json"]!.columnType).toBe("PgJsonb");
+    expect(cols["monthly_plan_json"]!.hasDefault).toBe(true);
+  });
+});

--- a/packages/db-schema/src/__tests__/sqlite-finyk-snapshot.test.ts
+++ b/packages/db-schema/src/__tests__/sqlite-finyk-snapshot.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it } from "vitest";
+import { getTableConfig } from "drizzle-orm/sqlite-core";
+import {
+  finykHiddenAccounts,
+  finykHiddenTransactions,
+  finykBudgets,
+  finykSubscriptions,
+  finykAssets,
+  finykDebts,
+  finykReceivables,
+  finykCustomCategories,
+  finykManualExpenses,
+  finykTxFilters,
+  finykTxCategories,
+  finykTxSplits,
+  finykMonoDebtLinks,
+  finykNetworthHistory,
+  finykPrefs,
+} from "../sqlite/finyk.js";
+import {
+  FINYK_CLIENT_MIGRATIONS,
+  FINYK_MIGRATIONS_TABLE,
+} from "../sqlite/migrations/index.js";
+
+/**
+ * Snapshot tests for the SQLite Drizzle schemas under `sqlite/finyk.ts`,
+ * mirroring the structural lock-down that `pg-finyk-snapshot.test.ts`
+ * applies to the Postgres source-of-truth.
+ *
+ * Stage 4 / PR #035 of `docs/planning/storage-roadmap.md`. PG↔SQLite
+ * schemas must stay aligned so push/pull round-trips are symmetric.
+ *
+ * The five-group structure (composite-PK tombstone, per-row+JSONB,
+ * per-tx mapping, time-series, singleton prefs) is the test's
+ * organising principle — one describe block per group.
+ */
+
+// ---------------------------------------------------------------------
+// Group 1 — composite-PK tombstone
+// ---------------------------------------------------------------------
+
+describe("sqlite/finykHiddenAccounts schema snapshot", () => {
+  const config = getTableConfig(finykHiddenAccounts);
+
+  it("has the canonical table name", () => {
+    expect(config.name).toBe("finyk_hidden_accounts");
+  });
+
+  it("declares all expected columns", () => {
+    expect(config.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "account_id",
+      "created_at",
+      "updated_at",
+      "deleted_at",
+    ]);
+  });
+
+  it("uses (user_id, account_id) composite PK", () => {
+    expect(config.primaryKeys).toHaveLength(1);
+    expect(config.primaryKeys[0]!.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "account_id",
+    ]);
+  });
+
+  it("declares the `_lite`-suffixed soft-delete partial index", () => {
+    const idxNames = config.indexes.map((i) => i.config.name);
+    expect(idxNames).toContain("finyk_hidden_accounts_user_active_idx_lite");
+  });
+});
+
+describe("sqlite/finykHiddenTransactions schema snapshot", () => {
+  const config = getTableConfig(finykHiddenTransactions);
+
+  it("uses (user_id, transaction_id) composite PK", () => {
+    expect(config.primaryKeys[0]!.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "transaction_id",
+    ]);
+  });
+
+  it("`_lite`-suffixed soft-delete partial index is declared", () => {
+    expect(config.indexes.map((i) => i.config.name)).toContain(
+      "finyk_hidden_transactions_user_active_idx_lite",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------
+// Group 2 — per-row + JSONB→TEXT
+// ---------------------------------------------------------------------
+
+const PER_ROW_TABLES: ReadonlyArray<{
+  name: string;
+  table: ReturnType<typeof getTableConfig>;
+}> = [
+  { name: "finyk_budgets", table: getTableConfig(finykBudgets) },
+  { name: "finyk_subscriptions", table: getTableConfig(finykSubscriptions) },
+  { name: "finyk_assets", table: getTableConfig(finykAssets) },
+  { name: "finyk_debts", table: getTableConfig(finykDebts) },
+  { name: "finyk_receivables", table: getTableConfig(finykReceivables) },
+  {
+    name: "finyk_custom_categories",
+    table: getTableConfig(finykCustomCategories),
+  },
+  {
+    name: "finyk_manual_expenses",
+    table: getTableConfig(finykManualExpenses),
+  },
+  { name: "finyk_tx_filters", table: getTableConfig(finykTxFilters) },
+];
+
+describe.each(PER_ROW_TABLES)(
+  "sqlite/$name (per-row + data_json TEXT)",
+  ({ name, table }) => {
+    it("declares the canonical (id, user_id, data_json, created_at, updated_at, deleted_at) shape", () => {
+      expect(table.columns.map((c) => c.name)).toEqual([
+        "id",
+        "user_id",
+        "data_json",
+        "created_at",
+        "updated_at",
+        "deleted_at",
+      ]);
+    });
+
+    it("id is TEXT PK (UUID-as-string), data_json is TEXT NOT NULL DEFAULT '{}'", () => {
+      const cols = Object.fromEntries(table.columns.map((c) => [c.name, c]));
+      expect(cols["id"]!.dataType).toBe("string");
+      expect(cols["id"]!.primary).toBe(true);
+      expect(cols["data_json"]!.dataType).toBe("string");
+      expect(cols["data_json"]!.notNull).toBe(true);
+      expect(cols["data_json"]!.hasDefault).toBe(true);
+      expect(cols["deleted_at"]!.notNull).toBe(false);
+    });
+
+    it("declares the `_lite` soft-delete partial index", () => {
+      expect(table.indexes.map((i) => i.config.name)).toContain(
+        `${name}_user_active_idx_lite`,
+      );
+    });
+  },
+);
+
+// ---------------------------------------------------------------------
+// Group 3 — per-tx mapping
+// ---------------------------------------------------------------------
+
+describe("sqlite/finykTxCategories schema snapshot", () => {
+  const config = getTableConfig(finykTxCategories);
+
+  it("declares the canonical column shape", () => {
+    expect(config.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "transaction_id",
+      "category_id",
+      "created_at",
+      "updated_at",
+    ]);
+  });
+
+  it("uses (user_id, transaction_id) composite PK", () => {
+    expect(config.primaryKeys[0]!.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "transaction_id",
+    ]);
+  });
+
+  it("has no soft-delete column", () => {
+    expect(config.columns.map((c) => c.name)).not.toContain("deleted_at");
+  });
+});
+
+describe("sqlite/finykTxSplits schema snapshot", () => {
+  const config = getTableConfig(finykTxSplits);
+
+  it("declares splits_json TEXT NOT NULL DEFAULT '[]'", () => {
+    const cols = Object.fromEntries(config.columns.map((c) => [c.name, c]));
+    expect(cols["splits_json"]!.dataType).toBe("string");
+    expect(cols["splits_json"]!.notNull).toBe(true);
+    expect(cols["splits_json"]!.hasDefault).toBe(true);
+  });
+
+  it("uses (user_id, transaction_id) composite PK", () => {
+    expect(config.primaryKeys[0]!.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "transaction_id",
+    ]);
+  });
+});
+
+describe("sqlite/finykMonoDebtLinks schema snapshot", () => {
+  const config = getTableConfig(finykMonoDebtLinks);
+
+  it("declares debt_ids_json TEXT NOT NULL DEFAULT '[]'", () => {
+    const cols = Object.fromEntries(config.columns.map((c) => [c.name, c]));
+    expect(cols["debt_ids_json"]!.dataType).toBe("string");
+    expect(cols["debt_ids_json"]!.notNull).toBe(true);
+    expect(cols["debt_ids_json"]!.hasDefault).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------
+// Group 4 — time-series
+// ---------------------------------------------------------------------
+
+describe("sqlite/finykNetworthHistory schema snapshot", () => {
+  const config = getTableConfig(finykNetworthHistory);
+
+  it("declares the canonical column shape", () => {
+    expect(config.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "month",
+      "networth",
+      "snapshot_json",
+      "created_at",
+      "updated_at",
+    ]);
+  });
+
+  it("uses (user_id, month) composite PK", () => {
+    expect(config.primaryKeys[0]!.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "month",
+    ]);
+  });
+
+  it("month is TEXT, networth is REAL DEFAULT 0", () => {
+    const cols = Object.fromEntries(config.columns.map((c) => [c.name, c]));
+    expect(cols["month"]!.dataType).toBe("string");
+    expect(cols["networth"]!.dataType).toBe("number");
+    expect(cols["networth"]!.notNull).toBe(true);
+    expect(cols["networth"]!.hasDefault).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------
+// Group 5 — singleton prefs
+// ---------------------------------------------------------------------
+
+describe("sqlite/finykPrefs schema snapshot", () => {
+  const config = getTableConfig(finykPrefs);
+
+  it("declares the canonical singleton column shape", () => {
+    expect(config.columns.map((c) => c.name)).toEqual([
+      "user_id",
+      "prefs_json",
+      "monthly_plan_json",
+      "show_balance",
+      "created_at",
+      "updated_at",
+    ]);
+  });
+
+  it("user_id is the primary key", () => {
+    const cols = Object.fromEntries(config.columns.map((c) => [c.name, c]));
+    expect(cols["user_id"]!.primary).toBe(true);
+  });
+
+  it("show_balance is INTEGER (boolean → 0/1) NOT NULL DEFAULT 1", () => {
+    const cols = Object.fromEntries(config.columns.map((c) => [c.name, c]));
+    expect(cols["show_balance"]!.dataType).toBe("number");
+    expect(cols["show_balance"]!.notNull).toBe(true);
+    expect(cols["show_balance"]!.hasDefault).toBe(true);
+  });
+
+  it("prefs_json + monthly_plan_json are TEXT NOT NULL DEFAULT '{}'", () => {
+    const cols = Object.fromEntries(config.columns.map((c) => [c.name, c]));
+    expect(cols["prefs_json"]!.dataType).toBe("string");
+    expect(cols["prefs_json"]!.notNull).toBe(true);
+    expect(cols["prefs_json"]!.hasDefault).toBe(true);
+    expect(cols["monthly_plan_json"]!.dataType).toBe("string");
+    expect(cols["monthly_plan_json"]!.notNull).toBe(true);
+    expect(cols["monthly_plan_json"]!.hasDefault).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------
+// Migrations export contract
+// ---------------------------------------------------------------------
+
+describe("sqlite/finyk migrations exports", () => {
+  it("exports a single 001_finyk_tables.sql migration", () => {
+    expect(FINYK_CLIENT_MIGRATIONS).toHaveLength(1);
+    expect(FINYK_CLIENT_MIGRATIONS[0]!.name).toBe("001_finyk_tables.sql");
+  });
+
+  it("inline SQL contains every finyk_* table CREATE", () => {
+    const sql = FINYK_CLIENT_MIGRATIONS[0]!.sql;
+    for (const table of [
+      "finyk_hidden_accounts",
+      "finyk_hidden_transactions",
+      "finyk_budgets",
+      "finyk_subscriptions",
+      "finyk_assets",
+      "finyk_debts",
+      "finyk_receivables",
+      "finyk_tx_categories",
+      "finyk_tx_splits",
+      "finyk_mono_debt_links",
+      "finyk_networth_history",
+      "finyk_custom_categories",
+      "finyk_manual_expenses",
+      "finyk_tx_filters",
+      "finyk_prefs",
+    ]) {
+      expect(sql).toMatch(new RegExp(`CREATE TABLE IF NOT EXISTS ${table}\\b`));
+    }
+  });
+
+  it("uses a separate `__finyk_migrations` ledger table", () => {
+    expect(FINYK_MIGRATIONS_TABLE).toBe("__finyk_migrations");
+  });
+});

--- a/packages/db-schema/src/pg/finyk.ts
+++ b/packages/db-schema/src/pg/finyk.ts
@@ -1,0 +1,405 @@
+import {
+  boolean,
+  index,
+  jsonb,
+  pgTable,
+  primaryKey,
+  real,
+  text,
+  timestamp,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+
+/**
+ * Postgres Drizzle schemas for the Finyk module's normalized cloud-sync
+ * target tables.
+ *
+ * Stage 4 / PR #035 of `docs/planning/storage-roadmap.md` — mirrors
+ * `apps/server/src/migrations/039_finyk_tables.sql` byte-for-byte
+ * (column ordering, types, defaults, indexes). Snapshot tests under
+ * `packages/db-schema/src/__tests__/pg-finyk-snapshot.test.ts` lock
+ * the shape so accidental drift between this Drizzle schema and the
+ * raw migration trips CI before it lands on main.
+ *
+ * Pattern reuse: the same five table shapes appear across the 15 finyk
+ * tables (per-row+JSONB, composite-PK tombstone, per-tx mapping,
+ * time-series, singleton prefs). See the migration's header comment
+ * for the rationale; each individual table doc-comment below repeats
+ * just enough context to be self-contained.
+ */
+
+// ---------------------------------------------------------------------
+// Composite-PK tombstone tables — hidden_accounts / hidden_transactions
+// ---------------------------------------------------------------------
+
+/**
+ * Per-user set of Mono account ids the user has hidden from the UI.
+ * Composite PK on `(user_id, account_id)`; soft-delete tombstone via
+ * `deleted_at` keeps LWW honest when an "unhide" on device A races a
+ * stale "hide" replay from device B.
+ */
+export const finykHiddenAccounts = pgTable(
+  "finyk_hidden_accounts",
+  {
+    userId: text("user_id").notNull(),
+    accountId: text("account_id").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.accountId] }),
+    index("finyk_hidden_accounts_user_active_idx")
+      .on(table.userId)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+/**
+ * Per-user set of Mono transaction ids hidden from the UI. Same shape
+ * as `finykHiddenAccounts` but keyed on `transaction_id`.
+ */
+export const finykHiddenTransactions = pgTable(
+  "finyk_hidden_transactions",
+  {
+    userId: text("user_id").notNull(),
+    transactionId: text("transaction_id").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.transactionId] }),
+    index("finyk_hidden_transactions_user_active_idx")
+      .on(table.userId)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+// ---------------------------------------------------------------------
+// Per-row + JSONB tables — open-ended user-edited shapes
+// ---------------------------------------------------------------------
+
+/**
+ * Per-row budget entries. `data_json` holds the open-ended `Budget`
+ * shape (categoryId, type, targetAmount, period, …) — UI reads the
+ * whole row at once so column-splitting buys nothing.
+ */
+export const finykBudgets = pgTable(
+  "finyk_budgets",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    userId: text("user_id").notNull(),
+    dataJson: jsonb("data_json").notNull().default({}),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+  },
+  (table) => [
+    index("finyk_budgets_user_active_idx")
+      .on(table.userId, table.deletedAt)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+/** Per-row recurring-payment definitions (`Subscription` shape). */
+export const finykSubscriptions = pgTable(
+  "finyk_subscriptions",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    userId: text("user_id").notNull(),
+    dataJson: jsonb("data_json").notNull().default({}),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+  },
+  (table) => [
+    index("finyk_subscriptions_user_active_idx")
+      .on(table.userId, table.deletedAt)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+/** Per-row manually tracked assets (`ManualAsset` shape). */
+export const finykAssets = pgTable(
+  "finyk_assets",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    userId: text("user_id").notNull(),
+    dataJson: jsonb("data_json").notNull().default({}),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+  },
+  (table) => [
+    index("finyk_assets_user_active_idx")
+      .on(table.userId, table.deletedAt)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+/** Per-row manually tracked debts the user owes (`Debt` shape from `debtEngine`). */
+export const finykDebts = pgTable(
+  "finyk_debts",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    userId: text("user_id").notNull(),
+    dataJson: jsonb("data_json").notNull().default({}),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+  },
+  (table) => [
+    index("finyk_debts_user_active_idx")
+      .on(table.userId, table.deletedAt)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+/** Money owed TO the user (`Receivable` shape). Same DDL as `finykDebts`. */
+export const finykReceivables = pgTable(
+  "finyk_receivables",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    userId: text("user_id").notNull(),
+    dataJson: jsonb("data_json").notNull().default({}),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+  },
+  (table) => [
+    index("finyk_receivables_user_active_idx")
+      .on(table.userId, table.deletedAt)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+/** User-defined transaction categories (label/color/icon/parentId). */
+export const finykCustomCategories = pgTable(
+  "finyk_custom_categories",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    userId: text("user_id").notNull(),
+    dataJson: jsonb("data_json").notNull().default({}),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+  },
+  (table) => [
+    index("finyk_custom_categories_user_active_idx")
+      .on(table.userId, table.deletedAt)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+/** User-entered cash expenses outside Mono (`ManualExpense` shape). */
+export const finykManualExpenses = pgTable(
+  "finyk_manual_expenses",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    userId: text("user_id").notNull(),
+    dataJson: jsonb("data_json").notNull().default({}),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+  },
+  (table) => [
+    index("finyk_manual_expenses_user_active_idx")
+      .on(table.userId, table.deletedAt)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+/** Saved transaction filter presets (date range, accounts, categories). */
+export const finykTxFilters = pgTable(
+  "finyk_tx_filters",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    userId: text("user_id").notNull(),
+    dataJson: jsonb("data_json").notNull().default({}),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+  },
+  (table) => [
+    index("finyk_tx_filters_user_active_idx")
+      .on(table.userId, table.deletedAt)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+// ---------------------------------------------------------------------
+// Per-tx mapping tables — composite-PK on (user_id, transaction_id)
+// ---------------------------------------------------------------------
+
+/**
+ * Per-transaction category override. The LS shape is
+ * `Record<txId, categoryId>` with `undefined` values meaning "fall
+ * back to MCC default". No `deleted_at` — absence of a row is the
+ * "no override" state, so sync `delete` ops just `DELETE FROM`.
+ */
+export const finykTxCategories = pgTable(
+  "finyk_tx_categories",
+  {
+    userId: text("user_id").notNull(),
+    transactionId: text("transaction_id").notNull(),
+    categoryId: text("category_id").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.transactionId] }),
+    index("finyk_tx_categories_user_idx").on(table.userId),
+  ],
+);
+
+/**
+ * Per-transaction split definitions. LS shape is
+ * `Record<txId, TxSplit[]>`; the array goes into `splits_json`.
+ */
+export const finykTxSplits = pgTable(
+  "finyk_tx_splits",
+  {
+    userId: text("user_id").notNull(),
+    transactionId: text("transaction_id").notNull(),
+    splitsJson: jsonb("splits_json").notNull().default([]),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.transactionId] }),
+    index("finyk_tx_splits_user_idx").on(table.userId),
+  ],
+);
+
+/**
+ * Maps Mono transactions to manual debts. LS shape is
+ * `Record<txId, debtId[]>`; `debt_ids_json` is the array of
+ * `finyk_debts.id` strings.
+ */
+export const finykMonoDebtLinks = pgTable(
+  "finyk_mono_debt_links",
+  {
+    userId: text("user_id").notNull(),
+    transactionId: text("transaction_id").notNull(),
+    debtIdsJson: jsonb("debt_ids_json").notNull().default([]),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.transactionId] }),
+    index("finyk_mono_debt_links_user_idx").on(table.userId),
+  ],
+);
+
+// ---------------------------------------------------------------------
+// Time-series — networth_history (one row per (user, month))
+// ---------------------------------------------------------------------
+
+/**
+ * Monthly net-worth snapshots. `month` stays TEXT (`YYYY-MM`) so LWW
+ * comparisons / API round-trips match the LS `NetworthEntry` shape
+ * byte-for-byte. `snapshot_json` reserves space for richer per-month
+ * payloads (per-asset breakdowns, FX rate at snapshot time) without a
+ * follow-up migration.
+ */
+export const finykNetworthHistory = pgTable(
+  "finyk_networth_history",
+  {
+    userId: text("user_id").notNull(),
+    month: text().notNull(),
+    networth: real().notNull().default(0),
+    snapshotJson: jsonb("snapshot_json").notNull().default({}),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.month] }),
+    index("finyk_networth_history_user_month_idx").on(
+      table.userId,
+      sql`${table.month} DESC`,
+    ),
+  ],
+);
+
+// ---------------------------------------------------------------------
+// Singleton prefs — one row per user
+// ---------------------------------------------------------------------
+
+/**
+ * Per-user singleton row of finyk preferences. `monthly_plan_json`
+ * carries `MonthlyPlan` (income/expense/savings — kept as the original
+ * LS string-or-number shape). `show_balance` is split out of the
+ * open-ended `prefs_json` so multi-device LWW on the
+ * balance-visibility toggle doesn't have to merge the JSONB. `user_id`
+ * is the PK — exactly one row per user.
+ */
+export const finykPrefs = pgTable("finyk_prefs", {
+  userId: text("user_id").primaryKey(),
+  prefsJson: jsonb("prefs_json").notNull().default({}),
+  monthlyPlanJson: jsonb("monthly_plan_json").notNull().default({}),
+  showBalance: boolean("show_balance").notNull().default(true),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});

--- a/packages/db-schema/src/pg/index.ts
+++ b/packages/db-schema/src/pg/index.ts
@@ -19,3 +19,20 @@ export {
   nutritionPrefs,
   nutritionRecipes,
 } from "./nutrition.js";
+export {
+  finykHiddenAccounts,
+  finykHiddenTransactions,
+  finykBudgets,
+  finykSubscriptions,
+  finykAssets,
+  finykDebts,
+  finykReceivables,
+  finykCustomCategories,
+  finykManualExpenses,
+  finykTxFilters,
+  finykTxCategories,
+  finykTxSplits,
+  finykMonoDebtLinks,
+  finykNetworthHistory,
+  finykPrefs,
+} from "./finyk.js";

--- a/packages/db-schema/src/sqlite/finyk.ts
+++ b/packages/db-schema/src/sqlite/finyk.ts
@@ -1,0 +1,354 @@
+import {
+  index,
+  integer,
+  primaryKey,
+  real,
+  sqliteTable,
+  text,
+} from "drizzle-orm/sqlite-core";
+import { sql } from "drizzle-orm";
+
+/**
+ * SQLite Drizzle schemas for the Finyk module's normalized tables.
+ *
+ * Mirrors the Postgres counterpart at `packages/db-schema/src/pg/finyk.ts`
+ * (which itself mirrors `apps/server/src/migrations/039_finyk_tables.sql`).
+ * Hosts finyk state on SQLite for both web (sqlite-wasm via OPFS-SAH) and
+ * mobile (`expo-sqlite`).
+ *
+ * Stage 4 / PR #035 of `docs/planning/storage-roadmap.md`.
+ *
+ * Differences from Postgres (same as nutrition / fizruk SQLite mirrors):
+ * - `id` is TEXT (UUID stored as a string — SQLite has no native UUID).
+ *   Generation is the client's responsibility (`crypto.randomUUID()`).
+ * - All TIMESTAMPTZ columns are TEXT (ISO-8601 with offset).
+ * - JSONB → TEXT (JSON stored as string in SQLite).
+ * - BOOLEAN → INTEGER (`0` / `1`) — SQLite has no native boolean.
+ * - REAL stays REAL (SQLite stores as 8-byte float; matches Postgres `real`).
+ * - No FK to `"user"(id)` — the client SQLite database has no auth tables.
+ * - Index names are `_lite`-suffixed to spot drift between server and
+ *   client at code-review time.
+ */
+
+// ---------------------------------------------------------------------
+// Composite-PK tombstone tables
+// ---------------------------------------------------------------------
+
+export const finykHiddenAccounts = sqliteTable(
+  "finyk_hidden_accounts",
+  {
+    userId: text("user_id").notNull(),
+    accountId: text("account_id").notNull(),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    deletedAt: text("deleted_at"),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.accountId] }),
+    index("finyk_hidden_accounts_user_active_idx_lite")
+      .on(table.userId)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+export const finykHiddenTransactions = sqliteTable(
+  "finyk_hidden_transactions",
+  {
+    userId: text("user_id").notNull(),
+    transactionId: text("transaction_id").notNull(),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    deletedAt: text("deleted_at"),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.transactionId] }),
+    index("finyk_hidden_transactions_user_active_idx_lite")
+      .on(table.userId)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+// ---------------------------------------------------------------------
+// Per-row + JSONB tables
+// ---------------------------------------------------------------------
+
+export const finykBudgets = sqliteTable(
+  "finyk_budgets",
+  {
+    id: text().primaryKey(),
+    userId: text("user_id").notNull(),
+    dataJson: text("data_json").notNull().default("{}"),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    deletedAt: text("deleted_at"),
+  },
+  (table) => [
+    index("finyk_budgets_user_active_idx_lite")
+      .on(table.userId, table.deletedAt)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+export const finykSubscriptions = sqliteTable(
+  "finyk_subscriptions",
+  {
+    id: text().primaryKey(),
+    userId: text("user_id").notNull(),
+    dataJson: text("data_json").notNull().default("{}"),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    deletedAt: text("deleted_at"),
+  },
+  (table) => [
+    index("finyk_subscriptions_user_active_idx_lite")
+      .on(table.userId, table.deletedAt)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+export const finykAssets = sqliteTable(
+  "finyk_assets",
+  {
+    id: text().primaryKey(),
+    userId: text("user_id").notNull(),
+    dataJson: text("data_json").notNull().default("{}"),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    deletedAt: text("deleted_at"),
+  },
+  (table) => [
+    index("finyk_assets_user_active_idx_lite")
+      .on(table.userId, table.deletedAt)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+export const finykDebts = sqliteTable(
+  "finyk_debts",
+  {
+    id: text().primaryKey(),
+    userId: text("user_id").notNull(),
+    dataJson: text("data_json").notNull().default("{}"),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    deletedAt: text("deleted_at"),
+  },
+  (table) => [
+    index("finyk_debts_user_active_idx_lite")
+      .on(table.userId, table.deletedAt)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+export const finykReceivables = sqliteTable(
+  "finyk_receivables",
+  {
+    id: text().primaryKey(),
+    userId: text("user_id").notNull(),
+    dataJson: text("data_json").notNull().default("{}"),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    deletedAt: text("deleted_at"),
+  },
+  (table) => [
+    index("finyk_receivables_user_active_idx_lite")
+      .on(table.userId, table.deletedAt)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+export const finykCustomCategories = sqliteTable(
+  "finyk_custom_categories",
+  {
+    id: text().primaryKey(),
+    userId: text("user_id").notNull(),
+    dataJson: text("data_json").notNull().default("{}"),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    deletedAt: text("deleted_at"),
+  },
+  (table) => [
+    index("finyk_custom_categories_user_active_idx_lite")
+      .on(table.userId, table.deletedAt)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+export const finykManualExpenses = sqliteTable(
+  "finyk_manual_expenses",
+  {
+    id: text().primaryKey(),
+    userId: text("user_id").notNull(),
+    dataJson: text("data_json").notNull().default("{}"),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    deletedAt: text("deleted_at"),
+  },
+  (table) => [
+    index("finyk_manual_expenses_user_active_idx_lite")
+      .on(table.userId, table.deletedAt)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+export const finykTxFilters = sqliteTable(
+  "finyk_tx_filters",
+  {
+    id: text().primaryKey(),
+    userId: text("user_id").notNull(),
+    dataJson: text("data_json").notNull().default("{}"),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    deletedAt: text("deleted_at"),
+  },
+  (table) => [
+    index("finyk_tx_filters_user_active_idx_lite")
+      .on(table.userId, table.deletedAt)
+      .where(sql`${table.deletedAt} IS NULL`),
+  ],
+);
+
+// ---------------------------------------------------------------------
+// Per-tx mapping tables
+// ---------------------------------------------------------------------
+
+export const finykTxCategories = sqliteTable(
+  "finyk_tx_categories",
+  {
+    userId: text("user_id").notNull(),
+    transactionId: text("transaction_id").notNull(),
+    categoryId: text("category_id").notNull(),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.transactionId] }),
+    index("finyk_tx_categories_user_idx_lite").on(table.userId),
+  ],
+);
+
+export const finykTxSplits = sqliteTable(
+  "finyk_tx_splits",
+  {
+    userId: text("user_id").notNull(),
+    transactionId: text("transaction_id").notNull(),
+    splitsJson: text("splits_json").notNull().default("[]"),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.transactionId] }),
+    index("finyk_tx_splits_user_idx_lite").on(table.userId),
+  ],
+);
+
+export const finykMonoDebtLinks = sqliteTable(
+  "finyk_mono_debt_links",
+  {
+    userId: text("user_id").notNull(),
+    transactionId: text("transaction_id").notNull(),
+    debtIdsJson: text("debt_ids_json").notNull().default("[]"),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.transactionId] }),
+    index("finyk_mono_debt_links_user_idx_lite").on(table.userId),
+  ],
+);
+
+// ---------------------------------------------------------------------
+// Time-series — networth_history
+// ---------------------------------------------------------------------
+
+export const finykNetworthHistory = sqliteTable(
+  "finyk_networth_history",
+  {
+    userId: text("user_id").notNull(),
+    month: text().notNull(),
+    networth: real().notNull().default(0),
+    snapshotJson: text("snapshot_json").notNull().default("{}"),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.month] }),
+    index("finyk_networth_history_user_month_idx_lite").on(
+      table.userId,
+      sql`${table.month} DESC`,
+    ),
+  ],
+);
+
+// ---------------------------------------------------------------------
+// Singleton prefs
+// ---------------------------------------------------------------------
+
+export const finykPrefs = sqliteTable("finyk_prefs", {
+  userId: text("user_id").primaryKey(),
+  prefsJson: text("prefs_json").notNull().default("{}"),
+  monthlyPlanJson: text("monthly_plan_json").notNull().default("{}"),
+  showBalance: integer("show_balance").notNull().default(1),
+  createdAt: text("created_at")
+    .notNull()
+    .default(sql`(datetime('now'))`),
+  updatedAt: text("updated_at")
+    .notNull()
+    .default(sql`(datetime('now'))`),
+});

--- a/packages/db-schema/src/sqlite/index.ts
+++ b/packages/db-schema/src/sqlite/index.ts
@@ -22,6 +22,8 @@ export {
   FIZRUK_MIGRATIONS_TABLE,
   NUTRITION_CLIENT_MIGRATIONS,
   NUTRITION_MIGRATIONS_TABLE,
+  FINYK_CLIENT_MIGRATIONS,
+  FINYK_MIGRATIONS_TABLE,
 } from "./migrations/index.js";
 export {
   fizrukWorkouts,
@@ -37,3 +39,20 @@ export {
   nutritionPrefs,
   nutritionRecipes,
 } from "./nutrition.js";
+export {
+  finykHiddenAccounts,
+  finykHiddenTransactions,
+  finykBudgets,
+  finykSubscriptions,
+  finykAssets,
+  finykDebts,
+  finykReceivables,
+  finykCustomCategories,
+  finykManualExpenses,
+  finykTxFilters,
+  finykTxCategories,
+  finykTxSplits,
+  finykMonoDebtLinks,
+  finykNetworthHistory,
+  finykPrefs,
+} from "./finyk.js";

--- a/packages/db-schema/src/sqlite/migrations/index.ts
+++ b/packages/db-schema/src/sqlite/migrations/index.ts
@@ -369,3 +369,220 @@ export const NUTRITION_CLIENT_MIGRATIONS: readonly MigrationFile[] = [
  * (fizruk) so the three modules' migration histories don't collide.
  */
 export const NUTRITION_MIGRATIONS_TABLE = "__nutrition_migrations";
+
+// ---------------------------------------------------------------------------
+// Finyk module — Stage 4 / PR #035
+// ---------------------------------------------------------------------------
+
+const FINYK_001_SQL = `
+CREATE TABLE IF NOT EXISTS finyk_hidden_accounts (
+  user_id     TEXT NOT NULL,
+  account_id  TEXT NOT NULL,
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  deleted_at  TEXT,
+  PRIMARY KEY (user_id, account_id)
+);
+
+CREATE INDEX IF NOT EXISTS finyk_hidden_accounts_user_active_idx_lite
+  ON finyk_hidden_accounts (user_id)
+  WHERE deleted_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS finyk_hidden_transactions (
+  user_id        TEXT NOT NULL,
+  transaction_id TEXT NOT NULL,
+  created_at     TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at     TEXT NOT NULL DEFAULT (datetime('now')),
+  deleted_at     TEXT,
+  PRIMARY KEY (user_id, transaction_id)
+);
+
+CREATE INDEX IF NOT EXISTS finyk_hidden_transactions_user_active_idx_lite
+  ON finyk_hidden_transactions (user_id)
+  WHERE deleted_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS finyk_budgets (
+  id          TEXT PRIMARY KEY,
+  user_id     TEXT NOT NULL,
+  data_json   TEXT NOT NULL DEFAULT '{}',
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  deleted_at  TEXT
+);
+
+CREATE INDEX IF NOT EXISTS finyk_budgets_user_active_idx_lite
+  ON finyk_budgets (user_id, deleted_at)
+  WHERE deleted_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS finyk_subscriptions (
+  id          TEXT PRIMARY KEY,
+  user_id     TEXT NOT NULL,
+  data_json   TEXT NOT NULL DEFAULT '{}',
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  deleted_at  TEXT
+);
+
+CREATE INDEX IF NOT EXISTS finyk_subscriptions_user_active_idx_lite
+  ON finyk_subscriptions (user_id, deleted_at)
+  WHERE deleted_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS finyk_assets (
+  id          TEXT PRIMARY KEY,
+  user_id     TEXT NOT NULL,
+  data_json   TEXT NOT NULL DEFAULT '{}',
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  deleted_at  TEXT
+);
+
+CREATE INDEX IF NOT EXISTS finyk_assets_user_active_idx_lite
+  ON finyk_assets (user_id, deleted_at)
+  WHERE deleted_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS finyk_debts (
+  id          TEXT PRIMARY KEY,
+  user_id     TEXT NOT NULL,
+  data_json   TEXT NOT NULL DEFAULT '{}',
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  deleted_at  TEXT
+);
+
+CREATE INDEX IF NOT EXISTS finyk_debts_user_active_idx_lite
+  ON finyk_debts (user_id, deleted_at)
+  WHERE deleted_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS finyk_receivables (
+  id          TEXT PRIMARY KEY,
+  user_id     TEXT NOT NULL,
+  data_json   TEXT NOT NULL DEFAULT '{}',
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  deleted_at  TEXT
+);
+
+CREATE INDEX IF NOT EXISTS finyk_receivables_user_active_idx_lite
+  ON finyk_receivables (user_id, deleted_at)
+  WHERE deleted_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS finyk_tx_categories (
+  user_id        TEXT NOT NULL,
+  transaction_id TEXT NOT NULL,
+  category_id    TEXT NOT NULL,
+  created_at     TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at     TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (user_id, transaction_id)
+);
+
+CREATE INDEX IF NOT EXISTS finyk_tx_categories_user_idx_lite
+  ON finyk_tx_categories (user_id);
+
+CREATE TABLE IF NOT EXISTS finyk_tx_splits (
+  user_id        TEXT NOT NULL,
+  transaction_id TEXT NOT NULL,
+  splits_json    TEXT NOT NULL DEFAULT '[]',
+  created_at     TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at     TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (user_id, transaction_id)
+);
+
+CREATE INDEX IF NOT EXISTS finyk_tx_splits_user_idx_lite
+  ON finyk_tx_splits (user_id);
+
+CREATE TABLE IF NOT EXISTS finyk_mono_debt_links (
+  user_id        TEXT NOT NULL,
+  transaction_id TEXT NOT NULL,
+  debt_ids_json  TEXT NOT NULL DEFAULT '[]',
+  created_at     TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at     TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (user_id, transaction_id)
+);
+
+CREATE INDEX IF NOT EXISTS finyk_mono_debt_links_user_idx_lite
+  ON finyk_mono_debt_links (user_id);
+
+CREATE TABLE IF NOT EXISTS finyk_networth_history (
+  user_id        TEXT NOT NULL,
+  month          TEXT NOT NULL,
+  networth       REAL NOT NULL DEFAULT 0,
+  snapshot_json  TEXT NOT NULL DEFAULT '{}',
+  created_at     TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at     TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (user_id, month)
+);
+
+CREATE INDEX IF NOT EXISTS finyk_networth_history_user_month_idx_lite
+  ON finyk_networth_history (user_id, month DESC);
+
+CREATE TABLE IF NOT EXISTS finyk_custom_categories (
+  id          TEXT PRIMARY KEY,
+  user_id     TEXT NOT NULL,
+  data_json   TEXT NOT NULL DEFAULT '{}',
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  deleted_at  TEXT
+);
+
+CREATE INDEX IF NOT EXISTS finyk_custom_categories_user_active_idx_lite
+  ON finyk_custom_categories (user_id, deleted_at)
+  WHERE deleted_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS finyk_manual_expenses (
+  id          TEXT PRIMARY KEY,
+  user_id     TEXT NOT NULL,
+  data_json   TEXT NOT NULL DEFAULT '{}',
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  deleted_at  TEXT
+);
+
+CREATE INDEX IF NOT EXISTS finyk_manual_expenses_user_active_idx_lite
+  ON finyk_manual_expenses (user_id, deleted_at)
+  WHERE deleted_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS finyk_tx_filters (
+  id          TEXT PRIMARY KEY,
+  user_id     TEXT NOT NULL,
+  data_json   TEXT NOT NULL DEFAULT '{}',
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  deleted_at  TEXT
+);
+
+CREATE INDEX IF NOT EXISTS finyk_tx_filters_user_active_idx_lite
+  ON finyk_tx_filters (user_id, deleted_at)
+  WHERE deleted_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS finyk_prefs (
+  user_id            TEXT PRIMARY KEY,
+  prefs_json         TEXT NOT NULL DEFAULT '{}',
+  monthly_plan_json  TEXT NOT NULL DEFAULT '{}',
+  show_balance       INTEGER NOT NULL DEFAULT 1,
+  created_at         TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at         TEXT NOT NULL DEFAULT (datetime('now'))
+);
+`;
+
+/**
+ * Ordered list of bundled client migrations for the Finyk module on
+ * SQLite. Pass this directly to `runMigrations` from
+ * `@sergeant/db-schema/migrate`.
+ *
+ * The Finyk module uses a separate ledger table
+ * (`__finyk_migrations`) so that routine, fizruk, nutrition, and
+ * finyk migrations are independent — each module can be migrated,
+ * rolled out, and rolled back without affecting the others. Same
+ * rationale as nutrition's split from fizruk in PR #031.
+ */
+export const FINYK_CLIENT_MIGRATIONS: readonly MigrationFile[] = [
+  { name: "001_finyk_tables.sql", sql: FINYK_001_SQL },
+] as const;
+
+/**
+ * Stable ledger table name used by the Finyk SQLite module.
+ * Separate from `__migrations` (routine), `__fizruk_migrations`
+ * (fizruk), and `__nutrition_migrations` (nutrition) so all four
+ * modules' migration histories stay independent.
+ */
+export const FINYK_MIGRATIONS_TABLE = "__finyk_migrations";


### PR DESCRIPTION
## Summary

Stage 4 PR #036 of `docs/planning/storage-roadmap.md`. Mirrors fizruk PR #028 / nutrition PR #032 for finyk: behind feature flag `feature.finyk.sqlite_v2.dual_write` (default off, experimental), every LS/MMKV write into the 14 finyk cloud-sync keys is now best-effort mirrored into the local SQLite tables shipped by **PR #035 (#1667)**. Reads still come from LS/MMKV — this is a pure shadow-write for validation. Cut-over to SQLite reads is PR #037.

**Web (`apps/web/src/modules/finyk/`):**
- `lib/dualWrite/diff.ts` — pure prev→next diff with five op kinds (id, blob, tx-{cat,splits,monoDebt}, networth, prefs).
- `lib/dualWrite/adapter.ts` — async LWW-guarded writers per table (composite-PK tombstones, per-row blobs with `data_json`, per-tx mappings, time-series, singleton prefs). Best-effort: errors logged, never abort the LS write.
- `lib/dualWrite/index.ts` — orchestrator (`registerFinykDualWriteContext`, `triggerFinykDualWrite`, `isFinykDualWriteRegistered`).
- `lib/dualWrite/extract.ts` — maps `FinykStorageSlots` → `FinykDualWriteState` (string-encodes blobs for stable diff).
- `lib/dualWriteBoot.ts` + `hooks/useFinykDualWriteBoot.ts` — React lifecycle wiring; idempotent migration on first use.
- `hooks/useFinykDualWriteSync.ts` — watches the slot bundle, fires `triggerFinykDualWrite(prev, next)` on every change.
- Boot + sync hooks installed in `useStorage.ts` so `FinykApp.tsx` stays untouched (avoids re-tripping the pre-existing `no-hash-router-in-modules` lint warning that lint-staged elevates to error via `--max-warnings=0`).
- Flag added to `core/lib/featureFlags.ts`.

**Mobile (`apps/mobile/src/modules/finyk/`):**
- Same `lib/dualWrite/{diff,adapter,index,extract}.ts` plus `lib/dualWriteBoot.ts` + `hooks/useFinykDualWriteBoot.ts`.
- `FinykApp.tsx` installs the boot hook.
- `assetsStore.ts`, `budgetsStore.ts`, `transactionsStore.ts` call `triggerFinykDualWrite(prev, next)` after each `safeWriteLS` via `stateWithSlice` so the diff sees only the changed key (other slots stay `EMPTY_FINYK_STATE`).
- Flag added to `core/lib/featureFlags.ts`.

`docs/planning/storage-roadmap.md` PR #036 entry expanded with the realised web + mobile artefact list; `Last validated` bumped to 2026-05-04.

**Dep:** PR #035 (#1667) — schema + client migration runner. Land #035 first.

## Governing Skill

- Primary skill: `sergeant-feature-delivery`
- Secondary skill (if truly needed): `sergeant-data-and-migrations`

## Playbook

- Primary playbook: dual-write rollout (mirrors nutrition PR #032 / fizruk PR #028).
- Why this playbook: identical pattern + SQLite shape + feature-flag gating — reuse the proven recipe.
- If no playbook matched, why: n/a.

## Verification

```bash
pnpm --filter @sergeant/web test src/modules/finyk/lib/dualWrite
# 25/25 tests pass (diff + integration + testSqlite helper).

pnpm --filter @sergeant/web typecheck
# Clean for finyk dual-write surface (no new errors).

pnpm --filter @sergeant/mobile typecheck
# Clean for the dual-write surface. Pre-existing test-config errors
# (`Cannot find name 'jest'`, `'describe'`, etc.) are unrelated.
```

Additional checks:

- [x] Local smoke / manual validation completed (25 vitest cases assert LWW guard, soft-delete, hard-delete, singleton prefs, networth month validation, orchestrator skip-reasons, fire-and-forget contract).
- [x] Surface-specific checks completed (web + mobile both compile clean for the dual-write surface).

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update — no changes needed (no new rules / scopes / module ownership).
- [x] I checked whether a playbook or skill needed an update — `sergeant-feature-delivery` covered it.
- [x] I checked whether governance docs or review docs needed an update — `docs/planning/storage-roadmap.md` PR #036 entry refreshed; `Last validated` bumped.

Updated docs:

- `docs/planning/storage-roadmap.md` — PR #036 entry expanded; header `Last validated` line refreshed.

## Risk and Rollout

- **User-visible risk:** none — dual-write path is gated by `feature.finyk.sqlite_v2.dual_write` (default off, experimental). Errors are logged and never abort the primary LS/MMKV write.
- **Rollout / deploy order:** ship after PR #035 lands. Then enable `feature.finyk.sqlite_v2.dual_write` for a small cohort, watch SQLite vs LS drift via observability, then ramp.
- **Backout plan:** disable the feature flag — the LS/MMKV write path is unchanged, SQLite tables become stale until next LS write. Cleaning the SQLite cache is a no-op since reads still come from LS until PR #037.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

- The diff layer is pure and intentionally extracted from any React / SQLite imports — easy to reason about against the storage shape.
- The adapter layer is the only side-effecting surface; LWW guard lives in the SQL `WHERE` clause (`excluded.updated_at > table.updated_at`) so concurrent writes can't roll the timestamp backwards.
- Web boot/sync hooks live inside `useStorage.ts`. This was a deliberate move from `FinykApp.tsx` to avoid touching the pre-existing `useHashRouter` callsites that ESLint warns on (the file lints clean if untouched, lint-staged re-checks the whole file once any line changes).
- Mobile per-store triggers use `stateWithSlice` so each `setManualAssets` / `setBudgets` / `overrideCategory` / etc. only emits ops for its own key — no extra LS reads per write.
- See PR #035 (#1667) for the SQLite schema this dual-write targets.