### PR TITLE
feat(web): conflict resolution UI for finyk_manual_expenses (PR #044)

### DIFF
--- a/apps/web/src/modules/finyk/FinykApp.tsx
+++ b/apps/web/src/modules/finyk/FinykApp.tsx
@@ -14,6 +14,7 @@ import {
   ModuleHeaderBackButton,
 } from "@shared/components/layout";
 import { NoBankBanner } from "./components/NoBankBanner";
+import { FinykManualExpenseConflictBanner } from "./components/FinykManualExpenseConflictBanner";
 import { SectionErrorBoundary } from "@shared/components/ui/SectionErrorBoundary";
 import { cn } from "@shared/lib/ui/cn";
 import { useToast } from "@shared/hooks/useToast";
@@ -41,6 +42,7 @@ const Analytics = lazyImport(() => import("./pages/Analytics"), "Analytics");
 import { ManualExpenseSheet } from "./components/ManualExpenseSheet";
 import { FinykLoginScreen } from "./components/FinykLoginScreen";
 import { NAV_ICONS, NAV_IDS, NAV_ITEMS } from "./components/finykNav";
+// eslint-disable-next-line sergeant-design/no-hash-router-in-modules -- pre-existing hash-router callsite (initiative 0006 Phase 2 migration на react-router-dom ще не дійшла до FinykApp shell-роутера).
 import { useHashRouter, useHashQueryParam } from "./hooks/useHashRouter";
 import { useUnifiedFinanceData } from "./hooks/useUnifiedFinanceData";
 import { useFinykPersonalization } from "./hooks/useFinykPersonalization";
@@ -70,6 +72,7 @@ export default function App({
   // collapsed everything except `error` to `success`, which blocked any
   // `warning`/`info`/`action` usage from the shared Toast module.
   const storage = useStorage({ toast });
+  // eslint-disable-next-line sergeant-design/no-hash-router-in-modules -- pre-existing hash-router callsite (initiative 0006 Phase 2 migration на react-router-dom ще не дійшла до FinykApp shell-роутера).
   const [page, navigate] = useHashRouter();
   // Підтримка глибоких лінків на конкретний ліміт із Hub-інсайту
   // (`#budgets?cat=smoking`). Передається у Budgets, щоб одразу
@@ -324,6 +327,17 @@ export default function App({
           }}
         />
       )}
+
+      {/*
+        Sync-v2 LWW-conflict banner для `finyk_manual_expenses` (Stage 5
+        PR #044, `docs/planning/storage-roadmap.md`). Self-renders як
+        no-op коли черга у `conflicts/store.ts` порожня — тому жодного
+        feature-flag-у тут не треба, гілка дешева. Розташований нижче
+        no-bank банера, щоб «налаштуй банк» залишався primary CTA для
+        свіжих юзерів, а conflict-warning спливав поверх для тих, хто
+        вже має data + race з іншого пристрою.
+      */}
+      <FinykManualExpenseConflictBanner />
 
       {/* Page content */}
       <div

--- a/apps/web/src/modules/finyk/components/FinykManualExpenseConflictBanner.test.tsx
+++ b/apps/web/src/modules/finyk/components/FinykManualExpenseConflictBanner.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { FinykManualExpenseConflictBanner } from "./FinykManualExpenseConflictBanner";
+import {
+  __resetFinykManualExpenseConflictsForTests,
+  dismissAllFinykManualExpenseConflicts,
+  type FinykManualExpenseConflict,
+  recordFinykManualExpenseConflict,
+} from "../lib/conflicts/store";
+
+function seedConflict(
+  overrides: Partial<FinykManualExpenseConflict> = {},
+): FinykManualExpenseConflict {
+  return {
+    transactionId: "tx-001",
+    reason: "lww_conflict",
+    localDataJson: '{"amount":42}',
+    attemptedClientTs: "2026-05-04T12:34:56.000Z",
+    detectedAt: 1714831200000,
+    ...overrides,
+  };
+}
+
+describe("FinykManualExpenseConflictBanner", () => {
+  // The repo's vitest setup (`src/test/setup.ts`) does not auto-cleanup
+  // RTL renders, so each test mounts into the same JSDOM document.
+  // Without an explicit cleanup the second `render()` finds duplicate
+  // banners by role+name. Pattern matches NoBankBanner.test.tsx.
+  afterEach(() => {
+    cleanup();
+    __resetFinykManualExpenseConflictsForTests();
+  });
+
+  it("renders nothing when there are no conflicts", () => {
+    const { container } = render(<FinykManualExpenseConflictBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders a polite live region when at least one conflict exists", () => {
+    act(() => {
+      recordFinykManualExpenseConflict(seedConflict());
+    });
+
+    render(<FinykManualExpenseConflictBanner />);
+
+    const region = screen.getByRole("status", {
+      name: /Конфлікти синхронізації витрат/i,
+    });
+    expect(region).toBeInTheDocument();
+    expect(region).toHaveAttribute("aria-live", "polite");
+    expect(region).toHaveAttribute(
+      "data-testid",
+      "finyk-manual-expense-conflict-banner",
+    );
+  });
+
+  it("uses Ukrainian one/few/many plural forms for the count noun", () => {
+    // Cyclomatic count of forms: 1 → «конфлікт», 2..4 → «конфлікти»,
+    // 5..20+ → «конфліктів». 11..14 — few-form виняток за UA-grammar
+    // (`Intl.PluralRules` обробляє це нативно, тому ми лише перевіряємо
+    // граничні випадки 1/3/5/12).
+    type Case = { count: number; expected: RegExp };
+    const cases: Case[] = [
+      { count: 1, expected: /1\s+конфлікт\s+синхронізації/i },
+      { count: 3, expected: /3\s+конфлікти\s+синхронізації/i },
+      { count: 5, expected: /5\s+конфліктів\s+синхронізації/i },
+      { count: 12, expected: /12\s+конфліктів\s+синхронізації/i },
+    ];
+
+    for (const { count, expected } of cases) {
+      __resetFinykManualExpenseConflictsForTests();
+      act(() => {
+        for (let i = 0; i < count; i++) {
+          recordFinykManualExpenseConflict(
+            seedConflict({ transactionId: `tx-${i}` }),
+          );
+        }
+      });
+
+      const { unmount } = render(<FinykManualExpenseConflictBanner />);
+      expect(screen.getByRole("status")).toHaveTextContent(expected);
+      unmount();
+    }
+  });
+
+  it("dismiss-all click invokes the override prop without touching the store", () => {
+    act(() => {
+      recordFinykManualExpenseConflict(seedConflict({ transactionId: "tx-1" }));
+      recordFinykManualExpenseConflict(seedConflict({ transactionId: "tx-2" }));
+    });
+
+    const onDismissAll = vi.fn();
+    render(<FinykManualExpenseConflictBanner onDismissAll={onDismissAll} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Відхилити попередження/i }),
+    );
+
+    expect(onDismissAll).toHaveBeenCalledTimes(1);
+    // Override cuts off the default path — store must remain untouched
+    // so callers who own conflict-resolution flow can sequence their
+    // own side-effects (e.g. trigger pull-then-merge) before clearing.
+    const banner = screen.getByRole("status");
+    expect(banner).toHaveTextContent(/2\s+конфлікти/i);
+  });
+
+  it("dismiss-all click without override clears the store + unmounts banner", () => {
+    act(() => {
+      recordFinykManualExpenseConflict(seedConflict({ transactionId: "tx-1" }));
+    });
+
+    render(<FinykManualExpenseConflictBanner />);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Відхилити попередження/i }),
+    );
+
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("re-renders when the store fan-outs an update to subscribers", () => {
+    render(<FinykManualExpenseConflictBanner />);
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+
+    act(() => {
+      recordFinykManualExpenseConflict(seedConflict({ transactionId: "tx-A" }));
+    });
+
+    expect(screen.getByRole("status")).toHaveTextContent(/1\s+конфлікт/i);
+
+    act(() => {
+      recordFinykManualExpenseConflict(seedConflict({ transactionId: "tx-B" }));
+      recordFinykManualExpenseConflict(seedConflict({ transactionId: "tx-C" }));
+    });
+
+    expect(screen.getByRole("status")).toHaveTextContent(/3\s+конфлікти/i);
+
+    act(() => {
+      dismissAllFinykManualExpenseConflicts();
+    });
+
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/modules/finyk/components/FinykManualExpenseConflictBanner.tsx
+++ b/apps/web/src/modules/finyk/components/FinykManualExpenseConflictBanner.tsx
@@ -1,0 +1,105 @@
+import { useCallback } from "react";
+import { Button } from "@shared/components/ui/Button";
+import { Icon } from "@shared/components/ui/Icon";
+import { useFinykManualExpenseConflicts } from "../lib/conflicts/useFinykManualExpenseConflicts";
+import { dismissAllFinykManualExpenseConflicts } from "../lib/conflicts/store";
+
+export interface FinykManualExpenseConflictBannerProps {
+  /**
+   * Optional override for the dismiss-all action. Tests pass a spy
+   * to assert click-flow без зачіпання реального module-level стора.
+   * Production callers (FinykApp) залишають дефолт — пряме звертання
+   * до `dismissAllFinykManualExpenseConflicts`.
+   */
+  onDismissAll?: () => void;
+}
+
+/**
+ * Stage 5 PR #044 (`docs/planning/storage-roadmap.md`). Surfaces sync-v2
+ * LWW-конфлікти на `finyk_manual_expenses` у вигляді inline-банера на
+ * шапці FinykApp.
+ *
+ * **Що рендериться:** counter «N конфліктів синхронізації» + кнопка
+ * «Відхилити всі». Список окремих рядків навмисно НЕ показуємо у MVP —
+ * розкриття у деталі вимагало б resolve-UX (keep local vs accept
+ * server vs merge), а серверна частина (sync-v2 client) ще не
+ * зашита; до того як підключимо real push-loop, банер виконує лише
+ * roleсurfacing — повідомити юзера, що пуш не пройшов, щоб він міг
+ * вручну ре-синхронізувати (smart pull → re-push) при наступній
+ * сесії. Деталізацію + per-row resolve-actions додамо у наступних PR
+ * Stage 5 серії.
+ *
+ * **Чому inline, а не toast:** конфлікт — стійкий стан (висить, поки
+ * юзер не вирішить), а toast — ефемерний. Якщо юзер закриє вкладку,
+ * conflict-store скине себе у пам'яті, але banner перевідкриється
+ * на наступному push-фейлі — це детермінований UX без race-у з
+ * toast-черги.
+ *
+ * **A11y:** `role="status"` + `aria-live="polite"` — сповіщення
+ * приходить асинхронно (server response), користувач має бути
+ * проінформований через screen reader, але без перебиття активного
+ * фокусу (тому polite, не assertive).
+ */
+export function FinykManualExpenseConflictBanner({
+  onDismissAll,
+}: FinykManualExpenseConflictBannerProps = {}) {
+  const conflicts = useFinykManualExpenseConflicts();
+
+  const handleDismissAll = useCallback(() => {
+    if (onDismissAll) {
+      onDismissAll();
+    } else {
+      dismissAllFinykManualExpenseConflicts();
+    }
+  }, [onDismissAll]);
+
+  if (conflicts.length === 0) return null;
+
+  // Pluralisation. `Intl.PluralRules` для українського «1 / 2-4 / 5+»
+  // — «1 конфлікт», «2 конфлікти», «5 конфліктів». Окремий case на
+  // 11-14 (few-форма-виняток) хендлиться `Intl.PluralRules` нативно.
+  const pluralizer = new Intl.PluralRules("uk-UA");
+  const form = pluralizer.select(conflicts.length);
+  const noun =
+    form === "one" ? "конфлікт" : form === "few" ? "конфлікти" : "конфліктів";
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label="Конфлікти синхронізації витрат"
+      className="mx-3 mt-3 mb-1 rounded-2xl border border-warning/30 bg-warning/10 p-4 shadow-card"
+      data-testid="finyk-manual-expense-conflict-banner"
+    >
+      <div className="flex items-start gap-3">
+        <span
+          className="shrink-0 w-9 h-9 rounded-xl bg-warning/20 text-warning flex items-center justify-center"
+          aria-hidden
+        >
+          <Icon name="alert-triangle" size={18} />
+        </span>
+        <div className="min-w-0 flex-1">
+          <h3 className="text-style-label text-text">
+            {conflicts.length} {noun} синхронізації
+          </h3>
+          <p className="text-xs text-muted mt-1 leading-snug">
+            На іншому пристрої цю витрату вже змінено. Хмарна версія актуальніша
+            — потягни вниз, щоб оновити, або відхили попередження, якщо не
+            критично.
+          </p>
+        </div>
+      </div>
+      <div className="mt-3 flex flex-col gap-2 sm:flex-row">
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          className="flex-1 min-h-[40px]"
+          onClick={handleDismissAll}
+        >
+          Відхилити попередження
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/modules/finyk/lib/conflicts/store.test.ts
+++ b/apps/web/src/modules/finyk/lib/conflicts/store.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetFinykManualExpenseConflictsForTests,
+  dismissAllFinykManualExpenseConflicts,
+  dismissFinykManualExpenseConflict,
+  FINYK_MANUAL_EXPENSE_CONFLICT_LIMIT,
+  type FinykManualExpenseConflict,
+  getFinykManualExpenseConflictsSnapshot,
+  recordFinykManualExpenseConflict,
+  subscribeFinykManualExpenseConflicts,
+} from "./store";
+
+function makeConflict(
+  overrides: Partial<FinykManualExpenseConflict> = {},
+): FinykManualExpenseConflict {
+  return {
+    transactionId: "tx-001",
+    reason: "lww_conflict",
+    localDataJson: '{"amount":42,"category":"food"}',
+    attemptedClientTs: "2026-05-04T12:34:56.000Z",
+    detectedAt: 1714831200000,
+    ...overrides,
+  };
+}
+
+describe("finyk manual-expense conflict store", () => {
+  afterEach(() => {
+    __resetFinykManualExpenseConflictsForTests();
+  });
+
+  it("starts with an empty snapshot whose reference is stable", () => {
+    const snap1 = getFinykManualExpenseConflictsSnapshot();
+    const snap2 = getFinykManualExpenseConflictsSnapshot();
+    expect(snap1.conflicts).toHaveLength(0);
+    // useSyncExternalStore relies on identity-comparison: idempotent
+    // reads MUST return the same reference, otherwise React tears.
+    expect(snap1).toBe(snap2);
+  });
+
+  it("records a conflict and notifies subscribers", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeFinykManualExpenseConflicts(listener);
+
+    const total = recordFinykManualExpenseConflict(makeConflict());
+
+    expect(total).toBe(1);
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(getFinykManualExpenseConflictsSnapshot().conflicts).toHaveLength(1);
+    expect(getFinykManualExpenseConflictsSnapshot().conflicts[0]).toMatchObject(
+      {
+        transactionId: "tx-001",
+        reason: "lww_conflict",
+      },
+    );
+
+    unsubscribe();
+  });
+
+  it("dedups by transactionId — newest record wins, no duplicate banner", () => {
+    recordFinykManualExpenseConflict(
+      makeConflict({
+        transactionId: "tx-1",
+        attemptedClientTs: "2026-01-01T00:00:00.000Z",
+      }),
+    );
+    recordFinykManualExpenseConflict(makeConflict({ transactionId: "tx-2" }));
+    // Second push of the SAME row — must replace, not duplicate.
+    recordFinykManualExpenseConflict(
+      makeConflict({
+        transactionId: "tx-1",
+        attemptedClientTs: "2026-05-04T12:34:56.000Z",
+        reason: "tombstoned",
+      }),
+    );
+
+    const conflicts = getFinykManualExpenseConflictsSnapshot().conflicts;
+    expect(conflicts).toHaveLength(2);
+    const tx1 = conflicts.find((c) => c.transactionId === "tx-1");
+    expect(tx1?.reason).toBe("tombstoned");
+    expect(tx1?.attemptedClientTs).toBe("2026-05-04T12:34:56.000Z");
+  });
+
+  it("after dedup-replace, the replaced conflict moves to tail (FIFO age-out invariant)", () => {
+    recordFinykManualExpenseConflict(makeConflict({ transactionId: "tx-A" }));
+    recordFinykManualExpenseConflict(makeConflict({ transactionId: "tx-B" }));
+    recordFinykManualExpenseConflict(makeConflict({ transactionId: "tx-C" }));
+    // Re-record A — should land at the tail of the array.
+    recordFinykManualExpenseConflict(makeConflict({ transactionId: "tx-A" }));
+
+    const ids = getFinykManualExpenseConflictsSnapshot().conflicts.map(
+      (c) => c.transactionId,
+    );
+    expect(ids).toEqual(["tx-B", "tx-C", "tx-A"]);
+  });
+
+  it("caps the queue at MAX_CONFLICTS — oldest entries age out FIFO", () => {
+    for (let i = 0; i < FINYK_MANUAL_EXPENSE_CONFLICT_LIMIT + 5; i++) {
+      recordFinykManualExpenseConflict(
+        makeConflict({ transactionId: `tx-${i}` }),
+      );
+    }
+
+    const conflicts = getFinykManualExpenseConflictsSnapshot().conflicts;
+    expect(conflicts).toHaveLength(FINYK_MANUAL_EXPENSE_CONFLICT_LIMIT);
+    // First 5 (tx-0..tx-4) must have aged out; tail must be the latest record.
+    expect(conflicts[0].transactionId).toBe("tx-5");
+    expect(conflicts[conflicts.length - 1].transactionId).toBe(
+      `tx-${FINYK_MANUAL_EXPENSE_CONFLICT_LIMIT + 4}`,
+    );
+  });
+
+  it("dismissFinykManualExpenseConflict removes one row and notifies", () => {
+    recordFinykManualExpenseConflict(makeConflict({ transactionId: "tx-1" }));
+    recordFinykManualExpenseConflict(makeConflict({ transactionId: "tx-2" }));
+
+    const listener = vi.fn();
+    const unsubscribe = subscribeFinykManualExpenseConflicts(listener);
+    listener.mockReset();
+
+    dismissFinykManualExpenseConflict("tx-1");
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    const conflicts = getFinykManualExpenseConflictsSnapshot().conflicts;
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].transactionId).toBe("tx-2");
+
+    unsubscribe();
+  });
+
+  it("dismiss for unknown transactionId is a no-op (no listener notification)", () => {
+    recordFinykManualExpenseConflict(makeConflict({ transactionId: "tx-1" }));
+
+    const listener = vi.fn();
+    const unsubscribe = subscribeFinykManualExpenseConflicts(listener);
+    listener.mockReset();
+    const before = getFinykManualExpenseConflictsSnapshot();
+
+    dismissFinykManualExpenseConflict("tx-does-not-exist");
+
+    expect(listener).not.toHaveBeenCalled();
+    // Snapshot reference must NOT change — useSyncExternalStore relies on
+    // identity-comparison to skip re-renders.
+    expect(getFinykManualExpenseConflictsSnapshot()).toBe(before);
+
+    unsubscribe();
+  });
+
+  it("dismissAll empties the queue and notifies once", () => {
+    recordFinykManualExpenseConflict(makeConflict({ transactionId: "tx-1" }));
+    recordFinykManualExpenseConflict(makeConflict({ transactionId: "tx-2" }));
+    recordFinykManualExpenseConflict(makeConflict({ transactionId: "tx-3" }));
+
+    const listener = vi.fn();
+    const unsubscribe = subscribeFinykManualExpenseConflicts(listener);
+    listener.mockReset();
+
+    dismissAllFinykManualExpenseConflicts();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(getFinykManualExpenseConflictsSnapshot().conflicts).toHaveLength(0);
+
+    unsubscribe();
+  });
+
+  it("dismissAll on empty queue is a no-op (no listener notification)", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeFinykManualExpenseConflicts(listener);
+
+    dismissAllFinykManualExpenseConflicts();
+
+    expect(listener).not.toHaveBeenCalled();
+
+    unsubscribe();
+  });
+
+  it("unsubscribed listeners stop receiving notifications", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeFinykManualExpenseConflicts(listener);
+
+    recordFinykManualExpenseConflict(makeConflict({ transactionId: "tx-1" }));
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+
+    recordFinykManualExpenseConflict(makeConflict({ transactionId: "tx-2" }));
+    // Still 1 — second record didn't fan out to detached listener.
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("a throwing listener does not block other listeners or break the publisher", () => {
+    // sync-error-isolation contract: bug у одному компоненті не повинен
+    // блокувати notify-fanout у решти підписників (інакше один поганий
+    // banner ламає всю систему сповіщень). Стори ре-кидає async-помилку
+    // через `setTimeout(0)` — у тестах ми стабуємо timer, щоб помилка
+    // не падала вже на наступний tick і не валила Vitest unhandled-error
+    // budget.
+    const setTimeoutSpy = vi
+      .spyOn(globalThis, "setTimeout")
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- мінімалістичний stub: ховаємо callback від реальної івент-петлі, повертаємо плейсхолдер-id який Vitest не валідує.
+      .mockImplementation((() => 0 as unknown) as any);
+
+    const angry = vi.fn(() => {
+      throw new Error("boom");
+    });
+    const calm = vi.fn();
+
+    const u1 = subscribeFinykManualExpenseConflicts(angry);
+    const u2 = subscribeFinykManualExpenseConflicts(calm);
+
+    // The publisher must not throw synchronously even though one
+    // listener throws.
+    expect(() =>
+      recordFinykManualExpenseConflict(makeConflict({ transactionId: "tx-1" })),
+    ).not.toThrow();
+
+    expect(angry).toHaveBeenCalledTimes(1);
+    expect(calm).toHaveBeenCalledTimes(1);
+    // Error is re-thrown async via setTimeout(0) so Sentry still
+    // captures it without breaking the synchronous mutation site.
+    expect(setTimeoutSpy).toHaveBeenCalled();
+
+    u1();
+    u2();
+    setTimeoutSpy.mockRestore();
+  });
+
+  it("snapshot reference changes on every mutation (re-render cue for React)", () => {
+    const before = getFinykManualExpenseConflictsSnapshot();
+    recordFinykManualExpenseConflict(makeConflict({ transactionId: "tx-1" }));
+    const after = getFinykManualExpenseConflictsSnapshot();
+    expect(after).not.toBe(before);
+    expect(after.conflicts).not.toBe(before.conflicts);
+  });
+});

--- a/apps/web/src/modules/finyk/lib/conflicts/store.ts
+++ b/apps/web/src/modules/finyk/lib/conflicts/store.ts
@@ -1,0 +1,177 @@
+/**
+ * In-process typed store for sync-v2 conflicts on `finyk_manual_expenses`.
+ *
+ * Stage 5 PR #044 (`docs/planning/storage-roadmap.md`). Provides the UI
+ * surface that the eventual sync-v2 client will populate when the
+ * server's per-row apply-fn rejects a push with `reason='lww_conflict'`
+ * або `reason='tombstoned'` для table=`finyk_manual_expenses`. The
+ * scope is intentionally narrow — we surface only this one table because
+ * it is the highest-touch finyk entity (manually-entered expenses are
+ * the path users notice first when two devices race), and the
+ * server-side LWW path on `applyFinykPerRowBlob` already gives us a
+ * deterministic loser to show. Інші finyk-таблиці (`finyk_budgets`,
+ * `finyk_subscriptions`, …) розділяють той же per-row blob apply-шлях,
+ * але мають значно меншу частоту правок із двох пристроїв одночасно;
+ * розширення скоупа — тривіальна композиція цього стора у наступних PR.
+ *
+ * Design choices:
+ *
+ * - **Module-level state, not React Context.** Conflicts can be
+ *   recorded outside any React tree (e.g., from the sync-v2 push hook
+ *   у фоні), and consumed from any component without prop-drilling.
+ *   Pattern matches `apps/web/src/shared/lib/modules/hubBus.ts`.
+ *
+ * - **Dedup by `transaction_id`.** Server повертає одне рішення на
+ *   рядок-конфлікт; повторний push того ж рядка просто оновлює запис
+ *   (свіжіший `serverUpdatedAt`/`detectedAt`), не створює дубль у
+ *   банері. Це навмисно: користувач має бачити «один конфлікт на одну
+ *   транзакцію», незалежно від кількості невдалих push-у.
+ *
+ * - **Bounded queue.** Жорсткий cap у `MAX_CONFLICTS = 25`: malformed
+ *   client / runaway push не може роздути LS / heap — старіші
+ *   записи витискаються FIFO-чином. Banner-UI у PR #044 показує
+ *   counter («N конфліктів»), а не повний список, тому FIFO-витискання
+ *   не міняє UX.
+ *
+ * - **No persistence (yet).** Конфлікти живуть лише у пам'яті вкладки.
+ *   Якщо юзер закриє таб до dismiss — конфлікт зникне, наступний push
+ *   або pull (PR #044+) їх відновить. Persistence у `localStorage`
+ *   додамо коли підключимо реальний sync-v2 client (поза скоупом #044).
+ */
+
+const MAX_CONFLICTS = 25;
+
+export type FinykManualExpenseConflictReason = "lww_conflict" | "tombstoned";
+
+export interface FinykManualExpenseConflict {
+  /** PK of the conflicting row у `finyk_manual_expenses` (UUID v4). */
+  readonly transactionId: string;
+  /**
+   * Server-reported rejection reason. `lww_conflict` означає, що
+   * локальний `clientTs` старіший за серверний `updated_at` —
+   * cloud має свіжішу версію. `tombstoned` означає, що рядок
+   * soft-deleted на сервері, а ми спробували insert/update —
+   * resurrection guard сработав.
+   */
+  readonly reason: FinykManualExpenseConflictReason;
+  /**
+   * Локальний snapshot `data_json` на момент push-у. Використовуємо
+   * у UI для підказки «що ти намагався зберегти», коли користувач
+   * вирішує — keep local чи accept server. Зберігаємо як string
+   * (не parsed JSON), щоб дешево порівняти ідентичність по checksum
+   * без re-stringify і не платити за allocation на кожному рендері.
+   */
+  readonly localDataJson: string;
+  /**
+   * `client_ts` push-у, який сервер відхилив (ISO-8601). Дозволяє UI
+   * показати «спроба збереження о 12:34» — конкретніше за просто
+   * `detectedAt`, який лише фіксує момент receipt-у відповіді.
+   */
+  readonly attemptedClientTs: string;
+  /** Date.now() коли запис зайшов у store; рендер `≈ X хв тому`. */
+  readonly detectedAt: number;
+}
+
+type Listener = () => void;
+
+interface ConflictState {
+  readonly conflicts: ReadonlyArray<FinykManualExpenseConflict>;
+}
+
+const EMPTY_STATE: ConflictState = { conflicts: [] };
+
+let state: ConflictState = EMPTY_STATE;
+const listeners = new Set<Listener>();
+
+function notify(): void {
+  listeners.forEach((listener) => {
+    try {
+      listener();
+    } catch (err) {
+      // Listener errors must NEVER prevent other listeners from firing,
+      // and must NEVER break the publishing site. Re-throw async via
+      // setTimeout(0) so the error still surfaces у Sentry without
+      // blocking the store mutation.
+      setTimeout(() => {
+        throw err;
+      }, 0);
+    }
+  });
+}
+
+/**
+ * Record a new conflict, or replace the existing record for the same
+ * `transactionId` (LWW on `detectedAt` — newest server response wins).
+ *
+ * Returns the new total conflict count after the operation; callers
+ * (analytics, tests) typically don't care about the value but it
+ * removes the need for an extra `getSnapshot().length` call.
+ */
+export function recordFinykManualExpenseConflict(
+  conflict: FinykManualExpenseConflict,
+): number {
+  const filtered = state.conflicts.filter(
+    (c) => c.transactionId !== conflict.transactionId,
+  );
+  // Push to tail; trim from head if cap exceeded. Tail-bias keeps the
+  // most recent conflicts visible if banner UI ever shows a list.
+  const next = [...filtered, conflict];
+  const trimmed =
+    next.length > MAX_CONFLICTS
+      ? next.slice(next.length - MAX_CONFLICTS)
+      : next;
+  state = { conflicts: trimmed };
+  notify();
+  return trimmed.length;
+}
+
+/**
+ * Drop a single conflict by `transactionId`. Used by the banner's
+ * "keep local" / "accept server" actions — both paths terminate the
+ * conflict for that row (the next push either writes through or no-ops).
+ */
+export function dismissFinykManualExpenseConflict(transactionId: string): void {
+  const filtered = state.conflicts.filter(
+    (c) => c.transactionId !== transactionId,
+  );
+  if (filtered.length === state.conflicts.length) return;
+  state = { conflicts: filtered };
+  notify();
+}
+
+/** Bulk-dismiss — used by "Закрити всі" button у банері. */
+export function dismissAllFinykManualExpenseConflicts(): void {
+  if (state.conflicts.length === 0) return;
+  state = EMPTY_STATE;
+  notify();
+}
+
+/**
+ * Stable reference returned by `getSnapshot` — `useSyncExternalStore`
+ * compares-by-identity and re-renders only when the reference changes.
+ * Mutations always allocate a new state object, so this is safe.
+ */
+export function getFinykManualExpenseConflictsSnapshot(): ConflictState {
+  return state;
+}
+
+/** Subscribe primitive — used directly by `useSyncExternalStore`. */
+export function subscribeFinykManualExpenseConflicts(
+  listener: Listener,
+): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/**
+ * Test-only escape hatch: clear store + drop subscribers. Production
+ * code MUST NOT call this — it would silently desync any live banner.
+ */
+export function __resetFinykManualExpenseConflictsForTests(): void {
+  state = EMPTY_STATE;
+  listeners.clear();
+}
+
+export const FINYK_MANUAL_EXPENSE_CONFLICT_LIMIT = MAX_CONFLICTS;

--- a/apps/web/src/modules/finyk/lib/conflicts/useFinykManualExpenseConflicts.ts
+++ b/apps/web/src/modules/finyk/lib/conflicts/useFinykManualExpenseConflicts.ts
@@ -1,0 +1,28 @@
+import { useSyncExternalStore } from "react";
+import {
+  type FinykManualExpenseConflict,
+  getFinykManualExpenseConflictsSnapshot,
+  subscribeFinykManualExpenseConflicts,
+} from "./store";
+
+/**
+ * React hook that subscribes a component to the finyk manual-expense
+ * conflict store. Reads through `useSyncExternalStore` so concurrent
+ * React doesn't tear when a conflict is recorded mid-render.
+ *
+ * The returned array reference is stable as long as the underlying
+ * conflicts list is unchanged (store mutations always swap in a fresh
+ * array), so it's safe to pass directly into memo-dependencies without
+ * `useMemo`-ing again.
+ */
+export function useFinykManualExpenseConflicts(): ReadonlyArray<FinykManualExpenseConflict> {
+  const snapshot = useSyncExternalStore(
+    subscribeFinykManualExpenseConflicts,
+    getFinykManualExpenseConflictsSnapshot,
+    // SSR snapshot — same reference as initial client snapshot since
+    // module-level state starts empty. Prevents hydration warnings if
+    // the banner ever renders на сервері.
+    getFinykManualExpenseConflictsSnapshot,
+  );
+  return snapshot.conflicts;
+}

--- a/docs/planning/storage-roadmap.md
+++ b/docs/planning/storage-roadmap.md
@@ -1,6 +1,6 @@
 # Storage & Sync — Roadmap до production-ready
 
-> **Last validated:** 2026-05-04 by Devin — **Stage 1 COMPLETE; Stage 4 Finyk Mono mirror in CI; Stage 5 op-log v2 hardening in flight.** Stage 1: all 8/8 PRs landed (PR #008 `ff217246`, PR #010 [#1543](https://github.com/Skords-01/Sergeant/pull/1543), PR #013 via 4 sub-PRs). Stage 4 Fizruk: 5/5 PRs merged (PR #027–#030 + #029a). Stage 4 Nutrition: PR #031 / #032 / #033 LANDED ([#1574](https://github.com/Skords-01/Sergeant/pull/1574)), PR #034 LANDED ([#1636](https://github.com/Skords-01/Sergeant/pull/1636)). Stage 4 Finyk: PR #035 LANDED ([#1667](https://github.com/Skords-01/Sergeant/pull/1667) — schema + apply-fns), PR #036 LANDED ([#1680](https://github.com/Skords-01/Sergeant/pull/1680) — dual-write web + mobile), PR #037 LANDED (`c89870c6` — read-overlay web + mobile under `feature.finyk.sqlite_v2.read_sqlite`, default off), PR #038 IN CI (Mono cache mirror у `finyk_mono_*` SQLite таблицях під `feature.finyk.sqlite_v2.mono_mirror`, default off). Stage 5: PR #040 LANDED (`ec1f3820` — persistent op-log retry policy у SQLite), PR #041 IN CI ([#1721](https://github.com/Skords-01/Sergeant/pull/1721) — SSE pull stream), PR #043 LANDED ([#1734](https://github.com/Skords-01/Sergeant/pull/1734) — G-set CRDT для `nutrition_meals` із tombstone інваріантом + 3 інтеграційні тести), PR #043a LANDED ([#1739](https://github.com/Skords-01/Sergeant/pull/1739) — tombstone-resurrection guard для routine + 5 fizruk apply-функцій + 6 інтеграційних кейсів), PR #043b LANDED ([#1743](https://github.com/Skords-01/Sergeant/pull/1743) — той самий guard для 3 nutrition non-meals apply-функцій + 2 finyk хелперів, які покривають усі 10 finyk soft-delete таблиць + 7 інтеграційних кейсів; разом із PR #043a закриває per-table TODO з PR #043), PR #043c LANDED ([#1754](https://github.com/Skords-01/Sergeant/pull/1754) — typed RejectReason allowlist для syncV2 apply-шляху: 45+4 літерали в exported `as const` масивах + regression-тест пінить cardinality budget), PR #048 LANDED ([#1737](https://github.com/Skords-01/Sergeant/pull/1737) — RED-метрики `sync_op_log_apply_total` / `sync_op_log_pull_lag_ms` / `sync_op_log_pull_queue_depth` + 4 нові Grafana панелі в `sync.json`). **Stage 6 ops:** PR #049 docs portion LANDED ([#1757](https://github.com/Skords-01/Sergeant/pull/1757) — Railway Postgres backup/restore runbook у `docs/runbooks/database-backup-restore.md` із pg_dump/pg_restore-командами, sync-aware row-level restore матрицею, smoke-test SQL); weekly-verify CI deferred до PR #049b (потребує `RAILWAY_TOKEN`). PR #042 (PN-counter for `routine_streaks`) deferred — потребує protocol-зміни (новий op kind `increment` у CHECK constraint + zod + DB migration); see PR #042 entry below. Stage 0: PR #003 LANDED ([#1497](https://github.com/Skords-01/Sergeant/pull/1497)). Boot-wiring follow-up для `register{Routine,Fizruk,Nutrition}DualWriteContext` ще не залендили. **Next review:** 2026-08-01.
+> **Last validated:** 2026-05-04 by Devin — **Stage 1 COMPLETE; Stage 4 Finyk Mono mirror in CI; Stage 5 op-log v2 hardening in flight.** Stage 1: all 8/8 PRs landed (PR #008 `ff217246`, PR #010 [#1543](https://github.com/Skords-01/Sergeant/pull/1543), PR #013 via 4 sub-PRs). Stage 4 Fizruk: 5/5 PRs merged (PR #027–#030 + #029a). Stage 4 Nutrition: PR #031 / #032 / #033 LANDED ([#1574](https://github.com/Skords-01/Sergeant/pull/1574)), PR #034 LANDED ([#1636](https://github.com/Skords-01/Sergeant/pull/1636)). Stage 4 Finyk: PR #035 LANDED ([#1667](https://github.com/Skords-01/Sergeant/pull/1667) — schema + apply-fns), PR #036 LANDED ([#1680](https://github.com/Skords-01/Sergeant/pull/1680) — dual-write web + mobile), PR #037 LANDED (`c89870c6` — read-overlay web + mobile under `feature.finyk.sqlite_v2.read_sqlite`, default off), PR #038 IN CI (Mono cache mirror у `finyk_mono_*` SQLite таблицях під `feature.finyk.sqlite_v2.mono_mirror`, default off). Stage 5: PR #040 LANDED (`ec1f3820` — persistent op-log retry policy у SQLite), PR #041 IN CI ([#1721](https://github.com/Skords-01/Sergeant/pull/1721) — SSE pull stream), PR #043 LANDED ([#1734](https://github.com/Skords-01/Sergeant/pull/1734) — G-set CRDT для `nutrition_meals` із tombstone інваріантом + 3 інтеграційні тести), PR #043a LANDED ([#1739](https://github.com/Skords-01/Sergeant/pull/1739) — tombstone-resurrection guard для routine + 5 fizruk apply-функцій + 6 інтеграційних кейсів), PR #043b LANDED ([#1743](https://github.com/Skords-01/Sergeant/pull/1743) — той самий guard для 3 nutrition non-meals apply-функцій + 2 finyk хелперів, які покривають усі 10 finyk soft-delete таблиць + 7 інтеграційних кейсів; разом із PR #043a закриває per-table TODO з PR #043), PR #043c LANDED ([#1754](https://github.com/Skords-01/Sergeant/pull/1754) — typed RejectReason allowlist для syncV2 apply-шляху: 45+4 літерали в exported `as const` масивах + regression-тест пінить cardinality budget), PR #048 LANDED ([#1737](https://github.com/Skords-01/Sergeant/pull/1737) — RED-метрики `sync_op_log_apply_total` / `sync_op_log_pull_lag_ms` / `sync_op_log_pull_queue_depth` + 4 нові Grafana панелі в `sync.json`). **Stage 6 ops:** PR #049 docs portion LANDED ([#1757](https://github.com/Skords-01/Sergeant/pull/1757) — Railway Postgres backup/restore runbook у `docs/runbooks/database-backup-restore.md` із pg_dump/pg_restore-командами, sync-aware row-level restore матрицею, smoke-test SQL); weekly-verify CI deferred до PR #049b (потребує `RAILWAY_TOKEN`). PR #042 PN-counter для `routine_streaks` розгорнуто двофазно: PR #042a LANDED ([#1769](https://github.com/Skords-01/Sergeant/pull/1769) — protocol-only scaffolding: розширений `op` CHECK constraint, zod-енам, engine-level reject `op_not_supported`), PR #042b LANDED ([#1776](https://github.com/Skords-01/Sergeant/pull/1776) — `applyRoutineStreaks` opt-in у `INCREMENT_OP_SUPPORTED_TABLES` + atomic `UPDATE … SET current_streak = current_streak + delta` із `GREATEST(0, …)` clamping та monotonic `longest_streak` оновленням, |delta| ≤ 1000, 6 нових інтеграційних тестів). PR #044 IN CI ([#1780](https://github.com/Skords-01/Sergeant/pull/1780) — typed module-level conflict store + `useFinykManualExpenseConflicts` hook + `FinykManualExpenseConflictBanner` з UA plural-формами; 18 тестів). Stage 0: PR #003 LANDED ([#1497](https://github.com/Skords-01/Sergeant/pull/1497)). Boot-wiring follow-up для `register{Routine,Fizruk,Nutrition}DualWriteContext` ще не залендили. **Next review:** 2026-08-01.
 > **Status:** Active
 
 > Зріз: 2026-05-02. Базується на storage-аудиті + поточний стек:
@@ -1209,22 +1209,56 @@ recreate indexes`) у `packages/db-schema/src/sqlite/migrations/index.ts`,
   у `syncV2Stream.handler.test.ts` із `vi.fakeTimers()`); E2E з
   реальним Postgres — follow-up в `syncV2.integration.test.ts`.
 
-#### **PR #042 — `feat(sync): per-row CRDT for routine_entries (PN-counter for streak)`** — _deferred_
+#### **PR #042 — `feat(sync): per-row CRDT for routine_entries (PN-counter for streak)`** — split into PR #042a + PR #042b
 
 - Scope. `routine_streaks.current_streak` стає PN-counter (positive/negative
   counter), не просто Int. Конкурентний toggle з двох девайсів дає коректний
   стрик.
-- **Status (2026-05-04).** Відкладено: pure-server PN-counter потребує
+- **Status (2026-05-04).** Доставлено двофазно (див. підрозділи нижче).
+  Початкова деферал-причина — pure-server PN-counter потребував
   протокольної зміни (новий op kind `increment` із `delta`-payload-ом
-  у `sync_op_log` CHECK constraint, у `SyncV2OpKindEnum` zod-схемі,
-  плюс client-side dual-write адаптер у outbox-і). Окремо до того:
-  server-side derivation streak-status-у не доступне, бо `Habit.schedule`
-  ще лежить у LS-блобі, тож сервер не знає, чи день було помічено
-  outside-of-schedule.
-- Plan. Окрема сесія: PR #042a (op-kind enum + zod + protocol docs)
-  → PR #042b (apply-fn + atomic UPDATE … SET current_streak =
-  current_streak + delta). PR #043 (`nutrition_meals` G-set) пройшов
-  першим — він не вимагає protocol-change.
+  у `sync_op_log` CHECK constraint + `SyncV2OpKindEnum`) — закрита
+  PR #042a; apply-fn-семантика для `routine_streaks` — закрита PR #042b.
+  Server-side derivation streak-status-у з `Habit.schedule` лишається
+  поза скоупом цієї пари (LS-блоб міграція — окрема ініціатива).
+
+#### **PR #042a — `feat(server): protocol scaffolding for op='increment'`** ✅ LANDED ([#1769](https://github.com/Skords-01/Sergeant/pull/1769))
+
+- Scope. Protocol-only scaffolding для PN-counter: розширений
+  `sync_op_log.op` CHECK constraint (додано `'increment'`), оновлений
+  `SyncV2OpKindEnum` zod-схеми та engine-level gate, який реджектить
+  усі `op='increment'` із `reason='op_not_supported'`, поки apply-fn-и
+  не заопт-іняться. Per-table allowlist `INCREMENT_OP_SUPPORTED_TABLES`
+  заводиться порожнім — кожна нова таблиця додається свідомо.
+- **Done.** Протокол-зміна merge-нута без runtime-effect-у; client-i,
+  які надсилатимуть `op='increment'` до non-allowlisted таблиці,
+  отримують детермінований reject (а не silent-drop). Migration
+  forward-compatible: старі сервери, які не знають `'increment'`,
+  падають на CHECK violation, що ловиться у sync-error-budget.
+- **Dep.** None (готує ґрунт для PR #042b).
+
+#### **PR #042b — `feat(server): PN-counter apply-fn for routine_streaks (op='increment')`** ✅ LANDED ([#1776](https://github.com/Skords-01/Sergeant/pull/1776))
+
+- Scope. `applyRoutineStreaks` опт-іняється у `INCREMENT_OP_SUPPORTED_TABLES`
+  і отримує атомарний UPDATE-шлях для `op='increment'`:
+  `UPDATE routine_streaks SET current_streak = GREATEST(0, current_streak + delta), longest_streak = GREATEST(longest_streak, GREATEST(0, current_streak + delta)) WHERE …`.
+  PN-counter-семантика: increments комутативні + ідемпотентні per
+  `(idempotency_key)`, тому LWW-guard на цій гілці навмисно вимкнено
+  (`AND op <> 'increment'` у LWW-SELECT-і).
+- **Done (2026-05-04).** Three-stage delta validation у engine-gate:
+  presence (`missing_delta`), type/finiteness/integrality (`invalid_delta`),
+  magnitude bound `|delta| ≤ 1000` (`delta_out_of_range`). `GREATEST(0, …)`
+  clamping не дає `current_streak` піти у мінус навіть при наївних
+  decrement-batch-ах; `longest_streak` оновлюється monotonically лише
+  коли новий `current_streak` його перевищує. 6 нових інтеграційних
+  тестів у `syncV2.integration.test.ts`: concurrent increment-merge,
+  clamp-at-zero, monotonic longest, missing/invalid/out-of-range delta
+  reject-paths. Locally green: typecheck + lint + sync test-suite.
+- **Risk.** Low — PN-counter scope обмежений однією таблицею;
+  client-side dual-write outbox-адаптер ще не написано (це окрема
+  PR серії), тому live-traffic-у на цій гілці поки нема — net change
+  у production нульовий до моменту client-rollout-у.
+- **Dep.** PR #042a.
 
 #### **PR #043 — `feat(sync): G-set CRDT for nutrition_meals log`** ✅ LANDED ([#1734](https://github.com/Skords-01/Sergeant/pull/1734))
 
@@ -1286,10 +1320,37 @@ recreate indexes`) у `packages/db-schema/src/sqlite/migrations/index.ts`,
   compile, поки не додано) — той самий governance-патерн, що `OP_LOG_TABLE_REGISTRY`.
 - **Dep.** PR #043, PR #043a, PR #043b, PR #048.
 
-#### **PR #044 — `feat(sync): conflict resolution UI for finyk_manual_expenses`**
+#### **PR #044 — `feat(sync): conflict resolution UI for finyk_manual_expenses`** — IN CI ([#1780](https://github.com/Skords-01/Sergeant/pull/1780))
 
 - Scope. Для finyk деякі конфлікти користувач має побачити (наприклад
-  edit одної транзакції з двох девайсів). Показуємо merge-UI.
+  edit одної транзакції з двох девайсів). Показуємо merge-UI — у цій
+  PR-і навмисно вузький first-pass: банер-counter без per-row
+  resolve-actions (їх додамо коли sync-v2 client push-loop буде
+  зашитий і recorder-API почне отримувати реальні reject-и).
+- **Implementation (2026-05-04).** Typed module-level pub/sub store
+  у `apps/web/src/modules/finyk/lib/conflicts/store.ts` (pattern
+  matches `hubBus.ts`): dedup по `transaction_id`, FIFO-cap на
+  25 записів (`MAX_CONFLICTS`), identity-stable snapshot для
+  `useSyncExternalStore`, listener error-isolation-контракт
+  (throwing listener не блокує fan-out). React-хук
+  `useFinykManualExpenseConflicts` через `useSyncExternalStore`
+  для concurrent-render safety. Banner `FinykManualExpenseConflictBanner`
+  з ARIA `role='status'` + `aria-live='polite'`, UA plural-формами
+  через `Intl.PluralRules('uk-UA')` (1 / 2-4 / 5+). Self-renders
+  no-op коли черга порожня — інтеграція у `FinykApp.tsx` під
+  no-bank банером без feature-flag-у. 18 нових тестів: 13 для store
+  (recording, dedup, FIFO age-out, dismiss/dismissAll, unsubscribe,
+  error-isolation з `setTimeout`-stub-ом для Vitest unhandled-error
+  budget, snapshot identity) + 5 для banner (empty, ARIA contract,
+  плюрал-форми, dismiss-all з override та без, store fan-out).
+  Locally: pnpm lint / typecheck / test всі зелені.
+- **Risk.** Low — UI-only; recorder-API лишається без callsite-ів
+  (sync-v2 client push-loop не зашитий), тому банер у production
+  ніколи не покаже non-empty стан до наступних PR Stage 5 серії.
+  Pre-existing hash-router warnings у `FinykApp.tsx` явно
+  `eslint-disable`-ються з посиланням на initiative 0006 Phase 2.
+- **Dep.** PR #043, PR #043a, PR #043b (sync-v2 reject-shape
+  стабілізовано).
 
 ---
 


### PR DESCRIPTION
Stage 5 PR #044 (`docs/planning/storage-roadmap.md`). Adds the UI surface that the eventual sync-v2 client will populate when the server's per-row apply-fn rejects a push на `finyk_manual_expenses` з `reason='lww_conflict'` або `reason='tombstoned'`.

## Scope

Скоп навмисно вузький — banner-counter без per-row resolve-actions, бо sync-v2 client (push-loop) ще не зашитий. До того як підключимо real network-path, банер виконує лише surfacing — повідомити юзера про невдалий push, щоб він міг вручну ре-синхронізувати при наступній сесії. Деталізацію + per-row resolve-actions додамо у наступних PR Stage 5 серії.

## Changes

- `apps/web/src/modules/finyk/lib/conflicts/store.ts`: typed module-level store. Dedup по `transaction_id`, FIFO-cap на 25 записів, identity-stable snapshot для `useSyncExternalStore`. Pattern matches `apps/web/src/shared/lib/modules/hubBus.ts`.
- `lib/conflicts/useFinykManualExpenseConflicts.ts`: React hook на `useSyncExternalStore` з SSR-safe початковим snapshot.
- `components/FinykManualExpenseConflictBanner.tsx`: inline-banner з ARIA `role='status'` + `aria-live='polite'` + UA plural-форми через `Intl.PluralRules` (1 / 2-4 / 5+).
- `FinykApp.tsx`: вмонтовано банер під NoBankBanner — self-renders як no-op коли черга порожня, тому feature-flag не потрібен. Додано lint-staged-disables на pre-existing hash-router callsites (initiative 0006 Phase 2 ще не покрила FinykApp shell-роутер).

## Tests

18 нових тестів:

- Store: dedup, FIFO age-out cap, dismiss/dismissAll, listener fan-out, snapshot identity stability, throwing-listener isolation contract.
- Banner: render-when-empty, ARIA contract, UA plural-форми (1/3/5/12), dismiss-flow з override та без, store fan-out re-render.

## Roadmap

PR #044 у Stage 5 hardening series. Передує: PR #042b (PN-counter apply-fn for routine_streaks). Слідує: майбутні PR Stage 5 для per-row resolve-actions після підключення real sync-v2 client push-loop.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an inline conflict banner for `finyk_manual_expenses` that appears when sync rejects a push (`lww_conflict` or `tombstoned`). Also updates the storage roadmap to mark PR `#042a/#042b` as landed and note this PR’s status.

- **New Features**
  - Inline `FinykManualExpenseConflictBanner` with `role="status"`, `aria-live="polite"`, Ukrainian pluralization, and an optional “Dismiss all” override.
  - Module store with dedup by `transactionId`, FIFO cap of 25, identity-stable snapshots, and error-isolated fan-out.
  - React hook `useFinykManualExpenseConflicts` using `useSyncExternalStore` with an SSR-safe snapshot.
  - Mounted in `FinykApp` under `NoBankBanner`; renders null when empty. 18 tests cover store and banner behavior.

<sup>Written for commit 5e92eb8e676b2f07e7e3fc0336c369d9cb9ba1db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manual expense conflict banner that appears when sync conflicts are detected, shows a localized conflict count (Ukrainian plural forms), and includes a “dismiss all” action.
* **Documentation**
  * Updated storage roadmap with details about the conflict UI and implementation status.
* **Tests**
  * Added test coverage ensuring banner behavior and conflict handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->