### PR TITLE
ci(ci): replace ls|grep with find in db-backup-verify (SC2010)

### DIFF
--- a/.github/workflows/db-backup-verify.yml
+++ b/.github/workflows/db-backup-verify.yml
@@ -139,7 +139,7 @@ jobs:
           echo "- Latest migration: \`${MAX_MIGRATION}\`" >> "$GITHUB_STEP_SUMMARY"
 
           # Compare with filesystem migration count
-          FS_COUNT=$(ls apps/server/src/migrations/*.sql 2>/dev/null | grep -v '.down.' | wc -l)
+          FS_COUNT=$(find apps/server/src/migrations -maxdepth 1 -name '*.sql' ! -name '*.down.*' 2>/dev/null | wc -l)
           echo "- Filesystem migrations (non-down): **${FS_COUNT}**" >> "$GITHUB_STEP_SUMMARY"
 
           if [ "$MIGRATION_COUNT" -lt 1 ]; then


### PR DESCRIPTION
## Summary

Закриваю довготривалу `Workflow lint (actionlint)` failure на main (досі red на `05679f91` і ще пів-десятка попередніх коммітах). Корінь — SC2010 від shellcheck в inline `run:` блоці `.github/workflows/db-backup-verify.yml:142`:

```diff
- FS_COUNT=$(ls apps/server/src/migrations/*.sql 2>/dev/null | grep -v '.down.' | wc -l)
+ FS_COUNT=$(find apps/server/src/migrations -maxdepth 1 -name '*.sql' ! -name '*.down.*' 2>/dev/null | wc -l)
```

Семантика лічильника не змінюється — попередній вираз виключав шляхи що містять `.down.` (всі такі — `*.down.sql` файли в migrations/), новий — імена що матчать `*.down.*`, що дає той самий set, бо `.down.` у migrations/ зустрічається лише як infix перед розширенням (`008_mono_integration.down.sql`).

Інші 3 пункти з вихідного бриф-A (mdlink check / ADR graph / Playbook trigger index) **вже залатано на main комітом** [`57b87c87`](https://github.com/Skords-01/Sergeant/commit/57b87c87) "chore(docs): unblock main CI — ADR-0035 status, playbook index, prettier ignore". На `05679f91`:
- `Markdown link checker` — ✅ success (4 broken external links покриті allowlist + npm/* pattern).
- `ADR graph (statuses, supersede, README index)` — ✅ success (ADR-0035 status canonicalized).
- `Playbook trigger index (in sync)` — ✅ success (INDEX.md re-generated).

Тому цей PR — точковий A1-only, як єдиний реально outstanding gate.

## Governing Skill

- Primary skill: `.agents/skills/sergeant-start-here/SKILL.md` (entrypoint + governance routing)
- Secondary skill (if truly needed): n/a (single-line shell-fix у CI workflow; no specialist surface)

## Playbook

- Primary playbook: n/a — це не feature-PR. Mechanical CI-fix.
- Why this playbook: однорядкова заміна shell-конструкції; жодний playbook не покриває цей клас змін окремо.
- If no playbook matched, why: одиночний shellcheck-fix без runtime-impact; рутинне обслуговування CI.

## Verification

```bash
# 1. actionlint locally — same flags as the workflow uses
actionlint -color -ignore 'shellcheck reported issue in this script: SC[0-9]+:(info|style):'
# → no diagnostics, exit 0.

# 2. Re-confirm the markdown / docs gates that A2/A3/A4 fixed are green here too
pnpm docs:check-adr-graph                       # OK — 44 ADR(s) checked, graph is consistent.
pnpm docs:gen-playbook-index --check            # ✅ docs/playbooks/INDEX.md is up to date (46 playbooks).
node scripts/docs/check-markdown-links.mjs --strict-external
                                                 # → 2647 internal links, 1296 external links.
                                                 # ✅ All markdown links resolve.
```

Additional checks:

- [x] Local smoke / manual validation completed (actionlint 1.7.7 ran clean against full `.github/workflows/`)
- [x] Surface-specific checks completed (no app surface — CI workflow only)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. (none — single-line shell-fix у `.github/workflows/`; no doc surface changed)
- [x] I checked whether `AGENTS.md` needed an update. (нічого — Hard Rules не зачіпає; `db-backup-verify.yml` Mirror на `docs/runbooks/database-backup-restore.md § 4` зберігається.)
- [x] I checked whether a playbook or skill needed an update. (n/a)
- [x] I checked whether governance docs or review docs needed an update. (n/a)

Updated docs:

- n/a

## Risk and Rollout

- User-visible risk: **none.** Workflow CI-only change; runtime apps untouched. Якщо `find ... -maxdepth 1 -name '*.sql' ! -name '*.down.*'` повертає інший count за тих самих файлів, то це бажана корекція (SC2010 й попереджав, що `ls | grep` ламається на dot-files / non-alphanumeric — тут таких немає, але майбутнє додання — наприклад, `028_payment.recovery.sql` — старим виразом не виключилось би, новим — теж не виключиться, бо `.down.` infix відсутній. Семантика тотожна).
- Rollout / deploy order: PR можна merge без координації — Workflow fires on `schedule:` + `workflow_dispatch:`, не блокує deploy.
- Backout plan: revert PR; вплив зворотний.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian. (no docs touched)
- [x] I did not use `--no-verify`.

## Reviewer Notes

- **Чому A2/A3/A4 не в цьому PR:** Я отримав scope "A1+A2+A3+A4 одним PR" від requester-а на основі знімку CI з мого попереднього PR ([#1895](https://github.com/Skords-01/Sergeant/pull/1895), коміт `0eb4fbef`). Між тим знімком та цим PR Skords-01 запушив `57b87c87` на main, що вже закрило 3 з 4. Тому коректний поточний скоуп — A1-only. Шапка PR і summary це фіксують, щоб не виглядало як scope-drift від requester-у.
- **Шкідні-ефекти, які я перевірив:** `find -maxdepth 1` НЕ йде у sub-каталоги (yдентично `ls migrations/*.sql`). `! -name '*.down.*'` — POSIX find primary, працює і на BSD-find (macOS) і на GNU-find (Linux runner). У workflow runs тільки на `ubuntu-latest` (рядок 16 файлу).
- **Не закриває в цьому PR:** Решту pre-existing main CI failures (`Test coverage (vitest)`, `Build debug APK`, `Build iOS Simulator (Debug)`, `Build Storybook`, `Visual regression (Argos)`, `Docs-automation scripts unit tests`, `Critical-flow E2E (Playwright)`) — це окремі PR-и (option A5/A6/A7/A8 у моєму попередньому уточненні). Вони не залежать від actionlint.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced ls|grep with find in the db-backup-verify workflow to safely count non-down .sql migrations and comply with shellcheck SC2010. This unblocks the Workflow lint (actionlint) job on main with no change to migration count semantics.

<sup>Written for commit 3595c02be4bf5507fe11c96bd74449dcf0fb2289. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

