### PR TITLE
docs(agents): align stale references in AGENTS.md, initiative 0001, eslint guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agents in Sergeant
 
-> **Last validated:** 2026-05-05 by @Skords-01. **Next review:** 2026-08-03.
+> **Last validated:** 2026-05-05 by @dmytro.skords. **Next review:** 2026-08-03.
 > **Status:** Active
 
 > **If you are an agent:** start with `.agents/skills/sergeant-start-here/SKILL.md`, then load exactly one Sergeant specialist skill for the touched surface. The routing catalog lives in `docs/agents/agent-skills-catalog.md`.
@@ -26,7 +26,7 @@ Repo policy lives here in `AGENTS.md`. Platform-specific wrappers such as `CLAUD
   - `apps/mobile-shell` — Capacitor wrapper for the web app.
   - `tools/console` — Telegram bot (grammy + Anthropic), internal ops/marketing.
 - **Packages** (11): `@sergeant/shared`, `@sergeant/api-client`, `@sergeant/config`, `@sergeant/db-schema`, `@sergeant/design-tokens`, `@sergeant/insights`, `eslint-plugin-sergeant-design`, and 4 domain packages (`@sergeant/finyk-domain`, `@sergeant/fizruk-domain`, `@sergeant/nutrition-domain`, `@sergeant/routine-domain`).
-- Pre-commit: **Husky** runs `lint-staged` (ESLint --fix + Prettier).
+- Pre-commit: **Husky** runs `lint-staged` — ESLint --fix + Prettier for code, `staged-typecheck.mjs` for staged TS/TSX, `bump-last-validated.mjs` for `.md`. Full pipeline matrix lives in [`CONTRIBUTING.md § Pre-commit hooks`](./CONTRIBUTING.md#pre-commit-hooks).
 
 ## Module ownership map
 
@@ -43,7 +43,7 @@ Quick lookup before editing: which path uses which test stack and which conventi
 | `apps/web/src/shared/**`                              | `@Skords-01` | Vitest                                  | factories defined here                | Pure utils. No React.                                                                                                                                                  |
 | `apps/server/src/modules/**`                          | `@Skords-01` | Vitest + Testcontainers (real Postgres) | n/a                                   | Always coerce bigint→number in serializers (rule #1). Update `api-client` types.                                                                                       |
 | `apps/server/src/modules/chat/**`                     | `@Skords-01` | Vitest                                  | n/a                                   | Anthropic tool defs split per domain in `toolDefs/`. See Architecture section.                                                                                         |
-| `apps/server/src/migrations/**`                       | `@Skords-01` | n/a                                     | n/a                                   | Sequential `NNN_*.sql` (currently 001–028). No gaps. Two-phase for DROP — see rule #4.                                                                                 |
+| `apps/server/src/migrations/**`                       | `@Skords-01` | n/a                                     | n/a                                   | Sequential `NNN_*.sql` (currently 001–044). No gaps. Two-phase for DROP — see rule #4.                                                                                 |
 | `apps/mobile/src/core/**`                             | `@Skords-01` | Jest                                    | (mobile RQ uses module-local keys)    | NativeWind (not Tailwind). MMKV (not localStorage). No DOM.                                                                                                            |
 | `apps/mobile/app/**`                                  | `@Skords-01` | Jest                                    | n/a                                   | Expo Router routes. Each `_layout.tsx` is a navigator.                                                                                                                 |
 | `apps/mobile-shell/**`                                | `@Skords-01` | none                                    | n/a                                   | Capacitor wrapper around `apps/web`. No app code lives here, only build glue.                                                                                          |
@@ -67,7 +67,7 @@ Quick lookup before editing: which path uses which test stack and which conventi
 > - **`lint-enforced-convention`** — стилістичне/процесне правило з механічним enforcement (ESLint plugin, commitlint, governance-sync, freshness). Severity blocker, але enforcement — лінтер, не ран-тайм.
 > - **`active-initiative`** — правило з allowlist + дедлайном (див. лінкований `TODO(NNNN-…): YYYY-MM-DD`). Для нового коду — blocker; винятки трекаються окремо.
 >
-> Поточний розподіл (18 правил): 6 `blocker-invariant` (нижче в цьому розділі), 11 `lint-enforced-convention` (5 — нижче, 6 design-конвенцій винесено в § [Lint-enforced design conventions](#lint-enforced-design-conventions)), 1 `active-initiative` (#18). Машино-читабельна матриця: [`docs/governance/hard-rules-matrix.md`](./docs/governance/hard-rules-matrix.md). Семантика категорій — у [`docs/adr/0045-hard-rules-taxonomy.md`](./docs/adr/0045-hard-rules-taxonomy.md). `id` стабільні в обох розділах і `hard-rules.json` — старі PR-описи лінкуються без змін.
+> Поточний розподіл (19 правил): 6 `blocker-invariant` (нижче в цьому розділі), 11 `lint-enforced-convention` (5 — нижче, 6 design-конвенцій винесено в § [Lint-enforced design conventions](#lint-enforced-design-conventions)), 2 `active-initiative` (#18 module-decomposition, #19 noUncheckedIndexedAccess). Машино-читабельна матриця: [`docs/governance/hard-rules-matrix.md`](./docs/governance/hard-rules-matrix.md). Семантика категорій — у [`docs/adr/0045-hard-rules-taxonomy.md`](./docs/adr/0045-hard-rules-taxonomy.md). `id` стабільні в обох розділах і `hard-rules.json` — старі PR-описи лінкуються без змін.
 
 ### 1. DB types: coerce `bigint` to `number` in serializers
 
@@ -112,7 +112,7 @@ Secrets (Mono token, etc.) **must** be hashed via `hashToken()` before going int
 When you change a JSON response shape in `apps/server/src/modules/*`, three things move together:
 
 ```diff
-  // apps/server/src/modules/finyk/transactionsHandler.ts
+  // apps/server/src/modules/mono/read.ts (transactionsHandler)
   return rows.map((r) => ({
     id: Number(r.id),
 +   merchantCategory: r.mcc ? String(r.mcc) : null,
@@ -121,7 +121,7 @@ When you change a JSON response shape in `apps/server/src/modules/*`, three thin
 ```
 
 ```diff
-  // packages/api-client/src/endpoints/finyk.ts
+  // packages/api-client/src/endpoints/mono.ts
   export interface MonoTransaction {
     id: number;
 +   merchantCategory: string | null;
@@ -130,7 +130,7 @@ When you change a JSON response shape in `apps/server/src/modules/*`, three thin
 ```
 
 ```diff
-  // apps/server/src/modules/finyk/transactionsHandler.test.ts
+  // apps/server/src/modules/mono/read.test.ts
   expect(result).toMatchInlineSnapshot(`
     {
       "id": 42,
@@ -144,7 +144,7 @@ If you change only one — CI will pass but consumers break. Always do all three
 
 ### 4. SQL migrations: sequential, no gaps, two-phase for DROP
 
-Files in `apps/server/src/migrations/` use the pattern `NNN_description.sql` (currently 001–028). Pre-deploy: `pnpm db:migrate` (Railway, runs `apps/server/migrate.mjs`). The build step copies them via `apps/server/build.mjs` (fixed in [#704](https://github.com/Skords-01/Sergeant/issues/704)).
+Files in `apps/server/src/migrations/` use the pattern `NNN_description.sql` (currently 001–044). Pre-deploy: `pnpm db:migrate` (Railway, runs `apps/server/migrate.mjs`). The build step copies them via `apps/server/build.mjs` (fixed in [#704](https://github.com/Skords-01/Sergeant/issues/704)).
 
 > **Local Postgres image:** `docker-compose.yml` uses `pgvector/pgvector:pg16`, not stock `postgres:16-alpine`. Migration `025_ai_memories_pgvector.sql` runs `CREATE EXTENSION IF NOT EXISTS vector;` and the alpine image does not ship the extension — `pnpm db:up` would fail at migrate-time. CI workflows (`ci.yml`, `extended-e2e.yml`, `visual-regression.yml`) already pin the same image.
 
@@ -340,7 +340,7 @@ Documentation is part of the change set, not a follow-up. Treat any of the follo
 | Code change                                       | Docs that must move with it                                                                                                                                            |
 | ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | New / changed JSON response shape                 | `packages/api-client/**` types **+** the matching contract test (Hard Rule #3). If the response is documented in `docs/api/*.md`, update there too.                    |
-| New SQL migration                                 | `apps/server/src/migrations/README.md` (if present), and any ER-diagram in `docs/architecture/`.                                                                       |
+| New SQL migration                                 | `docs/architecture/data-exchange-storage-audit.md` (DB-level invariants), and any ER-diagram in `docs/architecture/`.                                                  |
 | New / removed npm script                          | `CONTRIBUTING.md § Everyday Commands`, `CLAUDE.md § Quick commands`.                                                                                                   |
 | New Hard Rule, lint rule, or convention           | `AGENTS.md` § Hard Rules (the canonical entry) **+** mirror summary in `CONTRIBUTING.md § Hard rules`. PR template's "AGENTS.md updated?" checkbox **must** be ticked. |
 | New design token, palette, or component           | `docs/design/design-system.md`, `docs/design/brandbook.md`, and the relevant audit (`docs/audits/*-audit-*.md`) if it changes status.                                  |
@@ -369,7 +369,7 @@ If you genuinely change nothing in the doc but its claims still hold, leave the 
 The PR template includes the relevant boxes (`AGENTS.md updated?`, "Docs updated alongside code?"). CI catches the cases that are mechanically detectable:
 
 - `pnpm lint:governance-sync` — fails (error, not warning) on **concrete** dangling `apps/.../*.ts` / `packages/.../*.ts` / `scripts/...` refs in non-aspirational docs (anything outside `docs/launch/`, `docs/planning/`, `docs/integrations/*-roadmap.md`, `docs/audits/*-implementation-roadmap.md`, ADRs with `Status: proposed`). Refs containing glob/placeholder syntax (`*`, `?`, `<>`, `[]`, `{}`) are skipped — those are templates, not concrete claims.
-- `pnpm docs:check-freshness`, `pnpm docs:check-playbook-index`, `pnpm docs:check-playbook-schema`, `pnpm hard-rules:check`, `pnpm api:check-openapi` — supplementary gates per category.
+- `pnpm docs:check-freshness-coverage`, `pnpm docs:check-playbook-index`, `pnpm docs:check-playbook-schema`, `pnpm hard-rules:check`, `pnpm api:check-openapi` — supplementary gates per category.
 
 The remaining categories (api-client type drift, CHANGELOG entries, design-system updates) are still reviewer- and self-discipline-enforced. If a reviewer spots an unchecked-but-required doc update, that's a request-changes signal — not a "follow-up issue". And if `lint:governance-sync` shows a path you renamed/moved, **do not** silence it by adding `<>` placeholders unless the file truly is aspirational — fix the doc to reference the real new path.
 
@@ -417,9 +417,9 @@ If a reviewer sees a new prose paragraph or table cell in English in a doc that'
 }
 ```
 
-**Allowlist.** Існуючі файли-моноліти (16 на 2026-05-03) виключені окремим блоком `eslint.config.js` з `TODO(0001-module-decomposition): deadline 2026-06-15`. Кожна декомпозиція = видалення одного рядка з allowlist (видно у `git blame`). Allowlist — _не_ постійна fixture: dropping rate відстежується в [`docs/initiatives/0001-module-decomposition.md`](docs/initiatives/0001-module-decomposition.md) метрикою «Файлів `apps/web/src/**` ≥600 LOC: 16 → ≤ 2».
+**Allowlist.** Існуючі файли-моноліти (11 на 2026-05-05) виключені окремим блоком `eslint.config.js` з `TODO(0001-module-decomposition): deadline 2026-06-15`. Кожна декомпозиція = видалення одного рядка з allowlist (видно у `git blame`). Allowlist — _не_ постійна fixture: dropping rate відстежується в [`docs/initiatives/0001-module-decomposition.md`](docs/initiatives/0001-module-decomposition.md) метрикою «Файлів `apps/web/src/**` ≥600 LOC: 16 → 11 → ≤ 2».
 
-**Як декомпонувати.** Розкладаємо за роллю, не за алфавітом: окремо state (custom hook / `useReducer` / state-machine), окремо ефекти (один `useEffect` = один named hook), окремо UI (presentational sub-components без логіки). Прецедент — `apps/server/src/modules/chat/agent.ts → agent.handlers.ts / agent.tools.ts / agent.cache.ts`. Для web cookbook див. опис фази 2 в [`docs/initiatives/0001-module-decomposition.md`](docs/initiatives/0001-module-decomposition.md).
+**Як декомпонувати.** Розкладаємо за роллю, не за алфавітом: окремо state (custom hook / `useReducer` / state-machine), окремо ефекти (один `useEffect` = один named hook), окремо UI (presentational sub-components без логіки). Прецедент — `apps/server/src/modules/chat/` (раніше моноліт `agent.ts`): `chat.ts` orchestrator + `tools.ts` + `coach.ts` + `aiQuota.ts` + `toolMetrics.ts` + `toolDefs/<domain>/`. Для web cookbook див. опис фази 2 в [`docs/initiatives/0001-module-decomposition.md`](docs/initiatives/0001-module-decomposition.md).
 
 **Scope rationale.**
 

--- a/docs/diagnostics/2026-05-03-web-deep-dive/03-backend-and-performance.md
+++ b/docs/diagnostics/2026-05-03-web-deep-dive/03-backend-and-performance.md
@@ -220,7 +220,7 @@ const { foo } = await validateBody(schema, req); // throws BadRequestError
 
 **Recommendation / fix points.**
 
-1. Раз на квартал прогнати `vite-bundle-visualizer` і додати artifact в CI (`pnpm build && pnpm bundle-stats`).
+1. Раз на квартал прогнати `vite-bundle-visualizer` і додати artifact в CI (`pnpm build:analyze` — генерує `apps/web/dist/bundle-report.html` через `rollup-plugin-visualizer` за `ANALYZE=1`).
 2. Запровадити budget per-chunk через `size-limit`:
 
    ```json

--- a/docs/initiatives/0001-module-decomposition.md
+++ b/docs/initiatives/0001-module-decomposition.md
@@ -1,6 +1,6 @@
 # 0001 — Module decomposition + `max-lines` guard
 
-> **Last validated:** 2026-05-04 by @Skords-01. **Next review:** 2026-08-02.
+> **Last validated:** 2026-05-05 by @dmytro.skords. **Next review:** 2026-08-03.
 > **Status:** Done (Phase 1 + Phase 2 + Phase 3) — closed 2026-05-04
 > **Priority:** P0 (Sprint 1)
 > **Owner:** `@Skords-01`
@@ -33,7 +33,7 @@
 
 **Out:**
 
-- Декомпозиція файлів сервера (>600 LOC у `apps/server/src/modules/chat/agent.ts` уже зроблено — інші ліворуч від цієї межі).
+- Декомпозиція файлів сервера (>600 LOC у `apps/server/src/modules/chat/` уже зроблено — раніше моноліт `agent.ts`, тепер `chat.ts/tools.ts/coach.ts/aiQuota.ts/toolMetrics.ts/toolDefs/`; інші серверні файли ліворуч від межі).
 - Файли `apps/mobile/**` — окремий скоуп для ініціативи 0002.
 - Тести й сторібуки до декомпонованих кусків (буде в [0007 — Design-system tooling](./0007-design-system-tooling.md)).
 
@@ -70,7 +70,7 @@
 - [x] `pnpm lint` падає на будь-якому новому файлі ≥600 LOC у `apps/web/src/**/*.tsx`.
 - [ ] У `apps/web/src/**` лишається ≤2 файли в allowlist (тільки ті, що мають документований план в roadmap-і).
 - [x] Декомпонований `RoutineApp` не має `any`-типів та використовує `useReducer`/state-machine для головного потоку.
-- [x] Декомпонований `Icon.tsx`: `pnpm bundle:analyze` показує −15…−25 KB у chunk-і `shared` (бо мертві іконки тепер tree-shake-аються).
+- [x] Декомпонований `Icon.tsx`: `pnpm build:analyze` показує −15…−25 KB у chunk-і `shared` (бо мертві іконки тепер tree-shake-аються).
 - [x] CI job `lint:tech-debt-freshness` пройшов і `LARGE_FILES` зник з `frontend.md` watching-листа.
 - [x] У `AGENTS.md` додано пункт #11 (`max-lines`) з прикладом і покликанням сюди.
 
@@ -106,7 +106,7 @@
 - [`docs/tech-debt/frontend.md`](../tech-debt/frontend.md) — секція **LARGE_FILES**
 - [`AGENTS.md`](../../AGENTS.md) — Hard rules (де треба додати #11)
 - ADR-кандидат: «Component-size discipline + `max-lines` lint guard» (буде створений у фазі 1)
-- Прецедент: декомпозиція `apps/server/src/modules/chat/agent.ts` (агент розклали на handlers / tools / cache)
+- Прецедент: декомпозиція `apps/server/src/modules/chat/` (раніше моноліт `agent.ts`, тепер `chat.ts` orchestrator + `tools.ts` + `coach.ts` + `aiQuota.ts` + `toolMetrics.ts` + `toolDefs/<domain>/`)
 
 ## Outcome
 
@@ -247,18 +247,18 @@ API — `contextOrFilename.getFilename is not a function`). Phase 2 неможл
 | `apps/web/src/modules/finyk/pages/AssetsTable.tsx`                 | ≥600 | Drift                                                                                   | same                                                          |
 | `apps/web/src/modules/routine/components/RoutineCalendarPanel.tsx` | ≥600 | Drift                                                                                   | same                                                          |
 
-Ці 12 файлів **залишаються** в `eslint.config.js` allowlist із збереженим коментарем-deadline'ом — `pnpm lint` не червоніє через них, але CI job `lint:tech-debt-freshness` періодично нагадуватиме про потрібну декомпозицію. Hard Rule #18 продовжує блокувати будь-який **новий** ≥ 600 LOC файл.
+Ці 11 файлів (12 під час закриття 0001 → −1 після додаткового drop у `eslint.config.js`) **залишаються** в allowlist із збереженим коментарем-deadline'ом — `pnpm lint` не червоніє через них, але CI job `lint:tech-debt-freshness` періодично нагадуватиме про потрібну декомпозицію. Hard Rule #18 продовжує блокувати будь-який **новий** ≥ 600 LOC файл.
 
 **Done criteria — фінальна звірка:**
 
 - [x] `pnpm lint` падає на будь-якому новому файлі ≥600 LOC у `apps/web/src/**/*.tsx` — primary deliverable.
-- [ ] У `apps/web/src/**` лишається ≤2 файли в allowlist — **не виконано**: 12 файлів. Carry-over до 0009.
+- [ ] У `apps/web/src/**` лишається ≤2 файли в allowlist — **не виконано**: 11 файлів (12 на час закриття 0001, −1 після наступного drop у `eslint.config.js`). Carry-over до 0009.
 - [x] Декомпонований `RoutineApp` не має `any`-типів та використовує `useReducer`/state-machine для головного потоку — `useRoutineTimeState.ts`.
-- [x] Декомпонований `Icon.tsx` — `pnpm bundle:analyze` показує −22 KB у `shared` chunk-і (PR #1596 measurement).
+- [x] Декомпонований `Icon.tsx` — `pnpm build:analyze` показує −22 KB у `shared` chunk-і (PR #1596 measurement).
 - [x] CI job `lint:tech-debt-freshness` пройшов і `LARGE_FILES` зник з `frontend.md` watching-листа (тепер посилається сюди).
 - [x] У `AGENTS.md` додано Hard Rule #18 (`max-lines`) з прикладом і покликанням сюди.
 
-5 з 6 критеріїв виконано. **Критерій №2** (allowlist ≤ 2) переноситься як scope наступної ініціативи — це чітко окремий sprint роботи (12 файлів × ~200 LOC мережево), і змішувати його з фінально-документаційним PR було б неконструктивно.
+5 з 6 критеріїв виконано. **Критерій №2** (allowlist ≤ 2) переноситься як scope наступної ініціативи — це чітко окремий sprint роботи (≈11 файлів × ~200 LOC мережево), і змішувати його з фінально-документаційним PR було б неконструктивно.
 
 **Метрики Phase 3 (final):**
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -992,8 +992,10 @@ export default [
   //
   // Scope rationale:
   // - Limited to `apps/web/src/**` — the audit's red-flag table flagged
-  //   web-only monoliths; `apps/server/src/modules/chat/agent.ts` was
-  //   already decomposed (handlers / tools / cache) and is the precedent.
+  //   web-only monoliths; `apps/server/src/modules/chat/` was already
+  //   decomposed (was a single `agent.ts` monolith, now split into
+  //   `chat.ts` orchestrator + `tools.ts` + `coach.ts` + `aiQuota.ts` +
+  //   `toolMetrics.ts` + `toolDefs/<domain>/`) and is the precedent.
   //   `apps/mobile/**` is out of scope (initiative 0002 owns that surface).
   // - `**/__tests__/**` and `*.{test,spec}.{ts,tsx}` are exempt — large
   //   fixture files and snapshot-style suites are legitimate.


### PR DESCRIPTION
## Summary

Documentation drift cleanup uncovered by an audit run on 2026-05-05 (request: "перевір дріфт документації у проекті"). All four touched files contained references that no longer matched the codebase. No behavior, public contract, or runtime change — just docs and one comment in `eslint.config.js`.

**Quantitative drift in `AGENTS.md`:**

- Migrations bracket: `001–028` → `001–044` (rule #4 prose + module ownership map row). Reality: 44 forward migrations live under `apps/server/src/migrations/`.
- Hard rules headcount: `18 правил, 1 active-initiative` → `19 правил, 2 active-initiative (#18, #19)`. Already matched the registry (`docs/governance/hard-rules.json`), the auto-generated matrix (`docs/governance/hard-rules-matrix.md`), and `CONTRIBUTING.md`; only the recap paragraph in AGENTS.md was stale.
- Allowlist size: `16 на 2026-05-03` → `11 на 2026-05-05`. Five files were decomposed off the allowlist after the AGENTS recap was last bumped.

**Broken `pnpm` script references:**

- `AGENTS.md:372`: `pnpm docs:check-freshness` → `pnpm docs:check-freshness-coverage` (the only variant defined in `package.json`).
- `docs/initiatives/0001-module-decomposition.md:73, 257`: `pnpm bundle:analyze` → `pnpm build:analyze` (matches `package.json:23` + `apps/web/package.json:10`).
- `docs/diagnostics/2026-05-03-web-deep-dive/03-backend-and-performance.md:223`: `pnpm bundle-stats` → `pnpm build:analyze` with a note explaining the `ANALYZE=1 rollup-plugin-visualizer` setup. `bundle-stats` was never defined.

**Stale path examples replaced with real ones:**

- AGENTS.md hard rule #3 example used `apps/server/src/modules/finyk/transactionsHandler.ts` and `packages/api-client/src/endpoints/finyk.ts` — neither path ever existed (web module is `finyk`; the matching server module is `mono`). Replaced with the real handler at `apps/server/src/modules/mono/read.ts` (the actual `transactionsHandler`), `packages/api-client/src/endpoints/mono.ts`, and `mono/read.test.ts`.
- AGENTS.md hard rule #18 + initiative 0001 + `eslint.config.js` referenced a chat decomposition precedent of `chat/agent.ts → agent.handlers.ts / agent.tools.ts / agent.cache.ts`. The actual decomposed shape is `chat/` with `chat.ts` orchestrator + `tools.ts` + `coach.ts` + `aiQuota.ts` + `toolMetrics.ts` + `toolDefs/<domain>/`. Updated all three references to match.
- AGENTS.md doc-update map row "New SQL migration" pointed to `apps/server/src/migrations/README.md (if present)` — that README was never created. Pointer now goes to `docs/architecture/data-exchange-storage-audit.md`, which is the real DB-level invariants doc.

**Initiative 0001 internal headcount drift:**

- The doc claimed `12 файлів` carry-over (lines 250, 255, 261); `eslint.config.js` allowlist actually has 11. Three places aligned.

**Soft drift (description completeness):**

- `AGENTS.md:29`: `Pre-commit: Husky runs lint-staged (ESLint --fix + Prettier)` expanded to mention `staged-typecheck.mjs` (for TS/TSX) and `bump-last-validated.mjs` (for `.md`), with a link to `CONTRIBUTING.md § Pre-commit hooks` for the full pipeline matrix.

## Governing Skill

- Primary skill: `sergeant-start-here` → docs/governance maintenance flow (no UI/code surface touched).
- Secondary skill (if truly needed): n/a.

## Playbook

- Primary playbook: n/a — no specific playbook covers governance-side docs drift cleanup.
- Why this playbook: pure documentation cross-reference fix.
- If no playbook matched, why: this is a one-off audit-driven sweep across `AGENTS.md`, one initiative doc, one diagnostic doc, and one ESLint comment. Adding a "doc drift sweep" playbook is plausible but out of scope for this PR.

## Verification

```bash
pnpm install --frozen-lockfile
pnpm docs:check-links                  # 2649 internal + 1330 external — all internal resolve
pnpm lint:hard-rules-registry          # 19 rule(s) in sync with AGENTS.md and CONTRIBUTING.md
pnpm hard-rules:check                  # matrix up to date
pnpm docs:check-freshness-coverage     # all tracked .md files have freshness header
pnpm exec prettier --check AGENTS.md eslint.config.js \
  docs/initiatives/0001-module-decomposition.md \
  docs/diagnostics/2026-05-03-web-deep-dive/03-backend-and-performance.md
                                       # All matched files use Prettier code style!
node -e "(async()=>{const m=await import('./eslint.config.js');console.log('OK',m.default.length)})()"
                                       # OK 37 (config still loads cleanly)
pnpm lint:governance-sync              # 1 PRE-EXISTING error on docs/planning/talk-to-your-data.md
                                       # (missing Status badge) — not introduced or fixed by this PR
```

Additional checks:

- [x] Local smoke / manual validation completed (governance gates above).
- [x] Surface-specific checks completed (no app/server/mobile surface touched; only docs + one comment).

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update — yes, `AGENTS.md` is the primary file in this PR.
- [x] I checked whether a playbook or skill needed an update — no playbook/skill changes; the canonical reference paths used in playbooks/skills are unaffected.
- [x] I checked whether governance docs or review docs needed an update — `hard-rules.json`, `hard-rules-matrix.md`, and `CONTRIBUTING.md` already had the correct counts; this PR aligns the AGENTS.md recap to them.

Updated docs:

- `AGENTS.md` (recap headcount + ownership map row + hard rule #3 example + hard rule #4 prose + hard rule #15 verification command + hard rule #18 allowlist count + chat decomposition precedent + doc-update map + pre-commit description).
- `docs/initiatives/0001-module-decomposition.md` (allowlist headcount alignment + `bundle:analyze` → `build:analyze` + chat decomposition precedent).
- `docs/diagnostics/2026-05-03-web-deep-dive/03-backend-and-performance.md` (`bundle-stats` → `build:analyze`).
- `eslint.config.js` (chat decomposition precedent comment).

## Risk and Rollout

- User-visible risk: **None.** Pure docs + a single comment update; no exported APIs, lint rules, or runtime behavior change.
- Rollout / deploy order: ship anywhere; no order constraints.
- Backout plan: revert the single commit. No follow-up cleanup needed.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian where the surrounding prose was Ukrainian; English where surrounding was English (matches the existing AGENTS.md / initiative 0001 / eslint comment language conventions).
- [x] I did not use `--no-verify`.

## Reviewer Notes

**Flagged for separate review (NOT resolved by this PR):**

- **Initiative 0001 status conflict.** `docs/initiatives/0001-module-decomposition.md:3` says `Status: Done — closed 2026-05-04`, but `eslint.config.js:1023` still has `TODO(0001-module-decomposition): deadline 2026-06-15` with 11 allowlisted files. This PR aligns headcounts so both docs agree on `11 files`, but does **not** decide whether (a) initiative 0001 should be re-opened until the allowlist drains to ≤ 2, or (b) the allowlist+TODO should be retitled under a successor initiative (`0009 module-decomposition-round-2`, already referenced in initiative 0001 §"carry-over"). Owner call.

**Pre-existing governance-sync state:**

- `pnpm lint:governance-sync` reports 1 error on `docs/planning/talk-to-your-data.md` (missing `> **Status:** …` badge despite having a freshness marker) — verified to exist on `main` independently of this PR (stash + rerun confirms). 146 dangling-ref warnings (mostly `docs/security/hardening/*` referencing soon-to-land `apps/server/src/modules/...` paths) are also pre-existing. Out of scope for this PR.

**No CHANGELOG entry:** This is a documentation-internal cleanup that doesn't change product behavior or developer-facing commands; CHANGELOG conventions in this repo reserve entries for behavior/contract/feature changes.

Link to Devin session: https://app.devin.ai/sessions/dbb0d8c3d99640ad88ba7aadad8fe260
Requested by: @Skords-01

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up documentation drift across `AGENTS.md`, initiative 0001, diagnostics, and an `eslint.config.js` comment to match the current repo. Fixed counts, paths, and scripts; no behavior or runtime changes.

- **Bug Fixes**
  - `AGENTS.md`: updated migrations range to 001–044, hard rules to 19 (2 active initiatives), corrected pre-commit description, replaced fake `finyk` examples with real `mono` paths, switched `pnpm docs:check-freshness` → `pnpm docs:check-freshness-coverage`, and pointed “New SQL migration” to `docs/architecture/data-exchange-storage-audit.md`.
  - `docs/initiatives/0001-module-decomposition.md`: aligned allowlist to 11, replaced `pnpm bundle:analyze` → `pnpm build:analyze`, and updated the chat decomposition precedent to the actual `chat.ts/tools.ts/coach.ts/aiQuota.ts/toolMetrics.ts/toolDefs/` split.
  - `docs/diagnostics/.../03-backend-and-performance.md`: replaced `pnpm bundle-stats` → `pnpm build:analyze` with the `ANALYZE=1` note.
  - `eslint.config.js`: refreshed the chat decomposition precedent in comments to match the current structure.

<sup>Written for commit a3af63826b6ee558e77b05bf79124e40247c9b7f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

