### PR TITLE
docs(agents): add 30-minute onboarding doc (Initiative 0009 PR 5.2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
 ## Agent operating system
 
 - Start here: `.agents/skills/sergeant-start-here/SKILL.md`
+- 30-minute onboarding: [`docs/agents/onboarding.md`](./docs/agents/onboarding.md)
 - Skill routing catalog: `docs/agents/agent-skills-catalog.md`
 - Workflow decision trees: `docs/agents/agent-workflows.md`
 - Execution recipes: `docs/playbooks/README.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Claude in Sergeant
 
-> **Last validated:** 2026-05-02 by @Skords-01. **Next review:** 2026-07-31.
+> **Last validated:** 2026-05-04 by @Skords-01. **Next review:** 2026-08-02.
 > **Status:** Active
 
 > **Single source of truth → [AGENTS.md](./AGENTS.md).** Цей файл — тонкий вказівник із кількома Claude-specific нотатками. Уся repo policy, hard rules, routing catalog і playbook-індекс живуть там і в `docs/`.
@@ -11,6 +11,7 @@
 2. Почни з `.agents/skills/sergeant-start-here/SKILL.md`.
 3. Завантаж рівно один specialist skill для основної поверхні зміни.
 4. Якщо під задачу є playbook у [docs/playbooks/](./docs/playbooks/README.md) — виконуй його як canonical recipe.
+5. Перший раз у репо? Прогонись по [`docs/agents/onboarding.md`](./docs/agents/onboarding.md) — секрети, БД, hard-rule навігація, plop-генератори.
 
 ## Claude-specific нотатки
 

--- a/DEVIN.md
+++ b/DEVIN.md
@@ -11,6 +11,7 @@
 2. Почни з `.agents/skills/sergeant-start-here/SKILL.md`.
 3. Завантаж рівно один specialist skill для основної поверхні зміни (див. [agent-skills-catalog.md](./docs/agents/agent-skills-catalog.md)).
 4. Якщо під задачу є playbook у [docs/playbooks/](./docs/playbooks/README.md) — виконуй його як canonical recipe.
+5. Перший раз у репо? Пройди [`docs/agents/onboarding.md`](./docs/agents/onboarding.md) — секрети (`/run/repo_secrets/Sergeant/.env.secrets`), `pnpm db:up` із pgvector image, hard-rule навігація, plop-генератори.
 
 ## Devin-specific нотатки
 

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -18,6 +18,7 @@
 
 | Підрозділ                                              | Призначення                                                                    |
 | ------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| [`onboarding.md`](./onboarding.md)                     | Перші 30 хвилин агента в Sergeant: секрети, БД, hard-rule навігація, plop.     |
 | [`agent-skills-catalog.md`](./agent-skills-catalog.md) | Scenario -> skill -> what it enforces.                                         |
 | [`agent-workflows.md`](./agent-workflows.md)           | Decision trees для feature, bugfix, review, migration, release.                |
 | [`specialists-mapping.md`](./specialists-mapping.md)   | Runtime `SpecialistAgent` ↔ governance skill ↔ primary playbook ↔ ADR.         |

--- a/docs/agents/onboarding.md
+++ b/docs/agents/onboarding.md
@@ -1,0 +1,101 @@
+# Перші 30 хвилин агента в Sergeant
+
+> **Last validated:** 2026-05-04 by @Skords-01. **Next review:** 2026-08-02.
+> **Status:** Active
+
+Стартова шпаргалка для AI-агентів (Devin, Claude, локальні моделі) і нових контриб'юторів. Мета — за 30 хвилин довести середовище до стану «можна писати код, не порушуючи hard rules і не падаючи на pre-commit». Для повної repo policy джерело правди — [`AGENTS.md`](../../AGENTS.md). Цей файл — навігація і `quickstart`, не паралельний source-of-truth.
+
+## 0. Перш ніж почати
+
+1. Прочитай [`AGENTS.md`](../../AGENTS.md) — hard rules + module ownership map.
+2. Завантаж `.agents/skills/sergeant-start-here/SKILL.md` як вхідну точку.
+3. За [`agent-skills-catalog.md`](./agent-skills-catalog.md) обери **рівно один** specialist skill під поверхню зміни (web / server / mobile / hubchat / data / deploy / review / bugfix / feature).
+4. Якщо для задачі є playbook у [`docs/playbooks/`](../playbooks/README.md) — він canonical recipe; не імпровізуй.
+
+## 1. Секрети і env
+
+**Sergeant використовує `.env.example` (≈300 рядків) як reference для всіх змінних оточення.** Ніколи не комить `.env`, `.env.local`, `.env.secrets`.
+
+- **Devin:** секрети сесії живуть у `/run/repo_secrets/Sergeant/.env.secrets`. Завантаж їх у поточний shell перед запуском будь-чого: `set -a; . /run/repo_secrets/Sergeant/.env.secrets; set +a`. Якщо файлу немає — користувач не провіжнив секрети для цієї сесії; запитай через `secrets` tool у форматі «Skip / Session-only / Permanent».
+- **Локально:** копія `.env` поряд із `.env.example`. Мінімальний набір для `pnpm dev`: `DATABASE_URL`, `BETTER_AUTH_SECRET`, `ANTHROPIC_API_KEY` (для HubChat), `VAPID_PUBLIC_KEY`/`VAPID_PRIVATE_KEY` (для push). Решта — дивись `.env.example` per-feature.
+- **AI_QUOTA_DISABLED:** kill-switch для AI-квоти. У dev/test — `=1` (вимикає `assertAiQuota`, тобто кожен HubChat-запит проходить без перевірки бюджету). У production — **must be `=0`** (server-startup hardфайлить інакше — див. [`apps/server/src/env/env.ts`](../../apps/server/src/env/env.ts)).
+- **Production-критичні змінні:** `RESEND_API_KEY`, `MONO_WEBHOOK_SECRET`, `SENTRY_DSN_*`, `POSTHOG_API_KEY`, OAuth client IDs/secrets — НЕ комітити, навіть тестові.
+
+## 2. Postgres + міграції
+
+- **Підняти БД:** `pnpm db:up` (== `docker compose up -d` із [`docker-compose.yml`](../../docker-compose.yml)). Image — `pgvector/pgvector:pg16`, не stock `postgres:16-alpine` (міграція `025_ai_memories_pgvector.sql` робить `CREATE EXTENSION vector` — alpine падає). CI workflow'и `ci.yml`, `extended-e2e.yml`, `visual-regression.yml` пінять той же image.
+- **Прогнати міграції:** `pnpm db:migrate` (== `apps/server/migrate.mjs`). Sequential `NNN_*.sql` у [`apps/server/src/migrations/`](../../apps/server/src/migrations/), без gaps. Hard Rule #4 — drop колонок робиться у **двох фазах**, deployed окремо.
+- **Один-команда стартап:** `pnpm dev:db` (db:up + db:migrate).
+- **Reset:** `docker compose down -v && pnpm dev:db` (стирає volume — `dev` only).
+
+## 3. Що робити, коли CI впав на hard-rule помилці
+
+CI hard-rules ловляться різними механізмами. Стартова навігація:
+
+| Симптом                                                    | Куди дивитися                                                                                                                                                                                                                |
+| ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `lint:hard-rules-registry` падає                           | Drift `AGENTS.md` ↔ [`hard-rules.json`](../governance/hard-rules.json) ↔ `CONTRIBUTING.md`. Прогнати `pnpm hard-rules:list` побачиш точне правило.                                                                           |
+| `sergeant-design/no-hex-in-classname` (Hard Rule #11)      | `AGENTS.md` § [Lint-enforced design conventions](../../AGENTS.md#lint-enforced-design-conventions) → правило #11. ESLint plugin: [`packages/eslint-plugin-sergeant-design/`](../../packages/eslint-plugin-sergeant-design/). |
+| `sergeant-design/no-foreign-module-accent` (Hard Rule #12) | Те саме, правило #12. Cross-module surface (`core/`, `shared/`) — exempt.                                                                                                                                                    |
+| `sergeant-design/no-raw-palette-dark-pair` (Hard Rule #13) | Те саме, правило #13. Lift у design-tokens layer (`bg-success-soft`, `text-brand-strong`).                                                                                                                                   |
+| `sergeant-design/prefer-focus-visible` (Hard Rule #14)     | Те саме, правило #14. `focus:` → `focus-visible:` всюди, крім `focus:outline-none`.                                                                                                                                          |
+| `commitlint` (Hard Rule #5)                                | Дозволені scope-и в `AGENTS.md` § Hard rules → правило #5. Не вигадуй нові.                                                                                                                                                  |
+| `lint:codeowners`                                          | [`scripts/check-codeowners-coverage.mjs`](../../scripts/check-codeowners-coverage.mjs) — кожна governance/CI/migrations поверхня має CODEOWNERS-rule.                                                                        |
+| `docs:check-playbook-schema`                               | Trigger ≤ 240 chars, Status enum {Active, Scaffolded, Deprecated, Archived}, Verification ≥ 1 checkbox. Дивись `add-playbook.md` playbook (якщо є) або інший working playbook.                                               |
+
+Повна enforcement-матриця — у [`hard-rules-matrix.md`](../governance/hard-rules-matrix.md). Категорійна семантика (`blocker-invariant` / `lint-enforced-convention` / `active-initiative`) описана в `AGENTS.md` § Hard rules intro.
+
+## 4. Як обрати skill за тригерною фразою
+
+`agent-skills-catalog.md` — таблиця `Scenario → skill → what it enforces`. Швидкий decision tree:
+
+- **«додаю screen / компонент / Tailwind стиль»** → `sergeant-web-ui`.
+- **«додаю/міняю API endpoint, серіалізатор, RQ ключі»** → `sergeant-server-api`.
+- **«React Native / Expo screen, MMKV, Capacitor»** → `sergeant-mobile-expo`.
+- **«SQL міграція, схема, query, Postgres налаштування»** → `sergeant-data-and-migrations`.
+- **«HubChat tool, action card, prompt cache»** → `sergeant-hubchat`.
+- **«auth, login, session cookies, Better Auth»** → `better-auth-best-practices`.
+- **«deploy config, Vercel/Railway, env vars, Sentry»** → `sergeant-deploy-and-observability`.
+- **«review-and-merge / PR review / safe to ship»** → `sergeant-review-and-merge`.
+- **«фіксую регресію / прод-баг / flaky test»** → `sergeant-bugfix-and-regression`.
+- **«не впевнений / multi-surface / cross-package»** → `sergeant-monorepo-boundaries`.
+
+Більше одного скіла одночасно тримати не треба — [`AGENTS.md`](../../AGENTS.md) описує routing-disсipline.
+
+## 5. Plop generators (boilerplate без копіпаста)
+
+- `pnpm gen:adr` — створює `docs/adr/NNNN-<slug>.md` із валідною шапкою (Status / Date / Reviewers / Supersedes / Related). Номер обчислюється через `nextAdrNumber()` у [`plopfile.mjs`](../../plopfile.mjs), gaps пропускаються.
+- (Майбутнє, Initiative 0009 фаза 5.1) `pnpm gen:skill`, `pnpm gen:playbook`, `pnpm gen:n8n-workflow`, `pnpm gen:console-specialist`, `pnpm gen:package` — інтерактивні prompt'и зі smoke-тестами на shape contract. Слідкуй за оновленням цього розділу.
+
+## 6. Verification before PR
+
+Мінімальний green-set перед `git push`:
+
+```bash
+pnpm lint                    # ESLint flat config + custom plugin
+pnpm typecheck               # TypeScript per-app
+pnpm lint:skills             # SKILL.md shape + skills-lock SHA-256
+pnpm lint:hard-rules-registry  # hard-rules.json ↔ AGENTS.md ↔ CONTRIBUTING.md
+pnpm docs:check-playbook-schema  # якщо торкався playbook'ів
+pnpm docs:check-links        # якщо доді/змінив internal лінки
+```
+
+Husky pre-commit прогонить `lint-staged` (ESLint --fix + Prettier) і блокує commit, якщо щось не зеленіє. **Не передавай `--no-verify`** — це Hard Rule #7.
+
+## 7. PR лайфцикл
+
+- Один surface → один primary skill → один primary playbook.
+- Conventional Commits scope з enum у `AGENTS.md` Hard Rule #5 (наприклад: `docs(agents)`, `feat(server)`, `fix(web)`).
+- PR template — [`AGENTS.md`](../../AGENTS.md) § PR template секція в Verification before PR.
+- Post-PR: чекай CI. `pnpm lint` падає на новому ESLint warning'у → fix. `Markdown link checker` падає на pre-existing broken link → можна зберегти scope, але зазнач у PR description.
+- Якщо CI блок через pre-existing failure (не від твоєї роботи) — окремий міні-PR-розблокувач, не міксуй scope.
+
+## Дивись також
+
+- [`AGENTS.md`](../../AGENTS.md) — hard rules + module ownership + commit/PR conventions.
+- [`agent-skills-catalog.md`](./agent-skills-catalog.md) — full skill routing table.
+- [`agent-workflows.md`](./agent-workflows.md) — decision trees per workflow type.
+- [`specialists-mapping.md`](./specialists-mapping.md) — runtime SpecialistAgent ↔ skill ↔ playbook map.
+- [`docs/playbooks/README.md`](../playbooks/README.md) — execution recipes by trigger.
+- [`docs/governance/hard-rules-matrix.md`](../governance/hard-rules-matrix.md) — машино-читабельна enforcement-матриця.
+- [`AGENTS.md` § Hard rules intro](../../AGENTS.md#hard-rules-do-not-break) — таксономія категорій (`blocker-invariant` / `lint-enforced-convention` / `active-initiative`).


### PR DESCRIPTION
## Summary

Initiative 0009 фаза 5.2. Створив `docs/agents/onboarding.md` — quickstart для AI-агентів (Devin / Claude / локальні моделі) та нових контриб'юторів. Мета: за 30 хвилин довести середовище до робочого стану («можна писати код, не порушуючи hard rules і не падаючи на pre-commit»).

Зміст doc'а (UA, ~110 рядків):

- **§1 Секрети i env** — Devin шлях `/run/repo_secrets/Sergeant/.env.secrets`, локальний `.env`, мінімальний набір для `pnpm dev`, `AI_QUOTA_DISABLED` semantics (dev=`1`, prod=`0`).
- **§2 Postgres + міграції** — `pnpm db:up` (`pgvector/pgvector:pg16`), `pnpm db:migrate`, two-phase DROP, reset workflow.
- **§3 Hard-rule помилки CI** — таблиця симптом → де шукати (registry sync, ESLint plugin rules #11/12/13/14, commitlint scope enum, codeowners coverage, playbook schema). Лінки на `hard-rules-matrix.md` і `AGENTS.md` § Hard rules.
- **§4 Skill routing decision tree** — швидкий «trigger phrase → spec skill» map (10 поверхонь).
- **§5 Plop generators** — `pnpm gen:adr` зараз; майбутні `gen:skill` / `gen:playbook` / `gen:n8n-workflow` / `gen:console-specialist` / `gen:package` тегнуто як «майбутнє, Initiative 0009 фаза 5.1».
- **§6 Verification before PR** — мінімальний green-set команд (`lint`, `typecheck`, `lint:skills`, `lint:hard-rules-registry`, `docs:check-playbook-schema`, `docs:check-links`).
- **§7 PR лайфцикл** — Conventional Commits, PR template, CI failure tactics.

Wiring:

- `AGENTS.md` § Agent operating system — додано `30-minute onboarding: docs/agents/onboarding.md` між Start-here і Skill catalog.
- `CLAUDE.md` § Startup flow — додано крок 5 з посиланням на onboarding.
- `DEVIN.md` § Startup flow — додано крок 5 з тим же посиланням + примітка про `/run/repo_secrets/Sergeant/.env.secrets` і pgvector image.
- `docs/agents/README.md` — додано рядок у subsection table.

## Governing Skill

- Primary skill: `.agents/skills/sergeant-feature-delivery`
- Secondary skill (if truly needed): —

## Playbook

- Primary playbook: —
- Why this playbook: —
- If no playbook matched, why: новий doc-файл без runtime-зміни — execution рухався acceptance-критеріями PR 5.2 в [`docs/initiatives/0009-agent-os-hardening.md`](https://github.com/Skords-01/Sergeant/blob/main/docs/initiatives/0009-agent-os-hardening.md).

## Verification

```bash
pnpm docs:check-links
# 5 pre-existing broken internal links + 4 pre-existing 404s (unrelated to this PR).
# No links from docs/agents/onboarding.md fail.

pnpm docs:check-freshness-coverage
# All tracked markdown files have a freshness header.

pnpm lint:skills
# [lint:skills] OK — 12 skill(s) pass shape + lock.

pnpm prettier --write AGENTS.md CLAUDE.md DEVIN.md docs/agents/README.md docs/agents/onboarding.md
# all clean
```

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update. — додав рядок у § Agent operating system.
- [x] I checked whether a playbook or skill needed an update. — playbooks не зачеплено; skills не змінені.
- [x] I checked whether governance docs or review docs needed an update. — `docs/agents/README.md` subsection-table оновлено.

Updated docs:

- `docs/agents/onboarding.md` (new).
- `AGENTS.md` (link).
- `CLAUDE.md` (link, step 5).
- `DEVIN.md` (link, step 5).
- `docs/agents/README.md` (subsection table row).

## Risk and Rollout

- User-visible risk: жоден. Documentation-only.
- Rollout / deploy order: docs-only.
- Backout plan: revert PR — самодостатній файл + 4 link-додавання, тривіально reversible.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

- Onboarding-doc свідомо не переписує `AGENTS.md` чи playbooks — це навігаційна шпаргалка, source-of-truth лишається в `AGENTS.md`. Якщо щось у onboarding'у дрейфує від `AGENTS.md`, freshness-rev'ю на `Next review: 2026-08-02` має це зловити.
- Acceptance criteria PR 5.2 з ініціативи 0009: (a) doc існує — yes; (b) freshness header + Status: Active — yes; (c) лінки з AGENTS/CLAUDE/DEVIN — yes; (d) `docs:check-links` без нових broken — yes (5 pre-existing internal + 4 pre-existing external 404s, всі не від цього PR).
- §3 таблиця посилається на `AGENTS.md § Lint-enforced design conventions` (anchor `#lint-enforced-design-conventions`). Цей розділ створює PR 3.1 (#1725 у тій же ініціативі). Markdown link checker не валідовує fragment anchors окремо, лише існування файлу — `AGENTS.md` існує, тому лінк проходить незалежно від мерджу #1725.
- §5 Plop tagged як «майбутнє» для генераторів, що створює PR 5.1; це навмисно: doc-file пишеться до 5.1 як заглушка, після 5.1 рядок оновлюється з працюючими командами без перебудови doc'а.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 30‑minute onboarding guide for agents and new contributors, and links it across the agent docs to speed up first‑time setup and pass hard rules.

- **New Features**
  - New `docs/agents/onboarding.md` quickstart covering: secrets/env (incl. Devin `/run/repo_secrets/Sergeant/.env.secrets`), Postgres with `pgvector` image and migrations, `AI_QUOTA_DISABLED` semantics, hard‑rule triage, skill routing, plop generators, and pre‑PR checks.
  - Added links in `AGENTS.md` (Agent operating system), `CLAUDE.md` and `DEVIN.md` startup flow (step 5), and `docs/agents/README.md`.
  - Meets Initiative 0009 phase 5.2 requirements; link and freshness checks green with no new broken links.

<sup>Written for commit 5a3b12a6ab8ef3beb5495ef2a15732d5a39c4b1b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive 30-minute onboarding guide for AI agents, covering environment setup, secrets management, database configuration, hard-rule verification, generator usage, and pre-commit checks.
  * Updated agent navigation documentation and startup flow references to guide new users to onboarding materials for initial setup.

* **Chores**
  * Updated validation and review date metadata in agent configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->