### PR TITLE
fix(ci): add docs/i18n/ to governance-sync aspirational categories

### DIFF
--- a/scripts/check-governance-sync.mjs
+++ b/scripts/check-governance-sync.mjs
@@ -29,6 +29,8 @@
 //                                               components that may rename)
 //      - docs/playbooks/                       (recipes referencing template
 //                                               paths and example structures)
+//      - docs/i18n/                            (i18n migration roadmap; refs
+//                                               include planned target catalogs)
 //    Files in ADRs with Status: proposed are exempt (future refs OK).
 //    All other dangling refs are reported as ERRORS (Hard Rule #15 — docs
 //    that describe current behaviour must move with code).
@@ -231,6 +233,10 @@ function checkDanglingRefs() {
     // (e.g., `apps/web/src/App.tsx` as an illustrative anchor) and may
     // describe target structures rather than current code.
     if (relPath.startsWith("docs/playbooks/")) return true;
+    // `docs/i18n/` describes the i18n migration roadmap; refs include
+    // planned target catalogs (e.g., `apps/web/src/shared/i18n/en.ts`)
+    // that don't exist until the corresponding migration phase lands.
+    if (relPath.startsWith("docs/i18n/")) return true;
     if (
       relPath.startsWith("docs/integrations/") &&
       relPath.endsWith("-roadmap.md")


### PR DESCRIPTION
## Summary

Follow-up to #1764. After that PR landed, a fresh dangling-ref error appeared on main from `docs/i18n/readiness.md` → `apps/web/src/shared/i18n/en.ts` — a planned target catalog (Phase 1 of the i18n migration is to mirror `uk.ts` → `en.ts` when the product reaches the en-locale rollout).

This is the same pattern that motivated treating `docs/initiatives/` and `docs/security/hardening/` as aspirational in #1764: the doc itself is a tracker for planned work, not a description of current code.

## Governing Skill

- Primary skill: `sergeant-bugfix-and-regression`

## Playbook

- Primary playbook: n/a (CI-gate fix; no production behavior change)
- If no playbook matched, why: governance-sync rule is a meta-tool — its policy is set in this script + ADR-0045 (Hard Rules taxonomy), not in a playbook.

## Verification

```bash
node scripts/check-governance-sync.mjs
# Errors: 0
# Warnings: 129 (was 128)
# ⚠️  Governance sync check passed with warnings.
```

Additional checks:

- [x] Local smoke: `node scripts/check-governance-sync.mjs` exits 0 on this branch.

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. (script header doc updated to list `docs/i18n/`)
- [x] I checked whether `AGENTS.md` needed an update. (no — Hard Rule #15 unchanged; this only adjusts which categories are treated as `aspirational` for the dangling-ref subcheck)
- [x] I checked whether a playbook or skill needed an update. (no)
- [x] I checked whether governance docs or review docs needed an update. (no)

Updated docs:

- n/a

## Risk and Rollout

- User-visible risk: none (CI script only).
- Rollout / deploy order: merge → CI on Dependabot bumps unblocks.
- Backout plan: revert this commit.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian. (no internal docs touched, only script header comment in English)
- [x] I did not use `--no-verify`.

## Reviewer Notes

This is a 1-line addition to the aspirational allowlist established in #1764. No behavior change beyond reclassifying `docs/i18n/readiness.md` dangling refs from error → warning.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat `docs/i18n/` as aspirational in governance-sync so planned i18n refs don’t fail CI. This downgrades dangling refs in `docs/i18n/*` (e.g., `docs/i18n/readiness.md` → `apps/web/src/shared/i18n/en.ts`) from error to warning.

- **Bug Fixes**
  - Added `docs/i18n/` to the aspirational allowlist in `scripts/check-governance-sync.mjs` (CI-only change; no runtime impact).

<sup>Written for commit da87292cc1d36e350be0d3446952d8edca2f484a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified governance checking to treat internationalization documentation as aspirational content, converting missing file reference errors to warnings for these docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->