### PR TITLE
feat(db-schema): syncOpOutboxLifecycle helpers (PR #042e-lifecycle)

### DIFF
--- a/packages/db-schema/src/__tests__/sqlite-syncOpOutboxLifecycle.test.ts
+++ b/packages/db-schema/src/__tests__/sqlite-syncOpOutboxLifecycle.test.ts
@@ -1,0 +1,448 @@
+import Database from "better-sqlite3";
+import type { Database as BetterSqliteDatabase } from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  createSqliteAdapter,
+  type SqliteMigrationClient,
+} from "../migrate/adapters/sqlite.js";
+import { runMigrations } from "../migrate/runner.js";
+import {
+  ROUTINE_SPIKE_CLIENT_MIGRATIONS,
+  ROUTINE_SPIKE_MIGRATIONS_TABLE,
+} from "../sqlite/migrations/index.js";
+import { enqueueOutboxIncrement } from "../sqlite/syncOpOutboxEnqueue.js";
+import {
+  markOutboxRejected,
+  markOutboxRetry,
+  markOutboxSuccess,
+} from "../sqlite/syncOpOutboxLifecycle.js";
+import { planRetry } from "../sqlite/syncOpRetry.js";
+
+/**
+ * Integration tests for the write-side lifecycle helpers
+ * (`markOutboxSuccess` / `markOutboxRetry` / `markOutboxRejected`,
+ * PR #042e-lifecycle of `docs/planning/storage-roadmap.md`). Runs the
+ * full SPIKE + PR #040 + PR #042d-prep migration stack against a
+ * fresh `:memory:` engine and exercises every contract:
+ *
+ *  1. markOutboxSuccess — DELETEs by id; idempotent on a missing
+ *     row; does not touch sibling rows.
+ *  2. markOutboxRetry — UPDATEs `attempts/status/next_retry_at/last_error`
+ *     atomically from a `planRetry` plan; flips to `'dead_letter'`
+ *     after `SYNC_OP_MAX_ATTEMPTS`; guarded against terminal-status
+ *     rows; idempotent on a missing row.
+ *  3. markOutboxRejected — UPDATEs `status='rejected'` + `reject_reason`;
+ *     guarded against terminal-status rows; idempotent on a missing
+ *     row.
+ *  4. Cross-helper invariant — a row that has been advanced through
+ *     any helper is no longer drained on subsequent ticks (status
+ *     filter in `drainSyncOpOutbox` keeps lifecycle one-way).
+ */
+
+function syncClient(db: BetterSqliteDatabase): SqliteMigrationClient {
+  return {
+    exec(sql) {
+      db.exec(sql);
+    },
+    run(sql, params) {
+      db.prepare(sql).run(...(params as unknown[]));
+    },
+    all<R extends Record<string, unknown>>(
+      sql: string,
+      params?: readonly unknown[],
+    ): R[] {
+      const stmt = db.prepare(sql);
+      const result = params ? stmt.all(...(params as unknown[])) : stmt.all();
+      return result as R[];
+    },
+  };
+}
+
+interface OutboxRow {
+  id: number;
+  table_name: string;
+  op: string;
+  row: string;
+  client_ts: string;
+  idempotency_key: string;
+  status: string;
+  reject_reason: string | null;
+  attempts: number;
+  next_retry_at: string | null;
+  last_error: string | null;
+  created_at: string;
+}
+
+function readRow(db: BetterSqliteDatabase, id: number): OutboxRow | undefined {
+  return db.prepare(`SELECT * FROM sync_op_outbox WHERE id = ?`).get(id) as
+    | OutboxRow
+    | undefined;
+}
+
+function readAll(db: BetterSqliteDatabase): OutboxRow[] {
+  return db
+    .prepare(`SELECT * FROM sync_op_outbox ORDER BY id ASC`)
+    .all() as OutboxRow[];
+}
+
+async function enqueueFresh(
+  client: SqliteMigrationClient,
+  idempotencyKey: string,
+): Promise<number> {
+  const r = await enqueueOutboxIncrement(client, {
+    table: "routine_streaks",
+    row: { delta: 1 },
+    clientTs: "2026-05-05T10:00:00.000+00:00",
+    idempotencyKey,
+  });
+  return r.id;
+}
+
+describe("syncOpOutboxLifecycle", () => {
+  let db: BetterSqliteDatabase;
+  let client: SqliteMigrationClient;
+
+  beforeEach(async () => {
+    db = new Database(":memory:");
+    client = syncClient(db);
+    await runMigrations({
+      adapter: createSqliteAdapter(client),
+      files: ROUTINE_SPIKE_CLIENT_MIGRATIONS,
+      tableName: ROUTINE_SPIKE_MIGRATIONS_TABLE,
+    });
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  describe("markOutboxSuccess", () => {
+    it("deletes the row by id and leaves siblings untouched", async () => {
+      const a = await enqueueFresh(client, "idem-A");
+      const b = await enqueueFresh(client, "idem-B");
+      const c = await enqueueFresh(client, "idem-C");
+
+      await markOutboxSuccess(client, b);
+
+      const remaining = readAll(db);
+      expect(remaining.map((r) => r.id)).toEqual([a, c]);
+      expect(remaining.map((r) => r.idempotency_key)).toEqual([
+        "idem-A",
+        "idem-C",
+      ]);
+    });
+
+    it("is idempotent on a missing id (silent no-op)", async () => {
+      const a = await enqueueFresh(client, "idem-A");
+
+      await expect(markOutboxSuccess(client, 99_999)).resolves.toBeUndefined();
+
+      // Sibling row is untouched.
+      const row = readRow(db, a);
+      expect(row?.status).toBe("pending");
+    });
+
+    it("is idempotent on a re-call of an already-deleted id", async () => {
+      const a = await enqueueFresh(client, "idem-A");
+
+      await markOutboxSuccess(client, a);
+      // Second call must not throw and must leave state at "row gone".
+      await expect(markOutboxSuccess(client, a)).resolves.toBeUndefined();
+      expect(readRow(db, a)).toBeUndefined();
+    });
+
+    it("does not delete a non-pending row only by id (it deletes by id, period)", async () => {
+      // markOutboxSuccess intentionally has NO status guard — once the
+      // server says applied, the row is gone regardless of how it
+      // wound up in a non-pending state. This test pins that
+      // contract: callers should only ever invoke this on rows that
+      // a successful push acknowledged.
+      const a = await enqueueFresh(client, "idem-A");
+      db.prepare(
+        `UPDATE sync_op_outbox SET status = 'rejected', reject_reason = ? WHERE id = ?`,
+      ).run("engine_invalid_delta", a);
+
+      await markOutboxSuccess(client, a);
+      expect(readRow(db, a)).toBeUndefined();
+    });
+  });
+
+  describe("markOutboxRetry", () => {
+    const transientError = "http_503";
+
+    it("updates attempts/status/next_retry_at/last_error from planRetry on first failure", async () => {
+      const a = await enqueueFresh(client, "idem-A");
+      const now = new Date("2026-05-05T12:00:00.000Z");
+      const plan = planRetry(0, now, transientError);
+
+      await markOutboxRetry(client, a, plan);
+
+      const row = readRow(db, a);
+      expect(row).toBeDefined();
+      expect(row?.status).toBe("pending");
+      expect(row?.attempts).toBe(1);
+      expect(row?.last_error).toBe(transientError);
+      // Default base backoff = 1s after the first failed attempt.
+      expect(row?.next_retry_at).toBe("2026-05-05T12:00:01.000Z");
+    });
+
+    it("flips to dead_letter after SYNC_OP_MAX_ATTEMPTS failures and clears next_retry_at", async () => {
+      const a = await enqueueFresh(client, "idem-A");
+      const now = new Date("2026-05-05T12:00:00.000Z");
+      // After 9 prior failures, the 10th call reaches the cap.
+      const plan = planRetry(9, now, transientError);
+
+      await markOutboxRetry(client, a, plan);
+
+      const row = readRow(db, a);
+      expect(row?.status).toBe("dead_letter");
+      expect(row?.attempts).toBe(10);
+      expect(row?.next_retry_at).toBeNull();
+      expect(row?.last_error).toBe(transientError);
+    });
+
+    it("is a no-op on an already-rejected row (status='pending' guard)", async () => {
+      const a = await enqueueFresh(client, "idem-A");
+      db.prepare(
+        `UPDATE sync_op_outbox SET status = 'rejected', reject_reason = ? WHERE id = ?`,
+      ).run("engine_invalid_delta", a);
+
+      const plan = planRetry(
+        0,
+        new Date("2026-05-05T12:00:00.000Z"),
+        "http_503",
+      );
+      await markOutboxRetry(client, a, plan);
+
+      const row = readRow(db, a);
+      expect(row?.status).toBe("rejected");
+      expect(row?.reject_reason).toBe("engine_invalid_delta");
+      expect(row?.attempts).toBe(0);
+      expect(row?.next_retry_at).toBeNull();
+      expect(row?.last_error).toBeNull();
+    });
+
+    it("is a no-op on an already-dead-letter row (status='pending' guard)", async () => {
+      const a = await enqueueFresh(client, "idem-A");
+      db.prepare(
+        `UPDATE sync_op_outbox SET status = 'dead_letter', attempts = 10 WHERE id = ?`,
+      ).run(a);
+
+      const plan = planRetry(
+        0,
+        new Date("2026-05-05T12:00:00.000Z"),
+        "http_503",
+      );
+      await markOutboxRetry(client, a, plan);
+
+      const row = readRow(db, a);
+      expect(row?.status).toBe("dead_letter");
+      expect(row?.attempts).toBe(10);
+      expect(row?.last_error).toBeNull();
+    });
+
+    it("is idempotent on a missing id (silent no-op)", async () => {
+      const a = await enqueueFresh(client, "idem-A");
+
+      const plan = planRetry(
+        0,
+        new Date("2026-05-05T12:00:00.000Z"),
+        "http_503",
+      );
+      await expect(
+        markOutboxRetry(client, 99_999, plan),
+      ).resolves.toBeUndefined();
+
+      const row = readRow(db, a);
+      expect(row?.status).toBe("pending");
+      expect(row?.attempts).toBe(0);
+    });
+
+    it("does not touch siblings when one row is retried", async () => {
+      const a = await enqueueFresh(client, "idem-A");
+      const b = await enqueueFresh(client, "idem-B");
+
+      const plan = planRetry(
+        2,
+        new Date("2026-05-05T12:00:00.000Z"),
+        "http_503",
+      );
+      await markOutboxRetry(client, b, plan);
+
+      const rowA = readRow(db, a);
+      const rowB = readRow(db, b);
+      expect(rowA?.attempts).toBe(0);
+      expect(rowA?.last_error).toBeNull();
+      expect(rowA?.next_retry_at).toBeNull();
+      expect(rowB?.attempts).toBe(3);
+      expect(rowB?.last_error).toBe("http_503");
+      expect(rowB?.next_retry_at).toBe("2026-05-05T12:00:04.000Z");
+    });
+  });
+
+  describe("markOutboxRejected", () => {
+    it("sets status='rejected' and writes reject_reason", async () => {
+      const a = await enqueueFresh(client, "idem-A");
+
+      await markOutboxRejected(client, a, "op_not_supported");
+
+      const row = readRow(db, a);
+      expect(row?.status).toBe("rejected");
+      expect(row?.reject_reason).toBe("op_not_supported");
+      // attempts/next_retry_at/last_error untouched — they belong to
+      // the transient-retry path, not the terminal-reject path.
+      expect(row?.attempts).toBe(0);
+      expect(row?.next_retry_at).toBeNull();
+      expect(row?.last_error).toBeNull();
+    });
+
+    it("is a no-op on an already-rejected row (status='pending' guard)", async () => {
+      const a = await enqueueFresh(client, "idem-A");
+      db.prepare(
+        `UPDATE sync_op_outbox SET status = 'rejected', reject_reason = ? WHERE id = ?`,
+      ).run("first_reason", a);
+
+      await markOutboxRejected(client, a, "second_reason");
+
+      const row = readRow(db, a);
+      expect(row?.status).toBe("rejected");
+      // First reason wins — second call is suppressed.
+      expect(row?.reject_reason).toBe("first_reason");
+    });
+
+    it("is a no-op on a dead-letter row (status='pending' guard)", async () => {
+      const a = await enqueueFresh(client, "idem-A");
+      db.prepare(
+        `UPDATE sync_op_outbox SET status = 'dead_letter', attempts = 10 WHERE id = ?`,
+      ).run(a);
+
+      await markOutboxRejected(client, a, "op_not_supported");
+
+      const row = readRow(db, a);
+      expect(row?.status).toBe("dead_letter");
+      expect(row?.reject_reason).toBeNull();
+    });
+
+    it("is idempotent on a missing id (silent no-op)", async () => {
+      const a = await enqueueFresh(client, "idem-A");
+
+      await expect(
+        markOutboxRejected(client, 99_999, "op_not_supported"),
+      ).resolves.toBeUndefined();
+
+      const row = readRow(db, a);
+      expect(row?.status).toBe("pending");
+      expect(row?.reject_reason).toBeNull();
+    });
+
+    it("writes reject_reason verbatim (no canonicalisation)", async () => {
+      // Server emits stable enum strings — the helper must not
+      // re-encode them. A reason with internal whitespace / colons
+      // round-trips byte-for-byte so dashboard string-match alerts
+      // see what the server sent.
+      const a = await enqueueFresh(client, "idem-A");
+
+      await markOutboxRejected(client, a, "invalid_delta:non_finite");
+
+      const row = readRow(db, a);
+      expect(row?.reject_reason).toBe("invalid_delta:non_finite");
+    });
+
+    it("does not touch siblings when one row is rejected", async () => {
+      const a = await enqueueFresh(client, "idem-A");
+      const b = await enqueueFresh(client, "idem-B");
+
+      await markOutboxRejected(client, b, "op_not_supported");
+
+      const rowA = readRow(db, a);
+      const rowB = readRow(db, b);
+      expect(rowA?.status).toBe("pending");
+      expect(rowA?.reject_reason).toBeNull();
+      expect(rowB?.status).toBe("rejected");
+      expect(rowB?.reject_reason).toBe("op_not_supported");
+    });
+  });
+
+  describe("cross-helper invariants", () => {
+    it("a deleted row cannot be re-rejected or re-retried", async () => {
+      const a = await enqueueFresh(client, "idem-A");
+
+      await markOutboxSuccess(client, a);
+
+      // Both lifecycle calls on a now-missing row are silent no-ops;
+      // post-condition: row is still gone, no side-effect resurrected
+      // it.
+      await markOutboxRejected(client, a, "op_not_supported");
+      const plan = planRetry(
+        0,
+        new Date("2026-05-05T12:00:00.000Z"),
+        "http_503",
+      );
+      await markOutboxRetry(client, a, plan);
+
+      expect(readRow(db, a)).toBeUndefined();
+    });
+
+    it("a rejected row cannot be re-retried", async () => {
+      // Captures the contract that lifecycle is one-way: rejected is
+      // terminal, the engine never re-enters retry on it.
+      const a = await enqueueFresh(client, "idem-A");
+
+      await markOutboxRejected(client, a, "op_not_supported");
+      const plan = planRetry(
+        0,
+        new Date("2026-05-05T12:00:00.000Z"),
+        "http_503",
+      );
+      await markOutboxRetry(client, a, plan);
+
+      const row = readRow(db, a);
+      expect(row?.status).toBe("rejected");
+      expect(row?.reject_reason).toBe("op_not_supported");
+      expect(row?.attempts).toBe(0);
+      expect(row?.last_error).toBeNull();
+      expect(row?.next_retry_at).toBeNull();
+    });
+
+    it("a dead-letter row cannot be re-rejected without explicit reset", async () => {
+      // Dead-letter rows wait for human triage; the lifecycle helpers
+      // never auto-flip them to rejected. A triage path that
+      // resets to 'pending' out of band can re-engage them, but
+      // these helpers won't.
+      const a = await enqueueFresh(client, "idem-A");
+      const now = new Date("2026-05-05T12:00:00.000Z");
+      const plan = planRetry(9, now, "http_503");
+
+      await markOutboxRetry(client, a, plan);
+      const afterRetry = readRow(db, a);
+      expect(afterRetry?.status).toBe("dead_letter");
+
+      await markOutboxRejected(client, a, "op_not_supported");
+      const afterReject = readRow(db, a);
+      expect(afterReject?.status).toBe("dead_letter");
+      expect(afterReject?.reject_reason).toBeNull();
+    });
+
+    it("retry can succeed on the first attempt, then a follow-up success deletes the row", async () => {
+      // End-to-end: enqueue → first push fails (retry) → second push
+      // succeeds (delete). Captures the steady-state engine flow that
+      // PR #042e-pushloop consumes.
+      const a = await enqueueFresh(client, "idem-A");
+
+      const plan = planRetry(
+        0,
+        new Date("2026-05-05T12:00:00.000Z"),
+        "http_503",
+      );
+      await markOutboxRetry(client, a, plan);
+
+      const afterRetry = readRow(db, a);
+      expect(afterRetry?.status).toBe("pending");
+      expect(afterRetry?.attempts).toBe(1);
+
+      await markOutboxSuccess(client, a);
+      expect(readRow(db, a)).toBeUndefined();
+    });
+  });
+});

--- a/packages/db-schema/src/sqlite/index.ts
+++ b/packages/db-schema/src/sqlite/index.ts
@@ -36,6 +36,11 @@ export {
   type DrainedOutboxRow,
 } from "./syncOpOutboxDrain.js";
 export {
+  markOutboxSuccess,
+  markOutboxRetry,
+  markOutboxRejected,
+} from "./syncOpOutboxLifecycle.js";
+export {
   ROUTINE_CLIENT_MIGRATIONS,
   ROUTINE_MIGRATIONS_TABLE,
   ROUTINE_SPIKE_CLIENT_MIGRATIONS,

--- a/packages/db-schema/src/sqlite/syncOpOutboxLifecycle.ts
+++ b/packages/db-schema/src/sqlite/syncOpOutboxLifecycle.ts
@@ -1,0 +1,166 @@
+import type { SqliteMigrationClient } from "../migrate/adapters/sqlite.js";
+
+import type { SyncOpRetryPlan } from "./syncOpRetry.js";
+
+/**
+ * Write-side lifecycle helpers for the client-side `sync_op_outbox`
+ * (`docs/planning/storage-roadmap.md` Stage 5 / PR #042e-lifecycle).
+ *
+ * Mirror of {@link drainSyncOpOutbox} (PR #042e-drain) on the write
+ * side. Where the drain reader pulls due, pending rows out of the
+ * outbox in insertion order, these three helpers advance the row's
+ * lifecycle once `/api/v2/sync/push` returns:
+ *
+ * ```ts
+ * for (const row of due) {
+ *   const result = await syncV2Push({ ops: [mapToOp(row)] });
+ *   const status = result.results[0]?.status;
+ *   if (status === "applied" || status === "duplicate") {
+ *     await markOutboxSuccess(client, row.id);
+ *   } else if (status === "rejected") {
+ *     await markOutboxRejected(client, row.id, result.results[0]!.reason);
+ *   } else {
+ *     // 5xx, network, timeout — call planRetry on the previous attempts
+ *     await markOutboxRetry(
+ *       client,
+ *       row.id,
+ *       planRetry(row.attempts, new Date(), "http_503"),
+ *     );
+ *   }
+ * }
+ * ```
+ *
+ * The push-loop orchestrator that wires these calls together lives in
+ * `packages/api-client/src/sync/pushLoop.ts` (PR #042e-pushloop).
+ *
+ * Mutation contract:
+ *
+ * - {@link markOutboxSuccess} `DELETE`s the row by `id`. Calls on a
+ *   missing row are a silent no-op (idempotent) — concurrent workers
+ *   that drained the same `id` and both reach success after a
+ *   server-side `(user_id, idempotency_key)` dedup are safe.
+ * - {@link markOutboxRetry} and {@link markOutboxRejected} both update
+ *   under `WHERE id = ? AND status = 'pending'` so a row that was
+ *   already advanced to a terminal status by another worker is left
+ *   alone. The drain reader filters on `status='pending'` already, so
+ *   under normal operation only a parallel race ever puts a row out
+ *   of `'pending'` between drain and lifecycle.
+ * - All three helpers are tx-free — the engine batches its own
+ *   transactions at a higher level, and SQLite's single-writer model
+ *   means a tight `UPDATE` or `DELETE` does not need its own
+ *   `BEGIN`/`COMMIT` to be atomic.
+ *
+ * Why this lives in db-schema (not api-client):
+ *
+ * - The SQL it issues is bound to the `sync_op_outbox` schema shape
+ *   declared in `./routine.ts` (and provisioned by
+ *   `001_routine_spike.sql` + `002_sync_op_outbox_retry.sql` from
+ *   `./migrations/index.ts`). Keeping the helpers next to the schema
+ *   means a future column rename surfaces here at typecheck-time, not
+ *   in api-client.
+ * - api-client deliberately has no dependency on db-schema (mirror
+ *   shapes via tripwire tests; see PR #042e-mapping). The push-loop
+ *   in api-client takes these helpers via DI so the dependency
+ *   direction stays one-way.
+ *
+ * Failure modes:
+ *
+ * - The `client.run` shim does not surface SQLite's `changes()` count,
+ *   so the helpers cannot return "did we update a row" without an
+ *   extra `SELECT`. The cost is that callers cannot distinguish
+ *   "row already terminal" from "row still pending and got updated";
+ *   tests use a post-`SELECT` to assert state. This trade matches the
+ *   {@link drainSyncOpOutbox} stance — surface state via the schema,
+ *   not via helper return values — and keeps the wire-shape narrow.
+ * - Driver-level errors (disk full, schema drift, FS lock) propagate
+ *   to the caller unchanged. The push-loop converts them into
+ *   `last_error='driver_error:<msg>'` on the next retry tick rather
+ *   than swallowing them here.
+ */
+
+/**
+ * Advance a successfully-pushed row out of the outbox.
+ *
+ * Issues `DELETE FROM sync_op_outbox WHERE id = ?` unconditionally —
+ * SQLite's `DELETE` on a missing row is a silent no-op, which is the
+ * idempotency we want for concurrent workers that both drained the
+ * same id.
+ *
+ * @param client SQLite client (better-sqlite3 in tests; sqlite-wasm
+ *               in `apps/web`; expo-sqlite in `apps/mobile`).
+ * @param id     `sync_op_outbox.id` of the row that the server just
+ *               acknowledged with `applied` or `duplicate`.
+ */
+export async function markOutboxSuccess(
+  client: SqliteMigrationClient,
+  id: number,
+): Promise<void> {
+  await client.run(`DELETE FROM sync_op_outbox WHERE id = ?`, [id]);
+}
+
+/**
+ * Advance a row whose push attempt just failed transiently
+ * (network error, 5xx, timeout). Updates `attempts`, `status`,
+ * `next_retry_at`, and `last_error` from the {@link SyncOpRetryPlan}
+ * computed by `planRetry` (`./syncOpRetry.ts`).
+ *
+ * Guarded with `status = 'pending'` so a parallel worker that already
+ * advanced the row to `'rejected'` or `'dead_letter'` wins — this
+ * helper is a no-op in that case.
+ *
+ * @param client SQLite client.
+ * @param id     `sync_op_outbox.id` of the row whose push just failed.
+ * @param plan   {@link SyncOpRetryPlan} from
+ *               `planRetry(previousAttempts, now, lastError)`. The
+ *               plan is precomputed on the caller side so this helper
+ *               stays clock-pure (tests pin a deterministic clock).
+ */
+export async function markOutboxRetry(
+  client: SqliteMigrationClient,
+  id: number,
+  plan: SyncOpRetryPlan,
+): Promise<void> {
+  await client.run(
+    `UPDATE sync_op_outbox
+        SET attempts = ?,
+            status = ?,
+            next_retry_at = ?,
+            last_error = ?
+      WHERE id = ?
+        AND status = 'pending'`,
+    [plan.attempts, plan.status, plan.nextRetryAt, plan.lastError, id],
+  );
+}
+
+/**
+ * Advance a row whose push attempt was terminally rejected by the
+ * server (durable 4xx — for example, `op_not_supported`,
+ * `tombstoned`, `missing_delta`, `invalid_delta`). Sets
+ * `status='rejected'` and writes `reject_reason` for triage. The row
+ * stays in the outbox so the dev panel and human-triage flows can
+ * inspect it; the engine never retries `'rejected'` rows.
+ *
+ * Guarded with `status = 'pending'` so a parallel worker that already
+ * advanced the row to a terminal status wins.
+ *
+ * @param client SQLite client.
+ * @param id     `sync_op_outbox.id` of the rejected row.
+ * @param reason Server-supplied rejection reason — written verbatim
+ *               into `reject_reason`. Conventionally one of the
+ *               server's stable enum values (e.g. `op_not_supported`,
+ *               `tombstoned`, `invalid_delta`); not validated here.
+ */
+export async function markOutboxRejected(
+  client: SqliteMigrationClient,
+  id: number,
+  reason: string,
+): Promise<void> {
+  await client.run(
+    `UPDATE sync_op_outbox
+        SET status = 'rejected',
+            reject_reason = ?
+      WHERE id = ?
+        AND status = 'pending'`,
+    [reason, id],
+  );
+}


### PR DESCRIPTION
## Summary

Write-side mirror to `drainSyncOpOutbox` (PR #042e-drain). Three pure-SQL helpers that advance a `sync_op_outbox` row's lifecycle once the server's `/api/v2/sync/push` response is in:

- `markOutboxSuccess(client, id)` → `DELETE` on `applied`/`duplicate`.
- `markOutboxRetry(client, id, plan)` → `UPDATE attempts/status/next_retry_at/last_error` from a `planRetry` plan; flips to `dead_letter` at `SYNC_OP_MAX_ATTEMPTS`.
- `markOutboxRejected(client, id, reason)` → `UPDATE status='rejected' + reject_reason` for terminal server-side rejects (`op_not_supported`, `tombstoned`, `invalid_delta`, …).

All three guard non-pending rows (`status='pending'` `WHERE` clause for retry/rejected; success is a pure id-based `DELETE`) and are idempotent on missing ids so concurrent workers cannot corrupt each other.

Re-exported from `packages/db-schema/src/sqlite/index.ts`. **No production callsites yet** — first consumer is the sync-engine push-loop in the follow-up `PR #042e-pushloop`.

This is one of two surgical splits closing `PR #042e sync-engine writer wiring` (Stage 5 of `docs/planning/storage-roadmap.md`). The companion PR (push-loop orchestrator) is the next consumer of these helpers.

## Governing Skill

- Primary skill: `sergeant-data-and-migrations` — touched surface is `packages/db-schema/src/sqlite/**`, an SQLite-write-side helper that ships SQL bound to the existing `sync_op_outbox` schema.
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a — no migration, no rollout-coupled change. The closest playbook is the storage-roadmap PR series (PR #042d-builder / PR #042e-drain) which lives inline in the roadmap doc, not the playbook catalog.
- Why this playbook: the write-side mirror to `drainSyncOpOutbox` follows the exact pattern established by `enqueueOutboxIncrement` (PR #042d-builder) and `drainSyncOpOutbox` (PR #042e-drain): pure helper next to schema, JSDoc explaining the engine contract, integration tests against in-memory `better-sqlite3`.
- If no playbook matched, why: see above.

## Verification

```bash
pnpm --filter @sergeant/db-schema test -- --run sqlite-syncOpOutboxLifecycle
# Test Files  1 passed (1)
#       Tests  20 passed (20)

pnpm --filter @sergeant/db-schema test
# Test Files  18 passed (18)
#       Tests  322 passed (322)

pnpm --filter @sergeant/db-schema typecheck
# Exit code: 0

pnpm --filter @sergeant/db-schema lint
# Exit code: 0
```

20 new vitest tests covering:

- success-path delete + sibling isolation + re-call idempotency,
- non-pending no-op variants for retry/rejected (rejected, dead-letter),
- `dead_letter` flip at `SYNC_OP_MAX_ATTEMPTS` with `next_retry_at` cleared,
- `reject_reason` verbatim round-trip (no canonicalisation),
- cross-helper one-way invariants (deleted/rejected/dead-letter rows cannot be re-engaged without explicit reset).

Additional checks:

- [x] Local smoke / manual validation completed (full db-schema suite green; sibling-isolation post-`SELECT` assertions pin no-touch behavior).
- [x] Surface-specific checks completed (typecheck + ESLint clean; re-export wired in `sqlite/index.ts`).

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a — purely additive helper-surface, no behavior change. Roadmap status row + PR ledger will be updated together with the follow-up `PR #042e-pushloop` once both pieces of the split land, per the existing pattern (`PR #042e-mapping` / `PR #042e-submit` / `PR #042e-drain` were similarly batched into one roadmap update).

## Risk and Rollout

- User-visible risk: **None.** Additive public surface (three new exports), no callsites in production. JSDoc inline references the future consumer (`pushLoop` in the follow-up PR) so the engine contract is discoverable.
- Rollout / deploy order: ships independently. No client-data migration, no schema change, no flag flip. Helpers become exercised only when the follow-up `PR #042e-pushloop` lands and is wired into the routine boot path.
- Backout plan: `git revert`. No data on disk is affected because nothing calls the helpers yet.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

- The `client.run` shim (`SqliteMigrationClient`) does not surface `changes()` count, so the helpers cannot return "did we update a row" without an extra `SELECT`. Tests verify state via post-`SELECT` assertions; this matches the `drainSyncOpOutbox` stance — surface state via the schema, not via helper return values.
- `markOutboxSuccess` deliberately has **no** status guard (id-based `DELETE`). Pinned by a dedicated test: once the server says `applied`, the row is gone regardless of how it wound up in a non-pending state. Callers should only invoke this on rows that a successful push acknowledged; concurrent-worker idempotency falls out for free.
- Retry/rejected helpers use `WHERE status = 'pending'` so a parallel worker that already advanced the row to a terminal state wins. Pinned by tests on already-rejected and already-dead-letter rows.
- `planRetry` from `./syncOpRetry.ts` (PR #040) is the source-of-truth for backoff math. The lifecycle helper takes the precomputed plan as input — no clock, no jitter inside the helper — so tests can pin a deterministic backoff schedule.


Link to Devin session: https://app.devin.ai/sessions/de0008f4899e4250a7773b7a8252eac4
Requested by: @Skords-01

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add write-side lifecycle helpers for `sync_op_outbox` in `@sergeant/db-schema` to advance rows after a push response. Exposes three SQL helpers that are idempotent and safe for concurrent workers.

- **New Features**
  - `markOutboxSuccess(client, id)` deletes the row on success (applied/duplicate); idempotent on missing ids.
  - `markOutboxRetry(client, id, plan)` updates attempts/status/next_retry_at/last_error from a `planRetry` plan; flips to `dead_letter` at max attempts; guarded with `status='pending'`.
  - `markOutboxRejected(client, id, reason)` sets `status='rejected'` and `reject_reason`; guarded with `status='pending'`.
  - Concurrency-safe: retry/reject use `WHERE status='pending'`; success deletes by id only.
  - Re-exported in `packages/db-schema/src/sqlite/index.ts`. No schema or migration changes. 20 tests added. No production callsites yet.

<sup>Written for commit 4a2f849d80be99b4ab8be965ae951c136d587952. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

