### PR TITLE
docs(web): add Storybook stories for Avatar / Select / Stat / Segmented (Item #16 round 8)

### DIFF
--- a/apps/web/src/shared/components/ui/Avatar.stories.tsx
+++ b/apps/web/src/shared/components/ui/Avatar.stories.tsx
@@ -1,0 +1,89 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Avatar } from "./Avatar";
+
+/**
+ * `Avatar` — кругла аватарка з image-source, fallback на ініціали з `name`,
+ * та опційний status-dot (online / busy / offline).
+ *
+ * Розміри узгоджені з `Button` size-tokens: xs (24), sm (32), md (40),
+ * lg (48), xl (56). `getInitials(name)` бере перший символ першого слова +
+ * перший символ останнього слова, uppercased; для одного слова — лише
+ * перший символ. Status-dot ловить `ring-panel`, тож на темному фоні
+ * залишається видимим.
+ */
+const meta: Meta<typeof Avatar> = {
+  title: "UI / Avatar",
+  component: Avatar,
+  parameters: { layout: "centered" },
+  tags: ["autodocs"],
+  argTypes: {
+    size: { control: "select", options: ["xs", "sm", "md", "lg", "xl"] },
+    status: {
+      control: "select",
+      options: [undefined, "online", "busy", "offline"],
+    },
+  },
+  args: {
+    name: "Ка А",
+    size: "md",
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Avatar>;
+
+/** Default — ініціали `КА` з `name="Ка А"`. */
+export const Default: Story = {};
+
+/** З аватаркою-зображенням; `alt={name}` для a11y. */
+export const WithImage: Story = {
+  args: {
+    src: "https://i.pravatar.cc/96?img=12",
+    name: "Ка А",
+  },
+};
+
+/** Fallback на ініціали, коли `src` недоступний. */
+export const InitialsFallback: Story = {
+  args: { name: "Олена Шевченко" },
+};
+
+/** З status-dot — online (зелений). */
+export const StatusOnline: Story = {
+  args: { name: "Олена", status: "online" },
+};
+
+/** З status-dot — busy (жовтий). */
+export const StatusBusy: Story = {
+  args: { name: "Олена", status: "busy" },
+};
+
+/** З status-dot — offline (сірий). */
+export const StatusOffline: Story = {
+  args: { name: "Олена", status: "offline" },
+};
+
+/** Усі розміри в один ряд — для перевірки токенів та status-dot масштабу. */
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex items-end gap-4">
+      <Avatar name="К А" size="xs" status="online" />
+      <Avatar name="К А" size="sm" status="online" />
+      <Avatar name="К А" size="md" status="online" />
+      <Avatar name="К А" size="lg" status="online" />
+      <Avatar name="К А" size="xl" status="online" />
+    </div>
+  ),
+};
+
+/** Edge-cases для `getInitials` — порожнє ім'я, одне слово, не-латиниця. */
+export const InitialsEdgeCases: Story = {
+  render: () => (
+    <div className="flex items-center gap-4">
+      <Avatar name="" />
+      <Avatar name="Олена" />
+      <Avatar name="Олена Шевченко" />
+      <Avatar name="李 小龙" />
+    </div>
+  ),
+};

--- a/apps/web/src/shared/components/ui/Segmented.stories.tsx
+++ b/apps/web/src/shared/components/ui/Segmented.stories.tsx
@@ -1,0 +1,109 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Segmented, type SegmentedProps } from "./Segmented";
+
+/**
+ * `Segmented` — pill-style segmented control для mode/tab перемикання
+ * усередині сторінки. Консолідує drift між Fizruk Workouts (solid
+ * module-fill tabs) та Routine calendar time-mode chips (soft tinted chips).
+ *
+ * Two-axis API:
+ *   - `variant` — accent колір (`brand` за замовчуванням; чотири module-токени
+ *                 скоупують активний стан до конкретного модуля).
+ *   - `style`   — візуальне трактування активного chip-а:
+ *                 - `solid` — фон `bg-{c}-strong` + `text-white` (5.0–7.0:1
+ *                   contrast на 12 px → проходить WCAG AA для звичайного
+ *                   тексту, не покладаючись на large-text exemption).
+ *                 - `soft`  — `bg-{c}-soft` + accent-border + `text-{c}-strong`,
+ *                   більш subtle treatment для filtering chips.
+ *
+ * Без сабтабів: `<SubTabs>` залишається окремим повноширинним bar-style
+ * варіантом. Hapticи на iOS/Android викликаються через `hapticTap()`
+ * adapter тільки при зміні значення (не на повторному кліку).
+ */
+const meta: Meta<typeof Segmented> = {
+  title: "UI / Segmented",
+  component: Segmented,
+  parameters: { layout: "centered" },
+  tags: ["autodocs"],
+  argTypes: {
+    style: { control: "select", options: ["solid", "soft"] },
+    size: { control: "select", options: ["sm", "md"] },
+    variant: {
+      control: "select",
+      options: ["brand", "fizruk", "routine", "nutrition", "finyk"],
+    },
+  },
+  args: {
+    style: "soft",
+    size: "md",
+    variant: "brand",
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Segmented>;
+
+const items = [
+  { value: "day", label: "День" },
+  { value: "week", label: "Тиждень" },
+  { value: "month", label: "Місяць" },
+] as const;
+
+function ControlledDemo(
+  props: Omit<SegmentedProps<string>, "items" | "value" | "onChange">,
+) {
+  const [value, setValue] = useState<string>("week");
+  return (
+    <Segmented
+      {...props}
+      items={items}
+      value={value}
+      onChange={setValue}
+      ariaLabel="Період"
+    />
+  );
+}
+
+/** Default — `soft` style + `brand` variant. */
+export const Default: Story = {
+  render: (args) => <ControlledDemo {...args} />,
+};
+
+/** `solid` style — filled accent для primary mode-tabs (Fizruk Workouts). */
+export const Solid: Story = {
+  args: { style: "solid" },
+  render: (args) => <ControlledDemo {...args} />,
+};
+
+/** `sm` size — менший touch-target (36 px) для compact filters. */
+export const Small: Story = {
+  args: { size: "sm" },
+  render: (args) => <ControlledDemo {...args} />,
+};
+
+/** Усі 5 module-варіантів у `soft`-style — для перевірки brand-токенів. */
+export const ModuleVariantsSoft: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3">
+      <ControlledDemo variant="brand" />
+      <ControlledDemo variant="fizruk" />
+      <ControlledDemo variant="routine" />
+      <ControlledDemo variant="nutrition" />
+      <ControlledDemo variant="finyk" />
+    </div>
+  ),
+};
+
+/** Усі 5 module-варіантів у `solid`-style — для perf-тесту contrast. */
+export const ModuleVariantsSolid: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3">
+      <ControlledDemo variant="brand" style="solid" />
+      <ControlledDemo variant="fizruk" style="solid" />
+      <ControlledDemo variant="routine" style="solid" />
+      <ControlledDemo variant="nutrition" style="solid" />
+      <ControlledDemo variant="finyk" style="solid" />
+    </div>
+  ),
+};

--- a/apps/web/src/shared/components/ui/Select.stories.tsx
+++ b/apps/web/src/shared/components/ui/Select.stories.tsx
@@ -1,0 +1,95 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Select } from "./Select";
+
+/**
+ * `Select` — нативний `<select>` зі стилями, узгодженими з `<Input>`:
+ * ті самі sizes (sm / md / lg) і той самий border / focus-ring treatment,
+ * тож форми перестають мікшувати `h-11 rounded-2xl` поля з ad-hoc
+ * `h-10 rounded-xl` селектами.
+ *
+ * Залишаємо нативний `<select>` навмисно — на iOS/Android відкривається
+ * системний picker, що краще для a11y / UX, ніж кастомні дропдауни.
+ * Цей wrapper лише дає каретку та узгоджує стилі.
+ */
+const meta: Meta<typeof Select> = {
+  title: "UI / Select",
+  component: Select,
+  parameters: { layout: "centered" },
+  tags: ["autodocs"],
+  argTypes: {
+    size: { control: "select", options: ["sm", "md", "lg"] },
+    variant: { control: "select", options: ["default", "filled", "ghost"] },
+    error: { control: "boolean" },
+    disabled: { control: "boolean" },
+  },
+  args: {
+    size: "md",
+    variant: "default",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-64">
+        <Story />
+      </div>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof Select>;
+
+const months = ["Січень", "Лютий", "Березень", "Квітень", "Травень", "Червень"];
+
+function ControlledDemo(props: React.ComponentProps<typeof Select>) {
+  const [value, setValue] = useState("Лютий");
+  return (
+    <Select {...props} value={value} onChange={(e) => setValue(e.target.value)}>
+      {months.map((m) => (
+        <option key={m} value={m}>
+          {m}
+        </option>
+      ))}
+    </Select>
+  );
+}
+
+/** Default — `default` variant + `md` size; узгоджено з `<Input>`. */
+export const Default: Story = {
+  render: (args) => <ControlledDemo {...args} />,
+};
+
+/** `filled` variant — пасує темнішим формам всередині секцій-карт. */
+export const Filled: Story = {
+  args: { variant: "filled" },
+  render: (args) => <ControlledDemo {...args} />,
+};
+
+/** `ghost` variant — прозорий, lite-density, hover показує `bg-panelHi`. */
+export const Ghost: Story = {
+  args: { variant: "ghost" },
+  render: (args) => <ControlledDemo {...args} />,
+};
+
+/** Error-стан з `aria-invalid` — для invalid form-rows. */
+export const Error: Story = {
+  args: { error: true },
+  render: (args) => <ControlledDemo {...args} />,
+};
+
+/** Disabled — `opacity-50 cursor-not-allowed`. */
+export const Disabled: Story = {
+  args: { disabled: true },
+  render: (args) => <ControlledDemo {...args} />,
+};
+
+/** Усі три розміри в стек — для side-by-side візуальної перевірки. */
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3 w-64">
+      <ControlledDemo size="sm" />
+      <ControlledDemo size="md" />
+      <ControlledDemo size="lg" />
+    </div>
+  ),
+};

--- a/apps/web/src/shared/components/ui/Stat.stories.tsx
+++ b/apps/web/src/shared/components/ui/Stat.stories.tsx
@@ -1,0 +1,148 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Stat } from "./Stat";
+
+/**
+ * `Stat` — канонічний `eyebrow + big number + sublabel` triple, що повторюється
+ * десятки разів у Fizruk-дашбордах та Finyk-summary-картах.
+ *
+ * `variant` тонує колір значення (text-text за замовчуванням, success / warning /
+ * danger, плюс кожен з module-токенів finyk / fizruk / routine / nutrition).
+ * Module-варіанти беруть `text-{c}-strong` (= `[700]`, lime-800 для nutrition),
+ * щоб відповідати WCAG AA contrast на cream `bg-bg` — див.
+ * `docs/design/brand-palette-wcag-aa-proposal.md`.
+ *
+ * `tabular-nums` гарантує, що числа з різним кратним 0/1/8 не "стрибають" по
+ * ширині при анімації або swap-і значень.
+ */
+const meta: Meta<typeof Stat> = {
+  title: "UI / Stat",
+  component: Stat,
+  parameters: { layout: "centered" },
+  tags: ["autodocs"],
+  argTypes: {
+    variant: {
+      control: "select",
+      options: [
+        "default",
+        "success",
+        "warning",
+        "danger",
+        "finyk",
+        "fizruk",
+        "routine",
+        "nutrition",
+      ],
+    },
+    size: { control: "select", options: ["sm", "md", "lg"] },
+    align: { control: "select", options: ["left", "center", "right"] },
+  },
+  args: {
+    label: "Вага",
+    value: "82 кг",
+    sublabel: "+0.4 кг за тиждень",
+    variant: "default",
+    size: "md",
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Stat>;
+
+/** Default — нейтральний `text-text` колір, sublabel з трендом. */
+export const Default: Story = {};
+
+/** Success — за тиждень -300 ккал від цілі. */
+export const Success: Story = {
+  args: {
+    label: "Калорійність",
+    value: "1 850",
+    sublabel: "−150 від плану",
+    variant: "success",
+  },
+};
+
+/** Warning — наближаємось до budget-cap. */
+export const Warning: Story = {
+  args: {
+    label: "Витрати",
+    value: "₴ 18 230",
+    sublabel: "92% бюджету",
+    variant: "warning",
+  },
+};
+
+/** Danger — over-budget / red flag. */
+export const Danger: Story = {
+  args: {
+    label: "Овердрафт",
+    value: "₴ 1 240",
+    sublabel: "перевищено ліміт",
+    variant: "danger",
+  },
+};
+
+/** Із leading-emoji `icon` — швидка візуальна підказка модуля. */
+export const WithIcon: Story = {
+  args: {
+    label: "Кроки",
+    value: "11 240",
+    sublabel: "+1.2k vs учора",
+    icon: "🏃",
+    variant: "fizruk",
+  },
+};
+
+/** Усі 4 module-варіанти в один grid — для перевірки brand-токенів. */
+export const ModuleVariants: Story = {
+  render: () => (
+    <div className="grid grid-cols-2 gap-6">
+      <Stat
+        label="Finyk · Бюджет"
+        value="₴ 12 400"
+        sublabel="на тиждень"
+        variant="finyk"
+      />
+      <Stat
+        label="Fizruk · Сила"
+        value="92.5"
+        sublabel="kg PR"
+        variant="fizruk"
+      />
+      <Stat
+        label="Routine · Streak"
+        value="14 днів"
+        sublabel="ранкова медитація"
+        variant="routine"
+      />
+      <Stat
+        label="Nutrition · Білки"
+        value="142 г"
+        sublabel="з 150 г"
+        variant="nutrition"
+      />
+    </div>
+  ),
+};
+
+/** Усі три розміри — sm (chips / dense rows) до lg (hero metric). */
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex items-end gap-8">
+      <Stat label="Малий" value="42" sublabel="sm" size="sm" />
+      <Stat label="Середній" value="142" sublabel="md" size="md" />
+      <Stat label="Великий" value="1 042" sublabel="lg" size="lg" />
+    </div>
+  ),
+};
+
+/** Center-align — для full-width hero-stat-блоків. */
+export const Centered: Story = {
+  args: {
+    label: "Сьогодні",
+    value: "11 240 кроків",
+    sublabel: "85% денної мети",
+    align: "center",
+    size: "lg",
+    variant: "fizruk",
+  },
+};


### PR DESCRIPTION
## Summary

Web deep-dive **Item #16** (Storybook expansion) round-8 follow-up. Бамп Storybook coverage **12 → 16 components** з `apps/web/src/shared/components/ui/`. Стори додано на чотири найвживаніші раніше-непокриті примітиви:

- **`Avatar`** (4 stories + 2 layout-grids = 8) — image+initials fallback, status-dot (online/busy/offline), усі 5 розмірів, edge-cases для `getInitials` (порожнє ім'я, одне слово, не-латиниця).
- **`Select`** (5 stories + 1 size-grid = 6) — 3 variants (default/filled/ghost) × 3 sizes + error / disabled state.
- **`Stat`** (6 stories + 2 grids = 8) — 4 status variants (default / success / warning / danger), 4 module variants (finyk / fizruk / routine / nutrition), 3 sizes, з icon, з alignment.
- **`Segmented`** (3 stories + 2 module-grids = 5) — 5 variants × 2 styles (solid / soft) × 2 sizes.

Опис у JSDoc-блоках кожного `meta` робить story-page документацією варіантів і токенів — без дубляжу `docs/design/COMPONENT_API.md`. `@storybook/react-vite` autodocs підхоплює `tags: ["autodocs"]`.

## Governing Skill

- Primary skill: `sergeant-web-ui` — touches `apps/web` shared/components/ui.
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a — повторює патерн існуючих 12 story-файлів (Button.stories.tsx, Switch.stories.tsx тощо).
- Why this playbook: tracking initiative — `docs/diagnostics/2026-05-03-web-deep-dive/01-frontend-ergonomics.md §3.2`. Stories мають однакову форму: `meta.argTypes` для controls + `tags: ['autodocs']` для автоматичної документації + кілька названих `Story` для канонічних станів + один-два render-grid для side-by-side variant-checking.
- If no playbook matched, why: новий контент в стандартизованому форматі — потреби в окремому playbook нема.

## Verification

```bash
pnpm --filter @sergeant/web typecheck         # clean
pnpm --filter @sergeant/web lint              # 0 errors (pre-existing hash-router warnings only)
pnpm --filter @sergeant/web build-storybook   # success (4.96s)
```

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- (`docs/diagnostics/2026-05-03-web-deep-dive/00-overview.md` round-8 summary lands в окремому docs PR після merge усіх 4 round-8 follow-up-ів — pattern round-7-послідовності.)

## Risk and Rollout

- User-visible risk: **none**. Лише новий тестовий контент під `*.stories.tsx`. Жодних code-path-змін у production-bundle (Vite tree-shake-ить `*.stories.tsx` з production builds — див. `apps/web/vite.config.ts`).
- Rollout / deploy order: standard web build; жодного env / migration / feature-flag-у.
- Backout plan: revert цього PR; story-файли не імпортуються production-кодом.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

Залишок tracked-непокритих shared/components/ui примітивів (для майбутніх раундів): `AnimatedNumber`, `Banner` (вже покритий — done), `Card`, `EmptyState`, `FormField`, `Modal` (done), `Tabs` (done). 16 / ~25 компонентів покриті — більшість частоти-вживання вже задокументована.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Storybook stories for `Avatar`, `Select`, `Stat`, and `Segmented`, expanding UI docs from 12 to 16 components with `@storybook/react-vite` autodocs. Supports Item #16 (Storybook expansion) and improves docs and visual QA without touching production code.

- **New Features**
  - `Avatar` — image/initials fallback, status-dot (online/busy/offline), 5 sizes, initials edge cases.
  - `Select` — variants (default/filled/ghost), sizes (sm/md/lg), error and disabled.
  - `Stat` — status variants (default/success/warning/danger), module variants (`finyk`, `fizruk`, `routine`, `nutrition`), sizes (sm/md/lg), optional icon and alignment.
  - `Segmented` — styles (solid/soft), variants (brand + modules), sizes (sm/md), controlled demo.

<sup>Written for commit 5963a01c1284305a3f799816cdd1729c2c6f795e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Storybook component stories for Avatar, Segmented, Select, and Stat UI components, including variant previews, size demonstrations, state examples, and edge cases for internal design and development reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->