### PR TITLE
refactor(web): migrate WaitlistForm to useApiForm + zod

### DIFF
--- a/apps/web/src/core/pricing/WaitlistForm.test.tsx
+++ b/apps/web/src/core/pricing/WaitlistForm.test.tsx
@@ -1,0 +1,236 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { ApiError } from "@sergeant/api-client";
+
+/**
+ * Тести для `WaitlistForm` після міграції на `useApiForm` + zod.
+ * Покривають:
+ *
+ * - client-side zod-валідація (порожній / невалідний email → inline помилка,
+ *   `waitlistApi.submit` не викликається)
+ * - happy path (`created: true`) → toast.success, аналітика, `onSuccess(true)`,
+ *   email очищено, tier зберігається
+ * - ідемпотентний path (`created: false`) → toast.info, `onSuccess(false)`
+ * - ApiError 429 → toast.error "Забагато запитів", банер не зʼявляється
+ * - ApiError 400 з `details: [{path:"email", message:...}]` → inline помилка
+ *   на полі через `applyServerError` з `useApiForm`
+ * - default tier через preset prop
+ *
+ * `waitlistApi.submit` мокаємо напряму — швидше і дозволяє контролювати
+ * статус і `body.details` без MSW-рута.
+ */
+
+const submitMock = vi.fn();
+vi.mock("@shared/api", async () => {
+  const actual =
+    await vi.importActual<typeof import("@shared/api")>("@shared/api");
+  return {
+    ...actual,
+    waitlistApi: {
+      submit: (payload: unknown) => submitMock(payload),
+    },
+  };
+});
+
+const toastSuccessMock = vi.fn();
+const toastErrorMock = vi.fn();
+const toastInfoMock = vi.fn();
+vi.mock("@shared/hooks/useToast", () => ({
+  useToast: () => ({
+    success: toastSuccessMock,
+    error: toastErrorMock,
+    info: toastInfoMock,
+  }),
+}));
+
+const trackEventMock = vi.fn();
+vi.mock("../observability/analytics", async () => {
+  const actual = await vi.importActual<
+    typeof import("../observability/analytics")
+  >("../observability/analytics");
+  return {
+    ...actual,
+    trackEvent: (...args: unknown[]) => trackEventMock(...args),
+  };
+});
+
+import { WaitlistForm } from "./WaitlistForm";
+
+beforeEach(() => {
+  submitMock.mockReset();
+  toastSuccessMock.mockReset();
+  toastErrorMock.mockReset();
+  toastInfoMock.mockReset();
+  trackEventMock.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function fillEmail(value: string): void {
+  fireEvent.change(screen.getByLabelText("Email"), {
+    target: { value },
+  });
+}
+
+describe("WaitlistForm — client-side validation", () => {
+  it("показує inline помилку для порожнього email і не викликає API", async () => {
+    render(<WaitlistForm source="pricing_page" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Підписатись/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Некоректна email-адреса")).toBeTruthy();
+    });
+    expect(submitMock).not.toHaveBeenCalled();
+  });
+
+  it("показує inline помилку для невалідного email і не викликає API", async () => {
+    render(<WaitlistForm source="pricing_page" />);
+
+    fillEmail("not-an-email");
+    fireEvent.click(screen.getByRole("button", { name: /Підписатись/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Некоректна email-адреса")).toBeTruthy();
+    });
+    expect(submitMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("WaitlistForm — submit flow", () => {
+  it("happy path (created: true): toast.success + аналітика + reset email", async () => {
+    submitMock.mockResolvedValue({ ok: true, created: true });
+    const onSuccess = vi.fn();
+
+    render(
+      <WaitlistForm
+        source="pricing_page"
+        defaultTier="pro"
+        onSuccess={onSuccess}
+      />,
+    );
+
+    fillEmail("user@example.com");
+    fireEvent.click(screen.getByRole("button", { name: /Підписатись/ }));
+
+    await waitFor(() => {
+      expect(submitMock).toHaveBeenCalledWith({
+        // zod `.toLowerCase().trim()` нормалізує перед відправкою
+        email: "user@example.com",
+        tier_interest: "pro",
+        source: "pricing_page",
+      });
+    });
+    await waitFor(() => {
+      expect(toastSuccessMock).toHaveBeenCalledWith(
+        "Дякуємо! Повідомимо щойно Pro буде готовий.",
+      );
+    });
+    expect(onSuccess).toHaveBeenCalledWith(true);
+    expect(trackEventMock).toHaveBeenCalledWith(
+      "waitlist_submitted",
+      expect.objectContaining({
+        tier_interest: "pro",
+        source: "pricing_page",
+        created: true,
+      }),
+    );
+    // Email очищено, tier лишився `pro`.
+    await waitFor(() => {
+      expect((screen.getByLabelText("Email") as HTMLInputElement).value).toBe(
+        "",
+      );
+    });
+    expect(
+      (
+        screen.getByLabelText(/Pro — AI-чат/, {
+          selector: "label",
+        }) as HTMLLabelElement
+      ).className,
+    ).toContain("border-brand-500");
+  });
+
+  it("ідемпотентний path (created: false): toast.info замість success", async () => {
+    submitMock.mockResolvedValue({ ok: true, created: false });
+    const onSuccess = vi.fn();
+
+    render(<WaitlistForm source="paywall" onSuccess={onSuccess} />);
+
+    fillEmail("dupe@example.com");
+    fireEvent.click(screen.getByRole("button", { name: /Підписатись/ }));
+
+    await waitFor(() => {
+      expect(toastInfoMock).toHaveBeenCalledWith(
+        "Ми вже памʼятаємо твій інтерес — жодних дублікатів.",
+      );
+    });
+    expect(toastSuccessMock).not.toHaveBeenCalled();
+    expect(onSuccess).toHaveBeenCalledWith(false);
+  });
+});
+
+describe("WaitlistForm — server error mapping", () => {
+  it("429 (rate-limit): toast.error + банер не показується", async () => {
+    submitMock.mockRejectedValue(
+      new ApiError({
+        kind: "http",
+        status: 429,
+        message: "Too Many Requests",
+        body: { error: "rate limited" },
+        url: "/api/v1/waitlist",
+      }),
+    );
+
+    render(<WaitlistForm source="pricing_page" />);
+
+    fillEmail("user@example.com");
+    fireEvent.click(screen.getByRole("button", { name: /Підписатись/ }));
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "Забагато запитів. Спробуй за годину.",
+      );
+    });
+    // Банер `data-testid="waitlist-server-error"` має зникнути після того,
+    // як effect почистив `serverError`.
+    await waitFor(() => {
+      expect(screen.queryByTestId("waitlist-server-error")).toBeNull();
+    });
+  });
+
+  it("400 з details на email: помилка лягає на поле email, не як top-level", async () => {
+    submitMock.mockRejectedValue(
+      new ApiError({
+        kind: "http",
+        status: 400,
+        message: "validation",
+        body: {
+          error: "validation failed",
+          details: [{ path: "email", message: "Email уже у списку" }],
+        },
+        url: "/api/v1/waitlist",
+      }),
+    );
+
+    render(<WaitlistForm source="pricing_page" />);
+
+    fillEmail("user@example.com");
+    fireEvent.click(screen.getByRole("button", { name: /Підписатись/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Email уже у списку")).toBeTruthy();
+    });
+    // top-level банер не повинен зʼявитись (`bound > 0 && topLevel === null`
+    // у `applyServerError`).
+    expect(screen.queryByTestId("waitlist-server-error")).toBeNull();
+  });
+});

--- a/apps/web/src/core/pricing/WaitlistForm.tsx
+++ b/apps/web/src/core/pricing/WaitlistForm.tsx
@@ -1,14 +1,17 @@
-import { useState, type FormEvent } from "react";
+import { useEffect, useRef } from "react";
+import { z } from "zod";
 import { Button } from "@shared/components/ui/Button";
 import { Input } from "@shared/components/ui/Input";
 import { Label } from "@shared/components/ui/FormField";
 import { useToast } from "@shared/hooks/useToast";
+import { useApiForm } from "@shared/forms/useApiForm";
 import { waitlistApi } from "@shared/api";
 import { isApiError } from "@sergeant/api-client";
 import {
   type WaitlistSource,
   type WaitlistTier,
-  WaitlistSubmitSchema,
+  type WaitlistSubmitResponse,
+  WaitlistTierSchema,
 } from "@sergeant/shared";
 import { ANALYTICS_EVENTS, trackEvent } from "../observability/analytics";
 
@@ -53,6 +56,25 @@ export interface WaitlistFormProps {
   className?: string;
 }
 
+/**
+ * Форм-схема — підмножина `WaitlistSubmitSchema` з `@sergeant/shared`:
+ * `source` приходить пропсом і не редагується, тому виносимо його зі
+ * scope-у форми. Месиджі помилок збігаються з тими, що повертає сервер
+ * (Hard Rule #15: UA), щоб 400-валідація з бекенду і клієнтська помилка
+ * виглядали для користувача однаково.
+ */
+const waitlistFormSchema = z.object({
+  email: z
+    .string()
+    .trim()
+    .toLowerCase()
+    .email("Некоректна email-адреса")
+    .max(254, "Не більше 254 символів"),
+  tier_interest: WaitlistTierSchema,
+});
+
+type WaitlistFormValues = z.infer<typeof waitlistFormSchema>;
+
 export function WaitlistForm({
   source,
   defaultTier,
@@ -60,35 +82,51 @@ export function WaitlistForm({
   className,
 }: WaitlistFormProps) {
   const toast = useToast();
-  const [email, setEmail] = useState("");
-  const [tier, setTier] = useState<WaitlistTier>(defaultTier ?? "unsure");
-  const [pending, setPending] = useState(false);
-  const [emailError, setEmailError] = useState<string | null>(null);
+  // 429 — rate-limit ловимо окремим toast-ом і прибираємо top-level
+  // serverError-банер (інакше дублюємо повідомлення). Цей ref ставиться
+  // у `onSubmit` при rate-limit і скидається на наступному успішному
+  // submit / у `clearServerError`.
+  const rateLimitedRef = useRef(false);
 
-  async function handleSubmit(
-    event: FormEvent<HTMLFormElement>,
-  ): Promise<void> {
-    event.preventDefault();
-    setEmailError(null);
-
-    // Локальна валідація перед мережевим викликом — даємо швидкий
-    // feedback. Сервер усе одно валідує знову (rate-limit + Zod).
-    const parsed = WaitlistSubmitSchema.safeParse({
-      email,
-      tier_interest: tier,
-      source,
-    });
-    if (!parsed.success) {
-      const issue = parsed.error.issues.find((i) => i.path[0] === "email");
-      setEmailError(issue?.message ?? "Перевір email");
-      return;
-    }
-
-    setPending(true);
-    try {
-      const res = await waitlistApi.submit(parsed.data);
+  // `useApiForm` зводить zod-валідацію + isSubmitting + server-error mapping
+  // в один hook. 400-помилка з `details: [{path, message}]` від сервера
+  // автоматично кладеться у `formState.errors`; top-level `error` — у
+  // `serverError`. 429 (rate-limit) показуємо окремим toast-ом, щоб не
+  // конфліктувати з emailError у тій же позиції.
+  const {
+    register,
+    submit,
+    formState,
+    watch,
+    isSubmitting,
+    serverError,
+    reset,
+    clearServerError,
+  } = useApiForm<WaitlistFormValues, WaitlistSubmitResponse>({
+    schema: waitlistFormSchema,
+    defaultValues: {
+      email: "",
+      tier_interest: defaultTier ?? "unsure",
+    },
+    onSubmit: async (values) => {
+      rateLimitedRef.current = false;
+      try {
+        return await waitlistApi.submit({
+          email: values.email,
+          tier_interest: values.tier_interest,
+          source,
+        });
+      } catch (err) {
+        if (isApiError(err) && err.status === 429) {
+          rateLimitedRef.current = true;
+          toast.error("Забагато запитів. Спробуй за годину.");
+        }
+        throw err;
+      }
+    },
+    onSuccess: (res, values) => {
       trackEvent(ANALYTICS_EVENTS.WAITLIST_SUBMITTED, {
-        tier_interest: parsed.data.tier_interest,
+        tier_interest: values.tier_interest,
         source,
         created: res.created,
       });
@@ -97,24 +135,45 @@ export function WaitlistForm({
       } else {
         toast.info("Ми вже памʼятаємо твій інтерес — жодних дублікатів.");
       }
-      setEmail("");
+      reset({ email: "", tier_interest: values.tier_interest });
       onSuccess?.(res.created);
-    } catch (err) {
-      if (isApiError(err) && err.status === 429) {
-        toast.error("Забагато запитів. Спробуй за годину.");
-      } else if (isApiError(err) && err.status === 400) {
-        setEmailError("Перевір email-адресу");
-      } else {
-        toast.error("Не вдалося зберегти. Спробуй ще раз.");
-      }
-    } finally {
-      setPending(false);
+    },
+  });
+
+  // Якщо submit упав через 429, ефект після першого render-у з
+  // `serverError !== null` чистить банер: `applyServerError` уже встиг
+  // повернути серверний error-текст, але користувач бачить toast і не
+  // потребує дубля у формі.
+  useEffect(() => {
+    if (rateLimitedRef.current && serverError) {
+      rateLimitedRef.current = false;
+      clearServerError();
     }
-  }
+  }, [serverError, clearServerError]);
+
+  // Якщо preset tier змінився ззовні (батьківський компонент перерендерив
+  // форму з іншим defaultTier — напр. користувач клікнув іншу tier-картку
+  // у `/pricing`), синхронізуємо це з form-state. RHF не реєструє defaults
+  // після першого `useForm`, тому без цього effect-у форма залишилась би
+  // на старому виборі.
+  useEffect(() => {
+    if (defaultTier) {
+      reset({
+        email: watch("email") ?? "",
+        tier_interest: defaultTier,
+      });
+    }
+    // `reset` із RHF стабільний; `watch` не запускає лишніх render-ів через
+    // те, що ми його викликаємо вручну.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [defaultTier]);
+
+  const tierValue = watch("tier_interest");
+  const emailErrorMessage = formState.errors.email?.message;
 
   return (
     <form
-      onSubmit={handleSubmit}
+      onSubmit={submit}
       className={className}
       noValidate
       aria-label="Підписатись на waitlist Pro-тіру"
@@ -126,20 +185,22 @@ export function WaitlistForm({
             id="waitlist-email"
             type="email"
             placeholder="you@example.com"
-            value={email}
-            onChange={(e) => setEmail(e.currentTarget.value)}
             autoComplete="email"
-            required
-            disabled={pending}
-            aria-invalid={emailError ? true : undefined}
-            aria-describedby={emailError ? "waitlist-email-error" : undefined}
+            disabled={isSubmitting}
+            error={!!emailErrorMessage}
+            aria-invalid={emailErrorMessage ? true : undefined}
+            aria-describedby={
+              emailErrorMessage ? "waitlist-email-error" : undefined
+            }
+            {...register("email")}
           />
-          {emailError && (
+          {emailErrorMessage && (
             <p
               id="waitlist-email-error"
               className="mt-1 text-xs text-danger-strong"
+              role="alert"
             >
-              {emailError}
+              {emailErrorMessage}
             </p>
           )}
         </div>
@@ -150,7 +211,7 @@ export function WaitlistForm({
           </legend>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
             {TIER_OPTIONS.map((opt) => {
-              const checked = tier === opt.value;
+              const checked = tierValue === opt.value;
               const inputId = `waitlist-tier-${opt.value}`;
               return (
                 <label
@@ -167,12 +228,10 @@ export function WaitlistForm({
                   <input
                     id={inputId}
                     type="radio"
-                    name="waitlist-tier"
                     value={opt.value}
-                    checked={checked}
-                    onChange={() => setTier(opt.value)}
                     className="mt-1 accent-brand-strong"
-                    disabled={pending}
+                    disabled={isSubmitting}
+                    {...register("tier_interest")}
                   />
                   <span className="flex flex-col">
                     <span className="text-style-label text-text">
@@ -186,7 +245,22 @@ export function WaitlistForm({
           </div>
         </fieldset>
 
-        <Button type="submit" variant="primary" size="lg" loading={pending}>
+        {serverError && (
+          <p
+            className="text-xs text-danger-strong"
+            role="alert"
+            data-testid="waitlist-server-error"
+          >
+            {serverError}
+          </p>
+        )}
+
+        <Button
+          type="submit"
+          variant="primary"
+          size="lg"
+          loading={isSubmitting}
+        >
           Підписатись на waitlist
         </Button>
 


### PR DESCRIPTION
## Summary

Item #8 round-9 follow-up. Replace the bespoke `useState`-pending / `setEmailError` / `handleSubmit` pattern in `apps/web/src/core/pricing/WaitlistForm.tsx` with the centralised `useApiForm` hook + zod resolver, extending the form-engine rollout beyond auth (round 7) and `ChangePasswordSection` (round 8) into the public `/pricing` flow.

- `apps/web/src/core/pricing/WaitlistForm.tsx`
  - Local `waitlistFormSchema` mirrors the `email` + `tier_interest` fields of `WaitlistSubmitSchema` from `@sergeant/shared` (`source` still comes from props and is not user-editable).
  - 400 responses with `details: [{ path: "email", message }]` now flow through `useApiForm`'s `applyServerError` straight onto `formState.errors.email` — no more bespoke `emailError` state.
  - 429 keeps the original `"Забагато запитів. Спробуй за годину."` toast and clears the top-level `serverError` banner via `clearServerError()` so the rate-limit message is shown exactly once instead of duplicating in both surfaces.
  - `defaultTier` prop changes propagate via `reset()` in a `useEffect`, so external tier-card clicks in `/pricing` continue to update the radio group as before.
  - Both the radio group and the email field bind through `register("email")` / `register("tier_interest")` — no more local `useState` for inputs.
- New `apps/web/src/core/pricing/WaitlistForm.test.tsx` (6 specs covering: empty / invalid email validation; happy path `created=true` with analytics + `toast.success` + email reset + tier preserved; idempotent `created=false` with `toast.info`; `ApiError 429` → `toast.error` + no banner; `ApiError 400` with `details.email` → inline field error and no top-level banner; tier preset prop wiring).

Roadmap: `docs/diagnostics/2026-05-03-web-deep-dive/00-overview.md` Item #8 follow-up (round 9). Unification plan: `docs/diagnostics/2026-05-03-web-deep-dive/01-component-architecture-and-design-system.md` §3.1.

## Governing Skill

- Primary skill: `sergeant-web-ui`
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a (rolling Item #8 form-engine rollout — no dedicated playbook)
- Why this playbook: n/a
- If no playbook matched, why: previous Item #8 follow-ups (auth screens round 7, `ChangePasswordSection` round 8) shipped the same `useApiForm + zod` migration without a dedicated playbook because the pattern is fully captured in `apps/web/src/shared/forms/useApiForm.ts` JSDoc and the existing rollout examples.

## Verification

```bash
pnpm --filter @sergeant/db-schema build
pnpm --filter @sergeant/web exec eslint apps/web/src/core/pricing/WaitlistForm.tsx apps/web/src/core/pricing/WaitlistForm.test.tsx
pnpm --filter @sergeant/web exec tsc -p tsconfig.json --noEmit
pnpm --filter @sergeant/web exec vitest run src/core/pricing/WaitlistForm.test.tsx
```

Result:

- ESLint: 0 errors / 0 warnings.
- `tsc --noEmit`: clean.
- Vitest: `Test Files 1 passed (1) | Tests 6 passed (6)`.

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- The diagnostic overview round-9 summary entry will be added in a follow-up docs PR alongside the other three round-9 items, to keep the single roadmap-touching commit isolated.

## Risk and Rollout

- User-visible risk: low. The submitted payload shape (`{ email, tier_interest, source }`) is byte-for-byte identical to the previous version (zod normalises `email` via `.trim().toLowerCase()` exactly like `WaitlistSubmitSchema` already did server-side). 400/429 surface-area kept the same UX semantics (field-level vs. toast).
- Rollout / deploy order: Vercel auto-deploys on merge; no migration / env change.
- Backout plan: revert this single commit. The previous file is preserved verbatim in the diff.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

The 429 → "no banner" effect is handled with a `useRef<boolean>` toggled inside `onSubmit` and consumed by a `useEffect` that calls `clearServerError()` once the rate-limit error has been mapped into `serverError` by `applyServerError`. This is intentional — using a ref avoids an extra render-cycle that a state would force, and the dependency `[serverError, clearServerError]` ensures the cleanup runs exactly once per failed submit.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated `WaitlistForm` on `/pricing` to the shared `useApiForm` with `zod` validation. Advances Item #8 by unifying form handling and tightening error UX.

- **Refactors**
  - Switched to `useApiForm` + local `zod` schema for `email` and `tier_interest`; `source` stays a prop.
  - Bound inputs via `register("email")` and `register("tier_interest")`; removed local state and custom submit logic.
  - 400 errors map to `formState.errors.email`; banner shows only when needed. On success, reset only `email`, keep selected tier; `onSuccess(created)` and analytics preserved. `defaultTier` changes sync via `reset()`.
  - Added tests (6) for validation, success/idempotent, and 400/429 flows.

- **Bug Fixes**
  - Prevented duplicate rate-limit messaging (429) by showing a single toast and clearing `serverError`.

<sup>Written for commit 9d4acdf37f4646b3ecc45881f7332e148bf12d7b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for waitlist form covering validation, submission, and error handling scenarios

* **Bug Fixes**
  * Improved inline validation error messaging for form fields
  * Enhanced error feedback and recovery for rate-limited submissions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->