### PR TITLE
docs(docs): wire S0.5 founder-tasks (PostHog FTUX dashboards live)

### DIFF
--- a/docs/launch/ftux-sprint-plan.md
+++ b/docs/launch/ftux-sprint-plan.md
@@ -77,13 +77,15 @@
 
 **Порядок взяття:** S0.5 (docs) → S0.4 (web events) → S0.3 (mobile). S0.5 першим — щоб контракти dashboard-ів продиктували, як саме fired payload для S0.4. S0.3 останнім — після того як web payload устаткувався.
 
-**Status update 2026-05-04 v3:** Sprint 0 повністю закритий. S0.5 ([PR #1570](https://github.com/Skords-01/Sergeant/pull/1570)) → S0.4 ([PR #1582](https://github.com/Skords-01/Sergeant/pull/1582)) → S0.3 ([PR #1704](https://github.com/Skords-01/Sergeant/pull/1704)) shipped у тому ж порядку (docs → events → mobile). Drive-by hotfix [PR #1755](https://github.com/Skords-01/Sergeant/pull/1755) прибрав duplicate-import регресію, що з'явилася через паралельний rebase двох S0.3-related PR-ів і ламала `pnpm --filter @sergeant/mobile typecheck` на main. Лишились тільки founder-tasks: вставити `VITE_POSTHOG_KEY` у Vercel + `apps/web/.env.local`, створити 5 insights у PostHog UI (HogQL запити готові у [`posthog-ftux-dashboards.md` §3](../observability/posthog-ftux-dashboards.md#3-the-five-saved-insights)) і вставити screenshot-лінки замість «TBD».
+**Status update 2026-05-04 v3:** Sprint 0 повністю закритий. S0.5 ([PR #1570](https://github.com/Skords-01/Sergeant/pull/1570)) → S0.4 ([PR #1582](https://github.com/Skords-01/Sergeant/pull/1582)) → S0.3 ([PR #1704](https://github.com/Skords-01/Sergeant/pull/1704)) shipped у тому ж порядку (docs → events → mobile). Drive-by hotfix [PR #1755](https://github.com/Skords-01/Sergeant/pull/1755) прибрав duplicate-import регресію, що з'явилася через паралельний rebase двох S0.3-related PR-ів і ламала `pnpm --filter @sergeant/mobile typecheck` на main.
+
+**S0.5 founder-tasks (2026-05-04 v4):** закриті через PostHog API в `Default project` (id `167740`, prod). 5 створено інсайтів під [`Dashboards → FTUX overview`](https://eu.posthog.com/project/167740/dashboard/660031) (без «TBD» в документі); `VITE_POSTHOG_KEY` + `VITE_POSTHOG_HOST` виставлені у Vercel-проєкті `prj_WTfB58gE…` для `production` і `preview` (production = `Default project`, preview = `dev serg`). Скріншоти тайлів наберуть дані автоматично як тільки перший `onboarding_started` прилетить. Деталі: [`docs/observability/posthog-ftux-dashboards.md` §1](../observability/posthog-ftux-dashboards.md#1-where-this-lives-in-posthog) + §3.
 
 **Hosted vs self-hosted:** для S0 — hosted Cloud EU (10k events/month free). Self-host пізніше, якщо знадобиться (privacy / GDPR).
 
 **Risks:**
 
-- 2FA / SSO для PostHog account (founder-task — robotic note: створити acc заздалегідь). _Update 2026-05-03: account уже існує, ключ уже на Vercel._
+- 2FA / SSO для PostHog account (founder-task — robotic note: створити acc заздалегідь). _Update 2026-05-04: account існує, `VITE_POSTHOG_KEY` + `VITE_POSTHOG_HOST` виставлені в Vercel для обох targets — ролик почнеться від наступного деплою._
 - iOS App Tracking Transparency для mobile — пропустити, бо internal-only трекаємо.
 - Stub-режим має лишитись як fallback (CI без `VITE_POSTHOG_KEY` не падає). _Уже так працює — `posthog.ts` no-ops без ключа._
 - Mobile parity (S0.3) має не дублювати web `analytics.ts` — спільні рядки винести в `packages/shared` або шарити транспорт через `@sergeant/shared`. Інакше дріфт між web і mobile невпинно.

--- a/docs/observability/posthog-ftux-dashboards.md
+++ b/docs/observability/posthog-ftux-dashboards.md
@@ -1,6 +1,6 @@
 # PostHog FTUX dashboards — runbook
 
-> **Last validated:** 2026-05-03 by @Skords-01. **Next review:** 2026-08-01.
+> **Last validated:** 2026-05-04 by @Skords-01. **Next review:** 2026-08-01.
 > **Status:** Active
 
 Operational runbook for PostHog (Cloud EU) dashboards that monitor the
@@ -31,18 +31,21 @@ are normative for all `trackEvent(...)` callsites.
 ## 1. Where this lives in PostHog
 
 - **Account:** Sergeant Cloud EU (host `https://eu.i.posthog.com`).
-- **Project:** `sergeant-prod` (separate `sergeant-staging` project for
-  preview deployments — same dashboards, separate data).
-- **Folder:** `Dashboards → FTUX` — five insights below + one umbrella
-  dashboard `FTUX overview` that pins all five tiles in a 2×3 grid.
+- **Project:** `Default project` (id `167740`, prod token `phc_A8dsj…`).
+  Separate `dev serg` project (id `167756`, token `phc_mSvKK…`) covers
+  preview deployments — same dashboards, separate data.
+- **Folder:** [`Dashboards → FTUX overview`](https://eu.posthog.com/project/167740/dashboard/660031)
+  (id `660031`) — five insights below pinned to one umbrella dashboard.
+  Public shareable read-only mirror: [`shared/BUeYAKM…`](https://eu.posthog.com/shared/BUeYAKMJiAKLFfxexqYVD7cyJlo_2A).
 - **Permissions:** founders + on-call SRE have `Dashboard collaborator`.
   Anyone else with PostHog access can view but not edit.
 
-> **Founder-task:** create the five insights via PostHog UI (HogQL +
-> Insight builder), pin to `FTUX overview` dashboard, paste live links
-> back into the «Screenshot» column of §3 below. Until then the table
-> uses placeholder URLs — links are dead in this commit on purpose so
-> the diff is review-friendly.
+> **Founder-task status (2026-05-04):** the five insights and the
+> umbrella dashboard are created via PostHog API (see §3 for live
+> links). `VITE_POSTHOG_KEY` / `VITE_POSTHOG_HOST` are wired in Vercel
+> for both `production` and `preview` targets. Live screenshots will
+> populate inside each insight tile as soon as `onboarding_started`
+> traffic lands in `Default project`.
 
 ---
 
@@ -134,8 +137,10 @@ sprint depends on.
 
 **Targets:** see [§5](#5-alert-thresholds).
 
-**Screenshot:** _TBD founder-task — paste PostHog `Dashboards → FTUX →
-Activation funnel` link here once created._
+**Live insight:** [PostHog → Default project → Insights → `FTUX —
+Activation funnel`](https://eu.posthog.com/project/167740/insights/CAFlb0aB)
+(short_id `CAFlb0aB`, id `4067227`). Public read-only mirror:
+[`shared/U9UPIw5…`](https://eu.posthog.com/shared/U9UPIw5Qg0akOR2bMaWnWfh2ZRfqNQ).
 
 ### 3.2 TTV histogram
 
@@ -167,7 +172,9 @@ preset path and the manual path are diverging.
 p95 < 600 sec (10 min) — anything beyond is a stuck user, not a slow
 one.
 
-**Screenshot:** _TBD founder-task._
+**Live insight:** [PostHog → `FTUX — TTV histogram`](https://eu.posthog.com/project/167740/insights/P5LTH7Lx)
+(short_id `P5LTH7Lx`, id `4067225`). Public read-only mirror:
+[`shared/oCa-3B7…`](https://eu.posthog.com/shared/oCa-3B79r1fUKK0nBJZtO68TNiUskA).
 
 ### 3.3 Vibe → first-entry per module
 
@@ -200,7 +207,9 @@ GROUP BY vibe, first_entry_module
 ORDER BY users DESC
 ```
 
-**Screenshot:** _TBD founder-task._
+**Live insight:** [PostHog → `FTUX — Vibe → first-entry per module`](https://eu.posthog.com/project/167740/insights/tP7zi64v)
+(short_id `tP7zi64v`, id `4067226`). Public read-only mirror:
+[`shared/upU4TJs…`](https://eu.posthog.com/shared/upU4TJsJ9bPcXRplrcdmQaPBs3Aceg).
 
 ### 3.4 D1/D7 retention by signup-cohort
 
@@ -218,7 +227,9 @@ whether the FTUX promise sustained beyond a single session of curiosity.
 [`ftux-sprint-plan.md` §8](../launch/ftux-sprint-plan.md#8-roll-up-success-metrics-dashboard) —
 update both files together when the first 28 days of data land).
 
-**Screenshot:** _TBD founder-task._
+**Live insight:** [PostHog → `FTUX — D1/D7 retention by signup-cohort`](https://eu.posthog.com/project/167740/insights/zUCGdOKV)
+(short_id `zUCGdOKV`, id `4067228`). Public read-only mirror:
+[`shared/pdN2Nh3…`](https://eu.posthog.com/shared/pdN2Nh361uXIMuGZTfBpEUXp88jIXg).
 
 ### 3.5 Celebration drop-off
 
@@ -240,13 +251,17 @@ CelebrationModal headlines, see
 [`ftux-sprint-plan.md` §5](../launch/ftux-sprint-plan.md#5-sprint-3--reward-у-правильний-момент--value-progress-2-тижні))
 needs to ship.
 
-**Screenshot:** _TBD founder-task._
+**Live insight:** [PostHog → `FTUX — Celebration drop-off`](https://eu.posthog.com/project/167740/insights/tl8c3e1T)
+(short_id `tl8c3e1T`, id `4067229`). Public read-only mirror:
+[`shared/aKbPKJG…`](https://eu.posthog.com/shared/aKbPKJGCE0zW5dSl56gU1PhExMQ1UQ).
 
 ---
 
 ## 4. Umbrella dashboard
 
-`Dashboards → FTUX overview` pins:
+[`Dashboards → FTUX overview`](https://eu.posthog.com/project/167740/dashboard/660031)
+(id `660031`, public mirror: [`shared/BUeYAKM…`](https://eu.posthog.com/shared/BUeYAKMJiAKLFfxexqYVD7cyJlo_2A))
+pins:
 
 | Slot | Tile                                                                                                             |
 | ---- | ---------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Що це робить

Завершує **S0.5 founder-tasks** зі Sprint 0 [`docs/launch/ftux-sprint-plan.md`](docs/launch/ftux-sprint-plan.md): живі PostHog-інсайти + Vercel env vars.

### Зміни в документації
- `docs/observability/posthog-ftux-dashboards.md`
  - §1: `Default project` (id `167740`) для prod, `dev serg` (id `167756`) для preview; додано посилання на umbrella-дашборд `FTUX overview` (id `660031`).
  - §3.1–§3.5: усі placeholders «_TBD founder-task_» замінені на live PostHog-посилання (private + public read-only mirror через PostHog sharing).
  - §4: umbrella-dashboard URL.
- `docs/launch/ftux-sprint-plan.md` §2: додано параграф «**S0.5 founder-tasks (2026-05-04 v4)**», що позначає роботу як завершену; risk-нотатка про PostHog account оновлена.

### Інфраструктурні дії (поза репо)
- **Vercel** (project `prj_WTfB58gE…`, name `sergeant`): через Vercel API виставлено
  - `VITE_POSTHOG_KEY` для `production` (Default project token)
  - `VITE_POSTHOG_KEY` для `preview` (dev serg token)
  - `VITE_POSTHOG_HOST` = `https://eu.i.posthog.com` для `production` + `preview`
  - Sensitive env-vars вже існували порожніми — заповнено через `PATCH /v9/projects/{id}/env/{envId}`. Потрібен redeploy на main, щоб зміни взяли ефект.
- **PostHog** (Cloud EU, `Default project` id `167740`):
  - Створено 5 saved insights через REST API:
    - `FTUX — Activation funnel` (short_id `CAFlb0aB`, id `4067227`) — funnel `onboarding_started → … → celebration_shown`, breakdown by `vibe`, 28d.
    - `FTUX — TTV histogram` (short_id `P5LTH7Lx`, id `4067225`) — HogQL bucket-30s розподіл `ftux_time_to_value.durationSec`, 28d.
    - `FTUX — Vibe → first-entry per module` (short_id `tP7zi64v`, id `4067226`) — HogQL matrix `arrayJoin(vibe) × module`, 28d.
    - `FTUX — D1/D7 retention by signup-cohort` (short_id `zUCGdOKV`, id `4067228`) — Retention, target=`onboarding_started`, returning=`first_real_entry`, 30d.
    - `FTUX — Celebration drop-off` (short_id `tl8c3e1T`, id `4067229`) — funnel 6h conversion window.
  - Створено umbrella-дашборд `FTUX overview` (id `660031`) з 5 запінненими тайлами.
  - Усі 5 інсайтів + дашборд мають enabled sharing → public read-only mirror без логіну.

## Чому це треба
Без аналітики Sprint 1+ — сліпі гіпотези. Документ з «TBD»-плейсхолдерами був no-op для on-call/founder. Після цього коміту:
- Inсайти створені та готові накопичувати дані одразу як `onboarding_started` прилетить з прода.
- Vercel-проєкт винесе `VITE_POSTHOG_KEY` у наступний production-deploy.
- on-call SRE може landити на live-тайл за 2 кліки з документа.

## Limitations / next steps
- Скріншоти у тайлах будуть порожні до першого live-події. Це очікувано — як тільки прилетить `onboarding_started`, дані автоматично заповняться.
- Alerts (`PostHog → Alerts`) ще не сконфігуровані per §5 — окремий founder-task поза цим PR (потребує Slack-webhook у `#sergeant-ftux-alerts`).
- Mobile parity (S0.3) уже зроблена в PR #1704 — `platform` super-property сегментує тайли web ↔ mobile одразу як mobile почне постити.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires S0.5 founder-tasks by publishing live PostHog FTUX dashboards and setting `VITE_POSTHOG_KEY`/`VITE_POSTHOG_HOST` in Vercel for production and preview. Docs now link to five insights and the `FTUX overview` dashboard; Sprint 0 S0.5 is marked complete.

- **New Features**
  - Replaced all “TBD founder-task” placeholders in `docs/observability/posthog-ftux-dashboards.md` with live links to the five insights, their public read-only mirrors, and the `FTUX overview` dashboard.
  - Updated `docs/launch/ftux-sprint-plan.md` with “S0.5 founder-tasks (v4)” completion and a refreshed PostHog risk note.

- **Migration**
  - Redeploy `main` so Vercel-provisioned `VITE_POSTHOG_KEY` and `VITE_POSTHOG_HOST` take effect.

<sup>Written for commit cbeba9bf1d934ec9b98a81a7ac88ab6ef4a75b8c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated launch sprint documentation with Sprint 0 completion status and release order details.
  * Refreshed observability runbook with current configuration references and live insight links, replacing placeholder content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->