### PR TITLE
refactor(web): migrate nutritionBackup off direct localStorage (Item …

### DIFF
--- a/.tech-debt/localstorage-allowlist-budget.json
+++ b/.tech-debt/localstorage-allowlist-budget.json
@@ -1,4 +1,4 @@
 {
-  "production": 13,
-  "rationale": "Updated 2026-05-04 (Item 6 round-9 follow-up): production count 14 → 13 after migrating apps/web/src/shared/lib/storage/weeklyDigestStorage.ts off direct localStorage onto safeReadStringLS. (Headroom: 0 — bump only with a deliberate decision; new sites must migrate an existing one to keep parity.) Burndown plan in docs/diagnostics/2026-05-03-web-deep-dive/02-architecture-and-state.md §2.2 + docs/tech-debt/frontend.md §2."
+  "production": 12,
+  "rationale": "Updated 2026-05-04 (Item 6 round-11 follow-up): production count 13 → 12 after migrating apps/web/src/modules/nutrition/domain/nutritionBackup.ts off direct localStorage onto safeReadLS / safeReadStringLS / safeWriteLS (2 reads + 4 writes). (Headroom: 0 — bump only with a deliberate decision; new sites must migrate an existing one to keep parity.) Burndown plan in docs/diagnostics/2026-05-03-web-deep-dive/02-architecture-and-state.md §2.2 + docs/tech-debt/frontend.md §2."
 }

--- a/apps/web/src/modules/nutrition/domain/nutritionBackup.ts
+++ b/apps/web/src/modules/nutrition/domain/nutritionBackup.ts
@@ -1,4 +1,9 @@
 import {
+  safeReadLS,
+  safeReadStringLS,
+  safeWriteLS,
+} from "@shared/lib/storage/storage";
+import {
   NUTRITION_ACTIVE_PANTRY_KEY,
   NUTRITION_PANTRIES_KEY,
   NUTRITION_PREFS_KEY,
@@ -44,14 +49,10 @@ export interface NutritionBackupPayload {
 }
 
 function readJsonFromLocalStorage<T>(key: string, fallback: T): T | unknown {
-  if (typeof localStorage === "undefined") return fallback;
-  try {
-    const s = localStorage.getItem(key);
-    if (s === null) return fallback;
-    return JSON.parse(s);
-  } catch {
-    return fallback;
-  }
+  // safeReadLS повертає `T | null` (parse-fail / quota / private mode → null),
+  // а ми зберігаємо стару семантику «fallback при порожньому ключі / збої».
+  const value = safeReadLS<unknown>(key, null);
+  return value ?? fallback;
 }
 
 function safeString(x: unknown, fallback = ""): string {
@@ -132,9 +133,7 @@ function normalizePrefs(x: unknown): NutritionPrefs {
 export function buildNutritionBackupPayload(): NutritionBackupPayload {
   const pantries = readJsonFromLocalStorage(NUTRITION_PANTRIES_KEY, []);
   const activePantryId = safeString(
-    typeof localStorage !== "undefined"
-      ? localStorage.getItem(NUTRITION_ACTIVE_PANTRY_KEY)
-      : "",
+    safeReadStringLS(NUTRITION_ACTIVE_PANTRY_KEY, ""),
     "home",
   );
 
@@ -185,29 +184,14 @@ export function applyNutritionBackupPayload(payload: unknown): void {
   const activePantryId = safeString(data.activePantryId, "home") || "home";
   const prefs = normalizePrefs(data.prefs);
 
-  try {
-    localStorage.setItem(NUTRITION_PANTRIES_KEY, JSON.stringify(pantries));
-  } catch {
-    /* ignore */
-  }
-  try {
-    localStorage.setItem(NUTRITION_ACTIVE_PANTRY_KEY, activePantryId);
-  } catch {
-    /* ignore */
-  }
-  try {
-    localStorage.setItem(NUTRITION_PREFS_KEY, JSON.stringify(prefs));
-  } catch {
-    /* ignore */
-  }
+  // Кожен `safeWriteLS` глитає quota / private-mode помилку самостійно — це
+  // та сама `try/catch + ignore` семантика, що була inline-реалізована
+  // нижче: якщо одне поле бекапу не записалось через quota, продовжуємо
+  // зі скинутими іншими, замість обвалу всієї відновлюваної операції.
+  safeWriteLS(NUTRITION_PANTRIES_KEY, pantries);
+  safeWriteLS(NUTRITION_ACTIVE_PANTRY_KEY, activePantryId);
+  safeWriteLS(NUTRITION_PREFS_KEY, prefs);
   if (data.log && typeof data.log === "object" && !Array.isArray(data.log)) {
-    try {
-      localStorage.setItem(
-        NUTRITION_LOG_KEY,
-        JSON.stringify(normalizeNutritionLog(data.log)),
-      );
-    } catch {
-      /* ignore */
-    }
+    safeWriteLS(NUTRITION_LOG_KEY, normalizeNutritionLog(data.log));
   }
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -437,6 +437,9 @@ export default [
       //   2 writes + 4 removes на ключ `hub_push_subscribed`).
       // - apps/web/src/shared/lib/storage/weeklyDigestStorage.ts (round 9:
       //   `webStorageReader.getItem` → `safeReadStringLS`).
+      // - apps/web/src/modules/nutrition/domain/nutritionBackup.ts (round 11:
+      //   2 reads + 4 writes мігровано на `safeReadLS`/`safeReadStringLS`/
+      //   `safeWriteLS`; module wrapper більше не у allowlist-і).
       // Cloud-sync internals — the queue / enqueue / state writer all
       // need direct access; users should call the cloud-sync API.
       "apps/web/src/core/cloudSync/logger.ts",
@@ -452,7 +455,6 @@ export default [
       // Module storage wrappers (legitimate primitives in their own
       // namespace).
       "apps/web/src/modules/finyk/lib/storageManager.ts",
-      "apps/web/src/modules/nutrition/domain/nutritionBackup.ts",
       // useWorkouts.ts: intentional direct-storage access — dispatches
       // FIZRUK_WORKOUTS_STORAGE_ERROR custom event on quota failure so the
       // UI can show a banner. safeWriteLS swallows the error silently.


### PR DESCRIPTION
…6 round-11)

`apps/web/src/modules/nutrition/domain/nutritionBackup.ts` was the last domain-layer file still calling `localStorage.getItem`/`setItem` directly through inline `try/catch` blocks. Routing it through `safeReadLS` / `safeReadStringLS` / `safeWriteLS` (the helpers in `apps/web/src/shared/lib/storage/storage.ts`) gives us the same "swallow quota / private-mode" semantics with a single line per call-site, and lets us drop the file from the
`sergeant-design/no-raw-local-storage` allowlist in `eslint.config.js`.

Concretely:
- `buildNutritionBackupPayload`: 2 reads (`NUTRITION_PANTRIES_KEY` via `readJsonFromLocalStorage` → `safeReadLS`; `NUTRITION_ACTIVE_PANTRY_KEY` → `safeReadStringLS`).
- `applyNutritionBackupPayload`: 4 writes (pantries / active-pantry / prefs / log) → `safeWriteLS`. The prior 4 `try/catch + ignore` blocks collapse into a single line each.

Budget bumped down 13 → 12 in
`.tech-debt/localstorage-allowlist-budget.json` (headroom 0). Roadmap note added in eslint.config.js comment.

Refs: docs/diagnostics/2026-05-03-web-deep-dive/02-architecture-and-state.md §2.2
Refs: docs/tech-debt/frontend.md §2

## Summary

<!-- What changed in one tight paragraph or a short flat list. -->

## Governing Skill

- Primary skill:
- Secondary skill (if truly needed):

## Playbook

- Primary playbook:
- Why this playbook:
- If no playbook matched, why:

## Verification

<!-- Paste the exact commands you ran and the key result. -->

```bash
pnpm lint
pnpm typecheck
```

Additional checks:

- [ ] Local smoke / manual validation completed
- [ ] Surface-specific checks completed

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [ ] I checked whether `AGENTS.md` needed an update.
- [ ] I checked whether a playbook or skill needed an update.
- [ ] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a

## Risk and Rollout

- User-visible risk:
- Rollout / deploy order:
- Backout plan:

## Hard Rule #15

- [ ] I read `AGENTS.md` before coding.
- [ ] Internal docs I touched are in Ukrainian.
- [ ] I did not use `--no-verify`.

## Reviewer Notes

<!-- Flag migrations, env changes, HubChat tools, auth, or anything else that deserves extra reviewer attention. -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the nutrition backup module to use `safeReadLS`/`safeReadStringLS`/`safeWriteLS` instead of direct `localStorage`. Preserves quota/private-mode behavior and removes the module from the `sergeant-design/no-raw-local-storage` allowlist.

- **Refactors**
  - `buildNutritionBackupPayload`: replaced 2 reads (pantries via `safeReadLS`, active pantry via `safeReadStringLS`).
  - `applyNutritionBackupPayload`: replaced 4 writes (pantries, active pantry, prefs, log) with `safeWriteLS`, removing inline try/catch blocks.
  - Dropped production budget from 13 to 12 in `.tech-debt/localstorage-allowlist-budget.json`; updated `eslint.config.js` comments.

<sup>Written for commit f62d9fd9ab4ab28b677f5779418813856d5a22bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored nutrition data persistence to utilize shared storage utilities, improving reliability and error handling for backup operations.
  * Reduced technical debt by consolidating how the nutrition module accesses stored data.
  * Enhanced code quality through migration to safer, centralized storage helpers with improved failure recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->