### PR TITLE
fix(mobile): drop duplicate initPostHog import in app/_layout.tsx

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -29,7 +29,6 @@ import "@/lib/fileImport";
 // visual-keyboard-inset contract (`@sergeant/shared`). Import for side
 // effects only.
 import "@/hooks/useVisualKeyboardInset";
-import { initPostHog } from "@/lib/analytics";
 import { captureError, initObservability } from "@/lib/observability";
 import { IdentityBridge } from "@/observability/IdentityBridge";
 import { initPostHog } from "@/observability/posthog";


### PR DESCRIPTION
## Summary

`apps/mobile/app/_layout.tsx` imported `initPostHog` twice on `main`:

```ts
import { initPostHog } from "@/lib/analytics";        // line 32 (from PR #1729 e33001d83)
…
import { initPostHog } from "@/observability/posthog"; // line 35 (from PR #1741 6999c83db)
```

Both PRs landed back-to-back without rebasing each other. The duplicate slipped past per-PR CI but breaks `pnpm --filter @sergeant/mobile typecheck` on `main`:

```
app/_layout.tsx:32:10 - error TS2300: Duplicate identifier 'initPostHog'.
app/_layout.tsx:35:10 - error TS2300: Duplicate identifier 'initPostHog'.
```

This blocks every mobile PR from passing CI typecheck stage. Found while implementing S3.3 mobile parity — the fix is unrelated and worth landing in isolation.

Both imports resolve to the same function — `@/lib/analytics` re-exports `initPostHog` from `@/observability/posthog`. This PR removes the re-export-side import (`@/lib/analytics`) so the canonical source (`@/observability/posthog`) stays the single import line. Behaviour is byte-identical: the call sites at lines 109 + 132 still get the same function.

## Governing Skill

- Primary skill: `sergeant-bugfix-and-regression`
- Secondary skill (if truly needed): `sergeant-mobile-expo`

## Playbook

- Primary playbook: n/a
- Why this playbook: single-line fix to unbreak `main` typecheck; no behavioral change.
- If no playbook matched, why: trivial one-line import dedup; covered by `sergeant-bugfix-and-regression` directly.

## Verification

```bash
# Reproduces the failure on main:
git checkout main
pnpm --filter @sergeant/mobile typecheck
# error TS2300: Duplicate identifier 'initPostHog'.

# Passes on this branch:
pnpm --filter @sergeant/mobile typecheck
# (clean, exit 0)
```

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a — no behavioral change. The pre-existing import contract (single canonical source `@/observability/posthog`) is preserved.

## Risk and Rollout

- User-visible risk: none. `initPostHog` resolves to the same function from both paths today; this PR just removes one of two duplicate imports.
- Rollout / deploy order: ship as-is. No migration, no env var.
- Backout plan: revert this PR. Reverting restores the duplicate-identifier error on `main`, so backout would only be appropriate if a deeper issue surfaces.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

- The pre-existing re-export in `apps/mobile/src/lib/analytics.ts` (`export { initPostHog, … } from "@/observability/posthog"`) is left intact — other callers may still use it.
- This is the same pattern already used inside `_layout.tsx` for `captureError, initObservability` from `@/lib/observability` — keep the canonical source visible at the import site, not the re-export.
- Suggest backporting CI: when both PRs touch the same file imports, the merge-queue should run a final typecheck on the post-merge tree, not just on each PR's individual rebase. Outside scope here.


Link to Devin session: https://app.devin.ai/sessions/dc25f8711c27434d86b9991eab3c2b60

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed a duplicate `initPostHog` import in `apps/mobile/app/_layout.tsx` to fix TS2300 duplicate identifier errors and unblock `pnpm --filter @sergeant/mobile typecheck` on `main`.
Kept the canonical import from `@/observability/posthog`; behavior unchanged.

<sup>Written for commit 28e2bb7a9aabeb5a7dad80c1438ad418100b7fff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal reorganization of observability imports; no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->