### PR TITLE
feat(mobile): port ValueProgressBar to RN — S3.3 mobile parity

### DIFF
--- a/apps/mobile/src/core/dashboard/HubDashboard.tsx
+++ b/apps/mobile/src/core/dashboard/HubDashboard.tsx
@@ -47,6 +47,8 @@ import { useUser } from "@sergeant/api-client/react";
 import {
   getActiveModules,
   getHideInactiveModules,
+  getOnboardingGoals,
+  hasAnyValueProgressBar,
   isActiveModule,
   isFirstActionPending,
   isFirstRealEntryDone,
@@ -64,6 +66,7 @@ import { FirstActionHeroCard } from "./FirstActionHeroCard";
 import { HubInsightsPanel, type InsightItem } from "./HubInsightsPanel";
 import { SoftAuthPromptCard } from "./SoftAuthPromptCard";
 import { TodayFocusCard } from "./TodayFocusCard";
+import { ValueProgressBar } from "./ValueProgressBar";
 import { useDashboardFocus } from "./useDashboardFocus";
 import { useDashboardOrder } from "./useDashboardOrder";
 import { useModulePreviews } from "./useModulePreviews";
@@ -456,6 +459,23 @@ export function HubDashboard() {
             />
           )}
         </View>
+
+        {/* Value-promise bars (S3.3a + S3.3b mobile parity). Pre-FTUX
+            only — reads back the budget / habit / weekly target the
+            user spelled out in the wizard goals step so the empty hub
+            carries explicit intent. The shared helper returns []
+            when no active module has a goal, so we additionally
+            guard the entire row to avoid an empty wrapper view. */}
+        {!hasFirstRealEntry &&
+        hasAnyValueProgressBar({
+          activeModules,
+          goals: getOnboardingGoals(mmkvStore),
+        }) ? (
+          <ValueProgressBar
+            activeModules={activeModules}
+            goals={getOnboardingGoals(mmkvStore)}
+          />
+        ) : null}
 
         <View className="gap-2">
           <Text className="text-sm font-semibold text-fg-muted">Статус</Text>

--- a/apps/mobile/src/core/dashboard/ValueProgressBar.test.tsx
+++ b/apps/mobile/src/core/dashboard/ValueProgressBar.test.tsx
@@ -1,0 +1,81 @@
+import { render } from "@testing-library/react-native";
+
+import { EMPTY_GOALS } from "@sergeant/shared";
+
+import { ValueProgressBar } from "./ValueProgressBar";
+
+describe("ValueProgressBar (mobile, S3.3 parity)", () => {
+  it("renders nothing when no module has a goal", () => {
+    const { queryByTestId } = render(
+      <ValueProgressBar
+        activeModules={["finyk", "routine"]}
+        goals={EMPTY_GOALS}
+      />,
+    );
+    expect(queryByTestId("value-progress-bars")).toBeNull();
+  });
+
+  it("renders nothing when goals exist but their modules are not active", () => {
+    const { queryByTestId } = render(
+      <ValueProgressBar
+        activeModules={["fizruk"]}
+        goals={{ ...EMPTY_GOALS, finykBudget: 30000 }}
+      />,
+    );
+    expect(queryByTestId("value-progress-bars")).toBeNull();
+  });
+
+  it("renders a finyk bar with the wizard-formatted budget", () => {
+    const { getByTestId } = render(
+      <ValueProgressBar
+        activeModules={["finyk"]}
+        goals={{ ...EMPTY_GOALS, finykBudget: 30000 }}
+      />,
+    );
+
+    const bar = getByTestId("value-progress-bar-finyk");
+    // 30000 → "30 000 ₴" (NBSP between thousands; matches the wizard
+    // slider label).
+    expect(bar.props.accessibilityLabel).toMatch(
+      /Бюджет 30[ \u00a0]000 ₴ — Записано 0 ₴/,
+    );
+    expect(bar.props.accessibilityValue).toEqual({
+      now: 0,
+      min: 0,
+      max: 100,
+    });
+  });
+
+  it("renders a routine bar with the outcome-first label (S6.6 audit-guard)", () => {
+    const { getByTestId } = render(
+      <ValueProgressBar
+        activeModules={["routine"]}
+        goals={{ ...EMPTY_GOALS, routineFirstHabit: "water" }}
+      />,
+    );
+
+    const bar = getByTestId("value-progress-bar-routine");
+    expect(bar.props.accessibilityLabel).toBe(
+      "«Пити воду» — через 30 днів автоматично — Зараз: 0/30",
+    );
+  });
+
+  it("renders nutrition + fizruk bars when their goals are set (S3.3b)", () => {
+    const { getByTestId } = render(
+      <ValueProgressBar
+        activeModules={["nutrition", "fizruk"]}
+        goals={{
+          ...EMPTY_GOALS,
+          nutritionGoal: "maintain",
+          fizrukWeeklyGoal: 3,
+        }}
+      />,
+    );
+    expect(
+      getByTestId("value-progress-bar-nutrition").props.accessibilityLabel,
+    ).toBe("Підтримка ваги — 0 страв сьогодні");
+    expect(
+      getByTestId("value-progress-bar-fizruk").props.accessibilityLabel,
+    ).toBe("3×/тиждень — 0 з 3");
+  });
+});

--- a/apps/mobile/src/core/dashboard/ValueProgressBar.tsx
+++ b/apps/mobile/src/core/dashboard/ValueProgressBar.tsx
@@ -1,0 +1,80 @@
+/**
+ * Mobile port of `apps/web/src/core/hub/ValueProgressBar.tsx` — the
+ * pre-first-entry «value-promise» bar (FTUX S3.3a + S3.3b).
+ *
+ * Closes the S3.3 mobile parity gap explicitly tracked in
+ * `docs/launch/ftux-sprint-plan.md` (line 174):
+ *
+ *   > Mobile parity для `ValueProgressBar` (S3.3) ще не зроблена —
+ *   > окрема історія, відкладена як cross-cutting cleanup нижче.
+ *
+ * The bar list is computed by `buildValueProgressBars` from
+ * `@sergeant/shared` so this component only owns the RN/NativeWind
+ * presentation; copy and ordering are 100% in lockstep with web.
+ *
+ * Like the web version, this component is intentionally
+ * presentational:
+ *   - It renders `null` when no goal applies to any active module.
+ *   - It does not gate on `hasFirstRealEntry` — the parent
+ *     `HubDashboard` already drops the bar after the first real
+ *     entry, mirroring the web hub's render path.
+ *   - Goals come in as a prop; storage I/O lives at the call site.
+ */
+
+import { Text, View } from "react-native";
+
+import { buildValueProgressBars, type OnboardingGoals } from "@sergeant/shared";
+
+export interface ValueProgressBarProps {
+  /**
+   * Module ids the user has activated (e.g. via `getActiveModules`).
+   * A bar renders only when its module is in this list AND has a
+   * non-null goal. Empty list → no bars render.
+   */
+  activeModules: readonly string[];
+  /** Goals payload from `getOnboardingGoals(mobileKVStore)`. */
+  goals: OnboardingGoals;
+}
+
+export function ValueProgressBar({
+  activeModules,
+  goals,
+}: ValueProgressBarProps) {
+  const bars = buildValueProgressBars({ activeModules, goals });
+  if (bars.length === 0) return null;
+
+  return (
+    <View
+      className="flex flex-col gap-2"
+      testID="value-progress-bars"
+      accessibilityLabel="Прогрес до твоїх цілей"
+    >
+      {bars.map((bar) => (
+        <View
+          key={bar.testId}
+          testID={bar.testId}
+          className="flex-row items-center gap-3 px-1"
+          accessibilityRole="progressbar"
+          accessibilityValue={{ now: bar.percent, min: 0, max: 100 }}
+          accessibilityLabel={`${bar.label} — ${bar.current}`}
+        >
+          <View className="h-1.5 flex-1 overflow-hidden rounded-full bg-cream-200">
+            <View
+              style={{ width: `${bar.percent}%` }}
+              className="h-full rounded-full bg-brand-500"
+            />
+          </View>
+          <View className="flex-row items-center">
+            <Text className="text-xs font-medium text-fg" numberOfLines={1}>
+              {bar.label}
+            </Text>
+            <Text className="mx-1.5 text-xs text-fg-subtle">·</Text>
+            <Text className="text-xs text-fg-muted" numberOfLines={1}>
+              {bar.current}
+            </Text>
+          </View>
+        </View>
+      ))}
+    </View>
+  );
+}

--- a/apps/web/src/core/hub/ValueProgressBar.tsx
+++ b/apps/web/src/core/hub/ValueProgressBar.tsx
@@ -1,5 +1,5 @@
 /**
- * ValueProgressBar — pre-first-entry «value-promise» bar (FTUX S3.3a).
+ * ValueProgressBar — pre-first-entry «value-promise» bar (FTUX S3.3a + S3.3b).
  *
  * Sits where `OnboardingProgress` used to sit (above the bento grid,
  * gated on `!hasRealEntry`) but replaces the generic «N/4 модулів»
@@ -8,13 +8,10 @@
  * user just spelled out, so the «empty hub» moment carries explicit
  * intent instead of static guilt.
  *
- * For S3.3a we covered the two lowest-friction modules (routine +
- * finyk). S3.3b extends the same component to the remaining two
- * (fizruk + nutrition) without changing the public surface — the
- * call-site in `HubDashboard` keeps the original
- * `<ValueProgressBar activeModules goals/>` props.
- *
- * The component is intentionally _presentational_:
+ * The bar list is computed by `buildValueProgressBars` from
+ * `@sergeant/shared` so web and mobile (S3.3 mobile parity) share
+ * the exact same per-module copy and ordering. The component itself
+ * is intentionally _presentational_:
  *
  *   - It renders nothing when no goal applies to any active module.
  *   - It does not read `hasRealEntry` itself — the parent already
@@ -23,19 +20,14 @@
  *   - It does not read storage directly. Goals come in as a prop so
  *     this same component can be swapped into a Storybook fixture or
  *     a tour replay without seeding localStorage.
- *
- * Progress is always 0 % pre-first-entry (the only state in which the
- * bar renders), so the bar visually communicates «here's your goal,
- * here's where you are» rather than acting as a live tracker. Once
- * the user logs their first real entry the parent unmounts the bar
- * and the per-module dashboard cards take over the live-tracking
- * job. Keeping that contract explicit lets us avoid wiring real
- * data sources (manual expenses + Mono cache + routine completions
- * across multiple keys) into the hub-render path until the data is
- * actually meaningful.
  */
 
-import type { OnboardingGoals } from "@sergeant/shared";
+import {
+  buildValueProgressBars,
+  hasAnyValueProgressBar,
+  type OnboardingGoals,
+  type ValueProgressBarsInput,
+} from "@sergeant/shared";
 
 interface ValueProgressBarProps {
   /**
@@ -48,102 +40,11 @@ interface ValueProgressBarProps {
   goals: OnboardingGoals;
 }
 
-const ROUTINE_TARGET_DAYS = 30;
-
-const ROUTINE_HABIT_LABELS: Record<string, string> = {
-  water: "Пити воду",
-  exercise: "Зарядка",
-  reading: "Читання",
-  custom: "Своя звичка",
-};
-
-// Nutrition copy maps directly to the wizard's three goal options
-// (`packages/shared/src/lib/onboardingGoals.ts` — `nutrition_goal`).
-// We intentionally describe the *outcome the user picked* in the
-// label and the *daily-meal counter* in the `current` slot — the
-// daily counter resets, the goal does not, so they can't share a
-// surface without lying about progress.
-const NUTRITION_GOAL_LABELS: Record<"lose" | "gain" | "maintain", string> = {
-  lose: "Схуднути",
-  gain: "Набрати масу",
-  maintain: "Підтримка ваги",
-};
-
-function formatThousand(uah: number): string {
-  // 30000 → "30 000 ₴" — matches the slider label in the goals step
-  // (`apps/web/src/core/onboarding/GoalsStep.tsx`).
-  return `${uah.toLocaleString("uk-UA").replace(/,/g, " ")} ₴`;
-}
-
-interface BarData {
-  testId: string;
-  label: string;
-  current: string;
-  percent: number;
-}
-
-function buildBars(props: ValueProgressBarProps): BarData[] {
-  const { activeModules, goals } = props;
-  const active = new Set(activeModules);
-  const bars: BarData[] = [];
-
-  // Routine first — lowest-friction, matches FIRST_ACTION_PRIORITY.
-  // Outcome-first frame (S6.6 / B-4): the *label* names what the user
-  // is buying (an automatic habit after `ROUTINE_TARGET_DAYS` подряд),
-  // not the mechanism («Серія днів», «Streak»). The *current* slot is
-  // the position counter — kept terse so 0/N reads as "where you are
-  // on the way to automatic" rather than as a 0-streak shame indicator.
-  if (active.has("routine") && goals.routineFirstHabit) {
-    const habitLabel =
-      ROUTINE_HABIT_LABELS[goals.routineFirstHabit] ?? "Своя звичка";
-    bars.push({
-      testId: "value-progress-bar-routine",
-      label: `«${habitLabel}» — через ${ROUTINE_TARGET_DAYS} днів автоматично`,
-      current: `Зараз: 0/${ROUTINE_TARGET_DAYS}`,
-      percent: 0,
-    });
-  }
-
-  if (active.has("finyk") && goals.finykBudget !== null) {
-    bars.push({
-      testId: "value-progress-bar-finyk",
-      label: `Бюджет ${formatThousand(goals.finykBudget)}`,
-      current: "Записано 0 ₴",
-      percent: 0,
-    });
-  }
-
-  // Nutrition before fizruk — the wizard surfaces nutrition first when
-  // both goals exist, so the bar order mirrors the goal-step order
-  // and the user reads back their commitments in the same sequence
-  // they spelled them out.
-  if (active.has("nutrition") && goals.nutritionGoal !== null) {
-    bars.push({
-      testId: "value-progress-bar-nutrition",
-      label: NUTRITION_GOAL_LABELS[goals.nutritionGoal],
-      current: "0 страв сьогодні",
-      percent: 0,
-    });
-  }
-
-  if (active.has("fizruk") && goals.fizrukWeeklyGoal !== null) {
-    const target = goals.fizrukWeeklyGoal;
-    bars.push({
-      testId: "value-progress-bar-fizruk",
-      label: `${target}×/тиждень`,
-      current: `0 з ${target}`,
-      percent: 0,
-    });
-  }
-
-  return bars;
-}
-
 export function ValueProgressBar({
   activeModules,
   goals,
 }: ValueProgressBarProps) {
-  const bars = buildBars({ activeModules, goals });
+  const bars = buildValueProgressBars({ activeModules, goals });
   if (bars.length === 0) return null;
 
   return (
@@ -181,10 +82,10 @@ export function ValueProgressBar({
 }
 
 /**
- * Pure helper — exported for tests and for the hub render path that
- * needs to know «do we have any value-bar to show?» before deciding
- * whether to render the generic `OnboardingProgress` fallback.
+ * Re-export of the shared helper under the call-site's preferred
+ * name. The web `HubDashboard` reads back as `hasAnyValueBar(...)`
+ * and we keep that import surface stable across the refactor.
  */
-export function hasAnyValueBar(props: ValueProgressBarProps): boolean {
-  return buildBars(props).length > 0;
+export function hasAnyValueBar(props: ValueProgressBarsInput): boolean {
+  return hasAnyValueProgressBar(props);
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -57,6 +57,10 @@ export * from "./lib/onboarding";
 // Onboarding goal-setting (multi-step v2).
 export * from "./lib/onboardingGoals";
 
+// Pre-first-entry value-promise bars (S3.3 shared logic — used by
+// the web `<ValueProgressBar>` and the mobile RN port).
+export * from "./lib/valueProgressBars";
+
 // OnboardingWizard hero copy A/B (S1.1 + S1.2).
 export * from "./lib/onboardingHeroCopy";
 

--- a/packages/shared/src/lib/valueProgressBars.test.ts
+++ b/packages/shared/src/lib/valueProgressBars.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+
+import { EMPTY_GOALS } from "./onboardingGoals";
+
+import {
+  buildValueProgressBars,
+  hasAnyValueProgressBar,
+} from "./valueProgressBars";
+
+describe("buildValueProgressBars (S3.3 shared)", () => {
+  it("returns no bars when no module has a goal set", () => {
+    expect(
+      buildValueProgressBars({
+        activeModules: ["finyk", "routine"],
+        goals: EMPTY_GOALS,
+      }),
+    ).toEqual([]);
+  });
+
+  it("returns no bars when goals exist but their modules are not active", () => {
+    expect(
+      buildValueProgressBars({
+        activeModules: ["fizruk", "nutrition"],
+        goals: {
+          ...EMPTY_GOALS,
+          finykBudget: 30000,
+          routineFirstHabit: "water",
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  it("builds a routine bar with outcome-first label and 0/30 counter", () => {
+    const bars = buildValueProgressBars({
+      activeModules: ["routine"],
+      goals: { ...EMPTY_GOALS, routineFirstHabit: "water" },
+    });
+    expect(bars).toHaveLength(1);
+    expect(bars[0]).toEqual({
+      testId: "value-progress-bar-routine",
+      label: "«Пити воду» — через 30 днів автоматично",
+      current: "Зараз: 0/30",
+      percent: 0,
+    });
+  });
+
+  it("falls back to a generic habit label for unknown preset ids", () => {
+    const bars = buildValueProgressBars({
+      activeModules: ["routine"],
+      goals: { ...EMPTY_GOALS, routineFirstHabit: "custom" },
+    });
+    expect(bars).toHaveLength(1);
+    expect(bars[0]!.label).toBe("«Своя звичка» — через 30 днів автоматично");
+  });
+
+  it("formats the finyk budget in thousands with the wizard separator", () => {
+    const bars = buildValueProgressBars({
+      activeModules: ["finyk"],
+      goals: { ...EMPTY_GOALS, finykBudget: 30000 },
+    });
+    expect(bars).toHaveLength(1);
+    // 30000 → "30 000 ₴" (NBSP between thousands; `replace(/,/g, " ")` upgrades
+    // toLocaleString's separator to the visible space the slider label uses).
+    expect(bars[0]!.label).toMatch(/Бюджет 30[ \u00a0]000 ₴/);
+    expect(bars[0]!.current).toBe("Записано 0 ₴");
+  });
+
+  it("renders a nutrition bar with the goal-specific outcome label", () => {
+    const bars = buildValueProgressBars({
+      activeModules: ["nutrition"],
+      goals: { ...EMPTY_GOALS, nutritionGoal: "maintain" },
+    });
+    expect(bars).toHaveLength(1);
+    expect(bars[0]).toEqual({
+      testId: "value-progress-bar-nutrition",
+      label: "Підтримка ваги",
+      current: "0 страв сьогодні",
+      percent: 0,
+    });
+  });
+
+  it("renders a fizruk bar with the per-week target", () => {
+    const bars = buildValueProgressBars({
+      activeModules: ["fizruk"],
+      goals: { ...EMPTY_GOALS, fizrukWeeklyGoal: 3 },
+    });
+    expect(bars).toHaveLength(1);
+    expect(bars[0]).toEqual({
+      testId: "value-progress-bar-fizruk",
+      label: "3×/тиждень",
+      current: "0 з 3",
+      percent: 0,
+    });
+  });
+
+  it("orders bars routine → finyk → nutrition → fizruk", () => {
+    const bars = buildValueProgressBars({
+      activeModules: ["fizruk", "nutrition", "finyk", "routine"],
+      goals: {
+        finykBudget: 30000,
+        fizrukWeeklyGoal: 4,
+        nutritionGoal: "lose",
+        routineFirstHabit: "water",
+      },
+    });
+    expect(bars.map((b) => b.testId)).toEqual([
+      "value-progress-bar-routine",
+      "value-progress-bar-finyk",
+      "value-progress-bar-nutrition",
+      "value-progress-bar-fizruk",
+    ]);
+  });
+
+  it("hides bars whose module is not active even if goals are set", () => {
+    const bars = buildValueProgressBars({
+      activeModules: ["routine"],
+      goals: {
+        ...EMPTY_GOALS,
+        fizrukWeeklyGoal: 3,
+        nutritionGoal: "lose",
+        routineFirstHabit: "water",
+      },
+    });
+    expect(bars.map((b) => b.testId)).toEqual(["value-progress-bar-routine"]);
+  });
+});
+
+describe("hasAnyValueProgressBar (S3.3 shared)", () => {
+  it("is false for empty goals", () => {
+    expect(
+      hasAnyValueProgressBar({
+        activeModules: ["finyk", "routine"],
+        goals: EMPTY_GOALS,
+      }),
+    ).toBe(false);
+  });
+
+  it("is true when at least one active module has a goal", () => {
+    expect(
+      hasAnyValueProgressBar({
+        activeModules: ["routine"],
+        goals: { ...EMPTY_GOALS, routineFirstHabit: "water" },
+      }),
+    ).toBe(true);
+  });
+
+  it("is false when goals exist but their modules are not active", () => {
+    expect(
+      hasAnyValueProgressBar({
+        activeModules: ["fizruk"],
+        goals: { ...EMPTY_GOALS, finykBudget: 10000 },
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/shared/src/lib/valueProgressBars.ts
+++ b/packages/shared/src/lib/valueProgressBars.ts
@@ -1,0 +1,157 @@
+/**
+ * Value-progress bars — pure pre-first-entry «value-promise» logic
+ * shared between web (`apps/web/src/core/hub/ValueProgressBar.tsx`)
+ * and mobile (`apps/mobile/src/core/dashboard/ValueProgressBar.tsx`).
+ *
+ * The hub renders a per-module bar that reads back the budget /
+ * habit / weekly-target the user spelled out in the wizard goals
+ * step. Pre-first-entry the bar is always at 0 % — it visually
+ * communicates «here's your goal, here's where you are» rather than
+ * acting as a live tracker. After the first real entry the parent
+ * unmounts the bar entirely and the per-module dashboard cards take
+ * over the live-tracking job.
+ *
+ * Bar order mirrors the wizard goal-step order
+ * (`routine → finyk → nutrition → fizruk`) so the user reads back
+ * their commitments in the same sequence they spelled them out.
+ *
+ * Mirrors the FTUX S3.3 spec (`docs/launch/ftux-sprint-plan.md`):
+ *   - S3.3a — finyk + routine bars.
+ *   - S3.3b — nutrition + fizruk bars (extension without changing
+ *     the public surface).
+ *   - S3.3 mobile parity — RN port reusing this same shared helper.
+ *
+ * The helper is intentionally _presentational_:
+ *   - It returns nothing when no goal applies to any active module.
+ *   - It does not read `hasRealEntry` itself — the parent already
+ *     handles the «hide after first real entry» gate.
+ *   - It does not read storage directly. Goals come in as an
+ *     argument so the same helper can be swapped into a Storybook
+ *     fixture or a tour replay without seeding storage.
+ */
+
+import type { OnboardingGoals } from "./onboardingGoals";
+
+const ROUTINE_TARGET_DAYS = 30;
+
+const ROUTINE_HABIT_LABELS: Record<string, string> = {
+  water: "Пити воду",
+  exercise: "Зарядка",
+  reading: "Читання",
+  custom: "Своя звичка",
+};
+
+// Nutrition copy maps directly to the wizard's three goal options
+// (`nutrition_goal` in `onboardingGoals.ts`). We intentionally
+// describe the *outcome the user picked* in the label and the
+// *daily-meal counter* in the `current` slot — the daily counter
+// resets, the goal does not, so they can't share a surface without
+// lying about progress.
+const NUTRITION_GOAL_LABELS: Record<"lose" | "gain" | "maintain", string> = {
+  lose: "Схуднути",
+  gain: "Набрати масу",
+  maintain: "Підтримка ваги",
+};
+
+function formatThousand(uah: number): string {
+  // 30000 → "30 000 ₴" — matches the slider label in the goals step.
+  return `${uah.toLocaleString("uk-UA").replace(/,/g, " ")} ₴`;
+}
+
+export interface ValueProgressBarData {
+  /** Stable id used as `data-testid` (web) / `testID` (mobile). */
+  testId: string;
+  /** The outcome promise — what the user is buying. */
+  label: string;
+  /** Current position (counter, formatted). */
+  current: string;
+  /** 0–100, always 0 pre-first-entry. */
+  percent: number;
+}
+
+export interface ValueProgressBarsInput {
+  /**
+   * Module ids the user has activated (e.g. via vibePicks). A bar
+   * is included only when its module is in this list AND has a
+   * non-null goal. Empty list → no bars.
+   */
+  activeModules: readonly string[];
+  /** Goals payload from `getOnboardingGoals(store)`. */
+  goals: OnboardingGoals;
+}
+
+/**
+ * Build the ordered list of value-progress bars to render.
+ *
+ * Order mirrors the wizard goal-step order (and
+ * `FIRST_ACTION_PRIORITY`) so the user reads back their
+ * commitments in the same sequence they spelled them out.
+ */
+export function buildValueProgressBars(
+  input: ValueProgressBarsInput,
+): readonly ValueProgressBarData[] {
+  const { activeModules, goals } = input;
+  const active = new Set(activeModules);
+  const bars: ValueProgressBarData[] = [];
+
+  // Routine first — lowest-friction, matches FIRST_ACTION_PRIORITY.
+  // Outcome-first frame (S6.6 / B-4): the *label* names what the
+  // user is buying (an automatic habit after `ROUTINE_TARGET_DAYS`
+  // подряд), not the mechanism («Серія днів», «Streak»). The
+  // *current* slot is the position counter — kept terse so 0/N
+  // reads as "where you are on the way to automatic" rather than
+  // as a 0-streak shame indicator.
+  if (active.has("routine") && goals.routineFirstHabit) {
+    const habitLabel =
+      ROUTINE_HABIT_LABELS[goals.routineFirstHabit] ?? "Своя звичка";
+    bars.push({
+      testId: "value-progress-bar-routine",
+      label: `«${habitLabel}» — через ${ROUTINE_TARGET_DAYS} днів автоматично`,
+      current: `Зараз: 0/${ROUTINE_TARGET_DAYS}`,
+      percent: 0,
+    });
+  }
+
+  if (active.has("finyk") && goals.finykBudget !== null) {
+    bars.push({
+      testId: "value-progress-bar-finyk",
+      label: `Бюджет ${formatThousand(goals.finykBudget)}`,
+      current: "Записано 0 ₴",
+      percent: 0,
+    });
+  }
+
+  // Nutrition before fizruk — the wizard surfaces nutrition first
+  // when both goals exist, so the bar order mirrors the goal-step
+  // order and the user reads back their commitments in the same
+  // sequence they spelled them out.
+  if (active.has("nutrition") && goals.nutritionGoal !== null) {
+    bars.push({
+      testId: "value-progress-bar-nutrition",
+      label: NUTRITION_GOAL_LABELS[goals.nutritionGoal],
+      current: "0 страв сьогодні",
+      percent: 0,
+    });
+  }
+
+  if (active.has("fizruk") && goals.fizrukWeeklyGoal !== null) {
+    const target = goals.fizrukWeeklyGoal;
+    bars.push({
+      testId: "value-progress-bar-fizruk",
+      label: `${target}×/тиждень`,
+      current: `0 з ${target}`,
+      percent: 0,
+    });
+  }
+
+  return bars;
+}
+
+/**
+ * Pure helper — exported for callers that need to know «do we have
+ * any value-bar to show?» before deciding whether to render the
+ * generic `OnboardingProgress` fallback.
+ */
+export function hasAnyValueProgressBar(input: ValueProgressBarsInput): boolean {
+  return buildValueProgressBars(input).length > 0;
+}

--- a/scripts/staged-typecheck.mjs
+++ b/scripts/staged-typecheck.mjs
@@ -12,6 +12,16 @@
 // paths rewritten relative to that directory. That keeps `paths`/`extends`
 // resolution faithful to each sub-project (apps/web, apps/server, packages/*).
 //
+// `tsc-files` rewrites the project's `tsconfig.json` with `include: []` and
+// only the staged files in `files`. That drops any global type-augmentation
+// `.d.ts` that the project relies on through its `include` list (e.g. mobile's
+// `nativewind-env.d.ts` reference, which makes `className` valid on RN
+// `View`/`Text`/`Pressable`). Without it every staged mobile change would fail
+// pre-commit with TS2769 "No overload matches this call. Property 'className'
+// does not exist". We re-add those globals via `EXTRA_INPUTS_BY_TSCONFIG`,
+// keyed by the tsconfig's path relative to the repo root, so they ship as
+// extra `files` entries to `tsc-files`.
+//
 // Usage (from `lint-staged`):
 //   "*.{ts,tsx}": ["node scripts/staged-typecheck.mjs"]
 //
@@ -44,6 +54,17 @@ function findTsconfig(absFile) {
 }
 
 const TS_RE = /\.(ts|tsx)$/;
+
+/**
+ * Per-project global `.d.ts` references whose `include`-driven loading is
+ * stripped by `tsc-files`. Keyed by the tsconfig path relative to the repo
+ * root; each value is a list of paths relative to the same tsconfig's
+ * directory. Files listed here are appended to every `tsc-files` invocation
+ * for that group so the global type augmentations they bring in stay in scope.
+ */
+const EXTRA_INPUTS_BY_TSCONFIG = {
+  "apps/mobile/tsconfig.json": ["nativewind-env.d.ts"],
+};
 
 function main() {
   const staged = process.argv
@@ -80,12 +101,17 @@ function main() {
   for (const [tsconfig, files] of groups) {
     const dir = dirname(tsconfig);
     const rel = files.map((f) => relative(dir, f));
+    const tsconfigKey = relative(REPO_ROOT, tsconfig).replaceAll("\\", "/");
+    const extras = (EXTRA_INPUTS_BY_TSCONFIG[tsconfigKey] ?? []).filter(
+      (p) => existsSync(join(dir, p)) && !rel.includes(p),
+    );
     console.log(
-      `[staged-typecheck] ${rel.length} file(s) → ${relative(REPO_ROOT, tsconfig)}`,
+      `[staged-typecheck] ${rel.length} file(s) → ${tsconfigKey}` +
+        (extras.length ? ` (+${extras.length} global d.ts)` : ""),
     );
     const result = spawnSync(
       "pnpm",
-      ["exec", "tsc-files", "--noEmit", "--skipLibCheck", ...rel],
+      ["exec", "tsc-files", "--noEmit", "--skipLibCheck", ...rel, ...extras],
       {
         stdio: "inherit",
         cwd: dir,


### PR DESCRIPTION
## Summary

Closes the **S3.3 mobile parity** gap explicitly tracked in `docs/launch/ftux-sprint-plan.md` (cross-cutting cleanup, `~150 LOC RN port`). Mobile hub now renders the pre-first-entry **value-promise bars** so the empty-hub moment carries the user's spelled-out intent (budget / habit / weekly target) instead of a static guilt screen — same UX the web hub has shipped since S3.3a/b.

To prevent web↔mobile drift, the per-module copy and bar order live in a new shared helper (`buildValueProgressBars` / `hasAnyValueProgressBar` in `@sergeant/shared`); web `ValueProgressBar.tsx` is refactored to consume it, and the mobile component is a thin RN/NativeWind UI on top of the same data.

Also includes a small infra fix to `scripts/staged-typecheck.mjs` so global type-augmentation `.d.ts` (e.g. `nativewind-env.d.ts`) stay in scope under `tsc-files` — without it any staged mobile change touching `className=` would fail pre-commit.

Changes (split into 2 commits):

1. `chore(ci): preserve global d.ts in staged-typecheck for mobile className types` — `EXTRA_INPUTS_BY_TSCONFIG` re-adds globals stripped by `tsc-files` `include: []`. No behaviour change for projects without an entry.
2. `feat(mobile): port ValueProgressBar to RN — S3.3 mobile parity` — actual feature work:
   - `packages/shared/src/lib/valueProgressBars.{ts,test.ts}`: new pure helpers (`buildValueProgressBars`, `hasAnyValueProgressBar`) + barrel export.
   - `apps/web/src/core/hub/ValueProgressBar.tsx`: refactor to consume the shared helper. Existing tests pass via a thin `hasAnyValueBar` wrapper that preserves the call-site API.
   - `apps/mobile/src/core/dashboard/ValueProgressBar.tsx`: new RN component with `accessibilityRole="progressbar"` and matching testIDs (`value-progress-bar-finyk` etc.).
   - `apps/mobile/src/core/dashboard/ValueProgressBar.test.tsx`: Jest tests covering ordering / empty / nutrition+fizruk extension.
   - `apps/mobile/src/core/dashboard/HubDashboard.tsx`: render the bars between the hero slot and the status row, gated on `!hasFirstRealEntry && hasAnyValueProgressBar(...)`.

LOC (excluding test files): ~170. Well under the 300-LOC PR cap.

## Governing Skill

- Primary skill: `.agents/skills/sergeant-mobile/SKILL.md` (RN + NativeWind component port)
- Secondary skill (if truly needed): `.agents/skills/sergeant-shared/SKILL.md` (extracting cross-platform pure helper into `@sergeant/shared`)

## Playbook

- Primary playbook: n/a
- Why this playbook: n/a
- If no playbook matched, why: this is a feature port, not a recurring recipe in `docs/playbooks/`. The pattern (extract pure helper to `@sergeant/shared`, consume from both `apps/web` and `apps/mobile`) is documented in AGENTS.md "Module ownership map".

## Verification

```bash
pnpm --filter @sergeant/shared run lint
pnpm --filter @sergeant/web   run lint
pnpm --filter @sergeant/mobile run lint
pnpm --filter @sergeant/db-schema build      # required: provides ./migrate/sqlite types
pnpm --filter @sergeant/web    run typecheck # passes
pnpm --filter @sergeant/mobile run typecheck # passes
pnpm --filter @sergeant/web    exec vitest run src/core/hub/ValueProgressBar  # 16 / 16
pnpm --filter @sergeant/shared exec vitest run src/lib/valueProgressBars       # passes
```

Additional checks:

- [x] Local smoke / manual validation completed (lint + typecheck + targeted vitest suites pass).
- [x] Surface-specific checks completed (web tests still pass via `hasAnyValueBar` wrapper; shared lib has its own audit-guard test for outcome-first label frame).
- Note: `apps/mobile` jest run requires Node 20 (we verified the pre-existing test suites also fail under Node 22 due to `jest-expo`'s setup expecting RN 0.76 native modules; not introduced by this PR).

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. (`docs/launch/ftux-sprint-plan.md` updated as part of the sprint-status sweep alongside this PR.)
- [x] I checked whether `AGENTS.md` needed an update. (No update needed — the module ownership table already covers `apps/mobile/src/core/**` and `packages/shared/**`.)
- [x] I checked whether a playbook or skill needed an update. (No — existing skills already cover the patterns used.)
- [x] I checked whether governance docs or review docs needed an update. (No — same hard-rule surface.)

Updated docs:

- `docs/launch/ftux-sprint-plan.md` (sprint-status sweep PR, separate)

## Risk and Rollout

- User-visible risk: **low**. Mobile gains a new pre-first-entry visual on the empty hub for users who completed the onboarding wizard. Hidden once `hasFirstRealEntry === true`. Web is a non-functional refactor (delegates logic to shared helper); existing tests guarantee unchanged DOM/output.
- Rollout / deploy order: ship together — the shared helper is a build-time `@sergeant/shared` change consumed by both web and mobile from the same revision. No runtime feature flag needed (already gated on existing `!hasFirstRealEntry` guard).
- Backout plan: revert this PR; web component falls back to its previous in-file logic, mobile stops rendering the bars. No data shape changes, no migrations, no API changes.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian. (`docs/launch/ftux-sprint-plan.md` stays UA — sprint-status sweep PR.)
- [x] I did not use `--no-verify`.

## Reviewer Notes

- The `chore(ci)` commit is split out specifically so the diff is easy to review independently. It re-adds `nativewind-env.d.ts` to `tsc-files` invocations for `apps/mobile/tsconfig.json`. Without it, every staged mobile change touching a `className=` prop (which is most mobile UI work) fails pre-commit with TS2769. Verified by running `pnpm exec tsc-files --noEmit --skipLibCheck` against the unmodified `apps/mobile/src/core/dashboard/HubDashboard.tsx` from `main` — it fails until the global d.ts is appended.
- No HubChat tool / migration / auth surface touched.
- Outcome-first label frame from S6.6 audit-guard is preserved in the shared helper; the existing audit-guard test in `valueProgressBars.test.ts` locks the per-module wording.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports the ValueProgressBar to React Native to achieve S3.3 mobile parity. Mobile now shows pre-first-entry value bars (budget, habit, weekly target), and web/mobile share the same logic from `@sergeant/shared`.

- **New Features**
  - Added `apps/mobile` `ValueProgressBar` (RN/NativeWind) with `accessibilityRole="progressbar"` and stable testIDs; rendered in `HubDashboard` before the Status row when `!hasFirstRealEntry` and `hasAnyValueProgressBar(...)`.
  - Introduced shared helpers in `@sergeant/shared`: `buildValueProgressBars` and `hasAnyValueProgressBar` (unified copy and ordering; tests included).
  - Refactored web `ValueProgressBar` to consume the shared helper; kept a thin `hasAnyValueBar` wrapper for existing imports. No functional change on web.

- **Bug Fixes**
  - Updated `scripts/staged-typecheck.mjs` to preserve global `.d.ts` in staged typechecks via `EXTRA_INPUTS_BY_TSCONFIG` (adds `apps/mobile/nativewind-env.d.ts`) so RN `className` types don’t fail pre-commit.

<sup>Written for commit 8e91ee0fe4974b68caa4bed3d5b2c5a657f349d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

