### PR TITLE
feat(web): migrate useActiveFizrukWorkout off raw localStorage (Item 6 follow-up)

### DIFF
--- a/.tech-debt/localstorage-allowlist-budget.json
+++ b/.tech-debt/localstorage-allowlist-budget.json
@@ -1,4 +1,4 @@
 {
-  "production": 16,
-  "rationale": "Updated 2026-05-04 (Item 6 follow-up): production count 19 → 16 after migrating apps/web/src/shared/lib/ui/perf.ts and apps/web/src/shared/hooks/useDarkMode.ts off direct localStorage onto safeReadStringLS/safeReadLS/safeWriteLS. (Headroom: 0 — bump only with a deliberate decision; new sites must migrate an existing one to keep parity.) Burndown plan in docs/diagnostics/2026-05-03-web-deep-dive/02-architecture-and-state.md §2.2 + docs/tech-debt/frontend.md §2."
+  "production": 15,
+  "rationale": "Updated 2026-05-04 (Item 6 round-7 follow-up): production count 16 → 15 after migrating apps/web/src/shared/hooks/useActiveFizrukWorkout.ts off direct localStorage onto safeReadStringLS/safeRemoveLS. (Headroom: 0 — bump only with a deliberate decision; new sites must migrate an existing one to keep parity.) Burndown plan in docs/diagnostics/2026-05-03-web-deep-dive/02-architecture-and-state.md §2.2 + docs/tech-debt/frontend.md §2."
 }

--- a/apps/web/src/shared/hooks/useActiveFizrukWorkout.ts
+++ b/apps/web/src/shared/hooks/useActiveFizrukWorkout.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { safeReadStringLS, safeRemoveLS } from "@shared/lib/storage/storage";
 
 /**
  * Shared read-only pointer to the in-progress Fizruk workout.
@@ -39,26 +40,13 @@ const WORKOUTS_KEY = "fizruk_workouts_v1";
  * doesn't pull in the fizruk package.
  */
 function readActiveId(): string | null {
-  let id: string | null;
-  try {
-    id = localStorage.getItem(ACTIVE_WORKOUT_KEY) || null;
-  } catch {
-    return null;
-  }
+  const id = safeReadStringLS(ACTIVE_WORKOUT_KEY);
   if (!id) return null;
 
-  let raw: string | null;
-  try {
-    raw = localStorage.getItem(WORKOUTS_KEY);
-  } catch {
-    // If we can't read the workouts list we have no way to validate —
-    // fall back to the optimistic behaviour (show the banner) rather than
-    // hiding a legitimately active session.
-    return id;
-  }
-  if (!raw) {
-    // No workouts persisted at all → the active-id is definitely stale.
-    // Clear it so subsequent reads from any tab see the correct state.
+  const raw = safeReadStringLS(WORKOUTS_KEY);
+  if (raw === null) {
+    // No workouts persisted (or storage threw). Either way the pointer
+    // cannot be validated against the list, so clear it as stale.
     clearStaleActiveId();
     return null;
   }
@@ -74,8 +62,8 @@ function readActiveId(): string | null {
       list = (parsed as { workouts: unknown[] }).workouts;
     else list = [];
   } catch {
-    // Corrupt JSON — same reasoning as the read failure above: don't
-    // hide a potentially active session on parse error.
+    // Corrupt JSON — fail open: don't hide a potentially active session
+    // on parse error.
     return id;
   }
 
@@ -95,11 +83,7 @@ function readActiveId(): string | null {
 }
 
 function clearStaleActiveId(): void {
-  try {
-    localStorage.removeItem(ACTIVE_WORKOUT_KEY);
-  } catch {
-    /* best-effort cleanup */
-  }
+  safeRemoveLS(ACTIVE_WORKOUT_KEY);
 }
 
 export function useActiveFizrukWorkout(): string | null {

--- a/docs/tech-debt/frontend.md
+++ b/docs/tech-debt/frontend.md
@@ -5,9 +5,9 @@
 
 Аналіз кодової бази `apps/web/src` (649 source файлів, ~102k рядків — без тестів і `__tests__/`; 2026-05-03 re-audit).
 
-> **Оновлено 2026-05-03.** Sync з реальним станом коду після кількох wave-ів decomposition:
-> Розділ 2 (localStorage burndown) — TODO-allowlist у `eslint.config.js` скорочено з 41 до **17 файлів**
-> (нові хвилі міграцій у `routine`/`finyk`/`onboarding`/`chatActions`/`insights`/`recommendations`).
+> **Оновлено 2026-05-04.** Sync з реальним станом коду після кількох wave-ів decomposition:
+> Розділ 2 (localStorage burndown) — TODO-allowlist у `eslint.config.js` скорочено з 41 до **15 файлів**
+> (нові хвилі міграцій у `routine`/`finyk`/`onboarding`/`chatActions`/`insights`/`recommendations`/`useDarkMode`/`useActiveFizrukWorkout`).
 > Розділ 4 (великі файли) — у `apps/web/src` залишилось **16 файлів >600 LOC** (раніше 22; lookup-таблиця нижче синхронізована з `wc -l` 2026-05-03);
 > декомпозовано `Transactions.tsx`, `HubSearch.tsx`, `Budgets.tsx`, `Overview.tsx`, `DesignShowcase.tsx`,
 > `ActiveWorkoutPanel.tsx`, `core/App.tsx` (645 → 224 LOC, винесено
@@ -80,18 +80,22 @@ try/catch крашить на quota exceeded, corrupted storage або private b
   бо виконують роль фікстур і ізольовані від production-ризиків.
 - **Storage primitives** — самі обгортки (`safeReadLS`, `storageManager`,
   `storageQuota`, `typedStore`, `createModuleStorage`, `weeklyDigestStorage`,
-  `useLocalStorageState`, `useDarkMode`, `usePushNotifications`,
-  `useActiveFizrukWorkout`, `perf`).
+  `useLocalStorageState`, `useDarkMode`, `usePushNotifications`).
 - **Cloud-sync internals** — черга, патчер, state writer.
 - **Module storage wrappers** — `modules/finyk/lib/storageManager`,
   `modules/finyk/hooks/useStorage`, `modules/nutrition/domain/nutritionBackup`.
 - **TODO-список немігрованих файлів** — кожен файл, що ще
   читає/пише напряму, перерахований у `eslint.config.js` явно. Міграція
-  файла = видалення рядка зі списку. **На 2026-05-01 TODO-список
-  містить 17 файлів** (попередня хвиля: 46 → 41 → 27 → 17 після міграції
-  routine/finyk/onboarding/chatActions/insights/recommendations-сайтів).
+  файла = видалення рядка зі списку. **На 2026-05-04 TODO-список
+  містить 15 файлів** (попередня хвиля: 46 → 41 → 27 → 17 → 16 → 15
+  після міграції routine/finyk/onboarding/chatActions/insights/
+  recommendations/`useDarkMode`/`perf`/`useActiveFizrukWorkout`-сайтів).
+  Бюджет жорстко зафіксовано у
+  [`.tech-debt/localstorage-allowlist-budget.json`](../../.tech-debt/localstorage-allowlist-budget.json)
+  (15, headroom 0) і enforce-нутий у CI через
+  [`pnpm lint:localstorage-allowlist`](../../scripts/check-localstorage-allowlist.mjs).
   Фактичних production-файлів у `apps/web/src` з прямим `localStorage.*` —
-  **35** (з них ~18 — легітимні wrappers/primitives, 17 — у TODO-списку).
+  **~35** (з них ~20 — легітимні wrappers/primitives, 15 — у TODO-списку).
   Тести (`*.test.*`, `__tests__/`) повний opt-out і не лічаться.
 
 **Що це дає:** новий код / нові файли НЕ зможуть додати прямий

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -433,7 +433,6 @@ export default [
       // - apps/web/src/shared/lib/ui/perf.ts (1 LS read)
       // - apps/web/src/shared/hooks/useDarkMode.ts (4 LS reads/writes)
       "apps/web/src/shared/hooks/usePushNotifications.ts",
-      "apps/web/src/shared/hooks/useActiveFizrukWorkout.ts",
       // Cloud-sync internals — the queue / enqueue / state writer all
       // need direct access; users should call the cloud-sync API.
       "apps/web/src/core/cloudSync/logger.ts",


### PR DESCRIPTION
## Summary

Round 7 follow-up для item #6 з [`docs/diagnostics/2026-05-03-web-deep-dive/00-overview.md`](../blob/main/docs/diagnostics/2026-05-03-web-deep-dive/00-overview.md) і [`02-architecture-and-state.md` §2.2](../blob/main/docs/diagnostics/2026-05-03-web-deep-dive/02-architecture-and-state.md).

Хук `apps/web/src/shared/hooks/useActiveFizrukWorkout.ts` мігрує з прямих `localStorage.getItem`/`removeItem` на безпечні обгортки:

- `localStorage.getItem(ACTIVE_WORKOUT_KEY) || null` → `safeReadStringLS(ACTIVE_WORKOUT_KEY)`
- `localStorage.getItem(WORKOUTS_KEY)` → `safeReadStringLS(WORKOUTS_KEY)` з ручним `JSON.parse`-fallback (зберігає fail-open на corrupt JSON)
- `localStorage.removeItem(ACTIVE_WORKOUT_KEY)` → `safeRemoveLS(ACTIVE_WORKOUT_KEY)`

Файл прибрано з allowlist'у `sergeant-design/no-raw-local-storage` у `eslint.config.js`. Бюджет у [`.tech-debt/localstorage-allowlist-budget.json`](../blob/main/.tech-debt/localstorage-allowlist-budget.json) знижено **16 → 15** (headroom 0).

### Невелика семантична зміна

Старий код розрізняв "WORKOUTS_KEY missing" (clear pointer, return null) і "LS threw on WORKOUTS_KEY read" (optimistic — return id). Нова реалізація колапсує обидва кейси у "clear pointer", оскільки `safeReadStringLS` повертає null на обидва. Це приймається тому що:

- Хук поллить `readActiveId()` кожні 1.5 секунди + слухає `storage` event → транзитна LS-помилка відновлюється на наступному polling tick.
- Активна workout-сесія не втрачається: `fizruk_workouts_v1` лишається у LS з `endedAt: null`, користувач може зайти у Workouts і "відновити" сесію вручну.
- Тест ["keeps the pointer when the workouts JSON is corrupt (fail-open)"](../blob/devin/1777902065-active-workout-storage-helpers/apps/web/src/shared/hooks/useActiveFizrukWorkout.test.ts#L68-L75) лишається зеленим — параsе-помилка все ще дає optimistic `return id`.

## Governing Skill

- Primary skill: `sergeant-web-ui` — burndown localStorage-allowlist у `apps/web/src/shared`.
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a
- Why this playbook:
- If no playbook matched, why: тривіальна 1-файлова міграція по вже встановленому "safe wrappers" патерну (PR-серія #1454, #1462, #1471, etc.). Окремого playbook не потребує.

## Verification

```bash
pnpm --filter @sergeant/web exec vitest run src/shared/hooks/useActiveFizrukWorkout    # 10/10 passed
pnpm --filter @sergeant/web typecheck                                                  # 0 errors
pnpm --filter @sergeant/web exec eslint src/shared/hooks/useActiveFizrukWorkout.ts     # 0 violations
pnpm lint:localstorage-allowlist                                                       # 15/15 (headroom 0)
node tools/tsconfig-guard/check.mjs                                                    # OK
pnpm lint:hard-rules-registry                                                          # 18 rules in sync
pnpm lint:tech-debt-freshness                                                          # OK
```

Additional checks:

- [x] Local smoke / manual validation completed.
- [x] Surface-specific checks completed (Vitest hook tests + ESLint guardrail + budget gate).

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- `docs/tech-debt/frontend.md` §2 — "TODO-allowlist скорочено з 41 до **15 файлів**" (попереднє значення 17 застаріло на 2 wave-и). Додано лінк на budget-файл і CI-gate.
- `.tech-debt/localstorage-allowlist-budget.json` — `production: 16 → 15`, оновлено rationale.

## Risk and Rollout

- User-visible risk: minimal — на LS-throw під час читання workouts list, банер "Тренування триває" може зникнути на 1.5s до наступного polling tick. Дані не втрачаються (workout стоїть у `fizruk_workouts_v1`).
- Rollout / deploy order: standalone — мерджиться окремо.
- Backout plan: revert single commit; allowlist-бюджет повертається до 16 (одна строчка в budget JSON).

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

- Хук read-only — не пише у LS. Тому `safeWriteLS` не потрібен.
- `clearStaleActiveId()` спрощено з `try/catch` до прямого виклику `safeRemoveLS` (вона сама swallow-ить throws).
- Цей PR — частина серії "round 7 follow-ups" по `docs/diagnostics/2026-05-03-web-deep-dive`. Сусідні PR-и: insights strict ([#1689](https://github.com/Skords-01/Sergeant/pull/1689)), Storybook expansion (Item 16), `ResetPasswordPage` form-engine rollout (Item 8).

---
Devin run by Лупа За (zlupa005@gmail.com).
Session: https://app.devin.ai/sessions/faff104b9f7a4f19800438b52fc347c5


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the `useActiveFizrukWorkout` hook to safe localStorage helpers to harden storage access and remove it from the raw localStorage allowlist; reduces the allowlist budget from 16 to 15. Behavior change: if reading the workouts list fails or is missing, we now clear the active pointer instead of keeping it optimistically.

- **Refactors**
  - Use `safeReadStringLS` for `fizruk_active_workout_id_v1` and `fizruk_workouts_v1`, and `safeRemoveLS` to clear the pointer; keep fail-open on corrupt workouts JSON via manual `JSON.parse`.
  - Remove `apps/web/src/shared/hooks/useActiveFizrukWorkout.ts` from the `sergeant-design/no-raw-local-storage` allowlist; update `.tech-debt/localstorage-allowlist-budget.json` to `production: 15`.
  - Sync `docs/tech-debt/frontend.md` with the new allowlist count.

<sup>Written for commit a6808b76fce1dad3ec8f7f2f7e57fc013fb96ce9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

