### PR TITLE
chore(docs): add 4-week audit-freeze + PR-template warning

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -50,6 +50,16 @@ Updated docs:
 - [ ] Internal docs I touched are in Ukrainian.
 - [ ] I did not use `--no-verify`.
 
+## Audit-freeze (until 2026-06-02)
+
+<!-- Per `docs/governance/audit-freeze-2026-05-05.md`. New files under
+docs/audits/, docs/initiatives/, docs/playbooks/, docs/adr/ trigger a
+non-blocking CI warning. If this PR adds such a file, add `[skip-freeze]`
+or `[freeze-exception]` to the PR title and explain below. Otherwise leave
+this section as-is or remove. -->
+
+- [ ] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).
+
 ## Reviewer Notes
 
 <!-- Flag migrations, env changes, HubChat tools, auth, or anything else that deserves extra reviewer attention. -->

--- a/.github/workflows/audit-freeze.yml
+++ b/.github/workflows/audit-freeze.yml
@@ -1,0 +1,152 @@
+name: Audit-freeze
+
+# Owner: @Skords-01.
+# Active until 2026-06-02 (per docs/governance/audit-freeze-2026-05-05.md).
+# Behaviour: warns (does not block) when a PR adds new audit/initiative/playbook/ADR files.
+# Override: add `[skip-freeze]` or `[freeze-exception]` to PR title.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+concurrency:
+  group: audit-freeze-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  freeze-warn:
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout v6.0.2 (SHA-pinned for supply-chain hardening)
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+
+      - name: Detect new audit-frozen files and post warning
+        # actions/github-script v8.0.0 (SHA-pinned for supply-chain hardening)
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        with:
+          script: |
+            // Period: 2026-05-05 → 2026-06-02. Skip job after that.
+            const FREEZE_END = new Date('2026-06-02T00:00:00Z');
+            if (Date.now() > FREEZE_END.getTime()) {
+              core.info('Audit-freeze period ended (after 2026-06-02). Skipping.');
+              return;
+            }
+
+            const pr = context.payload.pull_request;
+            if (!pr) {
+              core.info('No pull_request on context — skipping.');
+              return;
+            }
+
+            // Override path: skip-freeze / freeze-exception in PR title.
+            const title = pr.title || '';
+            if (/\[skip-freeze\]|\[freeze-exception\]/i.test(title)) {
+              core.info(`PR #${pr.number} has freeze-exception marker in title — skipping.`);
+              return;
+            }
+
+            // Patterns that count as "new audit/initiative/playbook/ADR".
+            // Only `added` files; existing files are allowed (edits don't violate freeze).
+            const FROZEN_PATTERNS = [
+              { re: /^docs\/audits\/[^/]+\.md$/, kind: 'audit' },
+              { re: /^docs\/initiatives\/00\d{2}-.+\.md$/, kind: 'initiative' },
+              { re: /^docs\/playbooks\/[^/]+\.md$/, kind: 'playbook' },
+              { re: /^docs\/adr\/00\d{2}-.+\.md$/, kind: 'adr' },
+            ];
+
+            // Allow archive paths and INDEX/README files.
+            const ALLOWLIST = [
+              /^docs\/audits\/archive\//,
+              /^docs\/audits\/README\.md$/,
+              /^docs\/initiatives\/README\.md$/,
+              /^docs\/playbooks\/README\.md$/,
+              /^docs\/playbooks\/INDEX\.md$/,
+              /^docs\/playbooks\/playbook-catalog\.md$/,
+              /^docs\/adr\/README\.md$/,
+              /^docs\/adr\/index\.md$/,
+            ];
+
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                per_page: 100,
+              },
+            );
+
+            const violations = [];
+            for (const f of files) {
+              if (f.status !== 'added') continue;
+              if (ALLOWLIST.some((re) => re.test(f.filename))) continue;
+              const match = FROZEN_PATTERNS.find((p) => p.re.test(f.filename));
+              if (match) {
+                violations.push({ filename: f.filename, kind: match.kind });
+              }
+            }
+
+            if (violations.length === 0) {
+              core.info('No new frozen-pathspec files detected.');
+              return;
+            }
+
+            const list = violations.map(
+              (v) => `- \`${v.filename}\` (${v.kind})`,
+            ).join('\n');
+
+            const body = [
+              '⚠️ **Audit-freeze warning** — цей PR додає файли під заборонений pathspec.',
+              '',
+              'Період freeze: **2026-05-05 → 2026-06-02** (детально — [`docs/governance/audit-freeze-2026-05-05.md`](https://github.com/Skords-01/Sergeant/blob/main/docs/governance/audit-freeze-2026-05-05.md)).',
+              '',
+              '**Файли, що тригернули warning:**',
+              '',
+              list,
+              '',
+              '**Як override-нути** (якщо легітимний exception):',
+              '1. Додати `[skip-freeze]` або `[freeze-exception]` у PR title.',
+              '2. Додати у PR-description секцію `## Audit-freeze exception` з обґрунтуванням.',
+              '',
+              'Це **warning, не block** — PR можна merge-нути без override. Але override залишає audit-trail у CI-history. Через 4 тижні (2026-06-02) робимо огляд: extend / refine / release.',
+              '',
+              '_Triggered by [.github/workflows/audit-freeze.yml](https://github.com/Skords-01/Sergeant/blob/main/.github/workflows/audit-freeze.yml)._',
+            ].join('\n');
+
+            // Avoid duplicate warnings: check existing comments.
+            const existing = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                per_page: 100,
+              },
+            );
+            const already = existing.find(
+              (c) => c.user.type === 'Bot' && c.body && c.body.includes('Audit-freeze warning'),
+            );
+
+            if (already) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: already.id,
+                body,
+              });
+              core.info(`Updated existing audit-freeze comment ${already.id}.`);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body,
+              });
+              core.info('Posted new audit-freeze warning comment.');
+            }

--- a/docs/governance/README.md
+++ b/docs/governance/README.md
@@ -1,6 +1,6 @@
 # Governance
 
-> **Last validated:** 2026-05-02 by @claude. **Next review:** 2026-07-31.
+> **Last validated:** 2026-05-05 by @Skords-01. **Next review:** 2026-08-03.
 > **Status:** Active
 
 Governance in Sergeant is intentionally split between human-readable policy and machine-readable enforcement.
@@ -15,6 +15,7 @@ Governance in Sergeant is intentionally split between human-readable policy and 
 - [incident-severity-policy.md](./incident-severity-policy.md) - severity model and postmortem threshold.
 - [security-incident-policy.md](./security-incident-policy.md) - access compromise classification and first-response policy.
 - [policy-review.md](./policy-review.md) and [doc-freshness.md](./doc-freshness.md) - cadence and review process.
+- [audit-freeze-2026-05-05.md](./audit-freeze-2026-05-05.md) - active 4-week freeze on new audit/initiative/playbook/ADR files (until 2026-06-02).
 
 ## CI gates
 

--- a/docs/governance/audit-freeze-2026-05-05.md
+++ b/docs/governance/audit-freeze-2026-05-05.md
@@ -1,0 +1,160 @@
+# Audit-freeze 2026-05-05 → 2026-06-02
+
+> **Last validated:** 2026-05-05 by @Skords-01 / Devin. **Next review:** 2026-06-02.
+> **Status:** Active (4 weeks)
+
+> **Що це.** Тимчасова заморозка створення нових audit/initiative/governance документів. Працює як **process-level rate-limiter** на час, поки `main` повертає в баланс **product velocity ↔ docs velocity**.
+
+> **Контекст.** На 2026-05-05 в репо: 12 активних `docs/initiatives/`, 12 audit-документів у `docs/audits/`, 334 markdown-файли в `docs/`. AGENTS.md — 839 рядків. За попередні 2 тижні створено 5 нових audit-доків і 2 нові ініціативи (`0011-foundation-adoption`, `0012-perfect-strictness`). Водночас з 15 P0/P1 пунктів FTUX-roast (2026-05-03) частина все ще **open у коді**. Розрив між «закрите в плані» і «закрите для користувача».
+
+> **Мета freeze-у.** Дати product-cycle 4 тижні майже-без-нової-документації, щоб PR-flow зосередився на shippable code. Через 4 тижні — review: чи дійсно стало тісно (extend), чи навпаки темп пришвидшився (release).
+
+---
+
+## Період
+
+- **Старт:** 2026-05-05
+- **Кінець:** 2026-06-02 (4 тижні)
+- **Review:** 2026-06-02 (опційне продовження або release)
+
+---
+
+## Що ЗАБОРОНЕНО під час freeze
+
+1. **Нові аудит-документи** в `docs/audits/*.md` (топ-рівень).
+2. **Нові ініціативи** в `docs/initiatives/00NN-*.md`.
+3. **Нові playbook-и** в `docs/playbooks/*.md` без передумови — playbook народжується з хоча б 2 завершених PR-ів, що руками показали recipe (а не теоретичне «треба зробити»).
+4. **Нові ADR-и** без активного code-PR-у, що потребує decision.
+5. **Розширення AGENTS.md** новими правилами без обов'язкового lint-enforcement (нові rules → `docs/governance/hard-rules.json` + ESLint plugin або CI-gate; pure-text rules відкладаються до post-freeze).
+
+---
+
+## Що ДОЗВОЛЕНО під час freeze
+
+1. **Edit existing audit-doc-ів** з оновленнями статусів (`Last validated:` bump, status table refresh, нові P-items в існуючих P0/P1/P2 секціях).
+2. **Errata-блоки** як inline-коментарі в існуючих audit-доках (з посиланням на нову інформацію).
+3. **Status registry update-и** в master tracker-ах:
+   - [`docs/launch/ftux-master-tracker.md`](../launch/ftux-master-tracker.md) — FTUX SSOT.
+   - Інші master-tracker-и якщо з'являться post-freeze.
+4. **Post-mortem-и** завершених PR-серій у `docs/launch/post-mortems/` (1 page max).
+5. **Decisions log** — нові entries у §7 master tracker-у.
+6. **Consolidation-PR-и** — об'єднання 2+ існуючих доків в 1 (як [PR #1934 — FTUX consolidation](https://github.com/Skords-01/Sergeant/pull/1934)).
+7. **Архівація** stale audit-tracker-ів з `docs/audits/` → `docs/audits/archive/`.
+8. **Documentation для shipped code** (CHANGELOG, release notes, in-product whats-new — обов'язкові для PR-ів, які міняють user-visible behavior).
+9. **PR-template / CODEOWNERS / CI-config** оновлення — це process-tooling, не audit-content.
+
+---
+
+## Гард на freeze (CI warning)
+
+Cuộc CI-job, що warn-ить (не block-ить), якщо PR створює новий файл під заборонений path:
+
+```
+docs/audits/[^/]+\.md         (top-level only, archive/ allowed)
+docs/initiatives/00\d{2}-*.md (any new initiative number)
+docs/playbooks/*.md           (any new playbook)
+docs/adr/00\d{2}-*.md         (any new ADR)
+```
+
+CI-warning виводиться як comment на PR з:
+
+- Список файлів, що тригернули warning
+- Лінк на цей файл (`docs/governance/audit-freeze-2026-05-05.md`)
+- Інструкція як override: додати `[skip-freeze]` у PR title (або `[freeze-exception]`).
+
+> **Важливо:** це **warning, не block.** Override легкий — щоб не блокувати legitimate exceptions (наприклад, security-incident retro). Але кожен override залишає audit-trail у CI-history.
+
+CI-job: `.github/workflows/audit-freeze.yml` (додається у цьому PR).
+
+---
+
+## Override path
+
+Якщо потрібно створити новий audit/initiative/playbook/ADR під час freeze:
+
+1. **Додати у PR title маркер:** `[skip-freeze]` або `[freeze-exception]`.
+2. **Додати у PR-description секцію `## Audit-freeze exception`** з:
+   - Чому це exception?
+   - Чому не може почекати до 2026-06-02?
+   - Куди буде інтегровано після freeze (master-tracker, archive, тощо)?
+3. **Reviewer:** review-checklist додає 1 чек-пункт «freeze-exception обґрунтовано».
+
+Override — не sin, це signaling механізм. Якщо за 4 тижні буде >5 override-ів — це сигнал, що freeze не працює і треба переглянути правила.
+
+---
+
+## Огляд успіху (2026-06-02)
+
+**Метрики, які review-имо:**
+
+1. Кількість нових файлів за заборонений pathspec (target: ≤ 2, з justified override-ами).
+2. Кількість edit-ів у master tracker-ах (target: ≥ 8, оскільки PR-плани оновлюються з кожним shipped PR).
+3. Кількість shipped product-PR-ів (target: ≥ 25 за 4 тижні, що співпадає з 5-8 PR/тиждень з PR-плану).
+4. Subjective: чи відчувається, що cycle-time від ідеї до shipped стало коротшим?
+
+**Можливі результати огляду:**
+
+- **Release** (freeze знімається): pace відновився; product-PR-и переважають audit-PR-и; немає накопичення «треба написати документацію».
+- **Extend** (ще 4 тижні): freeze допомагає, але баланс ще не стабільний.
+- **Refine** (нові правила, не extend): з'явилися edge-cases, треба refine override-path або pathspec.
+
+---
+
+## Зв'язок з іншими governance-rules
+
+- **Hard Rule #10** (lifecycle markers) — не міняється: всі існуючі доки далі мають freshness-маркери.
+- **Hard Rule #15** (Ukrainian internal docs) — не міняється: всі ініціативи (як post-freeze, так і override-и) — українською.
+- **Hard Rule #18** (active-initiative `module-decomposition`) — не міняється: lazy-load модулів продовжується паралельно з freeze.
+- **`docs/governance/policy-review.md`** — каденс не міняється; freeze це point-in-time event, не permanent rule.
+
+---
+
+## Зв'язок з PR-планом 2026-05-05
+
+Цей файл — **PR-01** з 22-PR плану ([master tracker §3](../launch/ftux-master-tracker.md#3-pr-план)). Freeze-period (4 тижні) перетинається з Хвилями 1-2 з PR-плану:
+
+- **Week 1:** 8 PR (PR-00 ... PR-08).
+- **Week 2-3:** 6 PR (PR-09 ... PR-14).
+- **Week 3-4:** 4 PR (PR-15 ... PR-18).
+
+Жоден з цих 18 PR-ів **не створює** нових файлів за заборонений pathspec, окрім:
+
+- **PR-19 (paywall sketch doc)** — `docs/launch/paywall-ux-placement.md` — це **launch-doc**, не audit/initiative/playbook/ADR, тому freeze-clean.
+- **PR-22 (agents quick-reference)** — `docs/agents/quick-reference.md` — agents-folder, теж freeze-clean.
+
+---
+
+## Як scope було обрано
+
+**Pathspec обрано як «продукт-докі без mandatory CI-gate»**:
+
+- `docs/audits/`, `docs/initiatives/`, `docs/playbooks/`, `docs/adr/` — це місця, куди легко додати «ще один аудит» / «ще одна ініціатива», і де темп зростання випередив темп viability.
+- `docs/launch/`, `docs/observability/`, `docs/integrations/`, `docs/architecture/`, `docs/design/`, `docs/agents/`, **не** заморожуються — це функціональна документація, що часто синкається з shipped code.
+- `docs/diagnostics/` теж не заморожується — diagnostics створюються per-incident, не за роадмапом.
+- `AGENTS.md` під обмеженням «розширення без enforcement» — це найбільший read-tax файл.
+
+---
+
+## Зв'язок з мега-прожаркою 2026-05-05
+
+**Найголовніший finding мега-прожарки:**
+
+> Sergeant repo застрягло у "audit hyperloop" — 334 markdown-файли в `docs/`, 12 ініціатив, 12 audit-доків. Documentation-velocity > product-velocity. 13 з 15 P0/P1 проблем з FTUX-roast (2026-05-03) досі open у коді.
+
+Цей freeze — **direct mitigation**. Через 4 тижні очікуємо:
+
+- Всі (або майже всі) P0 з FTUX-roast будуть **shipped** (PR-04, PR-05, PR-09, PR-12, PR-15).
+- Master tracker матиме оновлений status (всі ✅ замість ⏳).
+- 0 нових audit-документів — replaced consolidations через master tracker-и.
+
+---
+
+## Питання й коментарі
+
+Під час freeze:
+
+- Питання щодо freeze-rule → review-comment у PR-1 (цей PR) або у [`docs/launch/ftux-master-tracker.md`](../launch/ftux-master-tracker.md) §1 TL;DR.
+- Override-сценарії → див. секцію [Override path](#override-path).
+- Бачив новий audit-файл, що пробився без override? → tag @Skords-01 у PR (або в issue).
+
+> Кінець. Цей файл — **active until 2026-06-02**. Після цієї дати — оновлюємо `Status:` на `Closed` і додаємо результати огляду.


### PR DESCRIPTION
## Summary

PR-01 з 22-PR плану. Тимчасова заморозка створення нових audit/initiative/playbook/ADR документів на 4 тижні (до 2026-06-02), щоб product-velocity повернулась у баланс із docs-velocity. **Warning, не block** — override через `[skip-freeze]` маркер у PR title.

Додає:

- `docs/governance/audit-freeze-2026-05-05.md` — повний контракт freeze-у (період, заборонено / дозволено / override path / огляд успіху).
- `.github/workflows/audit-freeze.yml` — non-blocking CI job, що виявляє нові файли під заборонений pathspec і постить warning-comment з override-інструкцією. Self-deactivates після 2026-06-02 (`Date.now() > FREEZE_END`).
- `.github/PULL_REQUEST_TEMPLATE.md` — нова секція «Audit-freeze (until 2026-06-02)» з посиланням на freeze-doc.
- `docs/governance/README.md` — індекс-bullet для freeze-doc.

Follow-up до [PR #1934 (FTUX master tracker, merged)](https://github.com/Skords-01/Sergeant/pull/1934). Cross-refs у freeze-doc на master tracker — це 3 робочих лінки (їх перевірив `pnpm docs:check-links`).

## Governing Skill

- Primary skill: `.agents/skills/sergeant-start-here/SKILL.md`
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a (governance-policy + CI workflow; немає playbook-а для freeze-rollout, бо це one-time event, не recurring recipe)
- Why this playbook: governance + CI bytes — це разовий housekeeping move
- If no playbook matched, why: за 4 тижні freeze-doc стане Closed (із результатами огляду). Recipe для майбутніх freeze-ів можна задокументувати тоді — як post-mortem по цій ітерації, не зараз.

## Verification

```bash
# 1. Markdown links resolve (freeze-doc cross-refs work)
pnpm docs:check-links
# → ✅All markdown links resolve.

# 2. CODEOWNERS coverage (no new sensitive paths added)
pnpm lint:codeowners
# → ✅CODEOWNERS coverage OK — 35 required path(s) all owned.

# 3. Doc-freshness coverage (audit-freeze-2026-05-05.md has freshness header)
node scripts/docs/check-freshness.mjs --check-coverage
# → All tracked markdown files have a freshness header.

# 4. YAML syntax for audit-freeze.yml
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/audit-freeze.yml'))"
# → no error
```

Additional checks:

- [x] Local smoke / manual validation completed (docs:check-links + freshness + codeowners pass)
- [x] Surface-specific checks completed (workflow YAML парс-it; freshness-маркер на freeze-doc є; lint-staged-hook прокатився при commit)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update. — _не оновлено: freeze — тимчасовий event, не permanent rule. AGENTS.md hard-rules-таблиця не має нової запис, бо нема enforcement-механізму crystalize-нутого як hard-rule. Через 4 тижні після огляду — рішення про permanent rule._
- [x] I checked whether a playbook or skill needed an update. — _не оновлено (поки що). Playbook народжується з recurring-need; ми не знаємо чи буде ще один freeze. Якщо так — playbook після 2-го freeze._
- [x] I checked whether governance docs or review docs needed an update. — `docs/governance/README.md` оновлено індекс-bullet-ом. `review-checklist.md` не оновлено бо warning не block — reviewer-у не треба робити нічого нового.

Updated docs:

- `docs/governance/audit-freeze-2026-05-05.md` (new) — freeze contract
- `docs/governance/README.md` — індекс
- `.github/PULL_REQUEST_TEMPLATE.md` — freeze-section
- `.github/workflows/audit-freeze.yml` (new) — CI warning workflow

## Risk and Rollout

- **User-visible risk:** None. Не міняє код. Не блокує жодного PR-а.
- **Contributor-visible risk:** Новий warning-comment на PR-ах, що додають audit/initiative/playbook/ADR файли. Перші 2-3 такі PR-и можуть здатися спам-ом — це expected. Override-path coверed.
- **CI-cost risk:** Workflow run-it на кожен PR opened/synchronize/reopened. Час виконання — ~15 секунд (єдиний step з actions/github-script). Negligible quota impact.
- **Self-deactivation risk:** Workflow check-ить `Date.now() > FREEZE_END`. Якщо забути merge cleanup-PR після 2026-06-02 — workflow тихо нічого не робить (skip line: 'Audit-freeze period ended'). Acceptable failure mode.
- **Rollout / deploy order:** Merge коли завгодно. Workflow стартує одразу після merge.
- **Backout plan:** `git revert <merge-commit>`. Жодних persistent state — нічого не залишиться окрім commented-out PR-ів (existing comments). Для cleanup можна manual видалити коментарі.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

_Цей PR створює freeze-rules самі по собі, але не додає audit/initiative/playbook/ADR файлів — `audit-freeze-2026-05-05.md` лежить у `docs/governance/`, який не входить у frozen pathspec. Тому PR валідний без override._

## Reviewer Notes

- **Override-механізм expressly soft:** не хочу блокувати legitimate exceptions (security incident retro, governance-rules-change). Якщо за 4 тижні буде >5 override-ів — сигнал, що freeze не працює, переглянемо.
- **Workflow self-deactivation** через `FREEZE_END` literal у скрипті: цей же файл після 2026-06-02 не виконує жодних дій (early return). Можна merged-cleanup-PR-ом видалити, або лишити як history.
- **`docs/governance/audit-freeze-2026-05-05.md` має `Status: Active (4 weeks)`** — після 2026-06-02 треба bump-нути на `Status: Closed (results: <X>)` як post-mortem. Це частина оглядового PR через 4 тижні.
- **YAML lint:** репо не має yaml-lint у lint-flow. Я перевірив локально через `python3 -c yaml.safe_load`. Workflow буде fully validated при першому push з PR-ом, що тригерить його (натуральний smoke test).

Test plan after merge:

1. Open existing open-PR → check, що audit-freeze workflow запустився, але comment не з'явився (PR не додає frozen-files).
2. Open new test-PR з фіктивним `docs/audits/test.md` файлом → check, що warning-comment з'явився із list violations + override-instruction.
3. Edit test-PR title → add `[skip-freeze]` → re-trigger → check, що warning не оновлюється (тому що override).
4. After 2026-06-02 → workflow тихо skips (early return на FREEZE_END check).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce a 4-week freeze on new audit/initiative/playbook/ADR docs (until 2026-06-02) to rebalance product vs docs velocity. Adds a non-blocking CI warning and a PR template reminder; code is unaffected.

- New Features
  - Added `docs/governance/audit-freeze-2026-05-05.md` describing the freeze period, scope, allowed/forbidden changes, and review plan.
  - Added `.github/workflows/audit-freeze.yml` to warn (not block) when PRs add new files under `docs/audits/`, `docs/initiatives/00NN-*.md`, `docs/playbooks/`, or `docs/adr/00NN-*.md`; override via `[skip-freeze]` or `[freeze-exception]` in the PR title; auto-skips after 2026-06-02.
  - Updated `.github/PULL_REQUEST_TEMPLATE.md` with an “Audit-freeze” checklist and link to the policy.
  - Updated `docs/governance/README.md` to index the freeze doc.

<sup>Written for commit ae5802050e1875fffd5762de9f9deb2743c27b77. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

