### PR TITLE
refactor(finyk-domain): enable noUncheckedIndexedAccess

### DIFF
--- a/packages/finyk-domain/src/domain/categories.test.ts
+++ b/packages/finyk-domain/src/domain/categories.test.ts
@@ -49,7 +49,7 @@ describe("categories: getCategorySpendList", () => {
     ];
     const res = getCategorySpendList(txs);
     expect(res.length).toBeGreaterThan(0);
-    expect(res[0].spent).toBeGreaterThanOrEqual(res[res.length - 1].spent);
+    expect(res[0]!.spent).toBeGreaterThanOrEqual(res[res.length - 1]!.spent);
     expect(res.every((c) => c.id !== "income")).toBe(true);
     expect(res.every((c) => c.spent > 0)).toBe(true);
   });

--- a/packages/finyk-domain/src/domain/categories.ts
+++ b/packages/finyk-domain/src/domain/categories.ts
@@ -69,17 +69,21 @@ const FALLBACK_COLORS = [
 ];
 
 // Повертає HEX-колір для категорії: базовий → користувацький → з палітри.
+// `FALLBACK_COLORS` гарантовано непорожня, тому fallback на `[0]` нижче
+// не буде null — індекс просто wrap-иться по модулю.
 export function getCatColor(
   categoryId: string,
   customCategories: CustomCategory[] = [],
   idx = 0,
 ): string {
-  if (CAT_COLORS[categoryId]) return CAT_COLORS[categoryId];
+  const base = CAT_COLORS[categoryId];
+  if (base) return base;
   const custom = Array.isArray(customCategories)
     ? customCategories.find((c) => c.id === categoryId)
     : null;
   if (custom?.color) return custom.color;
-  return FALLBACK_COLORS[idx % FALLBACK_COLORS.length];
+  const palette = FALLBACK_COLORS;
+  return palette[idx % palette.length] ?? palette[0]!;
 }
 
 // Повний список категорій витрат (базові + користувацькі). За замовчуванням

--- a/packages/finyk-domain/src/domain/overview.test.ts
+++ b/packages/finyk-domain/src/domain/overview.test.ts
@@ -89,8 +89,8 @@ describe("buildSubscriptionFlows", () => {
       currency: "₴",
       amount: null,
     });
-    expect(flows[0].daysLeft).toBe(5);
-    expect(flows[0].hint).toBe("через 5 дн");
+    expect(flows[0]!.daysLeft).toBe(5);
+    expect(flows[0]!.hint).toBe("через 5 дн");
   });
 });
 
@@ -119,9 +119,9 @@ describe("buildDebtOutFlows / buildReceivableInFlows", () => {
       NOW,
     );
     expect(flows).toHaveLength(1);
-    expect(flows[0].sign).toBe("+");
-    expect(flows[0].color).toBe(OVERVIEW_FLOW_COLOR.success);
-    expect(flows[0].daysLeft).toBe(7);
+    expect(flows[0]!.sign).toBe("+");
+    expect(flows[0]!.color).toBe(OVERVIEW_FLOW_COLOR.success);
+    expect(flows[0]!.daysLeft).toBe(7);
   });
 });
 

--- a/packages/finyk-domain/src/domain/overview.ts
+++ b/packages/finyk-domain/src/domain/overview.ts
@@ -56,7 +56,11 @@ export const OVERVIEW_FLOW_COLOR = {
  */
 export function parseLocalDate(isoDate: string | null | undefined): Date {
   const [y, m, d] = (isoDate || "").split("-").map(Number);
-  return new Date(y, (m || 1) - 1, d || 1);
+  // `y` буде `undefined` для пустого рядка — `Date(NaN, ...)` повертає
+  // Invalid Date, а ось `new Date(undefined as any, ...)` падає у TS під
+  // strict noUncheckedIndexedAccess. Дефолтимо у епоху, поведінка
+  // викликачів (`isNaN(date.getTime())`) лишається консистентною.
+  return new Date(y ?? 1970, (m || 1) - 1, d || 1);
 }
 
 /**

--- a/packages/finyk-domain/src/domain/personalization.test.ts
+++ b/packages/finyk-domain/src/domain/personalization.test.ts
@@ -96,7 +96,7 @@ describe("getFrequentCategories", () => {
     });
     const ids = result.map((r) => r.id);
     expect(ids[0]).toBe("food"); // 3 використання (2 банк + 1 manual)
-    expect(result[0].count).toBe(3);
+    expect(result[0]!.count).toBe(3);
     expect(ids).toContain("transport");
   });
 
@@ -117,7 +117,7 @@ describe("getFrequentCategories", () => {
       now,
       windowDays: 60,
     });
-    expect(res[0].count).toBe(1);
+    expect(res[0]!.count).toBe(1);
   });
 
   it("ігнорує виключені id", () => {
@@ -129,7 +129,7 @@ describe("getFrequentCategories", () => {
       now,
       excludedTxIds: new Set(["x"]),
     });
-    expect(res[0].count).toBe(1);
+    expect(res[0]!.count).toBe(1);
   });
 
   it("поважає overrides з txCategories", () => {
@@ -145,7 +145,7 @@ describe("getFrequentCategories", () => {
       now,
       txCategories: { t1: "entertainment" },
     });
-    expect(res[0].id).toBe("entertainment");
+    expect(res[0]!.id).toBe("entertainment");
   });
 });
 
@@ -179,9 +179,9 @@ describe("getFrequentMerchants", () => {
     const res = getFrequentMerchants(txs as never, [], { now });
     // АТБ — 2 хіти → у топі; Сільпо — 1, отже відфільтрований (threshold = 2).
     expect(res.length).toBe(1);
-    expect(res[0].count).toBe(2);
-    expect(res[0].total).toBe(300);
-    expect(res[0].suggestedCategoryId).toBe("food");
+    expect(res[0]!.count).toBe(2);
+    expect(res[0]!.total).toBe(300);
+    expect(res[0]!.suggestedCategoryId).toBe("food");
   });
 
   it("manual-витрати рахуються разом із банковими", () => {
@@ -203,8 +203,8 @@ describe("getFrequentMerchants", () => {
       }),
     ];
     const res = getFrequentMerchants(txs as never, manuals as never, { now });
-    expect(res[0].count).toBe(2);
-    expect(res[0].suggestedCategoryId).toBe("transport");
+    expect(res[0]!.count).toBe(2);
+    expect(res[0]!.suggestedCategoryId).toBe("transport");
   });
 
   it("поважає limit", () => {

--- a/packages/finyk-domain/src/domain/personalization.ts
+++ b/packages/finyk-domain/src/domain/personalization.ts
@@ -118,7 +118,9 @@ export const CANONICAL_TO_MANUAL_LABEL: Record<string, string> = {
 // stable across legacy and new entries.
 function stripLeadingSymbols(str: string): string {
   let i = 0;
-  while (i < str.length && !/[\p{L}\p{N}]/u.test(str[i])) i++;
+  // `str[i]` під strict noUncheckedIndexedAccess — `string | undefined`,
+  // але цикл уже обмежений `i < str.length`, тож non-null-assert безпечний.
+  while (i < str.length && !/[\p{L}\p{N}]/u.test(str[i]!)) i++;
   return str.slice(i);
 }
 

--- a/packages/finyk-domain/src/domain/transactions.test.ts
+++ b/packages/finyk-domain/src/domain/transactions.test.ts
@@ -173,7 +173,7 @@ describe("normalizeTransactions / dedupeAndSortTransactions", () => {
       { id: "b", time: 2, amount: -1 },
     ]);
     expect(list).toHaveLength(2);
-    expect(list[0].source).toBe("import");
+    expect(list[0]!.source).toBe("import");
   });
 
   it("дедуплікує за id та сортує за time desc", () => {
@@ -194,7 +194,7 @@ describe("normalizeTransactions / dedupeAndSortTransactions", () => {
       { id: "a", time: 3, amount: 1 },
     ] as never);
     expect(result).toHaveLength(1);
-    expect(result[0].id).toBe("a");
+    expect(result[0]!.id).toBe("a");
   });
 
   it("повертає порожній масив для не-масиву", () => {

--- a/packages/finyk-domain/src/lib/forecastEngine.test.ts
+++ b/packages/finyk-domain/src/lib/forecastEngine.test.ts
@@ -22,8 +22,8 @@ describe("finyk/forecastEngine", () => {
     const txCategories = { t1: "food", t2: "food" };
     const out = calcForecast(txs, categoryLimits, today, txCategories, {}, []);
     expect(out).toHaveLength(1);
-    expect(out[0].categoryId).toBe("food");
-    expect(out[0].spent).toBe(300);
-    expect(out[0].dailyData).toHaveLength(31);
+    expect(out[0]!.categoryId).toBe("food");
+    expect(out[0]!.spent).toBe(300);
+    expect(out[0]!.dailyData).toHaveLength(31);
   });
 });

--- a/packages/finyk-domain/src/lib/forecastEngine.ts
+++ b/packages/finyk-domain/src/lib/forecastEngine.ts
@@ -164,9 +164,12 @@ export function calcForecast(
       }
     }
 
-    // Add a bridge point at today connecting actual to forecast
+    // Add a bridge point at today connecting actual to forecast.
+    // `dailyData[dayOfMonth - 1]` гарантовано існує: умова `0 < dayOfMonth
+    // < daysInMonth` + цикл вище вже наповнив усі дні місяця.
     if (dayOfMonth > 0 && dayOfMonth < daysInMonth) {
-      dailyData[dayOfMonth - 1].forecast = Math.round(cumActual);
+      const bridge = dailyData[dayOfMonth - 1];
+      if (bridge) bridge.forecast = Math.round(cumActual);
     }
 
     return {

--- a/packages/finyk-domain/src/lib/goals.ts
+++ b/packages/finyk-domain/src/lib/goals.ts
@@ -42,7 +42,10 @@ export function calcMonthlyNeeded(
     const s = String(targetDate || "");
     if (/^\d{4}-\d{2}-\d{2}$/.test(s)) {
       const [y, m, d] = s.split("-").map(Number);
-      return new Date(Date.UTC(y, (m || 1) - 1, d || 1, 12, 0, 0, 0));
+      // Regex `^\d{4}-\d{2}-\d{2}$` гарантує, що `y/m/d` є числами,
+      // але під strict noUncheckedIndexedAccess TS не виводить це з
+      // `String.split` — `?? 0` тут чисто для типового задоволення.
+      return new Date(Date.UTC(y ?? 0, (m || 1) - 1, d || 1, 12, 0, 0, 0));
     }
     const dt = new Date(targetDate);
     return new Date(

--- a/packages/finyk-domain/src/lib/recurringDetect.test.ts
+++ b/packages/finyk-domain/src/lib/recurringDetect.test.ts
@@ -56,15 +56,15 @@ describe("finyk/recurringDetect", () => {
       const out = detectRecurring(txs, { nowSec: now });
       expect(out).toHaveLength(1);
       const [cand] = out;
-      expect(cand.cadence).toBe("monthly");
-      expect(cand.occurrences).toBe(4);
-      expect(cand.confidence).toBe("high");
-      expect(cand.avgAmount).toBe(199);
-      expect(cand.currency).toBe("UAH");
-      expect(cand.key).toBe("netflix");
-      expect(cand.billingDay).toBeGreaterThanOrEqual(1);
-      expect(cand.billingDay).toBeLessThanOrEqual(31);
-      expect(cand.sampleTxIds[0]).toBe("t4");
+      expect(cand!.cadence).toBe("monthly");
+      expect(cand!.occurrences).toBe(4);
+      expect(cand!.confidence).toBe("high");
+      expect(cand!.avgAmount).toBe(199);
+      expect(cand!.currency).toBe("UAH");
+      expect(cand!.key).toBe("netflix");
+      expect(cand!.billingDay).toBeGreaterThanOrEqual(1);
+      expect(cand!.billingDay).toBeLessThanOrEqual(31);
+      expect(cand!.sampleTxIds[0]).toBe("t4");
     });
 
     it("flags 3-occurrence group as medium", () => {
@@ -76,7 +76,7 @@ describe("finyk/recurringDetect", () => {
       ];
       const out = detectRecurring(txs, { nowSec: now });
       expect(out).toHaveLength(1);
-      expect(out[0].confidence).toBe("medium");
+      expect(out[0]!.confidence).toBe("medium");
     });
 
     it("flags 2-occurrence group as low", () => {
@@ -87,8 +87,8 @@ describe("finyk/recurringDetect", () => {
       ];
       const out = detectRecurring(txs, { nowSec: now });
       expect(out).toHaveLength(1);
-      expect(out[0].confidence).toBe("low");
-      expect(out[0].cadence).toBe("monthly");
+      expect(out[0]!.confidence).toBe("low");
+      expect(out[0]!.cadence).toBe("monthly");
     });
 
     it("rejects groups with high gap jitter", () => {
@@ -170,8 +170,8 @@ describe("finyk/recurringDetect", () => {
       });
       // Only 2 left → still low confidence monthly.
       expect(out).toHaveLength(1);
-      expect(out[0].occurrences).toBe(2);
-      expect(out[0].sampleTxIds).not.toContain("c");
+      expect(out[0]!.occurrences).toBe(2);
+      expect(out[0]!.sampleTxIds).not.toContain("c");
     });
 
     it("drops groups whose latest tx is older than maxAgeDays", () => {
@@ -195,7 +195,7 @@ describe("finyk/recurringDetect", () => {
       ];
       const out = detectRecurring(txs, { nowSec: now });
       expect(out).toHaveLength(1);
-      expect(out[0].cadence).toBe("weekly");
+      expect(out[0]!.cadence).toBe("weekly");
     });
 
     it("sorts by confidence desc, then amount desc", () => {
@@ -237,10 +237,10 @@ describe("finyk/recurringDetect", () => {
       ];
       const out = detectRecurring(clean, { nowSec: now });
       expect(out).toHaveLength(2);
-      expect(out[0].key).toBe("small often");
-      expect(out[0].confidence).toBe("high");
-      expect(out[1].key).toBe("big rare");
-      expect(out[1].confidence).toBe("low");
+      expect(out[0]!.key).toBe("small often");
+      expect(out[0]!.confidence).toBe("high");
+      expect(out[1]!.key).toBe("big rare");
+      expect(out[1]!.confidence).toBe("low");
     });
 
     it("returns USD for currencyCode 840", () => {
@@ -263,7 +263,7 @@ describe("finyk/recurringDetect", () => {
       ];
       const out = detectRecurring(txs, { nowSec: now });
       expect(out).toHaveLength(1);
-      expect(out[0].currency).toBe("USD");
+      expect(out[0]!.currency).toBe("USD");
     });
 
     it("ignores positive (income) transactions", () => {

--- a/packages/finyk-domain/src/lib/recurringDetect.ts
+++ b/packages/finyk-domain/src/lib/recurringDetect.ts
@@ -247,8 +247,13 @@ export function detectRecurring(
     const sorted = [...txs].sort((a, b) => (a.time || 0) - (b.time || 0));
     const gapsDays: number[] = [];
     for (let i = 1; i < sorted.length; i++) {
-      const prev = sorted[i - 1].time || 0;
-      const cur = sorted[i].time || 0;
+      // Цикл `i = 1..sorted.length-1` гарантує існування обох індексів,
+      // але `noUncheckedIndexedAccess` все одно вимагає явного narrow.
+      const prevTx = sorted[i - 1];
+      const curTx = sorted[i];
+      if (!prevTx || !curTx) continue;
+      const prev = prevTx.time || 0;
+      const cur = curTx.time || 0;
       if (prev && cur && cur > prev) {
         gapsDays.push((cur - prev) / DAY_SECONDS);
       }
@@ -261,7 +266,10 @@ export function detectRecurring(
     const cv = amountCoefficientOfVariation(absAmounts);
     if (cv > MAX_AMOUNT_CV) continue;
 
+    // `sorted.length >= MIN_OCCURRENCES` (filter вище), але індекс-доступ
+    // у TS під strict — типу `T | undefined`, тому явно narrow-имо.
     const lastTx = sorted[sorted.length - 1];
+    if (!lastTx) continue;
     const lastTxTime = lastTx.time || 0;
     if (!lastTxTime) continue;
 

--- a/packages/finyk-domain/src/lib/spending.ts
+++ b/packages/finyk-domain/src/lib/spending.ts
@@ -78,7 +78,10 @@ export function calcFinykSpendingByDate(
   const dailyRounded: Record<string, number> = {};
   let total = 0;
   for (const k of Object.keys(daily)) {
-    const r = Math.round(daily[k]);
+    // `Object.keys` гарантує, що `daily[k]` визначено, але strict
+    // noUncheckedIndexedAccess повертає `T | undefined` — `?? 0` тут
+    // safe-fallback для типового задоволення.
+    const r = Math.round(daily[k] ?? 0);
     dailyRounded[k] = r;
     total += r;
   }
@@ -164,7 +167,7 @@ export function calcFinykPeriodAggregate(
 
   const byCategoryRounded: Record<string, number> = {};
   for (const k of Object.keys(byCategory)) {
-    byCategoryRounded[k] = Math.round(byCategory[k]);
+    byCategoryRounded[k] = Math.round(byCategory[k] ?? 0);
   }
 
   return {

--- a/packages/finyk-domain/tsconfig.json
+++ b/packages/finyk-domain/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "allowJs": false,
     "checkJs": false,
-    "noUncheckedIndexedAccess": false,
+    "noUncheckedIndexedAccess": true,
     "lib": ["ES2022"],
     "types": ["node"],
     "rootDir": "./src",


### PR DESCRIPTION
## Summary

Item #15 round-9 follow-up. Розширюємо strict-index покриття далі по пакетах: `packages/finyk-domain` тепер компілюється з `noUncheckedIndexedAccess: true`. Strict-coverage **8/13 → 9/13 (69%)**.

- `packages/finyk-domain/tsconfig.json` — flag toggled `false` → `true`.
- **11 production-помилок** виправлено через дефенсивні narrow-и / fallback-и (`?? 0`, явні `if (!x) continue`, локальні `const`):
  - `domain/categories.ts.getCatColor` — `CAT_COLORS[id]` та `FALLBACK_COLORS[idx % len]` тепер narrow-яться через локальні змінні + `?? palette[0]!` fallback (палітра гарантовано непорожня).
  - `domain/overview.ts.parseLocalDate` — destructured `y` з `split("-")` отримує `?? 1970` fallback для empty-input шляху (поведінка через `isNaN(date.getTime())` у викликачів зберігається; `parseLocalDate("")` повертає Invalid Date і до round-9, і після).
  - `domain/personalization.ts.stripLeadingSymbols` — `str[i]!` safe assertion в межах перевіреного `i < str.length`.
  - `lib/forecastEngine.ts` — bridge-point write `dailyData[idx]` тепер під `if (bridge)` guard.
  - `lib/goals.ts` — `y ?? 0` fallback для regex-підтвердженого `YYYY-MM-DD` shape.
  - `lib/recurringDetect.ts` — `prev/curTx` та `lastTx` явно narrow-яться через `if (!x) continue` перед доступом до полів.
  - `lib/spending.ts` (×2) — `Math.round(daily[k] ?? 0)` для `Object.keys()` ітерацій.
- **41 test-assertion** полагоджено через non-null `!`-assertion на index-доступ (`out[0]!.foo`, `cand!.foo`) — у тестах ми гарантуємо довжину масиву через `expect(...).toHaveLength(N)` / `expect(...).toBeGreaterThan(0)` перед доступом, тож TS-noise усунуто без зміни runtime-поведінки. Аналогічний підхід використовувався у round 7 (insights) та round 8 (api-client).

Production sources в `@sergeant/finyk-domain` тепер не мають прихованих `undefined` шляхів через index-доступ — strict-index ловитиме їх на CI у наступних PR. Backlog: `apps/web`, `apps/server`, `apps/mobile`, `packages/fizruk-domain` (4 залишилось).

## Governing Skill

- Primary skill: `sergeant-monorepo-boundaries`
- Secondary skill (if truly needed): n/a (це фокусована TS-config зміна без cross-app boundary крос-чи)

## Playbook

- Primary playbook: n/a
- Why this playbook: round 6/7/8 follow-ups для `nutrition-domain` ([#1681](https://github.com/Skords-01/Sergeant/pull/1681)), `insights` ([#1689](https://github.com/Skords-01/Sergeant/pull/1689)) та `api-client` ([#1727](https://github.com/Skords-01/Sergeant/pull/1727)) встановили patтерн без окремого playbook-а.

## Verification

```bash
pnpm --filter @sergeant/finyk-domain exec tsc --noEmit
pnpm --filter @sergeant/finyk-domain exec vitest run
pnpm strict:coverage
```

Result:

- `tsc --noEmit`: clean (52 → 0 errors).
- Vitest: `Test Files 14 passed (14) | Tests 224 passed (224)`.
- `pnpm strict:coverage`: `noUncheckedIndexedAccess coverage: 9 / 13 packages (69%)`.

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- The diagnostic overview round-9 summary entry will be added in a follow-up docs PR alongside the other three round-9 items, to keep the single roadmap-touching commit isolated. Roadmap: `docs/diagnostics/2026-05-03-web-deep-dive/00-overview.md` Item #15 follow-up; deeper rationale already in `02-architecture-and-state.md` §1.0.

## Risk and Rollout

- User-visible risk: **none**. Це pure-TS-config зміна; production behavior 100% збережено (всі 224 тести зелені, runtime-патерни такі самі).
- Rollout / deploy order: Vercel auto-deploys on merge; no migration / env change.
- Backout plan: revert single commit (`a6019c21`); flag повернеться до `false` й TS-помилки ховатимуться знову.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

- Test fixes свідомо застосовують non-null `!`-assertion замість optional-chaining (`?.`): у round 7 (insights) ми використали `?.`, але у round 8 (api-client) перейшли на `!` через те, що "якщо тест assertion-ить значення, але масив порожній — тест має падати дзвінко з 'undefined is not a function', а не silently skip". Round 9 продовжує цей api-client-стиль.
- `domain/categories.ts.getCatColor` — fallback `?? palette[0]!` потрібен через те, що TS `noUncheckedIndexedAccess` не моделює `expr % len` як safe-mod. `palette[0]` гарантовано визначений (масив із 10 кольорів літерально нижче).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable TypeScript `noUncheckedIndexedAccess` in `@sergeant/finyk-domain` to catch unsafe index access at compile time as part of Item #15; runtime behavior stays the same, and strict-index coverage increases to 9/13 (69%).

- **Refactors**
  - Enabled `noUncheckedIndexedAccess` in `packages/finyk-domain/tsconfig.json`.
  - Added safe narrowings and fallbacks in `getCatColor`, `parseLocalDate`, `stripLeadingSymbols`, `calcForecast`, `calcMonthlyNeeded`, `detectRecurring`, and `spending`.
  - Updated tests to use non-null `!` on indexed values where array length is asserted.

<sup>Written for commit a6019c21b35cdca7d883b617aaa8f1032f195fc9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

