### PR TITLE
docs(docs): translate retire-feature-flag.md to UA (initiative 0009 PR 1.2b)

### DIFF
--- a/docs/playbooks/retire-feature-flag.md
+++ b/docs/playbooks/retire-feature-flag.md
@@ -1,9 +1,9 @@
 # Playbook: Retire Feature Flag
 
-> **Last validated:** 2026-05-04 by @Skords-01. **Next review:** 2026-08-02.
+> **Last validated:** 2026-05-05 by @Skords-01. **Next review:** 2026-08-03.
 > **Status:** Active
 
-**Trigger:** a feature flag has graduated, expired, or become dead rollout debt and should be removed from the codebase and registry.
+**Trigger:** feature flag завершив rollout, expired, або перетворився на rollout-debt і його треба прибрати з кодової бази та registry.
 
 ## Owner surface
 
@@ -12,39 +12,39 @@
 
 ## Required context
 
-- Review [feature-flags.md](../feature-flags.md) and [add-feature-flag.md](./add-feature-flag.md).
-- If the flag protects a mobile or backend release, also open the relevant release playbook.
+- Перегляньте [feature-flags.md](../feature-flags.md) і [add-feature-flag.md](./add-feature-flag.md).
+- Якщо прапор захищає mobile- або backend-реліз, відкрийте також відповідний release playbook.
 
 ## Steps
 
-### 1. Confirm retirement conditions
+### 1. Підтвердьте умови retirement
 
-- The rollout decision is done.
-- No active release still relies on the flag as a kill switch.
-- The default state is understood and can become permanent behavior.
+- Rollout-рішення прийнято.
+- Жоден активний реліз не покладається на цей прапор як kill switch.
+- Default-стан зрозумілий і може стати постійною поведінкою.
 
-### 2. Remove the flag end-to-end
+### 2. Приберіть прапор end-to-end
 
-- Delete the registry entry in code.
-- Remove all `useFlag`, `getFlag`, or equivalent branching.
-- Remove tests that only exist for the old branch split, while preserving behavior coverage.
+- Видаліть запис у registry в коді.
+- Приберіть усі `useFlag`, `getFlag` або еквівалентні розгалуження.
+- Видаліть тести, що існують лише для старої гілки розгалуження, зберігши покриття поточної поведінки.
 
-### 3. Clean the operational docs
+### 3. Приберіть operational docs
 
-- Remove the row from [feature-flags.md](../feature-flags.md).
-- Update release notes or playbooks if the flag was documented as a rollback lever.
+- Видаліть рядок із [feature-flags.md](../feature-flags.md).
+- Оновіть release notes або playbooks, якщо прапор був задокументований як rollback-важіль.
 
 ## Verification
 
-- [ ] Flag removed from code registry
-- [ ] Dead branches removed
-- [ ] Registry entry removed from `docs/feature-flags.md`
-- [ ] Verification still covers the surviving behavior
+- [ ] Прапор видалено з code registry
+- [ ] Мертві гілки видалено
+- [ ] Запис у registry видалено з `docs/feature-flags.md`
+- [ ] Verification покриває поведінку, що залишилася
 
 ## When not to use this playbook
 
-- The flag is still actively controlling a risky rollout.
-- The flag is only being introduced, not removed.
+- Прапор все ще активно керує ризиковим rollout.
+- Прапор лише вводиться, а не прибирається.
 
 ## Related playbooks and skills
 


### PR DESCRIPTION
## Summary

Translates `docs/playbooks/retire-feature-flag.md` prose to Ukrainian per Hard Rule #15 / initiative [0009 PR 1.2b](../docs/initiatives/0009-agent-os-hardening.md). Code samples, file paths, command names, identifiers (`useFlag`, `getFlag`, `feature-flags.md`), and structural section headings (`## Owner surface`, `## Required context`, `## Steps`, `## Verification`, `## When not to use this playbook`, `## Related playbooks and skills`) are kept untouched — they are governance anchors per the playbook-schema linter. Step subheadings (`### 1. …`) are translated, matching the pattern in #1825 (`add-feature-flag.md`) and #1826 (`cleanup-dead-code.md`). Cross-refs to `add-feature-flag.md`, `cleanup-dead-code.md`, `release.md`, and `../feature-flags.md` are preserved.

## Governing Skill

- Primary skill: `sergeant-review-and-merge` (the playbook itself owns rollout-hygiene retirement; this PR follows the playbook-translation pattern from prior 1.2b batches).

## Playbook

- Primary playbook: n/a — this is a documentation translation, not a behavior change.
- If no playbook matched, why: 0009 PR 1.2b is the initiative-driven backfill of EN-only governance prose; there is no per-translation playbook.

## Verification

```bash
pnpm lint:playbook-language
# warn-list dropped 33 → 32 file(s); retire-feature-flag.md no longer flagged.
```

Additional checks:

- [x] `pnpm lint:playbook-language` (warn-only) no longer flags this file.
- [x] Freshness header bumped by lint-staged `bump-last-validated` (`2026-05-04` → `2026-05-05`); next-review shifted accordingly.
- [x] All structural headings preserved (playbook-schema linter anchors).
- [x] Cross-refs and link anchors unchanged.

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update — n/a (only the playbook prose changed; Hard Rule #15 references stay accurate).
- [x] I checked whether a playbook or skill needed an update — this PR _is_ the playbook update.
- [x] I checked whether governance docs or review docs needed an update — initiative 0009 progress table will be updated in the cumulative initiative-status PR after the 1.2b batch lands.

Updated docs:

- `docs/playbooks/retire-feature-flag.md`

## Risk and Rollout

- User-visible risk: none (docs only).
- Rollout / deploy order: regular merge to `main`; no deploy.
- Backout plan: revert this commit.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

- The step subheadings (`### 1. Підтвердьте умови retirement`, etc.) are translated. The playbook-schema linter only anchors on top-level `##` headings (`Owner surface`, `Steps`, `Verification`, …), so this matches the pattern used by #1825 / #1826. Please confirm this is still the intended convention.
- Lexical choices kept terse and close to existing UA playbooks (`add-feature-flag.md`, `cleanup-dead-code.md`): "Прапор" for flag, "Default-стан", "kill switch" preserved as a recognised term.

Link to Devin session: https://app.devin.ai/sessions/db6dbfed38c1480f9d68a5b56110ac28

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Translated `docs/playbooks/retire-feature-flag.md` to Ukrainian per Hard Rule #15 (initiative 0009 PR 1.2b), docs-only change with no behavior impact.
Kept structural headings and identifiers (`useFlag`, `getFlag`, `feature-flags.md`) as anchors, updated freshness dates, and ensured `pnpm lint:playbook-language` passes.

<sup>Written for commit 41d1196a7c5456fe0803cdd6026f3893e2aca66b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

