### PR TITLE
feat(api-client): submitSyncV2IncrementOp composable build → map → enqueue helper (PR #042e-submit)

### DIFF
--- a/docs/planning/storage-roadmap.md
+++ b/docs/planning/storage-roadmap.md
@@ -1413,6 +1413,58 @@ recreate indexes`) у `packages/db-schema/src/sqlite/migrations/index.ts`,
   адаптер плоскує), PR #042d-builder (`enqueueOutboxIncrement` —
   consumer ouput-у адаптера; його `OutboxIncrementInput`-shape — mirror-target).
 
+#### **PR #042e-submit — `feat(api-client): submitSyncV2IncrementOp composable build → map → enqueue helper`** ✅ LANDED
+
+- Scope. Composable consumer-side хелпер, який зв'язує три вже-залендженi
+  компоненти у одну функцію: `buildSyncV2IncrementOp` (PR #042c),
+  `mapSyncV2IncrementOpToOutboxInput` (PR #042e-mapping) і
+  ін'єкційну `submit`-функцію (структурно-mirror-нуту з
+  `enqueueOutboxIncrement` із PR #042d-builder). Ціль — мати одну
+  three-step API-поверхню для майбутнього sync-engine writer-а у
+  power-PR #042e (push-loop refactor), щоб callsite-и зводилися до
+  одного виклику замість трьох-шарової композиції.
+- **Done (2026-05-05).** `packages/api-client/src/endpoints/syncV2.increment.submit.ts`
+  експортує:
+  - `submitSyncV2IncrementOp(submit, input)` — async-функція, що повертає
+    discriminated-union `{ ok: true, id, inserted } | { ok: false, reason }`.
+    Build-side reject-и (`op_not_supported` / `missing_delta` /
+    `invalid_delta`) короткозамикаються — `submit` НЕ викликається,
+    жодного outbox-row для envelope-у, який сервер однаково реджектить
+    engine-level. На happy-path `inserted: false` (idempotent replay,
+    знайдено existing row під тим же `idempotencyKey`) пробрасується
+    verbatim — replay-safety-контракт від `enqueueOutboxIncrement`
+    тримається 1:1.
+  - `SubmitSyncV2IncrementOpFn` — DI-функція-shape, що структурно
+    mirror-ить `enqueueOutboxIncrement` (приймає `OutboxIncrementInputShape`,
+    повертає `Promise<{ id, inserted }>`). Inversion-of-control патерн
+    тримає api-client / db-schema незалежними один від одного — adapter
+    на consumer-side у app-коді — це one-liner.
+  - `SubmitSyncV2IncrementOpResult`, `SubmitSyncV2IncrementOpEnqueued`,
+    `SubmitSyncV2IncrementOpRejected` — окремі типи для callsite-ів,
+    що narrow-ять на `result.ok`.
+  - `packages/api-client/src/endpoints/syncV2.increment.submit.test.ts`:
+    12 тестів (4 happy-path кейси з byte-aligned camelCase mapping і
+    insertion-order пресервом + boundary delta=−1000; 6 reject-route
+    кейсів — `op_not_supported`, `missing_delta` × 2 для null/undefined,
+    `invalid_delta` × 3 для non-finite/non-integer/out-of-bound; storage
+    error pass-through; cardinality-lock на 3 reject-reason-літерали).
+  - Re-export із `packages/api-client/src/index.ts`:
+    `submitSyncV2IncrementOp`, `SubmitSyncV2IncrementOpFn`,
+    `SubmitSyncV2IncrementOpResult`, `SubmitSyncV2IncrementOpEnqueued`,
+    `SubmitSyncV2IncrementOpRejected`.
+  - Locally: typecheck + lint + 102/102 api-client тестів зелені.
+- **Risk.** None — additive public surface без callsite-ів за межами
+  тестів. Storage-layer error-и (`submit` throw-ить) пробрасуються
+  callerу, не конвертуються у reject-reason — це тримає cardinality
+  `sync_op_outbox_reject_total{reason}` обмеженою трьома build-reason-ами
+  з PR #042c. Перший production-consumer — sync-engine writer у
+  full-scope PR #042e (push-loop refactor): зчитає payload із
+  dual-write-адаптера, передасть `BuildSyncV2IncrementOpInput` у helper,
+  ін'єктить `(input) => enqueueOutboxIncrement(sqliteClient, input)`
+  як `submit`.
+- **Dep.** PR #042c, PR #042d-builder (mirror-target для `submit`-shape),
+  PR #042e-mapping (mapper, який helper викликає внутрішньо).
+
 #### **PR #043 — `feat(sync): G-set CRDT for nutrition_meals log`** ✅ LANDED ([#1734](https://github.com/Skords-01/Sergeant/pull/1734))
 
 - Scope. `nutrition_meals` — append-only G-set. Видалення через

--- a/packages/api-client/src/endpoints/syncV2.increment.submit.test.ts
+++ b/packages/api-client/src/endpoints/syncV2.increment.submit.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi } from "vitest";
+
+import {
+  submitSyncV2IncrementOp,
+  type SubmitSyncV2IncrementOpFn,
+} from "./syncV2.increment.submit";
+import type { OutboxIncrementInputShape } from "./syncV2.increment.outboxEnqueue";
+
+// Stage 5 PR #042e (`docs/planning/storage-roadmap.md`).
+//
+// `submitSyncV2IncrementOp` composes three already-landed building
+// blocks:
+//
+//   - `buildSyncV2IncrementOp`              (PR #042c)
+//   - `mapSyncV2IncrementOpToOutboxInput`   (PR #042e-mapping)
+//   - injected `submit`                     (mirrors `enqueueOutboxIncrement`,
+//                                            PR #042d-builder)
+//
+// The tests here lock the contract of the composition itself — that
+// the upstream reject reasons propagate 1:1, that the build-side
+// short-circuits the `submit` call, and that the field-name mapping
+// on the way through is byte-aligned with the db-schema enqueue input
+// (mirror already verified in `syncV2.increment.outboxEnqueue.test.ts`;
+// here we just assert the helper does not perturb it).
+//
+// Builder-side validation is exhaustively covered in
+// `syncV2.increment.test.ts` — we don't re-prove `INCREMENT_DELTA_MAX_ABS=1000`
+// or the per-reason-string mapping; we just spot-check the routes
+// stay wired correctly.
+
+const HAPPY_INPUT = {
+  table: "routine_streaks",
+  delta: 1,
+  clientTs: "2026-05-05T00:00:00.000Z",
+  idempotencyKey: "01HXZW8K6T7N4QV5R3J2P1G8AB",
+} as const;
+
+function makeSubmitSpy(
+  result: { id: number; inserted: boolean } = { id: 42, inserted: true },
+): {
+  submit: SubmitSyncV2IncrementOpFn;
+  calls: OutboxIncrementInputShape[];
+} {
+  const calls: OutboxIncrementInputShape[] = [];
+  const submit: SubmitSyncV2IncrementOpFn = vi.fn(
+    async (input: OutboxIncrementInputShape) => {
+      calls.push(input);
+      return result;
+    },
+  );
+  return { submit, calls };
+}
+
+describe("submitSyncV2IncrementOp — happy path", () => {
+  it("builds → maps → enqueues with byte-aligned camelCase fields", async () => {
+    const { submit, calls } = makeSubmitSpy({ id: 7, inserted: true });
+
+    const result = await submitSyncV2IncrementOp(submit, HAPPY_INPUT);
+
+    expect(result).toEqual({ ok: true, id: 7, inserted: true });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({
+      table: "routine_streaks",
+      row: { delta: 1 },
+      clientTs: "2026-05-05T00:00:00.000Z",
+      idempotencyKey: "01HXZW8K6T7N4QV5R3J2P1G8AB",
+    });
+  });
+
+  it("threads `inserted=false` through verbatim (idempotent replay)", async () => {
+    // Replay-safety contract inherited from `enqueueOutboxIncrement`:
+    // `inserted=false` means an existing row was found under the
+    // same `idempotencyKey`. The helper must not flip it to a reject
+    // — replay is a successful no-op, not an error.
+    const { submit } = makeSubmitSpy({ id: 99, inserted: false });
+
+    const result = await submitSyncV2IncrementOp(submit, HAPPY_INPUT);
+
+    expect(result).toEqual({ ok: true, id: 99, inserted: false });
+  });
+
+  it("preserves `extraRow` fields with delta inserted last", async () => {
+    // Builder guarantees `row` insertion order: spread of `extraRow`
+    // first, then `delta`. The mapper passes `row` by reference, no
+    // copy / no key sort — so the helper must preserve that pin.
+    const { submit, calls } = makeSubmitSpy();
+
+    await submitSyncV2IncrementOp(submit, {
+      ...HAPPY_INPUT,
+      extraRow: { user_id: "u-1", aux: { z: 1, a: 2 } },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(Object.keys(calls[0]!.row)).toEqual(["user_id", "aux", "delta"]);
+    expect(calls[0]!.row).toEqual({
+      user_id: "u-1",
+      aux: { z: 1, a: 2 },
+      delta: 1,
+    });
+  });
+
+  it("supports negative deltas at the magnitude boundary", async () => {
+    const { submit, calls } = makeSubmitSpy({ id: 1, inserted: true });
+
+    const result = await submitSyncV2IncrementOp(submit, {
+      ...HAPPY_INPUT,
+      delta: -1000,
+    });
+
+    expect(result).toEqual({ ok: true, id: 1, inserted: true });
+    expect((calls[0]!.row as { delta: number }).delta).toBe(-1000);
+  });
+});
+
+describe("submitSyncV2IncrementOp — short-circuits on builder reject", () => {
+  it("propagates `op_not_supported` and does NOT call submit", async () => {
+    const { submit, calls } = makeSubmitSpy();
+
+    const result = await submitSyncV2IncrementOp(submit, {
+      table: "routine_entries", // not in INCREMENT_OP_SUPPORTED_TABLES
+      delta: 1,
+      clientTs: HAPPY_INPUT.clientTs,
+      idempotencyKey: HAPPY_INPUT.idempotencyKey,
+    });
+
+    expect(result).toEqual({ ok: false, reason: "op_not_supported" });
+    expect(calls).toHaveLength(0);
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  it("propagates `missing_delta` (delta=null) and does NOT call submit", async () => {
+    const { submit, calls } = makeSubmitSpy();
+
+    const result = await submitSyncV2IncrementOp(submit, {
+      ...HAPPY_INPUT,
+      delta: null,
+    });
+
+    expect(result).toEqual({ ok: false, reason: "missing_delta" });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("propagates `missing_delta` (delta=undefined) and does NOT call submit", async () => {
+    const { submit, calls } = makeSubmitSpy();
+
+    const result = await submitSyncV2IncrementOp(submit, {
+      ...HAPPY_INPUT,
+      delta: undefined,
+    });
+
+    expect(result).toEqual({ ok: false, reason: "missing_delta" });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("propagates `invalid_delta` for non-finite delta and does NOT call submit", async () => {
+    const { submit, calls } = makeSubmitSpy();
+
+    const result = await submitSyncV2IncrementOp(submit, {
+      ...HAPPY_INPUT,
+      delta: Number.POSITIVE_INFINITY,
+    });
+
+    expect(result).toEqual({ ok: false, reason: "invalid_delta" });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("propagates `invalid_delta` for non-integer delta", async () => {
+    const { submit, calls } = makeSubmitSpy();
+
+    const result = await submitSyncV2IncrementOp(submit, {
+      ...HAPPY_INPUT,
+      delta: 1.5,
+    });
+
+    expect(result).toEqual({ ok: false, reason: "invalid_delta" });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("propagates `invalid_delta` for delta beyond +/- INCREMENT_DELTA_MAX_ABS", async () => {
+    const { submit, calls } = makeSubmitSpy();
+
+    const result = await submitSyncV2IncrementOp(submit, {
+      ...HAPPY_INPUT,
+      delta: 1001,
+    });
+
+    expect(result).toEqual({ ok: false, reason: "invalid_delta" });
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe("submitSyncV2IncrementOp — error pass-through", () => {
+  it("does NOT swallow errors thrown by the injected submit", async () => {
+    // Storage-layer failures (FS disk full, unrelated CHECK
+    // violations, etc.) are the caller's concern — the helper must
+    // not convert them into a reject reason. That keeps the cardinality
+    // of `sync_op_outbox_reject_total{reason}` bounded to the 3 build
+    // reasons and lets transport-layer retry policy own everything else.
+    const submit: SubmitSyncV2IncrementOpFn = vi.fn(async () => {
+      throw new Error("sqlite disk full");
+    });
+
+    await expect(submitSyncV2IncrementOp(submit, HAPPY_INPUT)).rejects.toThrow(
+      /sqlite disk full/,
+    );
+    expect(submit).toHaveBeenCalledOnce();
+  });
+});
+
+describe("submitSyncV2IncrementOp — reject-reason cardinality lock", () => {
+  it("only emits the three documented reject reasons", async () => {
+    // Drift-tripwire: if the upstream `BuildSyncV2IncrementOpReason`
+    // grows a new literal, this test must change in lockstep —
+    // otherwise observability dashboards under
+    // `sync_op_outbox_reject_total{reason}` silently get a 4th
+    // bucket without anyone updating the legend.
+    const reasons = new Set<string>();
+    const cases = [
+      { ...HAPPY_INPUT, table: "routine_entries" },
+      { ...HAPPY_INPUT, delta: null },
+      { ...HAPPY_INPUT, delta: 9001 },
+    ];
+
+    for (const input of cases) {
+      const { submit } = makeSubmitSpy();
+      const result = await submitSyncV2IncrementOp(submit, input);
+      if (!result.ok) reasons.add(result.reason);
+    }
+
+    expect([...reasons].sort()).toEqual([
+      "invalid_delta",
+      "missing_delta",
+      "op_not_supported",
+    ]);
+  });
+});

--- a/packages/api-client/src/endpoints/syncV2.increment.submit.test.ts
+++ b/packages/api-client/src/endpoints/syncV2.increment.submit.test.ts
@@ -28,11 +28,19 @@ import type { OutboxIncrementInputShape } from "./syncV2.increment.outboxEnqueue
 // or the per-reason-string mapping; we just spot-check the routes
 // stay wired correctly.
 
+// Plain low-entropy fixture-style strings, picked deliberately so the
+// repo's gitleaks scanner does not flag them as `generic-api-key`
+// false-positives. The ULID/uuid character class is fine at runtime —
+// the helper only forwards `idempotencyKey` to the injected `submit`
+// — but a high-entropy literal in a freshly-added file is exactly the
+// shape gitleaks' default rule fires on.
+const FIXTURE_IDEMPOTENCY_KEY = "fixture-routine-streak-incr-001";
+
 const HAPPY_INPUT = {
   table: "routine_streaks",
   delta: 1,
   clientTs: "2026-05-05T00:00:00.000Z",
-  idempotencyKey: "01HXZW8K6T7N4QV5R3J2P1G8AB",
+  idempotencyKey: FIXTURE_IDEMPOTENCY_KEY,
 } as const;
 
 function makeSubmitSpy(
@@ -63,7 +71,7 @@ describe("submitSyncV2IncrementOp — happy path", () => {
       table: "routine_streaks",
       row: { delta: 1 },
       clientTs: "2026-05-05T00:00:00.000Z",
-      idempotencyKey: "01HXZW8K6T7N4QV5R3J2P1G8AB",
+      idempotencyKey: FIXTURE_IDEMPOTENCY_KEY,
     });
   });
 

--- a/packages/api-client/src/endpoints/syncV2.increment.submit.ts
+++ b/packages/api-client/src/endpoints/syncV2.increment.submit.ts
@@ -1,0 +1,155 @@
+import {
+  buildSyncV2IncrementOp,
+  type BuildSyncV2IncrementOpInput,
+  type BuildSyncV2IncrementOpReason,
+} from "./syncV2.increment";
+import {
+  mapSyncV2IncrementOpToOutboxInput,
+  type OutboxIncrementInputShape,
+  type SyncV2IncrementPushOp,
+} from "./syncV2.increment.outboxEnqueue";
+
+/**
+ * Composable consumer-side helper that ties together the three already-
+ * landed building blocks of the PN-counter `op='increment'` pipeline
+ * (`docs/planning/storage-roadmap.md` Stage 5):
+ *
+ * 1. {@link buildSyncV2IncrementOp} (PR #042c) — typed envelope builder
+ *    with bit-for-bit server-mirrored validation.
+ * 2. {@link mapSyncV2IncrementOpToOutboxInput} (PR #042e-mapping) —
+ *    snake_case → camelCase flattener for the db-schema enqueue input.
+ * 3. A dependency-injected `submit` function — supplied by the caller
+ *    and structurally mirrors `enqueueOutboxIncrement`
+ *    (`packages/db-schema/src/sqlite/syncOpOutboxEnqueue.ts`,
+ *    PR #042d-builder).
+ *
+ * Why DI rather than a direct import of `enqueueOutboxIncrement`?
+ * Because `api-client` and `db-schema` deliberately do NOT depend on
+ * each other (see PR #042d-builder Risk note in the roadmap). Inversion
+ * of control through a function-shaped dependency keeps the package
+ * boundaries clean while still letting consumer code (web / mobile
+ * routine modules, future PN-counter producers) call a single
+ * three-step pipeline:
+ *
+ * ```ts
+ * const result = await submitSyncV2IncrementOp(
+ *   (input) => enqueueOutboxIncrement(sqliteClient, input),
+ *   { table, delta, clientTs, idempotencyKey },
+ * );
+ * if (!result.ok) {
+ *   recordRejected(result.reason);
+ *   return;
+ * }
+ * recordOutboxEnqueued({ id: result.id, inserted: result.inserted });
+ * ```
+ *
+ * Stage 5 PR #042e of `docs/planning/storage-roadmap.md`. The full
+ * sync-engine writer (push-loop refactor that drains
+ * `sync_op_outbox` against `/api/v2/sync/push`) is the next step on
+ * top of this helper. This PR ships the composable surface so future
+ * call-sites — whichever module first wants to enqueue a PN-counter
+ * delta — can plug into a single API rather than wiring three
+ * layers individually.
+ *
+ * Result-discriminated-union mirror:
+ *
+ * - On `buildSyncV2IncrementOp` reject: `{ ok: false, reason }` with
+ *   the same `op_not_supported` / `missing_delta` / `invalid_delta`
+ *   string-literals as the upstream builder, threaded through 1:1.
+ *   `submit` is NOT called — no outbox row is written for an envelope
+ *   that the server would reject engine-level anyway.
+ * - On a successful build + enqueue: `{ ok: true, id, inserted }`
+ *   from the injected `submit`. `inserted=false` means the helper
+ *   found an existing row under the same `idempotencyKey` and the
+ *   call was a no-op replay; callers can wire telemetry on
+ *   `inserted` without branching on a reject reason.
+ *
+ * Idempotency contract is inherited verbatim from
+ * `enqueueOutboxIncrement` — see its docstring. Replaying the same
+ * `idempotencyKey` is safe and returns the original row's `id`.
+ */
+
+/**
+ * Successful outcome of the injected `submit` step. Structurally
+ * mirrors `EnqueueOutboxIncrementOk` from db-schema's
+ * `syncOpOutboxEnqueue.ts` so callers can pass the helper's result
+ * straight through to telemetry without branching.
+ *
+ * Keep the field set byte-aligned with db-schema; the regression
+ * test in `syncV2.increment.submit.test.ts` pins the shape.
+ */
+export interface SubmitSyncV2IncrementOpEnqueued {
+  readonly ok: true;
+  /** `sync_op_outbox.id` of the freshly-inserted or pre-existing row. */
+  readonly id: number;
+  /**
+   * `true` when the `submit` step inserted a new row, `false` when it
+   * found an existing row under the same `idempotencyKey` and
+   * returned its id verbatim (idempotent replay).
+   */
+  readonly inserted: boolean;
+}
+
+/**
+ * Reject outcome. `reason` is propagated 1:1 from
+ * `buildSyncV2IncrementOp`, so callers can record it under the same
+ * `sync_op_outbox_reject_total{reason}` cardinality budget that the
+ * upstream builder already uses.
+ */
+export interface SubmitSyncV2IncrementOpRejected {
+  readonly ok: false;
+  readonly reason: BuildSyncV2IncrementOpReason;
+}
+
+export type SubmitSyncV2IncrementOpResult =
+  | SubmitSyncV2IncrementOpEnqueued
+  | SubmitSyncV2IncrementOpRejected;
+
+/**
+ * Function-shaped dependency that durably enqueues an
+ * already-validated `op='increment'` envelope.
+ *
+ * Structurally mirrors the signature of `enqueueOutboxIncrement`
+ * from `packages/db-schema/src/sqlite/syncOpOutboxEnqueue.ts` so an
+ * adapter on the consumer side is a one-liner:
+ *
+ * ```ts
+ * const submit: SubmitSyncV2IncrementOpFn =
+ *   (input) => enqueueOutboxIncrement(sqliteClient, input);
+ * ```
+ *
+ * Implementations MUST be idempotent on `input.idempotencyKey` —
+ * `submitSyncV2IncrementOp` short-circuits on a build reject but does
+ * NOT pre-check the outbox for a duplicate. Idempotency is the
+ * `submit`-side responsibility; the canonical implementation
+ * (`enqueueOutboxIncrement`) covers it via the
+ * `sync_op_outbox_idem_uniq_lite` unique index.
+ */
+export type SubmitSyncV2IncrementOpFn = (
+  input: OutboxIncrementInputShape,
+) => Promise<{ readonly id: number; readonly inserted: boolean }>;
+
+/**
+ * Build → map → enqueue pipeline for a PN-counter `op='increment'`
+ * envelope.
+ *
+ * Never throws on validation failure — returns
+ * `{ ok: false, reason }` with the same string-literal that
+ * `buildSyncV2IncrementOp` would. Throws synchronously only if the
+ * injected `submit` throws (the helper does NOT swallow `submit`
+ * errors; storage-layer failures are the caller's concern).
+ */
+export async function submitSyncV2IncrementOp(
+  submit: SubmitSyncV2IncrementOpFn,
+  input: BuildSyncV2IncrementOpInput,
+): Promise<SubmitSyncV2IncrementOpResult> {
+  const built = buildSyncV2IncrementOp(input);
+  if (!built.ok) {
+    return { ok: false, reason: built.reason };
+  }
+  const outboxInput = mapSyncV2IncrementOpToOutboxInput(
+    built.op as SyncV2IncrementPushOp,
+  );
+  const enqueued = await submit(outboxInput);
+  return { ok: true, id: enqueued.id, inserted: enqueued.inserted };
+}

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -73,6 +73,14 @@ export {
 } from "./endpoints/syncV2.increment.outboxEnqueue";
 
 export {
+  submitSyncV2IncrementOp,
+  type SubmitSyncV2IncrementOpEnqueued,
+  type SubmitSyncV2IncrementOpFn,
+  type SubmitSyncV2IncrementOpRejected,
+  type SubmitSyncV2IncrementOpResult,
+} from "./endpoints/syncV2.increment.submit";
+
+export {
   createCoachEndpoints,
   type CoachEndpoints,
   type CoachInsightPayload,


### PR DESCRIPTION
## Summary

Composable consumer-side helper that ties together the three already-landed building blocks of the PN-counter `op='increment'` pipeline (`docs/planning/storage-roadmap.md` Stage 5):

- `buildSyncV2IncrementOp` (PR #042c, [#1787](https://github.com/Skords-01/Sergeant/pull/1787))
- `mapSyncV2IncrementOpToOutboxInput` (PR #042e-mapping, [#1827](https://github.com/Skords-01/Sergeant/pull/1827))
- injected `submit` fn — structurally mirrors `enqueueOutboxIncrement` from `packages/db-schema/src/sqlite/syncOpOutboxEnqueue.ts` (PR #042d-builder, [#1810](https://github.com/Skords-01/Sergeant/pull/1810))

**Why DI rather than a direct import of `enqueueOutboxIncrement`?** Because `api-client` and `db-schema` deliberately do NOT depend on each other (see PR #042d-builder Risk note in the roadmap). Inversion of control through a function-shaped dependency keeps the package boundaries clean while still letting consumer code call a single three-step pipeline:

```ts
const result = await submitSyncV2IncrementOp(
  (input) => enqueueOutboxIncrement(sqliteClient, input),
  { table, delta, clientTs, idempotencyKey },
);
if (!result.ok) {
  recordRejected(result.reason);
  return;
}
recordOutboxEnqueued({ id: result.id, inserted: result.inserted });
```

Result-discriminated-union mirror:

- On `buildSyncV2IncrementOp` reject: `{ ok: false, reason }` with the same `op_not_supported` / `missing_delta` / `invalid_delta` literals threaded 1:1. `submit` is NOT called — no outbox row for an envelope the server would reject engine-level anyway.
- On a successful build + enqueue: `{ ok: true, id, inserted }` from the injected `submit`. `inserted=false` means the helper found an existing row under the same `idempotencyKey` (idempotent replay).

Ships:

- `packages/api-client/src/endpoints/syncV2.increment.submit.ts` — the helper + types.
- `packages/api-client/src/endpoints/syncV2.increment.submit.test.ts` — 12 tests (4 happy-path, 6 reject-route, 1 storage-error pass-through, 1 cardinality-lock).
- `packages/api-client/src/index.ts` — re-export of `submitSyncV2IncrementOp`, `SubmitSyncV2IncrementOpFn`, `SubmitSyncV2IncrementOpResult`, `SubmitSyncV2IncrementOpEnqueued`, `SubmitSyncV2IncrementOpRejected`.
- `docs/planning/storage-roadmap.md` — new "PR #042e-submit" subsection in Stage 5 with `LANDED` marker and Done/Risk/Dep notes following the existing roadmap convention.

No callsite outside the test suite — additive public surface. The full sync-engine writer (push-loop refactor that drains `sync_op_outbox` against `/api/v2/sync/push`) is the next step on top of this helper — power-PR #042e.

## Governing Skill

- Primary skill: `.agents/skills/sergeant-routine/SKILL.md` — operating the routine sync slice (`routine_streaks` PN-counter is the first table in `INCREMENT_OP_SUPPORTED_TABLES`)
- Secondary skill (if truly needed): n/a — pure composition over already-landed building blocks; no new domain rules

## Playbook

- Primary playbook: n/a — additive helper in `packages/api-client`, не зачіпає migration / data-shape / cross-surface workflow, на які націлені існуючі playbook-и
- Why this playbook: n/a
- If no playbook matched, why: docs/playbooks інвентар орієнтований на rollout / DB-migration / cross-surface tasks; лендинг single composable helper у вже відомому пакеті — поза їх скоупом

## Verification

```bash
cd packages/api-client && pnpm test -- syncV2.increment.submit
# Test Files  1 passed (1)
#       Tests  12 passed (12)

cd packages/api-client && pnpm test
# Test Files  8 passed (8)
#       Tests  102 passed (102)

cd packages/api-client && pnpm typecheck
# (clean — exit 0)

cd packages/api-client && pnpm lint
# (clean — exit 0)

pnpm api:check-openapi-types  # (clean — no OpenAPI surface changes)
pnpm lint:imports             # Import check passed.
```

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. (storage-roadmap.md — new PR #042e-submit subsection in Stage 5)
- [x] I checked whether `AGENTS.md` needed an update. (no — additive api-client surface, no new hard rule / scope / convention)
- [x] I checked whether a playbook or skill needed an update. (no — composition over existing helpers, no new domain rule or workflow)
- [x] I checked whether governance docs or review docs needed an update. (no)

Updated docs:

- `docs/planning/storage-roadmap.md` — додано підсекцію "PR #042e-submit" у Stage 5 (§3 PR Plans) із Done/Risk/Dep-нотатками за існуючим патерном попередніх 042-sub-PR-ів.

## Risk and Rollout

- User-visible risk: **None.** Additive public surface на `packages/api-client`; жодного existing call-сайту не зачеплено, жодних behavior-змін у вже-залендженi `buildSyncV2IncrementOp` / `mapSyncV2IncrementOpToOutboxInput`. Re-export тільки додає п'ять нових символів у `packages/api-client/src/index.ts` — bundling-impact на web/mobile = 0 KB до першого callsite-у (tree-shaking).
- Rollout / deploy order: Single PR, тривіальний. Ніяких міграцій, ніяких feature-flag-ів, ніякої двофазової роботи. Сервер не зачеплений.
- Backout plan: Revert цієї PR-ки. Жодних перетекших side-effect-ів — додані файли self-contained, видалення re-export-ів з `index.ts` повертає публічну поверхню до стану до PR-ки.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian. (Нова PR #042e-submit підсекція у `docs/planning/storage-roadmap.md` ведеться в існуючому стилі цього документу — змішана UA-EN термінологія, що мирно з рештою файлу.)
- [x] I did not use `--no-verify`. (Husky pre-commit ran cleanly; lint-staged зробив re-format на нових файлах і застосував зміни автоматично.)

## Reviewer Notes

- **DI shape is intentionally structural.** `SubmitSyncV2IncrementOpFn` accepts `OutboxIncrementInputShape` (the existing structural mirror in `syncV2.increment.outboxEnqueue.ts`) and returns `Promise<{ id, inserted }>` — the minimum shape that lets a consumer-side adapter wrap `enqueueOutboxIncrement` as a one-liner. We intentionally do NOT re-import or re-export `EnqueueOutboxIncrementOk` from db-schema; the api-client mirror keeps the package boundary intact and is locked structurally by the existing PR #042e-mapping drift-tripwire test.
- **Storage errors propagate.** A `submit` throw is NOT swallowed — see the dedicated test. This keeps `sync_op_outbox_reject_total{reason}` cardinality bounded to the three documented build reasons; transport / FS-level retry policy lives one layer up (PR #040 retry policy, already landed).
- **Replay-safety contract is verbatim.** `inserted=false` (idempotent replay — existing row found under same `idempotencyKey`) is propagated as `{ ok: true, id, inserted: false }`, NOT a reject. This mirrors the contract documented in `enqueueOutboxIncrement`'s docstring and is asserted in the dedicated happy-path test.
- **Cardinality lock test** is a drift-tripwire: if `BuildSyncV2IncrementOpReason` ever grows a 4th literal, the assert fails — keeping observability dashboards under `sync_op_outbox_reject_total{reason}` from silently growing a new bucket without a legend update. Same pattern as `OP_LOG_TABLE_REGISTRY` / `APPLY_REJECT_REASONS` regression-locks elsewhere in the codebase.
- No migrations / no env changes / no HubChat tools / no auth surface touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `submitSyncV2IncrementOp` to `api-client` to build → map → enqueue PN-counter increment ops with one call. Uses a DI `submit` fn (mirror of `enqueueOutboxIncrement`) to keep `api-client` and `db-schema` decoupled.

- **New Features**
  - Exposes `submitSyncV2IncrementOp`, `SubmitSyncV2IncrementOpFn`, and result types.
  - Returns `{ ok: true, id, inserted }` or `{ ok: false, reason }` (`op_not_supported` | `missing_delta` | `invalid_delta`).
  - Passes through storage errors from `submit`; preserves idempotency via `idempotencyKey`.
  - Re-exported from `packages/api-client/src/index.ts`.
  - Adds 12 tests and updates `docs/planning/storage-roadmap.md`.

- **Bug Fixes**
  - Tests: replaced ULID-shaped `idempotencyKey` fixture with a low-entropy literal to avoid gitleaks false positives (no behavior change).

<sup>Written for commit 3489ac28fa8b7041b9409b702628eaa6d4498762. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

