### PR TITLE
docs(docs): record Stage 5 PR #043a LANDED + #043b IN CI in storage-roadmap

### DIFF
--- a/docs/planning/storage-roadmap.md
+++ b/docs/planning/storage-roadmap.md
@@ -1,6 +1,6 @@
 # Storage & Sync — Roadmap до production-ready
 
-> **Last validated:** 2026-05-04 by Devin — **Stage 1 COMPLETE; Stage 4 Finyk Mono mirror in CI; Stage 5 op-log v2 hardening in flight.** Stage 1: all 8/8 PRs landed (PR #008 `ff217246`, PR #010 [#1543](https://github.com/Skords-01/Sergeant/pull/1543), PR #013 via 4 sub-PRs). Stage 4 Fizruk: 5/5 PRs merged (PR #027–#030 + #029a). Stage 4 Nutrition: PR #031 / #032 / #033 LANDED ([#1574](https://github.com/Skords-01/Sergeant/pull/1574)), PR #034 LANDED ([#1636](https://github.com/Skords-01/Sergeant/pull/1636)). Stage 4 Finyk: PR #035 LANDED ([#1667](https://github.com/Skords-01/Sergeant/pull/1667) — schema + apply-fns), PR #036 LANDED ([#1680](https://github.com/Skords-01/Sergeant/pull/1680) — dual-write web + mobile), PR #037 LANDED (`c89870c6` — read-overlay web + mobile under `feature.finyk.sqlite_v2.read_sqlite`, default off), PR #038 IN CI (Mono cache mirror у `finyk_mono_*` SQLite таблицях під `feature.finyk.sqlite_v2.mono_mirror`, default off). Stage 5: PR #040 LANDED (`ec1f3820` — persistent op-log retry policy у SQLite), PR #041 IN CI ([#1721](https://github.com/Skords-01/Sergeant/pull/1721) — SSE pull stream), PR #043 LANDED ([#1734](https://github.com/Skords-01/Sergeant/pull/1734) — G-set CRDT для `nutrition_meals` із tombstone інваріантом + 3 інтеграційні тести), PR #048 LANDED ([#1737](https://github.com/Skords-01/Sergeant/pull/1737) — RED-метрики `sync_op_log_apply_total` / `sync_op_log_pull_lag_ms` / `sync_op_log_pull_queue_depth` + 4 нові Grafana панелі в `sync.json`). PR #042 (PN-counter for `routine_streaks`) deferred — потребує protocol-зміни (новий op kind `increment` у CHECK constraint + zod + DB migration); see PR #042 entry below. Stage 0: PR #003 LANDED ([#1497](https://github.com/Skords-01/Sergeant/pull/1497)). Boot-wiring follow-up для `register{Routine,Fizruk,Nutrition}DualWriteContext` ще не залендили. **Next review:** 2026-08-01.
+> **Last validated:** 2026-05-04 by Devin — **Stage 1 COMPLETE; Stage 4 Finyk Mono mirror in CI; Stage 5 op-log v2 hardening in flight.** Stage 1: all 8/8 PRs landed (PR #008 `ff217246`, PR #010 [#1543](https://github.com/Skords-01/Sergeant/pull/1543), PR #013 via 4 sub-PRs). Stage 4 Fizruk: 5/5 PRs merged (PR #027–#030 + #029a). Stage 4 Nutrition: PR #031 / #032 / #033 LANDED ([#1574](https://github.com/Skords-01/Sergeant/pull/1574)), PR #034 LANDED ([#1636](https://github.com/Skords-01/Sergeant/pull/1636)). Stage 4 Finyk: PR #035 LANDED ([#1667](https://github.com/Skords-01/Sergeant/pull/1667) — schema + apply-fns), PR #036 LANDED ([#1680](https://github.com/Skords-01/Sergeant/pull/1680) — dual-write web + mobile), PR #037 LANDED (`c89870c6` — read-overlay web + mobile under `feature.finyk.sqlite_v2.read_sqlite`, default off), PR #038 IN CI (Mono cache mirror у `finyk_mono_*` SQLite таблицях під `feature.finyk.sqlite_v2.mono_mirror`, default off). Stage 5: PR #040 LANDED (`ec1f3820` — persistent op-log retry policy у SQLite), PR #041 IN CI ([#1721](https://github.com/Skords-01/Sergeant/pull/1721) — SSE pull stream), PR #043 LANDED ([#1734](https://github.com/Skords-01/Sergeant/pull/1734) — G-set CRDT для `nutrition_meals` із tombstone інваріантом + 3 інтеграційні тести), PR #043a LANDED ([#1739](https://github.com/Skords-01/Sergeant/pull/1739) — tombstone-resurrection guard для routine + 5 fizruk apply-функцій + 6 інтеграційних кейсів), PR #043b IN CI ([#1743](https://github.com/Skords-01/Sergeant/pull/1743) — той самий guard для 3 nutrition non-meals apply-функцій + 2 finyk хелперів, які покривають усі 10 finyk soft-delete таблиць + 7 інтеграційних кейсів; разом із PR #043a закриває per-table TODO з PR #043), PR #048 LANDED ([#1737](https://github.com/Skords-01/Sergeant/pull/1737) — RED-метрики `sync_op_log_apply_total` / `sync_op_log_pull_lag_ms` / `sync_op_log_pull_queue_depth` + 4 нові Grafana панелі в `sync.json`). PR #042 (PN-counter for `routine_streaks`) deferred — потребує protocol-зміни (новий op kind `increment` у CHECK constraint + zod + DB migration); see PR #042 entry below. Stage 0: PR #003 LANDED ([#1497](https://github.com/Skords-01/Sergeant/pull/1497)). Boot-wiring follow-up для `register{Routine,Fizruk,Nutrition}DualWriteContext` ще не залендили. **Next review:** 2026-08-01.
 > **Status:** Active
 
 > Зріз: 2026-05-02. Базується на storage-аудиті + поточний стек:
@@ -1233,7 +1233,34 @@ recreate indexes`) у `packages/db-schema/src/sqlite/migrations/index.ts`,
   merge). Docstring документує G-set інваріант inline.
 - Note. Цей самий resurrection-via-update guard формально лишається
   TODO для `fizruk_workouts`/`finyk_*`/`routine_entries` apply-шляхів
-  — окрема сесія per-table.
+  — окрема сесія per-table. **Закрито PR #043a + PR #043b (нижче).**
+
+#### **PR #043a — `feat(server): tombstone resurrection guard for routine + fizruk apply paths`** ✅ LANDED ([#1739](https://github.com/Skords-01/Sergeant/pull/1739))
+
+- Scope. Дзеркалить інваріант із PR #043 на 6 інших soft-delete
+  apply-функціях: `applyRoutineEntries`, `applyFizrukWorkouts`,
+  `applyFizrukItems`, `applyFizrukSets`, `applyFizrukCustomExercises`,
+  `applyFizrukMeasurements`.
+- **Done (2026-05-04).** Кожна apply-функція тепер `SELECT`-ить
+  `deleted_at` поряд із `user_id`/`updated_at`; після LWW-guard-а додано
+  явну перевірку — якщо ряд tombstoned і `op !== "delete"`, повертаємо
+  `status='rejected', reason='tombstoned'`. `op='delete'` лишається
+  ідемпотентним. 6 нових інтеграційних кейсів у `syncV2.integration.test.ts`
+  (insert → delete → resurrect attempt → reject; final state: `deleted_at`
+  != null, оригінальні поля незмінні).
+- **Dep.** PR #043.
+
+#### **PR #043b — `feat(server): tombstone resurrection guard for nutrition + finyk apply paths`** 🚧 IN CI ([#1743](https://github.com/Skords-01/Sergeant/pull/1743))
+
+- Scope. Закриває залишок per-table TODO з PR #043: 3 nutrition non-meals
+  apply-функції (`applyNutritionPantries`, `applyNutritionPantryItems`,
+  `applyNutritionRecipes`) + 2 finyk хелпери, які покривають усі 10
+  finyk soft-delete таблиць (`applyFinykTombstone` — 2 composite-PK,
+  `applyFinykPerRowBlob` — 8 per-row + JSONB).
+- **Stage.** Implementation + 7 нових інтеграційних кейсів готові; PR
+  відкрито, очікуємо CI. Разом із PR #043a повністю покриває весь
+  сімейство soft-delete apply-шляхів.
+- **Dep.** PR #043, PR #043a.
 
 #### **PR #044 — `feat(sync): conflict resolution UI for finyk_manual_expenses`**
 


### PR DESCRIPTION
## Summary

Updates `docs/planning/storage-roadmap.md` to reflect the just-landed PR #043a (#1739) and the in-CI PR #043b (#1743). Together they close the per-table TODO from PR #043 (G-set CRDT for `nutrition_meals`):

> «Цей самий resurrection-via-update guard формально лишається TODO для `fizruk_workouts`/`finyk_*`/`routine_entries` apply-шляхів — окрема сесія per-table.»

Changes:

- Top-of-file status line — added PR #043a / #043b under the Stage 5 bullet.
- PR #043 'Note' — marked the per-table TODO as closed by PR #043a + #043b.
- Stage 5 section — added full entries for PR #043a (Done) and PR #043b (Stage IN CI), with scope, dependencies, and test coverage notes.

## Governing Skill

- Primary skill: sergeant-data-and-migrations (roadmap doc lives next to migration plans, but this is pure docs)
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a
- Why this playbook: pure docs sync — record completed/in-flight PRs against an existing roadmap section
- If no playbook matched, why: status-keeping change, no implementation

## Verification

```bash
# Pure docs change. Lint hooks (lint-staged via Husky) ran on commit; commitlint validated scope.
# No code changes — typecheck/tests not affected.
```

Additional checks:

- [x] Local smoke / manual validation completed (markdown rendered locally, links checked)
- [x] Surface-specific checks completed (planning doc only)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. — this PR is the docs update
- [x] I checked whether `AGENTS.md` needed an update. — no
- [x] I checked whether a playbook or skill needed an update. — no
- [x] I checked whether governance docs or review docs needed an update. — no

Updated docs:

- `docs/planning/storage-roadmap.md`

## Risk and Rollout

- User-visible risk: zero (docs only).
- Rollout / deploy order: any time, no deploy gating.
- Backout plan: revert.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

- Pairs with PR #1739 (already merged) and PR #1743 (open, in CI). If reviewing all three together, this PR is the docs trailer that captures their effect on the roadmap.
- The PR-#043b entry is marked 'IN CI' — once that PR merges, a follow-up commit can flip the marker to 'LANDED'.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `docs/planning/storage-roadmap.md` to record Stage 5 sub-PRs `#043a` (LANDED) and `#043b` (IN CI), closing the per‑table tombstone‑resurrection guard TODO from PR `#043`. Also updates the top status line and adds brief entries for `#043a`/`#043b` with scope, dependencies, and test coverage.

<sup>Written for commit 376d8223f61f415f24149021b7db5de396fe3e14. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development roadmap to reflect the completion of pipeline stages and current status of work deployed or in active development.
  * Extended roadmap documentation with detailed technical sections covering tombstone resurrection guard behavior and comprehensive implementation details across various database operations and apply paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->