### PR TITLE
feat(shared): goal-aware first-action priority (PR-11)

### DIFF
--- a/apps/mobile/src/core/dashboard/FirstActionHeroCard.test.tsx
+++ b/apps/mobile/src/core/dashboard/FirstActionHeroCard.test.tsx
@@ -61,6 +61,7 @@ describe("FirstActionHeroCard", () => {
     expect(onPicked).toHaveBeenCalledWith({
       module: "finyk",
       via: "primary",
+      primaryReason: "multi-pick-static",
     });
   });
 
@@ -84,6 +85,7 @@ describe("FirstActionHeroCard", () => {
     expect(onShown).toHaveBeenCalledWith({
       primary: "fizruk",
       picks: ["fizruk"],
+      primaryReason: "single-pick",
     });
   });
 
@@ -106,6 +108,37 @@ describe("FirstActionHeroCard", () => {
     expect(onPicked).toHaveBeenCalledWith({
       module: "finyk",
       via: "chip",
+      primaryReason: "multi-pick-static",
+    });
+  });
+
+  it("emits primaryReason='single-goal' when exactly one goal is set", () => {
+    seedPicks(["routine", "finyk", "fizruk"]);
+    seedGoals({ finykBudget: 30000 });
+    const onShown = jest.fn();
+    render(<FirstActionHeroCard onAction={jest.fn()} onShown={onShown} />);
+    expect(onShown).toHaveBeenCalledWith({
+      primary: "finyk",
+      picks: ["routine", "finyk", "fizruk"],
+      primaryReason: "single-goal",
+    });
+  });
+
+  it("emits primaryReason='multi-goal-vibe' and honours user pick order on tie-break", () => {
+    // Both fizruk and finyk have explicit goals. With user picks ordered
+    // [fizruk, finyk, …], PR-11 promotes fizruk over finyk — the previous
+    // static heuristic always picked finyk.
+    seedPicks(["fizruk", "finyk", "routine"]);
+    seedGoals({ finykBudget: 30000, fizrukWeeklyGoal: 3 });
+    const { getByText } = render(<FirstActionHeroCard onAction={jest.fn()} />);
+    expect(getByText(/Увімкни розминку/)).toBeTruthy();
+
+    const onShown = jest.fn();
+    render(<FirstActionHeroCard onAction={jest.fn()} onShown={onShown} />);
+    expect(onShown).toHaveBeenCalledWith({
+      primary: "fizruk",
+      picks: ["fizruk", "finyk", "routine"],
+      primaryReason: "multi-goal-vibe",
     });
   });
 

--- a/apps/mobile/src/core/dashboard/FirstActionHeroCard.tsx
+++ b/apps/mobile/src/core/dashboard/FirstActionHeroCard.tsx
@@ -33,8 +33,10 @@ import {
   getOnboardingGoals,
   getVibePicks,
   hapticTap,
-  pickPrimaryFirstAction,
+  rankFirstActionCandidates,
   type DashboardModuleId,
+  type FirstActionPrimaryReason,
+  type FirstActionRanking,
 } from "@sergeant/shared";
 
 import { Button } from "@/components/ui/Button";
@@ -82,18 +84,16 @@ const ACTIONS: Record<DashboardModuleId, ActionSpec> = {
 };
 
 /**
- * Goal-aware primary picker for the mobile FTUX hero (S2.1).
- *
- * Delegates to `pickPrimaryFirstAction` so web and mobile resolve the
- * primary identically: any module with an explicit goal beats one
- * without, with the shared `FIRST_ACTION_PRIORITY` (routine → finyk
- * → nutrition → fizruk) breaking ties. Nutrition is already filtered
- * out of `picks` upstream in `FirstActionHeroCard` (Phase 7 on
- * mobile), so the helper will never promote nutrition here even if a
+ * Goal-aware primary + chip ordering + analytics reason for the mobile
+ * FTUX hero (PR-11). Delegates to `rankFirstActionCandidates` so web
+ * and mobile resolve the primary, the alt-module chip-row order, and
+ * the SLO `primary_reason` faceting field identically. Nutrition is
+ * already filtered out of `picks` upstream (Phase 7 on mobile), so
+ * the helper will never promote nutrition here even if a
  * `nutritionGoal` happens to be persisted.
  */
-function pickPrimary(picks: readonly DashboardModuleId[]): DashboardModuleId {
-  return pickPrimaryFirstAction(picks, getOnboardingGoals(mmkvStore));
+function rankPrimary(picks: readonly DashboardModuleId[]): FirstActionRanking {
+  return rankFirstActionCandidates(picks, getOnboardingGoals(mmkvStore));
 }
 
 export interface FirstActionHeroCardProps {
@@ -105,10 +105,12 @@ export interface FirstActionHeroCardProps {
    *  fresh install / store wipe. */
   onDismiss?: () => void;
   /** Optional analytics hook: fires once on first render with the
-   *  resolved primary module. */
+   *  resolved primary module + selection reason (PR-11) so PostHog can
+   *  break the SLO down by `single-goal` / `multi-goal-vibe` / etc. */
   onShown?: (info: {
     primary: DashboardModuleId;
     picks: DashboardModuleId[];
+    primaryReason: FirstActionPrimaryReason;
   }) => void;
   /** Optional analytics hook: fires when the user taps a CTA. The
    *  `via` field carries the same vocabulary as the web counterpart
@@ -117,10 +119,15 @@ export interface FirstActionHeroCardProps {
    *  alt-module chip row. PostHog dashboards reading the canonical
    *  `onboarding_first_action_picked` event compute switch-rate as
    *  `count(via="chip") / count(*)`.
+   *
+   *  `primaryReason` (PR-11) carries the same `FirstActionPrimaryReason`
+   *  faceting field as `onShown` so dashboards can correlate hero
+   *  selection mode with first-entry rate.
    */
   onPicked?: (info: {
     module: DashboardModuleId;
     via: "primary" | "chip";
+    primaryReason: FirstActionPrimaryReason;
   }) => void;
 }
 
@@ -142,28 +149,37 @@ export function FirstActionHeroCard({
       : (["routine", "finyk", "fizruk"] as DashboardModuleId[]);
   }, []);
 
-  const primaryId = pickPrimary(picks);
+  const ranking = rankPrimary(picks);
+  const primaryId = ranking.primary;
   const primary = ACTIONS[primaryId];
   const others = useMemo(
-    () => picks.filter((id) => id !== primaryId && ACTIONS[id]),
-    [picks, primaryId],
+    () => ranking.others.filter((id) => ACTIONS[id]),
+    [ranking.others],
   );
 
   useEffect(() => {
-    onShown?.({ primary: primaryId, picks });
+    onShown?.({
+      primary: primaryId,
+      picks,
+      primaryReason: ranking.reason,
+    });
     // Report-on-mount only — treat like a mount-level analytics event.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handlePrimary = () => {
     hapticTap();
-    onPicked?.({ module: primaryId, via: "primary" });
+    onPicked?.({
+      module: primaryId,
+      via: "primary",
+      primaryReason: ranking.reason,
+    });
     onAction(primaryId);
   };
 
   const handleAltPick = (id: DashboardModuleId) => {
     hapticTap();
-    onPicked?.({ module: id, via: "chip" });
+    onPicked?.({ module: id, via: "chip", primaryReason: ranking.reason });
     onAction(id);
   };
 

--- a/apps/mobile/src/core/dashboard/HubDashboard.tsx
+++ b/apps/mobile/src/core/dashboard/HubDashboard.tsx
@@ -436,16 +436,18 @@ export function HubDashboard() {
             <FirstActionHeroCard
               onAction={(id) => openModule(id)}
               onDismiss={bumpHero}
-              onShown={({ primary, picks }) => {
+              onShown={({ primary, picks, primaryReason }) => {
                 trackEvent(ANALYTICS_EVENTS.ONBOARDING_FIRST_ACTION_SHOWN, {
                   picks,
                   primary,
+                  primary_reason: primaryReason,
                 });
               }}
-              onPicked={({ module, via }) => {
+              onPicked={({ module, via, primaryReason }) => {
                 trackEvent(ANALYTICS_EVENTS.ONBOARDING_FIRST_ACTION_PICKED, {
                   module,
                   via,
+                  primary_reason: primaryReason,
                 });
               }}
             />

--- a/apps/web/src/core/onboarding/FirstActionSheet.test.tsx
+++ b/apps/web/src/core/onboarding/FirstActionSheet.test.tsx
@@ -69,6 +69,8 @@ describe("FirstActionHeroCard — inline chips (S2.3)", () => {
       module: "finyk",
       primary: "routine",
       via: "chip",
+      // PR-11: PostHog faceting field — no goals, multiple picks → static.
+      primary_reason: "multi-pick-static",
     });
   });
 
@@ -89,6 +91,7 @@ describe("FirstActionHeroCard — inline chips (S2.3)", () => {
       module: "routine",
       primary: "routine",
       via: "primary",
+      primary_reason: "multi-pick-static",
     });
   });
 

--- a/apps/web/src/core/onboarding/FirstActionSheet.tsx
+++ b/apps/web/src/core/onboarding/FirstActionSheet.tsx
@@ -7,7 +7,11 @@ import { trackEvent, ANALYTICS_EVENTS } from "../observability/analytics";
 import { clearFirstActionPending, getVibePicks } from "./vibePicks";
 import { PresetSheet, getPresetModule } from "./PresetSheet";
 import type { ModuleId } from "./presetApply";
-import { getOnboardingGoals, pickPrimaryFirstAction } from "@sergeant/shared";
+import {
+  getOnboardingGoals,
+  rankFirstActionCandidates,
+  type FirstActionRanking,
+} from "@sergeant/shared";
 import { webKVStore } from "@shared/lib/storage/storage";
 
 type IconName = Parameters<typeof Icon>[0]["name"];
@@ -71,14 +75,16 @@ function isModuleId(id: string): id is ModuleId {
 }
 
 /**
- * Goal-aware primary picker for the FTUX hero (S2.1). Reads the
- * onboarding goals once per render and delegates the goal vs static
- * priority decision to `@sergeant/shared` so web and mobile resolve
- * the primary identically. Falls back to `routine` if `picks` is
- * empty (matches pre-S2.1 behaviour).
+ * Goal-aware primary + chip ordering + analytics reason for the FTUX
+ * hero (PR-11). Reads the onboarding goals once per render and delegates
+ * to `rankFirstActionCandidates` so web and mobile resolve the primary
+ * and the alt-module chip-row order identically. The returned `reason`
+ * is forwarded to PostHog through `onboarding_first_action_*` events so
+ * the SLO dashboard can break first-entry rate down by selection mode
+ * (`single-goal` vs `multi-goal-vibe` vs `multi-pick-static`).
  */
-function pickPrimary(picks: string[]): ModuleId {
-  return pickPrimaryFirstAction(picks, getOnboardingGoals(webKVStore));
+function rankPrimary(picks: string[]): FirstActionRanking {
+  return rankFirstActionCandidates(picks, getOnboardingGoals(webKVStore));
 }
 
 /**
@@ -136,18 +142,16 @@ export function FirstActionHeroCard({ onDismiss }: FirstActionHeroCardProps) {
     return raw.length > 0 ? raw : Object.keys(ACTIONS);
   }, []);
 
-  // `pickPrimary` reads onboarding goals once and runs a trivial
+  // `rankPrimary` reads onboarding goals once and runs a trivial
   // 4-module scan; memoising would add more bookkeeping than it
   // saves. The goals payload is stable for the FTUX session — once
   // wizard.finish() persists them they won't mutate until reset.
-  const primaryId = pickPrimary(picks);
+  const ranking = rankPrimary(picks);
+  const primaryId = ranking.primary;
   const primary = ACTIONS[primaryId];
   const others = useMemo<ModuleId[]>(
-    () =>
-      picks.filter(
-        (id: string): id is ModuleId => id !== primaryId && isModuleId(id),
-      ),
-    [picks, primaryId],
+    () => ranking.others.filter((id): id is ModuleId => isModuleId(id)),
+    [ranking.others],
   );
 
   // Module id whose PresetSheet is currently open, or `null` if closed.
@@ -160,8 +164,9 @@ export function FirstActionHeroCard({ onDismiss }: FirstActionHeroCardProps) {
     trackEvent(ANALYTICS_EVENTS.ONBOARDING_FIRST_ACTION_SHOWN, {
       picks,
       primary: primaryId,
+      primary_reason: ranking.reason,
     });
-  }, [picks, primaryId]);
+  }, [picks, primaryId, ranking.reason]);
 
   const dismiss = () => {
     clearFirstActionPending();
@@ -173,6 +178,7 @@ export function FirstActionHeroCard({ onDismiss }: FirstActionHeroCardProps) {
     trackEvent(ANALYTICS_EVENTS.ONBOARDING_FIRST_ACTION_PICKED, {
       module: id,
       primary: primaryId,
+      primary_reason: ranking.reason,
       // S2.3: "chip" replaces the legacy "expand" tag now that the inline
       // chip row is always-visible. PostHog dashboards reading the raw
       // event can compute switch-rate as `count(via="chip") /

--- a/docs/launch/product-os/ftux-master-tracker.md
+++ b/docs/launch/product-os/ftux-master-tracker.md
@@ -138,6 +138,8 @@
 | **PR-13** | feat(experiments): goal-first wizard variant (S5.1) | ~250 | PR-11        | D7 retention за goal-first arm vs current ≥ +5pp    |
 | **PR-14** | feat(observability): FTUX SLO + dashboard + alert   | ~100 | —            | Self-referential — alert fires when SLO breaches    |
 
+> **PR-11 status (2026-05-06):** in-flight як [#1991](https://github.com/Skords-01/Sergeant/pull/1991) — додав `rankFirstActionCandidates`, vibe-pick-order tie-break серед goal-set picks та `primary_reason` faceting field у `onboarding_first_action_*` події (Sentry/PostHog). Static fallback (без goals) — байт-в-байт як до S2.1.
+
 ### 3.3. Хвиля 3 — Platform parity (Week 3-4, 4 PR)
 
 | PR        | Назва                                                    | LOC  | Deps | Метрика                                             |

--- a/packages/shared/src/lib/onboardingGoals.test.ts
+++ b/packages/shared/src/lib/onboardingGoals.test.ts
@@ -8,6 +8,7 @@ import {
   getGoalQuestions,
   getOnboardingGoals,
   pickPrimaryFirstAction,
+  rankFirstActionCandidates,
   saveOnboardingGoals,
   type OnboardingGoals,
 } from "./onboardingGoals";
@@ -191,5 +192,100 @@ describe("onboardingGoals — pickPrimaryFirstAction (S2.1)", () => {
       "nutrition",
       "fizruk",
     ]);
+  });
+});
+
+describe("onboardingGoals — rankFirstActionCandidates (PR-11)", () => {
+  const ALL_PICKS = ["routine", "finyk", "nutrition", "fizruk"];
+
+  it("returns no-picks reason and routine default for empty picks", () => {
+    expect(rankFirstActionCandidates([], EMPTY_GOALS)).toEqual({
+      primary: "routine",
+      reason: "no-picks",
+      others: [],
+    });
+  });
+
+  it("returns single-pick reason when only one module is picked", () => {
+    expect(rankFirstActionCandidates(["fizruk"], EMPTY_GOALS)).toEqual({
+      primary: "fizruk",
+      reason: "single-pick",
+      others: [],
+    });
+  });
+
+  it("returns multi-pick-static reason when no goals are set", () => {
+    const ranking = rankFirstActionCandidates(
+      ["finyk", "fizruk", "nutrition"],
+      EMPTY_GOALS,
+    );
+    expect(ranking.primary).toBe("finyk");
+    expect(ranking.reason).toBe("multi-pick-static");
+    // Others preserve the user's vibe-pick order minus the primary.
+    expect(ranking.others).toEqual(["fizruk", "nutrition"]);
+  });
+
+  it("returns single-goal reason when exactly one module has a goal", () => {
+    const ranking = rankFirstActionCandidates(ALL_PICKS, {
+      ...EMPTY_GOALS,
+      nutritionGoal: "lose",
+    });
+    expect(ranking).toEqual({
+      primary: "nutrition",
+      reason: "single-goal",
+      others: ["routine", "finyk", "fizruk"],
+    });
+  });
+
+  it("breaks ties by user's vibe-pick order, not static priority", () => {
+    // User explicitly picked fizruk first; both fizruk and finyk have goals.
+    // Old behaviour: finyk wins by static priority. New: fizruk wins.
+    const ranking = rankFirstActionCandidates(["fizruk", "finyk", "routine"], {
+      ...EMPTY_GOALS,
+      finykBudget: 30000,
+      fizrukWeeklyGoal: 3,
+    });
+    expect(ranking.primary).toBe("fizruk");
+    expect(ranking.reason).toBe("multi-goal-vibe");
+    // Goal-set picks come first in `others` (finyk before routine).
+    expect(ranking.others).toEqual(["finyk", "routine"]);
+  });
+
+  it("ignores goals for modules outside picks", () => {
+    // finykBudget set but finyk not picked → goal is invisible, falls back
+    // to static priority among picks.
+    const ranking = rankFirstActionCandidates(["routine", "fizruk"], {
+      ...EMPTY_GOALS,
+      finykBudget: 30000,
+    });
+    expect(ranking).toEqual({
+      primary: "routine",
+      reason: "multi-pick-static",
+      others: ["fizruk"],
+    });
+  });
+
+  it("groups goal-set picks ahead of non-goal picks in others", () => {
+    // Picks order: routine, finyk, nutrition, fizruk; goals on finyk + fizruk.
+    // Primary = finyk (first goal-set in picks order). Others should list the
+    // remaining goal-set pick (fizruk) before the non-goal picks (routine,
+    // nutrition) in their original order.
+    const ranking = rankFirstActionCandidates(ALL_PICKS, {
+      ...EMPTY_GOALS,
+      finykBudget: 20000,
+      fizrukWeeklyGoal: 4,
+    });
+    expect(ranking.primary).toBe("finyk");
+    expect(ranking.reason).toBe("multi-goal-vibe");
+    expect(ranking.others).toEqual(["fizruk", "routine", "nutrition"]);
+  });
+
+  it("sanitises unknown ids and duplicates", () => {
+    const ranking = rankFirstActionCandidates(
+      ["unknown", "finyk", "finyk", "routine"],
+      EMPTY_GOALS,
+    );
+    expect(ranking.primary).toBe("routine");
+    expect(ranking.others).toEqual(["finyk"]);
   });
 });

--- a/packages/shared/src/lib/onboardingGoals.ts
+++ b/packages/shared/src/lib/onboardingGoals.ts
@@ -203,40 +203,133 @@ function hasGoalFor(
 }
 
 /**
+ * Why a particular module ended up as the FTUX primary. Surfaced through
+ * `rankFirstActionCandidates` so analytics can compute per-module first-
+ * entry rate variance broken down by selection reason — the SLO PR-11 is
+ * trying to move (`Per-module first-entry rate variance ↓`).
+ *
+ * - `no-picks` — empty picks; we fell back to the `routine` default.
+ * - `single-pick` — exactly one vibe pick; that pick wins regardless of goals.
+ * - `single-goal` — one goal-set module within picks; goal wins.
+ * - `multi-goal-vibe` — multiple goal-set modules; first in user's vibe-pick
+ *   order wins. Honours the user's explicit ordering over our static
+ *   friction-first heuristic, because once the user has committed to a goal
+ *   we trust their intent more than our preset.
+ * - `multi-pick-static` — multiple picks, zero goals; falls back to
+ *   `FIRST_ACTION_PRIORITY` (lowest-friction first) so empty-state UX is
+ *   unchanged from pre-S2.1.
+ */
+export type FirstActionPrimaryReason =
+  | "no-picks"
+  | "single-pick"
+  | "single-goal"
+  | "multi-goal-vibe"
+  | "multi-pick-static";
+
+export interface FirstActionRanking {
+  /** Module promoted into the hero CTA. */
+  primary: DashboardModuleId;
+  /** Why `primary` won — fed into `onboarding_first_action_*` events. */
+  reason: FirstActionPrimaryReason;
+  /**
+   * All other picks in chip-row display order. Goal-set modules come first
+   * (so a user with two goals sees both their committed modules adjacent to
+   * the hero), then non-goal picks; both groups preserve the user's
+   * original vibe-pick order. Sanitised: unknown ids and duplicates dropped.
+   */
+  others: DashboardModuleId[];
+}
+
+function sanitiseModuleIds(picks: readonly string[]): DashboardModuleId[] {
+  const known = new Set<DashboardModuleId>(FIRST_ACTION_PRIORITY);
+  const seen = new Set<string>();
+  const out: DashboardModuleId[] = [];
+  for (const id of picks) {
+    if (typeof id !== "string") continue;
+    if (!known.has(id as DashboardModuleId)) continue;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    out.push(id as DashboardModuleId);
+  }
+  return out;
+}
+
+/**
+ * Resolve the FTUX `FirstActionHeroCard` primary + chip ordering + analytics
+ * reason from the user's vibe picks and onboarding goals.
+ *
+ * Goal-aware (S2.1 evolved into PR-11): a module with an explicit goal still
+ * beats one without. When more than one goal is set, the **user's vibe-pick
+ * order** breaks ties (was: static `FIRST_ACTION_PRIORITY`). Picking `fizruk`
+ * before `finyk` in the wizard now actually surfaces fizruk as the hero when
+ * both have goals — the previous heuristic always promoted finyk on the basis
+ * that finance has lower setup friction, ignoring the explicit reorder.
+ *
+ * No-goals fallback is unchanged: `FIRST_ACTION_PRIORITY` (routine first)
+ * keeps empty-state UX byte-identical to pre-S2.1.
+ *
+ * `others` orders goal-set picks ahead of non-goal picks so the chip row
+ * groups committed modules next to the hero, surfacing the user's explicit
+ * intent on a single visual sweep.
+ */
+export function rankFirstActionCandidates(
+  picks: readonly string[],
+  goals: OnboardingGoals,
+): FirstActionRanking {
+  const sanitised = sanitiseModuleIds(picks);
+
+  if (sanitised.length === 0) {
+    return { primary: "routine", reason: "no-picks", others: [] };
+  }
+
+  const goalPicks = sanitised.filter((id) => hasGoalFor(id, goals));
+
+  if (goalPicks.length >= 1) {
+    const primary = goalPicks[0]!;
+    const remainingGoal = goalPicks.slice(1);
+    const noGoal = sanitised.filter((id) => !hasGoalFor(id, goals));
+    return {
+      primary,
+      reason: goalPicks.length === 1 ? "single-goal" : "multi-goal-vibe",
+      others: [...remainingGoal, ...noGoal],
+    };
+  }
+
+  if (sanitised.length === 1) {
+    return { primary: sanitised[0]!, reason: "single-pick", others: [] };
+  }
+
+  for (const moduleId of FIRST_ACTION_PRIORITY) {
+    if (!sanitised.includes(moduleId)) continue;
+    return {
+      primary: moduleId,
+      reason: "multi-pick-static",
+      others: sanitised.filter((id) => id !== moduleId),
+    };
+  }
+
+  // Defensive: sanitised is non-empty AND FIRST_ACTION_PRIORITY covers every
+  // DashboardModuleId, so the loop above always returns. This branch is here
+  // for type narrowing only.
+  return {
+    primary: sanitised[0]!,
+    reason: "multi-pick-static",
+    others: sanitised.slice(1),
+  };
+}
+
+/**
  * Pick the primary module promoted by the FTUX `FirstActionHeroCard`.
  *
- * Goal-aware (S2.1): if the user committed to an explicit goal in the
- * onboarding goals step (finyk budget, fizruk weekly target, routine
- * first habit, nutrition objective) AND that module is in their vibe
- * picks, it wins. The CTA then lines up with the intent the user just
- * spelled out — "Встанови бюджет 30k ₴" feels personal in a way that
- * the static-priority "Створи першу звичку" never could for a finance-
- * driven user.
- *
- * Tie-breaking: when more than one goal is set, falls back to
- * `FIRST_ACTION_PRIORITY` (lowest-friction first). Same rule applies
- * to the no-goals path so behaviour is byte-identical to the previous
- * static `pickPrimary` when goals are empty.
- *
- * Always returns a valid `DashboardModuleId` — `routine` when `picks`
- * is empty (lazy users still get a sensible default; matches pre-S2.1).
+ * Thin wrapper over `rankFirstActionCandidates` kept so existing call-sites
+ * that only need the hero id (and don't care about chip ordering or analytics
+ * reason) stay terse. Always returns a valid `DashboardModuleId` — `routine`
+ * when `picks` is empty (lazy users still get a sensible default; matches
+ * pre-S2.1).
  */
 export function pickPrimaryFirstAction(
   picks: readonly string[],
   goals: OnboardingGoals,
 ): DashboardModuleId {
-  const pickSet = new Set(picks);
-
-  // Goal-aware path: any module with an explicit goal beats one without.
-  for (const moduleId of FIRST_ACTION_PRIORITY) {
-    if (!pickSet.has(moduleId)) continue;
-    if (hasGoalFor(moduleId, goals)) return moduleId;
-  }
-
-  // Static fallback: highest-priority pick wins.
-  for (const moduleId of FIRST_ACTION_PRIORITY) {
-    if (pickSet.has(moduleId)) return moduleId;
-  }
-
-  return "routine";
+  return rankFirstActionCandidates(picks, goals).primary;
 }


### PR DESCRIPTION
## Summary

**PR-11** from the [FTUX master tracker](docs/launch/ftux-master-tracker.md) §3.2.

Evolves S2.1 goal-aware first-action to honour the user's explicit vibe-pick order when multiple goals are set, and surfaces a `primary_reason` faceting field to PostHog so the Wave 2 SLO ('per-module first-entry rate variance ↓') can be sliced by selection mode.

### Changes

- **`packages/shared`** — adds `rankFirstActionCandidates(picks, goals)` returning `{primary, reason, others}`. `reason` ∈ `no-picks | single-pick | single-goal | multi-goal-vibe | multi-pick-static`. Tie-break among goal-set picks now honours user's `vibePicks` order rather than static `FIRST_ACTION_PRIORITY`. No-goals path is byte-identical to pre-S2.1. `pickPrimaryFirstAction` becomes a thin wrapper for back-compat.
- **`apps/web/src/core/onboarding/FirstActionSheet.tsx`** — consume the ranking, emit `primary_reason` on `onboarding_first_action_shown` / `_picked`. Chip row uses the ordered `others` (goal-set picks first).
- **`apps/mobile/src/core/dashboard/FirstActionHeroCard.tsx`** — parity update; the `HubDashboard.tsx` caller forwards `primaryReason` through to PostHog as `primary_reason`.

### SLO

Metric per master tracker: **Per-module first-entry rate variance ↓**. The new `primary_reason` faceting lets the SLO dashboard correlate first-entry rate with hero-selection mode (e.g. `multi-goal-vibe` vs `multi-pick-static`).

### Tests

- `packages/shared/src/lib/onboardingGoals.test.ts` — adds 7 cases covering all five reasons, vibe-order tie-break, sanitisation of unknown picks/duplicates.
- `apps/web/src/core/onboarding/FirstActionSheet.test.tsx` — extends two existing tests to assert the new `primary_reason` field.
- `apps/mobile/src/core/dashboard/FirstActionHeroCard.test.tsx` — extends three callsites + adds two new tests for `single-goal` and `multi-goal-vibe` reasons.

All green locally:
- shared: 556/556
- web: 2247/2247
- mobile (FirstActionHeroCard): 14/14
- typecheck across 16 workspaces
- lint

---

Assisted by [Devin](https://app.devin.ai/sessions/f556eed472c648b4aaae181da3729ac5). Requested by @dmytro.s.stakhov.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors the user’s vibe-pick order for first-action when multiple goals are set, adds `primary_reason` to analytics, and orders alt-module chips with goal-set picks first. Updates the FTUX tracker docs.

- **New Features**
  - `packages/shared`: added `rankFirstActionCandidates(picks, goals)` → `{ primary, reason, others }`; reasons: `no-picks | single-pick | single-goal | multi-goal-vibe | multi-pick-static`. Tie-break among goal-set picks now uses the user’s pick order; `others` lists goal-set picks first then non-goal picks (both keep user order). Unknown ids and duplicates are sanitized. `pickPrimaryFirstAction` wraps this for back-compat.
  - `apps/web`: `FirstActionSheet` consumes ranking; emits `primary_reason` on `onboarding_first_action_shown` and `_picked`; chip row uses `others`.
  - `apps/mobile`: `FirstActionHeroCard` + `HubDashboard` consume ranking; forward `primaryReason`/`primary_reason` to PostHog; chip row uses `others`.

- **Migration**
  - No action needed. No-goals path is unchanged; existing `pickPrimaryFirstAction` calls still work. Analytics consumers can optionally read `primary_reason`.

<sup>Written for commit 73e6af29346f702d05e24d59d2419e102b8c25f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

