### PR TITLE
refactor(web): adopt <DataState> in HubChat / coach / digest

### DIFF
--- a/apps/web/src/core/insights/WeeklyDigestCard.datastate.test.tsx
+++ b/apps/web/src/core/insights/WeeklyDigestCard.datastate.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+// `vi.mock` is hoisted above any plain `const`, so we use `vi.hoisted` to
+// share fresh `vi.fn()` instances between the mock factory and the tests.
+const { useWeeklyDigestMock, useDigestHistoryMock } = vi.hoisted(() => ({
+  useWeeklyDigestMock: vi.fn(),
+  useDigestHistoryMock: vi.fn(),
+}));
+
+// Stub the digest-history overlay (irrelevant to the 4-state contract).
+vi.mock("./WeeklyDigestStories", () => ({
+  WeeklyDigestStories: () => null,
+}));
+
+vi.mock("./useWeeklyDigest", () => ({
+  useWeeklyDigest: (...args: unknown[]) => useWeeklyDigestMock(...args),
+  useDigestHistory: (...args: unknown[]) => useDigestHistoryMock(...args),
+  getWeekKey: () => "2025-W46",
+}));
+
+import { WeeklyDigestCard } from "./WeeklyDigestCard";
+
+describe("WeeklyDigestCard — DataState routing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useDigestHistoryMock.mockReturnValue({ data: [] });
+  });
+
+  // The shared apps/web vitest setup (src/test/setup.ts) does not register
+  // RTL's auto-cleanup, so two `render()` calls would otherwise stack their
+  // DOM trees and leak state between tests.
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the loading skeleton (`aria-busy`) while a digest is generating", () => {
+    useWeeklyDigestMock.mockReturnValue({
+      digest: null,
+      loading: true,
+      error: null,
+      weekRange: "10 — 16 листоп.",
+      generate: vi.fn(),
+      isCurrentWeek: true,
+    });
+
+    render(<WeeklyDigestCard />);
+
+    expect(screen.getByLabelText(/генеруємо звіт тижня/i)).toBeInTheDocument();
+    // No empty/error/content affordances while skeleton is up.
+    expect(
+      screen.queryByRole("button", { name: /згенерувати звіт/i }),
+    ).toBeNull();
+  });
+
+  it("renders the empty slot with a generate button on the current week when there is no digest", () => {
+    useWeeklyDigestMock.mockReturnValue({
+      digest: null,
+      loading: false,
+      error: null,
+      weekRange: "10 — 16 листоп.",
+      generate: vi.fn(),
+      isCurrentWeek: true,
+    });
+
+    render(<WeeklyDigestCard />);
+
+    expect(
+      screen.getByRole("button", { name: /згенерувати звіт/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText(/генеруємо звіт тижня/i)).toBeNull();
+  });
+
+  it("renders the empty slot with a 'not stored' message on a past week", () => {
+    useWeeklyDigestMock.mockReturnValue({
+      digest: null,
+      loading: false,
+      error: null,
+      weekRange: "03 — 09 листоп.",
+      generate: vi.fn(),
+      isCurrentWeek: false,
+    });
+
+    render(<WeeklyDigestCard />);
+
+    expect(
+      screen.getByText(/звіт за цей тиждень не збережено/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /згенерувати звіт/i }),
+    ).toBeNull();
+  });
+
+  it("renders the error slot (with retry on current week) when the mutation reports an error and loading has settled", () => {
+    useWeeklyDigestMock.mockReturnValue({
+      digest: null,
+      loading: false,
+      error: "Не вдалося згенерувати",
+      weekRange: "10 — 16 листоп.",
+      generate: vi.fn(),
+      isCurrentWeek: true,
+    });
+
+    render(<WeeklyDigestCard />);
+
+    expect(screen.getByText(/не вдалося згенерувати/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /спробувати знову/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders digest content (stories button) when at least one module has data", () => {
+    useWeeklyDigestMock.mockReturnValue({
+      digest: {
+        generatedAt: "2025-11-16T08:00:00Z",
+        finyk: {
+          summary: "Витрати в нормі",
+          comment: null,
+          recommendations: [],
+        },
+      },
+      loading: false,
+      error: null,
+      weekRange: "10 — 16 листоп.",
+      generate: vi.fn(),
+      isCurrentWeek: true,
+    });
+
+    render(<WeeklyDigestCard />);
+
+    expect(
+      screen.getByRole("button", { name: /переглянути як сторіс/i }),
+    ).toBeInTheDocument();
+    // Empty/error affordances are not on screen.
+    expect(
+      screen.queryByRole("button", { name: /згенерувати звіт/i }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: /спробувати знову/i }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/core/insights/WeeklyDigestCard.tsx
+++ b/apps/web/src/core/insights/WeeklyDigestCard.tsx
@@ -1,6 +1,10 @@
 import { useState } from "react";
 import { cn } from "@shared/lib/ui/cn";
 import { Icon } from "@shared/components/ui/Icon";
+import {
+  DataState,
+  type DataStateQueryLike,
+} from "@shared/components/ui/DataState";
 import { Skeleton, SkeletonText } from "@shared/components/ui/Skeleton";
 import { Tooltip } from "@shared/components/ui/Tooltip";
 import {
@@ -233,158 +237,174 @@ function DigestContent({
   onPlayStories,
 }: DigestContentProps) {
   const [expanded, setExpanded] = useState(false);
-  const hasData =
-    digest &&
-    (digest.finyk || digest.fizruk || digest.nutrition || digest.routine);
 
-  if (loading) return <LoadingSpinner />;
+  // DataState contract: `data === undefined` → render skeleton slot,
+  // otherwise content/empty/error are evaluated. We force `data` to
+  // `undefined` while `loading` is true so a stale/cached digest is
+  // hidden during regeneration (matches the prior `if (loading)`
+  // short-circuit). When `loading` is false but an error is present
+  // we surface `data: null` + `isError: true` so DataState's "error
+  // wins" branch picks the error slot.
+  const digestQuery: DataStateQueryLike<DigestPayload | null> = {
+    data: loading ? undefined : (digest ?? null),
+    isLoading: loading,
+    isError: !!error && !loading,
+    error: error ? new Error(error) : null,
+  };
 
-  if (error) {
-    return (
-      <div className="px-4 pb-3">
-        <p className="text-xs text-danger bg-danger/10 rounded-xl px-3 py-2 mb-2">
-          {error}
-        </p>
-        {isCurrentWeek && (
+  const errorSlot = (
+    <div className="px-4 pb-3">
+      <p className="text-xs text-danger bg-danger/10 rounded-xl px-3 py-2 mb-2">
+        {error}
+      </p>
+      {isCurrentWeek && (
+        <button
+          type="button"
+          onClick={onGenerate}
+          className="w-full h-9 rounded-xl border border-line text-xs font-semibold text-muted hover:text-text hover:bg-panelHi transition-colors"
+        >
+          Спробувати знову
+        </button>
+      )}
+    </div>
+  );
+
+  const emptySlot = (
+    <div className="px-4 pb-4">
+      {isCurrentWeek ? (
+        <>
+          <p className="text-xs text-muted mb-3 leading-relaxed">
+            AI-звіт підсумовує прогрес по всіх модулях і дає конкретні
+            рекомендації на наступний тиждень.
+          </p>
           <button
             type="button"
             onClick={onGenerate}
-            className="w-full h-9 rounded-xl border border-line text-xs font-semibold text-muted hover:text-text hover:bg-panelHi transition-colors"
+            className="w-full h-10 rounded-xl bg-primary text-bg text-style-label hover:brightness-110 transition-[filter,opacity,transform] active:scale-[0.98]"
           >
-            Спробувати знову
+            Згенерувати звіт
           </button>
-        )}
-      </div>
-    );
-  }
-
-  if (!hasData) {
-    return (
-      <div className="px-4 pb-4">
-        {isCurrentWeek ? (
-          <>
-            <p className="text-xs text-muted mb-3 leading-relaxed">
-              AI-звіт підсумовує прогрес по всіх модулях і дає конкретні
-              рекомендації на наступний тиждень.
-            </p>
-            <button
-              type="button"
-              onClick={onGenerate}
-              className="w-full h-10 rounded-xl bg-primary text-bg text-style-label hover:brightness-110 transition-[filter,opacity,transform] active:scale-[0.98]"
-            >
-              Згенерувати звіт
-            </button>
-          </>
-        ) : (
-          <p className="text-xs text-muted text-center py-2">
-            Звіт за цей тиждень не збережено
-          </p>
-        )}
-      </div>
-    );
-  }
+        </>
+      ) : (
+        <p className="text-xs text-muted text-center py-2">
+          Звіт за цей тиждень не збережено
+        </p>
+      )}
+    </div>
+  );
 
   return (
-    <>
-      <div className="px-4 pb-3 pt-1">
-        <button
-          type="button"
-          onClick={onPlayStories}
-          className={cn(
-            "w-full h-11 rounded-xl text-sm font-bold text-white",
-            "bg-linear-to-r from-brand-500 via-brand-400 to-teal-400",
-            "dark:from-brand-600 dark:via-brand-500 dark:to-teal-500",
-            "shadow-card hover:brightness-110 active:scale-[0.98] transition-[box-shadow,filter,opacity,transform]",
-            "flex items-center justify-center gap-2",
-            "focus-ring",
-          )}
-        >
-          <svg
-            width="15"
-            height="15"
-            viewBox="0 0 24 24"
-            fill="currentColor"
-            aria-hidden
-          >
-            <path d="M8 5v14l11-7z" />
-          </svg>
-          Переглянути як сторіс
-        </button>
-      </div>
-      <div
-        className={cn(
-          "grid transition-[grid-template-rows] duration-200 ease-in-out",
-          expanded ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
-        )}
-      >
-        <div className="overflow-hidden">
-          <div className="border-t border-line px-4 pt-3 pb-4 space-y-2">
-            {(["finyk", "fizruk", "nutrition", "routine"] as const).map(
-              (key) =>
-                digest?.[key] ? (
-                  <ModuleBlock key={key} moduleKey={key} data={digest[key]} />
-                ) : null,
+    <DataState
+      query={digestQuery}
+      skeleton={<LoadingSpinner />}
+      error={() => errorSlot}
+      empty={emptySlot}
+      isEmpty={(d) => !d || !(d.finyk || d.fizruk || d.nutrition || d.routine)}
+    >
+      {(d) => (
+        <>
+          <div className="px-4 pb-3 pt-1">
+            <button
+              type="button"
+              onClick={onPlayStories}
+              className={cn(
+                "w-full h-11 rounded-xl text-sm font-bold text-white",
+                "bg-linear-to-r from-brand-500 via-brand-400 to-teal-400",
+                "dark:from-brand-600 dark:via-brand-500 dark:to-teal-500",
+                "shadow-card hover:brightness-110 active:scale-[0.98] transition-[box-shadow,filter,opacity,transform]",
+                "flex items-center justify-center gap-2",
+                "focus-ring",
+              )}
+            >
+              <svg
+                width="15"
+                height="15"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden
+              >
+                <path d="M8 5v14l11-7z" />
+              </svg>
+              Переглянути як сторіс
+            </button>
+          </div>
+          <div
+            className={cn(
+              "grid transition-[grid-template-rows] duration-200 ease-in-out",
+              expanded ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
             )}
-            {Array.isArray(digest.overallRecommendations) &&
-              digest.overallRecommendations.length > 0 && (
-                <div className="rounded-xl border border-primary/20 bg-primary/5 px-3 py-2.5 space-y-1.5">
-                  {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift --
+          >
+            <div className="overflow-hidden">
+              <div className="border-t border-line px-4 pt-3 pb-4 space-y-2">
+                {(["finyk", "fizruk", "nutrition", "routine"] as const).map(
+                  (key) =>
+                    d?.[key] ? (
+                      <ModuleBlock key={key} moduleKey={key} data={d[key]} />
+                    ) : null,
+                )}
+                {d &&
+                  Array.isArray(d.overallRecommendations) &&
+                  d.overallRecommendations.length > 0 && (
+                    <div className="rounded-xl border border-primary/20 bg-primary/5 px-3 py-2.5 space-y-1.5">
+                      {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift --
                       Recommendation block eyebrow uses `text-primary` (a bespoke
                       accent not exposed through SectionHeading tone tokens) so
                       it stays inline until a `primary` tone is added to DS. */}
-                  <p className="text-2xs font-bold text-primary uppercase tracking-wider">
-                    Загальні рекомендації
-                  </p>
-                  {digest.overallRecommendations.map(
-                    (rec: string, i: number) => (
-                      <div key={i} className="flex items-start gap-1.5">
-                        <span className="text-2xs font-bold text-primary mt-0.5 shrink-0">
-                          ★
-                        </span>
-                        <span className="text-xs text-text leading-snug">
-                          {rec}
-                        </span>
-                      </div>
-                    ),
+                      <p className="text-2xs font-bold text-primary uppercase tracking-wider">
+                        Загальні рекомендації
+                      </p>
+                      {d.overallRecommendations.map(
+                        (rec: string, i: number) => (
+                          <div key={i} className="flex items-start gap-1.5">
+                            <span className="text-2xs font-bold text-primary mt-0.5 shrink-0">
+                              ★
+                            </span>
+                            <span className="text-xs text-text leading-snug">
+                              {rec}
+                            </span>
+                          </div>
+                        ),
+                      )}
+                    </div>
                   )}
-                </div>
-              )}
-            {isCurrentWeek && (
+                {isCurrentWeek && (
+                  <button
+                    type="button"
+                    onClick={onUpdate}
+                    className="w-full h-9 rounded-xl border border-line text-xs font-semibold text-muted hover:text-text hover:bg-panelHi transition-colors"
+                  >
+                    Оновити звіт
+                  </button>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {!expanded && (
+            <div className="px-4 pb-3">
               <button
                 type="button"
-                onClick={onUpdate}
+                onClick={() => setExpanded(true)}
                 className="w-full h-9 rounded-xl border border-line text-xs font-semibold text-muted hover:text-text hover:bg-panelHi transition-colors"
               >
-                Оновити звіт
+                Переглянути звіт
               </button>
-            )}
-          </div>
-        </div>
-      </div>
-
-      {!expanded && (
-        <div className="px-4 pb-3">
-          <button
-            type="button"
-            onClick={() => setExpanded(true)}
-            className="w-full h-9 rounded-xl border border-line text-xs font-semibold text-muted hover:text-text hover:bg-panelHi transition-colors"
-          >
-            Переглянути звіт
-          </button>
-        </div>
+            </div>
+          )}
+          {expanded && (
+            <div className="px-4 pb-3 border-t border-line pt-2">
+              <button
+                type="button"
+                onClick={() => setExpanded(false)}
+                className="w-full h-9 rounded-xl border border-line text-xs font-semibold text-muted hover:text-text hover:bg-panelHi transition-colors"
+              >
+                Згорнути
+              </button>
+            </div>
+          )}
+        </>
       )}
-      {expanded && (
-        <div className="px-4 pb-3 border-t border-line pt-2">
-          <button
-            type="button"
-            onClick={() => setExpanded(false)}
-            className="w-full h-9 rounded-xl border border-line text-xs font-semibold text-muted hover:text-text hover:bg-panelHi transition-colors"
-          >
-            Згорнути
-          </button>
-        </div>
-      )}
-    </>
+    </DataState>
   );
 }
 


### PR DESCRIPTION
## Summary

Адаптуємо `<DataState>` у HubChat / coach / digest зоні `apps/web/src/core/**`. Інспекція всіх Skeleton-споживачів і панельних loading-ladder-ів показала, що єдина точка з канонічним 4-станним контрактом (skeleton → error → empty → content) — `WeeklyDigestCard.DigestContent`. Інші компоненти з пропозиції 2.8 не мають panel-level skeleton-у:

- **`AssistantAdviceCard`** (`core/insights/AssistantAdviceCard.tsx`) — inline `<p>Готую пораду…</p>` без `Skeleton` import. Завжди має кеш last-good insight (через `safeReadStringLS`), тож loading-стейт є transient inline-аффордансом, не панельним skeleton-ом.
- **`HubChatHistoryDrawer`** (`core/hub/HubChatHistoryDrawer.tsx`) — local-first; `sessions` приходить пропом, без async fetch / Skeleton import. Empty-state — inline mini-state у scrollable списку.
- **`HubChat.tsx` / `HubChatBody.tsx` / `HubChatComposer.tsx`** — стрімінг-стейт повідомлень, без `Skeleton` import; `isPending` керує SSE-progress UI, не панельним skeleton-swap-ом.

Тому скоуп цього PR — `WeeklyDigestCard.DigestContent` 4-state ladder → `<DataState>` (єдиний `Skeleton`-споживач у `core/insights`). Це закриває весь `<DataState>` consumer-adoption блок Phase 2 ініціативи `0011`.

### Що змінилось

`apps/web/src/core/insights/WeeklyDigestCard.tsx`:

- Додано імпорт `DataState` + `DataStateQueryLike`.
- `DigestContent` (внутрішній компонент) переписаний з 3 ранніх `return`-ів (`if (loading) ... if (error) ... if (!hasData) ...`) на єдиний `<DataState>`-wrapper з 4 слотами.
- `LoadingSpinner` (`Skeleton`/`SkeletonText` matched-shape loader на 4 module-row-и) залишений без змін, передається як `skeleton`.
- `error`/`empty` слоти — JSX-константи у closure, мають доступ до `isCurrentWeek`/`onGenerate` через scope.
- `isEmpty` checker: `(d) => !d || !(d.finyk || d.fizruk || d.nutrition || d.routine)` — повторює прев `hasData` логіку (digest існує і має data хоча б у одному модулі).
- Body-рендер рухається в `children: (d) => <>...</>` — використовує `d` замість prop `digest`.

### Truth-table (поведінка 1:1 з prev)

| `loading` | `error` | `digest` (`hasData`) | `isCurrentWeek` | Раніше | Тепер |
| :-: | :-: | :-: | :-: | :-: | :-: |
| true  | —     | —      | —     | `<LoadingSpinner />` | skeleton (data=undefined) |
| false | "msg" | —      | true  | error block + retry | error slot (DataState "error wins") |
| false | "msg" | —      | false | error block без retry | error slot (DataState "error wins") |
| false | null  | null   | true  | empty + Згенерувати btn | empty slot |
| false | null  | null   | false | empty без btn ("не збережено") | empty slot |
| false | null  | hasData=false | true | empty + Згенерувати btn | empty slot (isEmpty=true) |
| false | null  | hasData=true | true | content body | children(d) |
| false | null  | hasData=true | false | content body (без update btn) | children(d) (без update btn) |

Mapping:

```ts
const digestQuery: DataStateQueryLike<DigestPayload | null> = {
  data: loading ? undefined : (digest ?? null),
  isLoading: loading,
  isError: !!error && !loading,
  error: error ? new Error(error) : null,
};
```

Force `data: undefined` під час loading зберігає попередній `if (loading)` short-circuit (стале digest приховується під час regen). `isError: !!error && !loading` гарантує, що під час regen-error spinner показується першим (як раніше), а error-block тільки після того, як loading осідає.

### Тести

`apps/web/src/core/insights/WeeklyDigestCard.datastate.test.tsx` (новий, 5 кейсів):

1. **Loading skeleton** — `loading=true` → `aria-busy` skeleton; жодного "Згенерувати" / "Спробувати знову" афорданс-у.
2. **Empty (current week)** — `loading=false, digest=null, isCurrentWeek=true` → empty-slot з кнопкою "Згенерувати звіт".
3. **Empty (past week)** — `isCurrentWeek=false` → empty-slot з текстом "Звіт за цей тиждень не збережено", БЕЗ "Згенерувати" кнопки.
4. **Error (current week)** — `loading=false, error="..."` → error-slot з retry-кнопкою.
5. **Content** — `loading=false, digest={finyk: {...}}` → content body з "Переглянути як сторіс" CTA.

Тести явно реєструють `afterEach(cleanup)` — apps/web vitest setup (`src/test/setup.ts`) не реєструє RTL auto-cleanup, тож без cleanup-у попередній render leaks DOM в наступний кейс.

Існуючий `WeeklyDigestCard.collapse.test.tsx` (2 кейси на header collapse-control) проходить без змін.

## Governing Skill

- Primary skill: `.agents/skills/sergeant-web-ui/SKILL.md`
- Secondary skill (if truly needed): `.agents/skills/sergeant-feature-delivery/SKILL.md` (для DataState consumer-adoption pattern, який розкатуємо інкрементально по модулях)

## Playbook

- Primary playbook: n/a — це pure presentational rewrite під canonical `<DataState>` контракт. Жодних playbook-ів для DS migration sweep-ів немає (поки що); патерн фіксується PRs 2.4–2.7 як reference.
- Why this playbook: see above.
- If no playbook matched, why: DataState consumer-adoption — це initiative `0011` Phase 2 work, який зараз триває; playbook буде створено після того, як ESLint rule (PR 2.9) буде enforced.

## Verification

```bash
pnpm --filter @sergeant/web typecheck                                           # exit 0
pnpm --filter @sergeant/web exec eslint src/core/insights/WeeklyDigestCard.tsx \
  src/core/insights/WeeklyDigestCard.datastate.test.tsx                         # clean
pnpm --filter @sergeant/web exec vitest run src/core                            # 91 files, 1136/1136 pass
pnpm --filter @sergeant/web exec vitest run src/core/insights/WeeklyDigestCard \
  src/core/insights/WeeklyDigestCard.datastate                                  # 7/7 pass
```

Additional checks:

- [x] Local smoke / manual validation completed (4-state ladder тест-кейси покривають всі гілки)
- [x] Surface-specific checks completed (web typecheck, eslint, vitest)

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout. (буде в окремому doc-update PR після цього)
- [x] I checked whether `AGENTS.md` needed an update. (no change — DataState contract уже задокументовано в попередніх PR)
- [x] I checked whether a playbook or skill needed an update. (`sergeant-web-ui` skill вже описує DataState; новий — в окремому doc PR після того, як 2.9 ESLint rule landings)
- [x] I checked whether governance docs or review docs needed an update. (no change у hard-rules)

Updated docs:

- буде окремий `docs(docs): record 0011 PR 2.8 ...` PR

## Risk and Rollout

- **User-visible risk:** мінімальний. Поведінка 1:1 з попередньою (truth-table вище). Єдина потенційна різниця — DataState додає wrapper `<div>` навколо рендереного слоту (без класу), що може вплинути на flexbox-edge-cases у parent-і. Перевірено: parent (`WeeklyDigestCard` outer card) — block-level `rounded-2xl border bg-panel`, всі діти — звичайні block-level `<div>`-и. Extra wrapper не змінює layout.
- **Rollout / deploy order:** регулярний Vercel deploy на merge до main. Без feature-flag-у (це presentation-only refactor).
- **Backout plan:** revert single commit на main; `WeeklyDigestCard.tsx` поверне 3 ранніх `return`-и. Тест-файл можна видалити окремо або залишити (він valid для будь-якої реалізації, поки контракт-prop-и DigestContent stable).

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

- DataState `error` слот — function-form `() => errorSlot` (а не `errorSlot` як ReactNode), бо TS не звужує union без callsite, але runtime однаково (DataState не передає `err`/`retry` у `errorSlot`).
- `isError: !!error && !loading` — навмисно False під час loading, щоб preserve "spinner wins" precedence з оригіналу. Якщо рев'юер вважає, що error-during-regen має показуватись одразу — змінити на `!!error` і прибрати `&& !loading`.
- `WeeklyDigestCard.datastate.test.tsx` явно додає `afterEach(cleanup)` — це local fix; глобальний RTL auto-cleanup для всіх web-тестів — окремий refactor (поза скоупом цього PR).
- Pre-existing CI failures на main (governance sync drift, server `apiV1.test.ts`, mobile build `vite build` vs `@sergeant/db-schema/sqlite`, E2E auth, Argos visual regression) — не від цього PR; той самий набір падає на 2.4 (#1703), 2.5 (#1709), 2.6 (#1713), 2.7 (#1714).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `WeeklyDigestCard.DigestContent` to use `@shared/components/ui/DataState`, unifying the 4-state flow (skeleton → error → empty → content) without changing behavior. Adds focused tests to cover all states.

- **Refactors**
  - Replaced early returns with `<DataState>` and a `DataStateQueryLike` mapping: `data=undefined` while loading, `isError` only when not loading, `error` passed through.
  - Kept existing `LoadingSpinner` as `skeleton`; moved body to `children(d)`; added `isEmpty` to mirror previous `hasData` check.
  - Added `apps/web/src/core/insights/WeeklyDigestCard.datastate.test.tsx` with 5 cases (skeleton, empty current/past, error, content) and explicit RTL cleanup.

<sup>Written for commit d2152bbe0c9918b6c2c8334c4b1633abdca81ab9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for Weekly Digest Card covering loading states, error handling, empty states, and content rendering scenarios.

* **Refactor**
  * Enhanced Weekly Digest Card component state management patterns for improved handling of loading, error, empty, and success states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->