### PR TITLE
refactor(web): adopt <DataState> in finyk Mono panels

### DIFF
--- a/apps/web/src/modules/finyk/pages/Overview.tsx
+++ b/apps/web/src/modules/finyk/pages/Overview.tsx
@@ -32,9 +32,14 @@ import {
 } from "@sergeant/finyk-domain/domain/budget";
 import { filterStatTransactions } from "@sergeant/finyk-domain/domain/transactions";
 import { Skeleton } from "@shared/components/ui/Skeleton";
+import {
+  DataState,
+  type DataStateQueryLike,
+} from "@shared/components/ui/DataState";
 import { safeReadStringLS, safeWriteLS } from "@shared/lib/storage/storage";
 import { THEME_HEX } from "@shared/lib/ui/themeHex";
 import { SyncStatusBadge } from "../components/SyncStatusBadge";
+import type { Transaction } from "@sergeant/finyk-domain/domain/types";
 
 import { FirstInsightBanner } from "./overview/FirstInsightBanner";
 import { HeroCard } from "./overview/HeroCard";
@@ -348,18 +353,26 @@ export function Overview({
     [subscriptionFlows, debtOutFlows, debtInFlows, currentYear, currentMonth],
   );
 
-  if (loadingTx && realTx.length === 0) {
-    return (
-      <div className="flex-1 overflow-y-auto">
-        <div className="px-4 pt-4 page-tabbar-pad space-y-4 max-w-4xl mx-auto">
-          <Skeleton className="h-[168px] rounded-3xl" />
-          <Skeleton className="h-[120px] opacity-80 rounded-2xl" />
-          <Skeleton className="h-[110px] opacity-60 rounded-2xl" />
-          <Skeleton className="h-[90px] opacity-40 rounded-2xl" />
-        </div>
+  // DataState contract: `data === undefined` triggers the skeleton slot.
+  // We treat the very first month load (no realTx yet) as loading;
+  // subsequent background refetches keep `data` defined so the page stays
+  // visible while a stale-revalidate happens. Mirrors the prior
+  // `if (loadingTx && realTx.length === 0)` early-return guard exactly.
+  const overviewQuery: DataStateQueryLike<readonly Transaction[]> = {
+    data: loadingTx && realTx.length === 0 ? undefined : realTx,
+    isLoading: loadingTx,
+  };
+
+  const overviewLoadingSkeleton = (
+    <div className="flex-1 overflow-y-auto">
+      <div className="px-4 pt-4 page-tabbar-pad space-y-4 max-w-4xl mx-auto">
+        <Skeleton className="h-[168px] rounded-3xl" />
+        <Skeleton className="h-[120px] opacity-80 rounded-2xl" />
+        <Skeleton className="h-[110px] opacity-60 rounded-2xl" />
+        <Skeleton className="h-[90px] opacity-40 rounded-2xl" />
       </div>
-    );
-  }
+    </div>
+  );
 
   const recurringOutThisMonth = monthFlows
     .filter(
@@ -400,78 +413,82 @@ export function Overview({
   });
 
   return (
-    <div className="flex-1 overflow-y-auto overscroll-contain">
-      <div className="px-4 pt-4 page-tabbar-pad space-y-4 max-w-4xl mx-auto">
-        {(clientInfo ||
-          syncState?.status === "error" ||
-          syncState?.status === "loading" ||
-          monoError) && (
-          <SyncStatusBadge
-            syncState={syncState}
-            lastUpdated={lastUpdated}
-            error={monoError}
-            onRetry={monoRefresh}
-            loading={loadingTx}
-          />
-        )}
+    <DataState query={overviewQuery} skeleton={overviewLoadingSkeleton}>
+      {() => (
+        <div className="flex-1 overflow-y-auto overscroll-contain">
+          <div className="px-4 pt-4 page-tabbar-pad space-y-4 max-w-4xl mx-auto">
+            {(clientInfo ||
+              syncState?.status === "error" ||
+              syncState?.status === "loading" ||
+              monoError) && (
+              <SyncStatusBadge
+                syncState={syncState}
+                lastUpdated={lastUpdated}
+                error={monoError}
+                onRetry={monoRefresh}
+                loading={loadingTx}
+              />
+            )}
 
-        {showFirstInsight && hasAnyData && (
-          <FirstInsightBanner
-            onSetBudget={handleSetBudgetFromInsight}
-            onDismiss={dismissFirstInsight}
-          />
-        )}
+            {showFirstInsight && hasAnyData && (
+              <FirstInsightBanner
+                onSetBudget={handleSetBudgetFromInsight}
+                onDismiss={dismissFirstInsight}
+              />
+            )}
 
-        <HeroCard
-          networth={networth}
-          monoTotal={monoTotal}
-          totalDebt={totalDebt}
-          daysInMonth={daysInMonth}
-          daysPassed={daysPassed}
-          dayBudget={dayBudget}
-          hasExpensePlan={hasExpensePlan}
-          spendPlanRatio={spendPlanRatio}
-          showBalance={showBalance}
-        />
+            <HeroCard
+              networth={networth}
+              monoTotal={monoTotal}
+              totalDebt={totalDebt}
+              daysInMonth={daysInMonth}
+              daysPassed={daysPassed}
+              dayBudget={dayBudget}
+              hasExpensePlan={hasExpensePlan}
+              spendPlanRatio={spendPlanRatio}
+              showBalance={showBalance}
+            />
 
-        <MonthPulseCard
-          dateLabel={dateLabel}
-          daysPassed={daysPassed}
-          spent={spent}
-          income={income}
-          showBalance={showBalance}
-          showMonthForecast={showMonthForecast}
-          projectedSpend={projectedSpend}
-          hasExpensePlan={hasExpensePlan}
-          spendPlanRatio={spendPlanRatio}
-          planExpense={planExpense}
-          forecastTrendPct={forecastTrendPct}
-          forecastBarClass={forecastBarClass}
-          recurringOutThisMonth={recurringOutThisMonth}
-          recurringInThisMonth={recurringInThisMonth}
-          unknownOutCount={unknownOutCount}
-        />
+            <MonthPulseCard
+              dateLabel={dateLabel}
+              daysPassed={daysPassed}
+              spent={spent}
+              income={income}
+              showBalance={showBalance}
+              showMonthForecast={showMonthForecast}
+              projectedSpend={projectedSpend}
+              hasExpensePlan={hasExpensePlan}
+              spendPlanRatio={spendPlanRatio}
+              planExpense={planExpense}
+              forecastTrendPct={forecastTrendPct}
+              forecastBarClass={forecastBarClass}
+              recurringOutThisMonth={recurringOutThisMonth}
+              recurringInThisMonth={recurringInThisMonth}
+              unknownOutCount={unknownOutCount}
+            />
 
-        <NetworthSection networthHistory={networthHistory} />
+            <NetworthSection networthHistory={networthHistory} />
 
-        <BudgetAlertsList
-          budgetAlerts={budgetAlerts}
-          statTx={statTx}
-          txCategories={txCategories}
-          txSplits={txSplits}
-          customCategories={customCategories}
-        />
+            <BudgetAlertsList
+              budgetAlerts={budgetAlerts}
+              statTx={statTx}
+              txCategories={txCategories}
+              txSplits={txSplits}
+              customCategories={customCategories}
+            />
 
-        <PlannedFlowsCard
-          plannedFlows={plannedFlows}
-          onNavigate={onNavigate ?? (() => {})}
-          showBalance={showBalance}
-        />
+            <PlannedFlowsCard
+              plannedFlows={plannedFlows}
+              onNavigate={onNavigate ?? (() => {})}
+              showBalance={showBalance}
+            />
 
-        {loadingTx && (
-          <p className="text-center text-xs text-subtle py-4">Оновлення…</p>
-        )}
-      </div>
-    </div>
+            {loadingTx && (
+              <p className="text-center text-xs text-subtle py-4">Оновлення…</p>
+            )}
+          </div>
+        </div>
+      )}
+    </DataState>
   );
 }

--- a/apps/web/src/modules/finyk/pages/budgets/Budgets.tsx
+++ b/apps/web/src/modules/finyk/pages/budgets/Budgets.tsx
@@ -1,6 +1,10 @@
 import { useMemo, useState, useCallback, useEffect, useRef } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import { Skeleton, SkeletonBudgetBar } from "@shared/components/ui/Skeleton";
+import {
+  DataState,
+  type DataStateQueryLike,
+} from "@shared/components/ui/DataState";
 import { calcCategorySpent } from "../../utils";
 import { computeFinykSchedule, startOfToday } from "../../lib/upcomingSchedule";
 import { FinykStatsStrip } from "../../components/FinykStatsStrip";
@@ -305,22 +309,29 @@ export function Budgets({
     resetForm();
   };
 
-  if (loadingTx && realTx.length === 0) {
-    return (
-      <div
-        className="flex-1 overflow-y-auto px-4 pt-4 page-tabbar-pad space-y-3 max-w-4xl mx-auto w-full"
-        aria-busy="true"
-        aria-live="polite"
-      >
-        {/* Shape-aware: header bar + 3 budget rows so the layout doesn't
-            reflow when data lands. */}
-        <Skeleton className="h-28 rounded-2xl" />
-        <SkeletonBudgetBar />
-        <SkeletonBudgetBar className="opacity-80" />
-        <SkeletonBudgetBar className="opacity-60" />
-      </div>
-    );
-  }
+  // DataState contract: `data === undefined` triggers the skeleton slot.
+  // First-paint of the Budgets page treats "loading and no realTx yet" as
+  // initial-load; once data lands we keep rendering even on background
+  // refetches so the page never blanks out.
+  const budgetsQuery: DataStateQueryLike<readonly Transaction[]> = {
+    data: loadingTx && realTx.length === 0 ? undefined : realTx,
+    isLoading: loadingTx,
+  };
+
+  const budgetsLoadingSkeleton = (
+    <div
+      className="flex-1 overflow-y-auto px-4 pt-4 page-tabbar-pad space-y-3 max-w-4xl mx-auto w-full"
+      aria-busy="true"
+      aria-live="polite"
+    >
+      {/* Shape-aware: header bar + 3 budget rows so the layout doesn't
+          reflow when data lands. */}
+      <Skeleton className="h-28 rounded-2xl" />
+      <SkeletonBudgetBar />
+      <SkeletonBudgetBar className="opacity-80" />
+      <SkeletonBudgetBar className="opacity-60" />
+    </div>
+  );
 
   const {
     remaining: remaining2,
@@ -334,89 +345,93 @@ export function Budgets({
   );
 
   return (
-    <div className="flex-1 overflow-y-auto">
-      <div className="max-w-4xl mx-auto px-4 pt-4 page-tabbar-pad space-y-4">
-        {/* Сума підписок + Наступний платіж з тих самих даних, що й на
+    <DataState query={budgetsQuery} skeleton={budgetsLoadingSkeleton}>
+      {() => (
+        <div className="flex-1 overflow-y-auto">
+          <div className="max-w-4xl mx-auto px-4 pt-4 page-tabbar-pad space-y-4">
+            {/* Сума підписок + Наступний платіж з тих самих даних, що й на
             сторінці Активи — без пасив-з-дедлайном тайлу (у Плануванні
             це не релевантно). Зникає цілком, якщо обидва слоти пусті. */}
-        <FinykStatsStrip
-          subsMonthly={schedule.subsMonthly}
-          subsCount={schedule.subsCount}
-          nextCharge={schedule.nextCharge}
-          urgentLiability={null}
-          todayStart={todayStart}
-          showBalance={showBalance}
-        />
+            <FinykStatsStrip
+              subsMonthly={schedule.subsMonthly}
+              subsCount={schedule.subsCount}
+              nextCharge={schedule.nextCharge}
+              urgentLiability={null}
+              todayStart={todayStart}
+              showBalance={showBalance}
+            />
 
-        <MonthlyPlanCard
-          monthlyPlan={monthlyPlan}
-          onChangeMonthlyPlan={setMonthlyPlan}
-          planIncome={planIncome}
-          planExpense={planExpense}
-          planSavings={planSavings}
-          totalExpenseFact={totalExpenseFact}
-          factIncome={factIncome}
-          factSavings={factSavings}
-          remaining={remaining2}
-          safePerDay={safePerDay}
-          pctExpense={pctExpense}
-          isOver={isOver}
-          daysLeft={daysLeft2}
-        />
+            <MonthlyPlanCard
+              monthlyPlan={monthlyPlan}
+              onChangeMonthlyPlan={setMonthlyPlan}
+              planIncome={planIncome}
+              planExpense={planExpense}
+              planSavings={planSavings}
+              totalExpenseFact={totalExpenseFact}
+              factIncome={factIncome}
+              factSavings={factSavings}
+              remaining={remaining2}
+              safePerDay={safePerDay}
+              pctExpense={pctExpense}
+              isOver={isOver}
+              daysLeft={daysLeft2}
+            />
 
-        <BudgetsLimitsSection
-          limitsOpen={limitsOpen}
-          toggleLimits={toggleLimits}
-          monthStart={monthStart}
-          limitBudgets={limitBudgets}
-          budgets={budgets}
-          setBudgets={setBudgets}
-          editIdx={editIdx}
-          setEditIdx={setEditIdx}
-          customCategories={customCategories}
-          calcSpent={calcSpent}
-          proactiveItems={proactiveItems}
-          proactiveAdvice={proactiveAdvice}
-          proactiveLoading={proactiveLoading}
-          dismissedAdvice={dismissedAdvice}
-          dismissAdvice={dismissAdvice}
-          highlightedCategoryId={highlightedCategoryId}
-          limitCardRefs={limitCardRefs}
-          toast={toast}
-        />
+            <BudgetsLimitsSection
+              limitsOpen={limitsOpen}
+              toggleLimits={toggleLimits}
+              monthStart={monthStart}
+              limitBudgets={limitBudgets}
+              budgets={budgets}
+              setBudgets={setBudgets}
+              editIdx={editIdx}
+              setEditIdx={setEditIdx}
+              customCategories={customCategories}
+              calcSpent={calcSpent}
+              proactiveItems={proactiveItems}
+              proactiveAdvice={proactiveAdvice}
+              proactiveLoading={proactiveLoading}
+              dismissedAdvice={dismissedAdvice}
+              dismissAdvice={dismissAdvice}
+              highlightedCategoryId={highlightedCategoryId}
+              limitCardRefs={limitCardRefs}
+              toast={toast}
+            />
 
-        <BudgetsGoalsSection
-          goalsOpen={goalsOpen}
-          toggleGoals={toggleGoals}
-          goalBudgets={goalBudgets}
-          budgets={budgets}
-          setBudgets={setBudgets}
-          editIdx={editIdx}
-          setEditIdx={setEditIdx}
-          now={now}
-          toast={toast}
-        />
+            <BudgetsGoalsSection
+              goalsOpen={goalsOpen}
+              toggleGoals={toggleGoals}
+              goalBudgets={goalBudgets}
+              budgets={budgets}
+              setBudgets={setBudgets}
+              editIdx={editIdx}
+              setEditIdx={setEditIdx}
+              now={now}
+              toast={toast}
+            />
 
-        {showForm ? (
-          <AddBudgetForm
-            formType={formType}
-            newB={newB}
-            onChangeFormType={setFormType}
-            onChangeNewB={setNewB}
-            expenseCategoryList={expenseCategoryList}
-            formError={formError}
-            onSubmit={addBudget}
-            onCancel={resetForm}
-          />
-        ) : (
-          <button
-            onClick={() => setShowForm(true)}
-            className="w-full py-3 text-sm text-muted border border-dashed border-line rounded-xl hover:border-primary hover:text-primary transition-colors"
-          >
-            + Додати ліміт або ціль
-          </button>
-        )}
-      </div>
-    </div>
+            {showForm ? (
+              <AddBudgetForm
+                formType={formType}
+                newB={newB}
+                onChangeFormType={setFormType}
+                onChangeNewB={setNewB}
+                expenseCategoryList={expenseCategoryList}
+                formError={formError}
+                onSubmit={addBudget}
+                onCancel={resetForm}
+              />
+            ) : (
+              <button
+                onClick={() => setShowForm(true)}
+                className="w-full py-3 text-sm text-muted border border-dashed border-line rounded-xl hover:border-primary hover:text-primary transition-colors"
+              >
+                + Додати ліміт або ціль
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </DataState>
   );
 }

--- a/apps/web/src/modules/finyk/pages/transactions/TransactionList.test.tsx
+++ b/apps/web/src/modules/finyk/pages/transactions/TransactionList.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+// `GroupedVirtuoso` needs ResizeObserver / a real layout to render its
+// items. For the DataState routing test we only care which slot is
+// rendered (skeleton / empty / list) — a trivial mock that surfaces
+// children via `groupContent` + `itemContent` is enough.
+vi.mock("react-virtuoso", () => ({
+  GroupedVirtuoso: ({
+    groupCounts,
+    groupContent,
+    itemContent,
+  }: {
+    groupCounts: number[];
+    groupContent: (i: number) => React.ReactNode;
+    itemContent: (i: number) => React.ReactNode;
+  }) => {
+    const total = groupCounts.reduce((s, n) => s + n, 0);
+    return (
+      <div data-testid="grouped-virtuoso">
+        {groupCounts.map((_, gi) => (
+          <div key={`g-${gi}`}>{groupContent(gi)}</div>
+        ))}
+        {Array.from({ length: total }).map((_, i) => (
+          <div key={`i-${i}`}>{itemContent(i)}</div>
+        ))}
+      </div>
+    );
+  },
+}));
+
+import { TransactionList } from "./TransactionList";
+import type { Transaction } from "@sergeant/finyk-domain/domain/types";
+
+/**
+ * Common no-op handlers + maps that every render needs but we don't
+ * exercise in DataState routing tests. Hoisted so each test stays
+ * focused on the props that change branch.
+ */
+const NOOP = (): void => undefined;
+const baseProps = {
+  groupedByDate: [] as { key: string; items: Transaction[] }[],
+  groupCounts: [] as number[],
+  flatItems: [] as Transaction[],
+  collapsedKeys: new Set<string>(),
+  daySummaries: {},
+  showBalance: true,
+  toggleDay: NOOP,
+  selectMode: false,
+  selectedIds: new Set<string>(),
+  hiddenTxIdSet: new Set<string>(),
+  txCategories: {},
+  txSplits: {},
+  accounts: undefined,
+  customCategories: undefined,
+  onToggleSelect: NOOP,
+  onSwipeHideTx: NOOP,
+  onSwipeDeleteManual: NOOP,
+  onEditManual: NOOP,
+  onHideTx: NOOP,
+  onCatChange: NOOP,
+  onSplitChange: NOOP,
+};
+
+const SAMPLE_TX: Transaction = {
+  id: "tx-1",
+  date: "2026-05-04",
+  description: "Сільпо",
+  amount: -250,
+  account: "mono-1",
+} as unknown as Transaction;
+
+describe("TransactionList — DataState routing", () => {
+  // The shared web vitest setup (`src/test/setup.ts`) does not auto-run
+  // `cleanup()` between tests — it stays focused on MSW lifecycle.
+  // Each render here mounts the same scrollable shell, so without
+  // explicit cleanup test N leaks DOM into test N+1 and the assertions
+  // matching by text/testid see duplicates from the previous case.
+  afterEach(() => cleanup());
+
+  it("renders the skeleton slot when first-paint loading and activeTx is empty", () => {
+    render(
+      <TransactionList
+        {...baseProps}
+        loading={true}
+        activeTx={[]}
+        filtered={[]}
+      />,
+    );
+
+    // The skeleton block is the only rendered branch — the live region
+    // we attach is the most stable assertion target.
+    const skeletons = document.querySelectorAll('[aria-busy="true"]');
+    expect(skeletons.length).toBeGreaterThan(0);
+
+    // The empty-state title and the virtualized list must NOT be
+    // rendered while skeleton is on.
+    expect(screen.queryByText("Немає транзакцій")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("grouped-virtuoso")).not.toBeInTheDocument();
+  });
+
+  it("renders the empty slot when not loading and filtered list is empty (with activeTx present)", () => {
+    render(
+      <TransactionList
+        {...baseProps}
+        loading={false}
+        activeTx={[SAMPLE_TX]}
+        filtered={[]}
+      />,
+    );
+
+    expect(screen.getByText("Немає транзакцій")).toBeInTheDocument();
+    expect(screen.queryByTestId("grouped-virtuoso")).not.toBeInTheDocument();
+  });
+
+  it("renders the virtualized list when filtered has rows", () => {
+    render(
+      <TransactionList
+        {...baseProps}
+        loading={false}
+        activeTx={[SAMPLE_TX]}
+        filtered={[SAMPLE_TX]}
+        groupedByDate={[{ key: "2026-05-04", items: [SAMPLE_TX] }]}
+        groupCounts={[1]}
+        flatItems={[SAMPLE_TX]}
+      />,
+    );
+
+    expect(screen.getByTestId("grouped-virtuoso")).toBeInTheDocument();
+    expect(screen.queryByText("Немає транзакцій")).not.toBeInTheDocument();
+  });
+
+  it("keeps the list visible during a background refetch (loading=true with prior activeTx)", () => {
+    // Stale-revalidate: a refetch is in flight but we already have a
+    // payload from the previous tick. The list must NOT collapse to
+    // the skeleton slot — that's the core of the DataState contract
+    // (`data` stays defined while `isLoading` is true).
+    render(
+      <TransactionList
+        {...baseProps}
+        loading={true}
+        activeTx={[SAMPLE_TX]}
+        filtered={[SAMPLE_TX]}
+        groupedByDate={[{ key: "2026-05-04", items: [SAMPLE_TX] }]}
+        groupCounts={[1]}
+        flatItems={[SAMPLE_TX]}
+      />,
+    );
+
+    expect(screen.getByTestId("grouped-virtuoso")).toBeInTheDocument();
+    expect(document.querySelectorAll('[aria-busy="true"]')).toHaveLength(0);
+  });
+});

--- a/apps/web/src/modules/finyk/pages/transactions/TransactionList.tsx
+++ b/apps/web/src/modules/finyk/pages/transactions/TransactionList.tsx
@@ -6,6 +6,10 @@ import { SkeletonTransactionRow } from "@shared/components/ui/Skeleton";
 import { EmptyState } from "@shared/components/ui/EmptyState";
 import { FinykEmptyIllustration } from "@shared/components/ui/EmptyStateIllustrations";
 import { PullToRefresh } from "@shared/components/ui/PullToRefresh";
+import {
+  DataState,
+  type DataStateQueryLike,
+} from "@shared/components/ui/DataState";
 import { cn } from "@shared/lib/ui/cn";
 import { TransactionDayHeader } from "./TransactionDayHeader";
 import type { computeDaySummary } from "./transactionsLib";
@@ -108,107 +112,127 @@ export function TransactionList({
 }: TransactionListProps) {
   const [scrollParent, setScrollParent] = useState<HTMLDivElement | null>(null);
 
+  // DataState contract:
+  //   - `data === undefined` triggers the skeleton slot. We mark the
+  //     query as still-loading only on the very first paint, when the
+  //     parent month list is empty (`activeTx.length === 0`); subsequent
+  //     background refetches keep `data` defined so the existing list
+  //     stays visible while a stale-revalidate happens.
+  //   - `isEmpty` reads the post-filter list (`filtered`) so the empty
+  //     slot shows when filters/exclusions hide every row, not when the
+  //     month payload itself is empty (which the skeleton already covers
+  //     during the first paint).
+  const txQuery: DataStateQueryLike<readonly Transaction[]> = {
+    data: loading && activeTx.length === 0 ? undefined : filtered,
+    isLoading: loading,
+  };
+
+  const skeleton = (
+    // Skeleton — shape-aware: matches a real TxRow (icon · 2-line
+    // description · amount). Stagger fades down so the list feels
+    // like it's "loading from the top" instead of pulsing as a slab.
+    <div className="space-y-2" aria-busy="true" aria-live="polite">
+      {Array(10)
+        .fill(0)
+        .map((_, i) => (
+          <SkeletonTransactionRow
+            key={i}
+            module="finyk"
+            className={cn(
+              i < 3
+                ? "opacity-100"
+                : i < 6
+                  ? "opacity-80"
+                  : i < 8
+                    ? "opacity-60"
+                    : "opacity-40",
+            )}
+          />
+        ))}
+    </div>
+  );
+
+  const emptyFallback = (
+    <div className="rounded-2xl border border-dashed border-line bg-panelHi/40">
+      <EmptyState
+        icon={<FinykEmptyIllustration size={80} />}
+        title="Немає транзакцій"
+        description="Зміни місяць, фільтр або переключи «приховані», якщо вони є."
+      />
+    </div>
+  );
+
   const content = (
     <div className="max-w-4xl mx-auto px-4 pt-4 page-tabbar-pad">
       {header}
-      {/* Skeleton — shape-aware: matches a real TxRow (icon · 2-line
-          description · amount). Stagger fades down so the list feels
-          like it's "loading from the top" instead of pulsing as a slab. */}
-      {loading && activeTx.length === 0 && (
-        <div className="space-y-2" aria-busy="true" aria-live="polite">
-          {Array(10)
-            .fill(0)
-            .map((_, i) => (
-              <SkeletonTransactionRow
-                key={i}
-                module="finyk"
-                className={cn(
-                  i < 3
-                    ? "opacity-100"
-                    : i < 6
-                      ? "opacity-80"
-                      : i < 8
-                        ? "opacity-60"
-                        : "opacity-40",
-                )}
-              />
-            ))}
-        </div>
-      )}
-
-      {/* Empty */}
-      {filtered.length === 0 && !loading && (
-        <div className="rounded-2xl border border-dashed border-line bg-panelHi/40">
-          <EmptyState
-            icon={<FinykEmptyIllustration size={80} />}
-            title="Немає транзакцій"
-            description="Зміни місяць, фільтр або переключи «приховані», якщо вони є."
-          />
-        </div>
-      )}
-
-      {/* Virtualized list */}
-      {filtered.length > 0 && (
-        <div className="rounded-2xl border border-line/40 overflow-hidden -mx-px">
-          <GroupedVirtuoso
-            customScrollParent={scrollParent ?? undefined}
-            groupCounts={groupCounts}
-            increaseViewportBy={{ top: 400, bottom: 400 }}
-            groupContent={(groupIndex) => {
-              const group = groupedByDate[groupIndex];
-              if (!group) return null;
-              const key = group.key;
-              const collapsed = collapsedKeys.has(key);
-              const summary = daySummaries[key] ?? {
-                total: 0,
-                count: 0,
-                statCount: 0,
-              };
-              // Коли у день є тільки «не в статистиці» транзакції, сховати
-              // суму — інакше побачимо «0,00₴» або (як раніше) злиплі
-              // перекази у вигляді доходу.
-              const showTotal = showBalance && summary.statCount > 0;
-              return (
-                <TransactionDayHeader
-                  dayKey={key}
-                  collapsed={collapsed}
-                  summary={summary}
-                  showTotal={showTotal}
-                  onToggle={toggleDay}
-                />
-              );
-            }}
-            itemContent={(index) => {
-              const t = flatItems[index];
-              if (!t) return null;
-              const rowTx = t as TxRowTx;
-              return (
-                <TxListItem
-                  tx={rowTx}
-                  rowIndex={index}
-                  selectMode={selectMode}
-                  selected={selectMode && selectedIds.has(t.id)}
-                  hidden={hiddenTxIdSet.has(t.id)}
-                  overrideCatId={txCategories[t.id]}
-                  txSplits={txSplits}
-                  accounts={accounts ?? []}
-                  hideAmount={!showBalance}
-                  customCategories={customCategories}
-                  onToggleSelect={onToggleSelect}
-                  onSwipeHideTx={onSwipeHideTx}
-                  onSwipeDeleteManual={() => onSwipeDeleteManual(t)}
-                  onEditManual={onEditManual}
-                  onHideTx={onHideTx}
-                  onCatChange={onCatChange}
-                  onSplitChange={(id, splits) =>
-                    onSplitChange(id, (splits ?? []) as TxSplit[])
-                  }
-                />
-              );
-            }}
-          />
-        </div>
-      )}
+      <DataState
+        query={txQuery}
+        skeleton={skeleton}
+        empty={emptyFallback}
+        isEmpty={(data) => data.length === 0}
+      >
+        {() => (
+          <div className="rounded-2xl border border-line/40 overflow-hidden -mx-px">
+            <GroupedVirtuoso
+              customScrollParent={scrollParent ?? undefined}
+              groupCounts={groupCounts}
+              increaseViewportBy={{ top: 400, bottom: 400 }}
+              groupContent={(groupIndex) => {
+                const group = groupedByDate[groupIndex];
+                if (!group) return null;
+                const key = group.key;
+                const collapsed = collapsedKeys.has(key);
+                const summary = daySummaries[key] ?? {
+                  total: 0,
+                  count: 0,
+                  statCount: 0,
+                };
+                // Коли у день є тільки «не в статистиці» транзакції, сховати
+                // суму — інакше побачимо «0,00₴» або (як раніше) злиплі
+                // перекази у вигляді доходу.
+                const showTotal = showBalance && summary.statCount > 0;
+                return (
+                  <TransactionDayHeader
+                    dayKey={key}
+                    collapsed={collapsed}
+                    summary={summary}
+                    showTotal={showTotal}
+                    onToggle={toggleDay}
+                  />
+                );
+              }}
+              itemContent={(index) => {
+                const t = flatItems[index];
+                if (!t) return null;
+                const rowTx = t as TxRowTx;
+                return (
+                  <TxListItem
+                    tx={rowTx}
+                    rowIndex={index}
+                    selectMode={selectMode}
+                    selected={selectMode && selectedIds.has(t.id)}
+                    hidden={hiddenTxIdSet.has(t.id)}
+                    overrideCatId={txCategories[t.id]}
+                    txSplits={txSplits}
+                    accounts={accounts ?? []}
+                    hideAmount={!showBalance}
+                    customCategories={customCategories}
+                    onToggleSelect={onToggleSelect}
+                    onSwipeHideTx={onSwipeHideTx}
+                    onSwipeDeleteManual={() => onSwipeDeleteManual(t)}
+                    onEditManual={onEditManual}
+                    onHideTx={onHideTx}
+                    onCatChange={onCatChange}
+                    onSplitChange={(id, splits) =>
+                      onSplitChange(id, (splits ?? []) as TxSplit[])
+                    }
+                  />
+                );
+              }}
+            />
+          </div>
+        )}
+      </DataState>
 
       {trailing}
     </div>


### PR DESCRIPTION
## Summary

Адаптуємо `<DataState>` wrapper у фінансових сторінках finyk: Overview, Budgets та `TransactionList`. Замінюємо ad-hoc патерн `if (loadingTx && realTx.length === 0) return <Skeleton />` на єдиний presentational-врапер з контрактом «`data === undefined` → skeleton; `data` визначено → content (навіть під час background refetch)».

- **Overview** (`apps/web/src/modules/finyk/pages/Overview.tsx`): skeleton/контент роутяться через `<DataState>`. Bottom-of-page «Оновлення…» індикатор лишається керованим `loadingTx`, тож stale-revalidate видно як раніше.
- **Budgets** (`apps/web/src/modules/finyk/pages/budgets/Budgets.tsx`): такий самий патерн — skeleton винесено в named slot, контент огорнуто render-prop-ом `<DataState>`.
- **TransactionList** (`apps/web/src/modules/finyk/pages/transactions/TransactionList.tsx`): skeleton + empty + virtualized-list тепер живуть в одному `<DataState>` з `isEmpty=(data) => data.length === 0`. Stale-revalidate тримає список видимим (тільки перший paint трактується як loading).

Поведінка-зберігаюча міграція. Hooks/business logic не змінюються — лише presentation. 0 active consumers `<DataState>` до цього PR; це перші три.

## Governing Skill

- Primary skill: `sergeant-web-ui`
- Secondary skill (if truly needed): `sergeant-feature-delivery` (для DataState contract + RTL test)

## Playbook

- Primary playbook: `docs/playbooks/web-feature-shipping.md`
- Why this playbook: presentational web рефактор з типчеком, ESLint, vitest + RTL і коротким risk-розбором.
- If no playbook matched, why: n/a

## Verification

```bash
pnpm --filter @sergeant/web typecheck
pnpm --filter @sergeant/web lint
pnpm --filter @sergeant/web exec vitest run \
  src/modules/finyk/pages/transactions/TransactionList.test.tsx \
  src/shared/components/ui/DataState.test.tsx
pnpm --filter @sergeant/web test
```

Результати локально:

- `typecheck` — pass.
- `lint` — pass (warnings лише від `sergeant-design/no-hash-router-in-modules` у файлах, які я не торкав; це pre-existing для finyk/fizruk).
- `vitest` (повний suite web) — **2050 passed / 1 failed**. Один failure — `src/test/vercelOutputConfig.test.ts` (шукає `/vercel.json` у repo root, якого немає) — pre-existing, відтворюється на чистому master і непов'язано з цим PR.
- Точково: `TransactionList.test.tsx` — 4/4 pass; `DataState.test.tsx` — 11/11 pass.

Additional checks:

- [x] Local smoke / manual validation completed (vitest + typecheck + lint вище)
- [x] Surface-specific checks completed (DataState contract — `data === undefined` triggers skeleton; persisted data + `isLoading=true` тримає content і не блимає у skeleton; новий RTL test це і фіксує)

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- `docs/initiatives/0011-foundation-adoption-and-process-discipline.md` буде оновлено в окремому follow-up commit / PR після merge обох PR-ів (2.4 і 2.5) — там відмітимо їх як done з лінками. `AGENTS.md` / playbooks / governance / review docs без змін — `<DataState>` API вже задокументовано в `apps/web/src/shared/components/ui/DataState.tsx` JSDoc + `DataState.stories.tsx`.

## Risk and Rollout

- **User-visible risk:** низький. Behavior-preserving presentational refactor — той самий skeleton, той самий empty state, той самий список. RTL test ловить регресії в роутингу slot-ів, у т.ч. stale-while-revalidate (loading=true з вже наявними даними не повинно повертати skeleton).
- **Rollout / deploy order:** звичайний deploy через Vercel preview → master. Без міграцій, без env-змін, без feature-flag.
- **Backout plan:** revert PR; жодних persisted side effects (localStorage / RQ keys / API contracts) не зачеплено.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

- DataState contract (з `apps/web/src/shared/components/ui/DataState.tsx` JSDoc): `data === undefined` тригерить skeleton, наявне `data` тримає content навіть коли `isLoading=true`. У трьох місцях контракт зведено через `loadingTx && realTx.length === 0 ? undefined : realTx`.
- У `TransactionList` `isEmpty` дивиться у `filtered` (post-filter), а skeleton-condition у `activeTx` (pre-filter). Це навмисно: «фільтр сховав усе» ≠ «місяць порожній під час першого завантаження».
- Bottom-of-page «Оновлення…» індикатор у Overview лишився керованим `loadingTx` усередині render-prop-а — DataState навмисно не «з'їдає» цей UX.
- Pre-existing failure `vercelOutputConfig.test.ts` у CI — окрема історія (відсутній `vercel.json` у repo root); не пов'язано з цим PR.
