### PR TITLE
docs(docs): add Renovate maintainer runbook (initiative 0009 PR 4.1)

### DIFF
--- a/docs/ops/renovate.md
+++ b/docs/ops/renovate.md
@@ -1,0 +1,127 @@
+# Renovate maintainer runbook
+
+> **Last validated:** 2026-05-04 by @Skords-01. **Next review:** 2026-08-02.
+> **Status:** Active
+
+Operational runbook для maintainer-а Sergeant. Описує **щотижневу рутину**, **триаж duplicate-PR-ів** з Dependabot (per [ADR-0044](../adr/0044-renovate-vs-dependabot.md)), **escalation-шлях** на випадок Mend Renovate downtime, і **monthly hygiene**. Контриб'юторам потрібна дочірня дока [`docs/integrations/renovate-usage.md`](../integrations/renovate-usage.md) — вона про «що приходитиме і як я review-ю». Ця — про «коли і чому щось не приходить».
+
+## Розподіл ролей з Dependabot
+
+Відповідно до [ADR-0044](../adr/0044-renovate-vs-dependabot.md):
+
+| Інструмент | Роль                                                       | Trigger                                  | Конфіг                                                   |
+| ---------- | ---------------------------------------------------------- | ---------------------------------------- | -------------------------------------------------------- |
+| Renovate   | **Primary** — regular bumps                                | `before 6am on monday Europe/Kyiv` (npm) | [`renovate.json`](../../renovate.json)                   |
+| Dependabot | **Security-only fallback**                                 | `daily 06:00 Europe/Kyiv` (npm)          | [`.github/dependabot.yml`](../../.github/dependabot.yml) |
+| Dependabot | github-actions / docker (overlap із Renovate `pinDigests`) | `weekly monday 06:00 Europe/Kyiv`        | [`.github/dependabot.yml`](../../.github/dependabot.yml) |
+
+Якщо одночасно бачиш PR від `renovate[bot]` і `dependabot[bot]` на той самий npm-пакет → це **bug у налаштуванні** (Dependabot мав опустити non-security update з npm-scope), закривай Dependabot-PR з коментарем `duplicate of Renovate group: <groupName>` і відкривай issue зі snapshot-конфігом.
+
+## Понеділкова рутина (8:00–8:30 Europe/Kyiv)
+
+1. Відкрий **Pull Requests** → filter `author:app/renovate`. Має бути 5–15 PR-ів.
+2. Швидко скрол по титулах — звертай увагу на:
+   - `chore(deps): refresh pnpm-lock.yaml` — lockfile maintenance, мерджиться сам після CI;
+   - `chore(deps): update <group> to <version>` — групові bumps, читаєш changelog;
+   - `chore(deps): update <single-pkg>` — non-grouped, переважно major.
+3. Перевір що CI зелений (Vercel Preview Comments + `check` + `Test coverage` + `Critical-flow E2E`). Якщо CI ще йде — повертайся через 30 хв.
+4. Auto-merge dev-only patches проходить сам — нічого робити не треба, якщо `Allow auto-merge` ввімкнено в `Settings → General → Pull Requests`.
+5. **Production-deps + minors + majors** — review вручну (див. cheatsheet в `renovate-usage.md` § Як ревʼюїти).
+6. Якщо PR-ів немає взагалі (понеділок, після 7:00) → див. § Mend Renovate downtime.
+
+## Monthly hygiene (1-й понеділок місяця)
+
+1. **Dependency Dashboard** (GitHub Issue з тайтлом `Dependency Dashboard`):
+   - Прочитати секцію **Errors** — будь-які unresolved configuration errors → fix або відкрий ADR-zmena.
+   - Прочитати секцію **Ignored or Blocked** — переконатись, що allow-list ще релевантний (наприклад, якщо Expo SDK вже оновили вручну, прибрати `pin` з пакету).
+   - Очистити `Awaiting Schedule` checkbox-и для пакетів, які не релізилися більше 6 місяців і явно мертві (рідкість, але буває).
+2. **`renovate.json` `packageRules`:**
+   - Знайти rule з `description:` без посилання на ADR/incident → додати посилання або видалити, якщо причина забута;
+   - Перевірити, що `groupName` все ще збігається з фактичним списком пакетів (наприклад, якщо `@anthropic-ai/sdk` був перейменований у `@anthropic-ai/sdk-v2`, оновити pattern).
+3. **Dependabot security-only:**
+   - У GitHub → Settings → Code security → Dependabot alerts → перевірити, що `Allow auto-merge` все ще дозволено для repo;
+   - Подивитися Dependabot dashboard (Insights → Dependency graph → Dependabot) → `Last updated` ≤ 24h на npm scope (security-feed жвавий).
+
+## Triage decision tree для Renovate-PR
+
+```mermaid
+flowchart TD
+    A[Renovate PR landed] --> B{CI зелений?}
+    B -- ні --> C[Failed checks?]
+    C -- API breaking --> D[Read changelog<br/>+ напиши ADR на upgrade<br/>або close PR]
+    C -- flake --> E[Re-run failed jobs]
+    C -- type-fail --> F[Запросити Devin сесію<br/>«fix types after <pkg> bump»]
+    B -- так --> G{Тип PR?}
+    G -- Lockfile maintenance --> H[Merge]
+    G -- Dev-only patch --> I[Auto-merged раніше, нічого не робити]
+    G -- Production patch --> J[Read changelog → merge]
+    G -- Minor/major --> K[Read changelog<br/>+ перевірити breaking-секцію<br/>+ запустити preview deploy]
+    G -- Security --> L[Read advisory<br/>+ merge ASAP<br/>+ зафіксувати MTTR в audit-trail]
+```
+
+## Mend Renovate downtime
+
+**Симптоми:** понеділок ранок, 8:00 Europe/Kyiv, нових PR-ів від `renovate[bot]` немає більше 24h після останнього успішного скану.
+
+1. Перевір <https://status.mend.io/> — якщо incident, чекай.
+2. Якщо status зелений — перевір **Mend dashboard** (<https://developer.mend.io/>):
+   - Sergeant репо у `Installed Repositories`?
+   - **Default Engine Settings → Dependency Updates** = `Auto` (не `Silent`)?
+   - Останній `Run Log` — є помилки?
+3. Якщо все OK у Mend, але PR-ів немає → подивись **Dependency Dashboard** GitHub Issue, секція `Errors`. Часто там вже є помилка типу «branch protection blocked merge» або «conflict resolved manually».
+4. **Якщо Mend off-line > 24 годин:** Dependabot security-fallback все одно піднімає security-PR-и (per ADR-0044). Regular bumps — пауза до відновлення Mend. Це **OK** — якщо за тиждень Mend відсутній, все ще не аварія, бо security-feed працює.
+5. **Якщо Mend off-line > 7 днів:** відкривай incident у `docs/postmortems/` (template є). Розгляд Option 1/2 з ADR-0044 — переключитися на Dependabot повністю або шукати альтернативу (Renovate Self-Hosted, GitHub Renovate Action).
+
+## Як зробити dry-run без створення PR
+
+```sh
+LOG_LEVEL=debug npx --package=renovate renovate \
+  --platform=local --dry-run=full
+```
+
+Покаже список PR-ів, які Renovate планує створити, без жодних реальних змін у GitHub.
+
+Корисно перед merge-ом великих змін у `renovate.json` (наприклад, новий `packageRule` із `automerge: true`).
+
+## Як заборонити апдейт пакета
+
+`renovate.json` → `packageRules` → новий запис:
+
+```jsonc
+{
+  "description": "Залишаємось на старій версії бо <причина + посилання на ADR/issue>",
+  "matchPackageNames": ["package-name"],
+  "enabled": false,
+}
+```
+
+Або пін на конкретну major-версію:
+
+```jsonc
+{
+  "matchPackageNames": ["package-name"],
+  "allowedVersions": "<5.0.0",
+}
+```
+
+Завжди додавай `description:` із посиланням на ADR або incident — інакше через 6 місяців ніхто не пам'ятатиме, чому правило існує (див. § Monthly hygiene).
+
+## Як обробити security-PR від Dependabot
+
+Per ADR-0044, Dependabot піднімає security-PR-и daily. Воркфлоу `dependabot-automerge.yml` auto-merge-ить тільки `version-update:semver-patch` для `direct:production`. Все інше — ручне review.
+
+1. **Patch-only direct production** → нічого не робити, auto-merge впорається після зеленого CI;
+2. **Minor/major security** → читай advisory (`Dependabot fetched: GHSA-...` лінк у тілі PR), оцінюй breaking-ризик, якщо OK — merge;
+3. **Indirect production** (наприклад, transitive `@types/node`) → переконайся, що pin у `package.json` overrides (якщо є) не блокує fix, merge або пін;
+4. **MTTR target:** ≤ 24 години від `disclosed_at` advisory до merged-PR. Якщо більше — додай рядок у `docs/security/nightly-audit.md` з причиною затримки.
+
+## Зв'язки
+
+- [ADR-0044 — Renovate vs Dependabot](../adr/0044-renovate-vs-dependabot.md) — рішення про розподіл ролей.
+- [`renovate.json`](../../renovate.json) — конфіг Renovate.
+- [`.github/dependabot.yml`](../../.github/dependabot.yml) — конфіг Dependabot (security-only npm + github-actions/docker overlap).
+- [`.github/workflows/dependabot-automerge.yml`](../../.github/workflows/dependabot-automerge.yml) — auto-merge patch-only npm + github-actions.
+- [`docs/integrations/renovate-usage.md`](../integrations/renovate-usage.md) — гід контриб'ютора (review-cheatsheet, FAQ).
+- [`docs/security/hardening/H2-dependabot.md`](../security/hardening/H2-dependabot.md) — Sprint 1 setup card (Dependabot scope-reduction).
+- [`docs/security/nightly-audit.md`](../security/nightly-audit.md) — реактивна частина (`pnpm audit` + OSV-Scanner).
+- [`docs/security/vulnerability-sla.md`](../security/vulnerability-sla.md) — SLA для security-bumps.


### PR DESCRIPTION
## Summary

Initiative 0009 PR 4.1 — додано operational runbook `docs/ops/renovate.md` для maintainer-а Sergeant (понеділкова рутина, monthly hygiene, triage decision tree, Mend Renovate downtime escalation, обробка security-PR-ів від Dependabot після ADR-0044).

PR-описі важливо: оригінальний скоуп PR 4.1 в `docs/initiatives/0009-agent-os-hardening.md` передбачав **видалення Dependabot повністю**, але [ADR-0044](https://github.com/Skords-01/Sergeant/blob/main/docs/adr/0044-renovate-vs-dependabot.md) (вже на main) обрав **Option 3 — Renovate primary + Dependabot security-only fallback**. Тому ця PR закриває PR 4.1 з оновленим скоупом: runbook, що документує спільну роботу обох інструментів. Cross-references на ADR-0044 уже наявні в `renovate-usage.md` (рядок 8) і `H2-dependabot.md` (рядок 12) — нічого додавати в них не треба.

## Governing Skill

- Primary skill: `sergeant-deploy-and-observability` (governance-skill для operational runbook-ів і incident response).

## Playbook

- Primary playbook: n/a — це **новий runbook**, не виконує існуючий playbook. Pluggable у `release-policy.md` (security MTTR target ≤ 24h).
- Why: PR 4.1 у `docs/initiatives/0009-agent-os-hardening.md` явно вимагає `docs/ops/renovate.md` як deliverable.

## Verification

```bash
pnpm lint:playbook-language   # OK — UA prose 0.55+ ratio
pnpm lint                      # OK
pnpm docs:check-links docs/ops/renovate.md  # OK — всі лінки резолвляться (relative paths перевірено вручну)
```

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed: links на `renovate.json`, `.github/dependabot.yml`, `.github/workflows/dependabot-automerge.yml`, `docs/adr/0044-renovate-vs-dependabot.md`, `docs/integrations/renovate-usage.md`, `docs/security/hardening/H2-dependabot.md`, `docs/security/nightly-audit.md`, `docs/security/vulnerability-sla.md` усі резолвляться.

## Docs and Governance

- [x] Створено `docs/ops/renovate.md` (новий operational runbook).
- [x] AGENTS.md не потребує оновлення (внутрішня ops-doc, не змінює hard rules чи playbook-routing).
- [x] Skill catalog не потребує оновлення — runbook посилається на `sergeant-deploy-and-observability`, але не зявається у tools-list.
- [x] Governance docs: cross-refs у `renovate-usage.md` і `H2-dependabot.md` уже містять посилання на ADR-0044 — не потребують змін.

Updated docs:

- `docs/ops/renovate.md` (new) — Renovate maintainer runbook.

## Risk and Rollout

- User-visible risk: **none** — ця PR додає лише documentation.
- Rollout / deploy order: merge → готово.
- Backout plan: revert PR.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian (Cyrillic ratio ~0.55+ у `docs/ops/renovate.md`).
- [x] I did not use `--no-verify`.

## Reviewer Notes

- Файл лежить у новому каталозі `docs/ops/`. Якщо `docs/ops/` не пройде `docs:gen-link-index` перевірку, можна перенести в `docs/runbooks/` (теж існує в репо). Поки `docs/ops/` уніфіковано з `docs/observability/` (також ops-related).
- Acceptance criteria PR 4.1 з `docs/initiatives/0009-agent-os-hardening.md`:
  - [x] ADR-XXXX мерджнуто. _(Вже зроблено — ADR-0044 на main, частина initiative 0008 Phase 3 + повторно фіксує scope тут.)_
  - [-] Один із двох інструментів вилучено. _(Замінено на ADR-0044 рішенням Option 3 — обидва лишаються, але з різними scope-ами. Це покращення скоупу, не регресія.)_
  - [ ] Перші 5 dependency-PR після merge — без конфлікту. _(Will validate post-merge over наступні 1-2 тижні.)_


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `docs/ops/renovate.md`: a maintainer runbook for Renovate covering Monday routine, monthly hygiene, duplicate-PR triage, Mend downtime escalation, and handling Dependabot security PRs. Aligns Initiative 0009 PR 4.1 with ADR-0044 (Renovate primary + Dependabot security-only).

<sup>Written for commit f15bc01acc3c711ee664fa1d07181f05b8ec7cb4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added maintainer documentation for dependency update workflows and maintenance procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->