### PR TITLE
test(server): cover digest/weekly-digest handler (PR-T05)

### DIFF
--- a/apps/server/src/modules/digest/weekly-digest.test.ts
+++ b/apps/server/src/modules/digest/weekly-digest.test.ts
@@ -1,0 +1,603 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Mock } from "vitest";
+import type { Request, Response } from "express";
+
+vi.mock("../../lib/anthropic.js", () => ({
+  anthropicMessages: vi.fn(),
+  extractAnthropicText: vi.fn(
+    (d: { content?: { type: string; text?: string }[] }) =>
+      (d?.content || [])
+        .filter((b) => b.type === "text")
+        .map((b) => b.text ?? "")
+        .join("\n")
+        .trim(),
+  ),
+}));
+
+vi.mock("../ai-memory/ingestQueue.js", () => ({
+  enqueueMemoryIngest: vi.fn(async () => undefined),
+}));
+
+import { anthropicMessages as _anthropicMessages } from "../../lib/anthropic.js";
+import { enqueueMemoryIngest as _enqueueMemoryIngest } from "../ai-memory/ingestQueue.js";
+import handler from "./weekly-digest.js";
+import { ExternalServiceError, ValidationError } from "../../obs/errors.js";
+
+const anthropicMessages = _anthropicMessages as unknown as Mock;
+const enqueueMemoryIngest = _enqueueMemoryIngest as unknown as Mock;
+
+interface TestRes {
+  statusCode: number;
+  body: unknown;
+  status(code: number): TestRes;
+  json(payload: unknown): TestRes;
+}
+
+function makeRes(): TestRes & Response {
+  const res: TestRes = {
+    statusCode: 200,
+    body: undefined,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+  };
+  return res as TestRes & Response;
+}
+
+interface ReqShape {
+  body: Record<string, unknown>;
+  anthropicKey?: string;
+  user?: { id: string };
+}
+
+function asReq(v: ReqShape): Request {
+  return v as unknown as Request;
+}
+
+const validReport = {
+  finyk: {
+    summary: "Витрати тижня в межах бюджету.",
+    comment: "Топ-категорія — продукти, але без різких аномалій.",
+    recommendations: ["Збережи темп витрат", "Перевір категорію 'кава'"],
+  },
+  fizruk: null,
+  nutrition: null,
+  routine: null,
+  overallRecommendations: ["Підвищ дисципліну сну"],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("weekly-digest handler · validation", () => {
+  it("400 коли body не валідне (заборонене поле або неправильний тип)", async () => {
+    const req = asReq({
+      anthropicKey: "k",
+      body: { weekRange: 1 as unknown as string }, // weekRange має бути string
+    });
+    const res = makeRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(anthropicMessages).not.toHaveBeenCalled();
+    expect((res.body as { error: string }).error).toBe(
+      "Некоректні дані запиту",
+    );
+  });
+
+  it("ValidationError якщо немає жодної секції (порожній звіт)", async () => {
+    const req = asReq({ anthropicKey: "k", body: { weekRange: "2026-W01" } });
+    const res = makeRes();
+
+    await expect(handler(req, res)).rejects.toBeInstanceOf(ValidationError);
+    expect(anthropicMessages).not.toHaveBeenCalled();
+  });
+});
+
+describe("weekly-digest handler · prompt assembly", () => {
+  function setupAnthropicSuccess(report: unknown = validReport) {
+    anthropicMessages.mockResolvedValue({
+      response: { ok: true, status: 200 } as unknown as Response,
+      data: {
+        content: [{ type: "text", text: JSON.stringify(report) }],
+      },
+    });
+  }
+
+  it("finyk-секція додає всі поля у системний промпт", async () => {
+    setupAnthropicSuccess();
+    const req = asReq({
+      anthropicKey: "k",
+      body: {
+        weekRange: "2026-W01",
+        finyk: {
+          totalSpent: 1200,
+          totalIncome: 4000,
+          monthlyBudget: 8000,
+          txCount: 42,
+          topCategories: [
+            { name: "Продукти", amount: 600 },
+            { name: "Транспорт", amount: 200 },
+          ],
+        },
+      },
+    });
+    const res = makeRes();
+
+    await handler(req, res);
+
+    expect(anthropicMessages).toHaveBeenCalledTimes(1);
+    const [, payload] = anthropicMessages.mock.calls[0]!;
+    expect(payload.model).toBe("claude-sonnet-4-6");
+    expect(payload.max_tokens).toBe(2500);
+    expect(payload.system).toContain("ФІНАНСИ (2026-W01)");
+    expect(payload.system).toContain("Витрати: 1200 грн");
+    expect(payload.system).toContain("Місячний бюджет: 8000 грн");
+    expect(payload.system).toContain("Продукти: 600 грн");
+    expect(payload.system).toContain("Транзакцій: 42");
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("finyk без monthlyBudget — рядок 'не встановлено'; пусті topCategories — 'Немає даних'", async () => {
+    setupAnthropicSuccess();
+    const req = asReq({
+      anthropicKey: "k",
+      body: { finyk: { totalSpent: 0, totalIncome: 0, txCount: 0 } },
+    });
+    const res = makeRes();
+    await handler(req, res);
+    const [, payload] = anthropicMessages.mock.calls[0]!;
+    expect(payload.system).toContain("Місячний бюджет: не встановлено");
+    expect(payload.system).toContain("Топ категорії витрат:\n  Немає даних");
+    expect(payload.system).toContain("ФІНАНСИ (тиждень)"); // weekRange fallback
+  });
+
+  it("fizruk-секція з топ-вправами рендериться повністю", async () => {
+    setupAnthropicSuccess();
+    const req = asReq({
+      anthropicKey: "k",
+      body: {
+        weekRange: "2026-W02",
+        fizruk: {
+          workoutsCount: 4,
+          totalVolume: 5400,
+          recoveryLabel: "Помірне",
+          topExercises: [
+            { name: "Squat", totalVolume: 2200 },
+            { name: "Bench", totalVolume: 1800 },
+          ],
+        },
+      },
+    });
+    const res = makeRes();
+    await handler(req, res);
+    const [, payload] = anthropicMessages.mock.calls[0]!;
+    expect(payload.system).toContain("Тренувань завершено: 4");
+    expect(payload.system).toContain("Загальний об'єм: 5400 кг");
+    expect(payload.system).toContain("Squat: 2200 кг");
+    expect(payload.system).toContain("Стан відновлення: Помірне");
+  });
+
+  it("nutrition: дефіцит / профіцит / баланс — три гілки", async () => {
+    setupAnthropicSuccess();
+
+    // Дефіцит (target=2000, avg=1500 → 500 ккал deficit)
+    let req = asReq({
+      anthropicKey: "k",
+      body: { nutrition: { avgKcal: 1500, targetKcal: 2000 } },
+    });
+    let res = makeRes();
+    await handler(req, res);
+    expect(anthropicMessages.mock.calls.at(-1)![1].system).toContain(
+      "дефіцит 500 ккал",
+    );
+
+    // Профіцит (target=2000, avg=2600 → -600 ккал, i.e. surplus)
+    req = asReq({
+      anthropicKey: "k",
+      body: { nutrition: { avgKcal: 2600, targetKcal: 2000 } },
+    });
+    res = makeRes();
+    await handler(req, res);
+    expect(anthropicMessages.mock.calls.at(-1)![1].system).toContain(
+      "профіцит 600 ккал",
+    );
+
+    // Баланс (target=2000, avg=2010 → -10, |10| <= 50)
+    req = asReq({
+      anthropicKey: "k",
+      body: { nutrition: { avgKcal: 2010, targetKcal: 2000 } },
+    });
+    res = makeRes();
+    await handler(req, res);
+    expect(anthropicMessages.mock.calls.at(-1)![1].system).toContain("баланс");
+  });
+
+  it("routine: пусті habits → 'Немає активних звичок'; з habits — рядок з %", async () => {
+    setupAnthropicSuccess();
+
+    let req = asReq({
+      anthropicKey: "k",
+      body: { routine: { overallRate: 0, habitCount: 0 } },
+    });
+    let res = makeRes();
+    await handler(req, res);
+    expect(anthropicMessages.mock.calls.at(-1)![1].system).toContain(
+      "Немає активних звичок",
+    );
+
+    req = asReq({
+      anthropicKey: "k",
+      body: {
+        routine: {
+          overallRate: 71,
+          habitCount: 2,
+          habits: [
+            { name: "Біг", completionRate: 80, done: 4, total: 5 },
+            { name: "Йога", completionRate: 60, done: 3, total: 5 },
+          ],
+        },
+      },
+    });
+    res = makeRes();
+    await handler(req, res);
+    const sys = anthropicMessages.mock.calls.at(-1)![1].system;
+    expect(sys).toContain("Загальний відсоток: 71%");
+    expect(sys).toContain("Біг: 80% (4/5 днів)");
+    expect(sys).toContain("Йога: 60% (3/5 днів)");
+  });
+});
+
+describe("weekly-digest handler · response & errors", () => {
+  it("успіх: 200 з { report, generatedAt }", async () => {
+    anthropicMessages.mockResolvedValue({
+      response: { ok: true, status: 200 } as unknown as Response,
+      data: { content: [{ type: "text", text: JSON.stringify(validReport) }] },
+    });
+    const req = asReq({
+      anthropicKey: "k",
+      body: {
+        weekRange: "2026-W01",
+        finyk: { totalSpent: 1, totalIncome: 1, txCount: 0 },
+      },
+    });
+    const res = makeRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    const body = res.body as { report: unknown; generatedAt: string };
+    expect(body.report).toEqual(validReport);
+    expect(body.generatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("ExternalServiceError 502 ANTHROPIC_ERROR коли Anthropic !ok", async () => {
+    anthropicMessages.mockResolvedValue({
+      response: { ok: false, status: 503 } as unknown as Response,
+      data: { error: { message: "overloaded" } },
+    });
+    const req = asReq({
+      anthropicKey: "k",
+      body: { finyk: { totalSpent: 0, totalIncome: 0, txCount: 0 } },
+    });
+    const res = makeRes();
+
+    await expect(handler(req, res)).rejects.toMatchObject({
+      name: "ExternalServiceError",
+      status: 503,
+      code: "ANTHROPIC_ERROR",
+      message: "overloaded",
+    });
+  });
+
+  it("ExternalServiceError fallback 'AI error' з status=502 коли response взагалі немає", async () => {
+    anthropicMessages.mockResolvedValue({
+      response: null,
+      data: null,
+    });
+    const req = asReq({
+      anthropicKey: "k",
+      body: { finyk: { totalSpent: 0, totalIncome: 0, txCount: 0 } },
+    });
+    const res = makeRes();
+
+    await expect(handler(req, res)).rejects.toMatchObject({
+      name: "ExternalServiceError",
+      status: 502,
+      code: "ANTHROPIC_ERROR",
+      message: "AI error",
+    });
+  });
+
+  it("ANTHROPIC_PARSE_ERROR коли LLM повертає не-JSON", async () => {
+    anthropicMessages.mockResolvedValue({
+      response: { ok: true, status: 200 } as unknown as Response,
+      data: { content: [{ type: "text", text: "просто текст без JSON" }] },
+    });
+    const req = asReq({
+      anthropicKey: "k",
+      body: { finyk: { totalSpent: 0, totalIncome: 0, txCount: 0 } },
+    });
+    const res = makeRes();
+
+    await expect(handler(req, res)).rejects.toMatchObject({
+      name: "ExternalServiceError",
+      status: 502,
+      code: "ANTHROPIC_PARSE_ERROR",
+    });
+  });
+
+  it("ANTHROPIC_PARSE_ERROR на незбалансованій { (fallback гілка теж кидає null)", async () => {
+    // Lone '{' ніколи не закриється, цикл завершиться з depth=1, далі
+    // fallback `JSON.parse(text.slice(start))` теж кидає → return null.
+    anthropicMessages.mockResolvedValue({
+      response: { ok: true, status: 200 } as unknown as Response,
+      data: {
+        content: [{ type: "text", text: 'before { "x": 1 ' }],
+      },
+    });
+    const req = asReq({
+      anthropicKey: "k",
+      body: { finyk: { totalSpent: 0, totalIncome: 0, txCount: 0 } },
+    });
+    const res = makeRes();
+
+    await expect(handler(req, res)).rejects.toMatchObject({
+      code: "ANTHROPIC_PARSE_ERROR",
+      status: 502,
+    });
+  });
+
+  it("extractAnthropicText повертає не-string (e.g. null) → ANTHROPIC_PARSE_ERROR", async () => {
+    // Імітуємо ситуацію, коли LLM віддає одну порожню/non-text-блочну
+    // відповідь — extractAnthropicText дає '' → extractJsonObject отримує
+    // string, не знаходить '{', повертає null.
+    anthropicMessages.mockResolvedValue({
+      response: { ok: true, status: 200 } as unknown as Response,
+      data: { content: [] },
+    });
+    const req = asReq({
+      anthropicKey: "k",
+      body: { finyk: { totalSpent: 0, totalIncome: 0, txCount: 0 } },
+    });
+    const res = makeRes();
+    await expect(handler(req, res)).rejects.toMatchObject({
+      code: "ANTHROPIC_PARSE_ERROR",
+    });
+  });
+
+  it("ANTHROPIC_SHAPE_MISMATCH коли JSON валідний, але не пройшов schema", async () => {
+    anthropicMessages.mockResolvedValue({
+      response: { ok: true, status: 200 } as unknown as Response,
+      data: {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              finyk: null,
+              fizruk: null,
+              nutrition: null,
+              routine: null,
+              // overallRecommendations missing → schema fails
+            }),
+          },
+        ],
+      },
+    });
+    const req = asReq({
+      anthropicKey: "k",
+      body: { finyk: { totalSpent: 0, totalIncome: 0, txCount: 0 } },
+    });
+    const res = makeRes();
+
+    await expect(handler(req, res)).rejects.toMatchObject({
+      name: "ExternalServiceError",
+      status: 502,
+      code: "ANTHROPIC_SHAPE_MISMATCH",
+    });
+  });
+
+  it("```json fence обгортка — успішно витягується", async () => {
+    anthropicMessages.mockResolvedValue({
+      response: { ok: true, status: 200 } as unknown as Response,
+      data: {
+        content: [
+          {
+            type: "text",
+            text:
+              "Ось звіт:\n```json\n" + JSON.stringify(validReport) + "\n```",
+          },
+        ],
+      },
+    });
+    const req = asReq({
+      anthropicKey: "k",
+      body: { finyk: { totalSpent: 0, totalIncome: 0, txCount: 0 } },
+    });
+    const res = makeRes();
+
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("вкладені {} та екранування у рядках — теж парсяться", async () => {
+    const reportWithBraces = {
+      ...validReport,
+      finyk: {
+        summary: "Зовсім без { }",
+        comment: 'A "quoted" \\\\backslash text {with} brackets',
+        recommendations: ["{nested object} hint", 'with "quotes"'],
+      },
+    };
+    anthropicMessages.mockResolvedValue({
+      response: { ok: true, status: 200 } as unknown as Response,
+      data: {
+        content: [
+          {
+            type: "text",
+            text:
+              "Префіксна болтанка перед JSON: " +
+              JSON.stringify(reportWithBraces) +
+              " — і трейл після",
+          },
+        ],
+      },
+    });
+    const req = asReq({
+      anthropicKey: "k",
+      body: { finyk: { totalSpent: 0, totalIncome: 0, txCount: 0 } },
+    });
+    const res = makeRes();
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+  });
+});
+
+describe("weekly-digest handler · memory ingest hook", () => {
+  function setupOK() {
+    anthropicMessages.mockResolvedValue({
+      response: { ok: true, status: 200 } as unknown as Response,
+      data: { content: [{ type: "text", text: JSON.stringify(validReport) }] },
+    });
+  }
+
+  it("anonymous (без user) — НЕ enqueue-ить memory", async () => {
+    setupOK();
+    const req = asReq({
+      anthropicKey: "k",
+      body: {
+        weekRange: "2026-W01",
+        finyk: { totalSpent: 1, totalIncome: 1, txCount: 0 },
+      },
+    });
+    const res = makeRes();
+    await handler(req, res);
+    expect(enqueueMemoryIngest).not.toHaveBeenCalled();
+  });
+
+  it("без weekRange (e.g. ad-hoc digest) — НЕ enqueue-ить memory", async () => {
+    setupOK();
+    const req = asReq({
+      anthropicKey: "k",
+      user: { id: "user_42" },
+      body: { finyk: { totalSpent: 1, totalIncome: 1, txCount: 0 } },
+    });
+    const res = makeRes();
+    await handler(req, res);
+    expect(enqueueMemoryIngest).not.toHaveBeenCalled();
+  });
+
+  it("user + weekRange — enqueue-ить content який злитий з усіх секцій", async () => {
+    setupOK();
+    const req = asReq({
+      anthropicKey: "k",
+      user: { id: "user_42" },
+      body: {
+        weekRange: "2026-W01",
+        finyk: { totalSpent: 1, totalIncome: 1, txCount: 0 },
+        nutrition: { avgKcal: 2000, targetKcal: 2000 },
+      },
+    });
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(enqueueMemoryIngest).toHaveBeenCalledTimes(1);
+    const payload = enqueueMemoryIngest.mock.calls[0]![0];
+    expect(payload.userId).toBe("user_42");
+    expect(payload.source).toBe("digest");
+    expect(payload.sourceRef).toBe("2026-W01");
+    expect(payload.content).toContain("Тижневий звіт 2026-W01");
+    expect(payload.content).toContain("finyk:");
+    expect(payload.content).toContain("overall:");
+    expect(payload.metadata.weekRange).toBe("2026-W01");
+    expect(payload.metadata.sections.finyk).toBe(true);
+    expect(payload.metadata.sections.fizruk).toBe(false);
+    expect(payload.metadata.sections.nutrition).toBe(true);
+    expect(payload.metadata.sections.routine).toBe(false);
+  });
+
+  it("memory-content усікається до AI_MEMORY_INGEST_MAX_CONTENT_LEN", async () => {
+    // Підставимо AI report з дуже довгими рядками — вийде >> 4000 символів.
+    const longText = "X".repeat(490);
+    const fattyReport = {
+      finyk: {
+        summary: longText,
+        comment: longText,
+        recommendations: [longText, longText],
+      },
+      fizruk: {
+        summary: longText,
+        comment: longText,
+        recommendations: [longText],
+      },
+      nutrition: {
+        summary: longText,
+        comment: longText,
+        recommendations: [longText],
+      },
+      routine: {
+        summary: longText,
+        comment: longText,
+        recommendations: [longText],
+      },
+      overallRecommendations: [longText, longText, longText],
+    };
+    anthropicMessages.mockResolvedValue({
+      response: { ok: true, status: 200 } as unknown as Response,
+      data: {
+        content: [{ type: "text", text: JSON.stringify(fattyReport) }],
+      },
+    });
+    const req = asReq({
+      anthropicKey: "k",
+      user: { id: "u" },
+      body: {
+        weekRange: "2026-W01",
+        finyk: { totalSpent: 0, totalIncome: 0, txCount: 0 },
+      },
+    });
+    const res = makeRes();
+    await handler(req, res);
+
+    const payload = enqueueMemoryIngest.mock.calls[0]![0];
+    // env.AI_MEMORY_INGEST_MAX_CONTENT_LEN default = 4000.
+    expect(payload.content.length).toBeLessThanOrEqual(4_000);
+    expect(payload.content.length).toBeGreaterThan(3_000);
+  });
+
+  it("викидання у buildDigestMemoryContent (через зіпсований report) — не валить response", async () => {
+    setupOK();
+    enqueueMemoryIngest.mockImplementationOnce(() => {
+      throw new Error("synchronous boom");
+    });
+
+    const req = asReq({
+      anthropicKey: "k",
+      user: { id: "u" },
+      body: {
+        weekRange: "2026-W01",
+        finyk: { totalSpent: 0, totalIncome: 0, txCount: 0 },
+      },
+    });
+    const res = makeRes();
+
+    // Має дописати 200 і не кинути назовні.
+    await expect(handler(req, res)).resolves.toBeUndefined();
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("ExternalServiceError тип — це справжній клас (не дубль)", () => {
+    // Sanity, щоб refactor-и не змінили expression тестів вище:
+    const e = new ExternalServiceError("x", { status: 502, code: "Y" });
+    expect(e).toBeInstanceOf(ExternalServiceError);
+    expect(e.status).toBe(502);
+    expect(e.code).toBe("Y");
+  });
+});


### PR DESCRIPTION
## Summary

Реалізація **PR-T05** з [`docs/testing/2026-05-05-tests-pr-plan.md`](https://github.com/Skords-01/Sergeant/blob/main/docs/testing/2026-05-05-tests-pr-plan.md). `weekly-digest.ts` — один із двох великих серверних файлів з ~0-1% coverage (другий — `syncV2.ts`, окремий PR-T06). Drift log у `apps/server/vitest.config.ts` назвав цей файл як один із рушіїв падіння серверного coverage 2026-04-25 → 2026-05-05.

22 тести розбиті на 4 describe-блоки:

1. **Validation** (2 tests): невалідне тіло → 400 + Anthropic не званий; порожній звіт (жодної секції) → `ValidationError`.
2. **Prompt assembly** (5 tests): кожна модульна секція (finyk, fizruk, nutrition, routine) окремо; finyk без `monthlyBudget` / порожні `topCategories`; nutrition deficit/surplus/balance три гілки; routine з habits та без.
3. **Response & errors** (9 tests): happy-path 200 з `{ report, generatedAt }`; Anthropic `!ok` → `ExternalServiceError` з правильним status/code; response=null fallback; не-JSON відповідь → `ANTHROPIC_PARSE_ERROR`; незбалансований `{` (fallback JSON.parse гілка); порожній content; schema-mismatch → `ANTHROPIC_SHAPE_MISMATCH`; `\`\`\`json` fence → успіх; вкладені `{}` + escape → успіх.
4. **Memory ingest hook** (6 tests): анон-юзер (без `user`) → пропуск; без `weekRange` → пропуск; `user` + `weekRange` → enqueue із перевіркою `userId`, `source`, `sourceRef`, `content`, `metadata.sections`; content cap до `AI_MEMORY_INGEST_MAX_CONTENT_LEN` (4000); синхронний throw у `enqueueMemoryIngest` → response 200 не падає; sanity на `ExternalServiceError` клас.

Coverage на `weekly-digest.ts`: **95.19% stmts / 82.81% branches / 100% fns / 95.65% lines** (було ~0%). Жодних змін у source. `anthropicMessages` та `enqueueMemoryIngest` мокані (vi.mock).

## Governing Skill

- Primary skill: `.agents/skills/sergeant-test-stack/SKILL.md` (server vitest)
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: `docs/playbooks/coverage-ratchet.md`
- Why this playbook: drift log у `vitest.config.ts` named `weekly-digest.ts` як 0-1% covered; план (PR-T05) — покрити його.
- If no playbook matched, why: n/a

## Verification

```bash
pnpm --filter @sergeant/server exec vitest run \
  src/modules/digest/weekly-digest.test.ts
# Test Files  1 passed (1)
#       Tests 22 passed (22)

pnpm --filter @sergeant/server exec vitest run --coverage \
  src/modules/digest/weekly-digest.test.ts \
  --coverage.include='src/modules/digest/weekly-digest.ts'
# Statements   : 95.19% ( 99/104 )
# Branches     : 82.81% ( 106/128 )
# Functions    : 100% ( 7/7 )
# Lines        : 95.65% ( 88/92 )

pnpm exec eslint apps/server/src/modules/digest/weekly-digest.test.ts  # clean
pnpm exec prettier --check apps/server/src/modules/digest/weekly-digest.test.ts  # clean

# NOTE: `tsc --noEmit` has 2 pre-existing errors on main
# (drizzle.ts + waitlistService.ts → @sergeant/db-schema/pg).
# This PR does not introduce new TS errors.
```

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a — оновлення `docs/testing/` піде окремим PR після merge серії T04-T06.

## Risk and Rollout

- User-visible risk: none — лише тести, source без змін.
- Rollout / deploy order: standard, після CI green.
- Backout plan: revert commit; жодних runtime-залежностей.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

- `anthropicMessages` мокається повністю (vi.mock). `extractAnthropicText` — дзеркало реальної реалізації (filter type=text → map text → join → trim), як у `coach.test.ts`.
- `enqueueMemoryIngest` мокається як async no-op; тест «синхронний throw» перевіряє, що handler ковтає помилку (fire-and-forget).
- Lines 95-104 (fallback `JSON.parse` гілка у `extractJsonObject`) — покриті тестом "незбалансований {", де цикл завершується з `depth > 0` і fallback теж кидає.
- 2 pre-existing TS errors on main (`@sergeant/db-schema/pg` module resolution) — не пов'язані з цим PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a comprehensive test suite for `apps/server/src/modules/digest/weekly-digest.ts` to raise coverage from ~0% to 95% statements / 83% branches and lock down validation, prompt assembly, response parsing, error handling, and the memory-ingest hook. No runtime code changes; `anthropicMessages` and `enqueueMemoryIngest` are mocked; 22 tests cover happy path, bad bodies, non-JSON and fenced JSON, schema mismatch, nested braces, and enqueue gating/capping.

<sup>Written for commit ee89cde3c05b893e54ed8b40b3e3dc01c9e0eff3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

