### PR TITLE
docs(root): add generated follow-ups index for initiatives + CI gate

### DIFF
--- a/.github/workflows/docs-automation.yml
+++ b/.github/workflows/docs-automation.yml
@@ -82,6 +82,32 @@ jobs:
       - name: Validate docs/adr/ graph integrity
         run: node scripts/docs/check-adr-graph.mjs
 
+  initiative-followups:
+    name: Initiative follow-ups (in sync)
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout v6.0.2 (SHA-pinned for supply-chain hardening)
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      # pnpm/action-setup v6.0.3 (SHA-pinned for supply-chain hardening)
+      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d
+
+      # actions/setup-node v6.4.0 (SHA-pinned for supply-chain hardening)
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "20"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check docs/initiatives/follow-ups.md is up to date
+        # Regenerate the consolidated follow-ups index from each initiative's
+        # `### Carry-over → successor` block and fail if the on-disk file
+        # diverges. Source-of-truth = the initiative files themselves; the
+        # index lives next to them and is rebuilt deterministically.
+        run: pnpm docs:check-initiative-followups
+
   hard-rules-matrix:
     name: Hard-rules matrix (in sync)
     runs-on: ubuntu-latest
@@ -177,6 +203,7 @@ jobs:
           node --test \
             scripts/docs/__tests__/check-freshness.test.mjs \
             scripts/docs/__tests__/generate-playbook-index.test.mjs \
+            scripts/docs/__tests__/generate-initiative-followups.test.mjs \
             scripts/docs/__tests__/generate-freshness-dashboard.test.mjs \
             scripts/docs/__tests__/check-markdown-links.test.mjs \
             scripts/docs/__tests__/check-adr-graph.test.mjs \

--- a/docs/initiatives/README.md
+++ b/docs/initiatives/README.md
@@ -26,6 +26,36 @@
 | **Власник / ETA** | Хто веде та орієнтовний дедлайн.                     |
 | **Посилання**     | Аудит-сорс, ADR, tech-debt, релевантні PR-и, issues. |
 
+## Зведений календар follow-up-ів
+
+Усі відкриті carry-over пункти зі всіх ініціатив зведено в один генерований файл — [`follow-ups.md`](./follow-ups.md). Source of truth = блок `### Carry-over → successor` у кожній ініціативі; індекс перебудовується скриптом `scripts/docs/generate-initiative-followups.mjs` і перевіряється в CI (`Initiative follow-ups (in sync)`).
+
+### Carry-over format
+
+У секції `### Carry-over → successor` пишемо top-level bullets з одним з 4 префіксів — парсер скрипта класифікує їх за патерном:
+
+```markdown
+### Carry-over → successor
+
+- [ ] **2026-05-12:** description … # one-shot, due-date (ISO)
+- [ ] **Recurring (weekly):** description … # recurring check
+- [ ] **Після baseline-week:** description … # trigger-based (вільна фраза)
+- [ ] description … # TBD (catch-all)
+```
+
+| Префікс                    | Куди потрапляє у `follow-ups.md`     | Приклад cadence-у                                        |
+| -------------------------- | ------------------------------------ | -------------------------------------------------------- |
+| `**YYYY-MM-DD[ (...)]:**`  | One-shot → колонка `Due` з ISO-датою | `**2026-05-12 (≈ +тиждень):**`                           |
+| `**Recurring (cadence):**` | Recurring → колонка `Cadence`        | `**Recurring (weekly):**`, `**Recurring (monthly):**`    |
+| `**Будь-яка фраза:**`      | One-shot → курсивом у колонці `Due`  | `**Після baseline-week:**`, `**When SLO breach:**`       |
+| Без bold-префіксу          | One-shot → `—` у колонці `Due`       | `Per-route hit-rate breakdown — додати endpoint label …` |
+
+Тільки `- [ ]` (unchecked) пункти потрапляють в індекс — `- [x]` (зроблено) лишається в файлі ініціативи як історія, але з агрегованого календаря випадає.
+
+Nested-bullets (відступ + `-`) **зливаються** у parent-описі — використовуйте їх для деталей кроків rollback / fixture-чеків, без шуму в індексі.
+
+Після правки carry-over: `pnpm docs:gen-initiative-followups` → закомітити оновлений `follow-ups.md` у тому самому PR-і. CI fail-ить, якщо checked-in `follow-ups.md` розходиться з тим, що згенерує скрипт.
+
 ## Активні ініціативи (травень 2026)
 
 | #    | Назва                                                                                                                | Пріоритет | Власник      | ETA                                               | Статус                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |

--- a/docs/initiatives/follow-ups.md
+++ b/docs/initiatives/follow-ups.md
@@ -1,0 +1,39 @@
+# Initiative follow-ups
+
+> **Last validated:** 2026-05-05 by @Skords-01. **Next review:** 2026-08-03.
+> **Status:** Active
+
+<!-- AUTO-GENERATED FILE. Do not edit by hand. Regenerate via `pnpm docs:gen-initiative-followups`. -->
+
+Зведений календар відкритих follow-up-ів з усіх ініціатив у [`docs/initiatives/`](./README.md). Source = `### Carry-over → successor` блок у кожному файлі (тільки `- [ ]`-пункти; checked-off — історія, в індекс не йдуть).
+
+Перевірка свіжості — `pnpm docs:check-initiative-followups` (CI gate). Формат пунктів — у [`README.md` § Carry-over format](./README.md#carry-over-format).
+
+## One-shot
+
+| Due                   | Initiative                                 | Item                                                                                                                                                                                                                                                                                    |
+| --------------------- | ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `2026-05-12`          | [0005](./0005-ai-cost-and-prompt-cache.md) | перевірити cache-hit-rate ≥60% (panel #3 у `ai-cost.json` + query #1 вище). Якщо <30% — fixture-чек `SYSTEM_PROMPT_VERSION` drift, перевірити що `system[1]` (context) не йде у `system[0]` (regression-тест `chat.test.ts:673`); за потреби — варіант A (drop cache) per ADR-0039 § 7. |
+| _Після baseline-week_ | [0005](./0005-ai-cost-and-prompt-cache.md) | cost-based alert `ai_daily_cost_usd > $X` — `X` обираємо з реальних spending-numbers (зараз < $5/day на staging, ставити cap на 50× від baseline передчасно). Додати у `alert_rules.yml` поряд з `AiErrorBudgetBurnFast`.                                                               |
+| —                     | [0004](./0004-server-observability.md)     | Перевести RED-deltas і AI-latency на span attributes замість Prom histograms — опційно, залежить від вибору OTLP-backend-у (Honeycomb derived columns vs Tempo metrics-from-traces). Не блокує закриття ініціативи; буде розглянуто в успадкованій 0006-RUM-spans-web ініціативі.       |
+| —                     | [0005](./0005-ai-cost-and-prompt-cache.md) | Per-route hit-rate breakdown — додати `endpoint` label на `anthropic_prompt_cache_hit_total` коли буде incident, що цього вимагає (поки що `aggregated` view достатньо).                                                                                                                |
+| —                     | [0005](./0005-ai-cost-and-prompt-cache.md) | OpenAI prompt cache (auto-cache після 1024 токенів) — окремий ADR, якщо/коли перейдемо на OpenAI або multi-provider routing. Тільки метрика, без коду — Anthropic SDK залишається primary.                                                                                              |
+
+Колонка `Due` — ISO-дата для дат-driven items (`⚠ overdue` на минулі), курсивом — trigger-based phrase (`Після baseline-week`, `When …`), `—` = unscheduled (TBD).
+
+## Recurring
+
+_Жодного recurring-чека._
+
+## How to add a follow-up
+
+Додайте top-level bullet до `### Carry-over → successor` секції відповідної ініціативи, дотримуючись формату:
+
+```markdown
+- [ ] **2026-05-12:** description … # one-shot, due-date
+- [ ] **Recurring (weekly):** description … # recurring check
+- [ ] **Після baseline-week:** description … # trigger-based
+- [ ] description … # TBD (catch-all)
+```
+
+Збережіть файл, виконайте `pnpm docs:gen-initiative-followups`, закомітьте змінений `follow-ups.md` у тому самому PR-і. CI гейт `Initiative follow-ups (in sync)` перевіряє, що згенерована версія = checked-in версія.

--- a/package.json
+++ b/package.json
@@ -65,6 +65,8 @@
     "docs:check-links": "node scripts/docs/check-markdown-links.mjs",
     "docs:gen-playbook-index": "node scripts/docs/generate-playbook-index.mjs",
     "docs:check-playbook-index": "node scripts/docs/generate-playbook-index.mjs --check",
+    "docs:gen-initiative-followups": "node scripts/docs/generate-initiative-followups.mjs",
+    "docs:check-initiative-followups": "node scripts/docs/generate-initiative-followups.mjs --check",
     "docs:check-playbook-schema": "node scripts/docs/check-playbook-schema.mjs",
     "docs:check-freshness-coverage": "node scripts/docs/check-freshness.mjs --check-coverage",
     "docs:check-adr-graph": "node scripts/docs/check-adr-graph.mjs",

--- a/scripts/docs/__tests__/generate-initiative-followups.test.mjs
+++ b/scripts/docs/__tests__/generate-initiative-followups.test.mjs
@@ -1,0 +1,241 @@
+// scripts/docs/__tests__/generate-initiative-followups.test.mjs
+//
+// Unit tests for the initiative follow-ups index generator.
+// Run with: node --test scripts/docs/__tests__/generate-initiative-followups.test.mjs
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  sliceCarryOverBlock,
+  parseCarryOverBullets,
+  classifyBullet,
+  compareCadence,
+  renderFollowUps,
+  addDays,
+} from "../generate-initiative-followups.mjs";
+
+describe("sliceCarryOverBlock", () => {
+  it("returns the block body when heading is present", () => {
+    const content = [
+      "# Title",
+      "",
+      "## Some section",
+      "",
+      "body",
+      "",
+      "### Carry-over → successor",
+      "",
+      "- [ ] Item one",
+      "- [ ] Item two",
+      "",
+    ].join("\n");
+    const block = sliceCarryOverBlock(content);
+    assert.match(block, /Item one/);
+    assert.match(block, /Item two/);
+  });
+
+  it("stops at the next heading", () => {
+    const content = [
+      "### Carry-over → successor",
+      "- [ ] keep",
+      "",
+      "## Next section",
+      "should-not-be-here",
+    ].join("\n");
+    const block = sliceCarryOverBlock(content);
+    assert.match(block, /keep/);
+    assert.doesNotMatch(block, /should-not-be-here/);
+  });
+
+  it("returns null when no Carry-over heading", () => {
+    assert.equal(sliceCarryOverBlock("# Title\n\nbody"), null);
+  });
+
+  it("supports both ## and ### levels", () => {
+    const at2 = sliceCarryOverBlock("## Carry-over → successor\n\n- [ ] x\n");
+    const at3 = sliceCarryOverBlock("### Carry-over → successor\n\n- [ ] x\n");
+    assert.match(at2, /- \[ \] x/);
+    assert.match(at3, /- \[ \] x/);
+  });
+});
+
+describe("classifyBullet", () => {
+  it("recognises an ISO-date prefix", () => {
+    const out = classifyBullet(
+      "**2026-05-12:** перевірити cache-hit-rate ≥60%",
+    );
+    assert.equal(out.kind, "one-shot-dated");
+    assert.equal(out.key, "2026-05-12");
+    assert.equal(out.description, "перевірити cache-hit-rate ≥60%");
+  });
+
+  it("recognises an ISO-date prefix with parenthetical hint", () => {
+    const out = classifyBullet(
+      "**2026-05-12 (≈ +тиждень):** перевірити hit-rate",
+    );
+    assert.equal(out.kind, "one-shot-dated");
+    assert.equal(out.key, "2026-05-12");
+    assert.equal(out.description, "перевірити hit-rate");
+  });
+
+  it("recognises a Recurring prefix and lowercases the cadence key", () => {
+    const out = classifyBullet("**Recurring (Weekly):** sweep stale flags");
+    assert.equal(out.kind, "recurring");
+    assert.equal(out.key, "weekly");
+    assert.equal(out.description, "sweep stale flags");
+  });
+
+  it("treats other **bold:** prefixes as trigger-based", () => {
+    const out = classifyBullet(
+      "**Після baseline-week:** cost-based alert threshold",
+    );
+    assert.equal(out.kind, "trigger");
+    assert.equal(out.key, "Після baseline-week");
+    assert.equal(out.description, "cost-based alert threshold");
+  });
+
+  it("falls through to TBD when no bold prefix", () => {
+    const out = classifyBullet(
+      "Per-route hit-rate breakdown — додати endpoint label",
+    );
+    assert.equal(out.kind, "tbd");
+    assert.equal(out.key, "");
+    assert.equal(
+      out.description,
+      "Per-route hit-rate breakdown — додати endpoint label",
+    );
+  });
+});
+
+describe("parseCarryOverBullets", () => {
+  it("returns top-level unchecked bullets only", () => {
+    const block = [
+      "",
+      "- [ ] **2026-05-12:** alpha",
+      "- [x] historical (should be ignored)",
+      "- [ ] beta",
+      "",
+    ].join("\n");
+    const bullets = parseCarryOverBullets(block);
+    assert.equal(bullets.length, 2);
+    assert.equal(bullets[0].description, "alpha");
+    assert.equal(bullets[1].description, "beta");
+  });
+
+  it("folds nested bullets into the parent description", () => {
+    const block = [
+      "- [ ] **2026-05-12:** parent",
+      "    - sub one",
+      "    - sub two",
+      "- [ ] solo",
+    ].join("\n");
+    const bullets = parseCarryOverBullets(block);
+    assert.equal(bullets.length, 2);
+    assert.match(bullets[0].description, /parent/);
+    assert.match(bullets[0].description, /sub one/);
+    assert.match(bullets[0].description, /sub two/);
+    assert.equal(bullets[1].description, "solo");
+  });
+
+  it("returns [] for null/empty input", () => {
+    assert.deepEqual(parseCarryOverBullets(null), []);
+    assert.deepEqual(parseCarryOverBullets(""), []);
+  });
+});
+
+describe("compareCadence", () => {
+  it("orders known cadences by frequency (faster first)", () => {
+    assert.ok(compareCadence("daily", "weekly") < 0);
+    assert.ok(compareCadence("weekly", "monthly") < 0);
+    assert.ok(compareCadence("monthly", "quarterly") < 0);
+  });
+
+  it("places unknown cadences after known ones", () => {
+    assert.ok(compareCadence("weekly", "fortnightly-on-fridays") < 0);
+    assert.ok(compareCadence("zzz", "weekly") > 0);
+  });
+
+  it("is alphabetical between two unknown cadences", () => {
+    assert.ok(compareCadence("alpha", "beta") < 0);
+  });
+});
+
+describe("renderFollowUps", () => {
+  const sample = [
+    {
+      file: "0005-ai-cost.md",
+      title: "AI cost",
+      kind: "one-shot-dated",
+      key: "2026-05-12",
+      description: "перевірити cache-hit-rate",
+    },
+    {
+      file: "0005-ai-cost.md",
+      title: "AI cost",
+      kind: "trigger",
+      key: "Після baseline-week",
+      description: "cost-based alert",
+    },
+    {
+      file: "0004-server-obs.md",
+      title: "Server obs",
+      kind: "tbd",
+      key: "",
+      description: "RED-deltas → span attributes",
+    },
+    {
+      file: "0008-platform.md",
+      title: "Platform hardening",
+      kind: "recurring",
+      key: "weekly",
+      description: "review stale audit-exceptions",
+    },
+  ];
+
+  it("emits two top-level sections in fixed order", () => {
+    const out = renderFollowUps(sample, { today: "2026-05-05" });
+    const oneShotIdx = out.indexOf("## One-shot");
+    const recurringIdx = out.indexOf("## Recurring");
+    assert.ok(oneShotIdx > 0);
+    assert.ok(recurringIdx > oneShotIdx);
+  });
+
+  it("places dated items before trigger before TBD inside One-shot", () => {
+    const out = renderFollowUps(sample, { today: "2026-05-05" });
+    const datedIdx = out.indexOf("2026-05-12");
+    const triggerIdx = out.indexOf("Після baseline-week");
+    const tbdIdx = out.indexOf("RED-deltas");
+    assert.ok(datedIdx < triggerIdx, "dated must precede trigger");
+    assert.ok(triggerIdx < tbdIdx, "trigger must precede TBD");
+  });
+
+  it("flags overdue dated items", () => {
+    const out = renderFollowUps(sample, { today: "2026-06-01" });
+    assert.match(out, /2026-05-12.*⚠ overdue/);
+  });
+
+  it("does NOT flag dated items that are still in the future", () => {
+    const out = renderFollowUps(sample, { today: "2026-05-05" });
+    assert.doesNotMatch(out, /2026-05-12.*⚠ overdue/);
+  });
+
+  it("renders an empty-section placeholder when no items match", () => {
+    const out = renderFollowUps([], { today: "2026-05-05" });
+    assert.match(out, /Жодного відкритого one-shot/);
+    assert.match(out, /Жодного recurring-чека/);
+  });
+
+  it("includes the freshness header with addDays(+90)", () => {
+    const out = renderFollowUps(sample, { today: "2026-05-05" });
+    assert.match(out, /Last validated:\*\* 2026-05-05/);
+    assert.match(out, /Next review:\*\* 2026-08-03/);
+  });
+});
+
+describe("addDays", () => {
+  it("adds 90 days correctly across month/quarter boundaries", () => {
+    assert.equal(addDays("2026-05-05", 90), "2026-08-03");
+    assert.equal(addDays("2026-01-01", 365), "2027-01-01");
+  });
+});

--- a/scripts/docs/freshness-config.json
+++ b/scripts/docs/freshness-config.json
@@ -20,5 +20,5 @@
     "docs/agents/specs/2026-04-25-assistant-capability-catalogue-design.md": 180
   },
   "explicitInclude": [],
-  "explicitExclude": []
+  "explicitExclude": ["docs/initiatives/follow-ups.md"]
 }

--- a/scripts/docs/generate-initiative-followups.mjs
+++ b/scripts/docs/generate-initiative-followups.mjs
@@ -1,0 +1,430 @@
+#!/usr/bin/env node
+// scripts/docs/generate-initiative-followups.mjs
+//
+// Scan `docs/initiatives/[0-9]*.md`, extract each initiative's
+// `### Carry-over → successor` block, and generate
+// `docs/initiatives/follow-ups.md` — a consolidated index of all open
+// follow-up items across initiatives, split into:
+//
+//   1. One-shot — date-driven items (sorted by due date), trigger-based
+//      items (sorted alphabetically by trigger phrase), and truly
+//      unscheduled items.
+//   2. Recurring — items with a `**Recurring (cadence):**` prefix.
+//
+// Single source of truth for `що мені треба перевірити цього тижня?`
+// — answers the question without grep-ing every initiative file.
+//
+// Format contract for top-level carry-over bullets:
+//
+//   - [ ] **YYYY-MM-DD[ ...]:** description …       ← one-shot, due-date
+//   - [ ] **Recurring (weekly):** description …     ← recurring check
+//   - [ ] **Після baseline-week:** description …    ← trigger-based
+//   - [ ] description …                             ← unscheduled (TBD)
+//
+// Only unchecked (`- [ ]`) bullets appear in the index. Checked items
+// are historical record and stay in the source initiative file as-is.
+//
+// Usage:
+//   node scripts/docs/generate-initiative-followups.mjs            # write
+//   node scripts/docs/generate-initiative-followups.mjs --check    # CI
+//
+// Exits 1 on `--check` diff or I/O error.
+
+import { readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { resolve, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import prettier from "prettier";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolve(__dirname, "../..");
+const INITIATIVES_DIR = resolve(REPO_ROOT, "docs/initiatives");
+const OUTPUT_PATH = join(INITIATIVES_DIR, "follow-ups.md");
+
+const RE_INITIATIVE_FILE = /^\d{4}-.+\.md$/;
+const RE_H1 = /^#\s+(.+?)\s*$/m;
+// Carry-over heading we recognise. Both `###` and `##` levels supported so
+// authors aren't forced to a specific depth.
+const RE_CARRY_OVER_HEADING = /^(#{2,3})\s+Carry-over\s+→\s+successor\s*$/m;
+// A bullet is a top-level `- [ ] ` / `- [x] ` line. Nested bullets (indented
+// with whitespace) are treated as continuation of the parent and are NOT
+// indexed independently — they explain the parent item.
+const RE_TOP_BULLET = /^- \[( |x)\] (.*)$/;
+// Prefix patterns. The order matters: ISO date is most specific, then
+// recurring, then any other `**bold prefix:**` is treated as a trigger.
+const RE_DATE_PREFIX = /^\*\*(\d{4}-\d{2}-\d{2})(?:\s+\([^)]*\))?:\*\*\s*(.*)$/;
+const RE_RECURRING_PREFIX = /^\*\*Recurring\s*\(([^)]+)\):\*\*\s*(.*)$/i;
+const RE_OTHER_PREFIX = /^\*\*([^*:]+):\*\*\s*(.*)$/;
+
+// ── Pure helpers (exported for tests) ────────────────────────────────────────
+
+/**
+ * Slice the carry-over block out of an initiative file's body. Returns the
+ * raw block text (without the heading line itself) or null if no carry-over
+ * heading is present.
+ */
+export function sliceCarryOverBlock(content) {
+  const match = RE_CARRY_OVER_HEADING.exec(content);
+  if (!match) return null;
+  const startIdx = match.index + match[0].length;
+  const after = content.slice(startIdx);
+  // Stop at the next heading of the same or higher level. We accept any
+  // heading `^#{1,3} ` because `### Carry-over → successor` is typically
+  // the last subsection in an initiative.
+  const stopMatch = /^#{1,3}\s/m.exec(after);
+  return stopMatch ? after.slice(0, stopMatch.index) : after;
+}
+
+/**
+ * Parse the carry-over block into top-level bullets. Returns an array of
+ * `{ checked, prefix, kind, key, description }` records:
+ *
+ *   - kind:        "one-shot-dated" | "recurring" | "trigger" | "tbd"
+ *   - key:         ISO date for dated, cadence string for recurring,
+ *                  trigger phrase for trigger-based, "" for tbd
+ *   - description: bullet body with prefix stripped
+ *
+ * Only `- [ ]` (unchecked) bullets are returned — checked items are not
+ * actionable and are excluded from the index.
+ *
+ * Indentation note: nested bullets (lines starting with whitespace + `-`)
+ * are folded into the parent's description so that authors can write
+ * sub-points like rollback steps without polluting the index.
+ */
+export function parseCarryOverBullets(block) {
+  if (!block) return [];
+  const lines = block.split(/\r?\n/);
+  const bullets = [];
+  let current = null;
+  for (const line of lines) {
+    const topMatch = RE_TOP_BULLET.exec(line);
+    if (topMatch) {
+      if (current) bullets.push(current);
+      current = {
+        checked: topMatch[1] === "x",
+        rawBody: topMatch[2].trim(),
+        continuation: [],
+      };
+      continue;
+    }
+    if (!current) continue;
+    if (/^\s+\S/.test(line)) {
+      current.continuation.push(line.trim());
+      continue;
+    }
+    // Blank or unrelated paragraph terminates the current bullet.
+    if (line.trim() === "") {
+      bullets.push(current);
+      current = null;
+    }
+  }
+  if (current) bullets.push(current);
+
+  return bullets
+    .filter((b) => !b.checked)
+    .map((b) => classifyBullet(joinBody(b)));
+}
+
+function joinBody(b) {
+  return b.continuation.length === 0
+    ? b.rawBody
+    : `${b.rawBody} ${b.continuation.join(" ")}`;
+}
+
+/**
+ * Classify a stripped bullet body into one of four kinds based on its
+ * leading `**...:**` prefix. Exported for tests.
+ */
+export function classifyBullet(body) {
+  const dateMatch = RE_DATE_PREFIX.exec(body);
+  if (dateMatch) {
+    return {
+      kind: "one-shot-dated",
+      key: dateMatch[1],
+      prefix: body.slice(0, body.indexOf(":**") + 3),
+      description: dateMatch[2].trim(),
+    };
+  }
+  const recMatch = RE_RECURRING_PREFIX.exec(body);
+  if (recMatch) {
+    return {
+      kind: "recurring",
+      key: recMatch[1].trim().toLowerCase(),
+      prefix: body.slice(0, body.indexOf(":**") + 3),
+      description: recMatch[2].trim(),
+    };
+  }
+  const otherMatch = RE_OTHER_PREFIX.exec(body);
+  if (otherMatch) {
+    return {
+      kind: "trigger",
+      key: otherMatch[1].trim(),
+      prefix: body.slice(0, body.indexOf(":**") + 3),
+      description: otherMatch[2].trim(),
+    };
+  }
+  return {
+    kind: "tbd",
+    key: "",
+    prefix: "",
+    description: body.trim(),
+  };
+}
+
+/** Today in YYYY-MM-DD UTC. */
+export function todayISO() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/** Add `days` calendar days to an ISO date string. */
+export function addDays(isoDate, days) {
+  const d = new Date(isoDate + "T00:00:00Z");
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+function escapePipes(s) {
+  return String(s).replace(/\|/g, "\\|");
+}
+
+function tableCell(s) {
+  return escapePipes(String(s).replace(/\r?\n/g, " ")).trim();
+}
+
+/**
+ * Truncate a description to keep the table readable. We don't truncate
+ * by default (rich descriptions are useful) but offer the helper for
+ * tests that need it.
+ */
+export function trimDescription(s, maxLen = Infinity) {
+  if (s.length <= maxLen) return s;
+  return s.slice(0, maxLen - 1).trimEnd() + "…";
+}
+
+/**
+ * Cadence ordering: weekly < bi-weekly < monthly < quarterly < yearly.
+ * Unknown cadences fall to the end, sorted alphabetically.
+ */
+const CADENCE_ORDER = [
+  "daily",
+  "weekly",
+  "bi-weekly",
+  "biweekly",
+  "fortnightly",
+  "monthly",
+  "quarterly",
+  "yearly",
+  "annually",
+];
+
+export function compareCadence(a, b) {
+  const ai = CADENCE_ORDER.indexOf(a);
+  const bi = CADENCE_ORDER.indexOf(b);
+  if (ai !== -1 && bi !== -1) return ai - bi;
+  if (ai !== -1) return -1;
+  if (bi !== -1) return 1;
+  return a.localeCompare(b);
+}
+
+/**
+ * Read every `*-*.md` file in `dir` (defaults to docs/initiatives/), parse
+ * each Carry-over block, and emit a flat list of items annotated with the
+ * source initiative's filename and short title.
+ */
+export function collectFollowUps(dir = INITIATIVES_DIR) {
+  const files = readdirSync(dir)
+    .filter((f) => RE_INITIATIVE_FILE.test(f))
+    .sort();
+
+  const items = [];
+  for (const file of files) {
+    const path = join(dir, file);
+    const content = readFileSync(path, "utf8");
+    const titleMatch = RE_H1.exec(content);
+    const title = titleMatch ? titleMatch[1].trim() : file.replace(/\.md$/, "");
+    const block = sliceCarryOverBlock(content);
+    if (!block) continue;
+    const bullets = parseCarryOverBullets(block);
+    for (const b of bullets) {
+      items.push({ file, title, ...b });
+    }
+  }
+  return items;
+}
+
+/**
+ * Build the consolidated follow-ups markdown. Pure (no I/O).
+ *
+ * Sections, in order:
+ *   1. One-shot (3 ordered groups: dated → trigger-based → tbd)
+ *   2. Recurring
+ *
+ * `today` is overridable for tests; default = current UTC date.
+ */
+export function renderFollowUps(items, { today = todayISO() } = {}) {
+  const dated = items
+    .filter((i) => i.kind === "one-shot-dated")
+    .sort((a, b) => a.key.localeCompare(b.key) || a.file.localeCompare(b.file));
+  const triggered = items
+    .filter((i) => i.kind === "trigger")
+    .sort(
+      (a, b) =>
+        a.key.localeCompare(b.key, undefined, { sensitivity: "base" }) ||
+        a.file.localeCompare(b.file),
+    );
+  const tbd = items
+    .filter((i) => i.kind === "tbd")
+    .sort((a, b) => a.file.localeCompare(b.file));
+  const recurring = items
+    .filter((i) => i.kind === "recurring")
+    .sort(
+      (a, b) => compareCadence(a.key, b.key) || a.file.localeCompare(b.file),
+    );
+
+  const lines = [];
+  lines.push("# Initiative follow-ups");
+  lines.push("");
+  lines.push(
+    `> **Last validated:** ${today} by @devin-ai. **Next review:** ${addDays(today, 90)}.`,
+  );
+  lines.push("> **Status:** Active");
+  lines.push("");
+  lines.push(
+    "<!-- AUTO-GENERATED FILE. Do not edit by hand. Regenerate via `pnpm docs:gen-initiative-followups`. -->",
+  );
+  lines.push("");
+  lines.push(
+    "Зведений календар відкритих follow-up-ів з усіх ініціатив у [`docs/initiatives/`](./README.md). Source = `### Carry-over → successor` блок у кожному файлі (тільки `- [ ]`-пункти; checked-off — історія, в індекс не йдуть).",
+  );
+  lines.push("");
+  lines.push(
+    "Перевірка свіжості — `pnpm docs:check-initiative-followups` (CI gate). Формат пунктів — у [`README.md` § Carry-over format](./README.md#carry-over-format).",
+  );
+  lines.push("");
+
+  // ── One-shot ──────────────────────────────────────────────────────────────
+  lines.push("## One-shot");
+  lines.push("");
+  if (dated.length + triggered.length + tbd.length === 0) {
+    lines.push("_Жодного відкритого one-shot follow-up-у._");
+    lines.push("");
+  } else {
+    lines.push("| Due | Initiative | Item |");
+    lines.push("| --- | ---------- | ---- |");
+    for (const i of dated) {
+      const overdue = i.key < today ? " ⚠ overdue" : "";
+      lines.push(
+        `| \`${i.key}\`${overdue} | ${initiativeLink(i)} | ${tableCell(i.description)} |`,
+      );
+    }
+    for (const i of triggered) {
+      lines.push(
+        `| _${tableCell(i.key)}_ | ${initiativeLink(i)} | ${tableCell(i.description)} |`,
+      );
+    }
+    for (const i of tbd) {
+      lines.push(`| — | ${initiativeLink(i)} | ${tableCell(i.description)} |`);
+    }
+    lines.push("");
+    lines.push(
+      "Колонка `Due` — ISO-дата для дат-driven items (`⚠ overdue` на минулі), курсивом — trigger-based phrase (`Після baseline-week`, `When …`), `—` = unscheduled (TBD).",
+    );
+    lines.push("");
+  }
+
+  // ── Recurring ─────────────────────────────────────────────────────────────
+  lines.push("## Recurring");
+  lines.push("");
+  if (recurring.length === 0) {
+    lines.push("_Жодного recurring-чека._");
+    lines.push("");
+  } else {
+    lines.push("| Cadence | Initiative | Item |");
+    lines.push("| ------- | ---------- | ---- |");
+    for (const i of recurring) {
+      lines.push(
+        `| \`${tableCell(i.key)}\` | ${initiativeLink(i)} | ${tableCell(i.description)} |`,
+      );
+    }
+    lines.push("");
+  }
+
+  // ── Format reminder ───────────────────────────────────────────────────────
+  lines.push("## How to add a follow-up");
+  lines.push("");
+  lines.push(
+    "Додайте top-level bullet до `### Carry-over → successor` секції відповідної ініціативи, дотримуючись формату:",
+  );
+  lines.push("");
+  lines.push("```markdown");
+  lines.push(
+    "- [ ] **2026-05-12:** description …            # one-shot, due-date",
+  );
+  lines.push(
+    "- [ ] **Recurring (weekly):** description …    # recurring check",
+  );
+  lines.push("- [ ] **Після baseline-week:** description …   # trigger-based");
+  lines.push(
+    "- [ ] description …                            # TBD (catch-all)",
+  );
+  lines.push("```");
+  lines.push("");
+  lines.push(
+    "Збережіть файл, виконайте `pnpm docs:gen-initiative-followups`, закомітьте змінений `follow-ups.md` у тому самому PR-і. CI гейт `Initiative follow-ups (in sync)` перевіряє, що згенерована версія = checked-in версія.",
+  );
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+function initiativeLink(item) {
+  const num = item.file.slice(0, 4);
+  return `[${num}](./${item.file})`;
+}
+
+/**
+ * Format markdown with the repo's Prettier config. Mirrors the
+ * `generate-hard-rules-matrix.mjs` pattern so on-disk output matches
+ * `pnpm format:check`.
+ */
+export async function formatMarkdown(content) {
+  const opts = (await prettier.resolveConfig(OUTPUT_PATH)) ?? {};
+  return prettier.format(content, { ...opts, parser: "markdown" });
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────────────
+
+const isMain =
+  process.argv[1] &&
+  resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+
+if (isMain) {
+  const args = process.argv.slice(2);
+  const items = collectFollowUps();
+  const raw = renderFollowUps(items);
+  const next = await formatMarkdown(raw);
+
+  if (args.includes("--check")) {
+    let current = "";
+    try {
+      current = readFileSync(OUTPUT_PATH, "utf8");
+    } catch {
+      // missing file — treated as a diff
+    }
+    if (current !== next) {
+      console.error(
+        `${OUTPUT_PATH} is out of date. Run \`pnpm docs:gen-initiative-followups\` and commit.`,
+      );
+      process.exit(1);
+    }
+    console.log(
+      `${OUTPUT_PATH} is up to date (${items.length} open follow-up${items.length === 1 ? "" : "s"}).`,
+    );
+    process.exit(0);
+  }
+
+  writeFileSync(OUTPUT_PATH, next);
+  console.log(
+    `Wrote ${OUTPUT_PATH} — ${items.length} open follow-up${items.length === 1 ? "" : "s"}.`,
+  );
+}


### PR DESCRIPTION
## Summary

Aggregates open carry-over items from every initiative's `### Carry-over → successor` block into a single calendar view at `docs/initiatives/follow-ups.md` so «що мені перевірити цього тижня?» has one place to look instead of grep-ing 12 markdown files.

Mirrors the existing generated-index pattern in this repo (`generate-playbook-index.mjs`, `generate-hard-rules-matrix.mjs`, `check-adr-graph.mjs`): sources stay where authors write them, the consolidated index is rebuilt deterministically, and CI fails on drift.

Follow-up to PR #1947. User pick from the two-question prompt: **B (generated index) + одна сторінка з двома секціями**.

## Governing Skill

- Primary skill: docs-tooling (mimic `generate-playbook-index.mjs` / `generate-hard-rules-matrix.mjs` patterns; same `--check`-exits-1-on-drift contract as the other 4 generated indices)
- Secondary skill (if truly needed): freshness-config integration (excludeGlobs entry so the husky `bump-last-validated` hook does not fight the generator's stamping)

## Playbook

- Primary playbook: `docs/initiatives/README.md` § "Carry-over format" (added in this PR — canonical bullet prefixes + authoring workflow + CI gate description)
- Why this playbook: README is the discoverable entry point for initiative authors; format spec lives next to the structural template they already follow.
- If no playbook matched, why: n/a — README updated.

## Verification

```bash
node --test scripts/docs/__tests__/generate-initiative-followups.test.mjs
# 22/22 pass — covers block extraction, prefix classification, nested-bullet
# folding, cadence ordering, sort order across kinds, overdue flagging,
# freshness-header math.

pnpm docs:gen-initiative-followups
# Wrote docs/initiatives/follow-ups.md — 5 open follow-ups.
# (1 dated 2026-05-12, 1 trigger «Після baseline-week», 3 TBD; 0 recurring.)

pnpm docs:check-initiative-followups
# follow-ups.md is up to date (5 open follow-ups).

pnpm docs:check-freshness-coverage
# All tracked markdown files have a freshness header.

pnpm exec prettier --check \
  docs/initiatives/follow-ups.md docs/initiatives/README.md \
  scripts/docs/generate-initiative-followups.mjs \
  scripts/docs/__tests__/generate-initiative-followups.test.mjs \
  scripts/docs/freshness-config.json package.json \
  .github/workflows/docs-automation.yml
# All matched files use Prettier code style!
```

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed (CI gate `Initiative follow-ups (in sync)` exercised end-to-end on this PR after the lazy-import-prettier + excludeGlobs fixes in commit `1ff3c541`)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- `docs/initiatives/follow-ups.md` — new generated index (one-shot + recurring sections, sorted by date / cadence; `⚠ overdue` flag for past-due dated items).
- `docs/initiatives/README.md` — new sections `## Зведений календар follow-up-ів` + `### Carry-over format` with the prefix table and authoring workflow.

Why no AGENTS.md / playbook / governance update: the format contract (`- [ ] **YYYY-MM-DD:** …` etc.) is opt-in for initiative authors and lives in `docs/initiatives/README.md` next to the structural template they already follow; AGENTS.md hard rules and the playbook library are unaffected.

## Risk and Rollout

- User-visible risk: zero — docs-only PR. Generator has no production code path; CI gate is additive (new job, new test entry).
- Rollout / deploy order: merge → next push to `main` triggers the new CI job; future initiative PRs that touch a `### Carry-over → successor` block must run `pnpm docs:gen-initiative-followups` and commit the regenerated `follow-ups.md` (CI fails otherwise with a clear message).
- Backout plan: revert is safe — removing `follow-ups.md`, the script, the workflow job, the pnpm scripts, the README section, and the freshness-config exclude restores the prior state with no migrations to undo.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian (`docs/initiatives/README.md` § Carry-over format and the `follow-ups.md` body text are in Ukrainian; identifiers and code remain in English per AGENTS.md hard rule #15).
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

`docs/initiatives/follow-ups.md` is a new file under `docs/initiatives/`, but it is **generated** (auto-stamped freshness header, regenerated on every PR via `pnpm docs:gen-initiative-followups`) — not an authored initiative spec. The audit-freeze workflow exists to prevent new authored audit/initiative/playbook/ADR files from accumulating during the freeze window; an auto-built index that consolidates already-existing initiatives' carry-over items is consistent with the freeze's intent (no new uncoordinated initiatives, just improved discoverability of follow-ups already authored before the freeze).

- [ ] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified above).

## Reviewer Notes

- New CI job `Initiative follow-ups (in sync)` does `pnpm install --frozen-lockfile` (needed because the script imports `prettier` for stable output formatting). The unit-test job (`Docs-automation scripts unit tests`) runs raw `node --test` without `pnpm install` — `prettier` is therefore lazily imported inside `formatMarkdown` so the test file can import the module to exercise its pure helpers (parsing / classification / sort / render) without resolving `node_modules/prettier`.
- `docs/initiatives/follow-ups.md` is added to `freshness-config.json` `excludeGlobs` (not `explicitExclude`) so the husky `bump-last-validated.mjs` hook leaves the file alone — only `excludeGlobs` is honoured by that hook; without this the hook rewrote `@devin-ai` → `@Skords-01` on commit and the `--check` CI gate diverged from on-disk content.
- Existing carry-over bullets in `0004-server-observability.md` and `0005-ai-cost-and-prompt-cache.md` already match the canonical format — no source-file edits in this PR. The other 10 initiatives have no `### Carry-over → successor` block, and the index correctly produces 5 entries from 0004 + 0005 only. Backfill for new initiatives happens organically as they ship.
- Out of scope: auto-issues / cron reminders on T-7 of dated items — natural Phase 2 once we see whether the calendar view is enough on its own (mentioned as Option C in the design discussion).
