### PR TITLE
fix(web): connectionGate.test.ts needs jsdom env (unblock Test coverage CI)

### DIFF
--- a/apps/web/src/core/lib/connectionGate.test.ts
+++ b/apps/web/src/core/lib/connectionGate.test.ts
@@ -1,3 +1,4 @@
+/** @vitest-environment jsdom */
 import { afterEach, describe, expect, it } from "vitest";
 import { shouldPrefetchOnConnection } from "./connectionGate";
 


### PR DESCRIPTION
## Summary

Тільки що змерджено PR `#1927` (`453152f7`) розблокував `governance-sync`/`Markdown link checker`/`Test coverage (vitest) — server`/`staged-typecheck`. На `main` лишилася ще одна `Test coverage (vitest)` блокуюча помилка — у **web** частині того ж jobу:

```
ReferenceError: navigator is not defined
 ❯ src/core/lib/connectionGate.test.ts:13:31
```

(Лог: https://github.com/Skords-01/Sergeant/actions/runs/25400003050/job/74497191836)

`apps/web/vitest.config.js` ставить `environment: "node"` глобально. Файли, яким потрібен DOM, мають per-file директиву `/** @vitest-environment jsdom */` (приклади: `Modal.test.tsx`, `SectionHeading.test.tsx`, `SwipeToAction.test.tsx`, `CollapsibleSection.test.tsx`, `ModuleAccentProvider.test.tsx`).

`connectionGate.test.ts` (доданий у `74c0bb4f` — `perf(web): module prefetch hardening`) звертається до `navigator` на верхньому рівні файлу:

```ts
const nav: NavigatorMutable = navigator as unknown as NavigatorMutable;
```

Node 20 не експонує `navigator` як global (він з'явився в Node 21). Тому модуль падає з `ReferenceError` ще до запуску будь-якого `it(...)`, ламає всю вебівську сюїту і завалює CI job. На локальному dev це не помітили бо інші web tests мають jsdom-директиву і файлово-ізольовані.

Фікс — додаю одну `/** @vitest-environment jsdom */` директиву зверху файлу, відповідно до існуючої convention. Без зміни самого `connectionGate.ts` (там вже є `typeof navigator === "undefined"` guard для прод-runtime).

## Governing Skill

- Primary skill: `sergeant-bugfix-and-regression`

## Playbook

- Primary playbook: `docs/playbooks/fix-failing-ci.md` — single-file CI unblock, log-цитована.

## Verification

```bash
pnpm --filter @sergeant/web exec vitest run \
  src/core/lib/connectionGate.test.ts
# Test Files 1 passed (1) / Tests 5 passed (5)

pnpm format:check    # All matched files use Prettier code style!
pnpm lint            # clean
pnpm typecheck       # 16 successful, 16 total
```

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [x] Docs не змінювались — це point-fix у тесті.
- [x] AGENTS.md / playbook update не потрібен.
- [x] Hard rules не зачіпаю.

## Risk and Rollout

- User-visible risk: none. Зміна тільки в тесті.
- Rollout / deploy: merge → CI на наступному main commit має бути зеленим у `Test coverage (vitest)` (єдиний прохідний блокер після `#1927`).
- Backout plan: revert PR.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs touched: none. (Тільки тест.)
- [x] I did not use `--no-verify`.

## Reviewer Notes

- Все ще червоні після цього PR: `Visual regression (Argos)` (Free-plan quota — потрібен upgrade від тебе) + `Build Storybook` (потрібен Pages source як `GitHub Actions` у Settings) + `Critical-flow E2E (Playwright)` / `detox-ios` — окремий діагноз, не робив у скоупі цього PR.
- `apps/mobile` Jest падає теж через `Object.defineProperty called on non-object` з `jest-expo/src/preset/setup.js:47` — це Dependabot bump `1b926d6e`, що підняв `jest-expo` 52 → 55 і `react-test-renderer` 18 → 19, тоді як `react@18.3.1` лишився на місці. Несумісно з Expo 52 / RN 0.76; треба revert цих 4 пакетів (`jest`, `@types/jest`, `jest-expo`, `react-test-renderer`). Не у скоупі цього PR — окремий follow-up.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-file `/** @vitest-environment jsdom */` to `apps/web/src/core/lib/connectionGate.test.ts` to fix "navigator is not defined" under Node 20 and unblock the web `Test coverage (vitest)` CI job.

<sup>Written for commit f3626006b262beb586357720408b4780eeeb432c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

