### PR TITLE
refactor(api-client): enable noUncheckedIndexedAccess (Item #15 round 8)

### DIFF
--- a/packages/api-client/src/__test-utils/firstCall.ts
+++ b/packages/api-client/src/__test-utils/firstCall.ts
@@ -1,0 +1,20 @@
+/**
+ * Test helper: повертає перший mock-call (типізований кортеж аргументів)
+ * або кидає AssertionError, якщо мок не викликали жодного разу.
+ *
+ * Існує спеціально для tsconfig `noUncheckedIndexedAccess: true` — без неї
+ * `fn.mock.calls[0]` має тип `T | undefined` і кожний test треба було б
+ * руками оголошувати `if (!call) throw ...`. Замість цього сайт-ами тестів
+ * пишемо `const [url, init] = firstCall(fn)`.
+ */
+export function firstCall<T extends unknown[]>(fn: {
+  mock: { calls: T[] };
+}): T {
+  const call = fn.mock.calls[0];
+  if (!call) {
+    throw new Error(
+      "firstCall: expected mock to have been called at least once, got 0 calls",
+    );
+  }
+  return call;
+}

--- a/packages/api-client/src/endpoints/me.test.ts
+++ b/packages/api-client/src/endpoints/me.test.ts
@@ -1,11 +1,13 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { createHttpClient } from "../httpClient";
+import { firstCall } from "../__test-utils/firstCall";
 import { createMeEndpoints } from "./me";
 
-// Повторюємо pattern із `httpClient.test.ts`: `vi.fn` без generic-параметра
-// повертає Mock з flexible-tuple args, тож `mock.calls[0][n]` індексується
-// без помилки TS2493 "has no element at index" під CI-strict tsconfig.
+// Pattern із `httpClient.test.ts`: `vi.fn` без generic повертає Mock з
+// flexible-tuple args. Перший виклик дістаємо через `firstCall(fn)` —
+// helper кидає `Error`, якщо мок не викликали; це задовольняє
+// `noUncheckedIndexedAccess: true` без `!` / `as` шуму на сайт-ах.
 type FetchMock = ReturnType<typeof vi.fn>;
 
 function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
@@ -59,7 +61,7 @@ describe("createMeEndpoints", () => {
       },
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    const url = fetchMock.mock.calls[0][0] as string;
+    const url = firstCall(fetchMock)[0] as string;
     // `createHttpClient()` defaults to `apiPrefix = "/api/v1"` (see
     // DEFAULT_API_PREFIX / PR #390), so `/api/me` is rewritten to
     // `/api/v1/me` before fetch. The server mirrors both `/api/me` and
@@ -103,7 +105,7 @@ describe("createMeEndpoints", () => {
     const me = createMeEndpoints(createHttpClient());
     const ctrl = new AbortController();
     await me.get({ signal: ctrl.signal });
-    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    const init = firstCall(fetchMock)[1] as RequestInit;
     expect(init.signal).toBe(ctrl.signal);
   });
 });

--- a/packages/api-client/src/endpoints/mono-webhook.test.ts
+++ b/packages/api-client/src/endpoints/mono-webhook.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { createHttpClient } from "../httpClient";
+import { firstCall } from "../__test-utils/firstCall";
 import { createMonoWebhookEndpoints } from "./mono";
 
 type FetchMock = ReturnType<typeof vi.fn>;
@@ -41,7 +42,7 @@ describe("createMonoWebhookEndpoints", () => {
 
     expect(result).toEqual(syncData);
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    const url = fetchMock.mock.calls[0][0] as string;
+    const url = firstCall(fetchMock)[0] as string;
     expect(url).toContain("/mono/sync-state");
   });
 
@@ -114,10 +115,7 @@ describe("createMonoWebhookEndpoints", () => {
     });
 
     expect(result).toEqual(page);
-    const url = new URL(
-      fetchMock.mock.calls[0][0] as string,
-      "http://localhost",
-    );
+    const url = new URL(firstCall(fetchMock)[0] as string, "http://localhost");
     expect(url.pathname).toContain("/mono/transactions");
   });
 
@@ -136,7 +134,7 @@ describe("createMonoWebhookEndpoints", () => {
     await endpoints.backfill();
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const [url, init] = firstCall(fetchMock) as [string, RequestInit];
     expect(url).toContain("/mono/backfill");
     expect(init.method).toBe("POST");
   });
@@ -161,7 +159,7 @@ describe("createMonoWebhookEndpoints", () => {
     const result = await endpoints.backfillProgress();
 
     expect(result).toEqual(snapshot);
-    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const [url, init] = firstCall(fetchMock) as [string, RequestInit];
     expect(url).toContain("/mono/backfill-progress");
     // HttpClient defaults GET to no `method` field; explicit POSTs set it.
     expect(init.method ?? "GET").toBe("GET");
@@ -179,7 +177,7 @@ describe("createMonoWebhookEndpoints", () => {
     const result = await endpoints.connect("my-token");
 
     expect(result).toEqual({ status: "active", accountsCount: 2 });
-    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const [, init] = firstCall(fetchMock) as [string, RequestInit];
     expect(init.method).toBe("POST");
     const body = JSON.parse(init.body as string);
     expect(body.token).toBe("my-token");
@@ -199,7 +197,7 @@ describe("createMonoWebhookEndpoints", () => {
     const endpoints = createMonoWebhookEndpoints(createHttpClient());
     await endpoints.disconnect();
 
-    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const [url, init] = firstCall(fetchMock) as [string, RequestInit];
     expect(url).toContain("/mono/disconnect");
     expect(init.method).toBe("POST");
   });

--- a/packages/api-client/src/endpoints/push.test.ts
+++ b/packages/api-client/src/endpoints/push.test.ts
@@ -1,11 +1,13 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { createHttpClient } from "../httpClient";
+import { firstCall } from "../__test-utils/firstCall";
 import { createPushEndpoints } from "./push";
 
-// Мокаємо глобальний fetch. `vi.fn` без generic-параметра повертає Mock з
-// flexible-tuple args — pattern із `me.test.ts` / `httpClient.test.ts`, щоб
-// `mock.calls[0][n]` індексувалось без TS2493 під CI-strict tsconfig.
+// Мокаємо глобальний fetch. `vi.fn` без generic повертає Mock з
+// flexible-tuple args — pattern із `me.test.ts` / `httpClient.test.ts`.
+// Перший виклик дістаємо через `firstCall(fn)` — задовольняє
+// `noUncheckedIndexedAccess: true` без `!` / `as` шуму на сайт-ах.
 type FetchMock = ReturnType<typeof vi.fn>;
 
 function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
@@ -44,7 +46,7 @@ describe("createPushEndpoints.register", () => {
 
     expect(res).toEqual({ ok: true, platform: "web" });
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    const init = firstCall(fetchMock)[1] as RequestInit;
     const parsed = JSON.parse(init.body as string) as {
       platform: string;
       token: string;
@@ -85,7 +87,7 @@ describe("createPushEndpoints.register", () => {
       { signal: ctrl.signal },
     );
 
-    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    const init = firstCall(fetchMock)[1] as RequestInit;
     expect(init.signal).toBe(ctrl.signal);
   });
 
@@ -95,7 +97,7 @@ describe("createPushEndpoints.register", () => {
     const push = createPushEndpoints(createHttpClient());
     await push.register({ platform: "android", token: "fcm-token" });
 
-    const url = fetchMock.mock.calls[0][0] as string;
+    const url = firstCall(fetchMock)[0] as string;
     expect(url).toContain("/api/v1/push/register");
     expect(url).not.toContain("/api/push/register");
   });
@@ -113,7 +115,7 @@ describe("createPushEndpoints.unregister", () => {
 
     expect(res).toEqual({ ok: true, platform: "web" });
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    const init = firstCall(fetchMock)[1] as RequestInit;
     const parsed = JSON.parse(init.body as string) as {
       platform: string;
       endpoint: string;
@@ -143,7 +145,7 @@ describe("createPushEndpoints.unregister", () => {
       endpoint: "https://fcm.googleapis.com/wp/xxx",
     });
 
-    const url = fetchMock.mock.calls[0][0] as string;
+    const url = firstCall(fetchMock)[0] as string;
     expect(url).toContain("/api/v1/push/unregister");
     expect(url).not.toContain("/api/push/unregister");
   });

--- a/packages/api-client/src/httpClient.test.ts
+++ b/packages/api-client/src/httpClient.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { createHttpClient, parseRetryAfterMs } from "./httpClient";
 import { ApiError } from "./ApiError";
+import { firstCall } from "./__test-utils/firstCall";
 
 // Test fixture — minimal client that uses default fetch and relative URLs,
 // matching the legacy `http` module export so the assertions below stay
@@ -58,7 +59,7 @@ describe("httpClient — успішні запити", () => {
   it("за замовчуванням credentials: 'include' та Accept: application/json", async () => {
     const fn = mockFetchOnce(jsonResponse({ ok: true }));
     await http.get("/api/ping");
-    const init = fn.mock.calls[0][1] as RequestInit;
+    const init = firstCall(fn)[1] as RequestInit;
     expect(init.credentials).toBe("include");
     const headers = init.headers as Headers;
     expect(headers.get("Accept")).toBe("application/json");
@@ -67,7 +68,7 @@ describe("httpClient — успішні запити", () => {
   it("POST: автоматично серіалізує plain-обʼєкт і ставить Content-Type", async () => {
     const fn = mockFetchOnce(jsonResponse({ ok: true }));
     await http.post("/api/x", { a: 1 });
-    const init = fn.mock.calls[0][1] as RequestInit;
+    const init = firstCall(fn)[1] as RequestInit;
     expect(init.method).toBe("POST");
     expect(init.body).toBe(JSON.stringify({ a: 1 }));
     const headers = init.headers as Headers;
@@ -77,7 +78,7 @@ describe("httpClient — успішні запити", () => {
   it("мерджить кастомні заголовки поверх дефолтів (X-Token)", async () => {
     const fn = mockFetchOnce(jsonResponse({ ok: true }));
     await http.get("/api/mono", { headers: { "X-Token": "secret" } });
-    const headers = (fn.mock.calls[0][1] as RequestInit).headers as Headers;
+    const headers = (firstCall(fn)[1] as RequestInit).headers as Headers;
     expect(headers.get("X-Token")).toBe("secret");
     expect(headers.get("Accept")).toBe("application/json");
   });
@@ -87,7 +88,7 @@ describe("httpClient — успішні запити", () => {
     await http.get("/api/search", {
       query: { q: "hello world", limit: 10, skip: undefined },
     });
-    const url = fn.mock.calls[0][0] as string;
+    const url = firstCall(fn)[0] as string;
     expect(url).toContain("q=hello+world");
     expect(url).toContain("limit=10");
     expect(url).not.toContain("skip=");
@@ -98,7 +99,7 @@ describe("httpClient — успішні запити", () => {
     const fd = new FormData();
     fd.append("file", new Blob(["x"]), "f.txt");
     await http.post("/api/upload", fd);
-    const init = fn.mock.calls[0][1] as RequestInit;
+    const init = firstCall(fn)[1] as RequestInit;
     expect(init.body).toBe(fd);
     const headers = init.headers as Headers;
     expect(headers.get("Content-Type")).toBeNull();
@@ -195,59 +196,59 @@ describe("httpClient — apiPrefix versioning", () => {
   it("за замовчуванням /api/* → /api/v1/*", async () => {
     const fn = mockFetchOnce(jsonResponse({ ok: true }));
     await http.get("/api/sync/push-all");
-    const url = fn.mock.calls[0][0] as string;
+    const url = firstCall(fn)[0] as string;
     expect(url).toBe("/api/v1/sync/push-all");
   });
 
   it("/api/auth/* НЕ версіонується (Better Auth basePath)", async () => {
     const fn = mockFetchOnce(jsonResponse({ ok: true }));
     await http.get("/api/auth/session");
-    expect(fn.mock.calls[0][0]).toBe("/api/auth/session");
+    expect(firstCall(fn)[0]).toBe("/api/auth/session");
   });
 
   it("уже версіонований /api/v1/foo → залишається як є", async () => {
     const fn = mockFetchOnce(jsonResponse({ ok: true }));
     await http.get("/api/v1/push/register");
-    expect(fn.mock.calls[0][0]).toBe("/api/v1/push/register");
+    expect(firstCall(fn)[0]).toBe("/api/v1/push/register");
   });
 
   it("не-/api/ шляхи прокидаються без змін", async () => {
     const fn = mockFetchOnce(jsonResponse({ ok: true }));
     await http.get("/healthz");
-    expect(fn.mock.calls[0][0]).toBe("/healthz");
+    expect(firstCall(fn)[0]).toBe("/healthz");
   });
 
   it("apiPrefix: '/api' — legacy-режим, без версіонування (escape hatch)", async () => {
     const legacy = createHttpClient({ apiPrefix: "/api" });
     const fn = mockFetchOnce(jsonResponse({ ok: true }));
     await legacy.get("/api/sync/push-all");
-    expect(fn.mock.calls[0][0]).toBe("/api/sync/push-all");
+    expect(firstCall(fn)[0]).toBe("/api/sync/push-all");
   });
 
   it("кастомний apiPrefix: /api/v2 → /api/v2/foo", async () => {
     const v2 = createHttpClient({ apiPrefix: "/api/v2" });
     const fn = mockFetchOnce(jsonResponse({ ok: true }));
     await v2.get("/api/coach/memory");
-    expect(fn.mock.calls[0][0]).toBe("/api/v2/coach/memory");
+    expect(firstCall(fn)[0]).toBe("/api/v2/coach/memory");
   });
 
   it("не чіпає /api-шляхи без слеша після (напр. /api-foo) щоб не поламати сусідні префікси", async () => {
     const fn = mockFetchOnce(jsonResponse({ ok: true }));
     await http.get("/api-foo");
-    expect(fn.mock.calls[0][0]).toBe("/api-foo");
+    expect(firstCall(fn)[0]).toBe("/api-foo");
   });
 
   it("прокидає baseUrl + apiPrefix у правильному порядку", async () => {
     const remote = createHttpClient({ baseUrl: "https://api.example.com" });
     const fn = mockFetchOnce(jsonResponse({ ok: true }));
     await remote.get("/api/me");
-    expect(fn.mock.calls[0][0]).toBe("https://api.example.com/api/v1/me");
+    expect(firstCall(fn)[0]).toBe("https://api.example.com/api/v1/me");
   });
 
   it("query-параметри коректно додаються до переписаного шляху", async () => {
     const fn = mockFetchOnce(jsonResponse({ ok: true }));
     await http.get("/api/food-search", { query: { q: "банан" } });
-    const url = fn.mock.calls[0][0] as string;
+    const url = firstCall(fn)[0] as string;
     expect(url.startsWith("/api/v1/food-search?")).toBe(true);
     expect(url).toContain("q=%D0%B1%D0%B0%D0%BD%D0%B0%D0%BD");
   });
@@ -258,7 +259,7 @@ describe("httpClient — AbortSignal", () => {
     const fn = mockFetchOnce(jsonResponse({ ok: true }));
     const ac = new AbortController();
     await http.get("/api/x", { signal: ac.signal });
-    const init = fn.mock.calls[0][1] as RequestInit;
+    const init = firstCall(fn)[1] as RequestInit;
     expect(init.signal).toBeDefined();
   });
 

--- a/packages/api-client/tsconfig.json
+++ b/packages/api-client/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "allowJs": false,
     "checkJs": false,
-    "noUncheckedIndexedAccess": false,
+    "noUncheckedIndexedAccess": true,
     "lib": ["ES2022", "DOM"],
     "jsx": "react-jsx",
     "rootDir": "./src",


### PR DESCRIPTION
## Summary

Web deep-dive **Item #15** (TypeScript strict — Phase 6a per-module rollout) round-8 follow-up. Removes `noUncheckedIndexedAccess: false` override from `packages/api-client/tsconfig.json`, bringing the package up to 100 % strict (matching `shared`, `nutrition-domain`, `routine-domain`, `db-schema`, `insights`). Strict-coverage **7 / 13 → 8 / 13 packages** (54 % → 62 %).

Surface: 4 test files (`httpClient.test.ts`, `endpoints/me.test.ts`, `endpoints/mono-webhook.test.ts`, `endpoints/push.test.ts`) — 24 `fn.mock.calls[0][i]` accesses where the indexed call could be `undefined` if the mock was never invoked. The previous override hid these — production sources had zero `noUncheckedIndexedAccess` errors, so this PR is test-only and ships no behavior change.

Fix introduces a tiny typed helper `firstCall(fn)` in `packages/api-client/src/__test-utils/firstCall.ts`:

```ts
export function firstCall<T extends unknown[]>(fn: { mock: { calls: T[] } }): T {
  const call = fn.mock.calls[0];
  if (!call) {
    throw new Error(
      "firstCall: expected mock to have been called at least once, got 0 calls",
    );
  }
  return call;
}
```

It asserts `mock.calls.length > 0` and returns the tuple. The call sites stay readable (`firstCall(fn)[1] as RequestInit`) without scattering `!` non-null assertions or `?? []` placeholders, and on the failure path the test produces a clear assertion message instead of a vague TS narrowing error.

## Governing Skill

- Primary skill: `sergeant-server-api` — touches `@sergeant/api-client`.
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a (matches the pattern of #1635 / #1681 / #1689 — per-module strict-flag flip)
- Why this playbook: tracking initiative is `docs/tech-debt/frontend.md §11.1` Phase 6a per-module rollout. Same shape as the round-7 `@sergeant/insights` rollout (#1689).
- If no playbook matched, why: rollout is mechanical: flip flag, fix errors via existing established patterns, validate.

## Verification

```bash
pnpm --filter @sergeant/api-client typecheck    # clean (was: 24 errors / 4 files)
pnpm --filter @sergeant/api-client test         # 57/57 passed
pnpm --filter @sergeant/api-client lint         # clean
node scripts/strict-coverage.mjs                # 8/13 packages with noUncheckedIndexedAccess: true
```

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- (`docs/tech-debt/frontend.md` §11.1 follow-up + `docs/diagnostics/2026-05-03-web-deep-dive/00-overview.md` round-8 summary land in a separate docs PR after all 4 round-8 follow-ups merge — matches the round-7 sequence.)

## Risk and Rollout

- User-visible risk: **none**. Test-only changes; production sources had no errors after the flag flip.
- Rollout / deploy order: standard build; no env / migration / feature flag.
- Backout plan: revert this PR; the helper file can stay in place harmlessly even if the flag is rolled back.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

Remaining packages still on `noUncheckedIndexedAccess: false`: `apps/web` (625 / 147), `apps/server` (335 / 57), `apps/mobile` (25 / 14), `packages/finyk-domain` (169 / 46), `packages/fizruk-domain` (52 / 14). These will land in subsequent per-module PRs per `docs/tech-debt/frontend.md §11.1`.

The outdated comment about `TS2493 has no element at index` in two test files was rewritten to reference the new `firstCall(fn)` helper and the actual `noUncheckedIndexedAccess: true` flag (the prior comment lied: `mock.calls[0][n]` did NOT index without the override).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable `noUncheckedIndexedAccess` for `@sergeant/api-client` as part of Item #15 strict rollout. Adds a small test helper to safely access mock calls; no production behavior changes.

- **Refactors**
  - Set `noUncheckedIndexedAccess: true` in `packages/api-client/tsconfig.json`.
  - Introduced `__test-utils/firstCall.ts` to assert at least one mock call and return the call tuple.
  - Updated 4 test files to use `firstCall` instead of `fn.mock.calls[0][i]`.

<sup>Written for commit fe420bde888e534a65d0e1c2f4c2b205c00394f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test utilities for improved type safety and consistency across test suites.

* **Chores**
  * Enabled stricter TypeScript type checking to improve code quality and catch potential errors during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->