### PR TITLE
docs(docs): finalize initiative 0005 — cache-prefix size + verify queries

### DIFF
--- a/docs/initiatives/0005-ai-cost-and-prompt-cache.md
+++ b/docs/initiatives/0005-ai-cost-and-prompt-cache.md
@@ -1,6 +1,6 @@
 # 0005 — AI cost optimisation (Anthropic prompt cache + AI-ops dashboards)
 
-> **Last validated:** 2026-05-04 by @Skords-01. **Next review:** 2026-08-02.
+> **Last validated:** 2026-05-05 by @Skords-01. **Next review:** 2026-08-03.
 > **Status:** Done (2026-05-04). Prompt-cache на 2 breakpoints (system + last tool), token / cost / cache-hit Prom counters, 7-panel `ai-cost` Grafana dashboard, alerts на cost / quota — усе шипнуто. Policy зафіксована у [ADR-0039](../adr/0039-anthropic-prompt-cache-policy.md).
 > **Priority:** P0 (Sprint 1)
 > **Owner:** `@Skords-01`
@@ -175,26 +175,32 @@ Sergeant досить агресивно використовує Anthropic Clau
 - Design Review 2026-05-03 — §8 AI Integration
 - [Anthropic Prompt Caching](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching)
 - [Anthropic Pricing](https://www.anthropic.com/pricing)
-- [`apps/server/src/modules/chat/`](../../apps/server/src/modules/chat/)
-- Координується з ініціативою 0004 (server observability) — `aiSpan` помічатиме cache_hit як attribute
-- [`docs/tech-debt/backend.md`](../tech-debt/backend.md) — запис «AI cost not measured»
+- [ADR-0039 — Anthropic prompt-cache breakpoint policy](../adr/0039-anthropic-prompt-cache-policy.md) — rationale для 2 breakpoints, ephemeral vs 1h, rollback порогу 30%.
+- [ADR-0005 — Anthropic model selection and prompt caching](../adr/0005-anthropic-model-selection-and-prompt-caching.md) — попередник, model-selection baseline.
+- [Playbook `enable-prompt-caching.md`](../playbooks/enable-prompt-caching.md) — операційний rollout-checklist + manual smoke-команди.
+- [`docs/observability/dashboards/ai-cost.json`](../observability/dashboards/ai-cost.json) (uid `sergeant-ai-cost`) — 7-panel Grafana.
+- [`docs/observability/metrics.md`](../observability/metrics.md) — реєстр метрик (`ai_tokens_total`, `anthropic_prompt_cache_hit_total`, `ai_cost_estimate_usd_total`).
+- [`docs/observability/runbook.md` § Troubleshooting](../observability/runbook.md#troubleshooting) — як інтерпретувати порожні Anthropic-spans + AI-алерти.
+- [`apps/server/src/modules/chat/`](../../apps/server/src/modules/chat/) — `chat.ts`, `tools.ts`, `toolDefs/systemPrompt.ts`.
+- Координується з ініціативою [0004 — server observability](./0004-server-observability.md) — `aiSpan` помічатиме `cache_hit` як attribute.
+- [`docs/tech-debt/backend.md`](../tech-debt/backend.md) — запис про AI cost (раніше «not measured»; зараз закритий, prompt-caching активний з [#864](https://github.com/Skords-01/Sergeant/pull/864), per-endpoint cost-метрики з [#1247](https://github.com/Skords-01/Sergeant/pull/1247)).
 
 ## Outcome (2026-05-04)
 
 ### Що реально шипнуто
 
-**Phase 1 — prompt cache: ✅ DONE (2 breakpoints, не 1)**
+**Phase 1 — prompt cache: ✅ DONE (2 breakpoints, не 1)** — [#864](https://github.com/Skords-01/Sergeant/pull/864) (audit PR-12.A, активація на `system` + tools), [#924](https://github.com/Skords-01/Sergeant/pull/924) (per-tool lifecycle-метрика, audit PR-12.C).
 
 - [`apps/server/src/modules/chat/chat.ts`](../../apps/server/src/modules/chat/chat.ts) `buildSystem(context)`:
-  - `system[0]` = `SYSTEM_PREFIX` з `cache_control: { type: "ephemeral" }`. Stable, ~6k+ токенів.
+  - `system[0]` = `SYSTEM_PREFIX` з `cache_control: { type: "ephemeral" }`. Сьогодні префікс ~987 токенів — **рівно під** Anthropic min-cacheable-prompt 1024 для Sonnet, тому окремий slot фактично не реєструється. Залишаємо breakpoint як **forward-looking marker**: щойно `SYSTEM_PREFIX` виросте понад 1024 — кеш ввімкнеться без зміни коду.
   - `system[1]` = per-user `context` **без** `cache_control` — інакше cache-key різниться між юзерами на тривіальних змінах і hit-rate валиться у 0%.
 - `applyToolsCacheBreakpoint(TOOLS)` додає `cache_control: ephemeral` на **останній tool** у масиві:
-  - Anthropic читає cache в order `system → tools → messages`; останній `cache_control` каже «кешуй усе до цього блоку **включно**». Тому cache реально покриває `system[0]` + усі tools (~6k + 5–15k tokens).
-  - **Без цього другого breakpoint-у** cache_control на `system[0]` сам по собі не вмикає кеш на tools. Це специфіка Anthropic, не очевидна з doc-ів — зафіксована в коментарях `chat.ts:30-39` і у [ADR-0039](../adr/0039-anthropic-prompt-cache-policy.md).
+  - Anthropic читає cache в order `system → tools → messages`; останній `cache_control` каже «кешуй усе до цього блоку **включно**». Тому cache реально покриває `system[0]` + усі tools (~5825 байт SYSTEM_PREFIX + 83 tool-definitions у `toolDefs/{finyk,fizruk,routine,nutrition,crossModule,utility,memory}.ts` ≈ **12k токенів** при першому write).
+  - **Без цього другого breakpoint-у** cache_control на `system[0]` сам по собі не вмикає кеш на tools (та й сам не реєструється на 987 токенах). Це специфіка Anthropic, не очевидна з doc-ів — зафіксована в коментарях `chat.ts:30-48` і у [ADR-0039](../adr/0039-anthropic-prompt-cache-policy.md). Operational rollout-checklist — у [playbook `enable-prompt-caching.md`](../playbooks/enable-prompt-caching.md) (включно з real-key smoke output: `cache_creation=12284` → `cache_read=12284` між першим і другим запитом).
 - `messages` НЕ кешуються (single-turn flow; cache-write-cost > read-saving).
-- Тести: [`apps/server/src/modules/chat/chat.stream.test.ts:732-844`](../../apps/server/src/modules/chat/chat.stream.test.ts) — 4 кейси для `recordAnthropicUsage` (cache_read>0, cache_creation>0, both, neither).
+- Тести: [`apps/server/src/modules/chat/chat.stream.test.ts:732-844`](../../apps/server/src/modules/chat/chat.stream.test.ts) — 4 кейси для `recordAnthropicUsage` (cache_read>0, cache_creation>0, both, neither). Структурні тести `system[]`/tools breakpoint — у [`chat.test.ts:673-731`](../../apps/server/src/modules/chat/chat.test.ts).
 
-**Phase 2 — cost-computation utility: ✅ DONE (повністю)**
+**Phase 2 — cost-computation utility: ✅ DONE (повністю)** — [#1247](https://github.com/Skords-01/Sergeant/pull/1247) (per-endpoint tokens + USD cost metrics), [#1248](https://github.com/Skords-01/Sergeant/pull/1248) (capture `output_tokens` з SSE `message_delta`, інакше `ai_cost_estimate_usd_total` систематично занижував spend для streaming-флоу).
 
 - [`apps/server/src/lib/anthropic.ts`](../../apps/server/src/lib/anthropic.ts):147-200 — `ANTHROPIC_PRICING_USD_PER_MTOK` keyed by model-prefix через `pickPricing()` + `startsWith` (стійкіше за повну назву моделі — Anthropic регулярно випускає subversions з тим самим прайсингом).
   - `claude-sonnet-4` / `claude-3-7-sonnet` / `claude-3-5-sonnet` / `claude-3-sonnet`: input $3, output $15, cache_write $3.75, cache_read $0.30 / 1M.
@@ -217,7 +223,7 @@ Sergeant досить агресивно використовує Anthropic Clau
   5. AI quota fail-open (CRITICAL) — `sum(increase(ai_quota_fail_open_total[1h]))`.
   6. AI request outcomes — `sum by (endpoint, outcome) (rate(ai_requests_total[5m]))`.
   7. AI p95 latency by endpoint — `histogram_quantile(0.95, sum by (le, endpoint) (rate(ai_request_duration_ms_bucket[5m])))`.
-- Alerts (у [`docs/observability/prometheus/alert_rules.yml`](../observability/prometheus/alert_rules.yml)): `AiErrorBudgetBurn`, `AiErrorBudgetBurnSlow`, `AiQuotaFailOpen` (10 хв вікно, severity=ticket). Runbook entries у [`docs/observability/runbook.md`](../observability/runbook.md).
+- Alerts (у [`docs/observability/prometheus/alert_rules.yml`](../observability/prometheus/alert_rules.yml)): `AiErrorBudgetBurnFast` / `AiErrorBudgetBurnSlow` (multi-window, multi-burn-rate per Google SRE), `AiQuotaStoreDown` / `AiQuotaFailOpen` (10 хв вікно, severity=ticket). Runbook entry «Anthropic-spans порожні (немає tokens, prompt_cache_hit)» — [`docs/observability/runbook.md` § Troubleshooting](../observability/runbook.md#troubleshooting).
 
 **Phase 4 — ADR: ✅ DONE**
 
@@ -261,9 +267,33 @@ Sergeant досить агресивно використовує Anthropic Clau
 | Pricing table                               | none                  | `ANTHROPIC_PRICING_USD_PER_MTOK` (8 model-prefix-ів × 4 rates) у `apps/server/src/lib/anthropic.ts` |
 | `ai_429_rate`                               | ?                     | < 1% (через `AiErrorBudgetBurn` alert; staging спостерігає)                                         |
 
+### Verification queries (PromQL)
+
+Копі-пейст у Grafana Explore (datasource `${DS_PROMETHEUS}`) після кожного релізу, що чіпає `chat.ts`/`tools.ts`/`SYSTEM_PREFIX`:
+
+```promql
+# 1. Cache-hit ratio за останню годину (target ≥60% за тиждень).
+#    Якщо у Grafana панелі #3 ця формула показує <30% — rollback policy у ADR-0039 § 7.
+sum(rate(anthropic_prompt_cache_hit_total{outcome="hit"}[1h]))
+  / clamp_min(sum(rate(anthropic_prompt_cache_hit_total[1h])), 1)
+
+# 2. Cost-decomposition за 24 год (cache_read дешевший у ~10× за prompt; cache_write — на 25% дорожчий).
+sum by (kind) (increase(ai_tokens_total{provider="anthropic"}[24h]))
+
+# 3. $/день per model — `ai_cost_estimate_usd_total` уже у USD-доларах, обернути в add().
+sum by (model) (increase(ai_cost_estimate_usd_total{provider="anthropic"}[24h]))
+
+# 4. Hit-rate per SYSTEM_PROMPT_VERSION — корисно після bump-у `SYSTEM_PROMPT_VERSION`,
+#    щоб побачити, як hit-rate деградував у нову епоху і відновлювався.
+sum by (version) (rate(anthropic_prompt_cache_hit_total{outcome="hit"}[1h]))
+  / clamp_min(sum by (version) (rate(anthropic_prompt_cache_hit_total[1h])), 1)
+```
+
+Manual smoke (потрібен реальний `ANTHROPIC_API_KEY`, не `AI_QUOTA_DISABLED`-режим) описаний у playbook-у [`enable-prompt-caching.md` § 7](../playbooks/enable-prompt-caching.md): два послідовні `/api/chat` мають дати `cache_creation_input_tokens > 0` (1-й) і `cache_read_input_tokens > 0` (2-й, у межах 5-хв TTL).
+
 ### Carry-over → successor
 
-- [ ] Перевірити cache-hit-rate ≥60% за тиждень після rollout-у (panel #3). Якщо <30% — перевірити `SYSTEM_PROMPT_VERSION` drift, повернутись до варіанту A (drop cache).
-- [ ] Cost-based alert `ai_daily_cost_usd > 50` — додати, коли baseline-week покаже цільовий threshold.
-- [ ] Per-route hit-rate breakdown — додати `endpoint` label на `anthropic_prompt_cache_hit_total` коли буде incident, що цього вимагає.
-- [ ] OpenAI prompt cache (auto-cache після 1024 токенів) — окремий ADR, якщо/коли перейдемо на OpenAI або multi-provider routing.
+- [ ] **2026-05-12 (≈ +тиждень):** перевірити cache-hit-rate ≥60% (panel #3 у `ai-cost.json` + query #1 вище). Якщо <30% — fixture-чек `SYSTEM_PROMPT_VERSION` drift, перевірити що `system[1]` (context) не йде у `system[0]` (regression-тест `chat.test.ts:673`); за потреби — варіант A (drop cache) per ADR-0039 § 7.
+- [ ] **Після baseline-week:** cost-based alert `ai_daily_cost_usd > $X` — `X` обираємо з реальних spending-numbers (зараз < $5/day на staging, ставити cap на 50× від baseline передчасно). Додати у `alert_rules.yml` поряд з `AiErrorBudgetBurnFast`.
+- [ ] Per-route hit-rate breakdown — додати `endpoint` label на `anthropic_prompt_cache_hit_total` коли буде incident, що цього вимагає (поки що `aggregated` view достатньо).
+- [ ] OpenAI prompt cache (auto-cache після 1024 токенів) — окремий ADR, якщо/коли перейдемо на OpenAI або multi-provider routing. Тільки метрика, без коду — Anthropic SDK залишається primary.


### PR DESCRIPTION
Доробив документ ініціативи 0005 (AI cost + Anthropic prompt cache):

- Виправив фактичну неточність про розмір `system[0]`/`SYSTEM_PREFIX`: doc стверджував ~6k+ токенів, реальність — ~987 токенів (рівно під Anthropic min-cacheable 1024). Реальний кеш-вин іде через **другий** breakpoint на останньому tool, який покриває `system + всі 19+ tools` ≈ 12k токенів. Збігається з чітким коментарем у `apps/server/src/modules/chat/chat.ts:30-48` і smoke output `cache_creation=12284 → cache_read=12284` у playbook-у.
- Додав посилання на конкретні shipped PR-и: [#864](https://github.com/Skords-01/Sergeant/pull/864) (Phase 1, audit PR-12.A), [#924](https://github.com/Skords-01/Sergeant/pull/924) (per-tool метрики, audit PR-12.C), [#1247](https://github.com/Skords-01/Sergeant/pull/1247) (per-endpoint Anthropic tokens + USD cost) і [#1248](https://github.com/Skords-01/Sergeant/pull/1248) (capture `output_tokens` зі стрімових `message_delta`, інакше `ai_cost_estimate_usd_total` систематично занижував spend для streaming).
- Додав секцію **Verification queries (PromQL)**: 4 готові запити для копі-пейсту в Grafana Explore (cache-hit ratio за 1h, token-decomposition за 24h, $/день per model, hit-rate per `SYSTEM_PROMPT_VERSION`) — повинні запускатися після кожного релізу, що чіпає `chat.ts`/`tools.ts`/`SYSTEM_PREFIX`.
- Уточнив carry-over deadlines: явна дата `2026-05-12` для перевірки cache-hit-rate ≥60%, посилання на regression-тест `chat.test.ts:673` для drift-checking, додав крок `AiErrorBudgetBurnFast` як сусіда для майбутнього cost-cap alert-а.
- Поправив назви alerts (`AiErrorBudgetBurnFast`/`Slow`, `AiQuotaStoreDown` — як вони реально називаються в `alert_rules.yml`), а не неіснуючі `AiErrorBudgetBurn`/`AiQuotaFailOpen`.
- Розширив **Посилання**: ADR-0039, ADR-0005 (попередник), playbook `enable-prompt-caching.md`, `metrics.md`, `runbook.md § Troubleshooting`, link на `0004-server-observability.md`. Виправив `tech-debt/backend.md` reference (запис закритий, активним є prompt-caching з #864 + cost-метрики з #1247).

Prettier check ✅ ; husky-хуки (`bump-last-validated.mjs`, `prettier --write`) пройшли під час коміту.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finalize initiative 0005 docs by correcting the `SYSTEM_PREFIX` token size and documenting how the second Anthropic prompt-cache breakpoint covers `system + tools`. Adds ready-to-run PromQL queries to verify cache-hit and cost after releases.

- **Bug Fixes**
  - Corrected `system[0]`/`SYSTEM_PREFIX` size (~987 tokens) and clarified that the real cache win comes from the last-tool breakpoint (~12k tokens covered).
  - Fixed alert names to match `alert_rules.yml` (`AiErrorBudgetBurnFast`/`Slow`, `AiQuotaStoreDown`, `AiQuotaFailOpen`) and clarified carry-over deadline (2026-05-12) with the relevant regression test reference.

- **New Features**
  - Added PromQL “Verification queries” (cache-hit ratio, token/cost breakdown, $/day per model, hit-rate per `SYSTEM_PROMPT_VERSION`) for Grafana Explore.
  - Linked shipped work: `#864` (Phase 1), `#924` (per-tool metrics), `#1247` (per-endpoint tokens + USD), `#1248` (streaming `output_tokens`).
  - Expanded references (ADR-0039, ADR-0005, playbook, dashboard JSON, metrics, runbook) and updated “Last validated”/“Next review” dates.

<sup>Written for commit 3480969ad35f972a865b5ccc4da1430ae585cfdf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

