### PR TITLE
docs(docs): extend round-7 documentation to initiatives 0007/0011 and tech-debt

### DIFF
--- a/docs/initiatives/0007-design-system-tooling.md
+++ b/docs/initiatives/0007-design-system-tooling.md
@@ -1,10 +1,13 @@
 # 0007 — Design-system tooling: Storybook + visual regression
 
-> **Last validated:** 2026-05-04 by @Skords-01. **Next review:** 2026-08-02.
-> **Status:** Proposed
+> **Last validated:** 2026-05-04 by @zlupa005. **Next review:** 2026-08-02.
+> **Status:** In Progress (Phase 1 готовий — каталог 12/20 компонентів, Phase 2+ ще)
 > **Priority:** P1 (Sprint 2)
 > **Owner:** `@Skords-01`
 > **ETA:** 2 weeks
+
+> **Progress (round-7, 2026-05-04):** Каталог Storybook у `apps/web/.storybook/` (а не у новому пакеті — рішення фази 1) тепер містить **12 компонентів** (60 % від цілі ≥ 20): `Button`, `Badge`, `Card` (foundation [#1647](https://github.com/Skords-01/Sergeant/pull/1647)) → +`Banner`, `Skeleton`, `Tooltip`, `DataState`, `Modal` (8 компонентів, [#1678](https://github.com/Skords-01/Sergeant/pull/1678)) → +`Input` / `Spinner` / `Switch` / `Tabs` (12 компонентів, [#1695](https://github.com/Skords-01/Sergeant/pull/1695)). Залишилось мінімум 8: `Avatar`, `Segmented`, `Toast` (потребує Provider у `preview.tsx`), плюс module-level (`FinykCard` / `FizrukCard` / `NutritionCard` / `RoutineCard` / `InsightsCard`). Phase 2 (Chromatic vs Playwright VRT decision) і Phase 5 (deploy live) — ще `Out`.
+>
 > **Sources:** Design Review 2026-05-03 §13 (Design system), [`docs/audits/UX-UI-AUDIT-2026.md`](../audits/UX-UI-AUDIT-2026.md)
 
 ## TL;DR

--- a/docs/initiatives/0011-foundation-adoption-and-process-discipline.md
+++ b/docs/initiatives/0011-foundation-adoption-and-process-discipline.md
@@ -1,6 +1,6 @@
 # 0011 — Foundation adoption + process discipline (post-launch sweep)
 
-> **Last validated:** 2026-05-04 by @Skords-01. **Next review:** 2026-08-02.
+> **Last validated:** 2026-05-04 by @zlupa005. **Next review:** 2026-08-02.
 > **Status:** Proposed (Phase 1 freeze-compatible — старт 2026-05-05; Phases 2–4 заплановані пост-0010-launch ≥ 2026-06-01)
 > **Priority:** P1 (subordinate to 0010-revenue-first-launch scope-freeze)
 > **Owner:** `@Skords-01`
@@ -9,7 +9,7 @@
 
 ## TL;DR
 
-За 100 PR з 2026-05-03/04 ми збудували **4 foundation-инструменти без масових споживачів** (`useApiForm` — 6 файлів; `<DataState>` — 0 реальних споживачів; типізований OpenAPI-клієнт — споживачі мігровані частково; Storybook 10 — 8 stories на ~50+ UI-компонентів) і допустили **3 типи процес-помилок** (порожнє тіло PR-ів, Vercel-конфіг flip-flop без staging-перевірки, ~4 тижні задвоєння Renovate × Dependabot до фіксу). [`0010-revenue-first-launch`](./0010-revenue-first-launch.md) фрізить product-scope на 4 тижні (до ~2026-06-01) для shipping білінгу — **0011 поважає цей freeze**: Phase 1 (process-discipline CI-guards) проходить паралельно (інкрементальні зміни в `.github/workflows/`, не блокує білінг-PR-и), а Phases 2–4 стартують **після** revenue-first launch. Ця ініціатива закриває **adoption-розрив + три CI-guard-и + один retrospective audit** — у двох вікнах: in-freeze (Phase 1) та post-freeze (Phases 2–4).
+За 100 PR з 2026-05-03/04 ми збудували **4 foundation-инструменти зі змінним adoption-рівнем** (станом на round-7: `useApiForm` — 8 файлів, у т.ч. **3/3 auth-екрани**: AuthPage login + AuthPage register + ResetPasswordPage [#1696](https://github.com/Skords-01/Sergeant/pull/1696); `<DataState>` — 0 реальних споживачів; типізований OpenAPI-клієнт — споживачі мігровані частково; Storybook — **12 stories** на ~50+ UI-компонентів [#1695](https://github.com/Skords-01/Sergeant/pull/1695)) і допустили **3 типи процес-помилок** (порожнє тіло PR-ів, Vercel-конфіг flip-flop без staging-перевірки, ~4 тижні задвоєння Renovate × Dependabot до фіксу). [`0010-revenue-first-launch`](./0010-revenue-first-launch.md) фрізить product-scope на 4 тижні (до ~2026-06-01) для shipping білінгу — **0011 поважає цей freeze**: Phase 1 (process-discipline CI-guards) проходить паралельно (інкрементальні зміни в `.github/workflows/`, не блокує білінг-PR-и), а Phases 2–4 стартують **після** revenue-first launch. Ця ініціатива закриває **adoption-розрив + три CI-guard-и + один retrospective audit** — у двох вікнах: in-freeze (Phase 1) та post-freeze (Phases 2–4).
 
 ## Чому зараз
 

--- a/docs/tech-debt/frontend.md
+++ b/docs/tech-debt/frontend.md
@@ -768,7 +768,7 @@ undefined-guard. Без `!` non-null assertions.
 
 - `packages/shared` — `noUncheckedIndexedAccess: true` (PR [#1635](https://github.com/Skords-01/Sergeant/pull/1635)).
 - `packages/nutrition-domain` — `true` (PR [#1681](https://github.com/Skords-01/Sergeant/pull/1681)), 10 errors / 4 файли закрито через `!` після `findIndex >= 0` guard.
-- `packages/insights` — `true` (Item 15 round-7 follow-up), 13 errors / 2 тестових файли закрито через `recs[0]?.x` після `expect(recs).toHaveLength(1)`.
+- `packages/insights` — `true` (Item 15 round-7 follow-up, PR [#1689](https://github.com/Skords-01/Sergeant/pull/1689)), 13 errors / 2 тестових файли закрито через `recs[0]?.x` після `expect(recs).toHaveLength(1)`.
 
 [`tools/tsconfig-guard`](../../tools/tsconfig-guard/check.mjs) розширено:
 `noUncheckedIndexedAccess` додано у `GUARDED_OPTIONS`. Allowlist


### PR DESCRIPTION
## Summary

Round-7 documentation extension за межі diagnostics — оновлення initiatives + tech-debt сторінок з final state після мерджу 4 follow-up PR-iв ([#1689](https://github.com/Skords-01/Sergeant/pull/1689), [#1692](https://github.com/Skords-01/Sergeant/pull/1692), [#1695](https://github.com/Skords-01/Sergeant/pull/1695), [#1696](https://github.com/Skords-01/Sergeant/pull/1696)). Доповнення до уже мерджнутого doc-PR [#1698](https://github.com/Skords-01/Sergeant/pull/1698).

### Зміни

- **`docs/initiatives/0007-design-system-tooling.md`** — Status з `Proposed` → `In Progress (Phase 1 готовий — каталог 12/20 компонентів)`. Додано progress-banner з PR-лінками (foundation [#1647](https://github.com/Skords-01/Sergeant/pull/1647) → 8 компонентів [#1678](https://github.com/Skords-01/Sergeant/pull/1678) → 12 компонентів [#1695](https://github.com/Skords-01/Sergeant/pull/1695)) і списком залишкових (`Avatar`, `Segmented`, `Toast` (потребує Provider), module-level cards). Phase 2 (Chromatic vs Playwright VRT decision) і Phase 5 (deploy live) — все ще `Out`.
- **`docs/initiatives/0011-foundation-adoption-and-process-discipline.md`** — TL;DR оновлено з реальними adoption-числами: `useApiForm` 6 → 8 файлів (включно з 3/3 auth-екранами після `ResetPasswordPage` rollout), Storybook 8 → 12 stories. Це актуалізує core argument ініціативи про "foundation-инструменти зі змінним adoption-рівнем".
- **`docs/tech-debt/frontend.md`** — у списку round-7 follow-up міграцій noUncheckedIndexedAccess додано PR-лінк #1689 для `packages/insights` (раніше було лише textual reference на "Item 15 round-7 follow-up").

## Governing Skill

- Primary skill: `sergeant-review-and-merge` — review/merge governance, doc-freshness, multi-PR summary.

## Playbook

- Primary playbook: n/a (round-7 закриття)
- Why this playbook: окремого playbook для post-merge cross-doc update немає; pattern скопійовано з round-6.

## Verification

```bash
pnpm prettier --check docs/initiatives/0007-design-system-tooling.md docs/initiatives/0011-foundation-adoption-and-process-discipline.md docs/tech-debt/frontend.md
# All matched files use Prettier code style!
```

CI gates `lint:tech-debt-freshness` (60-day threshold) і `lint:link-check` запустяться у PR pipeline.

Additional checks:

- [x] Local Prettier `--check` clean.
- [x] All linked PRs (#1689, #1692, #1695, #1696, #1698) verified merged via GitHub API.

## Docs and Governance

- [x] Docs updated to reflect behaviour/contract/workflow changes після round-7.
- [x] AGENTS.md/playbooks/skills review: no changes needed (доповнення тільки до initiative + tech-debt сторінок).

## Risk and Rollout

- User-visible risk: **none** — лише doc-зміни.
- Rollout: standalone — мерджиться окремо.
- Backout plan: revert single commit.

## Hard Rule #15

- [x] Read AGENTS.md before coding.
- [x] Internal docs in Ukrainian.
- [x] No `--no-verify`.

---
Devin run by Лупа За (zlupa005@gmail.com).
Session: https://app.devin.ai/sessions/faff104b9f7a4f19800438b52fc347c5


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends round‑7 docs beyond diagnostics by updating initiatives 0007/0011 and the frontend tech-debt page.
0007 moves to “In Progress” with 12/20 Storybook components in `apps/web/.storybook/` and a progress note; 0011 TL;DR updates adoption numbers (`useApiForm` now in 8 files incl. 3/3 auth; Storybook at 12 stories); and tech-debt adds a link to PR #1689 for the `packages/insights` `noUncheckedIndexedAccess` migration.

<sup>Written for commit 60a8edccc4091d663ea31747774ba798c540267f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

