### PR TITLE
refactor(web): adopt <DataState> in fizruk Workouts journal

### DIFF
--- a/apps/web/src/modules/fizruk/pages/Workouts.tsx
+++ b/apps/web/src/modules/fizruk/pages/Workouts.tsx
@@ -9,6 +9,10 @@ import { PullToRefresh } from "@shared/components/ui/PullToRefresh";
 import { Button } from "@shared/components/ui/Button";
 import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
 import { Skeleton } from "@shared/components/ui/Skeleton";
+import {
+  DataState,
+  type DataStateQueryLike,
+} from "@shared/components/ui/DataState";
 import { useToast } from "@shared/hooks/useToast";
 import { showUndoToast } from "@shared/lib/ui/undoToast";
 import { WorkoutTemplatesSection } from "../components/WorkoutTemplatesSection";
@@ -36,6 +40,7 @@ import { useWorkouts } from "../hooks/useWorkouts";
 import { recoveryConflictsForExercise } from "@sergeant/fizruk-domain";
 import type { RawExerciseDef } from "@sergeant/fizruk-domain/data";
 import type {
+  Workout,
   WorkoutFinishSummary,
   WorkoutGroup,
   WorkoutItem,
@@ -446,6 +451,33 @@ export function Workouts() {
   // re-render automatically once the engine writes new state.
   const handlePullRefresh = useCallback(() => requestCloudPull(2500), []);
 
+  // DataState contract for the workout journal:
+  //   - `useWorkouts` flips `loaded` from false → true after the first
+  //     hydration tick. While `loaded === false` we feed `data: undefined`
+  //     so DataState renders the skeleton slot; from the second tick on
+  //     `data` is the real list (possibly empty), which lets the journal
+  //     render its own "порожньо" empty-state without flashing it during
+  //     mount.
+  //   - `isLoading` mirrors the inverted `loaded` flag so a future
+  //     stale-revalidate (cloud pull → re-merge) keeps the list visible.
+  const journalQuery: DataStateQueryLike<readonly Workout[]> = {
+    data: workoutsLoaded ? workouts : undefined,
+    isLoading: !workoutsLoaded,
+  };
+
+  const workoutsLoadingSkeleton = (
+    <div
+      className="space-y-3"
+      role="status"
+      aria-live="polite"
+      aria-label="Завантажуємо тренування"
+    >
+      <Skeleton className="h-28 w-full" />
+      <Skeleton className="h-20 w-full" />
+      <Skeleton className="h-20 w-full" />
+    </div>
+  );
+
   return (
     <PullToRefresh onRefresh={handlePullRefresh} variant="fizruk">
       <div className="max-w-4xl mx-auto px-4 pt-4 page-tabbar-pad">
@@ -511,51 +543,46 @@ export function Workouts() {
           />
         ) : null}
 
-        {view === "log" && !workoutsLoaded && (
-          // First-paint placeholder while `useWorkouts` is still rehydrating
-          // from `localStorage` (one tick on mount). Prevents the "порожньо"
-          // empty-state from flashing before real data renders — matches the
-          // Skeleton pattern already used in Finyk.
-          <div
-            className="space-y-3"
-            role="status"
-            aria-live="polite"
-            aria-label="Завантажуємо тренування"
-          >
-            <Skeleton className="h-28 w-full" />
-            <Skeleton className="h-20 w-full" />
-            <Skeleton className="h-20 w-full" />
-          </div>
-        )}
-        {view === "log" && workoutsLoaded && (
-          <WorkoutJournalSection
-            activeWorkout={activeWorkout}
-            activeDuration={activeDuration}
-            workouts={workouts}
-            activeWorkoutId={activeWorkoutId}
-            setActiveWorkoutId={setActiveWorkoutId}
-            retroOpen={retroOpen}
-            setRetroOpen={setRetroOpen}
-            retroDate={retroDate}
-            setRetroDate={setRetroDate}
-            retroTime={retroTime}
-            setRetroTime={setRetroTime}
-            createWorkout={createWorkout}
-            setMode={setView}
-            musclesUk={musclesUk}
-            recBy={rec.by}
-            lastByExerciseId={lastByExerciseId}
-            setRestTimer={setRestTimer}
-            updateWorkout={updateWorkout}
-            updateItem={updateItem}
-            removeItem={removeItemWithUndo}
-            setFinishFlash={setFinishFlash}
-            endWorkout={endWorkout}
-            summarizeWorkoutForFinish={summarizeWorkoutForFinish}
-            submitRetroWorkout={submitRetroWorkout}
-            deleteWorkout={deleteWorkout}
-            restoreWorkout={restoreWorkout}
-          />
+        {view === "log" && (
+          // DataState contract: `data === undefined` triggers the skeleton
+          // slot. `useWorkouts` flips `loaded` from false → true after one
+          // tick on mount (it rehydrates from `localStorage` / SQLite),
+          // so on first paint we feed `data: undefined` and from the
+          // second tick onwards `data` is the real list — even when it
+          // happens to be empty. This prevents the "порожньо" empty-state
+          // inside `WorkoutJournalSection` from flashing during hydration.
+          <DataState query={journalQuery} skeleton={workoutsLoadingSkeleton}>
+            {() => (
+              <WorkoutJournalSection
+                activeWorkout={activeWorkout}
+                activeDuration={activeDuration}
+                workouts={workouts}
+                activeWorkoutId={activeWorkoutId}
+                setActiveWorkoutId={setActiveWorkoutId}
+                retroOpen={retroOpen}
+                setRetroOpen={setRetroOpen}
+                retroDate={retroDate}
+                setRetroDate={setRetroDate}
+                retroTime={retroTime}
+                setRetroTime={setRetroTime}
+                createWorkout={createWorkout}
+                setMode={setView}
+                musclesUk={musclesUk}
+                recBy={rec.by}
+                lastByExerciseId={lastByExerciseId}
+                setRestTimer={setRestTimer}
+                updateWorkout={updateWorkout}
+                updateItem={updateItem}
+                removeItem={removeItemWithUndo}
+                setFinishFlash={setFinishFlash}
+                endWorkout={endWorkout}
+                summarizeWorkoutForFinish={summarizeWorkoutForFinish}
+                submitRetroWorkout={submitRetroWorkout}
+                deleteWorkout={deleteWorkout}
+                restoreWorkout={restoreWorkout}
+              />
+            )}
+          </DataState>
         )}
 
         {view === "templates" && (


### PR DESCRIPTION
## Summary

Адаптуємо `<DataState>` wrapper у `fizruk/pages/Workouts.tsx` — другий споживач (після PR 2.4) присутньої але до цього часу не використаної інфраструктури з PR 2.2. Замінюємо ad-hoc патерн `view === "log" && !workoutsLoaded ? <Skeleton /> : <WorkoutJournalSection />` на `<DataState>` з контрактом «`data === undefined` → skeleton; `data` визначено → content (навіть під час cloud-pull stale-revalidate)».

- **Workouts** (`apps/web/src/modules/fizruk/pages/Workouts.tsx`): єдина точка з Skeleton-based loading state у fizruk модулі. `useWorkouts` flip-ає `loaded` з `false → true` після першого tick гідрації (з localStorage / SQLite). DataState query: `data: workoutsLoaded ? workouts : undefined, isLoading: !workoutsLoaded`. Це дозволяє `WorkoutJournalSection` рендерити свою власну `«порожньо»` empty-state без миготіння під час mount.
- Skeleton-розмітка залишається ідентичною (3 row-shaped Skeleton) — лише огорнута DataState `skeleton` slot-ом.

Поведінка-зберігаюча міграція. Hooks/business logic не змінюються — лише presentation.

Інші fizruk-сторінки (`Dashboard`, `Programs`, `Atlas`, `Body/*`, `Progress`, `Exercise`) не мають Skeleton-based loading state — вони або працюють синхронно з local-first MMKV-web даними, або вже degrade-ять до empty defaults. Тому скоуп цього PR — рівно один файл (на відміну від 2.4, який торкав три).

## Governing Skill

- Primary skill: `sergeant-web-ui`
- Secondary skill (if truly needed): `sergeant-feature-delivery`

## Playbook

- Primary playbook: `docs/playbooks/web-feature-shipping.md`
- Why this playbook: presentational web рефактор з типчеком, ESLint, vitest. Той самий patternі формат, що й 2.4 (#1703).
- If no playbook matched, why: n/a

## Verification

```bash
pnpm --filter @sergeant/web typecheck
pnpm exec eslint src/modules/fizruk/pages/Workouts.tsx
pnpm --filter @sergeant/web exec vitest run src/modules/fizruk
```

Результати локально:

- `typecheck` — pass.
- `eslint` (точково на Workouts.tsx) — pass без warnings.
- `vitest` (`src/modules/fizruk`) — **15 files / 93 tests pass**. Жодних регресій у workout-related тестах (`useWorkouts.test.tsx`, `WorkoutJournalSection.finish.test.tsx`, тощо).

Без нового RTL-теста для `Workouts.tsx`: компонент композитує 8+ хуків (`useExerciseCatalog`, `useRecovery`, `useWorkouts`, `useMonthlyPlan`, `useWorkoutTemplates`, `useToast`, `useFizrukRestSound`, `useActiveFizrukWorkout`) і переносний integration test потребував би мокати їх усі. DataState routing логіка вже покрита 11 тестами в `apps/web/src/shared/components/ui/DataState.test.tsx`, а існуючі `useWorkouts.test.tsx` (4 tests) фіксують контракт `loaded` flag. Якщо рев'юер вважає за потрібне — можемо додати окремим follow-up.

Additional checks:

- [x] Local smoke / manual validation completed (typecheck + eslint + vitest fizruk above)
- [x] Surface-specific checks completed (DataState contract: `data === undefined` triggers skeleton; persisted data + `isLoading=true` тримає content і не блимає у skeleton)

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- `docs/initiatives/0011-foundation-adoption-and-process-discipline.md` буде оновлено в окремому follow-up commit / PR після merge обох PR-ів (2.4 #1703 і 2.5) — там відмітимо їх як done з лінками. `AGENTS.md` / playbooks / governance / review docs без змін — `<DataState>` API вже задокументовано в `apps/web/src/shared/components/ui/DataState.tsx` JSDoc + `DataState.stories.tsx`.

## Risk and Rollout

- **User-visible risk:** низький. Behavior-preserving presentational refactor — той самий skeleton, той самий журнал тренувань. Stale-revalidate (cloud pull → re-merge) тепер не повертає skeleton (раніше `workoutsLoaded` залишалося `true` після гідрації, тож практично ніколи не повертало skeleton; цей invariant збережено).
- **Rollout / deploy order:** звичайний deploy через Vercel preview → main. Без міграцій, без env-змін, без feature-flag.
- **Backout plan:** revert PR; жодних persisted side effects (localStorage / MMKV / RQ keys / API contracts) не зачеплено.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

- DataState contract зведено через `data: workoutsLoaded ? workouts : undefined`. Семантика — точно та сама, що й попередній `view === "log" && workoutsLoaded` guard, але виражена через єдину абстракцію.
- `useWorkouts.loaded` гарантовано flip-ається в `true` після `useEffect` mount-а (підтверджено `useWorkouts.test.tsx` line 30 — `await waitFor(() => expect(result.current.loaded).toBe(true))`). Тож DataState skeleton slot бачимо лише на першому tick після mount.
- Залишок Workouts JSX (`view === "home" / "catalog" / "templates"`, `WorkoutsHome`, `WorkoutCatalogSection`, `WorkoutTemplatesSection`) не має loading state і свідомо лишений поза DataState — це не RQ-driven UI.
- Pair-PR 2.4 (`refactor(web): adopt <DataState> in finyk Mono panels`) — #1703.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopted `<DataState>` in the Fizruk Workouts journal to centralize loading and prevent the empty-state flash during hydration. Replaces the ad‑hoc `view === "log"` skeleton guard without changing behavior.

- **Refactors**
  - Uses `<DataState>` from `@shared/components/ui/DataState` with: `data === undefined` → skeleton; defined `data` → content (even when `isLoading` is true).
  - Maps query as `data: workoutsLoaded ? workouts : undefined` and `isLoading: !workoutsLoaded` to show the list across stale‑revalidate.
  - Keeps the same 3‑row skeleton, now in the `skeleton` slot.
  - No hooks or business logic changed; scope is `apps/web/src/modules/fizruk/pages/Workouts.tsx` only.

<sup>Written for commit 1d6998531fe658dc08a6c36903f5b54c72be6474. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved loading state handling for the workout journal with enhanced skeleton display during initial data loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->