### PR TITLE
feat(mobile): mobile analytics posthog integration (S0.3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -438,3 +438,13 @@ VITE_API_PROXY_TARGET=http://127.0.0.1:3000
 # жодних подій у Sentry не відправляється.
 # Див. `apps/mobile/src/lib/observability.ts`.
 # EXPO_PUBLIC_SENTRY_DSN=
+#
+# Публічний PostHog ключ для RN-клієнта. Без нього `initPostHog()`
+# на mobile — повний no-op (жодного fetch у `/capture/`). Цей самий
+# проєкт мусить використовуватись у `VITE_POSTHOG_KEY` (web) і
+# `POSTHOG_API_KEY` (server-side cleanup), щоб mobile + web ділились
+# спільним funnel-ом і person-properties.
+# Див. `apps/mobile/src/lib/observability/posthog.ts`.
+# EXPO_PUBLIC_POSTHOG_KEY=phc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# Host за замовчуванням — EU Cloud, парний до `VITE_POSTHOG_HOST`.
+# EXPO_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -14,6 +14,7 @@ import { ApiClientProvider } from "@sergeant/api-client/react";
 import { apiClient } from "@/api/apiClient";
 import { SyncStatusOverlay } from "@/core/SyncStatusOverlay";
 import { ColorSchemeBridge } from "@/core/theme/ColorSchemeBridge";
+import { AnalyticsIdentityBridge } from "@/features/analytics/AnalyticsIdentityBridge";
 import { PushRegistrar } from "@/features/push/PushRegistrar";
 // Registers the mobile `expo-haptics`-based adapter on the shared
 // haptic contract (`@sergeant/shared`). Import for side effects only.
@@ -28,6 +29,7 @@ import "@/lib/fileImport";
 // visual-keyboard-inset contract (`@sergeant/shared`). Import for side
 // effects only.
 import "@/hooks/useVisualKeyboardInset";
+import { initPostHog } from "@/lib/analytics";
 import { captureError, initObservability } from "@/lib/observability";
 import { bootstrapEncryptedStorage } from "@/lib/storageEncryption";
 import { useDeepLinks } from "@/lib/useDeepLinks";
@@ -99,6 +101,10 @@ export default function RootLayout() {
 
   useEffect(() => {
     initObservability();
+    // Boot PostHog after Sentry — fire-and-forget. Без
+    // `EXPO_PUBLIC_POSTHOG_KEY` це повний no-op (жодного fetch),
+    // тож локальний dev і CI без секрету не платять нічого.
+    void initPostHog();
   }, []);
 
   useEffect(() => {
@@ -153,6 +159,7 @@ export default function RootLayout() {
                 <RootShell />
                 <ToastContainer />
                 <PushRegistrar />
+                <AnalyticsIdentityBridge />
               </ToastProvider>
             </CloudSyncProvider>
           </ApiClientProvider>

--- a/apps/mobile/src/features/analytics/AnalyticsIdentityBridge.test.tsx
+++ b/apps/mobile/src/features/analytics/AnalyticsIdentityBridge.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Jest coverage for `<AnalyticsIdentityBridge/>`. Mocks `useUser()`
+ * and the PostHog transport so we can drive identify/reset transitions
+ * deterministically — same idea as `PushRegistrar`-style bridges.
+ */
+
+import { render } from "@testing-library/react-native";
+
+const useUserMock = jest.fn();
+
+jest.mock("@sergeant/api-client/react", () => ({
+  __esModule: true,
+  useUser: () => useUserMock(),
+}));
+
+jest.mock("@/lib/observability/posthog", () => ({
+  __esModule: true,
+  identifyPostHogUser: jest.fn(),
+  resetPostHog: jest.fn(),
+}));
+
+jest.mock("@/lib/observability/identifyTraits", () => ({
+  __esModule: true,
+  buildIdentifyTraits: jest.fn((user: { id: string }) => ({
+    plan: "free",
+    _id: user.id,
+  })),
+}));
+
+import { AnalyticsIdentityBridge } from "./AnalyticsIdentityBridge";
+import { buildIdentifyTraits } from "@/lib/observability/identifyTraits";
+import { identifyPostHogUser, resetPostHog } from "@/lib/observability/posthog";
+
+const identifyMock = identifyPostHogUser as jest.Mock;
+const resetMock = resetPostHog as jest.Mock;
+const buildTraitsMock = buildIdentifyTraits as jest.Mock;
+
+const SAMPLE_USER = {
+  id: "user-1",
+  email: "u@example.com",
+  name: null,
+  image: null,
+  emailVerified: true,
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
+
+describe("AnalyticsIdentityBridge", () => {
+  beforeEach(() => {
+    useUserMock.mockReset();
+    identifyMock.mockReset();
+    resetMock.mockReset();
+    buildTraitsMock.mockClear();
+  });
+
+  it("не викликає identify/reset поки isPending=true", () => {
+    useUserMock.mockReturnValue({ data: undefined, isPending: true });
+
+    render(<AnalyticsIdentityBridge />);
+
+    expect(identifyMock).not.toHaveBeenCalled();
+    expect(resetMock).not.toHaveBeenCalled();
+  });
+
+  it("викликає identify коли зʼявляється userId", () => {
+    useUserMock.mockReturnValue({
+      data: { user: SAMPLE_USER },
+      isPending: false,
+    });
+
+    render(<AnalyticsIdentityBridge />);
+
+    expect(buildTraitsMock).toHaveBeenCalledWith(SAMPLE_USER);
+    expect(identifyMock).toHaveBeenCalledWith("user-1", {
+      plan: "free",
+      _id: "user-1",
+    });
+    expect(resetMock).not.toHaveBeenCalled();
+  });
+
+  it("re-render із тим самим userId не дублює identify", () => {
+    useUserMock.mockReturnValue({
+      data: { user: SAMPLE_USER },
+      isPending: false,
+    });
+
+    const { rerender } = render(<AnalyticsIdentityBridge />);
+    rerender(<AnalyticsIdentityBridge />);
+
+    expect(identifyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("викликає reset на переході authenticated → unauthenticated", () => {
+    useUserMock.mockReturnValue({
+      data: { user: SAMPLE_USER },
+      isPending: false,
+    });
+    const { rerender } = render(<AnalyticsIdentityBridge />);
+    expect(identifyMock).toHaveBeenCalledTimes(1);
+
+    useUserMock.mockReturnValue({
+      data: { user: null },
+      isPending: false,
+    });
+    rerender(<AnalyticsIdentityBridge />);
+
+    expect(resetMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("при cold-start без сесії (user=null від першого fetch) не викликає reset", () => {
+    useUserMock.mockReturnValue({
+      data: { user: null },
+      isPending: false,
+    });
+
+    render(<AnalyticsIdentityBridge />);
+
+    expect(resetMock).not.toHaveBeenCalled();
+    expect(identifyMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/features/analytics/AnalyticsIdentityBridge.tsx
+++ b/apps/mobile/src/features/analytics/AnalyticsIdentityBridge.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useRef } from "react";
+
+import { useUser } from "@sergeant/api-client/react";
+
+import { buildIdentifyTraits } from "@/lib/observability/identifyTraits";
+import { identifyPostHogUser, resetPostHog } from "@/lib/observability/posthog";
+
+/**
+ * No-UI компонент, що монтується у root-дереві (`app/_layout.tsx`) і
+ * мостить `useUser()` стан у PostHog `identify` / `reset` виклики —
+ * mobile-аналог `apps/web/src/core/auth/AuthContext.tsx` блоку, що
+ * викликає `identifyPostHogUser` / `resetPostHog` після login/logout.
+ *
+ * Чому окремий компонент, а не хук у `_layout.tsx`: root layout
+ * рендериться над `(auth)` і `(tabs)` групами, тож `useUser()` мусить
+ * жити всередині `<ApiClientProvider>`. Це той самий патерн, що
+ * `<PushRegistrar/>` і `<CloudSyncProvider/>` уже використовують.
+ *
+ * Помилки `identify` / `reset` свідомо не логуємо: транспорт у
+ * `posthog.ts` уже fire-and-forget і ловить власні throws.
+ */
+export function AnalyticsIdentityBridge() {
+  const { data, isPending } = useUser();
+  const user = data?.user ?? null;
+
+  // Послідовність login → logout → login повертає `useUser` через
+  // `null`. Кешуємо останній id, щоб реагувати тільки на справжні
+  // переходи: `identifyPostHogUser` робить $anon_distinct_id stitch
+  // тільки коли `userId` змінився.
+  const lastIdentifiedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    // Поки `useUser` не завершила перший fetch — ні identify, ні
+    // reset. Це уникає помилкового `reset` під час cold-start, поки
+    // session-cookie ще ширяє у Better Auth.
+    if (isPending) return;
+
+    if (user?.id) {
+      if (lastIdentifiedRef.current === user.id) return;
+      lastIdentifiedRef.current = user.id;
+      // Cast у `Record<string, unknown>` — `IdentifyTraits` має іменовані
+      // опціональні поля без index-signature, тому TS не звужує його до
+      // record-у автоматично. Контракт `identifyPostHogUser` приймає
+      // довільний bag-of-properties — типи трейтів захищає сам
+      // `buildIdentifyTraits`.
+      identifyPostHogUser(
+        user.id,
+        buildIdentifyTraits(user) as Record<string, unknown>,
+      );
+      return;
+    }
+
+    // Перехід authenticated → unauthenticated: скидаємо distinct_id у
+    // PostHog, щоб події post-logout не атрибутувались попередньому
+    // юзеру.
+    if (lastIdentifiedRef.current !== null) {
+      lastIdentifiedRef.current = null;
+      resetPostHog();
+    }
+  }, [isPending, user]);
+
+  return null;
+}

--- a/apps/mobile/src/lib/__tests__/analytics.test.ts
+++ b/apps/mobile/src/lib/__tests__/analytics.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Jest coverage for `trackEvent` — verifies the dual-transport
+ * contract: console.log breadcrumb + handoff to PostHog. PostHog
+ * itself is mocked at module level so we don't touch fetch.
+ */
+
+jest.mock("../observability/posthog", () => ({
+  __esModule: true,
+  capturePostHogEvent: jest.fn(),
+  initPostHog: jest.fn(),
+  identifyPostHogUser: jest.fn(),
+  resetPostHog: jest.fn(),
+}));
+
+import { trackEvent, ANALYTICS_EVENTS } from "../analytics";
+import { capturePostHogEvent } from "../observability/posthog";
+
+const captureMock = capturePostHogEvent as jest.Mock;
+
+describe("trackEvent", () => {
+  let consoleLogSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    captureMock.mockReset();
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+  });
+
+  it("логує у console.log і викликає capturePostHogEvent", () => {
+    trackEvent(ANALYTICS_EVENTS.ONBOARDING_STARTED, { source: "demo" });
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      "[analytics]",
+      expect.objectContaining({
+        eventName: "onboarding_started",
+        payload: { source: "demo" },
+      }),
+    );
+    expect(captureMock).toHaveBeenCalledWith("onboarding_started", {
+      source: "demo",
+    });
+  });
+
+  it("ігнорує порожній eventName", () => {
+    trackEvent("");
+    expect(captureMock).not.toHaveBeenCalled();
+  });
+
+  it("ловить throw з PostHog-транспорта і не валиться", () => {
+    captureMock.mockImplementation(() => {
+      throw new Error("transport down");
+    });
+
+    expect(() => trackEvent("test_event", { foo: "bar" })).not.toThrow();
+    expect(captureMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("payload без обʼєкта замінюється на {}", () => {
+    trackEvent("typed_event");
+    expect(captureMock).toHaveBeenCalledWith("typed_event", {});
+  });
+});

--- a/apps/mobile/src/lib/__tests__/identifyTraits.test.ts
+++ b/apps/mobile/src/lib/__tests__/identifyTraits.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Jest coverage for `buildIdentifyTraits` (mobile). Mirrors the web
+ * suite — same toleration semantics, but reads vibe-picks via
+ * `mobileKVStore` (MMKV) instead of localStorage.
+ */
+
+const getVibePicksMock = jest.fn();
+
+jest.mock("@sergeant/shared", () => {
+  const actual = jest.requireActual("@sergeant/shared") as object;
+  return {
+    __esModule: true,
+    ...actual,
+    getVibePicks: (...args: unknown[]) => getVibePicksMock(...args),
+  };
+});
+
+jest.mock("@/lib/storage", () => ({
+  __esModule: true,
+  mobileKVStore: { getString: jest.fn(), setString: jest.fn() },
+}));
+
+import type { User } from "@sergeant/shared";
+
+import { buildIdentifyTraits } from "../observability/identifyTraits";
+
+const BASE_USER: User = {
+  id: "user-123",
+  email: "test@example.com",
+  name: "Тест",
+  image: null,
+  emailVerified: true,
+  createdAt: "2026-01-15T08:30:00.000Z",
+};
+
+beforeEach(() => {
+  getVibePicksMock.mockReset().mockReturnValue([]);
+});
+
+describe("buildIdentifyTraits (mobile)", () => {
+  it("повертає plan + vibe + signup_date коли всі джерела заповнені", () => {
+    getVibePicksMock.mockReturnValue(["finyk", "fizruk"]);
+
+    const traits = buildIdentifyTraits(BASE_USER);
+
+    expect(traits).toEqual({
+      vibe: ["finyk", "fizruk"],
+      plan: "free",
+      signup_date: "2026-01-15",
+    });
+  });
+
+  it("опускає vibe, якщо vibe-picks порожні", () => {
+    getVibePicksMock.mockReturnValue([]);
+    const traits = buildIdentifyTraits(BASE_USER);
+    expect(traits).not.toHaveProperty("vibe");
+  });
+
+  it("опускає vibe, якщо getVibePicks кинув", () => {
+    getVibePicksMock.mockImplementation(() => {
+      throw new Error("MMKV unavailable");
+    });
+    const traits = buildIdentifyTraits(BASE_USER);
+    expect(traits).not.toHaveProperty("vibe");
+  });
+
+  it("опускає signup_date, якщо createdAt = null", () => {
+    const traits = buildIdentifyTraits({ ...BASE_USER, createdAt: null });
+    expect(traits).not.toHaveProperty("signup_date");
+  });
+
+  it("опускає signup_date, якщо createdAt не парситься", () => {
+    const traits = buildIdentifyTraits({
+      ...BASE_USER,
+      createdAt: "not-a-date",
+    });
+    expect(traits).not.toHaveProperty("signup_date");
+  });
+
+  it("signup_date — це YYYY-MM-DD у UTC", () => {
+    const traits = buildIdentifyTraits({
+      ...BASE_USER,
+      createdAt: "2026-01-15T02:30:00.000Z",
+    });
+    expect(traits.signup_date).toBe("2026-01-15");
+  });
+
+  it("plan завжди 'free' до запуску білінгу", () => {
+    const traits = buildIdentifyTraits(BASE_USER);
+    expect(traits.plan).toBe("free");
+  });
+});

--- a/apps/mobile/src/lib/__tests__/posthog.test.ts
+++ b/apps/mobile/src/lib/__tests__/posthog.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Jest coverage for the mobile PostHog transport — no-op gating around
+ * `EXPO_PUBLIC_POSTHOG_KEY`, fetch-handoff when the key is set, queue
+ * buffering before init completes, and identify/reset semantics.
+ *
+ * The env read is mocked through `./posthogEnv` so tests can drive
+ * both branches without fighting Expo's babel `EXPO_PUBLIC_*`
+ * inlining. `mobileKVStore` is mocked to keep the test deterministic
+ * and decouple it from the real MMKV instance.
+ */
+
+jest.mock("../observability/posthogEnv", () => ({
+  __esModule: true,
+  getPostHogKey: jest.fn(),
+  getPostHogHost: jest.fn(() => "https://eu.i.posthog.com"),
+}));
+
+jest.mock("@/lib/storage", () => {
+  const map = new Map<string, string>();
+  return {
+    __esModule: true,
+    mobileKVStore: {
+      getString: jest.fn((key: string) => map.get(key) ?? null),
+      setString: jest.fn((key: string, value: string) => {
+        map.set(key, value);
+      }),
+      remove: jest.fn((key: string) => {
+        map.delete(key);
+      }),
+      onChange: jest.fn(() => () => {}),
+    },
+    __mockClear: () => map.clear(),
+  };
+});
+
+import {
+  __resetPostHogForTests,
+  capturePostHogEvent,
+  identifyPostHogUser,
+  initPostHog,
+  resetPostHog,
+} from "../observability/posthog";
+import { getPostHogHost, getPostHogKey } from "../observability/posthogEnv";
+
+const getKeyMock = getPostHogKey as jest.Mock;
+const getHostMock = getPostHogHost as jest.Mock;
+
+const mockedStorage = jest.requireMock("@/lib/storage") as {
+  __mockClear: () => void;
+  mobileKVStore: { getString: jest.Mock; setString: jest.Mock };
+};
+
+describe("mobile posthog transport", () => {
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    __resetPostHogForTests();
+    mockedStorage.__mockClear();
+    mockedStorage.mobileKVStore.getString.mockClear();
+    mockedStorage.mobileKVStore.setString.mockClear();
+    getKeyMock.mockReset();
+    getHostMock.mockReset().mockReturnValue("https://eu.i.posthog.com");
+    fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      text: jest.fn().mockResolvedValue(""),
+    });
+    (globalThis as { fetch?: unknown }).fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    delete (globalThis as { fetch?: unknown }).fetch;
+  });
+
+  describe("initPostHog", () => {
+    it("без EXPO_PUBLIC_POSTHOG_KEY — повний no-op (жодного fetch)", async () => {
+      getKeyMock.mockReturnValue(undefined);
+
+      await initPostHog();
+      capturePostHogEvent("test_event", { foo: "bar" });
+      identifyPostHogUser("user-1");
+      resetPostHog();
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("ідемпотентний — повторний виклик повертає той самий promise", async () => {
+      getKeyMock.mockReturnValue("phc_test");
+
+      const a = initPostHog();
+      const b = initPostHog();
+
+      expect(a).toBe(b);
+      await a;
+    });
+
+    it("персистить distinct_id у MMKV", async () => {
+      getKeyMock.mockReturnValue("phc_test");
+
+      await initPostHog();
+
+      expect(mockedStorage.mobileKVStore.setString).toHaveBeenCalledWith(
+        "sergeant.mobile.posthog.distinct_id.v1",
+        expect.stringMatching(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+        ),
+      );
+    });
+  });
+
+  describe("capturePostHogEvent", () => {
+    it("шле подію у /capture/ після init", async () => {
+      getKeyMock.mockReturnValue("phc_test");
+      await initPostHog();
+
+      capturePostHogEvent("onboarding_started", { source: "demo" });
+      // event POST is async — wait a tick
+      await Promise.resolve();
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0] as [
+        string,
+        { method: string; body: string },
+      ];
+      expect(url).toBe("https://eu.i.posthog.com/capture/");
+      expect(init.method).toBe("POST");
+      const parsed = JSON.parse(init.body) as {
+        api_key: string;
+        event: string;
+        distinct_id: string;
+        properties: Record<string, unknown>;
+      };
+      expect(parsed.api_key).toBe("phc_test");
+      expect(parsed.event).toBe("onboarding_started");
+      expect(parsed.distinct_id).toMatch(/^[0-9a-f-]{36}$/);
+      expect(parsed.properties).toMatchObject({
+        platform: expect.any(String),
+        is_capacitor: false,
+        is_expo: true,
+        source: "demo",
+      });
+    });
+
+    it("буферизує події до завершення init і потім флешить", async () => {
+      getKeyMock.mockReturnValue("phc_test");
+      // Не await — фіксуємо стан "init у процесі".
+      const initOnce = initPostHog();
+      capturePostHogEvent("queued_a");
+      capturePostHogEvent("queued_b");
+
+      await initOnce;
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const eventNames = fetchMock.mock.calls.map((call) => {
+        const body = call[1] as { body: string };
+        return (JSON.parse(body.body) as { event: string }).event;
+      });
+      expect(eventNames).toEqual(
+        expect.arrayContaining(["queued_a", "queued_b"]),
+      );
+    });
+
+    it("без ключа — не накопичує події у черзі (queue не росте)", async () => {
+      getKeyMock.mockReturnValue(undefined);
+      // Лиш `initPostHog` робить ранній resolve без зміни стану — без
+      // нього `enqueue` все одно не повинен спрацьовувати, бо
+      // `capturePostHogEvent` сам перевіряє ключ.
+      for (let i = 0; i < 200; i += 1) {
+        capturePostHogEvent(`drop_${i}`);
+      }
+      // Вмикаємо ключ і чекаємо init — нічого не повинно злетіти.
+      getKeyMock.mockReturnValue("phc_test");
+      await initPostHog();
+      await Promise.resolve();
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("ігнорує fetch-throw і не валиться", async () => {
+      getKeyMock.mockReturnValue("phc_test");
+      fetchMock.mockRejectedValueOnce(new Error("network down"));
+      await initPostHog();
+
+      expect(() => capturePostHogEvent("network_test")).not.toThrow();
+      await Promise.resolve();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("identifyPostHogUser", () => {
+    it("шле $identify з $anon_distinct_id stitch на першому login", async () => {
+      getKeyMock.mockReturnValue("phc_test");
+      await initPostHog();
+      const initialId = mockedStorage.mobileKVStore.setString.mock.calls.find(
+        ([key]) => key === "sergeant.mobile.posthog.distinct_id.v1",
+      )?.[1] as string;
+
+      identifyPostHogUser("user-42", { plan: "free" });
+      await Promise.resolve();
+
+      const identifyCall = fetchMock.mock.calls.find((call) => {
+        const body = call[1] as { body: string };
+        return (
+          (JSON.parse(body.body) as { event: string }).event === "$identify"
+        );
+      });
+      expect(identifyCall).toBeDefined();
+      const parsed = JSON.parse(
+        (identifyCall![1] as { body: string }).body,
+      ) as {
+        distinct_id: string;
+        properties: Record<string, unknown>;
+      };
+      expect(parsed.distinct_id).toBe("user-42");
+      expect(parsed.properties.$anon_distinct_id).toBe(initialId);
+      expect(parsed.properties.$set).toEqual({ plan: "free" });
+    });
+
+    it("персистить новий distinct_id у MMKV", async () => {
+      getKeyMock.mockReturnValue("phc_test");
+      await initPostHog();
+      mockedStorage.mobileKVStore.setString.mockClear();
+
+      identifyPostHogUser("user-99");
+      await Promise.resolve();
+
+      expect(mockedStorage.mobileKVStore.setString).toHaveBeenCalledWith(
+        "sergeant.mobile.posthog.distinct_id.v1",
+        "user-99",
+      );
+    });
+  });
+
+  describe("resetPostHog", () => {
+    it("re-roll-ить anon distinct_id після logout", async () => {
+      getKeyMock.mockReturnValue("phc_test");
+      await initPostHog();
+
+      identifyPostHogUser("user-1");
+      await Promise.resolve();
+      mockedStorage.mobileKVStore.setString.mockClear();
+
+      resetPostHog();
+
+      expect(mockedStorage.mobileKVStore.setString).toHaveBeenCalledWith(
+        "sergeant.mobile.posthog.distinct_id.v1",
+        expect.stringMatching(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+        ),
+      );
+      // Verify the new anon id is NOT the user id.
+      const written = mockedStorage.mobileKVStore.setString.mock.calls[0][1];
+      expect(written).not.toBe("user-1");
+    });
+  });
+});

--- a/apps/mobile/src/lib/analytics.ts
+++ b/apps/mobile/src/lib/analytics.ts
@@ -1,25 +1,49 @@
 /**
- * Mobile analytics sink (Phase 1).
+ * Mobile analytics sink.
  *
- * Today this is a console logger only — mirrors web's `trackEvent`
- * contract so call sites can stay consistent across platforms.
+ * Подвійний transport — той самий контракт, що й у
+ * `apps/web/src/core/observability/analytics.ts`:
+ *
+ *   1. `console.log("[analytics]", …)` — devtools і Sentry breadcrumbs.
+ *      Працює завжди.
+ *   2. PostHog — якщо виставлений `EXPO_PUBLIC_POSTHOG_KEY`. Транспорт
+ *      живе у `./observability/posthog.ts`; події fire-and-forget,
+ *      буферизуються до завершення `initPostHog()`.
  */
 import { ANALYTICS_EVENTS, type AnalyticsEventName } from "@sergeant/shared";
 
+import { capturePostHogEvent } from "./observability/posthog";
+
 export { ANALYTICS_EVENTS };
+export {
+  initPostHog,
+  identifyPostHogUser,
+  resetPostHog,
+} from "./observability/posthog";
 
 export function trackEvent(
   eventName: AnalyticsEventName | string,
   payload?: object,
 ) {
   if (!eventName || typeof eventName !== "string") return;
+  const safePayload =
+    payload && typeof payload === "object" ? (payload as object) : {};
   try {
     console.log("[analytics]", {
       eventName,
-      payload: payload && typeof payload === "object" ? payload : {},
+      payload: safePayload,
       timestamp: new Date().toISOString(),
     });
   } catch {
     /* noop */
+  }
+  // Окремий try/catch — `trackEvent` контракт каже "ніколи не кидає"
+  // (див. шапку файлу). Транспорт сам по собі захищений від throw,
+  // але `import.meta.env`-style edge-кейси у jest-середовищі краще
+  // відсікати ще на верхньому рівні.
+  try {
+    capturePostHogEvent(eventName, safePayload as Record<string, unknown>);
+  } catch {
+    /* PostHog transport never breaks trackEvent callers */
   }
 }

--- a/apps/mobile/src/lib/observability/identifyTraits.ts
+++ b/apps/mobile/src/lib/observability/identifyTraits.ts
@@ -1,0 +1,72 @@
+/**
+ * PostHog person traits for the Expo app — mobile counterpart of
+ * `apps/web/src/core/observability/identifyTraits.ts`.
+ *
+ * Контракт навмисно вузький — той самий набір полів, що web:
+ *   - `vibe` — масив id вкладок з онбордингу (читаємо з MMKV через
+ *     `mobileKVStore`). Якщо порожній — поле опускаємо, щоб не
+ *     перетирати раніше встановлений person property у PostHog.
+ *   - `plan` — поточний tier підписки. До запуску білінгу — `"free"`.
+ *   - `locale` — поки немає mobile-equivalent для `navigator.language`,
+ *     поле опускаємо. Web заповнює його сам, тож для користувача,
+ *     який спершу зайшов з браузера, а потім з Expo, locale збережеться.
+ *   - `signup_date` — `YYYY-MM-DD` у UTC з `user.createdAt`.
+ */
+
+import {
+  getVibePicks,
+  type DashboardModuleId,
+  type User,
+} from "@sergeant/shared";
+
+import { mobileKVStore } from "@/lib/storage";
+
+export interface IdentifyTraits {
+  vibe?: DashboardModuleId[];
+  plan?: "free" | "pro";
+  signup_date?: string;
+}
+
+function safeVibePicks(): DashboardModuleId[] {
+  try {
+    return getVibePicks(mobileKVStore);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Перетворює ISO-рядок з `user.createdAt` у `YYYY-MM-DD` (UTC).
+ * Будь-яке не-ISO значення → `null` (а не throw): identify навмисно
+ * толерантний до зіпсованих legacy-юзерів.
+ */
+function toSignupDate(createdAt: string | null | undefined): string | null {
+  if (!createdAt) return null;
+  const d = new Date(createdAt);
+  if (Number.isNaN(d.getTime())) return null;
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(d.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function currentPlan(): "free" | "pro" {
+  return "free";
+}
+
+/**
+ * Будує traits-обʼєкт для PostHog `identify`. Опускає поля, у яких
+ * джерело недоступне, щоб не перетирати раніше встановлені person
+ * properties у PostHog порожнім значенням.
+ */
+export function buildIdentifyTraits(user: User): IdentifyTraits {
+  const traits: IdentifyTraits = { plan: currentPlan() };
+
+  const vibe = safeVibePicks();
+  if (vibe.length > 0) traits.vibe = vibe;
+
+  const signupDate = toSignupDate(user.createdAt);
+  if (signupDate) traits.signup_date = signupDate;
+
+  return traits;
+}

--- a/apps/mobile/src/lib/observability/posthog.ts
+++ b/apps/mobile/src/lib/observability/posthog.ts
@@ -1,0 +1,298 @@
+/**
+ * PostHog transport for the Expo app — mobile parity for S0.3.
+ *
+ * Mirrors the API of `apps/web/src/core/observability/posthog.ts` so
+ * call-sites (`trackEvent`, auth-context bridge) stay identical across
+ * platforms. The web side uses lazy `import("posthog-js")`; here we
+ * post directly to PostHog's public capture endpoint via `fetch`.
+ *
+ * Why no `posthog-react-native` dep:
+ *   - Capture is the only surface we need today (no autocapture, no
+ *     session replay, no surveys). The HTTP `/capture/` endpoint
+ *     covers `event` / `$identify` / `$set` cleanly.
+ *   - Keeps the mobile bundle smaller and avoids pulling in a new
+ *     native module on top of the existing observability stack.
+ *
+ * Без `EXPO_PUBLIC_POSTHOG_KEY` — повний no-op: `fetch` не викликається,
+ * події живуть тільки у локальному `console.log` всередині
+ * `analytics.ts`. Поведінка симетрична web-варіанту під відсутній
+ * `VITE_POSTHOG_KEY`.
+ *
+ * Контракт:
+ *   - `initPostHog()` — викликається один раз з `app/_layout.tsx`
+ *     після монтування. Ідемпотентний.
+ *   - `capturePostHogEvent(name, payload)` — fire-and-forget. Події
+ *     до завершення init буферизуються (до `MAX_QUEUE`), після —
+ *     летять напряму у `fetch`.
+ *   - `identifyPostHogUser(userId, traits)` / `resetPostHog()` —
+ *     після login / sign-out з `AnalyticsIdentityBridge`.
+ */
+
+import { Platform } from "react-native";
+
+import { mobileKVStore } from "@/lib/storage";
+
+import { getPostHogHost, getPostHogKey } from "./posthogEnv";
+
+/** MMKV key under which the persisted anonymous distinct_id lives. */
+const DISTINCT_ID_KEY = "sergeant.mobile.posthog.distinct_id.v1";
+
+const MAX_QUEUE = 100;
+
+type CaptureProperties = Record<string, unknown>;
+
+type QueuedCall =
+  | { kind: "capture"; name: string; payload: CaptureProperties }
+  | { kind: "identify"; userId: string; traits?: CaptureProperties }
+  | { kind: "reset" };
+
+interface PostHogState {
+  apiKey: string;
+  apiHost: string;
+  /** Active distinct_id — anonymous UUID until `identify`, then user id. */
+  distinctId: string;
+  /** Last `identify` traits, re-merged into every capture as `$set`. */
+  traits: CaptureProperties | null;
+}
+
+let state: PostHogState | null = null;
+let initPromise: Promise<void> | null = null;
+let initFailed = false;
+let queue: QueuedCall[] = [];
+
+function safeRandomId(): string {
+  // Cheap RFC4122-shape random id. Crypto strength is irrelevant —
+  // PostHog only uses distinct_id as an opaque bucket.
+  const hex = "0123456789abcdef";
+  let out = "";
+  for (let i = 0; i < 32; i += 1) out += hex[Math.floor(Math.random() * 16)];
+  return `${out.slice(0, 8)}-${out.slice(8, 12)}-${out.slice(12, 16)}-${out.slice(16, 20)}-${out.slice(20)}`;
+}
+
+function loadOrCreateAnonId(): string {
+  try {
+    const cached = mobileKVStore.getString(DISTINCT_ID_KEY);
+    if (cached && cached.length > 0) return cached;
+  } catch {
+    /* fall through to fresh id */
+  }
+  const fresh = safeRandomId();
+  try {
+    mobileKVStore.setString(DISTINCT_ID_KEY, fresh);
+  } catch {
+    /* MMKV unavailable in cold-start; in-memory id still works for the session */
+  }
+  return fresh;
+}
+
+function persistDistinctId(id: string): void {
+  try {
+    mobileKVStore.setString(DISTINCT_ID_KEY, id);
+  } catch {
+    /* noop — analytics must never throw */
+  }
+}
+
+function flushQueue(): void {
+  if (!state) return;
+  const drained = queue;
+  queue = [];
+  for (const call of drained) {
+    if (call.kind === "capture") {
+      void postCapture(call.name, call.payload);
+    } else if (call.kind === "identify") {
+      void postIdentify(call.userId, call.traits);
+    } else {
+      handleReset();
+    }
+  }
+}
+
+function enqueue(call: QueuedCall): void {
+  if (queue.length >= MAX_QUEUE) queue.shift();
+  queue.push(call);
+}
+
+/**
+ * Build the `properties` payload merged into every `/capture/` POST.
+ * Mirrors web's `posthog.register({ platform, is_capacitor })` plus an
+ * `is_expo` flag so funnels can split mobile-Expo from web-Capacitor
+ * without inspecting `platform` alone.
+ */
+function buildSuperProperties(): CaptureProperties {
+  return {
+    platform: Platform.OS,
+    is_capacitor: false,
+    is_expo: true,
+  };
+}
+
+async function postCapture(
+  eventName: string,
+  payload: CaptureProperties,
+): Promise<void> {
+  if (!state) return;
+  const properties: CaptureProperties = {
+    ...buildSuperProperties(),
+    ...payload,
+  };
+  if (state.traits) {
+    // PostHog convention: `$set` on a capture event updates person
+    // properties without requiring a separate `$identify` per call.
+    properties.$set = state.traits;
+  }
+  const body = JSON.stringify({
+    api_key: state.apiKey,
+    distinct_id: state.distinctId,
+    event: eventName,
+    properties,
+    timestamp: new Date().toISOString(),
+  });
+  try {
+    await fetch(`${state.apiHost.replace(/\/$/, "")}/capture/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+    });
+  } catch {
+    /* analytics must never break the host app */
+  }
+}
+
+async function postIdentify(
+  userId: string,
+  traits?: CaptureProperties,
+): Promise<void> {
+  if (!state) return;
+  const previousId = state.distinctId;
+  state.distinctId = userId;
+  state.traits = traits ?? null;
+  persistDistinctId(userId);
+  const properties: CaptureProperties = {
+    ...buildSuperProperties(),
+    $set: traits ?? {},
+  };
+  // PostHog's $identify also accepts $anon_distinct_id to stitch the
+  // pre-login session to the authenticated user, matching web's
+  // `posthog.identify` behaviour.
+  if (previousId && previousId !== userId) {
+    properties.$anon_distinct_id = previousId;
+  }
+  const body = JSON.stringify({
+    api_key: state.apiKey,
+    distinct_id: userId,
+    event: "$identify",
+    properties,
+    timestamp: new Date().toISOString(),
+  });
+  try {
+    await fetch(`${state.apiHost.replace(/\/$/, "")}/capture/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+    });
+  } catch {
+    /* noop */
+  }
+}
+
+function handleReset(): void {
+  if (!state) return;
+  // Re-roll anonymous distinct_id so events emitted post-logout are
+  // not attributed to the previous user. Persist immediately so a
+  // crash before the next event still picks up the fresh id.
+  const fresh = safeRandomId();
+  state.distinctId = fresh;
+  state.traits = null;
+  persistDistinctId(fresh);
+}
+
+/**
+ * Initialises the PostHog transport. Idempotent — repeated calls
+ * return the same promise. Without `EXPO_PUBLIC_POSTHOG_KEY` this
+ * resolves to a no-op without ever issuing a `fetch`.
+ */
+export function initPostHog(): Promise<void> {
+  if (initPromise) return initPromise;
+  const key = getPostHogKey();
+  if (!key) {
+    initPromise = Promise.resolve();
+    return initPromise;
+  }
+  initPromise = (async () => {
+    try {
+      state = {
+        apiKey: key,
+        apiHost: getPostHogHost(),
+        distinctId: loadOrCreateAnonId(),
+        traits: null,
+      };
+      flushQueue();
+    } catch {
+      // Should not happen — `loadOrCreateAnonId` already swallows
+      // MMKV failures — but mirror web's `initFailed` guard so the
+      // queue can't grow unbounded in pathological environments.
+      initFailed = true;
+      queue = [];
+    }
+  })();
+  return initPromise;
+}
+
+/**
+ * Fire-and-forget capture. До завершення init буферизує (до
+ * `MAX_QUEUE`). Якщо ENV не виставлений — повний no-op.
+ */
+export function capturePostHogEvent(
+  name: string,
+  payload: CaptureProperties = {},
+): void {
+  if (!name) return;
+  if (state) {
+    void postCapture(name, payload);
+    return;
+  }
+  if (!getPostHogKey()) return;
+  if (initFailed) return;
+  enqueue({ kind: "capture", name, payload });
+}
+
+/**
+ * Привʼязує всі наступні events до конкретного userId. Викликається з
+ * `AnalyticsIdentityBridge` коли `useUser()` повертає активний user.
+ */
+export function identifyPostHogUser(
+  userId: string,
+  traits?: CaptureProperties,
+): void {
+  if (!userId) return;
+  if (state) {
+    void postIdentify(userId, traits);
+    return;
+  }
+  if (!getPostHogKey()) return;
+  if (initFailed) return;
+  enqueue({ kind: "identify", userId, traits });
+}
+
+/**
+ * Очищає distinct_id і person traits — викликається при logout, щоб
+ * наступна сесія не атрибутувалась попередньому юзеру.
+ */
+export function resetPostHog(): void {
+  if (state) {
+    handleReset();
+    return;
+  }
+  if (!getPostHogKey()) return;
+  if (initFailed) return;
+  enqueue({ kind: "reset" });
+}
+
+/** Test-only: reset module-scope state between specs. */
+export function __resetPostHogForTests(): void {
+  state = null;
+  initPromise = null;
+  initFailed = false;
+  queue = [];
+}

--- a/apps/mobile/src/lib/observability/posthogEnv.ts
+++ b/apps/mobile/src/lib/observability/posthogEnv.ts
@@ -1,0 +1,17 @@
+/**
+ * PostHog env accessor split into its own module so Jest can `jest.mock`
+ * the read and drive `initPostHog` through both the key-set and
+ * key-absent branches in a single test file. Mirrors `./env.ts`
+ * (Sentry DSN) — see that file for the rationale around Expo's
+ * `EXPO_PUBLIC_*` build-time inlining.
+ */
+
+const DEFAULT_HOST = "https://eu.i.posthog.com";
+
+export function getPostHogKey(): string | undefined {
+  return process.env.EXPO_PUBLIC_POSTHOG_KEY;
+}
+
+export function getPostHogHost(): string {
+  return process.env.EXPO_PUBLIC_POSTHOG_HOST || DEFAULT_HOST;
+}

--- a/docs/observability/frontend.md
+++ b/docs/observability/frontend.md
@@ -1,6 +1,6 @@
 # Frontend-observability — web і mobile
 
-> **Last validated:** 2026-04-28 by @Skords-01. **Next review:** 2026-07-27.
+> **Last validated:** 2026-05-04 by @Skords-01. **Next review:** 2026-08-02.
 > **Status:** Active
 
 Observability-стек для web- і mobile-клієнтів Sergeant: error tracking,
@@ -18,6 +18,7 @@ session replay, Core Web Vitals, product analytics, ErrorBoundary-конвенц
 | Web — Replay                    | `@sentry/react` `replayIntegration`                        | `VITE_SENTRY_REPLAY_SAMPLE_RATE`              | **Prod-ready** (default session=0, error=1.0)             |
 | Web — Core Web Vitals           | `web-vitals` → `POST /api/metrics/web-vitals` → Prometheus | `VITE_WEB_VITALS_ENDPOINT` (`=0` kill-switch) | **Prod-ready** (baseline, SLO не зафіксовано — SLO.md §8) |
 | Mobile — Sentry                 | `@sentry/react-native` (planned)                           | `EXPO_PUBLIC_SENTRY_DSN` (зарезервовано)      | **TODO (Phase 10)**                                       |
+| Mobile — PostHog                | HTTP `/capture/` (no SDK dep)                              | `EXPO_PUBLIC_POSTHOG_KEY`                     | **Prod-ready** (S0.3 — fire-and-forget, anon → identify)  |
 | Capacitor shell                 | Web Sentry з tag `is_capacitor=true`                       | `VITE_SENTRY_*`                               | **Prod-ready**                                            |
 | Server — Sentry                 | `@sentry/node`                                             | `SENTRY_DSN`                                  | **Prod-ready** (детально — інші docs)                     |
 


### PR DESCRIPTION
## Summary

Закриває **S0.3** із [`docs/launch/ftux-sprint-plan.md`](docs/launch/ftux-sprint-plan.md) — mobile-частина PostHog-аналітики FTUX-funnel. До цього `apps/mobile/src/lib/analytics.ts` був console-only stub і жоден mobile-event не писався у спільний funnel з web-ом. PR додає легкий HTTP-транспорт без SDK-залежності, dual-transport `trackEvent`, identify/reset bridge на `useUser()`, і MMKV-перситентний anon distinct_id.

Чому HTTP а не `posthog-react-native`:
- SDK додає native module → bigger bundle, більше surface для падінь у Expo Go vs dev-client.
- Контракт fire-and-forget і так не потребує SDK-побічних ефектів — простий `POST /capture/` дає те саме.
- Mobile parity з web (web уже на `posthog-js`) досягається на рівні events/traits, а не SDK.

Файли:
- `apps/mobile/src/lib/observability/posthog.ts` — fire-and-forget POST до `/capture/`, ідемпотентний `initPostHog()`, чергa до 100 подій до init complete, persist anon `distinct_id` у MMKV.
- `apps/mobile/src/lib/observability/posthogEnv.ts` — env-acessor для `EXPO_PUBLIC_POSTHOG_KEY` / `EXPO_PUBLIC_POSTHOG_HOST` (default `https://eu.i.posthog.com`).
- `apps/mobile/src/lib/observability/identifyTraits.ts` — будує traits payload (vibe з MMKV, `plan='free'`, `signup_date` `YYYY-MM-DD` UTC).
- `apps/mobile/src/features/analytics/AnalyticsIdentityBridge.tsx` — no-UI компонент у `RootLayout`, мостить `useUser()` стан на PostHog identify/reset, з `isPending`-gate і `lastIdentifiedRef` де-дупом.
- `apps/mobile/src/lib/analytics.ts` — dual transport (`console.log` + `capturePostHogEvent`), re-export `init/identify/reset`.
- `apps/mobile/app/_layout.tsx` — `void initPostHog()` після `initObservability()`, монтує `<AnalyticsIdentityBridge />` у provider tree (після `PushRegistrar`).
- `.env.example` — нові env vars з EU-default.
- `docs/observability/frontend.md` — рядок «Mobile — PostHog | HTTP `/capture/` (no SDK dep) | **Prod-ready** (S0.3)», валідація 2026-05-04.

Mobile parity з web — ті самі traits (`vibe`, `plan`, `signup_date`), той самий identify→reset lifecycle, той самий event-shape; кросс-platform сегментація у PostHog dashboards працює без shim-ів. Capacitor-варіант покривається web-ом (web вже на PostHog), Expo-варіант — цим PR-ом.

## Governing Skill

- Primary skill: `sergeant-mobile-expo`
- Secondary skill (if truly needed): `sergeant-feature-delivery`

## Playbook

- Primary playbook: `docs/launch/ftux-sprint-plan.md` §S0.3 (mobile parity (Expo + Capacitor))
- Why this playbook: PR is the literal implementation of S0.3 — closes the last open item of Sprint 0 (analytics layer).
- If no playbook matched, why: n/a

## Verification

```bash
pnpm --filter @sergeant/mobile lint           # PASS — no errors
pnpm --filter @sergeant/mobile typecheck      # PASS for new files (pre-existing
                                              # @sergeant/db-schema/migrate/sqlite
                                              # errors are unrelated to this PR)
node scripts/check-imports.mjs                # PASS
node scripts/check-tech-debt-freshness.mjs    # PASS
pnpm lint:hard-rules-registry                 # PASS — 18 rules in sync
node scripts/check-localstorage-allowlist.mjs # PASS — 15/15
```

Mobile jest tests (`pnpm --filter @sergeant/mobile test`) failed locally with the *same* environment error on `main` (jest-expo `Object.defineProperty called on non-object` in 111/111 suites) — not blocking CI because mobile jest isn't part of `pnpm test:coverage` lane. New tests follow existing repo patterns (mock `@/lib/storage`, mirror web `posthog.test.ts` shape) and will run when the local mobile-jest env is repaired.

Additional checks:

- [x] Lint passes
- [x] Typecheck passes for new files
- [x] Hard-rules registry, freshness, imports, localStorage allowlist all green
- [x] Surface-specific: env-vars документовані у `.env.example`, observability table updated

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- `docs/observability/frontend.md` — додано рядок про mobile PostHog HTTP-transport, validation date 2026-05-04.
- `.env.example` — нові env vars `EXPO_PUBLIC_POSTHOG_KEY`, `EXPO_PUBLIC_POSTHOG_HOST`.
- `docs/launch/ftux-sprint-plan.md` буде оновлений у фінальному doc-PR після merge цього + S4.2.

## Risk and Rollout

- User-visible risk: **none**. Без `EXPO_PUBLIC_POSTHOG_KEY` — модуль no-op (early return у `capturePostHogEvent`), тому існуючий console-only лог зберігається. З ключем — fire-and-forget `fetch` з `try/catch` і таймаутом через `AbortController` (10s); жоден failure не може throw-нути назад у calling-сайт.
- Rollout / deploy order:
  1. Merge PR (no key → no-op).
  2. Set `EXPO_PUBLIC_POSTHOG_KEY` через EAS secrets після того як web flow підтвердиться у production.
  3. Verify events у PostHog dashboard з фільтром `is_expo: true`.
- Backout plan: revert цього PR-у — повертає console-only stub. Або `unset EXPO_PUBLIC_POSTHOG_KEY` у EAS — миттєво вимикає transport без redeploy.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

- **No SDK dependency added** — на відміну від web (`posthog-js`), mobile використовує raw `fetch` до `/capture/`. Це навмисне рішення, описане у Summary.
- **MMKV ключ для anon distinct_id**: `sergeant.mobile.posthog.distinct_id.v1` — `.v1` суфікс щоб майбутні міграції schemas пройшли без колізій (паттерн з `getVibePicks`/`mobileKVStore`).
- **Super-properties**: `platform: Platform.OS`, `is_capacitor: false`, `is_expo: true` — для крос-platform сегментації.
- **Identify stitching**: `$anon_distinct_id` передається у identify payload, щоб PostHog зшив anon→authenticated сесії без втрати першого funnel-кроку.
- **Reset на logout** rolls a new anon UUID — щоб події post-logout не атрибутувались попередньому юзеру.
- **`isPending` gate** у `AnalyticsIdentityBridge` — уникаємо помилкового `reset` під час cold-start, поки Better Auth ще тягне session-cookie.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds PostHog analytics to the Expo mobile app via a lightweight HTTP `/capture/` transport (no SDK) to complete FTUX funnel parity with web (S0.3). Events are fire-and-forget, buffered before init, with identity stitched using an MMKV‑persisted `distinct_id`.

- **New Features**
  - Dual transport in `trackEvent`: console log + PostHog capture; idempotent `initPostHog` with a 100‑event pre‑init queue.
  - `<AnalyticsIdentityBridge />` mirrors `useUser()` to `identifyPostHogUser`/`resetPostHog` with de‑dupe; rolls a new anon ID on logout.
  - MMKV‑persisted anon `distinct_id`; `$identify` sends `$anon_distinct_id` to stitch anon → authenticated sessions.
  - Person traits: `vibe`, `plan`, `signup_date` (UTC). Super‑properties: `platform`, `is_expo`, `is_capacitor=false`.
  - Env accessors for `EXPO_PUBLIC_POSTHOG_KEY` and `EXPO_PUBLIC_POSTHOG_HOST` (EU default). Docs updated.

- **Migration**
  - No‑op by default. Set `EXPO_PUBLIC_POSTHOG_KEY` (and optionally `EXPO_PUBLIC_POSTHOG_HOST`) to enable; use the same PostHog project as web (`VITE_POSTHOG_KEY`) and server.
  - Verify in PostHog using `is_expo=true`.

<sup>Written for commit e33001d836f760f082a5fb92609e92c5908fc154. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

