### PR TITLE
test(web): cover shared/lib/ui/{amountTone,export,perf} (PR-T04)

### DIFF
--- a/apps/web/src/shared/lib/ui/amountTone.test.ts
+++ b/apps/web/src/shared/lib/ui/amountTone.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { signedDeltaClass, transactionAmountClass } from "./amountTone";
+
+describe("signedDeltaClass", () => {
+  it("позитивна дельта → success-strong зі світлим dark-варіантом", () => {
+    expect(signedDeltaClass(1)).toBe("text-success-strong dark:text-success");
+    expect(signedDeltaClass(0.5)).toBe("text-success-strong dark:text-success");
+    expect(signedDeltaClass(Number.MAX_SAFE_INTEGER)).toBe(
+      "text-success-strong dark:text-success",
+    );
+  });
+
+  it("від'ємна дельта → danger без dark-перекриття", () => {
+    expect(signedDeltaClass(-1)).toBe("text-danger");
+    expect(signedDeltaClass(-0.0001)).toBe("text-danger");
+    expect(signedDeltaClass(Number.MIN_SAFE_INTEGER)).toBe("text-danger");
+  });
+
+  it("нуль → muted (нейтрально)", () => {
+    expect(signedDeltaClass(0)).toBe("text-muted");
+  });
+
+  it("−0 трактує як нуль (тут це навмисно — IEEE-754 -0 === 0)", () => {
+    // Це задокументована поведінка: ні `> 0`, ні `< 0` не спрацює,
+    // тому −0 потрапляє у нейтральну гілку.
+    expect(signedDeltaClass(-0)).toBe("text-muted");
+  });
+
+  it("NaN — не позитивне і не від'ємне → muted (fallback гілка)", () => {
+    // Жоден з порівнянь у NaN не true, тож хелпер чесно віддає muted.
+    expect(signedDeltaClass(Number.NaN)).toBe("text-muted");
+  });
+
+  it("Infinity → success, -Infinity → danger", () => {
+    expect(signedDeltaClass(Number.POSITIVE_INFINITY)).toBe(
+      "text-success-strong dark:text-success",
+    );
+    expect(signedDeltaClass(Number.NEGATIVE_INFINITY)).toBe("text-danger");
+  });
+});
+
+describe("transactionAmountClass", () => {
+  it("дохід (>0) → success-strong зі світлим dark-варіантом", () => {
+    expect(transactionAmountClass(0.01)).toBe(
+      "text-success-strong dark:text-success",
+    );
+    expect(transactionAmountClass(1_000_000)).toBe(
+      "text-success-strong dark:text-success",
+    );
+  });
+
+  it("витрата (<0) → нейтральний text-text (не danger)", () => {
+    // Sergeant philosophy: expense ≠ alarm. Лишаємо нейтральним.
+    expect(transactionAmountClass(-0.01)).toBe("text-text");
+    expect(transactionAmountClass(-50_000)).toBe("text-text");
+  });
+
+  it("нульова сума → text-text (не виділяємо)", () => {
+    expect(transactionAmountClass(0)).toBe("text-text");
+    expect(transactionAmountClass(-0)).toBe("text-text");
+  });
+
+  it("NaN → text-text (fallback гілка, не падає)", () => {
+    expect(transactionAmountClass(Number.NaN)).toBe("text-text");
+  });
+
+  it("Infinity → success, -Infinity → text-text", () => {
+    expect(transactionAmountClass(Number.POSITIVE_INFINITY)).toBe(
+      "text-success-strong dark:text-success",
+    );
+    expect(transactionAmountClass(Number.NEGATIVE_INFINITY)).toBe("text-text");
+  });
+});

--- a/apps/web/src/shared/lib/ui/export.test.ts
+++ b/apps/web/src/shared/lib/ui/export.test.ts
@@ -1,0 +1,334 @@
+/** @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  arrayToCSV,
+  dataToHTMLTable,
+  downloadString,
+  exportToCSV,
+  exportToPDF,
+  generatePDFReport,
+  type ExportColumn,
+} from "./export";
+
+type Row = {
+  id: number;
+  name: string;
+  amount: number;
+  meta?: { tag: string };
+} & Record<string, unknown>;
+
+const rows: Row[] = [
+  { id: 1, name: "Aldi", amount: 120.5, meta: { tag: "groceries" } },
+  { id: 2, name: 'Cafe "Lviv"', amount: 65, meta: { tag: "coffee" } },
+  { id: 3, name: "Multi\nline", amount: -10.42 },
+];
+
+const columns: ExportColumn<Row>[] = [
+  { key: "id", header: "ID" },
+  { key: "name", header: "Назва" },
+  { key: "amount", header: "Сума", format: (v) => Number(v).toFixed(2) },
+  { key: "meta.tag", header: "Тег" },
+];
+
+describe("arrayToCSV", () => {
+  it("дефолтний separator — кома, з заголовком", () => {
+    const csv = arrayToCSV(rows, columns);
+    const lines = csv.split("\n");
+    expect(lines[0]).toBe("ID,Назва,Сума,Тег");
+    expect(lines[1]).toBe("1,Aldi,120.50,groceries");
+  });
+
+  it("екранує лапки, коми та переноси рядка", () => {
+    const csv = arrayToCSV(rows, columns);
+    const lines = csv.split("\n");
+    // Cafe "Lviv" — лапки задвоюються, поле в лапках
+    expect(lines[2]).toContain('"Cafe ""Lviv"""');
+    // Multi\nline — поле в лапках бо містить перенос; CSV.split("\n")
+    // фізично розриває такий запис, тому асертимо на raw csv.
+    expect(csv).toContain('"Multi\nline"');
+  });
+
+  it("не екранує значення без спецсимволів", () => {
+    const csv = arrayToCSV(rows, columns);
+    expect(csv).toContain(",groceries\n");
+    expect(csv).not.toContain('"groceries"');
+  });
+
+  it("кастомний separator (`;`) — переекранує тільки за `;`", () => {
+    const data = [{ a: "1;2", b: "no-semi" }];
+    const cols: ExportColumn<(typeof data)[number]>[] = [
+      { key: "a", header: "A" },
+      { key: "b", header: "B" },
+    ];
+    const csv = arrayToCSV(data, cols, { separator: ";" });
+    expect(csv.split("\n")[0]).toBe("A;B");
+    expect(csv.split("\n")[1]).toBe('"1;2";no-semi');
+  });
+
+  it("includeHeader=false — не друкує перший рядок", () => {
+    const csv = arrayToCSV(rows, columns, { includeHeader: false });
+    expect(csv.split("\n")[0]).toBe("1,Aldi,120.50,groceries");
+  });
+
+  it("nested key (`meta.tag`) дістає вкладене значення", () => {
+    const csv = arrayToCSV(rows, columns);
+    expect(csv).toContain("groceries");
+    expect(csv).toContain("coffee");
+  });
+
+  it("nested key для рядка без вкладеного об'єкта — пустий рядок", () => {
+    // У третій row немає meta, тож тег має бути порожній.
+    const csv = arrayToCSV(rows, columns);
+    const last = csv.split("\n").at(-1)!;
+    // Останнє значення — порожнє, тобто рядок завершується розділювачем.
+    expect(last.endsWith(",")).toBe(true);
+  });
+
+  it("null/undefined значення — пустий рядок", () => {
+    const data = [{ a: null, b: undefined }];
+    const cols: ExportColumn<(typeof data)[number]>[] = [
+      { key: "a", header: "A" },
+      { key: "b", header: "B" },
+    ];
+    const csv = arrayToCSV(data, cols);
+    expect(csv.split("\n")[1]).toBe(",");
+  });
+
+  it("порожній набір даних із заголовком — лише заголовковий рядок", () => {
+    expect(arrayToCSV<Row>([], columns)).toBe("ID,Назва,Сума,Тег");
+  });
+});
+
+describe("downloadString / exportToCSV", () => {
+  beforeEach(() => {
+    vi.stubGlobal("URL", {
+      createObjectURL: vi.fn(() => "blob:mock-url"),
+      revokeObjectURL: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("downloadString створює <a> з href, проставляє download та клікає", () => {
+    const clickSpy = vi.fn();
+    const origCreate = document.createElement.bind(document);
+    const createSpy = vi
+      .spyOn(document, "createElement")
+      .mockImplementation((tag: string) => {
+        const el = origCreate(tag);
+        if (tag === "a") {
+          (el as HTMLAnchorElement).click = clickSpy;
+        }
+        return el;
+      });
+
+    downloadString("hello", "file.txt", "text/plain");
+
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+
+    createSpy.mockRestore();
+  });
+
+  it("downloadString дефолтний mime-type — text/plain", () => {
+    const clickSpy = vi.fn();
+    vi.spyOn(document, "createElement").mockImplementation(((tag: string) => {
+      const el = document.implementation
+        .createHTMLDocument()
+        .createElement(tag);
+      if (tag === "a") (el as HTMLAnchorElement).click = clickSpy;
+      return el;
+    }) as typeof document.createElement);
+
+    downloadString("payload", "out.txt");
+    expect(clickSpy).toHaveBeenCalled();
+  });
+
+  it("exportToCSV викликає downloadString з text/csv та переданим filename", () => {
+    const clickSpy = vi.fn();
+    const created: HTMLAnchorElement[] = [];
+    vi.spyOn(document, "createElement").mockImplementation(((tag: string) => {
+      const el = document.implementation
+        .createHTMLDocument()
+        .createElement(tag);
+      if (tag === "a") {
+        (el as HTMLAnchorElement).click = clickSpy;
+        created.push(el as HTMLAnchorElement);
+      }
+      return el;
+    }) as typeof document.createElement);
+
+    exportToCSV(rows, columns, "report.csv");
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(created[0]!.download).toBe("report.csv");
+  });
+
+  it("exportToCSV дефолтний filename — export.csv", () => {
+    const clickSpy = vi.fn();
+    const created: HTMLAnchorElement[] = [];
+    vi.spyOn(document, "createElement").mockImplementation(((tag: string) => {
+      const el = document.implementation
+        .createHTMLDocument()
+        .createElement(tag);
+      if (tag === "a") {
+        (el as HTMLAnchorElement).click = clickSpy;
+        created.push(el as HTMLAnchorElement);
+      }
+      return el;
+    }) as typeof document.createElement);
+
+    exportToCSV(rows, columns);
+    expect(created[0]!.download).toBe("export.csv");
+  });
+});
+
+describe("generatePDFReport", () => {
+  it("включає title, subtitle, всі sections та footer", () => {
+    const html = generatePDFReport({
+      title: "Звіт",
+      subtitle: "квітень 2026",
+      sections: [
+        { title: "Доходи", content: "<p>+1000</p>" },
+        { title: "Витрати", content: "<p>-500</p>" },
+      ],
+      footerText: "Sergeant",
+    });
+    expect(html).toContain("<h1>Звіт</h1>");
+    expect(html).toContain("квітень 2026");
+    expect(html).toContain("Доходи");
+    expect(html).toContain("Витрати");
+    expect(html).toContain("+1000");
+    expect(html).toContain("Sergeant");
+  });
+
+  it("підтримує HTMLElement як content — серіалізує через outerHTML", () => {
+    const div = document.createElement("div");
+    div.innerHTML = "<span>elem</span>";
+    const html = generatePDFReport({
+      title: "T",
+      sections: [{ title: "Sec", content: div }],
+    });
+    expect(html).toContain("<div><span>elem</span></div>");
+  });
+
+  it("dark theme — тло #1a1a1a", () => {
+    const html = generatePDFReport({
+      title: "T",
+      sections: [],
+      theme: "dark",
+    });
+    expect(html).toContain("background: #1a1a1a");
+    expect(html).toContain("color: #e5e5e5");
+  });
+
+  it("light theme (default) — тло #ffffff", () => {
+    const html = generatePDFReport({ title: "T", sections: [] });
+    expect(html).toContain("background: #ffffff");
+    expect(html).toContain("color: #1a1a1a");
+  });
+
+  it("logo — додає <img src=…>", () => {
+    const html = generatePDFReport({
+      title: "T",
+      sections: [],
+      logo: "https://example.com/l.png",
+    });
+    expect(html).toContain('<img src="https://example.com/l.png"');
+  });
+
+  it("без logo — секцію <img> не додає", () => {
+    const html = generatePDFReport({ title: "T", sections: [] });
+    expect(html).not.toContain("<img");
+  });
+
+  it("без footerText — підставляє локалізовану дату/час uk-UA", () => {
+    const html = generatePDFReport({ title: "T", sections: [] });
+    expect(html).toMatch(/Згенеровано .+ о .+/);
+  });
+});
+
+describe("exportToPDF", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("відкриває нове вікно, пише HTML і запускає print після onload", () => {
+    const printSpy = vi.fn();
+    const focusSpy = vi.fn();
+    const writeSpy = vi.fn();
+    const closeSpy = vi.fn();
+
+    const fakeWindow = {
+      document: { write: writeSpy, close: closeSpy },
+      onload: null as (() => void) | null,
+      focus: focusSpy,
+      print: printSpy,
+    };
+
+    vi.spyOn(window, "open").mockReturnValue(
+      fakeWindow as unknown as Window & typeof globalThis,
+    );
+
+    exportToPDF({
+      title: "Report",
+      sections: [{ title: "X", content: "<p>x</p>" }],
+    });
+
+    expect(window.open).toHaveBeenCalledWith("", "_blank");
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+
+    // onload встановлено — стрельнемо вручну.
+    expect(typeof fakeWindow.onload).toBe("function");
+    fakeWindow.onload!();
+    expect(focusSpy).toHaveBeenCalledTimes(1);
+    expect(printSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("якщо window.open повернув null — нічого не падає", () => {
+    vi.spyOn(window, "open").mockReturnValue(null);
+    expect(() => exportToPDF({ title: "T", sections: [] })).not.toThrow();
+  });
+});
+
+describe("dataToHTMLTable", () => {
+  it("рендерить thead + tbody з усіма рядками", () => {
+    const html = dataToHTMLTable(rows, columns);
+    expect(html).toContain("<th>ID</th>");
+    expect(html).toContain("<th>Назва</th>");
+    expect(html).toContain("<td>Aldi</td>");
+    // Custom format на amount → 120.50 (2 знаки)
+    expect(html).toContain("<td>120.50</td>");
+  });
+
+  it("nested key (`meta.tag`) — дістає значення", () => {
+    const html = dataToHTMLTable(rows, columns);
+    expect(html).toContain("<td>groceries</td>");
+    expect(html).toContain("<td>coffee</td>");
+  });
+
+  it("null/undefined → порожня клітинка (без 'undefined' тексту)", () => {
+    const data = [{ a: null, b: undefined }];
+    const cols: ExportColumn<(typeof data)[number]>[] = [
+      { key: "a", header: "A" },
+      { key: "b", header: "B" },
+    ];
+    const html = dataToHTMLTable(data, cols);
+    expect(html).toContain("<td></td><td></td>");
+    expect(html).not.toContain("undefined");
+  });
+
+  it("порожній dataset — лише header, рядків нема", () => {
+    const html = dataToHTMLTable<Row>([], columns);
+    expect(html).toContain("<thead>");
+    expect(html).toContain("<th>ID</th>");
+    // tbody присутній, але без <tr>.
+    const tbody = html.split("<tbody>")[1]!.split("</tbody>")[0]!;
+    expect(tbody.trim()).toBe("");
+  });
+});

--- a/apps/web/src/shared/lib/ui/perf.test.ts
+++ b/apps/web/src/shared/lib/ui/perf.test.ts
@@ -1,0 +1,93 @@
+/** @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { perfEnd, perfMark } from "./perf";
+
+describe("perfMark / perfEnd", () => {
+  beforeEach(() => {
+    // Reset localStorage між тестами щоб гілки isPerfEnabled() не текли.
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  describe("без `hub_perf=1` у localStorage", () => {
+    it("perfMark повертає null", () => {
+      expect(perfMark("anything")).toBeNull();
+    });
+
+    it("perfEnd на null-mark — no-op, повертає undefined", () => {
+      expect(perfEnd(null)).toBeUndefined();
+    });
+
+    it("perfEnd на навіть валідній mark — теж no-op (немає flag-а)", () => {
+      // Створюємо mark "вручну" як було б, якби flag був раніше.
+      const fakeMark = { name: "x", t: performance.now() };
+      expect(perfEnd(fakeMark)).toBeUndefined();
+    });
+  });
+
+  describe("з увімкненим `hub_perf=1`", () => {
+    beforeEach(() => {
+      window.localStorage.setItem("hub_perf", "1");
+    });
+
+    it("perfMark повертає об'єкт із name та numeric t", () => {
+      const mark = perfMark("hub-load");
+      expect(mark).not.toBeNull();
+      expect(mark).toMatchObject({ name: "hub-load" });
+      expect(typeof mark!.t).toBe("number");
+      expect(Number.isFinite(mark!.t)).toBe(true);
+    });
+
+    it("perfEnd друкує до console.debug і повертає додатню дельту", () => {
+      const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+
+      const nowSpy = vi.spyOn(performance, "now");
+      nowSpy.mockReturnValueOnce(1000); // perfMark() reads
+      nowSpy.mockReturnValueOnce(1042.5); // perfEnd() reads
+
+      const mark = perfMark("op");
+      const dt = perfEnd(mark, { extra: 1 });
+
+      expect(dt).toBeCloseTo(42.5, 5);
+      expect(debugSpy).toHaveBeenCalledTimes(1);
+      const [msg, extra] = debugSpy.mock.calls[0]!;
+      expect(msg).toContain("[perf] op:");
+      expect(msg).toContain("42.5ms");
+      expect(extra).toEqual({ extra: 1 });
+    });
+
+    it("perfEnd без extra підставляє порожній рядок у лог", () => {
+      const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+      const mark = perfMark("op2");
+      perfEnd(mark);
+      expect(debugSpy).toHaveBeenCalledTimes(1);
+      const args = debugSpy.mock.calls[0]!;
+      expect(args[1]).toBe("");
+    });
+
+    it("ковтає винятки з console.debug і все одно повертає дельту", () => {
+      vi.spyOn(console, "debug").mockImplementation(() => {
+        throw new Error("console wedge");
+      });
+      const nowSpy = vi.spyOn(performance, "now");
+      nowSpy.mockReturnValueOnce(0);
+      nowSpy.mockReturnValueOnce(7);
+
+      const mark = perfMark("safe");
+      // Має не кинути попри console-wedge.
+      const dt = perfEnd(mark);
+      expect(dt).toBe(7);
+    });
+
+    it("perfEnd на null-mark — no-op навіть з flag-ом", () => {
+      const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+      expect(perfEnd(null)).toBeUndefined();
+      expect(debugSpy).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Реалізація **PR-T04** з [`docs/testing/2026-05-05-tests-pr-plan.md`](https://github.com/Skords-01/Sergeant/blob/main/docs/testing/2026-05-05-tests-pr-plan.md). Три pure-utility файли під `apps/web/src/shared/lib/ui/` мали 0% coverage кожен — це разом із `sergeantDb.ts` (закрив [#1971](https://github.com/Skords-01/Sergeant/pull/1971)) було головним рушієм просідання web coverage 2026-04-25 → 2026-05-05, явно зафіксованим у drift log `apps/web/vitest.config.js`.

- `amountTone.test.ts` — `signedDeltaClass` + `transactionAmountClass` на кожній гілці: positive / negative / zero / `-0` / `NaN` / `+Infinity` / `-Infinity`. Документує Sergeant tone-філософію (expense ≠ alarm-red).
- `perf.test.ts` — `perfMark` / `perfEnd` happy + disabled paths, `console.debug` throw swallow, `performance.now` мокається для детермінованої дельти, `localStorage.hub_perf=1` toggle обидва напрями.
- `export.test.ts` — `arrayToCSV` (separator / quoting / newlines / nested keys / empty data), `downloadString` + `exportToCSV` (Blob, `URL.createObjectURL`, anchor click), `generatePDFReport` (light/dark/logo/footer/HTMLElement content), `exportToPDF` (`window.open` + `onload` + null-window fallback), `dataToHTMLTable` (header + rows + null cells).

Coverage по трьох цільових файлах: **100% lines / branches / functions / statements** (було 0% / 0% / 0% / 0%). Жодних змін у source — лише нові тести.

Web vitest floors у цьому PR не рухаю — наступний ratchet піде разом із подальшими PR-T05+ (drift log named `shared-lib-ui` як один із залишкових просіданців).

## Governing Skill

- Primary skill: `.agents/skills/sergeant-test-stack/SKILL.md` (web vitest + RTL/jsdom)
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: `docs/playbooks/coverage-ratchet.md` (за духом — додавання тестів під drift-log named surfaces)
- Why this playbook: PR з плану explicitly націлений на лікування web coverage drift — drift log у `vitest.config.js` уже named ці три файли як залишкові 0%-поверхні.
- If no playbook matched, why: n/a

## Verification

```bash
pnpm --filter @sergeant/web exec vitest run \
  src/shared/lib/ui/amountTone.test.ts \
  src/shared/lib/ui/perf.test.ts \
  src/shared/lib/ui/export.test.ts
# Test Files  3 passed (3)
#       Tests 45 passed (45)

pnpm --filter @sergeant/web exec vitest run --coverage \
  src/shared/lib/ui/amountTone.test.ts \
  src/shared/lib/ui/perf.test.ts \
  src/shared/lib/ui/export.test.ts \
  --coverage.include='src/shared/lib/ui/amountTone.ts' \
  --coverage.include='src/shared/lib/ui/export.ts' \
  --coverage.include='src/shared/lib/ui/perf.ts'
# Statements   : 100% ( 79/79 )
# Branches     : 100% ( 67/67 )
# Functions    : 100% (  22/22 )
# Lines        : 100% ( 73/73 )

pnpm --filter @sergeant/web typecheck   # OK
pnpm exec eslint apps/web/src/shared/lib/ui/{amountTone,export,perf}.test.ts  # clean
pnpm exec prettier --check apps/web/src/shared/lib/ui/{amountTone,export,perf}.test.ts  # clean
```

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a — окремий docs PR для оновлення `docs/testing/2026-05-05-tests-pr-plan.md` під новий статус піде після merge цього PR (разом із PR-T05 та PR-T06 з тієї ж серії).

## Risk and Rollout

- User-visible risk: none — лише тести, source без змін.
- Rollout / deploy order: standard, після CI green.
- Backout plan: revert commit; жодних runtime-залежностей.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

- `Row` у `export.test.ts` оголошений як `… & Record<string, unknown>` щоб задовольнити generic constraint `T extends Record<string, unknown>` у `arrayToCSV`/`dataToHTMLTable` (інакше TS2344/2345). Це лише test-side type-massage, не торкається `export.ts`.
- `perf.test.ts` мокає `performance.now` через `vi.spyOn(...).mockReturnValueOnce(...)` двічі для детермінованої дельти — типово для shared lib тестів у репо.
- `export.test.ts` мокає `URL.createObjectURL`, `document.createElement('a')` (зі `click` спай), `window.open` для перевірки exportToPDF / exportToCSV без реального DOM-завантаження.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests for `apps/web/src/shared/lib/ui/{amountTone,export,perf}` to raise coverage from 0% to 100% and harden CSV/PDF/HTML export and perf timing paths. Exercises all branches (±, 0/-0/NaN/±∞), the `localStorage` perf flag, and `URL.createObjectURL`/`window.open` fallbacks; source code unchanged.

<sup>Written for commit bc2ca67211c74d5415d4d3d1034df8b5bb7a1166. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

