### PR TITLE
ci(ci): build @sergeant/db-schema before web bundle in mobile-shell workflows

### DIFF
--- a/.github/workflows/mobile-shell-android-release.yml
+++ b/.github/workflows/mobile-shell-android-release.yml
@@ -92,6 +92,15 @@ jobs:
       - name: Install JS deps
         run: pnpm install --frozen-lockfile
 
+      # Vite/Rolldown needs `@sergeant/db-schema`'s `dist/` to resolve
+      # `@sergeant/db-schema/sqlite/migrations` from the web bundle (see
+      # `apps/web/src/modules/{nutrition,fizruk,routine}/lib/clientMigrate.ts`).
+      # The exports map only ships built artefacts; without this step
+      # `pnpm --filter @sergeant/mobile-shell build:web` errors with
+      # `Rolldown failed to resolve import "@sergeant/db-schema/sqlite/migrations"`.
+      - name: Build @sergeant/db-schema
+        run: pnpm --filter @sergeant/db-schema build
+
       - name: Build web bundle
         # `VITE_TARGET=capacitor` via `@sergeant/mobile-shell#build:web`
         # disables vite-plugin-pwa for the shell build. Emits to

--- a/.github/workflows/mobile-shell-android.yml
+++ b/.github/workflows/mobile-shell-android.yml
@@ -82,6 +82,18 @@ jobs:
       - name: Install JS deps
         run: pnpm install --frozen-lockfile
 
+      # `pnpm build:web` (vite build) calls Rolldown to resolve the web
+      # bundle's imports. `apps/web/src/modules/{nutrition,fizruk,routine}/lib/clientMigrate.ts`
+      # imports `@sergeant/db-schema/sqlite/migrations`, whose `exports`
+      # map points at `./dist/sqlite/migrations/index.js` — the package's
+      # build artefact. Without this step the resolver errors with
+      # `Rolldown failed to resolve import "@sergeant/db-schema/sqlite/migrations"`
+      # and the whole job aborts before Capacitor sync. Mirrors the
+      # explicit prebuild already present in `ci.yml > critical-flow`,
+      # `extended-e2e.yml`, and `visual-regression.yml`.
+      - name: Build @sergeant/db-schema
+        run: pnpm --filter @sergeant/db-schema build
+
       - name: Build web bundle
         # Emits to apps/server/dist (see apps/web/vite.config.js).
         # capacitor.config.ts points `webDir` at this path.

--- a/.github/workflows/mobile-shell-ios-release.yml
+++ b/.github/workflows/mobile-shell-ios-release.yml
@@ -113,6 +113,15 @@ jobs:
       - name: Install JS deps
         run: pnpm install --frozen-lockfile
 
+      # Vite/Rolldown needs `@sergeant/db-schema`'s `dist/` to resolve
+      # `@sergeant/db-schema/sqlite/migrations` from the web bundle (see
+      # `apps/web/src/modules/{nutrition,fizruk,routine}/lib/clientMigrate.ts`).
+      # Without this step `pnpm --filter @sergeant/mobile-shell build:web`
+      # fails with `Rolldown failed to resolve import` and aborts the
+      # release archive.
+      - name: Build @sergeant/db-schema
+        run: pnpm --filter @sergeant/db-schema build
+
       - name: Build web bundle (Capacitor variant)
         # `mobile-shell#build:web` delegates to `@sergeant/web build:capacitor`
         # (`VITE_TARGET=capacitor`), which strips `vite-plugin-pwa` out of

--- a/.github/workflows/mobile-shell-ios.yml
+++ b/.github/workflows/mobile-shell-ios.yml
@@ -80,6 +80,18 @@ jobs:
       - name: Install JS deps
         run: pnpm install --frozen-lockfile
 
+      # `pnpm build:web` (vite build) calls Rolldown to resolve the web
+      # bundle's imports. `apps/web/src/modules/{nutrition,fizruk,routine}/lib/clientMigrate.ts`
+      # imports `@sergeant/db-schema/sqlite/migrations`, whose `exports`
+      # map points at `./dist/sqlite/migrations/index.js` — the package's
+      # build artefact. Without this step the resolver errors with
+      # `Rolldown failed to resolve import "@sergeant/db-schema/sqlite/migrations"`
+      # and the whole job aborts before xcodebuild. Mirrors the explicit
+      # prebuild already present in `ci.yml > critical-flow`,
+      # `extended-e2e.yml`, and `visual-regression.yml`.
+      - name: Build @sergeant/db-schema
+        run: pnpm --filter @sergeant/db-schema build
+
       - name: Build web bundle
         run: pnpm build:web
 


### PR DESCRIPTION
## Summary

Fix `Rolldown failed to resolve import "@sergeant/db-schema/sqlite/migrations"` in the 4 `mobile-shell-*` workflows by adding the explicit `pnpm --filter @sergeant/db-schema build` step that `ci.yml > critical-flow`, `extended-e2e.yml`, and `visual-regression.yml` already use.

The `apps/web/src/modules/{nutrition,fizruk,routine}/lib/clientMigrate.ts` files import the `./sqlite/migrations` subpath of `@sergeant/db-schema`, whose `exports` map only ships **built** artefacts (`./dist/sqlite/migrations/index.js`). Without prebuild, Vite/Rolldown can't resolve the import and aborts before Capacitor sync — this is the cause of the persistent red on `Mobile Shell (Android)` / `Mobile Shell (iOS)` on every push to main since the subpath landed.

Touched 4 workflows (block A of the CI audit triage):

- `.github/workflows/mobile-shell-android.yml` — debug APK on PR
- `.github/workflows/mobile-shell-android-release.yml` — release AAB+APK on tag
- `.github/workflows/mobile-shell-ios.yml` — Simulator debug build on PR
- `.github/workflows/mobile-shell-ios-release.yml` — TestFlight archive on tag

`detox-android.yml` / `detox-ios.yml` are out of scope of this PR — they fail with a different root cause (`TypeError: Listener is not a constructor` in Detox + Jest 30 `testEnvironment` glue, see `apps/mobile/e2e/environment.js:18`). Tracked separately.

## Governing Skill

- Primary skill: `.agents/skills/sergeant-start-here/SKILL.md` (entrypoint + governance routing)
- Secondary skill (if truly needed): n/a (CI workflow YAML edits — no specialist surface)

## Playbook

- Primary playbook: `docs/playbooks/fix-failing-ci.md`
- Why this playbook: persistent red on a workflow class after a package's `exports` map gained a new subpath; trigger matches "build/runtime-specific job".
- If no playbook matched, why: n/a — playbook-aligned.

## Verification

```bash
# 1. Reproduce the failure mode locally
rm -rf packages/db-schema/dist
pnpm --filter @sergeant/web build
# → Rolldown failed to resolve import "@sergeant/db-schema/sqlite/migrations"
#   from ".../apps/web/src/modules/nutrition/lib/clientMigrate.ts" (matches CI red)

# 2. Apply the fix
pnpm --filter @sergeant/db-schema build
ls packages/db-schema/dist/sqlite/migrations/
# → index.d.ts  index.d.ts.map  index.js  index.js.map

# 3. Re-run the failing command
pnpm build:web
# → ✓ built (no Rolldown error; vite emits apps/server/dist as expected)
```

Additional checks:

- [x] Local smoke / manual validation completed (`pnpm build:web` clean after explicit `pnpm --filter @sergeant/db-schema build`)
- [x] Surface-specific checks completed (workflow YAML — diff is 4 × `Build @sergeant/db-schema` step + comment block; nothing else moved)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. (none — CI step parity with already-correct workflows; no doc surface changed)
- [x] I checked whether `AGENTS.md` needed an update. (Hard Rules / monorepo invariants untouched.)
- [x] I checked whether a playbook or skill needed an update. (Playbook `docs/playbooks/fix-failing-ci.md` already covers this trigger class; no edit needed.)
- [x] I checked whether governance docs or review docs needed an update. (n/a)

Updated docs:

- n/a

## Risk and Rollout

- User-visible risk: **none.** CI-only change; runtime apps untouched. Adds ~6-10 s of `tsc` per affected workflow run, recovered next time the action cache hits the same step.
- Rollout / deploy order: merge whenever — workflows trigger on next push / tag.
- Backout plan: revert the commit; the previous (red) state is restored.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian. (n/a — no doc edits)
- [x] I did not use `--no-verify`.

## Reviewer Notes

- This is **block A** of a 4-block CI triage series (A: db-schema build step, B: server vitest fixes, C: mobile Jest jest-expo, D: branch protection). Other blocks land as separate PRs.
- The fix mirrors the explicit prebuild already present in the green workflows, rather than introducing a new pattern. If we want to enforce it globally we could move the build to a composite action — out of scope here.


Link to Devin session: https://app.devin.ai/sessions/3424ed8aac6b4b12856297bb5c7a82a0
Requested by: @Skords-01

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prebuilds `@sergeant/db-schema` before the web bundle in mobile-shell workflows to fix failed imports. This unblocks Android and iOS builds by letting Vite/Rolldown resolve `@sergeant/db-schema/sqlite/migrations`.

- **Bug Fixes**
  - Add `pnpm --filter @sergeant/db-schema build` before `pnpm build:web`.
  - Applied to `mobile-shell-android.yml`, `mobile-shell-android-release.yml`, `mobile-shell-ios.yml`, and `mobile-shell-ios-release.yml`.
  - Matches the prebuild used in `ci.yml` critical flow, `extended-e2e.yml`, and `visual-regression.yml`.

<sup>Written for commit 31a9b1b6fe3783cb65512845bd48e1778020b204. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

