### PR TITLE
feat(api-client): syncEngineFlushOnReconnect adapter (PR #042e-flush)

### DIFF
--- a/packages/api-client/src/endpoints/syncV2.flushOnReconnect.test.ts
+++ b/packages/api-client/src/endpoints/syncV2.flushOnReconnect.test.ts
@@ -1,0 +1,611 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createSyncEngineFlushOnReconnect,
+  type SyncEngineEventTarget,
+  type SyncEngineFlushOnReconnectDeps,
+  type SyncEngineFlushOnReconnectOptions,
+} from "./syncV2.flushOnReconnect";
+import type { SyncEnginePushResult } from "./syncV2.pushLoop";
+import type { SyncEnginePushScheduler } from "./syncV2.pushScheduler";
+
+/**
+ * Tests for the DOM-event → scheduler bridge `createSyncEngineFlushOnReconnect`
+ * (PR #042e-flush of `docs/planning/storage-roadmap.md`). Eight test
+ * groups pin the subscription contract, the de-duplication invariant
+ * delegated to the scheduler, the error-swallow policy, the
+ * visibility-edge filter, and the dispose lifecycle.
+ *
+ * Test fixtures (no real `window`):
+ *
+ *  - `makeEventTarget()` — a hand-rolled `addEventListener` /
+ *    `removeEventListener` stub that records each registration and
+ *    can fire stored handlers on demand. Mirrors `EventTarget`
+ *    semantics minimally; we don't need bubbles / capture for the
+ *    flush bridge. Exposes a `dispatch(type)` helper that calls
+ *    every listener registered for the given type.
+ *  - `makeScheduler()` — a stub `Pick<SyncEnginePushScheduler, 'flushNow'>`
+ *    whose `flushNow` is a `vi.fn()` returning a configurable
+ *    Promise. Used to exercise both the happy path and the rejection
+ *    path without spinning up the real scheduler factory.
+ */
+
+interface EventTargetStubHandle {
+  readonly target: SyncEngineEventTarget;
+  /** All listener registrations that ever happened, in order. */
+  readonly addCalls: ReadonlyArray<{
+    type: string;
+    listener: (event: Event) => void;
+  }>;
+  /** All listener removals that ever happened, in order. */
+  readonly removeCalls: ReadonlyArray<{
+    type: string;
+    listener: (event: Event) => void;
+  }>;
+  /** Currently-active listeners (after add/remove resolution). */
+  active(): ReadonlyArray<{
+    type: string;
+    listener: (event: Event) => void;
+  }>;
+  dispatch(type: string, event?: Event): void;
+}
+
+function makeEventTarget(): EventTargetStubHandle {
+  const addCalls: Array<{
+    type: string;
+    listener: (event: Event) => void;
+  }> = [];
+  const removeCalls: Array<{
+    type: string;
+    listener: (event: Event) => void;
+  }> = [];
+
+  const target: SyncEngineEventTarget = {
+    addEventListener(type, listener) {
+      addCalls.push({ type, listener });
+    },
+    removeEventListener(type, listener) {
+      removeCalls.push({ type, listener });
+    },
+  };
+
+  return {
+    target,
+    addCalls,
+    removeCalls,
+    active(): ReadonlyArray<{
+      type: string;
+      listener: (event: Event) => void;
+    }> {
+      const result: Array<{
+        type: string;
+        listener: (event: Event) => void;
+      }> = [];
+      for (const add of addCalls) {
+        const removed = removeCalls.some(
+          (r) => r.type === add.type && r.listener === add.listener,
+        );
+        if (!removed) {
+          result.push(add);
+        }
+      }
+      return result;
+    },
+    dispatch(type, event = new Event(type)): void {
+      for (const sub of this.active()) {
+        if (sub.type === type) {
+          sub.listener(event);
+        }
+      }
+    },
+  };
+}
+
+interface SchedulerStubHandle {
+  readonly scheduler: Pick<SyncEnginePushScheduler, "flushNow">;
+  readonly flushNow: ReturnType<typeof vi.fn>;
+}
+
+function makeScheduler(): SchedulerStubHandle {
+  const flushNow = vi.fn();
+  flushNow.mockResolvedValue({
+    drained: 0,
+    pushed: 0,
+    retried: 0,
+    rejected: 0,
+  } satisfies SyncEnginePushResult);
+  return {
+    scheduler: { flushNow: flushNow as () => Promise<SyncEnginePushResult> },
+    flushNow,
+  };
+}
+
+interface MakeAdapterArgs {
+  readonly options?: SyncEngineFlushOnReconnectOptions;
+  readonly onFlushError?: (err: unknown) => void;
+  readonly onFlushComplete?: (result: SyncEnginePushResult) => void;
+  readonly isDocumentVisible?: () => boolean;
+}
+
+function makeAdapter(args: MakeAdapterArgs = {}): {
+  adapter: ReturnType<typeof createSyncEngineFlushOnReconnect>;
+  target: EventTargetStubHandle;
+  schedulerHandle: SchedulerStubHandle;
+} {
+  const target = makeEventTarget();
+  const schedulerHandle = makeScheduler();
+  const deps: SyncEngineFlushOnReconnectDeps = {
+    target: target.target,
+    scheduler: schedulerHandle.scheduler,
+    ...(args.onFlushError ? { onFlushError: args.onFlushError } : {}),
+    ...(args.onFlushComplete ? { onFlushComplete: args.onFlushComplete } : {}),
+    ...(args.isDocumentVisible
+      ? { isDocumentVisible: args.isDocumentVisible }
+      : {}),
+  };
+  const adapter = createSyncEngineFlushOnReconnect(deps, args.options ?? {});
+  return { adapter, target, schedulerHandle };
+}
+
+describe("createSyncEngineFlushOnReconnect", () => {
+  // ─────────────────────────────────────────────────────────────
+  // Group 1 — subscription registration
+  // ─────────────────────────────────────────────────────────────
+
+  describe("subscription registration", () => {
+    it("subscribes only to 'online' by default", () => {
+      const { target } = makeAdapter();
+
+      expect(target.addCalls.map((c) => c.type)).toEqual(["online"]);
+    });
+
+    it("subscribes to 'online' when kind='online'", () => {
+      const { target } = makeAdapter({ options: { kind: "online" } });
+
+      expect(target.addCalls.map((c) => c.type)).toEqual(["online"]);
+    });
+
+    it("subscribes to 'visibilitychange' when kind='visible'", () => {
+      const { target } = makeAdapter({ options: { kind: "visible" } });
+
+      expect(target.addCalls.map((c) => c.type)).toEqual(["visibilitychange"]);
+    });
+
+    it("subscribes to both event types when kind='both'", () => {
+      const { target } = makeAdapter({ options: { kind: "both" } });
+
+      expect(target.addCalls.map((c) => c.type).sort()).toEqual([
+        "online",
+        "visibilitychange",
+      ]);
+    });
+
+    it("registers fresh handler references per event so removal is exact", () => {
+      const { target } = makeAdapter({ options: { kind: "both" } });
+
+      // The two handler references must be distinct so removeEventListener
+      // can target each independently.
+      const [first, second] = target.addCalls;
+      expect(first?.listener).not.toBe(second?.listener);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────
+  // Group 2 — flushNow invocation on online event
+  // ─────────────────────────────────────────────────────────────
+
+  describe("flushNow on 'online' event", () => {
+    it("calls flushNow exactly once per online event", () => {
+      const { target, schedulerHandle } = makeAdapter();
+
+      target.dispatch("online");
+
+      expect(schedulerHandle.flushNow).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls flushNow once per dispatch, not once per listener", () => {
+      const { target, schedulerHandle } = makeAdapter();
+
+      target.dispatch("online");
+      target.dispatch("online");
+      target.dispatch("online");
+
+      expect(schedulerHandle.flushNow).toHaveBeenCalledTimes(3);
+    });
+
+    it("does not fire flushNow for unrelated event types", () => {
+      const { target, schedulerHandle } = makeAdapter();
+
+      target.dispatch("offline");
+      target.dispatch("focus");
+      target.dispatch("visibilitychange");
+
+      expect(schedulerHandle.flushNow).not.toHaveBeenCalled();
+    });
+
+    it("invokes onFlushComplete with the result Promise resolved value", async () => {
+      const onFlushComplete = vi.fn();
+      const { target, schedulerHandle } = makeAdapter({ onFlushComplete });
+      schedulerHandle.flushNow.mockResolvedValueOnce({
+        drained: 3,
+        pushed: 2,
+        retried: 1,
+        rejected: 0,
+      });
+
+      target.dispatch("online");
+      // flushNow returns a Promise; observer fires after resolution.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(onFlushComplete).toHaveBeenCalledTimes(1);
+      expect(onFlushComplete).toHaveBeenCalledWith({
+        drained: 3,
+        pushed: 2,
+        retried: 1,
+        rejected: 0,
+      });
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────
+  // Group 3 — error policy on flushNow rejection
+  // ─────────────────────────────────────────────────────────────
+
+  describe("error policy on flushNow rejection", () => {
+    it("routes a flushNow rejection to onFlushError", async () => {
+      const onFlushError = vi.fn();
+      const { target, schedulerHandle } = makeAdapter({ onFlushError });
+      const boom = new Error("boom");
+      schedulerHandle.flushNow.mockRejectedValueOnce(boom);
+
+      target.dispatch("online");
+      // Allow the rejected promise to settle.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(onFlushError).toHaveBeenCalledTimes(1);
+      expect(onFlushError).toHaveBeenCalledWith(boom);
+    });
+
+    it("does NOT bubble flushNow rejection as an unhandled rejection", async () => {
+      const unhandled = vi.fn();
+      const onUnhandled = (event: { reason?: unknown }): void => {
+        unhandled(event.reason);
+      };
+      // Best-effort: in node this fires on `process.on('unhandledRejection')`.
+      // Vitest also captures unhandled rejections via its own listener.
+      process.on("unhandledRejection", onUnhandled as never);
+
+      try {
+        const { target, schedulerHandle } = makeAdapter({
+          onFlushError: () => {
+            // swallow
+          },
+        });
+        schedulerHandle.flushNow.mockRejectedValueOnce(new Error("boom"));
+
+        target.dispatch("online");
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(unhandled).not.toHaveBeenCalled();
+      } finally {
+        process.off("unhandledRejection", onUnhandled as never);
+      }
+    });
+
+    it("tolerates an onFlushError observer that itself throws", async () => {
+      // The DOM event listener returns synchronously, but we want
+      // to verify the observer-throw is *swallowed*, not thrown.
+      const onFlushError = vi.fn().mockImplementation(() => {
+        throw new Error("observer-bug");
+      });
+      const { target, schedulerHandle } = makeAdapter({ onFlushError });
+      schedulerHandle.flushNow.mockRejectedValueOnce(new Error("boom"));
+
+      target.dispatch("online");
+      // Observer is async (post-rejection); flush microtasks.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(onFlushError).toHaveBeenCalledTimes(1);
+      // No second listener exists (and the throw didn't escape into
+      // the dispatch loop) — sanity check by dispatching again.
+      target.dispatch("online");
+      expect(schedulerHandle.flushNow).toHaveBeenCalledTimes(2);
+    });
+
+    it("tolerates an onFlushComplete observer that throws", async () => {
+      const onFlushComplete = vi.fn().mockImplementation(() => {
+        throw new Error("observer-bug");
+      });
+      const { target, schedulerHandle } = makeAdapter({ onFlushComplete });
+
+      target.dispatch("online");
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(onFlushComplete).toHaveBeenCalledTimes(1);
+      // Subsequent dispatches still work.
+      target.dispatch("online");
+      expect(schedulerHandle.flushNow).toHaveBeenCalledTimes(2);
+    });
+
+    it("missing onFlushError + rejection is silent (no second-best logging side effect)", async () => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+      try {
+        const { target, schedulerHandle } = makeAdapter();
+        schedulerHandle.flushNow.mockRejectedValueOnce(new Error("boom"));
+
+        target.dispatch("online");
+        await Promise.resolve();
+        await Promise.resolve();
+
+        // Adapter does not fall back to console.error when no
+        // observer is provided — that policy belongs to the boot
+        // path (e.g., Sentry breadcrumbs).
+        expect(consoleError).not.toHaveBeenCalled();
+      } finally {
+        consoleError.mockRestore();
+      }
+    });
+
+    it("guards against a synchronous throw from a buggy flushNow stub", () => {
+      const onFlushError = vi.fn();
+      const { target, schedulerHandle } = makeAdapter({ onFlushError });
+      schedulerHandle.flushNow.mockImplementationOnce(() => {
+        throw new Error("sync-bug");
+      });
+
+      // Must not throw out of the event listener.
+      expect(() => target.dispatch("online")).not.toThrow();
+      expect(onFlushError).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────
+  // Group 4 — visibility-edge filter (kind='visible')
+  // ─────────────────────────────────────────────────────────────
+
+  describe("visibility-edge filter", () => {
+    it("fires flushNow when the page is becoming visible", () => {
+      const { target, schedulerHandle } = makeAdapter({
+        options: { kind: "visible" },
+        isDocumentVisible: () => true,
+      });
+
+      target.dispatch("visibilitychange");
+
+      expect(schedulerHandle.flushNow).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not fire flushNow when the page is going hidden", () => {
+      const { target, schedulerHandle } = makeAdapter({
+        options: { kind: "visible" },
+        isDocumentVisible: () => false,
+      });
+
+      target.dispatch("visibilitychange");
+
+      expect(schedulerHandle.flushNow).not.toHaveBeenCalled();
+    });
+
+    it("re-evaluates the predicate on each event (transition appear→hide→appear)", () => {
+      let visible = false;
+      const { target, schedulerHandle } = makeAdapter({
+        options: { kind: "visible" },
+        isDocumentVisible: () => visible,
+      });
+
+      visible = true;
+      target.dispatch("visibilitychange");
+      visible = false;
+      target.dispatch("visibilitychange");
+      visible = true;
+      target.dispatch("visibilitychange");
+
+      expect(schedulerHandle.flushNow).toHaveBeenCalledTimes(2);
+    });
+
+    it("default predicate returns false when target has no document", () => {
+      // No document on the stub target; default predicate must
+      // degrade to "not visible" rather than throwing.
+      const { target, schedulerHandle } = makeAdapter({
+        options: { kind: "visible" },
+      });
+
+      target.dispatch("visibilitychange");
+
+      expect(schedulerHandle.flushNow).not.toHaveBeenCalled();
+    });
+
+    it("default predicate fires when target.document.visibilityState='visible'", () => {
+      const target = makeEventTarget();
+      const docState = { visibilityState: "visible" as const };
+      // Splice a document onto the structural target — production
+      // `window` exposes this; our stub does not by default.
+      const targetWithDoc: SyncEngineEventTarget = Object.assign(
+        target.target,
+        { document: docState },
+      );
+      const schedulerHandle = makeScheduler();
+      createSyncEngineFlushOnReconnect(
+        {
+          target: targetWithDoc,
+          scheduler: schedulerHandle.scheduler,
+        },
+        { kind: "visible" },
+      );
+
+      target.dispatch("visibilitychange");
+
+      expect(schedulerHandle.flushNow).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────
+  // Group 5 — kind='both' fan-out
+  // ─────────────────────────────────────────────────────────────
+
+  describe("kind='both' fan-out", () => {
+    it("fires flushNow on 'online' even when 'visibilitychange' has not fired", () => {
+      const { target, schedulerHandle } = makeAdapter({
+        options: { kind: "both" },
+        isDocumentVisible: () => true,
+      });
+
+      target.dispatch("online");
+
+      expect(schedulerHandle.flushNow).toHaveBeenCalledTimes(1);
+    });
+
+    it("fires flushNow on visible-edge 'visibilitychange' even when 'online' has not fired", () => {
+      const { target, schedulerHandle } = makeAdapter({
+        options: { kind: "both" },
+        isDocumentVisible: () => true,
+      });
+
+      target.dispatch("visibilitychange");
+
+      expect(schedulerHandle.flushNow).toHaveBeenCalledTimes(1);
+    });
+
+    it("fires once per matching event (no de-dup at adapter layer)", () => {
+      // The scheduler's own concurrency guard de-dupes overlapping
+      // calls; the adapter does NOT add a second layer. This test
+      // pins that behavior so a future change to add adapter-level
+      // de-dup is a deliberate decision.
+      const { target, schedulerHandle } = makeAdapter({
+        options: { kind: "both" },
+        isDocumentVisible: () => true,
+      });
+
+      target.dispatch("online");
+      target.dispatch("visibilitychange");
+
+      expect(schedulerHandle.flushNow).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────
+  // Group 6 — dispose lifecycle
+  // ─────────────────────────────────────────────────────────────
+
+  describe("dispose lifecycle", () => {
+    it("removes every listener it registered (kind='online')", () => {
+      const { adapter, target } = makeAdapter();
+
+      adapter.dispose();
+
+      expect(target.removeCalls.map((c) => c.type)).toEqual(["online"]);
+      expect(target.active()).toEqual([]);
+    });
+
+    it("removes every listener it registered (kind='both')", () => {
+      const { adapter, target } = makeAdapter({ options: { kind: "both" } });
+
+      adapter.dispose();
+
+      expect(target.removeCalls.map((c) => c.type).sort()).toEqual([
+        "online",
+        "visibilitychange",
+      ]);
+      expect(target.active()).toEqual([]);
+    });
+
+    it("uses the same handler reference for register and unregister (so removal is exact)", () => {
+      const { adapter, target } = makeAdapter({ options: { kind: "both" } });
+
+      adapter.dispose();
+
+      for (const add of target.addCalls) {
+        const removeMatch = target.removeCalls.find((r) => r.type === add.type);
+        expect(removeMatch?.listener).toBe(add.listener);
+      }
+    });
+
+    it("is idempotent on a second dispose call (no double-remove)", () => {
+      const { adapter, target } = makeAdapter();
+
+      adapter.dispose();
+      const callsAfterFirst = target.removeCalls.length;
+      adapter.dispose();
+
+      expect(target.removeCalls.length).toBe(callsAfterFirst);
+    });
+
+    it("after dispose, dispatched events do not call flushNow", () => {
+      const { adapter, target, schedulerHandle } = makeAdapter();
+
+      adapter.dispose();
+      target.dispatch("online");
+      target.dispatch("online");
+
+      expect(schedulerHandle.flushNow).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────
+  // Group 7 — concurrency invariant delegated to scheduler
+  // ─────────────────────────────────────────────────────────────
+
+  describe("concurrency invariant delegated to scheduler", () => {
+    it("forwards every event call to flushNow without adapter-side de-dup", () => {
+      // The adapter intentionally does NOT track in-flight state.
+      // Pinning this contract prevents a future change that
+      // accidentally adds a second concurrency layer (would
+      // double-guard against the scheduler's own merge).
+      const { target, schedulerHandle } = makeAdapter();
+
+      // Hold the scheduler's flushNow Promise open.
+      let resolveFlush: (result: SyncEnginePushResult) => void = () => {
+        throw new Error("flushNow not awaited");
+      };
+      schedulerHandle.flushNow.mockImplementationOnce(
+        () =>
+          new Promise<SyncEnginePushResult>((resolve) => {
+            resolveFlush = resolve;
+          }),
+      );
+
+      target.dispatch("online");
+      target.dispatch("online");
+      target.dispatch("online");
+
+      // Adapter calls flushNow once per event — the scheduler is
+      // responsible for merging overlapping calls into a single tick.
+      expect(schedulerHandle.flushNow).toHaveBeenCalledTimes(3);
+
+      resolveFlush({
+        drained: 0,
+        pushed: 0,
+        retried: 0,
+        rejected: 0,
+      });
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────
+  // Group 8 — interaction with stopped scheduler
+  // ─────────────────────────────────────────────────────────────
+
+  describe("interaction with stopped scheduler", () => {
+    it("calls flushNow even when the scheduler is stopped (per scheduler contract)", () => {
+      // The scheduler contract (PR #042e-scheduler) allows flushNow
+      // before/without start(). The adapter does not consult
+      // isRunning() because that would create a class of bug where
+      // a flush triggered by going-online is silently dropped just
+      // because the scheduler hasn't been started yet (e.g., during
+      // an out-of-order boot path).
+      const { target, schedulerHandle } = makeAdapter();
+      // Stub returns a result; we don't touch isRunning here.
+      target.dispatch("online");
+
+      expect(schedulerHandle.flushNow).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/api-client/src/endpoints/syncV2.flushOnReconnect.ts
+++ b/packages/api-client/src/endpoints/syncV2.flushOnReconnect.ts
@@ -1,0 +1,303 @@
+import type { SyncEnginePushResult } from "./syncV2.pushLoop";
+import type { SyncEnginePushScheduler } from "./syncV2.pushScheduler";
+
+/**
+ * DOM-event → scheduler bridge for the client-side sync engine
+ * (`docs/planning/storage-roadmap.md` Stage 5 / PR #042e-flush).
+ *
+ * Wraps a {@link SyncEnginePushScheduler} (PR #042e-scheduler) so a
+ * DOM-event source — typically `window` — calls `scheduler.flushNow()`
+ * the moment the device comes back online (or, optionally, the moment
+ * the tab becomes visible again after backgrounding). Pure DI: the
+ * event target is supplied by the caller, never imported, so the
+ * adapter is unit-testable without a real `window` and re-usable
+ * from a service worker / web-worker / `apps/mobile` shim that
+ * exposes the same `addEventListener` shape.
+ *
+ * Why this is a separate adapter, not a method on the scheduler:
+ *
+ * - The scheduler owns timer state (interval handle, inflight tick).
+ *   Subscribing to DOM events is a different lifetime: the user can
+ *   pause the engine via `stop()` while the page is offline and
+ *   still want a flush to fire when they re-connect (the `online`
+ *   event would otherwise bounce off a stopped scheduler with
+ *   nothing to do). Keeping subscriptions external means the boot
+ *   path can compose the two pieces independently.
+ * - The same DOM-event semantics will reappear in the future
+ *   `pushOnEnqueue` adapter (when an `outboxEnqueue` event fires,
+ *   call `scheduler.flushNow()`). Factoring out a small generic
+ *   "fire on event → flushNow" bridge here pays a portion of that
+ *   future cost in advance.
+ *
+ * Subscription contract:
+ *
+ * - Subscribes to one or more event names on the supplied target.
+ *   `kind: 'online'` (default) listens to the standard browser
+ *   `online` event. `kind: 'visible'` listens to `visibilitychange`
+ *   and only fires `flushNow()` when `target.document?.visibilityState`
+ *   transitions to `'visible'` (best-effort — see the
+ *   `isDocumentVisible` callback below). `kind: 'both'` subscribes
+ *   to both, with the same de-duplication and error policy applied
+ *   uniformly across both sources.
+ * - Each event handler calls `scheduler.flushNow()` and routes the
+ *   resulting Promise so a rejection is captured by the optional
+ *   `onFlushError` observer rather than escaping as an unhandled
+ *   promise rejection. The handler does NOT `await` the Promise —
+ *   the DOM event listener callback returns synchronously, the
+ *   flush runs in the background.
+ * - Overlapping event fires are de-duplicated by the scheduler's
+ *   own concurrency guard (PR #042e-scheduler): every concurrent
+ *   `flushNow()` returns the same in-flight Promise, so two
+ *   `online` events 100ms apart still result in exactly one tick.
+ *   This adapter does not add a second layer of de-duplication;
+ *   the scheduler's invariant is enough.
+ * - {@link SyncEngineFlushOnReconnect.dispose} removes every
+ *   listener that was registered. Idempotent — calling `dispose()`
+ *   twice is a no-op the second time.
+ *
+ * Error policy:
+ *
+ * - A rejection from `flushNow()` is reported to `onFlushError`
+ *   (default no-op) and then *swallowed*. The DOM event source
+ *   does not provide a retry channel, and we never want a transient
+ *   sync failure to escalate into a window-level
+ *   `unhandledrejection` event that could trip Sentry / surface in
+ *   the user's devtools. The scheduler's periodic interval will
+ *   pick up the next push on its own schedule.
+ * - `onFlushError` itself is `try`/`catch`-ed inside the handler so
+ *   a buggy observer cannot blow up the event listener. The wrapped
+ *   throw is silently swallowed (no log) — we treat observer
+ *   failures the same way Sentry's own transports do: never let an
+ *   error in the error path crash the app.
+ *
+ * Visibility heuristic (`kind: 'visible'`):
+ *
+ * - Browsers fire `visibilitychange` for both directions; we only
+ *   want to flush on the *appear* edge. The standard read is
+ *   `document.visibilityState === 'visible'`, but `document` is not
+ *   present on all targets (workers, react-native shims) and
+ *   subscribing to a target that is *not* `window` should not silently
+ *   short-circuit. Callers can override the visibility check via the
+ *   optional `isDocumentVisible` DI; the default reads
+ *   `target.document?.visibilityState === 'visible'`, gracefully
+ *   reporting "appear" only when the target actually exposes a
+ *   `document.visibilityState`.
+ *
+ * Lifetime:
+ *
+ * - Adapter is a one-shot — call the factory once on engine boot,
+ *   keep the returned `dispose` reference, call it on engine
+ *   teardown (`apps/web` `<App>` cleanup, `apps/mobile` shim
+ *   teardown). Re-subscribing to the same target with a fresh
+ *   factory call is supported but issues fresh listeners — the
+ *   caller is responsible for disposing the previous handle.
+ *
+ * Tested invariants (see `syncV2.flushOnReconnect.test.ts`):
+ *
+ *  1. Subscription registers exactly the expected event names per
+ *     `kind` (`'online'` / `'visible'` / `'both'`); fresh handler
+ *     references per event so removal is exact.
+ *  2. `flushNow()` is called exactly once per `online` event; the
+ *     scheduler's concurrency guard de-duplicates overlapping
+ *     fires (test exercises this against a stub that holds the
+ *     in-flight Promise open).
+ *  3. `onFlushError` is invoked when `flushNow()` rejects; the
+ *     rejection does NOT bubble up as an unhandled promise.
+ *  4. `onFlushError` that itself throws is swallowed (event handler
+ *     returns normally; no DOM-side unhandledrejection).
+ *  5. `kind: 'visible'` filters `visibilitychange` events on the
+ *     `isDocumentVisible` predicate (no flush when the page is
+ *     going *away*, only on the appear edge).
+ *  6. `dispose()` removes every listener it added; idempotent on
+ *     second call (no double-removal call).
+ *  7. `kind: 'both'` subscribes to both event sources and each
+ *     fires `flushNow()` independently; `dispose()` removes both.
+ *  8. Subscribing while the scheduler is `stopped` still flushes —
+ *     `flushNow()` does not require `start()` per the scheduler
+ *     contract.
+ */
+
+/**
+ * Minimal `addEventListener` / `removeEventListener` surface the
+ * adapter needs. `window` (browser), `globalThis`, and `document`
+ * all satisfy it; tests pass a hand-rolled stub.
+ */
+export interface SyncEngineEventTarget {
+  addEventListener(
+    type: string,
+    listener: (event: Event) => void,
+    options?: AddEventListenerOptions | boolean,
+  ): void;
+  removeEventListener(
+    type: string,
+    listener: (event: Event) => void,
+    options?: EventListenerOptions | boolean,
+  ): void;
+}
+
+export type SyncEngineFlushTriggerKind = "online" | "visible" | "both";
+
+export interface SyncEngineFlushOnReconnectDeps {
+  /** DOM event source (`window` in production; stub in tests). */
+  readonly target: SyncEngineEventTarget;
+  /** Scheduler whose `flushNow()` will be invoked on each event. */
+  readonly scheduler: Pick<SyncEnginePushScheduler, "flushNow">;
+  /**
+   * Optional observer fired when `flushNow()` rejects. Receives the
+   * thrown value verbatim. Errors thrown by the observer itself are
+   * swallowed.
+   */
+  readonly onFlushError?: (err: unknown) => void;
+  /**
+   * Optional observer fired after `flushNow()` resolves. Receives
+   * the {@link SyncEnginePushResult}. Useful for telemetry /
+   * Sentry breadcrumbs.
+   */
+  readonly onFlushComplete?: (result: SyncEnginePushResult) => void;
+  /**
+   * Optional predicate used by `kind: 'visible' | 'both'` to decide
+   * whether a `visibilitychange` event represents the "appear" edge.
+   * Default reads `target.document?.visibilityState === 'visible'`.
+   * A target that does not expose `document.visibilityState` will
+   * cause the default predicate to return `false` for every event,
+   * effectively disabling visibility flushes on that target.
+   */
+  readonly isDocumentVisible?: () => boolean;
+}
+
+export interface SyncEngineFlushOnReconnectOptions {
+  /**
+   * Which DOM event(s) to listen for.
+   *
+   * - `'online'` (default): listens to `online`. Suitable for
+   *   `window` in `apps/web`.
+   * - `'visible'`: listens to `visibilitychange`, fires only on
+   *   appear edge.
+   * - `'both'`: listens to both.
+   */
+  readonly kind?: SyncEngineFlushTriggerKind;
+}
+
+export interface SyncEngineFlushOnReconnect {
+  /**
+   * Remove every listener this subscription registered. Idempotent —
+   * safe to call before any event has fired and safe to double-call.
+   */
+  dispose(): void;
+}
+
+/**
+ * Subscribe a {@link SyncEnginePushScheduler} to DOM event signals
+ * that mean "the user is back". On each matching event the adapter
+ * calls `scheduler.flushNow()`, routes the result through optional
+ * observers, and swallows the resulting Promise so a rejection
+ * cannot escape as `unhandledrejection`.
+ *
+ * @param deps Event target + scheduler + optional observers.
+ * @param options `kind` (default `'online'`).
+ */
+export function createSyncEngineFlushOnReconnect(
+  deps: SyncEngineFlushOnReconnectDeps,
+  options: SyncEngineFlushOnReconnectOptions = {},
+): SyncEngineFlushOnReconnect {
+  const kind: SyncEngineFlushTriggerKind = options.kind ?? "online";
+
+  const isDocumentVisible =
+    deps.isDocumentVisible ?? defaultIsDocumentVisible(deps.target);
+
+  const fireFlush = (): void => {
+    let promise: Promise<SyncEnginePushResult>;
+    try {
+      promise = deps.scheduler.flushNow();
+    } catch (err: unknown) {
+      // flushNow() should not synchronously throw per the scheduler
+      // contract, but the DI shape technically permits a sync
+      // throw — guard so a buggy stub cannot blow up the listener.
+      reportFlushError(deps.onFlushError, err);
+      return;
+    }
+    promise.then(
+      (result) => {
+        if (deps.onFlushComplete !== undefined) {
+          try {
+            deps.onFlushComplete(result);
+          } catch {
+            // Observer faults are swallowed by design (see
+            // module-level error policy above).
+          }
+        }
+      },
+      (err: unknown) => {
+        reportFlushError(deps.onFlushError, err);
+      },
+    );
+  };
+
+  const handleOnline = (_event: Event): void => {
+    fireFlush();
+  };
+
+  const handleVisibilityChange = (_event: Event): void => {
+    if (!isDocumentVisible()) {
+      return;
+    }
+    fireFlush();
+  };
+
+  const subscriptions: Array<{
+    type: string;
+    listener: (event: Event) => void;
+  }> = [];
+
+  if (kind === "online" || kind === "both") {
+    deps.target.addEventListener("online", handleOnline);
+    subscriptions.push({ type: "online", listener: handleOnline });
+  }
+  if (kind === "visible" || kind === "both") {
+    deps.target.addEventListener("visibilitychange", handleVisibilityChange);
+    subscriptions.push({
+      type: "visibilitychange",
+      listener: handleVisibilityChange,
+    });
+  }
+
+  let disposed = false;
+  return {
+    dispose(): void {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      for (const { type, listener } of subscriptions) {
+        deps.target.removeEventListener(type, listener);
+      }
+    },
+  };
+}
+
+function reportFlushError(
+  onFlushError: ((err: unknown) => void) | undefined,
+  err: unknown,
+): void {
+  if (onFlushError === undefined) {
+    return;
+  }
+  try {
+    onFlushError(err);
+  } catch {
+    // Observer faults are swallowed — see module-level error policy.
+  }
+}
+
+function defaultIsDocumentVisible(
+  target: SyncEngineEventTarget,
+): () => boolean {
+  // `target` is a structural type; reach for `document` defensively.
+  // Browsers expose it as `window.document`; workers / RN shims do
+  // not, and our default predicate must return `false` (not throw)
+  // in that case so the adapter degrades cleanly.
+  const targetWithDoc = target as {
+    readonly document?: { readonly visibilityState?: string };
+  };
+  return () => targetWithDoc.document?.visibilityState === "visible";
+}

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -107,6 +107,15 @@ export {
 } from "./endpoints/syncV2.pushScheduler";
 
 export {
+  createSyncEngineFlushOnReconnect,
+  type SyncEngineEventTarget,
+  type SyncEngineFlushOnReconnect,
+  type SyncEngineFlushOnReconnectDeps,
+  type SyncEngineFlushOnReconnectOptions,
+  type SyncEngineFlushTriggerKind,
+} from "./endpoints/syncV2.flushOnReconnect";
+
+export {
   createCoachEndpoints,
   type CoachEndpoints,
   type CoachInsightPayload,


### PR DESCRIPTION
## Summary

Stage 5 PR #042e-flush of `docs/planning/storage-roadmap.md`. DOM-event → scheduler bridge for the client-side sync engine. Wraps a `SyncEnginePushScheduler` (PR #042e-scheduler) so a DOM-event source — typically `window` — calls `scheduler.flushNow()` the moment the device comes back online (or, optionally, the moment the tab becomes visible again after backgrounding).

Pure DI: the event target is supplied by the caller, never imported, so the adapter is unit-testable without a real `window` and re-usable from a service worker / web-worker / `apps/mobile` shim that exposes the same `addEventListener` shape. No production callsites yet — the wiring PR composes this with the scheduler in the `apps/web` boot path.

Public surface (re-exported from `packages/api-client/src/index.ts`):

- `createSyncEngineFlushOnReconnect(deps, options) → { dispose }`
- `type SyncEngineEventTarget` — minimal `addEventListener` / `removeEventListener` shape
- `type SyncEngineFlushOnReconnectDeps` — `target` + `scheduler` + optional `onFlushError` / `onFlushComplete` / `isDocumentVisible`
- `type SyncEngineFlushOnReconnectOptions` — `kind?: 'online' | 'visible' | 'both'` (default `'online'`)
- `type SyncEngineFlushTriggerKind`, `type SyncEngineFlushOnReconnect`

**Why a separate adapter, not a method on the scheduler.** The scheduler owns timer state (interval handle, inflight tick); DOM-event subscriptions are a different lifetime. The user can `stop()` the engine while offline and still want a flush on reconnect — the `online` event would otherwise bounce off a stopped scheduler with nothing to do. Keeping subscriptions external lets the boot path compose the two pieces independently. The same DOM-event shape will reappear in the future `pushOnEnqueue` adapter, so factoring out a small generic "fire on event → flushNow" bridge here pays part of that future cost in advance.

**Concurrency invariant delegated to scheduler.** Adapter does NOT add a second de-duplication layer. Two `online` events 100ms apart still result in exactly one tick because the scheduler's own concurrency guard (PR #042e-scheduler) merges overlapping `flushNow()` calls into a single in-flight Promise. Pinned by test in group 7 — preserves single-source-of-truth for "is a tick in flight".

**Error policy.** A rejection from `flushNow()` is reported to `onFlushError` (default no-op) and then *swallowed*. The DOM event source has no retry channel, and we never want a transient sync failure to escalate into a window-level `unhandledrejection` that could trip Sentry / surface in the user's devtools. `onFlushError` itself is `try`/`catch`-ed so a buggy observer cannot blow up the event listener — observer faults are silently swallowed (same posture as Sentry's own transports).

## Governing Skill

- Primary skill: `.agents/skills/sergeant-start-here/SKILL.md`
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a
- Why this playbook: n/a
- If no playbook matched, why: This continues the `#042e-*` surgical-PR cadence inline with `docs/planning/storage-roadmap.md` Stage 5; no playbook in `docs/playbooks/` covers per-PR sync-engine work, and the precedent set by PR #042e-mapping / #042e-submit / #042e-drain / #042e-lifecycle / #042e-pushloop / #042e-scheduler / #042e-status / #042e-recover is to track each PR plan inline in storage-roadmap §3 (will be added in a single docs PR after this one lands).

## Verification

```bash
pnpm --filter @sergeant/api-client typecheck
# clean

pnpm --filter @sergeant/api-client lint
# clean

pnpm --filter @sergeant/api-client test -- --run
# Test Files  11 passed (11)
#      Tests  187 passed (187)   (was 157; +30 new for flushOnReconnect)
```

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed (typecheck + lint + test for the touched package)
- [x] AGENTS hard rule #1 (`bigint` → `number`): N/A — adapter does not surface DB types, only DOM events and the scheduler result Promise.
- [x] Error policy pinned by test: rejection from `flushNow()` reaches `onFlushError`; does NOT escape as `unhandledrejection`; observer-throw is swallowed.
- [x] Concurrency-invariant pinned by test: adapter forwards every event to `flushNow()` without adapter-side de-dup; merging is the scheduler's responsibility (PR #042e-scheduler).

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a in this PR — `docs/planning/storage-roadmap.md` and `CHANGELOG.md` will be updated in the docs follow-up that closes the session (one batch covering PR #042e-scheduler / #042e-status / #042e-recover / #042e-flush, matching the cadence of PR #1929: code lands first, then a dedicated docs PR). This is allowed under the active audit-freeze (`docs/governance/audit-freeze-2026-05-05.md`) — documentation for shipped code is explicitly permitted.

## Risk and Rollout

- User-visible risk: None. Additive composable surface without callsites in production code yet.
- Rollout / deploy order: Land freely. Wires into `apps/web` `<App>` boot path + `apps/mobile` shim teardown in a follow-up wiring PR alongside the rest of the `#042e` family.
- Backout plan: `git revert`. No DB / contract / env / migration changes.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian (none in this PR — N/A).
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

- The `kind: 'visible'` predicate defaults to `target.document?.visibilityState === 'visible'`. Targets without a `document` (workers, RN shims) will see the predicate return `false` for every event and effectively get visibility-based flushing disabled — that is the conservative degradation; callers that need a different signal supply `isDocumentVisible` via DI.
- `dispose()` is idempotent and uses the same handler reference for `addEventListener` and `removeEventListener`. The internal `subscriptions` log records both the event type and the *exact* listener function, so `removeEventListener` matches the real registration even if the same target is shared with other code.
- The default error path swallows `flushNow` rejections silently when no `onFlushError` is provided. We deliberately do *not* fall back to `console.error` — that policy belongs to the boot path (e.g., a Sentry-breadcrumb observer) so the adapter stays single-purpose. Pinned by test in group 3.
- No `apps/web` / `apps/mobile` integration in this PR. The wiring PR will: (1) construct the scheduler at `<App>` mount, (2) call `createSyncEngineFlushOnReconnect({ target: window, scheduler })` next to the scheduler's `start()`, (3) call `dispose()` + `stop()` in the matching cleanup. Sentry breadcrumbs slot in via the `onFlushError` / `onFlushComplete` observers.
- Tests use a hand-rolled `addEventListener` stub instead of `EventTarget` to avoid pulling in jsdom-specific quirks; the stub records every registration / removal so we can assert exact-match removal in dispose tests. The "no double-remove" test pins idempotency by capturing `removeCalls.length` before the second `dispose()` call.

Link to Devin session: https://app.devin.ai/sessions/de0008f4899e4250a7773b7a8252eac4
Requested by: @Skords-01

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a DOM-event to scheduler adapter to flush the client sync engine when the device comes online or the tab becomes visible. Small, DI-friendly bridge around the push scheduler; re-exported in the API client, no production wiring yet.

- New Features
  - Introduces `createSyncEngineFlushOnReconnect(deps, options) -> { dispose }` that listens to `'online'` and optionally `'visibilitychange'`, then calls `scheduler.flushNow()`.
  - `options.kind`: `'online'` (default), `'visible'`, or `'both'`.
  - DI-based: caller supplies `target` (e.g., `window`) and `scheduler`; exported types include `SyncEngineEventTarget`, `SyncEngineFlushOnReconnectDeps`, `SyncEngineFlushOnReconnectOptions`, and `SyncEngineFlushTriggerKind`.
  - Error policy: rejections from `flushNow()` go to `onFlushError` and are swallowed; observer throws are caught to avoid `unhandledrejection`.
  - Concurrency: no adapter-side de-dup; overlapping calls are merged by the scheduler.
  - Visibility edge: fires only when `isDocumentVisible()` is true; default checks `target.document?.visibilityState === 'visible'` and degrades safely when absent.
  - Lifecycle: `dispose()` removes all listeners and is idempotent.

<sup>Written for commit 8186856266ca1e539c0a9c4df0adc9220900ef70. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

