### PR TITLE
docs(docs): align 0001 Phase 2 status + LOC drift with reality

### DIFF
--- a/docs/initiatives/0001-module-decomposition.md
+++ b/docs/initiatives/0001-module-decomposition.md
@@ -1,6 +1,6 @@
 # 0001 — Module decomposition + `max-lines` guard
 
-> **Last validated:** 2026-05-05 by @Skords-01. **Next review:** 2026-08-03.
+> **Last validated:** 2026-05-06 by @Skords-01. **Next review:** 2026-08-04.
 > **Status:** Done (Phase 1 + Phase 2 + Phase 3) — closed 2026-05-04
 > **Priority:** P0 (Sprint 1)
 > **Owner:** `@Skords-01`
@@ -155,7 +155,9 @@ PR `decomp-finalize` видаляє `overrides` allowlist цілком і зак
 
 Відхилення від плану: жодних — Phase 1 пройшла рівно за описом, без зсувів.
 
-### Фаза 2 — топ-4 декомпозиція (IN PROGRESS — 4 of 5 PRs відкрито 2026-05-04)
+### Фаза 2 — топ-4 декомпозиція (DONE — 2026-05-04)
+
+> Цей підрозділ описує першу пачку з 4 PR-ів, відкритих 2026-05-04 (#1593, #1594, #1596, #1597). П'ятий файл Phase 2 (`RoutineApp.tsx`) виведено в окремий PR #1603 — див. наступний підрозділ.
 
 Pre-requisite: `eslint` бамп до 10.x з [#1572](https://github.com/Skords-01/Sergeant/pull/1572) ламав
 Husky pre-commit hook (`eslint-plugin-react@7.37.5` ще не сумісний з ESLint 10
@@ -165,17 +167,17 @@ API — `contextOrFilename.getFilename is not a function`). Phase 2 неможл
 - **[#1592 — `chore(deps): pin eslint to ^9.39.4 …`](https://github.com/Skords-01/Sergeant/pull/1592)**
   повертає `eslint` + `@eslint/js` на 9.x, поки впереднього `eslint-plugin-react@7.38+` (Issue #6018) ще не вийшло. Усі 4 decomp-PR-и нижче базуються на цій гілці.
 
-| #   | Файл                       | LOC до | Розклали на                                                                                                                                                                          | LOC після      | PR                                                       |
-| --- | -------------------------- | -----: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------- | -------------------------------------------------------- |
-| 1   | `useStorage.ts` (finyk)    |    685 | composition root + `useStorage.types.ts` (73), `useStorage.persist.ts` (37), `useFinykStorageSlots.ts` (175), `useFinykStorageMutations.ts` (343), `useFinykBackupSync.ts` (187)     | **174** entry  | [#1593](https://github.com/Skords-01/Sergeant/pull/1593) |
-| 2   | `chatActions/types.ts`     |    672 | barrel + `types.result.ts` (34), `types.finyk.ts` (188), `types.fizruk.ts` (135), `types.routine.ts` (85), `types.nutrition.ts` (103), `types.cross.ts` (116)                        | **281** barrel | [#1594](https://github.com/Skords-01/Sergeant/pull/1594) |
-| 3   | `Icon.tsx`                 |    660 | composition root + 4 path-shards: `Icon.paths.system.tsx` (141, 27 glyphs), `Icon.paths.status.tsx` (180, 25), `Icon.paths.domain.tsx` (154, 21), `Icon.paths.content.tsx` (111, 15) | **109** entry  | [#1596](https://github.com/Skords-01/Sergeant/pull/1596) |
-| 4   | `sw.ts`                    |    643 | entry + 6 шарів: `sw/version.ts` (19), `sw/cache.ts` (122), `sw/notifiedKeys.ts` (140), `sw/reminders.ts` (267), `sw/debug.ts` (74), `sw/messages.ts` (126)                          | **100** entry  | [#1597](https://github.com/Skords-01/Sergeant/pull/1597) |
-| 5   | `RoutineApp.tsx` (745 LOC) |        | _залишається на наступний sprint_ — найбільший ризик регресії, потребує `useReducer`/state-machine рефакторингу + happy-path RTL fixture перед розбиттям.                            | _pending_      | (не відкрито)                                            |
+| #   | Файл                    | LOC до | Розклали на                                                                                                                                                                             | LOC після      | PR                                                       |
+| --- | ----------------------- | -----: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | -------------------------------------------------------- |
+| 1   | `useStorage.ts` (finyk) |    685 | composition root + `useStorage.types.ts` (73), `useStorage.persist.ts` (37), `useFinykStorageSlots.ts` (215), `useFinykStorageMutations.ts` (346), `useFinykBackupSync.ts` (187)        | **195** entry  | [#1593](https://github.com/Skords-01/Sergeant/pull/1593) |
+| 2   | `chatActions/types.ts`  |    672 | barrel + `types.result.ts` (34), `types.finyk.ts` (188), `types.fizruk.ts` (135), `types.routine.ts` (85), `types.nutrition.ts` (103), `types.cross.ts` (116)                           | **281** barrel | [#1594](https://github.com/Skords-01/Sergeant/pull/1594) |
+| 3   | `Icon.tsx`              |    660 | composition root + 4 path-shards: `Icon.paths.system.tsx` (157, 27 glyphs), `Icon.paths.status.tsx` (180, 25), `Icon.paths.domain.tsx` (154, 21), `Icon.paths.content.tsx` (111, 15)    | **111** entry  | [#1596](https://github.com/Skords-01/Sergeant/pull/1596) |
+| 4   | `sw.ts`                 |    643 | entry + 6 шарів: `sw/version.ts` (19), `sw/cache.ts` (122), `sw/notifiedKeys.ts` (140), `sw/reminders.ts` (267), `sw/debug.ts` (71), `sw/messages.ts` (127)                             | **100** entry  | [#1597](https://github.com/Skords-01/Sergeant/pull/1597) |
+| 5   | `RoutineApp.tsx`        |    745 | винесено в окремий PR `decomp-routine-app` — найбільший ризик регресії, потребував `useReducer`/state-machine + happy-path RTL fixture перед розбиттям. Деталі у наступному підрозділі. | **88** entry   | [#1603](https://github.com/Skords-01/Sergeant/pull/1603) |
 
 Що саме збережено / змінено:
 
-- **Public API stability:** для всіх 4 декомпонованих файлів зовнішні консьюмери НЕ змінюються:
+- **Public API stability:** для всіх 4 декомпонованих в цій пачці файлів зовнішні консьюмери НЕ змінюються:
   - `useStorage()` повертає той самий tuple, що раніше; усі 14 persisted-state slots і 15 mutation-функцій — ті самі.
   - `import { ChatAction } from "./types"` resolves у тип-юніон з усіх 6 доменів через barrel.
   - `<Icon name="..." />` рендериться так само — `IconName` далі типобезпечно derives з `keyof typeof PATHS` (тепер це spread 4 path-shards).
@@ -183,17 +185,17 @@ API — `contextOrFilename.getFilename is not a function`). Phase 2 неможл
 - **Behavior identity:** `vite build` емітує SW bundle 32.39 kB (gzip 10.75 kB) — байт-в-байт ідентично до baseline. 99 finyk vitest, 293 chatActions vitest, 144 ui vitest — all green, без жодного diff в snapshots.
 - **Lint cleanup:** `useFinykStorageMutations.ts` мав raw `localStorage.getItem/setItem` (порушення `sergeant-design/no-raw-local-storage`) — виправлено через `safeReadStringLS`/`safeWriteLS` з `shared/lib/storage`.
 
-Метрики Phase 2 (станом на 2026-05-04, після відкриття 4 PR-ів):
+Метрики Phase 2 (проміжний зріз 2026-05-04, після першої пачки з 4 PR-ів; фінал — у підрозділі `decomp-routine-app` нижче):
 
-| Метрика                                       | Phase 1 (post-#1555)   | Phase 2 (post-1593/1594/1596/1597)                                                                                                     | Target (2026-06-15) |
-| --------------------------------------------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
-| Файлів `apps/web/src/**` ≥600 LOC у allowlist | 7                      | **3** (`fizrukActions.ts`, `Exercise.tsx`, `AssetsTable.tsx`, `RoutineApp.tsx`, `RoutineCalendarPanel.tsx` — підмножина того, що було) | ≤ 2                 |
-| Найбільший файл у allowlist                   | 745 (`RoutineApp.tsx`) | 745 (`RoutineApp.tsx` — поки на наступний sprint)                                                                                      | ≤ 600               |
-| Сумарний LOC у allowlist                      | ~4500                  | ~3100                                                                                                                                  | ≤ 1500              |
+| Метрика                                       | Phase 1 (post-#1555)   | Phase 2 (post-1593/1594/1596/1597)                                                                                                                                     | Target (2026-06-15) |
+| --------------------------------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| Файлів `apps/web/src/**` ≥600 LOC у allowlist | 7                      | **3** з списку Top-7 (`fizrukActions.ts`, `Exercise.tsx`, `AssetsTable.tsx`) + `RoutineApp.tsx` + `RoutineCalendarPanel.tsx` — сукупно 5 в allowlist до розбиття #1603 | ≤ 2                 |
+| Найбільший файл у allowlist                   | 745 (`RoutineApp.tsx`) | 745 (`RoutineApp.tsx` — розбивається у наступному PR цієї ж фази)                                                                                                      | ≤ 600               |
+| Сумарний LOC у allowlist                      | ~4500                  | ~3100                                                                                                                                                                  | ≤ 1500              |
 
-Що далі:
+Що залишалося на цей момент (після #1597, перед #1603):
 
-1. PR `decomp-routine-app` (RoutineApp.tsx 745 → ≤200 LOC по компонентах + `useRoutineAppState.ts`) — наступний sprint, з RTL happy-path fixture перед розбиттям.
+1. PR `decomp-routine-app` (RoutineApp.tsx 745 → ≤200 LOC по компонентах + `useRoutineAppState.ts`) — з RTL happy-path fixture перед розбиттям. Відкрито того ж дня як [#1603](https://github.com/Skords-01/Sergeant/pull/1603) — деталі в наступному підрозділі.
 2. Phase 3 (`decomp-finalize`) — після PR `decomp-routine-app`, видалити `overrides` allowlist цілком і закрити цю ініціативу як **Done**.
 
 ### Фаза 2 — `decomp-routine-app` (DONE — 2026-05-04)
@@ -202,17 +204,17 @@ API — `contextOrFilename.getFilename is not a function`). Phase 2 неможл
 
 Останній файл Phase 2 (`RoutineApp.tsx` 745 LOC) розкладено на 8 шардів, кожен ≤ 350 LOC, всі під 600-LOC lint-гардом:
 
-| Файл                          |  LOC | Роль                                                                                                  |
-| ----------------------------- | ---: | ----------------------------------------------------------------------------------------------------- |
-| `RoutineApp.tsx`              |   88 | Тонкий composition root — тільки wires `useRoutineAppState` до візуальних шардів.                     |
-| `RoutineApp.helpers.ts`       |  100 | Чисті date/grouping helpers, без React.                                                               |
-| `useRoutineAppState.ts`       | ~350 | Orchestrator: routine state, main tab, filters, quick-add, deep-link / PWA effects, callbacks.        |
-| `useRoutineTimeState.ts`      |  212 | `useReducer` state-machine для `timeMode` + `monthCursor` + `selectedDay`.                            |
-| `useRoutineDerivedData.ts`    |  267 | Чисті derived memos: range, events, filtered, listEvents, grouped, dayCounts, tagChips, monthTitle, … |
-| `RoutineHeader.tsx`           |   57 | Module header bar.                                                                                    |
-| `RoutineTimeline.tsx`         |  115 | Calendar/stats body + storage-error banner + pull-to-refresh.                                         |
-| `RoutineActions.tsx`          |   53 | Bottom nav + quick-add dialog.                                                                        |
-| `useRoutineTimeState.test.ts` |  200 | Новий test fixture (14 кейсів) фіксує state-machine.                                                  |
+| Файл                          | LOC | Роль                                                                                                  |
+| ----------------------------- | --: | ----------------------------------------------------------------------------------------------------- |
+| `RoutineApp.tsx`              |  87 | Тонкий composition root — тільки wires `useRoutineAppState` до візуальних шардів.                     |
+| `RoutineApp.helpers.ts`       | 100 | Чисті date/grouping helpers, без React.                                                               |
+| `useRoutineAppState.ts`       | 350 | Orchestrator: routine state, main tab, filters, quick-add, deep-link / PWA effects, callbacks.        |
+| `useRoutineTimeState.ts`      | 201 | `useReducer` state-machine для `timeMode` + `monthCursor` + `selectedDay`.                            |
+| `useRoutineDerivedData.ts`    | 267 | Чисті derived memos: range, events, filtered, listEvents, grouped, dayCounts, tagChips, monthTitle, … |
+| `RoutineHeader.tsx`           |  57 | Module header bar.                                                                                    |
+| `RoutineTimeline.tsx`         | 130 | Calendar/stats body + storage-error banner + pull-to-refresh.                                         |
+| `RoutineActions.tsx`          |  53 | Bottom nav + quick-add dialog.                                                                        |
+| `useRoutineTimeState.test.ts` | 200 | Новий test fixture (14 кейсів) фіксує state-machine.                                                  |
 
 **Public API stability:** `RoutineApp` default export і `RoutineAppProps` interface не змінилися — жоден consumer (App-shell, lazy router, tests) не оновлював імпорти.
 


### PR DESCRIPTION
## Summary

Re-verifies Phase 2 points 4 (`sw.ts`) and 5 (`Icon.tsx`) of initiative [`0001-module-decomposition`](https://github.com/Skords-01/Sergeant/blob/main/docs/initiatives/0001-module-decomposition.md) against the live `apps/web/src` tree, then aligns the document's internal narrative with the actual on-disk state. No source code changes — only `docs/initiatives/0001-module-decomposition.md`.

## Governing Skill

- Primary skill: docs governance (initiative-docs accuracy)
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a (no matching playbook for retroactive doc-consistency edits to a closed initiative)
- Why this playbook: n/a
- If no playbook matched, why: This is a small post-closure correction within a single initiative document. AGENTS.md doc rules cover the substance; no dedicated playbook for this micro-task.

## Verification

```bash
pnpm exec eslint apps/web/src/sw.ts apps/web/src/sw apps/web/src/shared/components/ui/Icon.tsx apps/web/src/shared/components/ui/Icon.paths.system.tsx apps/web/src/shared/components/ui/Icon.paths.status.tsx apps/web/src/shared/components/ui/Icon.paths.domain.tsx apps/web/src/shared/components/ui/Icon.paths.content.tsx
pnpm --filter @sergeant/web typecheck
pnpm --filter @sergeant/web build
pnpm --filter @sergeant/web test -- --run src/shared/components/ui/Icon.test src/core/app/swControl.test
pnpm docs:check-links
pnpm lint:hard-rules-registry
```

Key results:

- ESLint on the `sw.ts`/`sw/*` and `Icon.tsx`/`Icon.paths.*.tsx` files: 0 errors / 0 warnings.
- `pnpm --filter @sergeant/web typecheck`: pass.
- `pnpm --filter @sergeant/web build`: pass; `dist/sw-*.js` Service Worker bundle 32.39 kB (gzip 10.75 kB) — byte-identical to baseline.
- `Icon.test.tsx` (4 cases) + `swControl.test.ts` (2 cases): green.
- `docs:check-links`: 3 broken internal links flagged in *other* docs (`0013-module-decomposition-round-2.md`, `pii-handling.md`) — pre-existing on `main`, not introduced by this PR.
- `lint:hard-rules-registry`: OK — 19 rules in sync.

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- `docs/initiatives/0001-module-decomposition.md` — Phase 2 section header IN PROGRESS → DONE; row 5 (`RoutineApp.tsx`) no longer marked pending and now points to PR #1603 + dedicated subsection; LOC drift refreshed to current values; metrics row label clarified.

## Risk and Rollout

- User-visible risk: none — pure documentation edit inside a closed initiative; no code, schema, or config changes.
- Rollout / deploy order: merges as a regular doc PR; no rollout sequencing.
- Backout plan: revert single commit if needed.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

This PR only edits an existing initiative file (`0001-module-decomposition.md`); no new files added.

## Reviewer Notes

- This is a follow-up consistency pass on the already-closed 0001 initiative — `Status: Done` was already set at the top of the doc, but the inline section header still read `IN PROGRESS`, and row 5 of the topo-4 table still said `_pending_ / (не відкрито)` for `RoutineApp.tsx` even though PR #1603 had landed and the dedicated `decomp-routine-app` subsection was already present below. This PR brings the in-section narrative and tables into line with reality.
- LOC drift refreshed against current files: `useStorage` entry 174 → 195; `useFinykStorageSlots.ts` 175 → 215; `useFinykStorageMutations.ts` 343 → 346; `Icon.tsx` entry 109 → 111; `Icon.paths.system.tsx` 141 → 157; `sw/debug.ts` 74 → 71; `sw/messages.ts` 126 → 127; `decomp-routine-app` table updated (`RoutineApp.tsx` 87, `useRoutineTimeState.ts` 201, `RoutineTimeline.tsx` 130).
- Live-state allowlist drift (e.g. `HubDashboard.tsx`, `DailyPlanCard.tsx` now in `eslint.config.js`) is intentionally left to successor initiative [`0013-module-decomposition-round-2`](https://github.com/Skords-01/Sergeant/blob/main/docs/initiatives/0013-module-decomposition-round-2.md) — 0001 is closed and that's the agreed boundary.
- No `eslint.config.js` or source-code edits in this PR.