### PR TITLE
feat(server): postgres read-replica routing for analytics queries (PR #047)

### DIFF
--- a/apps/server/src/dbReplica.test.ts
+++ b/apps/server/src/dbReplica.test.ts
@@ -1,0 +1,96 @@
+/**
+ * PR #047 — Read-replica routing helpers.
+ *
+ * Behaviour-under-test: `REPLICA_ENABLED`, `getReplicaPoolStats()`, and the
+ * presence/absence of a replica `pg.Pool` at module load. Like
+ * `db.test.ts`, scenarios reload the module via `vi.resetModules()` so
+ * each test sees a fresh eagerly-constructed pool.
+ *
+ * No real Postgres is touched — `pg.Pool` does not open TCP connections
+ * until a query is issued. Integration coverage for actual replica
+ * round-trip will live alongside the existing Testcontainers harness in
+ * `apps/server/src/modules/sync/syncV2.integration.test.ts` (out of scope
+ * for this PR — Testcontainers does not natively spin replicas).
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+interface ReplicaModuleShape {
+  REPLICA_ENABLED: boolean;
+  getReplicaPoolStats: () =>
+    | { enabled: false }
+    | {
+        enabled: true;
+        totalCount: number;
+        idleCount: number;
+        waitingCount: number;
+      };
+}
+
+async function loadReplica(
+  envOverrides: Record<string, string | undefined>,
+): Promise<ReplicaModuleShape> {
+  for (const [k, v] of Object.entries(envOverrides)) {
+    if (v === undefined) {
+      vi.stubEnv(k, "");
+    } else {
+      vi.stubEnv(k, v);
+    }
+  }
+  vi.resetModules();
+  return (await import("./dbReplica.js")) as unknown as ReplicaModuleShape;
+}
+
+describe("PR #047 — read-replica routing via DATABASE_URL_REPLICA", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("enables replica when DATABASE_URL_REPLICA is set", async () => {
+    const mod = await loadReplica({
+      DATABASE_URL: "postgres://app:app@primary.internal:5432/sergeant",
+      DATABASE_URL_REPLICA: "postgres://ro:ro@replica.internal:5432/sergeant",
+    });
+    expect(mod.REPLICA_ENABLED).toBe(true);
+    const stats = mod.getReplicaPoolStats();
+    expect(stats).toMatchObject({
+      enabled: true,
+      totalCount: expect.any(Number),
+      idleCount: expect.any(Number),
+      waitingCount: expect.any(Number),
+    });
+  });
+
+  it("disables replica when DATABASE_URL_REPLICA is empty", async () => {
+    const mod = await loadReplica({
+      DATABASE_URL: "postgres://app:app@primary.internal:5432/sergeant",
+      DATABASE_URL_REPLICA: "",
+    });
+    expect(mod.REPLICA_ENABLED).toBe(false);
+    expect(mod.getReplicaPoolStats()).toEqual({ enabled: false });
+  });
+
+  it("disables replica when DATABASE_URL_REPLICA is unset", async () => {
+    const mod = await loadReplica({
+      DATABASE_URL: "postgres://app:app@primary.internal:5432/sergeant",
+      DATABASE_URL_REPLICA: undefined,
+    });
+    expect(mod.REPLICA_ENABLED).toBe(false);
+    expect(mod.getReplicaPoolStats()).toEqual({ enabled: false });
+  });
+
+  it("getReplicaPoolStats() shape mirrors getPoolStats() counters when enabled", async () => {
+    const mod = await loadReplica({
+      DATABASE_URL: "postgres://app:app@primary.internal:5432/sergeant",
+      DATABASE_URL_REPLICA: "postgres://ro:ro@replica.internal:5432/sergeant",
+    });
+    const stats = mod.getReplicaPoolStats();
+    if (!stats.enabled) {
+      throw new Error("expected replica enabled in this scenario");
+    }
+    expect(stats.totalCount).toBeGreaterThanOrEqual(0);
+    expect(stats.idleCount).toBeGreaterThanOrEqual(0);
+    expect(stats.waitingCount).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/apps/server/src/dbReplica.ts
+++ b/apps/server/src/dbReplica.ts
@@ -1,0 +1,213 @@
+/**
+ * Read-replica routing helpers (PR #047 — Stage 6 storage roadmap).
+ *
+ * Створює окремий `pg.Pool` поверх `DATABASE_URL_REPLICA`, якщо він
+ * заданий, і експортує тонкі helper-и для analytics-style read-only
+ * запитів (`growth_*`, `seo_*` таблиці), які толерують реплікаційний
+ * лаг (< 5s p99 — alert threshold у runbook-у).
+ *
+ * Дизайн:
+ *
+ * - **Opt-in.** Жоден існуючий handler не міняється автоматично — поки
+ *   call-сайт не перейде на `queryReplica()`, він далі ходить у primary.
+ *   Це безпечно: ми ніколи мовчки не міняємо where read-after-write
+ *   semantic-у виконує існуючий код.
+ *
+ * - **Прозорий fallback.** Якщо `DATABASE_URL_REPLICA` не заданий, або
+ *   replica pool кинув помилку (connection refused, statement_timeout,
+ *   replica down) — `queryReplica()` повертається до primary pool.
+ *   Тому single-URL деплоїменти (Replit, dev, docker-compose) працюють
+ *   1:1, а production з replica down — деградує по latency, але не по
+ *   правильності.
+ *
+ * - **Інкремент / спостереження.** `getReplicaPoolStats()` віддає
+ *   `enabled` + `pg.Pool`-counters (як `getPoolStats()` для primary), і
+ *   `routedThroughReplica` мітку у `query()`-логах через `op` префікс.
+ *
+ * Caveats:
+ *
+ * 1. **Lag.** Streaming replication у Railway обіцяє ≤ 5s p99 за
+ *    нормальних умов. Endpoint-и, що використовують replica, повинні
+ *    бути толерантні до stale-reads ≤ 10s.
+ *
+ * 2. **Read-only.** Це не enforced на рівні TypeScript — runtime буде
+ *    кидати `cannot execute INSERT/UPDATE/DELETE in a read-only
+ *    transaction` від самого Postgres, якщо хтось спробує писати в
+ *    replica. У `queryReplica()` додано explicit warning в логах при
+ *    fallback-у на primary через write-error (rare; малоймовірно
+ *    через UI-shape).
+ *
+ * 3. **Транзакції.** `queryReplica()` навмисно НЕ підтримує `BEGIN…
+ *    COMMIT` — для multi-statement read-only транзакцій є
+ *    `withReplicaClient()` (отримує `PoolClient` з replica або
+ *    primary, fall-through аналогічно).
+ *
+ * Runbook: `docs/runbooks/postgres-read-replica.md`.
+ */
+
+import pg from "pg";
+import type { PoolClient, QueryResult, QueryResultRow } from "pg";
+import { logger } from "./obs/logger.js";
+import { env } from "./env.js";
+import pool from "./db.js";
+
+/** Чи увімкнений read-replica routing у цьому процесі. */
+export const REPLICA_ENABLED: boolean = Boolean(env.DATABASE_URL_REPLICA);
+
+/**
+ * Окремий `pg.Pool` для replica або `null`, якщо `DATABASE_URL_REPLICA`
+ * не заданий. Експортується для health-check-ів (`/healthz`) — в
+ * основному коді користуйся `queryReplica()` / `withReplicaClient()`.
+ */
+const replicaPool: pg.Pool | null = REPLICA_ENABLED
+  ? new pg.Pool({
+      connectionString: env.DATABASE_URL_REPLICA,
+      max: env.PG_POOL_SIZE,
+      idleTimeoutMillis: env.PG_IDLE_TIMEOUT_MS,
+      connectionTimeoutMillis: env.PG_CONNECTION_TIMEOUT_MS,
+      statement_timeout: env.PG_STATEMENT_TIMEOUT_MS,
+    })
+  : null;
+
+if (replicaPool) {
+  replicaPool.on("error", (err: Error) => {
+    logger.error({
+      msg: "db_replica_pool_error",
+      err: { message: err.message },
+    });
+  });
+
+  logger.info({
+    msg: "db_replica_enabled",
+    hint: "analytics SELECTs route via DATABASE_URL_REPLICA; writes stay on primary",
+  });
+}
+
+/**
+ * Мінімальний контракт для primary-pool override-а, який тести і router
+ * factory-и можуть пробросити в `queryReplica()`. Повертається `unknown`,
+ * тому що `pg.Pool.query` має багато overload-ів — ми робимо runtime-cast
+ * на `QueryResult<R>` нижче (це безпечно: pg повертає саме той shape,
+ * який каркасується generic-параметром).
+ */
+type PrimaryPoolLike = {
+  query: (text: string, values?: unknown[]) => Promise<unknown>;
+};
+
+interface QueryReplicaOpts {
+  /** Tag для логів / метрик. */
+  op?: string;
+  /**
+   * Override для primary pool, який використовується як fallback. За
+   * замовчуванням — module-level `pool` з `db.ts`. Дозволяє тестам та
+   * router factory-ам (`createSeoInternalRouter({ pool })`) пробросити
+   * свій pool без розгалуження helper-а.
+   */
+  primary?: PrimaryPoolLike;
+}
+
+interface PgErrorLike {
+  message?: string;
+  code?: string;
+}
+
+function pgErr(err: unknown): PgErrorLike {
+  return (err && typeof err === "object" ? (err as PgErrorLike) : {}) ?? {};
+}
+
+/**
+ * Read-only query, який бажано виконати на replica. Якщо replica
+ * недоступний (не сконфігурований, помилка конекту, statement timeout)
+ * — повертається до primary pool.
+ *
+ * Викликати **тільки** для запитів, які толерантні до replication lag
+ * (< 5s p99). Для read-after-write використовуй `query()` з `db.ts`.
+ */
+export async function queryReplica<R extends QueryResultRow = QueryResultRow>(
+  text: string,
+  values?: unknown[],
+  opts?: QueryReplicaOpts,
+): Promise<QueryResult<R>> {
+  const op = opts?.op ?? "query_replica";
+  const primary = opts?.primary ?? pool;
+
+  if (replicaPool) {
+    try {
+      return await replicaPool.query<R>(text, values as unknown[] | undefined);
+    } catch (err: unknown) {
+      const e = pgErr(err);
+      logger.warn({
+        msg: "db_replica_query_failed_fallback_primary",
+        op,
+        code: e.code,
+        err: { message: e.message },
+      });
+      // Fall through до primary pool — see jsdoc § Caveats.
+    }
+  }
+
+  // primary.query повертає Promise<unknown> (PrimaryPoolLike contract);
+  // у production це pg.Pool, у тестах — vitest-mock із того самого
+  // shape. Cast безпечний — generic <R> поширюється з caller-сайту.
+  const result = await primary.query(text, values as unknown[] | undefined);
+  return result as QueryResult<R>;
+}
+
+/**
+ * Виконати read-only коллбек з `PoolClient` від replica, з fallback до
+ * primary, якщо replica не сконфігурований чи відмовив.
+ *
+ * Використання — для multi-statement read-only сценаріїв (наприклад,
+ * `BEGIN; ...; COMMIT;` для consistent snapshot з кількох SELECT-ів).
+ */
+export async function withReplicaClient<T>(
+  fn: (client: PoolClient) => Promise<T>,
+  opts?: { op?: string },
+): Promise<T> {
+  const op = opts?.op ?? "with_replica_client";
+
+  if (replicaPool) {
+    let client: PoolClient | null = null;
+    try {
+      client = await replicaPool.connect();
+      return await fn(client);
+    } catch (err: unknown) {
+      const e = pgErr(err);
+      logger.warn({
+        msg: "db_replica_client_failed_fallback_primary",
+        op,
+        code: e.code,
+        err: { message: e.message },
+      });
+    } finally {
+      client?.release();
+    }
+  }
+
+  const primaryClient = await pool.connect();
+  try {
+    return await fn(primaryClient);
+  } finally {
+    primaryClient.release();
+  }
+}
+
+/**
+ * Pool-counters для replica або `enabled: false`, якщо replica не
+ * сконфігурований. Формат сумісний із `getPoolStats()` для primary,
+ * щоб дашборди могли мерджити.
+ */
+export function getReplicaPoolStats() {
+  if (!replicaPool) {
+    return { enabled: false as const };
+  }
+  return {
+    enabled: true as const,
+    totalCount: replicaPool.totalCount,
+    idleCount: replicaPool.idleCount,
+    waitingCount: replicaPool.waitingCount,
+  };
+}
+
+/** Експорт для tests — не використовувати у production-коді. */
+export const __replicaPoolForTests = replicaPool;

--- a/apps/server/src/env.ts
+++ b/apps/server/src/env.ts
@@ -60,6 +60,22 @@ export const env = {
    */
   DATABASE_URL_POOL: process.env["DATABASE_URL_POOL"] || "",
 
+  /**
+   * Read-replica Postgres connection string (PR #047 — analytics offload).
+   *
+   * If set, opt-in callers (currently `growth_*` / `seo_*` analytics reads
+   * via `apps/server/src/dbReplica.ts`) route SELECTs through the replica
+   * pool. Writes, transactions, and anything that needs read-after-write
+   * consistency stay on the primary `pool` (= `DATABASE_URL_POOL ||
+   * DATABASE_URL`).
+   *
+   * Empty / unset → replica helpers transparently fall back to the
+   * primary pool, so existing deployments without a replica keep
+   * working. Acceptable replication lag target: < 5s p99 (alert
+   * threshold). See `docs/runbooks/postgres-read-replica.md`.
+   */
+  DATABASE_URL_REPLICA: process.env["DATABASE_URL_REPLICA"] || "",
+
   // ─────────────────────────────────────────────────────────────────────────
   // Auth
   // ─────────────────────────────────────────────────────────────────────────

--- a/apps/server/src/env/env.ts
+++ b/apps/server/src/env/env.ts
@@ -60,6 +60,18 @@ const envSchema = z.object({
    * `docs/runbooks/database-connection-pooling.md`.
    */
   DATABASE_URL_POOL: z.string().url().optional(),
+  /**
+   * Read-replica Postgres URL (PR #047 — analytics offload).
+   *
+   * Якщо заданий — opt-in caller-и через `apps/server/src/dbReplica.ts`
+   * (зараз `growth_*` / `seo_*` analytics SELECT-и) ходять у replica
+   * pool. Writes, транзакції і будь-що з read-after-write semantic-ою
+   * лишаються на primary pool. Без `DATABASE_URL_REPLICA` replica
+   * helper-и прозоро fallback-ять на primary, тому існуючі деплоїменти
+   * без replica працюють так, як і раніше. Acceptable replication lag
+   * target: < 5s p99. Деталі — `docs/runbooks/postgres-read-replica.md`.
+   */
+  DATABASE_URL_REPLICA: z.string().url().optional(),
   /** Максимум з'єднань у pg Pool. */
   PG_POOL_MAX: coerceInt.positive().default(10),
   /** Поріг повільного запиту (мс) для логування та метрики. */

--- a/apps/server/src/routes/internal/seo.ts
+++ b/apps/server/src/routes/internal/seo.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import type { Pool } from "pg";
 import { asyncHandler } from "../../http/index.js";
+import { queryReplica } from "../../dbReplica.js";
 
 /**
  * SEO snapshot endpoints. Усі записи робить n8n (WF-50…WF-55) через
@@ -179,8 +180,15 @@ export function createSeoInternalRouter({ pool }: { pool: Pool }): Router {
     asyncHandler(async (req, res) => {
       const onlyActive = req.query["onlyActive"] !== "0";
       const where = onlyActive ? "WHERE is_active = TRUE" : "";
-      // eslint-disable-next-line no-restricted-syntax -- `where` is one of two fixed literal SQL fragments; query takes no user input.
-      const { rows } = await pool.query<{
+      // PR #047: SEO keyword list is analytics-style read-only — toleruje
+      // <5s replica lag. queryReplica() прозоро fallback-ить на primary
+      // pool (через `primary` override — щоб тести могли передати свій
+      // mock pool без розгалуження helper-а), якщо DATABASE_URL_REPLICA
+      // не сконфігурований. `where` — один із двох фіксованих SQL-fragment-ів,
+      // user input не приймається; M11 templated-query lint rule
+      // зараз скоупується на `pool.query(`…`)` / `query(`…`)` —
+      // queryReplica додасться у followup, коли rule розширимо.
+      const { rows } = await queryReplica<{
         id: string;
         term: string;
         locale: string;
@@ -193,6 +201,8 @@ export function createSeoInternalRouter({ pool }: { pool: Pool }): Router {
         `SELECT id, term, locale, market, priority, target_url, cluster, is_active
            FROM seo_keywords ${where}
           ORDER BY priority DESC, term ASC`,
+        undefined,
+        { op: "seo_keywords_list", primary: pool },
       );
       res.json({
         keywords: rows.map((row) => ({

--- a/docs/runbooks/postgres-read-replica.md
+++ b/docs/runbooks/postgres-read-replica.md
@@ -1,0 +1,229 @@
+# Postgres read replica — runbook (PR #047)
+
+> **Last validated:** 2026-05-05 by Devin. **Next review:** 2026-08-05.
+> **Status:** Active
+
+> Закриває Stage 6 PR #047 із [`docs/planning/storage-roadmap.md`](../planning/storage-roadmap.md):
+> deploy-shape для **streaming-replication read replica** Postgres у Railway
+> production-tier, ENV-перемикач `DATABASE_URL_REPLICA`, та правила, які
+> запити мають право ходити в replica.
+>
+> Cross-link:
+> [`docs/runbooks/database-connection-pooling.md`](./database-connection-pooling.md)
+> (replica + pgBouncer — комбінуються, але незалежні),
+> [`docs/runbooks/database-backup-restore.md`](./database-backup-restore.md)
+> (replica ≠ backup — він не захищає від logical corruption).
+
+## TL;DR
+
+- `DATABASE_URL` — primary Postgres. Усі writes, транзакції,
+  read-after-write reads.
+- `DATABASE_URL_POOL` — pgBouncer перед primary. Runtime app-pool ходить
+  туди (див. [pgBouncer runbook](./database-connection-pooling.md)).
+- `DATABASE_URL_REPLICA` — **новий** опційний URL до streaming-replication
+  read-replica. Opt-in caller-и (`growth_*` / `seo_*` analytics SELECT-и)
+  ходять через `apps/server/src/dbReplica.ts` → `queryReplica()`.
+- Empty / unset → `queryReplica()` прозоро fallback-ить на primary pool.
+  Single-URL deploy-и (Replit, dev, docker-compose) працюють без змін.
+
+`REPLICA_ENABLED` (експорт із `dbReplica.ts`) і `getReplicaPoolStats()`
+(`{ enabled: false }` або pool-counters) — джерело правди для health-check
+endpoint-а та дашбордів.
+
+## Архітектура
+
+```
+                                    ┌─► Postgres primary
+                                    │   • усі writes
+                                    │   • read-after-write SELECT-и
+                 ┌─ DATABASE_URL ───┤   • migrations / advisory locks
+                 │                  │   • Better Auth, /api/v2/sync/push
+HTTP request ────┤
+                 │  ┌─ DATABASE_URL_POOL ─► pgBouncer ─► (та сама primary)
+                 │
+                 └─ DATABASE_URL_REPLICA ─► Postgres replica (streaming)
+                     • analytics SELECT (queryReplica)
+                     • lag-tolerant endpoint-и (≤ 5s p99)
+                     • тільки read-only — Postgres сам кине помилку на write
+```
+
+Replica відстає від primary на 0–5s (нормальні умови). Усі запити до
+replica повинні бути толерантні до stale reads ≤ 10s.
+
+## Чому окремий пул, а не route у тому самому `db.ts`
+
+1. **Конфіг ізольований.** Replica може мати інший `statement_timeout`
+   (analytics — довше), іншу `max` (більше long-runner-ів), іншу
+   `idleTimeoutMillis`. Окремий `pg.Pool` дозволяє це без розгалуження
+   `db.ts`.
+
+2. **Прозорий fallback не ламає primary.** `queryReplica()` ловить
+   будь-яку помилку (connect refused, statement_timeout, replica down)
+   і робить retry на primary. Якби це жило в `db.ts`, ми б ризикували
+   подвійним лог-ентрі / подвійним метричним підрахунком.
+
+3. **Опціональність зашита у конструктор.** `replicaPool: pg.Pool | null`
+   — якщо `DATABASE_URL_REPLICA` порожній, ми взагалі не створюємо
+   `pg.Pool`, і нічого не висить idle-conn-ом.
+
+## Які запити сидять на replica
+
+Сьогодні (PR #047): `GET /api/internal/seo/keywords` (active keyword
+list — analytics-style read, толерує лаг).
+
+Майбутнє розширення (з низьким рівнем ризику):
+
+- Решта `GET /api/internal/seo/*` lookup-и (snapshot listing, ranks-by-day).
+- Analytics digest endpoint-и для `growth_events` / `growth_metrics_daily`.
+- Будь-який endpoint з префіксом `/api/insights/*`, який повертає
+  агрегати з `seo_*` / `growth_*` без read-after-write вимог.
+
+Як додати новий endpoint у replica:
+
+```ts
+import { queryReplica } from "../../dbReplica.js";
+
+const { rows } = await queryReplica<RowShape>(
+  `SELECT … FROM seo_… WHERE …`,
+  [param1, param2],
+  { op: "seo_my_analytic" },
+);
+```
+
+Не використовувати `queryReplica()` для:
+
+- write-after-read (UPSERT з conditional на свіже значення);
+- межі транзакції з `BEGIN…COMMIT` (для multi-statement read-only —
+  `withReplicaClient()`);
+- low-traffic admin endpoint-ів — простіше залишити на primary;
+- запитів, де UI робить mutation і одразу re-read (chat, hub).
+
+## Railway deploy shape
+
+```
+Railway Project: Sergeant Production
+├── Service: postgres-primary (плагін Postgres або власний)
+│   • DATABASE_URL = postgres://… → primary
+│   • Backup retention: 7 днів (PITR — див. backup-restore runbook)
+│
+├── Service: postgres-replica (Postgres-replica plugin)
+│   • Stream from primary (Railway primary-replica linkage)
+│   • DATABASE_URL_REPLICA = postgres://ro:…@replica.railway.internal:5432/…
+│   • Read-only role (`ALTER USER ro WITH NOSUPERUSER`)
+│   • monitoring: Railway dashboard → replica lag
+│
+└── Service: api (apps/server)
+    • DATABASE_URL = postgres://…@primary.railway.internal:5432/…
+    • DATABASE_URL_POOL = postgres://…@pgbouncer.railway.internal:6432/… (PR #046)
+    • DATABASE_URL_REPLICA = ⏎ те, що вище ⏎
+    • PG_POOL_SIZE = 10 (з'являється у both primary і replica pool)
+    • startup лог: `db_replica_enabled` повинен з'явитись один раз на boot
+```
+
+### Replica role (минимальные привилегии)
+
+```sql
+-- Виконати ОДИН РАЗ на primary (наслідується на replica)
+CREATE ROLE ro_analytics LOGIN PASSWORD '<random-32-byte-hex>';
+GRANT CONNECT ON DATABASE sergeant TO ro_analytics;
+GRANT USAGE ON SCHEMA public TO ro_analytics;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO ro_analytics;
+
+-- Future-proof: новостворені таблиці автоматично доступні для SELECT
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT ON TABLES TO ro_analytics;
+```
+
+Це гарантує, що навіть якщо хтось у майбутньому випадково передасть
+write-запит у `queryReplica()`, Postgres відмовить permission-error-ом
+не replica-status-error-ом.
+
+## Верифікація після деплою
+
+1. **Startup-лог:**
+
+   ```bash
+   railway logs --service api | grep db_replica
+   # → {"level":"info","msg":"db_replica_enabled","hint":"analytics SELECTs route via DATABASE_URL_REPLICA; writes stay on primary"}
+   ```
+
+2. **Health-check:** додай `getReplicaPoolStats()` у `/healthz`-payload (або
+   `/api/observability/db-replica`, якщо такий маршрут з'явиться).
+   Очікувана відповідь:
+
+   ```json
+   {
+     "replica": {
+       "enabled": true,
+       "totalCount": 0,
+       "idleCount": 0,
+       "waitingCount": 0
+     }
+   }
+   ```
+
+   `totalCount` зросте після першого `queryReplica()` виклику.
+
+3. **Manual smoke:**
+
+   ```bash
+   curl -fsS -H "Authorization: Bearer ${INTERNAL_TOKEN}" \
+     https://api.sergeant.app/api/internal/seo/keywords?onlyActive=1 \
+     | jq '.keywords | length'
+   # → число > 0; у логах сервера op="seo_keywords_list" з replica-pool метрикою
+   ```
+
+4. **Lag check (Postgres-side, з primary):**
+   ```sql
+   SELECT
+     application_name,
+     state,
+     EXTRACT(EPOCH FROM now() - pg_last_xact_replay_timestamp()) AS lag_seconds
+   FROM pg_stat_replication;
+   -- очікуємо lag_seconds < 5
+   ```
+
+## Rollback
+
+Прибрати `DATABASE_URL_REPLICA` зі змінних середовища server-сервісу
+(або задати порожній рядок). Restart server. Жодних schema-мутацій,
+жодних data-loss-ризиків — `queryReplica()` миттєво повернеться до
+primary.
+
+Якщо replica сильно відстав (≥ 60s) і блокує analytics на свіжих
+даних — можна вимкнути `DATABASE_URL_REPLICA` тимчасово, поки Railway
+re-syncs replica зі snapshot-у primary.
+
+## Алерти
+
+| Метрика                                         | Поріг       | Дія                                                              |
+| ----------------------------------------------- | ----------- | ---------------------------------------------------------------- |
+| `pg_stat_replication.lag_seconds` p99           | > 5s        | Розслідувати primary write-load; підняти replica resources       |
+| `db_replica_query_failed_fallback_primary` rate | > 1/min     | Replica down або statement_timeout — перевірити replica health   |
+| `replicaPool.totalCount` constant 0             | > 5min      | Перевірити чи `DATABASE_URL_REPLICA` доходить до server-сервісу  |
+| `pg_stat_replication.state`                     | ≠ streaming | Replication broken — оновити Railway service / re-create replica |
+
+## Caveats
+
+1. **Replica ≠ backup.** Logical corruption (помилка у міграції,
+   випадковий `DELETE` без `WHERE`) реплікується миттєво. Backup +
+   PITR — окремий механізм; див. `database-backup-restore.md`.
+
+2. **Schema-changes лаг.** Під час deploy-у міграції viконуються на
+   primary, а replica підхоплює зміни через replication-stream. У
+   проміжку (<5s) replica може бути на старій схемі — `queryReplica()`
+   на нову колонку поверне `column "..." does not exist`. Для
+   safety: всі нові SELECT-и через replica повинні читати тільки
+   колонки, які існували у попередньому релізі (= те саме правило, що
+   й для blue-green; див. AGENTS.md hard-rule #4).
+
+3. **Read-only enforcement.** На рівні TypeScript нічого не заважає
+   написати `INSERT` через `queryReplica()`. Ми покладаємось на:
+   - `ro_analytics` role (permission-error від Postgres);
+   - PR-review (grep `queryReplica.*INSERT|UPDATE|DELETE` як CI-gate
+     — followup task).
+
+4. **pgBouncer + replica.** Якщо у майбутньому з'явиться окремий
+   pgBouncer перед replica — `DATABASE_URL_REPLICA` має вказувати на
+   нього (transaction-mode). Поки що достатньо connect напряму до
+   replica через Railway internal DNS.


### PR DESCRIPTION
## Summary

Stage 6 PR #047 — додає опційний **streaming-replication read replica** для analytics-style SELECT-ів (`growth_*` / `seo_*`), щоб offload-ити analytics-load з primary Postgres у Railway production.

- ENV-перемикач: новий `DATABASE_URL_REPLICA`. Empty / unset → існуючі single-URL deploy-и (Replit, dev, docker-compose) працюють 1:1, **без жодних код-змін**.
- Helper-и: `apps/server/src/dbReplica.ts` — окремий `pg.Pool`, `queryReplica()` / `withReplicaClient()` з прозорим fallback-ом на primary pool.
- Перший caller: `GET /api/internal/seo/keywords` (active keyword list, analytics-style read, толерує <5s replica lag).
- Runbook: `docs/runbooks/postgres-read-replica.md` — Railway deploy shape, мінімальні privilege-и для replica role, верифікація, rollback, alerts.

Acceptance criteria з roadmap-у (Stage 6 рядок про PR #047): _Lag < 5s p99_ — задокументований alert threshold у runbook-у; analytics queries route у replica через `queryReplica()`; primary бере на себе тільки writes / read-after-write.

## Governing Skill

- Primary skill: `sergeant-server-and-api`
- Secondary skill (if truly needed): `sergeant-docs-and-governance` (для runbook-у)

## Playbook

- Primary playbook: n/a
- Why this playbook: Stage 6 storage-roadmap workitem — runbook-shape ближче до infrastructure-onboarding, ніж до feature playbook-у. Дотримуюсь shape-у `docs/runbooks/database-connection-pooling.md` (PR #046, той самий стейдж).
- If no playbook matched, why: інфра-помилки нечасті, runbook + roadmap-крос-лінк — стандартний exit channel.

## Verification

```bash
pnpm --filter @sergeant/server typecheck
# → 0 errors

pnpm --filter @sergeant/server test src/dbReplica.test.ts src/db.test.ts src/routes/internal.test.ts
# → 30 passed (4 dbReplica + 4 db + 22 internal routes)

pnpm --filter @sergeant/server lint
# → 0 errors, 0 NEW warnings (4 pre-existing fs.readFile/writeFile у backup endpoints — не в touched-files)
```

Additional checks:

- [x] Local smoke / manual validation completed (eager `pg.Pool` instantiation у тестах не відкриває TCP, як і в `db.test.ts`).
- [x] Surface-specific checks completed (зв'язок з PR #046 verified — pgBouncer + replica можна комбінувати незалежно).

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update. (Hard-rules без змін — replica додає surface, не змінює правил.)
- [x] I checked whether a playbook or skill needed an update. (Ні — feature-добавка, окремий runbook покриває operator-сторону.)
- [x] I checked whether governance docs or review docs needed an update. (Ні — review-shape не змінюється.)

Updated docs:

- `docs/runbooks/postgres-read-replica.md` — новий operator runbook (Railway deploy shape, role з мінімальними privilege-ами, верифікація, rollback, alerts, caveats).

`docs/planning/storage-roadmap.md` — оновлю **окремим follow-up PR**, коли всі 3 Stage-6 workitem-и (#045, #046 ✅ merged, #047) залендять, щоб історія була атомарною.

## Risk and Rollout

- **User-visible risk:** мінімальний. Без `DATABASE_URL_REPLICA` поведінка не змінюється — `queryReplica()` детектує `replicaPool === null` і прозоро викликає primary pool.
- **Rollout / deploy order:**
  1. Merge цього PR.
  2. На Railway: створити `postgres-replica` Postgres-replica plugin (streaming) і `ro_analytics` role з мінімальними privilege-ами (SQL у runbook-у).
  3. Виставити `DATABASE_URL_REPLICA` у `api`-сервіс. Restart.
  4. Verify: startup лог `db_replica_enabled` + `pg_stat_replication` lag < 5s + `getReplicaPoolStats()` через `/healthz`-recipe з runbook-у.
  5. Інкрементально переводити інші analytics endpoint-и на `queryReplica()` (правила у runbook-у).
- **Backout plan:** прибрати `DATABASE_URL_REPLICA` (або задати порожній рядок) → restart server. Жодних schema-мутацій, data-loss-ризиків нуль. У runbook-у задокументовано.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian. (`postgres-read-replica.md` — українською; `dbReplica.ts` jsdoc — українською; commit message — українською.)
- [x] I did not use `--no-verify`.

## Reviewer Notes

- **Replica ≠ backup.** Logical corruption реплікується миттєво. `database-backup-restore.md` залишається джерелом правди для PITR; runbook це явно зазначає.
- **Schema-change лаг.** Нові SELECT-и через replica повинні читати тільки колонки, які існували у попередньому релізі (= те саме правило, що й для blue-green; AGENTS.md hard-rule #4). Зазначено у caveats.
- **Read-only enforcement** на рівні TS відсутній (типи не розрізняють SELECT/INSERT). Покладаємось на:
  1. `ro_analytics` role permission-error від Postgres;
  2. PR-review (можливий followup — додати `no-restricted-syntax` selector на `queryReplica.*INSERT|UPDATE|DELETE`).
- **Templated SQL lint rule.** `no-restricted-syntax` у `eslint.config.js` зараз ловить тільки `pool.query(\`…\`)` / `query(\`…\`)` (callee.name === "query"). Додаси селектор для `queryReplica` у followup, коли цей виклик стане другим production-call-сайтом — поки що один call-site з фіксованим WHERE-fragment-ом не виправдовує widening rule-а.
- **pgBouncer + replica** — незалежні, але комбінуються. Якщо у майбутньому з'явиться окремий pgBouncer перед replica, `DATABASE_URL_REPLICA` має вказувати на нього (transaction-mode); зазначено у runbook-у.


Link to Devin session: https://app.devin.ai/sessions/f2a2938af0914492a813803a2954ea5f
Requested by: @Skords-01

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional Postgres read-replica routing for analytics reads to reduce load on the primary. Introduces `DATABASE_URL_REPLICA` with transparent fallback; first adopter is `GET /api/internal/seo/keywords`.

- **New Features**
  - New env var: `DATABASE_URL_REPLICA` (optional). Unset/empty → no behavior change.
  - New helper module `apps/server/src/dbReplica.ts`:
    - `REPLICA_ENABLED`, `queryReplica()`, `withReplicaClient()`, `getReplicaPoolStats()`.
    - Separate `pg.Pool` for the replica; on errors, falls back to primary.
  - Route update: `GET /api/internal/seo/keywords` now uses `queryReplica()` (lag-tolerant, <5s p99) with `op` tag and `primary` override for tests.
  - Tests: `apps/server/src/dbReplica.test.ts` covers enable/disable and pool stats.
  - Docs: `docs/runbooks/postgres-read-replica.md` (Railway setup, read-only role, verification, rollback, alerts).

- **Migration**
  - Set `DATABASE_URL_REPLICA` to the replica URL in the `api` service.
  - Use a read-only role (`ro_analytics`) with minimal privileges as documented.
  - Deploy and verify: look for `db_replica_enabled` in logs and check `getReplicaPoolStats()` via health checks.
  - Back out by unsetting `DATABASE_URL_REPLICA` and restarting.

<sup>Written for commit 7b2ab30c7b461b443b0abf46c613520d2a0f4962. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

