### PR TITLE
fix(root): make initiative-followups generator CI-stable

### DIFF
--- a/scripts/docs/freshness-config.json
+++ b/scripts/docs/freshness-config.json
@@ -19,6 +19,7 @@
     "docs/agents/specs/2026-04-24-assistant-quick-actions-v1-design.md": 180,
     "docs/agents/specs/2026-04-25-assistant-capability-catalogue-design.md": 180
   },
+  "excludeGlobs": ["docs/initiatives/follow-ups.md"],
   "explicitInclude": [],
-  "explicitExclude": ["docs/initiatives/follow-ups.md"]
+  "explicitExclude": []
 }

--- a/scripts/docs/generate-initiative-followups.mjs
+++ b/scripts/docs/generate-initiative-followups.mjs
@@ -33,7 +33,12 @@
 import { readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { resolve, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import prettier from "prettier";
+
+// `prettier` is loaded lazily inside `formatMarkdown` so importing this
+// module never requires `node_modules/prettier` on disk. The
+// `Docs-automation scripts unit tests` CI job runs raw `node --test`
+// without `pnpm install`, and the unit tests do not exercise the
+// formatting path — only the CLI does.
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -388,6 +393,7 @@ function initiativeLink(item) {
  * `pnpm format:check`.
  */
 export async function formatMarkdown(content) {
+  const { default: prettier } = await import("prettier");
   const opts = (await prettier.resolveConfig(OUTPUT_PATH)) ?? {};
   return prettier.format(content, { ...opts, parser: "markdown" });
 }


### PR DESCRIPTION
## Summary

Follow-up to #1950 (merged at 22:13:12 UTC), which landed before two fix commits could land and left the docs-automation workflow red on `main`:

- `Docs-automation scripts unit tests` — failing with `Cannot find package 'prettier' imported from .../generate-initiative-followups.mjs` because that job runs raw `node --test` without `pnpm install`, so `node_modules/prettier` does not exist when the test file imports the module.
- `Initiative follow-ups (in sync)` — failing with `docs/initiatives/follow-ups.md is out of date. Run pnpm docs:gen-initiative-followups and commit.` because the husky `bump-last-validated.mjs` hook was rewriting the freshness header (`@devin-ai` → `@Skords-01`) on every commit, so the on-disk file diverged from what the generator produces.

Three minimal changes:

1. **Lazy-import `prettier`** inside `formatMarkdown` so the module can be imported without resolving `node_modules/prettier`. The CLI still loads it (the CLI runs only after `pnpm install --frozen-lockfile`); the unit tests do not exercise the formatting path.
2. **Move `docs/initiatives/follow-ups.md` from `explicitExclude` to `excludeGlobs`** in `freshness-config.json`. The husky hook only honours `excludeGlobs` when deciding which files to leave alone — `explicitExclude` is read only by the coverage checker. Moving the entry stops the hook fighting the generator. The coverage checker honours both lists, so coverage is still asserted.
3. **Regenerate `docs/initiatives/follow-ups.md`** with the now-stable generator output (header no longer drifts).

## Governing Skill

- Primary skill: docs-tooling (CI-stability fix for the generator skill shipped in #1950 — same patterns as the four sibling generated indices).
- Secondary skill (if truly needed): freshness-config integration (correcting which exclusion list a generated file belongs in for the husky hook).

## Playbook

- Primary playbook: `docs/initiatives/README.md` § "Carry-over format" (no body changes — the workflow / authoring contract introduced in #1950 stays the same).
- Why this playbook: this PR is a CI-only fix; behaviour and authoring contract remain identical.
- If no playbook matched, why: n/a — README unchanged.

## Verification

```bash
node --test scripts/docs/__tests__/generate-initiative-followups.test.mjs
# 22/22 pass — same suite as #1950, now actually loadable without
# `pnpm install` (the unit-test job's environment).

node scripts/docs/generate-initiative-followups.mjs --check
# follow-ups.md is up to date (5 open follow-ups).

pnpm exec prettier --check \
  docs/initiatives/follow-ups.md \
  scripts/docs/generate-initiative-followups.mjs \
  scripts/docs/freshness-config.json
# All matched files use Prettier code style!

pnpm docs:check-freshness-coverage
# Pre-existing main breakage on docs/superpowers/plans/2026-05-06-sync-engine-writer-wiring.md
# (added in 142a03a3 by the sync-engine-writer commit) — NOT addressed here, NOT my regression.
# follow-ups.md itself is properly excluded via `excludeGlobs`.
```

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed (will be re-confirmed end-to-end by `Initiative follow-ups (in sync)` and `Docs-automation scripts unit tests` jobs on this PR — those are the ones that broke on main and need to flip green again)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs: only the generated `docs/initiatives/follow-ups.md` (regenerated for a stable header). The authoring contract in `docs/initiatives/README.md` is unchanged from #1950.

## Risk and Rollout

- User-visible risk: zero — internal CI/tooling fix. No production code path. Generator output is byte-identical apart from the freshness-header author (now stable across hook + script).
- Rollout / deploy order: merge → next push to `main` re-runs `Docs automation` and both red jobs flip green; future initiative PRs that touch `### Carry-over → successor` continue to work the same way (`pnpm docs:gen-initiative-followups`).
- Backout plan: revert is safe — restoring the `explicitExclude` placement and the top-level `import prettier` returns main to its current (broken) state. No migrations to undo.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian (n/a — only the generated file's body is touched, and its Ukrainian text from #1950 is unchanged; identifiers / code stay in English per AGENTS.md hard rule #15).
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files. Only the previously-shipped generated index `docs/initiatives/follow-ups.md` is regenerated, plus two small CI-stability tweaks under `scripts/docs/`. No new authored initiative, playbook, ADR, or audit file is added.

## Reviewer Notes

- The pre-existing `pnpm check` failure on `main` (prettier flagging `docs/launch/03-services-and-toolstack.md` from commit `c81da616`) is unrelated to this PR and will continue to be flagged here too — it is an existing main-branch breakage. Same applies to the `docs/superpowers/plans/2026-05-06-sync-engine-writer-wiring.md` freshness-header gap from commit `142a03a3`. Neither file is touched by this PR, and addressing them belongs in dedicated cleanup PRs.
- After this lands, the canonical place for follow-ups remains `docs/initiatives/follow-ups.md`; CI gating remains the same `Initiative follow-ups (in sync)` job that was added in #1950.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the initiative follow-ups generator in CI by lazy-loading `prettier` and fixing the freshness exclusion so the generated file stops drifting. This makes the docs-automation jobs pass again on `main`.

- **Bug Fixes**
  - Lazy-import `prettier` in `formatMarkdown` so unit tests run without `pnpm install`; CLI still formats when installed.
  - Move `docs/initiatives/follow-ups.md` from `explicitExclude` to `excludeGlobs` in `freshness-config.json` so the husky hook stops rewriting the header; coverage remains enforced.
  - Regenerate `docs/initiatives/follow-ups.md` to match the stable header, unblocking “Docs-automation scripts unit tests” and “Initiative follow-ups (in sync)”.

<sup>Written for commit 1f059f59a9190cd0e24799f71e15f9537db43485. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

