### PR TITLE
feat(shared): outcome-first hero copy + 3-arm A/B (S1.1 + S1.2)

### DIFF
--- a/apps/mobile/src/core/OnboardingWizard.test.tsx
+++ b/apps/mobile/src/core/OnboardingWizard.test.tsx
@@ -42,12 +42,19 @@ describe("OnboardingWizard", () => {
     return screen;
   }
 
-  it("renders the welcome headline and all four module cards", () => {
-    const { getByText, getByTestId } = render(
+  it("renders the outcome-variant hero copy and all four module cards", () => {
+    const { getByText, queryByText, getByTestId } = render(
       <OnboardingWizard onDone={jest.fn()} />,
     );
-    expect(getByText("Привіт. Це Sergeant.")).toBeTruthy();
-    expect(getByText(/Гроші, тіло, звички, їжа/)).toBeTruthy();
+    // S1.1 + S1.2: outcome variant ships at 100% (`weights: [1, 0, 0]`).
+    // Mobile parity must show the same headline/subtitle as the web wizard.
+    expect(
+      getByText("Запиши перший зум — і побачиш, куди йде твоє життя."),
+    ).toBeTruthy();
+    expect(getByText(/30 секунд, без реєстрації/)).toBeTruthy();
+    // Audit-guard: the pre-S1.1 copy must not resurrect.
+    expect(queryByText("Привіт. Це Sergeant.")).toBeNull();
+    expect(queryByText(/Гроші, тіло, звички, їжа/)).toBeNull();
 
     fireEvent.press(getByTestId("onboarding-next-welcome"));
 

--- a/apps/mobile/src/core/OnboardingWizard.tsx
+++ b/apps/mobile/src/core/OnboardingWizard.tsx
@@ -53,6 +53,11 @@ import {
   getGoalQuestions,
   saveOnboardingGoals,
   type OnboardingGoals,
+  ONBOARDING_HERO_COPY_EXPERIMENT,
+  assignVariant,
+  getOnboardingHeroCopy,
+  type OnboardingHeroCopy,
+  type OnboardingHeroCopyVariant,
 } from "@sergeant/shared";
 
 import { mobileKVStore } from "@/lib/storage";
@@ -201,7 +206,13 @@ function StepIndicator({ current, total }: { current: number; total: number }) {
 // Step 1: Welcome
 // ---------------------------------------------------------------------------
 
-function WelcomeStep({ onContinue }: { onContinue: () => void }) {
+function WelcomeStep({
+  onContinue,
+  copy,
+}: {
+  onContinue: () => void;
+  copy: OnboardingHeroCopy;
+}) {
   return (
     <View className="items-center gap-5">
       <View className="h-20 w-20 items-center justify-center rounded-3xl bg-brand-500/10">
@@ -209,16 +220,16 @@ function WelcomeStep({ onContinue }: { onContinue: () => void }) {
       </View>
       <View className="items-center gap-2">
         <Text className="text-center text-2xl font-bold text-fg">
-          Привіт. Це Sergeant.
+          {copy.title}
         </Text>
         <Text className="text-center text-sm leading-relaxed text-fg-muted">
-          Гроші, тіло, звички, їжа — все в одному місці. Офлайн. Приватно.
+          {copy.subtitle}
         </Text>
       </View>
       <View className="flex-row items-center gap-3">
-        <Text className="text-xs text-fg-subtle">📶 Офлайн</Text>
-        <Text className="text-xs text-fg-subtle">🔒 Локально</Text>
-        <Text className="text-xs text-fg-subtle">⚡ ~30 сек</Text>
+        <Text className="text-xs text-fg-subtle">🔒 {copy.badges[0]}</Text>
+        <Text className="text-xs text-fg-subtle">☁️ {copy.badges[1]}</Text>
+        <Text className="text-xs text-fg-subtle">🚫 {copy.badges[2]}</Text>
       </View>
       <Button
         variant="primary"
@@ -227,7 +238,7 @@ function WelcomeStep({ onContinue }: { onContinue: () => void }) {
         testID="onboarding-next-welcome"
         className="w-full"
       >
-        Далі
+        {copy.primaryCta}
       </Button>
     </View>
   );
@@ -531,6 +542,32 @@ export function OnboardingWizard({
     trackEvent(ANALYTICS_EVENTS.ONBOARDING_STEP_VIEWED, { step: "welcome" });
   }, [isTour]);
 
+  // Hero copy A/B (S1.1 + S1.2). Mirrors the web wizard so a single
+  // user on both surfaces sees the same arm. Tour replay bypasses
+  // assignment so it never contaminates the experiment dataset.
+  const heroVariant = useMemo<OnboardingHeroCopyVariant>(
+    () =>
+      isTour
+        ? "outcome"
+        : (assignVariant(
+            mobileKVStore,
+            ONBOARDING_HERO_COPY_EXPERIMENT,
+          ) as OnboardingHeroCopyVariant),
+    [isTour],
+  );
+  const heroCopy = useMemo(
+    () => getOnboardingHeroCopy(heroVariant),
+    [heroVariant],
+  );
+
+  useEffect(() => {
+    if (isTour) return;
+    trackEvent(ANALYTICS_EVENTS.EXPERIMENT_EXPOSED, {
+      experiment_id: ONBOARDING_HERO_COPY_EXPERIMENT.id,
+      variant: heroVariant,
+    });
+  }, [isTour, heroVariant]);
+
   // Per-step view event whenever `state.step` changes. The first paint
   // (welcome) is fired by the mount effect above so the dedupe logic
   // here only re-fires when the step *transitions*. Tour mode skips
@@ -686,7 +723,9 @@ export function OnboardingWizard({
         )
       )}
       <StepIndicator current={stepIdx} total={ONBOARDING_STEPS.length} />
-      {state.step === "welcome" && <WelcomeStep onContinue={handleNext} />}
+      {state.step === "welcome" && (
+        <WelcomeStep onContinue={handleNext} copy={heroCopy} />
+      )}
       {state.step === "modules" && (
         <ModulesStep
           picks={state.picks}

--- a/apps/web/src/core/onboarding/OnboardingWizard.tour.test.tsx
+++ b/apps/web/src/core/onboarding/OnboardingWizard.tour.test.tsx
@@ -50,20 +50,32 @@ describe("OnboardingWizard — tour mode (read-only replay)", () => {
     ).toBeNull();
   });
 
-  it("renders the «Закрити» CTA instead of «Відкрити Sergeant»", () => {
+  it("renders the «Закрити» CTA instead of the experiment-arm CTA", () => {
     render(<OnboardingWizard mode="tour" onDone={() => {}} />);
     expect(
       screen.getByRole("button", { name: /Закрити/i }),
     ).toBeInTheDocument();
+    // Tour mode must override `copy.primaryCta` so the user always sees
+    // «Закрити» regardless of which hero variant is assigned.
+    expect(
+      screen.queryByRole("button", { name: /Розпочати/i }),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: /Відкрити Sergeant/i }),
     ).not.toBeInTheDocument();
   });
 
-  it("default mode still renders «Відкрити Sergeant» CTA", () => {
+  it("default mode renders the outcome-variant CTA (mainline post-S1.1)", () => {
     render(<OnboardingWizard onDone={() => {}} />);
+    // `weights: [1, 0, 0]` ships outcome at 100%, so a fresh fingerprint
+    // always lands on the outcome arm: «Розпочати — 30 секунд».
     expect(
-      screen.getByRole("button", { name: /Відкрити Sergeant/i }),
+      screen.getByRole("button", { name: /Розпочати/i }),
     ).toBeInTheDocument();
+    // Audit-guard — the pre-S1.1 «Відкрити Sergeant» CTA must not
+    // resurrect from a stale assignment or a forgotten code path.
+    expect(
+      screen.queryByRole("button", { name: /Відкрити Sergeant/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/core/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/core/onboarding/OnboardingWizard.tsx
@@ -4,6 +4,7 @@ import {
   safeReadStringLS,
   safeWriteLS,
   safeRemoveLS,
+  webKVStore,
 } from "@shared/lib/storage/storage";
 import { Button } from "@shared/components/ui/Button";
 import { Icon } from "@shared/components/ui/Icon";
@@ -25,6 +26,11 @@ import {
   ONBOARDING_MODULE_DESCRIPTIONS,
   ONBOARDING_VIBE_ICONS,
   ONBOARDING_VIBE_TEASERS,
+  ONBOARDING_HERO_COPY_EXPERIMENT,
+  assignVariant,
+  getOnboardingHeroCopy,
+  type OnboardingHeroCopy,
+  type OnboardingHeroCopyVariant,
 } from "@sergeant/shared";
 
 // Re-exported so `App.tsx` and any legacy call-site keep importing
@@ -224,44 +230,45 @@ function WelcomeOneScreen({
   onOpen,
   expanded,
   onToggleExpanded,
-  ctaLabel = "Відкрити Sergeant",
+  copy,
+  ctaLabelOverride,
 }: {
   picks: string[];
   togglePick: (id: string) => void;
   onOpen: () => void;
   expanded: boolean;
   onToggleExpanded: () => void;
-  /** Override label for the primary CTA (e.g. tour replay shows "Закрити"). */
-  ctaLabel?: string;
+  /** Resolved A/B copy for the splash hero (S1.1 + S1.2). */
+  copy: OnboardingHeroCopy;
+  /**
+   * Override label for the primary CTA. Used by tour replay to swap
+   * `copy.primaryCta` for "Закрити". Real wizard always renders
+   * `copy.primaryCta` so the experiment arm controls the text.
+   */
+  ctaLabelOverride?: string;
 }) {
   return (
     <div className="flex flex-col items-center text-center space-y-5">
       <div className="space-y-2">
-        <h2 className="text-style-hero text-text">
-          <BrandLogo
-            size="md"
-            variant="inline"
-            className="inline-flex align-baseline"
-          />{" "}
-          — твій хаб.
-        </h2>
+        <BrandLogo size="md" variant="inline" className="mx-auto" />
+        <h2 className="text-style-hero text-text">{copy.title}</h2>
         <p className="text-sm text-muted leading-relaxed max-w-xs mx-auto">
-          Гроші, тіло, звички, їжа — все в одному місці. Офлайн. Приватно.
+          {copy.subtitle}
         </p>
       </div>
 
       <div className="flex items-center gap-3 text-xs text-muted">
         <span className="flex items-center gap-1">
-          <Icon name="wifi-off" size={14} aria-hidden />
-          Офлайн
-        </span>
-        <span className="flex items-center gap-1">
           <Icon name="lock" size={14} aria-hidden />
-          Локально
+          {copy.badges[0]}
         </span>
         <span className="flex items-center gap-1">
-          <Icon name="zap" size={14} aria-hidden />
-          ~10 сек
+          <Icon name="cloud-off" size={14} aria-hidden />
+          {copy.badges[1]}
+        </span>
+        <span className="flex items-center gap-1">
+          <Icon name="eye-off" size={14} aria-hidden />
+          {copy.badges[2]}
         </span>
       </div>
 
@@ -296,7 +303,7 @@ function WelcomeOneScreen({
         size="lg"
         className="w-full"
       >
-        {ctaLabel}
+        {ctaLabelOverride ?? copy.primaryCta}
         <Icon name="chevron-right" size={16} />
       </Button>
 
@@ -447,6 +454,37 @@ export function OnboardingWizard({
     });
   }, [picks, onDone, isTour]);
 
+  // Hero copy A/B (S1.1 + S1.2). Assignment is deterministic per
+  // device fingerprint and persists across renders, so the user always
+  // sees the same headline / CTA throughout the funnel. Tour replay
+  // bypasses assignment so it never gets counted as an exposure.
+  const heroVariant = useMemo<OnboardingHeroCopyVariant>(
+    () =>
+      isTour
+        ? "outcome"
+        : (assignVariant(
+            webKVStore,
+            ONBOARDING_HERO_COPY_EXPERIMENT,
+          ) as OnboardingHeroCopyVariant),
+    [isTour],
+  );
+  const heroCopy = useMemo(
+    () => getOnboardingHeroCopy(heroVariant),
+    [heroVariant],
+  );
+
+  // Fire `EXPERIMENT_EXPOSED` on the same render the user actually sees
+  // the variant. Real wizard only — tour replay must not contaminate
+  // the experiment dataset. Effect runs once because `heroVariant` is
+  // stable for the lifetime of the wizard mount.
+  useEffect(() => {
+    if (isTour) return;
+    trackEvent(ANALYTICS_EVENTS.EXPERIMENT_EXPOSED, {
+      experiment_id: ONBOARDING_HERO_COPY_EXPERIMENT.id,
+      variant: heroVariant,
+    });
+  }, [isTour, heroVariant]);
+
   const content = useMemo(
     () => (
       <WelcomeOneScreen
@@ -455,10 +493,11 @@ export function OnboardingWizard({
         onOpen={finish}
         expanded={expanded}
         onToggleExpanded={toggleExpanded}
-        ctaLabel={isTour ? "Закрити" : "Відкрити Sergeant"}
+        copy={heroCopy}
+        ctaLabelOverride={isTour ? "Закрити" : undefined}
       />
     ),
-    [picks, togglePick, finish, expanded, toggleExpanded, isTour],
+    [picks, togglePick, finish, expanded, toggleExpanded, heroCopy, isTour],
   );
 
   if (variant === "fullPage") {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -57,6 +57,9 @@ export * from "./lib/onboarding";
 // Onboarding goal-setting (multi-step v2).
 export * from "./lib/onboardingGoals";
 
+// OnboardingWizard hero copy A/B (S1.1 + S1.2).
+export * from "./lib/onboardingHeroCopy";
+
 // Reset helpers for Settings ("Restart onboarding").
 export * from "./lib/onboardingReset";
 

--- a/packages/shared/src/lib/analyticsEvents.ts
+++ b/packages/shared/src/lib/analyticsEvents.ts
@@ -47,6 +47,18 @@ export const ANALYTICS_EVENTS = Object.freeze({
   AUTH_PROMPT_DISMISSED: "auth_prompt_dismissed",
   AUTH_AFTER_VALUE: "auth_after_value",
 
+  // A/B experiments — exposure event. Payload contract:
+  //
+  //   EXPERIMENT_EXPOSED { experiment_id: string, variant: string }
+  //
+  // Fired exactly once per render-of-the-arm-the-user-sees so PostHog
+  // funnels can do `breakdown by properties.variant` without inflating
+  // counts. Pre-S1.1 the only experiment was `soft_auth_copy_v1`,
+  // which historically smuggled the variant through `auth_prompt_shown.variant`.
+  // Post-S1.1 every experiment fires this event in addition, so the
+  // funnel definition stays uniform across copies.
+  EXPERIMENT_EXPOSED: "experiment_exposed",
+
   // Module checklists (Phase 2 — activation)
   MODULE_CHECKLIST_SHOWN: "module_checklist_shown",
   MODULE_CHECKLIST_STEP_DONE: "module_checklist_step_done",

--- a/packages/shared/src/lib/onboardingHeroCopy.test.ts
+++ b/packages/shared/src/lib/onboardingHeroCopy.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import {
+  ONBOARDING_HERO_COPY_EXPERIMENT,
+  getOnboardingHeroCopy,
+} from "./onboardingHeroCopy";
+
+describe("getOnboardingHeroCopy — outcome variant (S1.1 mainline)", () => {
+  it("leads with a user-outcome promise, not a product category", () => {
+    const copy = getOnboardingHeroCopy("outcome");
+    expect(copy.title).toBe(
+      "Запиши перший зум — і побачиш, куди йде твоє життя.",
+    );
+    // The audit explicitly called out "хаб" as marketer-speak.
+    expect(copy.title).not.toMatch(/хаб/i);
+    // "все в одному місці" is the dead overused cliché we're replacing.
+    expect(copy.subtitle).not.toMatch(/все в одному місці/i);
+  });
+
+  it("anchors the next-30-seconds promise in the subtitle", () => {
+    const copy = getOnboardingHeroCopy("outcome");
+    expect(copy.subtitle).toContain("30 секунд");
+    expect(copy.subtitle).toContain("без реєстрації");
+  });
+
+  it("uses three concrete negative-claim badges (verifiable)", () => {
+    const copy = getOnboardingHeroCopy("outcome");
+    expect(copy.badges).toEqual([
+      "Без реєстрації",
+      "Без cloud-у",
+      "Без реклами",
+    ]);
+    // Banned: vague privacy claims that the user can't verify.
+    for (const badge of copy.badges) {
+      expect(badge).not.toMatch(/^Приватн/i);
+      expect(badge).not.toMatch(/^Локальн/i);
+    }
+  });
+
+  it("uses an action verb in the primary CTA, not a feature-noun", () => {
+    const copy = getOnboardingHeroCopy("outcome");
+    expect(copy.primaryCta).toBe("Розпочати — 30 секунд");
+    // Banned: pre-S1.2 feature-flavoured CTA copy.
+    expect(copy.primaryCta).not.toMatch(/^Відкрити Sergeant/);
+    expect(copy.primaryCta).not.toMatch(/^Налаштувати модулі/);
+    expect(copy.primaryCta).not.toMatch(/^Створити акаунт/);
+  });
+});
+
+describe("getOnboardingHeroCopy — safe variant", () => {
+  it("removes 'хаб' but keeps the four-domain list", () => {
+    const copy = getOnboardingHeroCopy("safe");
+    expect(copy.title).toBe("Один екран замість шести застосунків.");
+    expect(copy.title).not.toMatch(/хаб/i);
+    expect(copy.subtitle).toContain("Гроші");
+    expect(copy.subtitle).toContain("тренування");
+  });
+});
+
+describe("getOnboardingHeroCopy — bold variant", () => {
+  it("uses an exclusionary lead targeting the 'tired of forgetting' cohort", () => {
+    const copy = getOnboardingHeroCopy("bold");
+    expect(copy.title).toBe("Не для всіх. Для тих, хто втомився забувати.");
+    expect(copy.subtitle).toContain("пам'ятає за тебе");
+  });
+});
+
+describe("ONBOARDING_HERO_COPY_EXPERIMENT", () => {
+  it("declares three variants with outcome as the mainline default", () => {
+    expect(ONBOARDING_HERO_COPY_EXPERIMENT.id).toBe("onboarding_hero_copy_v1");
+    expect(ONBOARDING_HERO_COPY_EXPERIMENT.variants).toEqual([
+      "outcome",
+      "safe",
+      "bold",
+    ]);
+    expect(ONBOARDING_HERO_COPY_EXPERIMENT.weights).toEqual([1, 0, 0]);
+  });
+
+  it("keeps weights summing to 1 so abTest assignment never falls through", () => {
+    const weights = ONBOARDING_HERO_COPY_EXPERIMENT.weights;
+    expect(weights).toBeDefined();
+    if (!weights) return;
+    const sum = weights.reduce((acc, w) => acc + w, 0);
+    expect(sum).toBeCloseTo(1, 5);
+  });
+});
+
+describe("audit-guard — banned phrasing must not return", () => {
+  it("none of the variants resurrect 'хаб' or 'все в одному місці'", () => {
+    for (const variant of ["outcome", "safe", "bold"] as const) {
+      const copy = getOnboardingHeroCopy(variant);
+      const all = `${copy.title} ${copy.subtitle} ${copy.primaryCta}`;
+      expect(all, `variant=${variant}`).not.toMatch(/твій хаб/i);
+      expect(all, `variant=${variant}`).not.toMatch(/все в одному місці/i);
+    }
+  });
+});

--- a/packages/shared/src/lib/onboardingHeroCopy.ts
+++ b/packages/shared/src/lib/onboardingHeroCopy.ts
@@ -1,0 +1,105 @@
+/**
+ * Copy generator for the OnboardingWizard splash hero (S1.1 + S1.2) — A/B-ready.
+ *
+ * The pre-S1.1 copy was feature-driven:
+ *   «Sergeant — твій хаб.» / «Гроші, тіло, звички, їжа — все в одному місці.»
+ * That copy reads like marketer-speak («хаб», «все в одному місці») and
+ * frames the product as a *category*, not as a *user outcome*. The audit
+ * (`docs/audits/2026-05-03-ftux-onboarding-roast.md`) flagged this as the
+ * single biggest «benefit→feature» drift in the funnel.
+ *
+ * The new mainline (`outcome`) is outcome-first: it leads with what the
+ * user *gets* in the next 30 seconds, not with the product's category.
+ * Two alternative arms are kept for A/B-testing:
+ *   - `safe`  — conservative rewrite that just removes "хаб"
+ *   - `bold`  — provocative framing that targets the "втомився забувати"
+ *               cohort. Higher conversion-or-bounce variance expected.
+ *
+ * `assignVariant(ONBOARDING_HERO_COPY_EXPERIMENT)` defaults to 100% `outcome`
+ * (`weights: [1, 0, 0]`); flip the weights or call `overrideVariant` to
+ * start a real split. Per `docs/launch/posthog-ftux-dashboards.md`, the
+ * winning metric is `wizard_started → wizard_completed` per-arm.
+ */
+
+import type { ExperimentDefinition } from "./abTest";
+
+/**
+ * Experiment definition for the OnboardingWizard hero copy A/B.
+ * `outcome` is the mainline; `safe` and `bold` are preserved for testing.
+ */
+export const ONBOARDING_HERO_COPY_EXPERIMENT: ExperimentDefinition = {
+  id: "onboarding_hero_copy_v1",
+  variants: ["outcome", "safe", "bold"] as const,
+  weights: [1, 0, 0] as const,
+};
+
+export type OnboardingHeroCopyVariant = "outcome" | "safe" | "bold";
+
+export interface OnboardingHeroCopy {
+  /** Hero headline (h2). ≤ 64 chars. */
+  title: string;
+  /** Subtext under the headline. ≤ 140 chars. */
+  subtitle: string;
+  /**
+   * Three trust-fasets shown as inline icon+label pills under the
+   * subtitle. Each label ≤ 16 chars so it fits on one line on a 320px
+   * viewport.
+   */
+  badges: readonly [string, string, string];
+  /** Primary CTA label. Always action-orientated. ≤ 32 chars. */
+  primaryCta: string;
+}
+
+/**
+ * Pure copy resolver. Web and mobile call the same function so the
+ * surface stays in sync — no platform-specific copy drift.
+ */
+export function getOnboardingHeroCopy(
+  variant: OnboardingHeroCopyVariant,
+): OnboardingHeroCopy {
+  if (variant === "safe") return SAFE_COPY;
+  if (variant === "bold") return BOLD_COPY;
+  return OUTCOME_COPY;
+}
+
+/**
+ * Variant `outcome` — current mainline (S1.1 + S1.2).
+ *
+ * Outcome-first framing: leads with the *next-30-seconds promise* and
+ * uses domain words the user actually thinks in («перший запис», «куди
+ * йде твоє життя») instead of category words («хаб», «все в одному
+ * місці»). Trust badges flip from generic privacy claims to three
+ * concrete *negative claims* the user can verify.
+ */
+const OUTCOME_COPY: OnboardingHeroCopy = {
+  title: "Запиши перший зум — і побачиш, куди йде твоє життя.",
+  subtitle: "Бюджет, тренування, звички, їжа — за 30 секунд, без реєстрації.",
+  badges: ["Без реєстрації", "Без cloud-у", "Без реклами"],
+  primaryCta: "Розпочати — 30 секунд",
+};
+
+/**
+ * Variant `safe` — conservative rewrite. Keeps the four-domain list
+ * but removes "хаб" and the "все в одному місці" cliché. Useful as a
+ * fallback if `outcome` tests as too aggressive for the audience.
+ */
+const SAFE_COPY: OnboardingHeroCopy = {
+  title: "Один екран замість шести застосунків.",
+  subtitle: "Гроші, тренування, звички, їжа. Без акаунта. Без cloud-у.",
+  badges: ["Без реєстрації", "Без cloud-у", "Без реклами"],
+  primaryCta: "Розпочати — 30 секунд",
+};
+
+/**
+ * Variant `bold` — provocative framing. Targets the «втомився
+ * забувати» cohort with an exclusionary lead («Не для всіх. Для тих,
+ * хто…»). Expected higher variance: better conversion among matched
+ * audience, higher early bounce among mismatched.
+ */
+const BOLD_COPY: OnboardingHeroCopy = {
+  title: "Не для всіх. Для тих, хто втомився забувати.",
+  subtitle:
+    "Записуй один раз — Sergeant пам'ятає за тебе. Офлайн, без акаунта.",
+  badges: ["Без реєстрації", "Без cloud-у", "Без реклами"],
+  primaryCta: "Спробувати — 30 секунд",
+};


### PR DESCRIPTION
## Summary

Replaces the pre-S1.1 splash copy («Sergeant — твій хаб.» / «Гроші, тіло, звички, їжа — все в одному місці. Офлайн. Приватно.») with an **outcome-first hero** across web + mobile, gated by a 3-arm PostHog A/B (`onboarding_hero_copy_v1`) shipped at **100% `outcome`** to start.

**The new mainline copy** (variant `outcome`):

| | Pre-S1.1 | Post-S1.1 (`outcome`) |
| --- | --- | --- |
| **H2** | `Sergeant — твій хаб.` | `Запиши перший зум — і побачиш, куди йде твоє життя.` |
| **Subtitle** | `Гроші, тіло, звички, їжа — все в одному місці. Офлайн. Приватно.` | `Бюджет, тренування, звички, їжа — за 30 секунд, без реєстрації.` |
| **Badges** | `Офлайн / Локально / ~10 сек` | `Без реєстрації / Без cloud-у / Без реклами` |
| **Primary CTA** | `Відкрити Sergeant` | `Розпочати — 30 секунд` |

Two alternative arms (`safe`, `bold`) live in the same resolver and are ready to flip via `weights` for A/B-testing. No code changes needed to start a real split — change `[1, 0, 0]` → `[0.34, 0.33, 0.33]` and ship.

**Why** (per `docs/audits/2026-05-03-ftux-onboarding-roast.md`):
- "Хаб" is marketer-speak — users don't think in product categories.
- "Все в одному місці" is a dead cliché every app uses.
- "Офлайн / Приватно" are vague unverifiable claims; "Без реєстрації / Без cloud-у / Без реклами" are concrete negative claims a user can verify.
- Primary CTA was a feature-noun ("Відкрити Sergeant"); now it's an action verb + time anchor.

**Architecture follows the existing `softAuthCopy.ts` (S3.2) pattern exactly:** one shared resolver, web + mobile share assignment via `assignVariant(KVStore, EXPERIMENT)`, exposure event fires once per arm-render so PostHog funnel breakdowns stay uniform.

## Governing Skill

- Primary skill: `sergeant-feature-delivery`
- Secondary skill (if truly needed): `sergeant-monorepo-boundaries` — touches `packages/shared` + both `apps/web` and `apps/mobile`.

## Playbook

- Primary playbook: ad-hoc — no playbook for "ship a copy A/B" exists yet; followed the `softAuthCopy.ts` pattern as canonical reference.
- Why this playbook: copy A/B with shared web+mobile assignment was already solved once for S3.2; replicating that pattern keeps experiment infra uniform.
- If no playbook matched, why: A/B copy experiments aren't yet codified into a reusable playbook. Worth adding after this PR if a third copy A/B lands.

## Verification

```bash
pnpm --filter @sergeant/shared exec vitest run
# 37 files, 513 tests passed (incl. 9 new for onboardingHeroCopy)

pnpm --filter @sergeant/web exec vitest run src/core/onboarding/OnboardingWizard
# 1 file, 4 tests passed (tour + outcome-variant audit-guard)

pnpm --filter @sergeant/web typecheck
# clean

pnpm --filter @sergeant/mobile typecheck
# clean

pnpm exec prettier --write <touched files>
# all formatted

git commit  # husky lint-staged: lint+prettier on staged files — passed
```

Mobile jest run was attempted locally but blocked by a pre-existing `jest-expo` setup failure on this VM (`TypeError: Object.defineProperty called on non-object` at `node_modules/jest-expo/src/preset/setup.js:47`); same failure reproduces on `main` without my changes, so it is environment-only. CI will execute the mobile jest suite in a clean container.

Additional checks:

- [x] Local smoke / manual validation completed (typecheck + tests on web + shared).
- [x] Surface-specific checks completed (web wizard tour test + mobile wizard test updated).

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
  - Inline comment in `packages/shared/src/lib/onboardingHeroCopy.ts` explains how to flip the experiment to a real split.
  - Inline comment in `packages/shared/src/lib/analyticsEvents.ts` documents the `EXPERIMENT_EXPOSED` payload contract.
- [x] I checked whether `AGENTS.md` needed an update. No — the file already covers shared/web/mobile parity rules and analytics conventions.
- [x] I checked whether a playbook or skill needed an update. None of the existing ones describe copy A/B; deferring to a follow-up doc PR (combined with `S2.2a/b` doc rollup).
- [x] I checked whether governance docs or review docs needed an update. No hard-rule changes.

Updated docs:

- n/a (inline doc comments only; FTUX sprint-plan rollup will land in a follow-up doc PR after S2.2a/b ships).

## Risk and Rollout

- **User-visible risk:** Hero copy on `/welcome` and the OnboardingWizard splash changes for 100% of fresh installs. The mainline (`outcome`) is the variant I would have chosen if asked to write the new mainline copy directly — `safe` and `bold` are ready as A/B arms but not active until weights flip. Existing users who already completed onboarding never re-enter the wizard.
- **Rollout / deploy order:** Single PR, merge → ship. No migrations, no env vars, no server changes.
- **Backout plan:**
  - Fast: flip `weights` to `[0, 1, 0]` (variant `safe` — keeps the feature-list framing but removes "хаб") in a one-line revert PR.
  - Full: revert this PR; the only persisted side effect is `hub_ab_assignments_v1["onboarding_hero_copy_v1"]` in localStorage / MMKV, which becomes inert when the experiment definition is removed.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian (inline comments are bilingual; `analyticsEvents.ts` follows the existing English-comment convention there).
- [x] I did not use `--no-verify`.

## Reviewer Notes

- **Where to start the review:** `packages/shared/src/lib/onboardingHeroCopy.ts` is the single source of truth — three variants + experiment definition. The web/mobile wizard changes are mechanical wiring of that resolver.
- **The new `EXPERIMENT_EXPOSED` event is intentional:** historically `SOFT_AUTH_COPY_EXPERIMENT` smuggled the variant through `auth_prompt_shown.variant`, which makes funnel queries inconsistent across experiments. Standardising on `EXPERIMENT_EXPOSED { experiment_id, variant }` from this PR onward; existing `auth_prompt_shown.variant` is left intact (no churn for active dashboards).
- **Brand logo placement:** moved from inline-inside-h2 to standalone-above-h2. The h2 now carries pure copy, which makes the variant arms easier to reason about (no per-variant brand-positioning quirks).
- **No changes to `WelcomeScreen.tsx`:** the welcome screen's primary CTA *is* the wizard's primary CTA (the wizard renders inline inside the welcome page in `fullPage` variant), so updating the wizard CTA covers S1.2. The two secondary CTAs ("Подивитись приклад" / "У мене вже є акаунт") are intentionally left as-is.


Link to Devin session: https://app.devin.ai/sessions/dc25f8711c27434d86b9991eab3c2b60

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the onboarding hero with outcome‑first copy across web and mobile, gated by a 3‑arm PostHog A/B (`onboarding_hero_copy_v1`) shipping 100% `outcome`. Adds a shared resolver and a one-time exposure event so web/mobile stay in sync and funnels break down cleanly.

- **New Features**
  - Shared resolver in `@sergeant/shared` (`onboardingHeroCopy.ts`) with three variants: `outcome`, `safe`, `bold`; `ONBOARDING_HERO_COPY_EXPERIMENT` defaults to `[1, 0, 0]`. Exported via `packages/shared/src/index.ts`.
  - Wizards in `apps/web` and `apps/mobile` use `assignVariant` + `getOnboardingHeroCopy` to render title, subtitle, badges, and CTA; tour mode forces «Закрити» and skips assignment/exposure; logo moved above the headline.
  - New analytics event `ANALYTICS_EVENTS.EXPERIMENT_EXPOSED` fires once with `{ experiment_id, variant }` on arm render.
  - Start a real split by updating weights (e.g. `[0.34, 0.33, 0.33]`); no other code changes.
  - Tests: added shared variant tests and audit guards; updated web tour and mobile onboarding tests.

<sup>Written for commit 9bfd66832a95e47206333e8d455da2bd13f45eed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

