### PR TITLE
docs(root): add 2026-05-05 tests review + PR plan

### DIFF
--- a/docs/testing/2026-05-05-tests-pr-plan.md
+++ b/docs/testing/2026-05-05-tests-pr-plan.md
@@ -1,0 +1,439 @@
+# Sergeant — PR-план для тестів
+
+> **Last validated:** 2026-05-05 by @Skords-01. **Next review:** 2026-08-03.
+> **Status:** Active
+>
+> Repo: `Skords-01/Sergeant`. Базується на [`2026-05-05-tests-review.md`](./2026-05-05-tests-review.md) (попередній аналіз).
+
+## Як читати
+
+Кожен PR має **scope** (що додаємо), **acceptance** (як CI підтвердить, що ок), **size** (рядків приблизно), **deps** (на чому стоїть). Один PR = один логічний крок (≤ ~400 LoC змін, бажано ≤ ~200), щоб ревʼю було швидке і pr-size workflow не сварився.
+
+Гілки — `devin/{ts}-{slug}` (як стандарт у репо).
+
+Послідовність трекаєтся через **wave** — wave A треба перш ніж wave B (через залежності або щоб коридор coverage thresholds рухався вгору без флапу).
+
+---
+
+## Wave A — P0 unblock (срочне, тиждень 1)
+
+### PR-T01 — `coverageThreshold` для `apps/mobile`
+
+- **Branch:** `devin/{ts}-mobile-coverage-floor`
+- **Files:** `apps/mobile/jest.config.js`, `apps/mobile/package.json` (script `test:coverage`)
+- **Scope:** додати `coverageThreshold` (consensus floor: lines 30 / branches 25 / fns 30 / stmts 30 — на 1pp нижче поточного факту, як і у web/server). Додати `test:coverage` script. Підвʼязати у `ci.yml` lane `coverage` (паралельно до vitest job).
+- **Acceptance:** CI `coverage` job піднімає mobile-jest з coverage; артефакт `mobile-coverage-summary` зʼявляється; падає при дрейфі вниз.
+- **Size:** ~30 LoC + ~50 LoC у `ci.yml`.
+- **Deps:** —. Можна першим.
+
+### PR-T02 — Service-worker testability (`apps/web/src/sw/**`)
+
+- **Branch:** `devin/{ts}-web-sw-coverage-decision`
+- **Files:** додати `apps/web/src/sw/__tests__/*.test.ts` АБО `apps/web/vitest.config.js` (виключення).
+- **Scope (варіант A — preferred):** перепис SW-факторів так, щоб `self`/registration/clients передавалися як параметр (DI). Юніт-тестуємо `cache.ts`, `messages.ts`, `notifiedKeys.ts`, `reminders.ts`, `version.ts` без `self`. (`debug.ts` — суто proxy, можна виключити.)
+- **Scope (варіант B — fallback):** виключити `src/sw/**` з coverage (`exclude: [...baseExclude, "src/sw/**"]`) і розширити `tests/a11y/sw-smoke.spec.ts` до повноцінного e2e (cache hit / offline navigation / SW-update / push reminder fire).
+- **Acceptance:** web `branches` floor підіймається з 30 → ≥ 50; `functions` з 27 → ≥ 45; `lines/stmts` стабільні. Drift log оновлюється з новим baseline.
+- **Size:** варіант A — ~250 LoC тестів + 80 LoC рефакторингу; варіант B — ~150 LoC e2e + 5 LoC config.
+- **Deps:** —. Окремо від T03.
+
+### PR-T03 — Тести для `apps/web/src/shared/lib/idb/sergeantDb.ts`
+
+- **Branch:** `devin/{ts}-web-idb-tests`
+- **Files:** `apps/web/src/shared/lib/idb/sergeantDb.test.ts`, можливо `apps/web/src/test/setup.ts` (fake-indexeddb).
+- **Scope:** покрити open/upgrade/version-migration/CRUD на кожному store. Використати `fake-indexeddb` (популярний).
+- **Acceptance:** `sergeantDb.ts` ≥ 80% lines/branches.
+- **Size:** ~250 LoC тестів.
+- **Deps:** —.
+
+### PR-T04 — Тести для `apps/web/src/shared/lib/ui/{amountTone,export,perf}.ts`
+
+- **Branch:** `devin/{ts}-web-shared-ui-utils-tests`
+- **Files:** три `*.test.ts` поряд з джерелом.
+- **Scope:** pure-utils, тривіальні юніт-кейси (всі гілки + edge cases: 0, NaN, від'ємні, локалі для `export`, raf для `perf`).
+- **Acceptance:** кожен файл ≥ 90% lines.
+- **Size:** ~180 LoC.
+- **Deps:** —.
+
+### PR-T05 — Тести для `apps/server/src/modules/digest/weekly-digest.ts`
+
+- **Branch:** `devin/{ts}-server-weekly-digest-tests`
+- **Files:** `apps/server/src/modules/digest/weekly-digest.test.ts`, можливо fixtures у `apps/server/src/modules/digest/__fixtures__/`.
+- **Scope:** мокати DB (vi.mock pg) і Anthropic (для summary), перевірити: empty-week branch, partial data, full data, formatting locale, повторний запуск idempotent.
+- **Acceptance:** файл ≥ 80% lines/branches; server `lines` floor +1pp.
+- **Size:** ~200 LoC.
+- **Deps:** —.
+
+### PR-T06 — Server `sync/syncV2.ts` юніт-тести (no-DB)
+
+- **Branch:** `devin/{ts}-server-syncv2-unit`
+- **Files:** `apps/server/src/modules/sync/syncV2.test.ts`.
+- **Scope:** виокремити чисті функції (pull-merge, conflict-resolution, version-vector update). Мокати pg-pool. Покрити: pull empty, pull with deltas, push happy, push conflict (server-newer / client-newer), idempotency-key replay, dirty-skip.
+- **Acceptance:** `syncV2.ts` ≥ 60% lines/branches; server `lines` floor + 2pp.
+- **Size:** ~350 LoC.
+- **Deps:** —.
+
+### PR-T07 — Server `sync/syncV2.integration.test.ts` доповнення
+
+- **Branch:** `devin/{ts}-server-syncv2-integration`
+- **Files:** `apps/server/src/modules/sync/syncV2.integration.test.ts` (вже існує — розширюємо).
+- **Scope:** додати кейси з реальною БД через Testcontainers: дві паралельні сесії юзера → конфлікт → детермінований resolver; replay після відновлення зʼєднання; RLS-перевірки (інший userId не бачить).
+- **Acceptance:** integration suite додає 5–8 нових кейсів, всі зелені.
+- **Size:** ~300 LoC.
+- **Deps:** PR-T06 (щоб у мутаційному прогоні юніти не дублювали інтеграцію).
+
+---
+
+## Wave B — P0 AI-tools (тиждень 1–2, можна паралельно з Wave A)
+
+### PR-T08 — Anthropic-mock harness для server tools
+
+- **Branch:** `devin/{ts}-server-anthropic-mock-harness`
+- **Files:** `apps/server/src/test/__mocks__/anthropic.ts`, `apps/server/src/test/anthropicFixtures/*.json`, маленький README.
+- **Scope:** єдиний reusable mock для `@anthropic-ai/sdk` з програмованими responses (tool_use turn / text / error). Звільняє T09–T11 від copy-paste.
+- **Acceptance:** використовується у наступних PR; nutrition tools тести стабільні.
+- **Size:** ~150 LoC.
+- **Deps:** —. Робимо першим у Wave B.
+
+### PR-T09 — Nutrition tools (1/3): `day-hint`, `day-plan`
+
+- **Branch:** `devin/{ts}-server-nutrition-tools-day`
+- **Files:** `apps/server/src/modules/nutrition/day-hint.test.ts`, `day-plan.test.ts`.
+- **Scope:** на файл — happy path + invalid args + Anthropic error + DB-RLS. Зразок: `me.contract.test.ts` + harness з PR-T08.
+- **Acceptance:** обидва файли ≥ 70% lines/branches.
+- **Size:** ~250 LoC.
+- **Deps:** PR-T08.
+
+### PR-T10 — Nutrition tools (2/3): `food-search`, `parse-pantry`
+
+- **Branch:** `devin/{ts}-server-nutrition-tools-search-pantry`
+- **Files:** `food-search.test.ts`, `parse-pantry.test.ts`.
+- **Scope:** як T09 + мок Open Food Facts (через MSW або nock). Покрити пагінацію, кеш, парсер missing-nutrients fallback.
+- **Acceptance:** обидва ≥ 70%.
+- **Size:** ~280 LoC.
+- **Deps:** PR-T08.
+
+### PR-T11 — Nutrition tools (3/3): `find-recipes`, `shopping-list`, `week-plan`
+
+- **Branch:** `devin/{ts}-server-nutrition-tools-recipes-week`
+- **Files:** три `*.test.ts`.
+- **Scope:** як T09. Особливо: `shopping-list` — aggregate by aisle + dedup; `week-plan` — розкладка днів + повторюваність.
+- **Acceptance:** усі три ≥ 70%.
+- **Size:** ~320 LoC.
+- **Deps:** PR-T08.
+
+### PR-T12 — Openclaw `tools.ts` + `write-tools.ts`
+
+- **Branch:** `devin/{ts}-server-openclaw-tools-tests`
+- **Files:** `apps/server/src/modules/openclaw/tools.test.ts`, `write-tools.test.ts`.
+- **Scope:** registry round-trip, dispatch, авторизація writes (юзер не може писати в чужий userId), validation помилок Anthropic tool_use args.
+- **Acceptance:** обидва ≥ 70%; server `branches` floor +3pp.
+- **Size:** ~220 LoC.
+- **Deps:** PR-T08.
+
+**Після Wave B**: підняти server thresholds до lines 64 / branches 55 / fns 67 / stmts 63 (drift log оновити).
+
+---
+
+## Wave C — P1 Smoke E2E (тиждень 2–3)
+
+> Шаблон у `apps/web/tests/smoke/auth.spec.ts` — seedLocalStorage + Playwright. Кожен PR — окремий spec + testID hints у компонентах.
+
+### PR-T13 — Web smoke E2E: Finyk
+
+- **Branch:** `devin/{ts}-web-smoke-finyk`
+- **Files:** `apps/web/tests/smoke/finyk-add-transaction.spec.ts`, можливо `data-testid` додати в 2-3 компонентах.
+- **Scope:** додати manual transaction → видно у списку → balance оновився. Тег `@critical` щоб ловив `critical-flow` lane.
+- **Acceptance:** spec зелений у `playwright.smoke.config.ts` з реальним server + Postgres.
+- **Size:** ~120 LoC + кілька data-testid.
+- **Deps:** —.
+
+### PR-T14 — Web smoke E2E: Fizruk
+
+- **Branch:** `devin/{ts}-web-smoke-fizruk`
+- **Files:** `apps/web/tests/smoke/fizruk-log-set.spec.ts`.
+- **Scope:** start training → log set → метрика змінилась.
+- **Size:** ~120 LoC.
+- **Deps:** —.
+
+### PR-T15 — Web smoke E2E: Nutrition
+
+- **Branch:** `devin/{ts}-web-smoke-nutrition`
+- **Files:** `apps/web/tests/smoke/nutrition-add-meal.spec.ts`, `apps/web/src/test/msw/nutritionHandlers.ts` (мокаємо OFF + Anthropic для `parse-pantry`).
+- **Scope:** додати meal → barcode-сценарій → AI-підказка → запис у БД.
+- **Size:** ~180 LoC.
+- **Deps:** —.
+
+### PR-T16 — Web smoke E2E: Routine
+
+- **Branch:** `devin/{ts}-web-smoke-routine`
+- **Files:** `apps/web/tests/smoke/routine-checkin.spec.ts`.
+- **Scope:** check-in → стрік++ → календар відмалював сьогодні.
+- **Size:** ~100 LoC.
+- **Deps:** —.
+
+### PR-T17 — Web smoke E2E: HubChat
+
+- **Branch:** `devin/{ts}-web-smoke-hubchat`
+- **Files:** `apps/web/tests/smoke/hubchat-tool-call.spec.ts`, мок Anthropic у server side через AI_QUOTA_DISABLED + responses fixture.
+- **Scope:** надіслати команду коучу → tool execution → візуальний ефект на іншому модулі (наприклад: «додай витрату 100 грн на каву» → у Finyk транзакція).
+- **Size:** ~200 LoC.
+- **Deps:** PR-T15 (msw harness).
+
+---
+
+## Wave D — P1 Mobile Detox (тиждень 3–4)
+
+> Шаблон у `apps/mobile/e2e/finyk-manual-expense.e2e.ts` + `apps/mobile/e2e/README.md`. Кожен PR — один spec + testID hints.
+
+### PR-T18 — Detox: Auth login
+
+- **Branch:** `devin/{ts}-mobile-detox-auth`
+- **Files:** `apps/mobile/e2e/auth-login.e2e.ts`.
+- **Scope:** Better Auth flow на нативному стеку — sign-in / sign-up / logout.
+- **Acceptance:** проходить у `detox-android.yml` і `detox-ios.yml`.
+- **Size:** ~150 LoC.
+- **Deps:** —.
+
+### PR-T19 — Detox: Nutrition (add meal + barcode)
+
+- **Branch:** `devin/{ts}-mobile-detox-nutrition`
+- **Files:** `apps/mobile/e2e/nutrition-add-meal.e2e.ts`, `nutrition-barcode.e2e.ts`.
+- **Scope:** ручне додавання + barcode-сценарій (мокаємо камеру через Detox URL-param).
+- **Size:** ~200 LoC.
+- **Deps:** —.
+
+### PR-T20 — Detox: Fizruk log set
+
+- **Branch:** `devin/{ts}-mobile-detox-fizruk`
+- **Files:** `apps/mobile/e2e/fizruk-log-set.e2e.ts`.
+- **Scope:** start workout → log set → save.
+- **Size:** ~130 LoC.
+- **Deps:** —.
+
+### PR-T21 — Detox: Deep link
+
+- **Branch:** `devin/{ts}-mobile-detox-deeplink`
+- **Files:** `apps/mobile/e2e/deep-link.e2e.ts`.
+- **Scope:** inbound `sergeant://` link → правильний screen, у `mobile-shell` юніти вже є, тут — нативний flow end-to-end.
+- **Size:** ~120 LoC.
+- **Deps:** —.
+
+### PR-T22 — Detox: Offline sync
+
+- **Branch:** `devin/{ts}-mobile-detox-offline-sync`
+- **Files:** `apps/mobile/e2e/offline-sync.e2e.ts`.
+- **Scope:** offline → дії в кількох модулях → online → reconcile. Використати Detox network mock.
+- **Size:** ~200 LoC.
+- **Deps:** —. Найскладніший з Detox-set, ставити останнім у wave.
+
+---
+
+## Wave E — P1 Mutation testing scope (тиждень 4)
+
+### PR-T23 — Stryker для `packages/finyk-domain`
+
+- **Branch:** `devin/{ts}-stryker-finyk-domain`
+- **Files:** `packages/finyk-domain/stryker.conf.json`, оновлення `package.json` script `test:mutation`, `.github/workflows/mutation-testing.yml` (додаємо job).
+- **Scope:** money math + amount formatting. Очікуваний baseline ≥ 80% (домен чистий).
+- **Acceptance:** workflow `mutation-testing` зелений, `break: 70` / `low: 75` / `high: 85`.
+- **Size:** ~80 LoC.
+- **Deps:** —.
+
+### PR-T24 — Stryker для `apps/server/src/modules/sync/syncV2.ts`
+
+- **Branch:** `devin/{ts}-stryker-server-syncv2`
+- **Files:** `apps/server/stryker.syncV2.conf.json`, mutation workflow.
+- **Scope:** мутувати тільки `syncV2.ts`. Baseline залежить від наявності тестів з PR-T06.
+- **Size:** ~80 LoC.
+- **Deps:** PR-T06 (без тестів немає що killувати).
+
+### PR-T25 — Stryker для `apps/server/src/lib/normalizers/*`
+
+- **Branch:** `devin/{ts}-stryker-server-normalizers`
+- **Files:** `apps/server/stryker.normalizers.conf.json`.
+- **Size:** ~80 LoC.
+- **Deps:** —. Tests вже є (5 файлів).
+
+### PR-T26 — Stryker для `apps/server/src/auth/passwordHash.ts`
+
+- **Branch:** `devin/{ts}-stryker-passwordhash`
+- **Files:** `apps/server/stryker.passwordHash.conf.json`.
+- **Scope:** малий файл, але boundary безпеки.
+- **Size:** ~50 LoC.
+- **Deps:** —.
+
+### PR-T27 — Stryker для `packages/insights`
+
+- **Branch:** `devin/{ts}-stryker-insights`
+- **Files:** `packages/insights/stryker.conf.json`.
+- **Deps:** **PR-T31** (треба спершу підняти test/src ratio).
+
+---
+
+## Wave F — P1 Visual + Contract (тиждень 4–5)
+
+### PR-T28 — Argos visual: розширити поверхні
+
+- **Branch:** `devin/{ts}-visual-extend-surfaces`
+- **Files:** `apps/web/tests/a11y/ds-visual-qa.spec.ts`.
+- **Scope:** додати ще 6–8 surfaces: transaction-detail, workout-detail, meal-detail, settings, error-state, empty-state, FTUX-step-2/3. Залишити 4 viewports × 2 themes.
+- **Acceptance:** Argos diff показує нові baseline кадри; CI час < 15 хв (timeout у workflow).
+- **Size:** ~200 LoC.
+- **Deps:** —.
+
+### PR-T29 — Contract tests: chat (consumer + producer)
+
+- **Branch:** `devin/{ts}-contract-chat`
+- **Files:** `packages/shared/contract-fixtures/chat/*.ts`, `apps/server/src/modules/chat/chat.contract.test.ts`, `apps/web/src/test/contract/chat.contract.test.ts`.
+- **Scope:** клонувати шаблон з `me.contract.test.ts`. Покрити streaming response shape + tool_use turns.
+- **Size:** ~250 LoC.
+- **Deps:** —.
+
+### PR-T30 — Contract tests: sync v2 + finyk/routine/nutrition/fizruk hub-endpoints
+
+- **Branch:** `devin/{ts}-contract-modules`
+- **Files:** 5 пар (consumer/producer) під відповідні endpoints.
+- **Scope:** один endpoint на модуль (як стрижень). Інші можна додати наступними хвилями.
+- **Size:** ~500 LoC (можна розбити на 2–3 PR).
+- **Deps:** —.
+
+---
+
+## Wave G — P2 гігієна (тиждень 5+)
+
+### PR-T31 — Підняти `packages/insights` (3 → ~12 тестів)
+
+- **Branch:** `devin/{ts}-insights-tests`
+- **Files:** `packages/insights/src/**/*.test.ts`.
+- **Scope:** unit-coverage для кожної pure-функції агрегації. Додати fast-check (див. T35).
+- **Size:** ~250 LoC.
+- **Deps:** —. Розблоковує T27.
+
+### PR-T32 — Підняти `packages/nutrition-domain` (4 → ~12)
+
+- **Branch:** `devin/{ts}-nutrition-domain-tests`
+- **Files:** `packages/nutrition-domain/src/**/*.test.ts`.
+- **Size:** ~200 LoC.
+- **Deps:** —.
+
+### PR-T33 — Підняти `packages/api-client` (11 → ~20)
+
+- **Branch:** `devin/{ts}-api-client-boundary-tests`
+- **Files:** `packages/api-client/src/**/*.test.ts`.
+- **Scope:** retry / timeout / 401 refresh / network error / 5xx backoff.
+- **Size:** ~250 LoC.
+- **Deps:** —.
+
+### PR-T34 — Server `modules/observability/` deep tests
+
+- **Branch:** `devin/{ts}-server-observability-tests`
+- **Files:** `apps/server/src/modules/observability/*.test.ts`.
+- **Scope:** sentry beforeSend filter, posthog identify shape, web-vitals reception, sensitive URL mask edge cases.
+- **Size:** ~200 LoC.
+- **Deps:** —.
+
+### PR-T35 — Property-based tests (fast-check) у `finyk-domain`, `insights`, `cloudSync/queue`
+
+- **Branch:** `devin/{ts}-fast-check-properties`
+- **Files:** додати `fast-check` як dev-dep, нові `.property.test.ts` поряд з юніт-тестами.
+- **Scope:** finyk amount math (round-trip, associativity, currency-conversion identity), insights aggregations (sum-empty=0, sum monotonicity), queue dedup (idempotent enqueue, fifo per-key).
+- **Size:** ~250 LoC + 1 dep.
+- **Deps:** PR-T31 (insights).
+
+### PR-T36 — Axe spec: deep screens
+
+- **Branch:** `devin/{ts}-axe-deep-screens`
+- **Files:** `apps/web/tests/a11y/axe.spec.ts`.
+- **Scope:** додати тести на форми (add transaction, log workout, meal entry), modals/sheets, settings.
+- **Size:** ~150 LoC.
+- **Deps:** —.
+
+### PR-T37 — k6/Artillery nightly performance
+
+- **Branch:** `devin/{ts}-perf-nightly`
+- **Files:** `scripts/perf/k6-chat.js`, `scripts/perf/k6-sync.js`, `.github/workflows/perf-nightly.yml`.
+- **Scope:** сценарії на `chat` (single-turn + tool_use) і `sync/v2` (concurrent). Експортувати `p95` у dashboard артефакт.
+- **Size:** ~250 LoC.
+- **Deps:** PR-T29 (контракти chat дають стабільний shape для load).
+
+### PR-T38 — Migration rollback за замовчуванням
+
+- **Branch:** `devin/{ts}-migration-rollback-template`
+- **Files:** `plop-templates/new-migration/**`, `packages/db-schema/migrations/__tests__/template.test.ts`, `scripts/lint-migrations.mjs`.
+- **Scope:** plop-генератор кладе `down()` + rollback-asserцію за замовчуванням; lint падає якщо `down` пустий.
+- **Size:** ~150 LoC.
+- **Deps:** —.
+
+### PR-T39 — `tools/console` end-to-end бот-сценарій
+
+- **Branch:** `devin/{ts}-console-bot-e2e`
+- **Files:** `tools/console/src/__tests__/bot.e2e.test.ts`.
+- **Scope:** mock grammy update → assert reply text + side effects. Не блокує core продукт, дешевий PR.
+- **Size:** ~150 LoC.
+- **Deps:** —.
+
+---
+
+## Залежності (компактно)
+
+```
+T01    └─ PR-T01 (mobile floor) — independent
+T02    └─ PR-T02 (sw)            — independent
+T03    └─ PR-T03 (idb)           — independent
+T04    └─ PR-T04 (ui utils)      — independent
+T05    └─ PR-T05 (digest)        — independent
+T06    └─ PR-T06 (sync unit)     — independent
+T07    └─ PR-T07 (sync integ)    — needs T06
+T08    └─ PR-T08 (anthropic mock harness) — independent
+T09–11 └─ PR-T09/10/11 (nutrition tools) — need T08
+T12    └─ PR-T12 (openclaw)     — needs T08
+T13–17 └─ PR-T13/.../17 (web smoke) — independent (T17 wants msw з T15)
+T18–22 └─ PR-T18/.../22 (mobile detox) — independent
+T23    └─ PR-T23 (stryker finyk) — independent
+T24    └─ PR-T24 (stryker syncV2) — needs T06
+T25    └─ PR-T25 (stryker normalizers) — independent
+T26    └─ PR-T26 (stryker passwordHash) — independent
+T27    └─ PR-T27 (stryker insights) — needs T31
+T28    └─ PR-T28 (visual extend) — independent
+T29    └─ PR-T29 (contract chat) — independent
+T30    └─ PR-T30 (contract modules) — independent
+T31    └─ PR-T31 (insights tests) — independent
+T32    └─ PR-T32 (nutrition-domain tests) — independent
+T33    └─ PR-T33 (api-client boundary) — independent
+T34    └─ PR-T34 (observability deep) — independent
+T35    └─ PR-T35 (fast-check) — needs T31
+T36    └─ PR-T36 (axe deep) — independent
+T37    └─ PR-T37 (k6 perf) — needs T29
+T38    └─ PR-T38 (migration rollback) — independent
+T39    └─ PR-T39 (console bot e2e) — independent
+```
+
+## Порядок мерджу (рекомендований)
+
+1. **Wave A першим:** T01, T03, T04, T05, T06 → T07, T02 — підіймає floor, відкриває drift log.
+2. **Wave B після Anthropic-mock-harness (T08):** T09 → T10 → T11 → T12 — піднімає server thresholds.
+3. **Wave C/D паралельно** (web smoke + mobile detox).
+4. **Wave E (mutation):** T23 → T25 → T26 → T24 → T27.
+5. **Wave F (visual + contract):** T28 → T29 → T30.
+6. **Wave G (гігієна):** T31 → T32 → T33 → T34 → T35 → T36 → T37 → T38 → T39.
+
+## Загальні acceptance-критерії (для будь-якого PR з цього списку)
+
+- `pnpm check` зелений (format + lint + typecheck + test + build).
+- Якщо торкаєшся coverage thresholds — drift log у `vitest.config` оновлений з новим baseline.
+- `pr-size` workflow не перевищує liмits (≤ 400 LoC NET — інакше розбий PR).
+- Якщо це E2E lane — критичні теги `@critical` тільки на справді критичних шляхах (інакше блокує main без потреби).
+- Якщо PR додає нову dev-dep (fast-check, fake-indexeddb, nock тощо) — згадка у `.tech-debt/` або хоча б в README пакета.
+
+## Підсумок розміру
+
+| Wave  | PRs       | Сумарно ~LoC  | Час одного інженера |
+| ----- | --------- | ------------- | ------------------- |
+| A     | 7         | ~1500         | 1 тиждень           |
+| B     | 5         | ~1100         | 1 тиждень           |
+| C     | 5         | ~720          | 0.5–1 тиждень       |
+| D     | 5         | ~800          | 1 тиждень           |
+| E     | 5         | ~370          | 2–3 дні             |
+| F     | 3         | ~950          | 0.5–1 тиждень       |
+| G     | 9         | ~1800         | 1.5–2 тижні         |
+| **Σ** | **39 PR** | **~7240 LoC** | **~6–8 тижнів**     |

--- a/docs/testing/2026-05-05-tests-review.md
+++ b/docs/testing/2026-05-05-tests-review.md
@@ -1,0 +1,209 @@
+# Sergeant — стан тестів і що покращити
+
+> **Last validated:** 2026-05-05 by @Skords-01. **Next review:** 2026-08-03.
+> **Status:** Active
+>
+> Repo: `Skords-01/Sergeant`. Тип: аналіз без змін у коді. Парний документ — [`2026-05-05-tests-pr-plan.md`](./2026-05-05-tests-pr-plan.md).
+
+## TL;DR
+
+Тестова інфраструктура **зріла** (Vitest + Jest + Playwright + Detox + Stryker + Argos + MSW + Testcontainers, 667 файлів тестів, ~14 vitest-конфігів, окремі смоук/а11y/визуал/мутаційні CI-лейни). Слабких місць — три категорії:
+
+1. **Web coverage сильно дрейфонув вниз** (functions 27%, branches 30%) через нові непокриті поверхні: `src/sw/**`, `src/shared/lib/idb/sergeantDb.ts`, `src/shared/lib/ui/{amountTone,export,perf}.ts` — це знає сама команда (з коментарів у `apps/web/vitest.config.js`), але floor поки не повертається.
+2. **Server AI-tool handlers фактично без юніт-тестів** — `nutrition/{day-hint,day-plan,food-search,parse-pantry,find-recipes,shopping-list,week-plan}.ts`, `openclaw/{tools,write-tools}.ts`, `digest/weekly-digest.ts` (0/1), `sync/syncV2.ts` (0–1% покриття).
+3. **E2E/смоук дуже вузькі**: web — 4 спеки (auth, navigation/offline, bottom-nav, dashboard-health); mobile Detox — 4 спеки (тільки finyk + routine + hub UX). Цілих модулів `nutrition`, `fizruk`, `HubChat` нема в e2e ні на web, ні на mobile.
+
+## Що вже є (інвентар)
+
+### Тестові фреймворки
+
+| Шар                                 | Інструменти                                                                                                             |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Unit / integration (web/server/lib) | **Vitest** (14 конфігів), shared base — `packages/config/vitest.base.js` (v8 coverage, lcov+json-summary)               |
+| Web component / hook unit           | Vitest + Testing Library + jsdom-style env через `apps/web/src/test/setup.ts`                                           |
+| HTTP-моки                           | **MSW** — `apps/web/src/test/msw/{handlers,server}.ts`                                                                  |
+| Server integration                  | **Testcontainers** + окремий конфіг `apps/server/vitest.integration.config.ts` (singleFork, реальний Postgres pgvector) |
+| Mobile (RN/Expo)                    | **Jest** з `jest-expo` пресетом (`apps/mobile/jest.config.js`)                                                          |
+| Web E2E (smoke)                     | Playwright `playwright.smoke.config.ts` — піднімає Postgres + server + web preview                                      |
+| Web a11y                            | Playwright + `@axe-core/playwright` (`tests/a11y/axe.spec.ts`)                                                          |
+| Visual regression                   | Playwright + Argos CI (`tests/a11y/ds-visual-qa.spec.ts`, 56 скрінів)                                                   |
+| Service-worker e2e                  | Playwright `tests/a11y/sw-smoke.spec.ts`                                                                                |
+| Mobile E2E                          | **Detox** — `apps/mobile/e2e/*.e2e.ts` (iOS + Android), окремі workflow                                                 |
+| Mutation testing                    | **Stryker** + `@stryker-mutator/vitest-runner` — `apps/web/stryker.cloudSync*.conf.json`                                |
+| Contract tests                      | Producer/consumer пара через `@sergeant/shared/contract-fixtures` (приклад: `me.contract.test.ts`)                      |
+| ESLint plugin tests                 | `node --test` + `packages/eslint-plugin-sergeant-design/__tests__/*.test.mjs`                                           |
+| Storybook                           | `apps/web` (`storybook dev`, `build-storybook`), CI `storybook-deploy.yml`                                              |
+
+### CI-лейни для тестів
+
+```
+ci.yml:
+  - check         # pnpm check = format:check + lint + typecheck + test + build
+  - coverage      # Test coverage (vitest)  — артефакти vitest-coverage-html / -summary
+  - a11y          # Accessibility (axe-core)
+  - critical-flow # Critical-flow E2E (Playwright @critical)
+  - migration-lint, secret-scan, actionlint, pipeline-duration-summary
+
+extended-e2e.yml         — nightly Playwright (з реальною БД)
+detox-android.yml        — Detox Android
+detox-ios.yml            — Detox iOS
+mutation-testing.yml     — Stryker (cloudSync) — weekly + при змінах файлів
+flaky-tests-dashboard.yml— збір JSON-репорту vitest, weekly
+visual-regression.yml    — Argos visual diff на кожен PR
+storybook-deploy.yml     — деплой Storybook
+container-scan.yml, codeql.yml, audit-freeze.yml — security side
+```
+
+### Кількість тестових файлів за зонами (667 разом)
+
+| Зона                                                                     |       Файлів |
+| ------------------------------------------------------------------------ | -----------: |
+| `apps/web`                                                               |          228 |
+| `apps/server`                                                            |          117 |
+| `apps/mobile`                                                            |          115 |
+| `packages/shared`                                                        |           40 |
+| `packages/eslint-plugin-sergeant-design`                                 |           27 |
+| `packages/fizruk-domain`                                                 |           25 |
+| `packages/db-schema`                                                     |           20 |
+| `tools/console`                                                          |           19 |
+| `packages/finyk-domain`                                                  |           14 |
+| `packages/api-client`                                                    |           11 |
+| `packages/routine-domain`                                                |            9 |
+| `apps/mobile-shell`                                                      |            7 |
+| `packages/nutrition-domain`                                              |            4 |
+| `packages/insights`                                                      |            3 |
+| `packages/design-tokens`                                                 |            3 |
+| `scripts/__tests__`, `scripts/ci`, `scripts/docs`, `scripts/flaky-tests` |           25 |
+| `packages/config`                                                        | 0 (намірено) |
+
+### Coverage thresholds (актуальні floors)
+
+`apps/web/vitest.config.js`
+
+```
+lines: 37   branches: 30   functions: 27   statements: 36
+```
+
+_Drift log у самому файлі чесно фіксує: 2026-04-25 baseline був lines/statements 17.42 / branches 65.51 / fns 52.42, тепер lines 39.29 / branches 32.83 / fns 29.3 / statements 38.06. Branches просіли на −32.7pp, functions на −23.1pp._
+
+`apps/server/vitest.config.ts`
+
+```
+lines: 60   branches: 48   functions: 63   statements: 59
+```
+
+_Drift: з 2026-04-25 baseline lines/statements 67.13 / branches 79.31 / fns 72.80 → 2026-05-05 lines 60.51 / branches 48.97 / fns 63.97 / statements 59.54._
+
+`apps/mobile`: `coverageThreshold` **не сконфігуровано** — `jest --passWithNoTests`, тобто немає floor.
+
+Інші пакети: per-package threshold у відповідних `vitest.config.ts` (рекомендований стандарт у `packages/config/vitest.base.js`: lines/fn/stmt ≥ 60, branches ≥ 55).
+
+---
+
+## Прогалини за пріоритетом
+
+### P0 — критичне для надійності, треба ближче до зараз
+
+1. **`src/sw/**`— ~600 LoC, 0% покриття.** Service-worker (cache, debug, messages, notifiedKeys, reminders, version) додавався під PWA push reminders і ніколи не імпортується з vitest, бо jsdom не дає`self`. Два валідні шляхи (з коментаря в `vitest.config.js`):
+   - **(a)** node-only suite, що імпортує SW-фактори без `self` (передавати скоуп явно як параметр), або
+   - **(b)** виключити `src/sw/**` з coverage і вкласти весь захист у Playwright `tests/a11y/sw-smoke.spec.ts` + розширити його до повноцінного e2e (cache hit / offline navigation / SW-update / push reminder fire).
+
+2. **`apps/server/src/modules/digest/weekly-digest.ts`** — 0 тестів на 1 src-файл. Weekly digest формує важливий e-mail/повідомлення; регресії невидимі до релізу.
+
+3. **AI-tool handlers (`apps/server/src/modules/nutrition/*` + `openclaw/{tools,write-tools}.ts`)** — гілки rolejob → Anthropic → DB, кожен — 0–15% покриття. Це поверхня, яка буде розростатися (нові tool definitions). Мінімум: для кожного tool — happy path + один failure path (Anthropic error / invalid args / БД-RLS). Таблиця:
+
+   | Файл                                  | Поточно | Що додати                                                        |
+   | ------------------------------------- | ------- | ---------------------------------------------------------------- |
+   | `nutrition/day-hint.ts`               | ~0–15%  | unit: tool args validation, БД-збережений hint, кейш             |
+   | `nutrition/day-plan.ts`               | ~0–15%  | unit: побудова плану, kcal/macro обмеження, fallback             |
+   | `nutrition/food-search.ts`            | ~0–15%  | unit: пагінація, кешування результату, error від Open Food Facts |
+   | `nutrition/parse-pantry.ts`           | ~0–15%  | unit: parser, missing nutrients fallback                         |
+   | `nutrition/find-recipes.ts`           | ~0–15%  | unit: фільтр алергенів, score                                    |
+   | `nutrition/shopping-list.ts`          | ~0–15%  | unit: aggregate by aisle, dedup                                  |
+   | `nutrition/week-plan.ts`              | ~0–15%  | unit: розкладка днів, повторюваність                             |
+   | `openclaw/tools.ts`, `write-tools.ts` | низьке  | unit: registry, dispatch, write-перевірка авторизації            |
+
+4. **`apps/server/src/modules/sync/syncV2.ts`** — ~0–1% line coverage, при тому що це серверна сторона, симетрична до `apps/web/src/core/cloudSync/queue/` (де вже є Stryker з 64% mutation score). Сильна асиметрія: клієнт перевіряємо мутаціями, сервер — майже ніяк.
+
+5. **`apps/mobile` без enforcement coverage.** 115 тестів — не мало, але немає `coverageThreshold` у `jest.config.js`, тож регресії не помітяться. Мінімум — додати floor навіть низький (наприклад 30/25/30/30) і fail CI на drift.
+
+### P1 — додає реальну цінність
+
+6. **Розширити web smoke E2E.** Зараз 4 спеки (`auth`, `bottom-nav`, `dashboard-health`, `navigation-offline-sw`). Бракує golden-path по модулях, тих, що в README як основні:
+   - **Finyk:** додати manual transaction → бачиш у списку → balance оновився.
+   - **Fizruk:** запустити training → залогувати підхід → метрика змінилась.
+   - **Nutrition:** додати meal → barcode-сценарій (мокований OFF) → AI-підказка через `parse-pantry` (мокований Anthropic).
+   - **Routine:** check-in → стрік++ → календар відмалював сьогодні.
+   - **HubChat:** надіслати команду коучу → tool execution → візуальний ефект на іншому модулі.
+
+7. **Mobile Detox: пропущені модулі.** Зараз `finyk-manual-expense`, `finyk-transactions`, `routine-smoke`, `hub-ux-smoke`. Бракує:
+   - `auth-login.e2e.ts` (Better Auth flow на нативі — він і так найкрихкіший).
+   - `nutrition-add-meal.e2e.ts` + `nutrition-barcode.e2e.ts`.
+   - `fizruk-log-set.e2e.ts`.
+   - `deep-link.e2e.ts` (сайди вже unit-тестовано в `mobile-shell`, але повного flow з нативного inbound link нема).
+   - `offline-sync.e2e.ts` (offline → дії → online → reconcile).
+
+8. **Visual regression: розширити поверхні.** `ds-visual-qa.spec.ts` — 56 скрінів, але тільки 7 surfaces (welcome, hub-pre-ftux, hub, +4 модульних shell). Не покрито: транзакція-detail, тренування-detail, страва-detail, форми FTUX-кроків, settings, error/empty states. Дешеві додаткові кадри ловлять найбільше регресій DS.
+
+9. **Mutation testing: розширити scope.** Зараз тільки `cloudSync/conflict` (87.16%) і `cloudSync/queue` (64.38%). Кандидати з найвищим blast radius:
+   - `packages/finyk-domain/src/**` — money math (округлення, FX, формули балансу). Помилка тут — мовчазна крадіжка копійок.
+   - `apps/server/src/modules/sync/syncV2.ts` — серверний bookend cloudSync.
+   - `apps/server/src/lib/normalizers/*` — нормалізація даних, легко регресує тихо.
+   - `apps/server/src/auth/passwordHash.ts` — boundary безпеки.
+   - `packages/insights/src/**` — формули агрегації.
+
+10. **Contract tests тільки одна пара.** `me.contract.test.ts` (consumer/producer) — зразок є, шаблон в `@sergeant/shared/contract-fixtures`. Реплікувати на:
+    - `POST /api/chat/*` (HubChat — найбільш важлива поверхня).
+    - `GET/POST /api/sync/v2/*`.
+    - `GET /api/v1/finyk/*`, `routine/*`, `nutrition/*`, `fizruk/*` (хоча б по одному endpoint на модуль, типізація через openapi-typescript і так є — лишилось зафіксувати фактичні response shapes).
+
+### P2 — health & гігієна
+
+11. **Слабкі пакети за співвідношенням test/src:**
+    - `packages/insights` — 3 тести / 13 src. Це cross-module аналітика, чисті функції; ідеально під property-based (fast-check).
+    - `packages/nutrition-domain` — 4 / 13. Найслабший з домен-пакетів.
+    - `packages/api-client` — 11 / 30. Бракує retry/timeout/auth-refresh boundary тестів.
+    - `packages/routine-domain` — 9 / 19.
+
+12. **Server `modules/observability/` — 2 тести.** Спан-сенсітивні URL-маски, sampler, tracing вже мають по 1 тесту, але poshlog/sentry/web-vitals — без юніт-тестів виносу даних. Це місце, де мовчазний регрес відключає весь моніторинг.
+
+13. **No property-based tests взагалі.** При наявній математиці (finyk amounts, sync version vectors, queue dedup, normalizers) `fast-check` дав би в десятки разів більше assert'ів за рядок коду. Stryker і fast-check добре спарюються (Stryker мутує → fast-check ловить).
+
+14. **No load/perf tests** на Anthropic-важких ендпойнтах (chat, parse-pantry) і `sync/v2` під contention. Хоча б один Artillery/k6 сценарій у nightly — щоб p95-регресію ловити до релізу.
+
+15. **`tools/console`** — 19 unit-тестів, але немає end-to-end бот-сценарію (моковий grammy update → асерти на reply). Не критично для основного продукту, але дешево додається.
+
+16. **Migrations rollback.** `packages/db-schema` має `migrations/__tests__/` (3 файли) + `lint-migrations.mjs` — добре. Не ясно, чи кожна нова міграція тестує і `down()` — варто перевірити шаблон `plop-templates/new-migration` і додати rollback-assertion за замовчуванням.
+
+17. **A11y deep screens.** `axe.spec.ts` ходить тільки по hub-сторінках. Внутрішні форми (add transaction, log workout, барcode-сканер, settings sheets) — поза axe-перевіркою. Дешево додаються в той же spec.
+
+18. **`apps/server` без MSW для outbound HTTP.** Anthropic / Voyage / Monobank / OFF — зараз моки розкидані по тестах через `vi.mock`. Можна централізувати під nock або msw-server для consistency і простіше змінювати fixtures.
+
+---
+
+## Швидкий план “що ставити в roadmap”
+
+| Пріоритет | Що зробити                                                                                          | Розмір                |
+| --------: | --------------------------------------------------------------------------------------------------- | --------------------- |
+|        P0 | Тести для `digest/weekly-digest.ts` + `nutrition/{7 tools}.ts` + `openclaw/tools.ts,write-tools.ts` | ~1 спринт, 8–12 PR-ів |
+|        P0 | Розблокувати coverage для `src/sw/**` (node-only suite або excludе + e2e)                           | 1 PR                  |
+|        P0 | `coverageThreshold` для `apps/mobile` (Jest)                                                        | 1 PR                  |
+|        P0 | Тести для `apps/server/src/modules/sync/syncV2.ts` + Stryker-конфіг для нього                       | 2 PR                  |
+|        P1 | 5 web smoke E2E (по одному на модуль + HubChat)                                                     | 1 спринт              |
+|        P1 | 5 Detox suites (auth, nutrition×2, fizruk, deep-link, offline-sync)                                 | 1 спринт              |
+|        P1 | Stryker scope: `finyk-domain`, `insights`, `normalizers`, `passwordHash`                            | 4 PR                  |
+|        P1 | Розширити Argos surfaces до module-detail/forms/error states                                        | 2 PR                  |
+|        P1 | Контрактні пари ще для 4–5 ключових ендпойнтів                                                      | 4–5 PR                |
+|        P2 | fast-check у `finyk-domain`, `insights`, `cloudSync/queue`                                          | 3 PR                  |
+|        P2 | k6/Artillery нічний lane на chat + sync/v2                                                          | 1 PR                  |
+|        P2 | Розширити axe spec на форми/sheets                                                                  | 1 PR                  |
+|        P2 | Підняти test/src-співвідношення в `insights`, `nutrition-domain`, `api-client`                      | поступово             |
+
+---
+
+## Що **не зламано** (щоб не чіпати)
+
+- `packages/eslint-plugin-sergeant-design` — 27 тестів через `node --test` для ESLint-правил, окремий lint-лейн. Все ок.
+- Stryker налаштований правильно (paths-фільтр на cloudSync, weekly cron, threshold break/low/high), документація є (`docs/testing/mutation.md`). Бракує лише розширення scope.
+- Contract-fixtures шаблон через `@sergeant/shared` — вже архітектурно правильний, лишилося реплікувати.
+- Testcontainers + pgvector у server-integration і extended-e2e — теж правильна форма. Тільки треба більше інтеграційних кейсів (зараз 4: `migrate-routine-from-blob`, `mono/read`, `ai-memory/vectorStore`, `sync/syncV2`).


### PR DESCRIPTION
Adds two analysis docs into the repo (no source changes):

- `docs/testing/2026-05-05-tests-review.md` — стан тестів, інвентар фреймворків / CI-лейнів, drift coverage, прогалини за пріоритетом (P0/P1/P2).
- `docs/testing/2026-05-05-tests-pr-plan.md` — розписаний PR-план (39 PR у 7 хвилях A–G) з scope / acceptance / size / deps / dependency graph / merge-order.

Це підкладка під наступні implementation-PR (T01 / T02 / T03 ідуть слідом).

Paired with subsequent PRs that consume the plan.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add two testing documents: a current test suite review and a step‑by‑step PR rollout plan. This sets baselines, priorities, and merge order for upcoming testing work; no source code changes.

- New Features
  - Added `docs/testing/2026-05-05-tests-review.md` — inventory of frameworks/CI lanes, coverage drift, and prioritized gaps (P0/P1/P2).
  - Added `docs/testing/2026-05-05-tests-pr-plan.md` — 39‑PR plan (waves A–G) with scope, acceptance, size, dependencies, and merge order.

<sup>Written for commit 19e3ac33bee3cf088f6664041c568e1fcf2e6231. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

