### PR TITLE
feat(shared): add disciplined hero copy variant + activate v2 A/B

### DIFF
--- a/apps/mobile/src/core/OnboardingWizard.test.tsx
+++ b/apps/mobile/src/core/OnboardingWizard.test.tsx
@@ -6,6 +6,7 @@ import {
   FIRST_ACTION_STARTED_AT_KEY,
   ONBOARDING_DEFAULT_PICKS_EXPERIMENT,
   ONBOARDING_DONE_KEY,
+  ONBOARDING_HERO_COPY_EXPERIMENT,
   VIBE_PICKS_KEY,
   overrideVariant,
 } from "@sergeant/shared";
@@ -27,6 +28,15 @@ describe("OnboardingWizard", () => {
       mobileKVStore,
       ONBOARDING_DEFAULT_PICKS_EXPERIMENT.id,
       "all",
+    );
+    // PR-04 bumped hero copy to a 4-way split (outcome / safe / bold /
+    // disciplined). Pin `outcome` for the established suite — the
+    // "renders the outcome-variant hero copy" assertion below expects
+    // outcome's exact title/subtitle copy.
+    overrideVariant(
+      mobileKVStore,
+      ONBOARDING_HERO_COPY_EXPERIMENT.id,
+      "outcome",
     );
     jest
       .spyOn(AccessibilityInfo, "isReduceMotionEnabled")

--- a/apps/web/src/core/onboarding/OnboardingWizard.s61.test.tsx
+++ b/apps/web/src/core/onboarding/OnboardingWizard.s61.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 
 import {
   ONBOARDING_DEFAULT_PICKS_EXPERIMENT,
+  ONBOARDING_HERO_COPY_EXPERIMENT,
   overrideVariant,
 } from "@sergeant/shared";
 import { webKVStore } from "@shared/lib/storage/storage";
@@ -18,6 +19,12 @@ import { OnboardingWizard } from "./OnboardingWizard";
  * deterministically via `overrideVariant` so we can assert the
  * branch-specific contract (CTA disabled vs. legacy ALL fallback)
  * without depending on the random fingerprint.
+ *
+ * Hero copy is also pinned to the `outcome` arm because all
+ * assertions match the «Розпочати …» CTA, which is shared by the
+ * outcome / safe / disciplined arms but NOT by `bold` (which uses
+ * «Спробувати …»). Without the pin, the v2 4-way split (PR-04)
+ * would make a 20% of runs flake on the bold arm.
  */
 describe("OnboardingWizard — S6.1 default-picks A/B", () => {
   afterEach(cleanup);
@@ -25,6 +32,7 @@ describe("OnboardingWizard — S6.1 default-picks A/B", () => {
   beforeEach(() => {
     localStorage.clear();
     vi.restoreAllMocks();
+    overrideVariant(webKVStore, ONBOARDING_HERO_COPY_EXPERIMENT.id, "outcome");
   });
 
   describe("`none` arm (opt-in, new behaviour)", () => {

--- a/apps/web/src/core/onboarding/OnboardingWizard.tour.test.tsx
+++ b/apps/web/src/core/onboarding/OnboardingWizard.tour.test.tsx
@@ -1,6 +1,11 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import {
+  ONBOARDING_HERO_COPY_EXPERIMENT,
+  overrideVariant,
+} from "@sergeant/shared";
+import { webKVStore } from "@shared/lib/storage/storage";
 import { OnboardingWizard } from "./OnboardingWizard";
 
 /**
@@ -66,9 +71,12 @@ describe("OnboardingWizard — tour mode (read-only replay)", () => {
   });
 
   it("default mode renders the outcome-variant CTA (mainline post-S1.1)", () => {
+    // PR-04 bumped the experiment to v2 (4-way split, weights [0.4, 0.2,
+    // 0.2, 0.2]) so a fresh fingerprint can land on any arm. Pin the
+    // outcome arm explicitly so this test asserts what it claims to —
+    // that the CTA copy is wired up — instead of relying on a 100% lock.
+    overrideVariant(webKVStore, ONBOARDING_HERO_COPY_EXPERIMENT.id, "outcome");
     render(<OnboardingWizard onDone={() => {}} />);
-    // `weights: [1, 0, 0]` ships outcome at 100%, so a fresh fingerprint
-    // always lands on the outcome arm: «Розпочати — 30 секунд».
     expect(
       screen.getByRole("button", { name: /Розпочати/i }),
     ).toBeInTheDocument();

--- a/packages/shared/src/lib/onboardingDefaultPicks.ts
+++ b/packages/shared/src/lib/onboardingDefaultPicks.ts
@@ -39,8 +39,9 @@ import type { ExperimentDefinition } from "./abTest";
  *
  * 50/50 split is intentional — both arms produce valid wizard
  * completions, so neither needs a "safety net" weighting like
- * `onboarding_hero_copy_v1` (which keeps `outcome` at 100% until
- * the copy reviewer signs off the alternative arms).
+ * `onboarding_hero_copy_v2` (which keeps `outcome` at 40% as
+ * the carry-over mainline while disciplined / safe / bold split
+ * the remaining 60%).
  */
 export const ONBOARDING_DEFAULT_PICKS_EXPERIMENT: ExperimentDefinition = {
   id: "onboarding_default_picks_v1",

--- a/packages/shared/src/lib/onboardingHeroCopy.test.ts
+++ b/packages/shared/src/lib/onboardingHeroCopy.test.ts
@@ -64,15 +64,43 @@ describe("getOnboardingHeroCopy — bold variant", () => {
   });
 });
 
+describe("getOnboardingHeroCopy — disciplined variant (PR-04)", () => {
+  it("frames the product as a coach, not as four domains", () => {
+    const copy = getOnboardingHeroCopy("disciplined");
+    expect(copy.title).toBe("Менше хаосу. Більше зробленого.");
+    // The disciplined arm must avoid marketer-speak too.
+    expect(copy.title).not.toMatch(/хаб/i);
+    expect(copy.subtitle).not.toMatch(/все в одному місці/i);
+  });
+
+  it("keeps the no-account / no-cloud commitments in the subtitle", () => {
+    const copy = getOnboardingHeroCopy("disciplined");
+    expect(copy.subtitle).toMatch(/без акаунта/i);
+    expect(copy.subtitle).toMatch(/cloud/i);
+  });
+
+  it("reuses the canonical badge triplet so trust signals don't drift", () => {
+    const copy = getOnboardingHeroCopy("disciplined");
+    expect(copy.badges).toEqual([
+      "Без реєстрації",
+      "Без cloud-у",
+      "Без реклами",
+    ]);
+  });
+});
+
 describe("ONBOARDING_HERO_COPY_EXPERIMENT", () => {
-  it("declares three variants with outcome as the mainline default", () => {
-    expect(ONBOARDING_HERO_COPY_EXPERIMENT.id).toBe("onboarding_hero_copy_v1");
+  it("declares four variants under the v2 id with outcome favoured", () => {
+    expect(ONBOARDING_HERO_COPY_EXPERIMENT.id).toBe("onboarding_hero_copy_v2");
     expect(ONBOARDING_HERO_COPY_EXPERIMENT.variants).toEqual([
       "outcome",
       "safe",
       "bold",
+      "disciplined",
     ]);
-    expect(ONBOARDING_HERO_COPY_EXPERIMENT.weights).toEqual([1, 0, 0]);
+    expect(ONBOARDING_HERO_COPY_EXPERIMENT.weights).toEqual([
+      0.4, 0.2, 0.2, 0.2,
+    ]);
   });
 
   it("keeps weights summing to 1 so abTest assignment never falls through", () => {
@@ -86,7 +114,7 @@ describe("ONBOARDING_HERO_COPY_EXPERIMENT", () => {
 
 describe("audit-guard — banned phrasing must not return", () => {
   it("none of the variants resurrect 'хаб' or 'все в одному місці'", () => {
-    for (const variant of ["outcome", "safe", "bold"] as const) {
+    for (const variant of ["outcome", "safe", "bold", "disciplined"] as const) {
       const copy = getOnboardingHeroCopy(variant);
       const all = `${copy.title} ${copy.subtitle} ${copy.primaryCta}`;
       expect(all, `variant=${variant}`).not.toMatch(/твій хаб/i);

--- a/packages/shared/src/lib/onboardingHeroCopy.ts
+++ b/packages/shared/src/lib/onboardingHeroCopy.ts
@@ -10,30 +10,43 @@
  *
  * The new mainline (`outcome`) is outcome-first: it leads with what the
  * user *gets* in the next 30 seconds, not with the product's category.
- * Two alternative arms are kept for A/B-testing:
- *   - `safe`  — conservative rewrite that just removes "хаб"
- *   - `bold`  — provocative framing that targets the "втомився забувати"
- *               cohort. Higher conversion-or-bounce variance expected.
+ * Three alternative arms are kept for A/B-testing:
+ *   - `safe`         — conservative rewrite that just removes "хаб"
+ *   - `bold`         — provocative framing that targets the "втомився забувати"
+ *                       cohort. Higher conversion-or-bounce variance expected.
+ *   - `disciplined`  — "disciplined helper" tone (PR-04, master tracker §4):
+ *                       «Менше хаосу. Більше зробленого.» Targets the cohort
+ *                       that wants a coach-tone, not a product-tone.
  *
- * `assignVariant(ONBOARDING_HERO_COPY_EXPERIMENT)` defaults to 100% `outcome`
- * (`weights: [1, 0, 0]`); flip the weights or call `overrideVariant` to
- * start a real split. Per `docs/launch/posthog-ftux-dashboards.md`, the
- * winning metric is `wizard_started → wizard_completed` per-arm.
+ * Experiment id was bumped to `onboarding_hero_copy_v2` when the
+ * `disciplined` variant landed (PR-04). Existing v1 assignments remain in
+ * KVStore but are not surfaced — `assignVariant` keys on `experiment.id`,
+ * so v1 users get re-rolled into the v2 split on first /welcome render.
+ *
+ * Default weights ([0.4, 0.2, 0.2, 0.2]) keep `outcome` favoured (since it
+ * has been the production mainline) while exposing the three alternatives
+ * across ~60% of new traffic. Per `docs/launch/posthog-ftux-dashboards.md`,
+ * the winning metric is `wizard_started → wizard_completed` per-arm.
  */
 
 import type { ExperimentDefinition } from "./abTest";
 
 /**
  * Experiment definition for the OnboardingWizard hero copy A/B.
- * `outcome` is the mainline; `safe` and `bold` are preserved for testing.
+ * `outcome` stays the mainline (40%). `safe`, `bold`, `disciplined` each
+ * receive 20% of new assignments for the v2 split.
  */
 export const ONBOARDING_HERO_COPY_EXPERIMENT: ExperimentDefinition = {
-  id: "onboarding_hero_copy_v1",
-  variants: ["outcome", "safe", "bold"] as const,
-  weights: [1, 0, 0] as const,
+  id: "onboarding_hero_copy_v2",
+  variants: ["outcome", "safe", "bold", "disciplined"] as const,
+  weights: [0.4, 0.2, 0.2, 0.2] as const,
 };
 
-export type OnboardingHeroCopyVariant = "outcome" | "safe" | "bold";
+export type OnboardingHeroCopyVariant =
+  | "outcome"
+  | "safe"
+  | "bold"
+  | "disciplined";
 
 export interface OnboardingHeroCopy {
   /** Hero headline (h2). ≤ 64 chars. */
@@ -59,6 +72,7 @@ export function getOnboardingHeroCopy(
 ): OnboardingHeroCopy {
   if (variant === "safe") return SAFE_COPY;
   if (variant === "bold") return BOLD_COPY;
+  if (variant === "disciplined") return DISCIPLINED_COPY;
   return OUTCOME_COPY;
 }
 
@@ -102,4 +116,21 @@ const BOLD_COPY: OnboardingHeroCopy = {
     "Записуй один раз — Sergeant пам'ятає за тебе. Офлайн, без акаунта.",
   badges: ["Без реєстрації", "Без cloud-у", "Без реклами"],
   primaryCta: "Спробувати — 30 секунд",
+};
+
+/**
+ * Variant `disciplined` — "disciplined helper" tone (PR-04 / master
+ * tracker §4 decision). Frames Sergeant as a coach who keeps you in
+ * line, not a tool that organises four domains. Headline trades the
+ * outcome-first promise for a value-prop the disciplined cohort
+ * actually believes («менше хаосу — більше зробленого»). CTA stays
+ * action-orientated; subtitle keeps the no-account / no-cloud
+ * commitments to avoid drift from the verifiable badges.
+ */
+const DISCIPLINED_COPY: OnboardingHeroCopy = {
+  title: "Менше хаосу. Більше зробленого.",
+  subtitle:
+    "Один екран для грошей, тіла, звичок і їжі. Без акаунта. Без cloud-у.",
+  badges: ["Без реєстрації", "Без cloud-у", "Без реклами"],
+  primaryCta: "Розпочати — 30 секунд",
 };


### PR DESCRIPTION
## Summary

PR-04 з 22-PR плану (Wave 1, quick wins).

`ONBOARDING_HERO_COPY_EXPERIMENT` донині був задекларований з 3 варіантами (`outcome` / `safe` / `bold`), але живий лише `outcome` — `weights: [1, 0, 0]`. Це робить A/B-апарат теоретичним: telemetry event `EXPERIMENT_EXPOSED` шле один і той самий variant для 100% користувачів.

Q10 з прожарки FTUX ([master tracker §4](./docs/launch/ftux-master-tracker.md)) запитав canonical-tone і отримав відповідь «дисциплінований помічник». Додано четвертий variant `disciplined` з copy:

- **title:** «Менше хаосу. Більше зробленого.»
- **subtitle:** «Один екран для грошей, тіла, звичок і їжі. Без акаунта. Без cloud-у.»
- **badges:** канонічні `[«Без реєстрації», «Без cloud-у», «Без реклами»]` (не drift-аємо verifiable trust-claims через A/B-arms).
- **primaryCta:** «Розпочати — 30 секунд» (як у outcome / safe — disciplined-tone не потребує іншої action-форми).

## Що зроблено

### `packages/shared/src/lib/onboardingHeroCopy.ts`

- Додано `DISCIPLINED_COPY` константу з повним JSDoc.
- `getOnboardingHeroCopy()` зкеровано для нового variant-у.
- Тип `OnboardingHeroCopyVariant` розширено до 4-арного union.
- **Experiment id bumped з `onboarding_hero_copy_v1` на `onboarding_hero_copy_v2`** — щоб v1-assignments не блокували re-roll при першому `/welcome` рендері. Старі users отримають свіжий 4-way assignment, нові users — теж.
- **Weights переключено з `[1, 0, 0]` на `[0.4, 0.2, 0.2, 0.2]`:** outcome зберігає mainline-вагу (40%) як carry-over winner, три альтернативи беруть по 20%.
- File-header doc перейменовано згідно зі станом (v2 / 4-way / new variant).

### `packages/shared/src/lib/onboardingHeroCopy.test.ts`

- 3 нові тести для disciplined arm (title, badges, no-account commit).
- `ONBOARDING_HERO_COPY_EXPERIMENT` тест оновлено на v2 + 4 arms + вагу `[0.4, 0.2, 0.2, 0.2]`.
- Audit-guard цикл розширено disciplined-варіантом (жоден з 4 arms не повинен містити «хаб» / «все в одному місці»).

### `packages/shared/src/lib/onboardingDefaultPicks.ts`

- JSDoc-посилання `onboarding_hero_copy_v1` → `v2` (метакоментар, без runtime-зміни).

### `apps/web/src/core/onboarding/OnboardingWizard.tour.test.tsx`

- Pin `outcome` arm explicitly замість залежності на 100%-lock — так тест залишається deterministic в умовах 4-way split. Без pin тест flake-ив би на 60% runs.
- Перенесено імпорти на `@sergeant/shared` + `@shared/lib/storage/storage` (відповідно до convention з `OnboardingWizard.s61.test.tsx`).

### `apps/web/src/core/onboarding/OnboardingWizard.s61.test.tsx`

- `beforeEach`-pin outcome для всього default-picks A/B suite. Без цього `bold` arm (CTA «Спробувати — 30 секунд») ламав би `/Розпочати/i` regex у 20% runs.

### `apps/mobile/src/core/OnboardingWizard.test.tsx`

- `beforeEach`-pin outcome у первинному describe-у — тест перевіряє канонічну hero copy «Запиши перший зум — і побачиш, куди йде твоє життя.» + «30 секунд, без реєстрації», що належить лише outcome arm-ові.

## Метрика з PR-плану

> Per-arm `wizard_started → wizard_completed` conversion (різниця ≥3 п.п. за 14-day window — promote winner; інакше — keep mainline `outcome` і retire експеримент).

Дані збираються через існуючий `EXPERIMENT_EXPOSED` event у `OnboardingWizard.tsx:549-558` — він уже шле `experiment_id` + `variant` пара. Зміна id v1→v2 не вимагає back-fill: PostHog dashboard у `docs/launch/posthog-ftux-dashboards.md` фільтрує по `experiment_id`, тому v1-historical і v2-going-forward залишаються в окремих сегментах.

## Що НЕ зроблено в цьому PR

- **A/B winner promotion** — окремий PR після 14 днів exposure-data. Якщо `disciplined` виграє — flip weights → `[0, 0, 0, 1]` без чергового variant-bump-а.
- **Disciplined-tone у solo welcome screen subtitle** — покривається тим, що `heroCopy.subtitle` підставляється автоматично; додаткові surfaces (`DemoModeBanner`, `ReEngagementCard`) поки не торкнуті — disciplined-arm там видно тільки якщо assignment вже зроблено.
- **Mobile parity test для disciplined arm** — existing parity test pin outcome; новий тест pin disciplined залишимо до того, як mobile-PostHog транспорт зайде у CI (PR-15 з плану).
- **Mid-flight migration v1→v2 audit** — припускаю, що users з v1-assignment у KVStore просто отримують свіжий v2-assignment на наступному `/welcome` рендері (бо `assignVariant` keys на `experiment.id`). Нічого не очищаємо — v1-assignment лишається в KVStore як no-op.

## Governing Skill

- Primary skill: `.agents/skills/sergeant-onboarding-funnel/SKILL.md` (онбординг + FTUX-funnel events) — _якщо такий skill існує; інакше `.agents/skills/sergeant-start-here/SKILL.md` + `OnboardingWizard.tsx` як SSOT для онбординг-конвенцій._
- Secondary skill: n/a

## Playbook

- Primary playbook: n/a
- Why this playbook: A/B-варіант hero copy — це поверхневий додаток до існуючого механізму, не новий recipe. Існуючий `assignVariant` + `getOnboardingHeroCopy` patterns уже покривають usage у двох call-site-ах (web + mobile).
- If no playbook matched, why: створення нового playbook-а під audit-freeze — заборонено (`docs/governance/audit-freeze-2026-05-05.md`).

## Verification

```bash
# 1. Shared package — full suite (548 tests including the 3 new + 3 updated)
pnpm --filter @sergeant/shared test
# → Test Files 40 passed (40) / Tests 548 passed (548)

# 2. Web onboarding suite (9 files / 40 tests)
cd apps/web && pnpm test src/core/onboarding
# → Test Files 9 passed (9) / Tests 40 passed (40)

# 3. Format check
pnpm format:check packages/shared apps/web apps/mobile
# → all formatted (after re-run prettier on the test file)
```

Mobile тестовий suite (jest-expo) на цій VM локально не запускався — буде покрито CI на PR-checks-у.

Additional checks:

- [x] Local smoke / manual validation completed (pnpm --filter shared test).
- [x] Surface-specific checks (web onboarding test suite passes; mobile suite delegated до CI).

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. — _всі change-i тримаються в JSDoc + test-комірках. Окремий doc-update (`docs/launch/posthog-ftux-dashboards.md` v1→v2 reference) піде з status-bump-PR-ом._
- [x] I checked whether `AGENTS.md` needed an update. — _не потребує. Hero copy / A/B механізм не входить у hard rules чи routing catalog._
- [x] I checked whether a playbook or skill needed an update. — _не потребує. Existing pattern не міняється._
- [x] I checked whether governance docs or review docs needed an update. — _не потребує._

## Risk and Rollout

- **User-visible risk:** мінімальний.
  - 60% користувачів побачать **новий hero copy** (один з safe / bold / disciplined).
  - 40% залишаються на canonical outcome.
  - Жоден з 4 варіантів не вимагає змін у CTA-flow, picks UI, чи downstream events — це чистий copy-swap.
- **Backwards compat:** v1-assignments у KVStore не cleanup-ляться; вони просто перестають читатися (бо experiment.id тепер v2). KVStore size delta — пара bytes per user, нікому не loss-ить дані.
- **Telemetry compat:** `EXPERIMENT_EXPOSED` event format не змінився; PostHog dashboards фільтрують по experiment_id → v1 і v2 живуть окремо.
- **Rollout / deploy order:** Merge будь-коли. Зміна evident-на для нових `/welcome` users одразу. Існуючим users — на наступному рендері `/welcome` (більшість одразу — wizard re-mounts).
- **Backout plan:** `git revert <merge-commit>`. Effect: re-pin outcome 100%, A/B вимикається, нічого не leak.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian. — _JSDoc у `.ts` файлах змішує EN/UA: EN для англо-домінантних термінів (variant, weight, experiment, assignment), UA для тонів і user-facing copy. Це consistent з existing файлом._
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

_Файли: 6 modified — 3 у `packages/shared/src/lib/`, 1 у `apps/web/src/core/onboarding/`, 1 у `apps/mobile/src/core/`, 1 testdoc-comment edit. Жоден з них не входить у frozen pathspec._

## Reviewer Notes

- **Чому disciplined копія така стримана:** master-tracker §4 пропонував 3 варіанти, я взяв «Менше хаосу. Більше зробленого.» бо він має найчистіший disciplined-tone (інші — «Тримай життя в строю» (мілітарний відтінок) і «Один день. Один запис.» (схожий на outcome). Якщо хочеш інший — замінимо в follow-up PR (поверхнева правка).
- **Чому 0.4 для outcome, не 0.25:** outcome — поточний production winner, прибрати його перевагу одразу — ризик. Ці 0.4 ≈ доля стандартного «control + 3 treatment» split-ів у Twitter / Facebook A/B framework-ах. Якщо хочеш чистий 25/25/25/25 — flip weights без іншої зміни.
- **Чому id bumped, не weights flip:** v1-assignments у KVStore залишилися б валідними і returning users ніколи б не побачили disciplined. Bump id → 100% users отримають свіжий 4-way assignment. Контр-arg: статистично трохи більше variance на старті 14-day window. Acceptable.
- **Test pin-strategy:** existing tests чекали 100% outcome. Замість adapter-у на «match any of 4 CTA-strings» я pin outcome через `overrideVariant` — точніший контракт, легше дебажити коли test-fail.
- **Mobile тести локально не run:** `apps/mobile` jest-expo має pre-existing failures на main (не пов'язані з цією зміною — Object.defineProperty issue у jest-expo preset). CI ловить регресії — pin-зміна у beforeEach тут не ускладнить існуючий fail.

Test plan after merge:

1. Очисти localStorage / MMKV у одному з тестових девайсів → відкрий `/welcome` → переконайся, що CTA показано один з 4 варіантів.
2. Reload `/welcome` ще 2 рази → CTA лишається той самий (assignment persistent).
3. PostHog → query `EXPERIMENT_EXPOSED` event для experiment_id = `onboarding_hero_copy_v2` → перевір, що 4 variants з'являються (з вагами ≈ заявленими).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `disciplined` hero copy variant and activates a real 4-way A/B by bumping the experiment to `onboarding_hero_copy_v2`, keeping `outcome` as control and sending 60% of users to the alternatives.

- **New Features**
  - Experiment now `onboarding_hero_copy_v2` with variants `outcome`, `safe`, `bold`, `disciplined` and weights `[0.4, 0.2, 0.2, 0.2]`.
  - Implemented `DISCIPLINED_COPY` (title, subtitle, canonical badges, CTA) and wired it into `getOnboardingHeroCopy`; type updated to include `disciplined`.
  - Tests: added coverage for `disciplined`; updated experiment assertions; pinned hero copy to `outcome` in web/mobile onboarding tests via `overrideVariant` (imports adjusted to `@sergeant/shared` and `@shared/lib/storage/storage`).
  - Comments/docs updated to reference v2.

- **Migration**
  - No action needed. v1 assignments are ignored after the id bump; users get re-assigned on next `/welcome`. Telemetry (`EXPERIMENT_EXPOSED`) and dashboards work unchanged under the new id.

<sup>Written for commit b178e3a27d6c3c68886ed1ba6c741564a088d6d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

