### PR TITLE
feat(agents): wf-15 drop intermediate Railway statuses (PR-16)

### DIFF
--- a/ops/n8n-workflows/15-railway-deployment-notify.README.md
+++ b/ops/n8n-workflows/15-railway-deployment-notify.README.md
@@ -2,8 +2,7 @@
 
 > **Status:** Active. Live since 2026-05-03 (parse_mode=HTML cutover, Wave 1 §3.4) — production n8n workflow `CygZ4vLxTm2ltuRW`.
 
-> **Last validated:** 2026-05-03 by @Skords-01. **Next review:** 2026-08-03.
-
+> **Last validated:** 2026-05-06 by @Skords-01. **Next review:** 2026-08-04.
 > Webhook (`POST /webhook/railway-deploy`) → Telegram message in
 > `Sergeant_ops` (`⚙️ Контрол-план` topic, success → ops; failure →
 > incidents).
@@ -78,7 +77,7 @@ consumes are listed (anything else is ignored). Confirmed from a live
 ### Fields used by `Parse Railway payload`
 
 | Output field | Source path (in order, first non-empty wins)                                                     |
-| ------------ | ------------------------------------------------------------------------------------------------ |
+| ------------ | ------------------------------------------------------------------------------------------------ | --- | ------------------------------------------------------------------- |
 | `status`     | `details.status` → `body.status` → `body.type` → `'UNKNOWN'`                                     |
 | `service`    | `resource.service.name` → `body.service.name` → `body.serviceName` → `'—'`                       |
 | `env`        | `resource.environment.name` → `body.environment.name` → `body.environmentName` → `'—'`           |
@@ -88,10 +87,43 @@ consumes are listed (anything else is ignored). Confirmed from a live
 | `url`        | `body.deployment.url` → `body.deploymentUrl` → `''`                                              |
 | `duration`   | `Math.round(body.buildDuration / 1000) + 's'` → `'—'`                                            |
 | `ok`         | `['SUCCESS', 'DEPLOYED', 'ACTIVE'].includes(status.toUpperCase())`                               |
+| `failed`     | `['FAILED', 'CRASHED'].includes(status.toUpperCase())`                                           |
+| `terminal`   | `ok                                                                                              |     | failed`— used by the`Is terminal status?` filter (PR-16, see below) |
 
 `*Html` variants (`serviceHtml`, `envHtml`, …) apply `htmlEscape()` to
 the same value — that's the ONLY thing the Telegram node should
 interpolate, never the raw fields.
+
+## PR-16 (pr-plan-2026-05) — drop intermediate-state noise
+
+**Problem.** До PR-16 кожен Railway webhook викликав Telegram-повідомлення,
+навіть для проміжних станів `BUILDING`, `DEPLOYING`, `INITIALIZING`,
+`QUEUED`, `REMOVING`, `WAITING`, `CANCELLED`, `SKIPPED`. У парсері
+`ok = ['SUCCESS','DEPLOYED','ACTIVE'].includes(status)`, тож усе, що
+не входило в цей set, показувалося як «❌ Deploy Failed» — false-positive
+incident-noise (включно з нормальним `BUILDING` під час кожного re-deploy).
+
+**Fix.** Додано node `Is terminal status?` (`n8n-nodes-base.if` v2)
+між `Parse Railway payload` і `Telegram → #deploys`. Filter пускає тільки
+terminal-стани:
+
+- ✅ **success terminal** — `SUCCESS`, `DEPLOYED`, `ACTIVE` → `$json.ok = true`
+- ❌ **failed terminal** — `FAILED`, `CRASHED` → `$json.failed = true`
+- 🔇 **drop** — `BUILDING`, `DEPLOYING`, `INITIALIZING`, `QUEUED`,
+  `REMOVING`, `REMOVED`, `WAITING`, `CANCELLED`, `SKIPPED`, `UNKNOWN`
+
+IF-node читає булевий `$json.terminal` (parser виставляє `terminal = ok || failed`).
+Лише true-вихід заведений у Telegram-нотифікатор; false-вихід порожній
+(execution тихо завершується). У UI це видно як 2-pin IF-node, де права
+гілка веде в Telegram, а ліва (`false`) обірвана.
+
+**Acceptance.** За 7-денне вікно після cutover у production-середовищі
+Кількість `n8n_API GET /executions?workflowId=CygZ4vLxTm2ltuRW` для
+instance-iв `BUILDING/QUEUED/INITIALIZING/DEPLOYING` = X (запис), а
+кількість Telegram-повідомлень у `Sergeant_ops:⚙ Контрол-план` від
+WF-15 = тільки success/failed cases. Регресійний канарок — додати
+injection-test у `n8n_API` (POST `/webhook-test/railway-deploy` з
+`status: "BUILDING"` → expect 200 + 0 Telegram-викликів).
 
 ## Wiring (Railway-side)
 

--- a/ops/n8n-workflows/15-railway-deployment-notify.json
+++ b/ops/n8n-workflows/15-railway-deployment-notify.json
@@ -15,13 +15,36 @@
     },
     {
       "parameters": {
-        "jsCode": "// WF-15 §3.4 fix (Wave 1): switched parse_mode from \"Markdown\" → \"HTML\"\n// because legacy Markdown has no backslash-escape and broke whenever a\n// commit message contained `*`, `_`, `` ` ``, or `[` (e.g. \"applyFizruk*\").\n// HTML only needs `&<>` escaped, which is trivial and bullet-proof.\nfunction htmlEscape(s) {\n  return String(s ?? '')\n    .replace(/&/g, '&amp;')\n    .replace(/</g, '&lt;')\n    .replace(/>/g, '&gt;');\n}\nconst root = $input.first().json;\nconst body = root.body ?? root;\nconst details = body.details ?? {};\nconst resource = body.resource ?? {};\nconst status = (details.status ?? body.status ?? body.type ?? 'UNKNOWN').toString();\nconst service = resource.service?.name ?? body.service?.name ?? body.serviceName ?? '—';\nconst env = resource.environment?.name ?? body.environment?.name ?? body.environmentName ?? '—';\nconst branch = details.branch ?? body.deployment?.meta?.branch ?? body.branch ?? '—';\nconst commitMsg = (details.commitMessage ?? body.deployment?.meta?.commitMessage ?? body.commitMessage ?? '—').split('\\n')[0];\nconst commitHash = (details.commitHash ?? body.deployment?.meta?.commitHash ?? body.commitHash ?? '').slice(0, 7);\nconst url = body.deployment?.url ?? body.deploymentUrl ?? '';\nconst duration = body.buildDuration ? `${Math.round(body.buildDuration / 1000)}s` : '—';\nconst ok = ['SUCCESS', 'DEPLOYED', 'ACTIVE'].includes(status.toUpperCase());\nreturn [{ json: {\n  status, service, env, branch, commitMsg, commitHash, url, duration, ok,\n  type: body.type ?? null,\n  // _html-escaped variants for direct interpolation into the Telegram\n  // node text — keep raw values around for downstream branches that may\n  // want them un-escaped (alerts, future rich cards).\n  serviceHtml: htmlEscape(service),\n  envHtml: htmlEscape(env),\n  branchHtml: htmlEscape(branch),\n  commitMsgHtml: htmlEscape(commitMsg),\n  commitHashHtml: htmlEscape(commitHash),\n  durationHtml: htmlEscape(duration),\n  urlHtml: htmlEscape(url),\n} }];"
+        "jsCode": "// WF-15 §3.4 fix (Wave 1): switched parse_mode from \"Markdown\" → \"HTML\"\n// because legacy Markdown has no backslash-escape and broke whenever a\n// commit message contained `*`, `_`, `` ` ``, or `[` (e.g. \"applyFizruk*\").\n// HTML only needs `&<>` escaped, which is trivial and bullet-proof.\n//\n// PR-16 (pr-plan-2026-05): added `terminal` boolean so the downstream IF\n// node drops transient states (BUILDING / DEPLOYING / QUEUED /\n// INITIALIZING / REMOVING / WAITING / CANCELLED / SKIPPED). Telegram\n// тільки terminal-стани: SUCCESS / DEPLOYED / ACTIVE → ✅; FAILED /\n// CRASHED → ❌. До цього кожен intermediate-статус слав\n// false-positive «Deploy Failed», бо `ok` був true тільки для\n// `[SUCCESS, DEPLOYED, ACTIVE]`, а решта (включно з BUILDING) показувалась\n// як failure.\nfunction htmlEscape(s) {\n  return String(s ?? '')\n    .replace(/&/g, '&amp;')\n    .replace(/</g, '&lt;')\n    .replace(/>/g, '&gt;');\n}\nconst SUCCESS_TERMINAL = new Set(['SUCCESS', 'DEPLOYED', 'ACTIVE']);\nconst FAILED_TERMINAL = new Set(['FAILED', 'CRASHED']);\nconst root = $input.first().json;\nconst body = root.body ?? root;\nconst details = body.details ?? {};\nconst resource = body.resource ?? {};\nconst status = (details.status ?? body.status ?? body.type ?? 'UNKNOWN').toString();\nconst statusUpper = status.toUpperCase();\nconst service = resource.service?.name ?? body.service?.name ?? body.serviceName ?? '—';\nconst env = resource.environment?.name ?? body.environment?.name ?? body.environmentName ?? '—';\nconst branch = details.branch ?? body.deployment?.meta?.branch ?? body.branch ?? '—';\nconst commitMsg = (details.commitMessage ?? body.deployment?.meta?.commitMessage ?? body.commitMessage ?? '—').split('\\n')[0];\nconst commitHash = (details.commitHash ?? body.deployment?.meta?.commitHash ?? body.commitHash ?? '').slice(0, 7);\nconst url = body.deployment?.url ?? body.deploymentUrl ?? '';\nconst duration = body.buildDuration ? `${Math.round(body.buildDuration / 1000)}s` : '—';\nconst ok = SUCCESS_TERMINAL.has(statusUpper);\nconst failed = FAILED_TERMINAL.has(statusUpper);\nconst terminal = ok || failed;\nreturn [{ json: {\n  status, service, env, branch, commitMsg, commitHash, url, duration, ok, failed, terminal,\n  type: body.type ?? null,\n  // _html-escaped variants for direct interpolation into the Telegram\n  // node text — keep raw values around for downstream branches that may\n  // want them un-escaped (alerts, future rich cards).\n  serviceHtml: htmlEscape(service),\n  envHtml: htmlEscape(env),\n  branchHtml: htmlEscape(branch),\n  commitMsgHtml: htmlEscape(commitMsg),\n  commitHashHtml: htmlEscape(commitHash),\n  durationHtml: htmlEscape(duration),\n  urlHtml: htmlEscape(url),\n} }];"
       },
       "id": "parse-payload",
       "name": "Parse Railway payload",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "conditions": [
+            {
+              "id": "is-terminal",
+              "leftValue": "={{ $json.terminal }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              }
+            }
+          ]
+        }
+      },
+      "id": "is-terminal",
+      "name": "Is terminal status?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [580, 300]
     },
     {
       "parameters": {
@@ -36,7 +59,7 @@
       "name": "Telegram → #deploys",
       "type": "n8n-nodes-base.telegram",
       "typeVersion": 1.2,
-      "position": [680, 300],
+      "position": [800, 300],
       "credentials": {
         "telegramApi": {
           "id": "ggxeCc1ALZKLuMPV",
@@ -61,11 +84,23 @@
       "main": [
         [
           {
-            "node": "Telegram → #deploys",
+            "node": "Is terminal status?",
             "type": "main",
             "index": 0
           }
         ]
+      ]
+    },
+    "Is terminal status?": {
+      "main": [
+        [
+          {
+            "node": "Telegram → #deploys",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        []
       ]
     }
   },


### PR DESCRIPTION
## Summary

WF-15 (`ops/n8n-workflows/15-railway-deployment-notify.json`) тепер фільтрує Railway webhook events: Telegram отримує тільки terminal-стани (`SUCCESS / DEPLOYED / ACTIVE / FAILED / CRASHED`), а проміжні (`BUILDING / DEPLOYING / INITIALIZING / QUEUED / REMOVING / WAITING / CANCELLED / SKIPPED`) дропаються тихо.

До цього кожен Railway webhook слав Telegram-повідомлення, бо парсер виставляв `ok = ['SUCCESS','DEPLOYED','ACTIVE'].includes(status)` — і будь-що інше показувалося як «❌ Deploy Failed». На кожен re-deploy (4–6 інстансів кроків `BUILDING`/`DEPLOYING`/`INITIALIZING`/`SUCCESS`) `Sergeant_ops:⚙ Контрол-план` отримував 4-5 false-positive incident-повідомлень.

Зміни:

- **`ops/n8n-workflows/15-railway-deployment-notify.json`**:
  - `Parse Railway payload` (Code node) тепер додатково виставляє `failed = ['FAILED','CRASHED'].includes(status)` і `terminal = ok || failed`.
  - Новий node `Is terminal status?` (`n8n-nodes-base.if` v2) — boolean filter на `={{ $json.terminal }} === true`. Лише true-вихід заведений у `Telegram → #deploys`; false-вихід порожній (execution тихо завершується).
  - Connections перебудовано: `Webhook → Parse → IF → Telegram` (раніше `Webhook → Parse → Telegram`).
  - `position` Telegram-ноди зсунута з `[680,300]` на `[800,300]`, IF на `[580,300]` — щоб у n8n UI лишити чистий лінійний layout.
- **`ops/n8n-workflows/15-railway-deployment-notify.README.md`**: нова секція «PR-16 — drop intermediate-state noise» (problem / fix / acceptance / canary). Таблиця fields оновлена — додано `failed`, `terminal`. Старий §3.4 fix лишається як history-context.

## Governing Skill

- Primary skill: `sergeant-feature-delivery` (точкова зміна поведінки з оновленням контракту README).
- Secondary skill: n/a — n8n-only PR без коду апи/web.

## Playbook

- Primary playbook: n/a — n8n workflow filter додавання, без processuаl recipe.
- Чому без playbook: зміна одного workflow + його README, без deploy-procedure / migration / data-migration. Live n8n потребує імпорту нового JSON у workflow `CygZ4vLxTm2ltuRW` після merge — `pnpm n8n:import` (manifest's deploy verb).

## Verification

```bash
pnpm ops:n8n:validate
pnpm format:check ops/n8n-workflows/15-railway-deployment-notify.json \
  ops/n8n-workflows/15-railway-deployment-notify.README.md
pnpm docs:check-links
```

Результати:

- `ops:n8n:validate` — `Validated 23 n8n workflows.` (схема, env-vars, credentials, connections — clean).
- `format:check` — після `prettier --write` чистий на обох файлах.
- `docs:check-links` — внутрішні лінки 100%; 2 external warnings — preexisting, не пов'язані з цим PR.

Live n8n smoke-test (post-merge, потребує `n8n_API` credential):

```bash
# inject BUILDING (має бути дропнутий — 0 Telegram повідомлень)
curl -X POST https://n8n-production-09ac.up.railway.app/webhook/railway-deploy \
  -H 'Content-Type: application/json' \
  -d '{"type":"Deployment.building","details":{"status":"BUILDING","branch":"main"}}'

# inject SUCCESS (має пройти — 1 Telegram повідомлення в TOPIC_OPS)
curl -X POST https://n8n-production-09ac.up.railway.app/webhook/railway-deploy \
  -H 'Content-Type: application/json' \
  -d '{"type":"Deployment.deployed","details":{"status":"SUCCESS","branch":"main"}}'
```

Additional checks:

- [x] Local smoke / manual validation completed (n8n schema validator + prettier + markdown links)
- [x] Surface-specific checks completed — workflow JSON валідний для n8n v2 IF-node (boolean operator, singleValue:true)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- `ops/n8n-workflows/15-railway-deployment-notify.README.md` — нова секція PR-16 + рядки `failed`/`terminal` у таблиці. Last-validated bumped по pre-commit hook.
- `AGENTS.md` змін не потребує: contract WF-15 описаний у його README, не в кореневих rules.
- Manifest entry для WF-15 не змінювався (env-vars/credentials/owner/риск ті самі).

## Risk and Rollout

- User-visible risk: **none** для prod-runtime, поки live workflow `CygZ4vLxTm2ltuRW` не імпортував нову версію через `pnpm n8n:import`. Після імпорту — Telegram-канал `#deploys` отримуватиме 70-80% менше повідомлень (тільки terminal-стани). Зворотний сценарій — Telegram-mute під час масового re-deploy виключений (filter не блокує SUCCESS/FAILED).
- Rollout / deploy order: merge → `pnpm n8n:import` (or n8n UI: workflow `CygZ4vLxTm2ltuRW` → Replace JSON). 
- Backout plan: повторно імпортувати попередню версію JSON з main pre-PR — single-step revert, без міграцій / state.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

- IF-node читає булевий `$json.terminal` через `operator.type: "boolean", operation: "true", singleValue: true` — це канонічний шаблон для n8n v2 IF, де ми хочемо просто truthy-перевірку без other-side data. Sentry WF-03 використовує string-equality (`level === "fatal"`) як reference; тут булеве — щоб майбутнє розширення SUCCESS/FAILED списків не вимагало торкатися IF-конфіг.
- Я свідомо НЕ додавав окремі гілки success/failed в IF (`success_only` + `failed_only`) — Telegram nod уже розгалужує через `$json.ok ? OPS : INCIDENTS` для `message_thread_id`. Один filter + один nod — простіше.
- `CANCELLED` потрапив у drop-list тому, що Railway emits його коли deploy скасовано вручну в UI — це не incident і не success-deploy. Якщо в майбутньому виявимо, що CANCELLED треба алертити окремо — переробимо `terminal` у tri-state і добавимо третю гілку.
- Plan-ID: **PR-16** з `docs/planning/pr-plan-2026-05.md` (Phase 2, S effort). Progress log оновиться окремим закриваючим PR після того, як ця ланка з 4 PR-ів замерджиться.

Link to Devin session: https://app.devin.ai/sessions/67b23beccb6a427c858b9c37e176f2a4
Requested by: @Skords-01

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
WF-15 now filters Railway deploy webhooks so Telegram only gets terminal statuses. This stops false “Deploy Failed” messages from intermediate states.

- **Bug Fixes**
  - Added `Is terminal status?` (`n8n-nodes-base.if` v2) after the parser; forwards only when `$json.terminal` is true.
  - Parser now sets `failed` and `terminal = ok || failed`; success: SUCCESS/DEPLOYED/ACTIVE, failed: FAILED/CRASHED, all others are dropped.
  - Updated `ops/n8n-workflows/15-railway-deployment-notify.README.md` with the new fields and PR-16 notes.

- **Migration**
  - After merge, import the workflow to live n8n: `pnpm n8n:import`.

<sup>Written for commit acd456d45d30e4de1c922ba83993442484bdd816. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

