### PR TITLE
refactor(web): migrate weeklyDigestStorage off raw localStorage

### DIFF
--- a/.tech-debt/localstorage-allowlist-budget.json
+++ b/.tech-debt/localstorage-allowlist-budget.json
@@ -1,4 +1,4 @@
 {
-  "production": 14,
-  "rationale": "Updated 2026-05-04 (Item 6 round-8 follow-up): production count 15 → 14 after migrating apps/web/src/shared/hooks/usePushNotifications.ts off direct localStorage onto safeReadStringLS/safeWriteLS/safeRemoveLS. (Headroom: 0 — bump only with a deliberate decision; new sites must migrate an existing one to keep parity.) Burndown plan in docs/diagnostics/2026-05-03-web-deep-dive/02-architecture-and-state.md §2.2 + docs/tech-debt/frontend.md §2."
+  "production": 13,
+  "rationale": "Updated 2026-05-04 (Item 6 round-9 follow-up): production count 14 → 13 after migrating apps/web/src/shared/lib/storage/weeklyDigestStorage.ts off direct localStorage onto safeReadStringLS. (Headroom: 0 — bump only with a deliberate decision; new sites must migrate an existing one to keep parity.) Burndown plan in docs/diagnostics/2026-05-03-web-deep-dive/02-architecture-and-state.md §2.2 + docs/tech-debt/frontend.md §2."
 }

--- a/apps/web/src/shared/lib/storage/weeklyDigestStorage.test.ts
+++ b/apps/web/src/shared/lib/storage/weeklyDigestStorage.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { loadDigest, hasLiveWeeklyDigest } from "./weeklyDigestStorage";
 
 beforeEach(() => {
@@ -19,6 +19,46 @@ describe("loadDigest", () => {
 
 describe("hasLiveWeeklyDigest", () => {
   it("повертає false коли дайджестів немає", () => {
+    expect(hasLiveWeeklyDigest(new Date("2025-06-15"))).toBe(false);
+  });
+});
+
+// `safeReadStringLS` — це новий адаптер замість inline try/catch (Item 6
+// round 9). Перевіряємо, що Safari Private Mode / quota / disabled-storage
+// випадки не пробивають через `loadDigest` як throw.
+describe("storage adapter resilience (Item 6 round 9)", () => {
+  const original = Object.getOwnPropertyDescriptor(
+    Storage.prototype,
+    "getItem",
+  );
+
+  afterEach(() => {
+    if (original) {
+      Object.defineProperty(Storage.prototype, "getItem", original);
+    }
+  });
+
+  it("повертає null коли localStorage.getItem кидає (Safari Private Mode)", () => {
+    Object.defineProperty(Storage.prototype, "getItem", {
+      configurable: true,
+      value: vi.fn(() => {
+        throw new DOMException("SecurityError");
+      }),
+    });
+
+    expect(() => loadDigest("2025-W24")).not.toThrow();
+    expect(loadDigest("2025-W24")).toBeNull();
+  });
+
+  it("hasLiveWeeklyDigest не кидає коли storage недоступний", () => {
+    Object.defineProperty(Storage.prototype, "getItem", {
+      configurable: true,
+      value: vi.fn(() => {
+        throw new Error("disabled");
+      }),
+    });
+
+    expect(() => hasLiveWeeklyDigest(new Date("2025-06-15"))).not.toThrow();
     expect(hasLiveWeeklyDigest(new Date("2025-06-15"))).toBe(false);
   });
 });

--- a/apps/web/src/shared/lib/storage/weeklyDigestStorage.ts
+++ b/apps/web/src/shared/lib/storage/weeklyDigestStorage.ts
@@ -7,6 +7,12 @@
  * adapts the real `localStorage` to that contract and returns wrapped
  * helpers with the storage argument pre-bound. Every web call-site
  * keeps its old signature after importing from here.
+ *
+ * The adapter delegates to `safeReadStringLS` so quota-exceeded /
+ * Safari Private Mode / disabled-storage failures collapse to `null`
+ * — the same try/catch contract the prior inline version provided.
+ * Going through the shared helper keeps this file off the
+ * `no-raw-local-storage` allowlist (Item 6 burndown).
  */
 
 import {
@@ -15,14 +21,11 @@ import {
   type StorageReader,
   type WeeklyDigestRecord,
 } from "@sergeant/shared";
+import { safeReadStringLS } from "./storage";
 
 const webStorageReader: StorageReader = {
   getItem(key) {
-    try {
-      return localStorage.getItem(key);
-    } catch {
-      return null;
-    }
+    return safeReadStringLS(key);
   },
 };
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -426,7 +426,6 @@ export default [
       "apps/web/src/shared/lib/storage/storageQuota.ts",
       "apps/web/src/shared/lib/storage/typedStore.ts",
       "apps/web/src/shared/lib/storage/createModuleStorage.ts",
-      "apps/web/src/shared/lib/storage/weeklyDigestStorage.ts",
       "apps/web/src/shared/hooks/useLocalStorageState.ts",
       // Мігровано на `safeReadStringLS`/`safeReadLS`/`safeWriteLS` у PR-и Item 6
       // follow-up (docs/diagnostics/2026-05-03-web-deep-dive/02 §2.2):
@@ -435,6 +434,8 @@ export default [
       // - apps/web/src/shared/hooks/useActiveFizrukWorkout.ts (round 7)
       // - apps/web/src/shared/hooks/usePushNotifications.ts (round 8: 1 read +
       //   2 writes + 4 removes на ключ `hub_push_subscribed`).
+      // - apps/web/src/shared/lib/storage/weeklyDigestStorage.ts (round 9:
+      //   `webStorageReader.getItem` → `safeReadStringLS`).
       // Cloud-sync internals — the queue / enqueue / state writer all
       // need direct access; users should call the cloud-sync API.
       "apps/web/src/core/cloudSync/logger.ts",


### PR DESCRIPTION
## Summary

Item #6 round-9 follow-up. The web-side `StorageReader` adapter in `apps/web/src/shared/lib/storage/weeklyDigestStorage.ts` was the last remaining higher-level wrapper still calling `localStorage.getItem` inside its own inline `try/catch`. Replace that with a delegation to the shared `safeReadStringLS` helper from `./storage` so the file no longer needs to live in the `sergeant-design/no-raw-local-storage` allowlist.

- `apps/web/src/shared/lib/storage/weeklyDigestStorage.ts` — `webStorageReader.getItem` now calls `safeReadStringLS(key)`. Same try/catch contract (returns `null` on failure), one fewer file with raw `localStorage` access.
- `eslint.config.js` — drop `weeklyDigestStorage.ts` from the web `no-raw-local-storage` allowlist; extend the round-9 migration comment.
- `.tech-debt/localstorage-allowlist-budget.json` — production budget `14 → 13` (headroom 0). Updated rationale.
- `apps/web/src/shared/lib/storage/weeklyDigestStorage.test.ts` — keep the existing 3 happy-path scenarios and add 2 hardening cases that mock `Storage.prototype.getItem` to throw (Safari Private Mode / disabled storage), asserting `loadDigest` and `hasLiveWeeklyDigest` collapse to `null`/`false` instead of throwing.

Roadmap: `docs/diagnostics/2026-05-03-web-deep-dive/00-overview.md` Item #6 follow-up (round 9). Burndown plan: `docs/diagnostics/2026-05-03-web-deep-dive/02-architecture-and-state.md` §2.2 + `docs/tech-debt/frontend.md` §2.

## Governing Skill

- Primary skill: `sergeant-web-ui`
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a (rolling Item #6 burndown — no dedicated playbook)
- Why this playbook: n/a
- If no playbook matched, why: Item #6 burndown is a single-file localStorage migration that consistently follows the `safeRead*LS`/`safeWriteLS` pattern documented in `docs/tech-debt/frontend.md` §2 and the diagnostic; previous rounds (5–8) shipped without a dedicated playbook for the same reason.

## Verification

```bash
pnpm --filter @sergeant/db-schema build
pnpm --filter @sergeant/web exec eslint apps/web/src/shared/lib/storage/weeklyDigestStorage.ts
pnpm --filter @sergeant/web exec tsc -p tsconfig.json --noEmit
pnpm --filter @sergeant/web exec vitest run src/shared/lib/storage/weeklyDigestStorage.test.ts
pnpm lint:localstorage-allowlist
```

Result:

- ESLint: 0 errors / 0 warnings.
- `tsc --noEmit`: clean.
- Vitest: `Test Files 1 passed (1) | Tests 5 passed (5)`.
- `lint:localstorage-allowlist`: `13/13 (headroom 0)`.

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- The diagnostic overview round-9 summary entry will be added in a follow-up docs PR alongside the other three round-9 items (Storybook expansion, finyk-domain `noUncheckedIndexedAccess`, WaitlistForm useApiForm migration), to keep that single roadmap-touching commit isolated.

## Risk and Rollout

- User-visible risk: zero. The new `webStorageReader.getItem` returns the exact same shape (`string | null`) and silently catches failures the same way the previous implementation did; `@sergeant/shared` `loadDigest`/`hasLiveWeeklyDigest` are unchanged.
- Rollout / deploy order: Vercel auto-deploys on merge; no migration / env change.
- Backout plan: revert this single commit. The allowlist entry can be re-added if needed without server-side coordination.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

The two new tests stub `Storage.prototype.getItem` directly via `Object.defineProperty` and restore the descriptor in `afterEach`; this matches the pattern used elsewhere in the repo for Safari Private Mode coverage and keeps the existing happy-path tests untouched.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the web `weeklyDigestStorage` adapter off raw `localStorage` to use `safeReadStringLS`, keeping the same null-on-failure behavior and improving resilience. Removed the file from the `sergeant-design/no-raw-local-storage` allowlist and lowered the production budget to 13.

- **Refactors**
  - `apps/web/src/shared/lib/storage/weeklyDigestStorage.ts`: `webStorageReader.getItem` now calls `safeReadStringLS(key)`; same `string | null` contract.
  - `apps/web/src/shared/lib/storage/weeklyDigestStorage.test.ts`: added two resilience tests where `Storage.getItem` throws; `loadDigest` returns `null`, `hasLiveWeeklyDigest` returns `false`.
  - `eslint.config.js`: dropped `weeklyDigestStorage.ts` from the allowlist and documented the round-9 change.
  - `.tech-debt/localstorage-allowlist-budget.json`: updated rationale; production count `14 → 13`.

<sup>Written for commit abce050c2fc856843fabe51156f473dd60d34d9c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced resilience of weekly digest functionality with improved error handling for scenarios where local storage is unavailable or inaccessible, including Safari Private Mode and disabled storage configurations.

* **Chores**
  * Reduced technical debt through migration of storage access patterns and corresponding configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->