### PR TITLE
feat(root): canonical Cyrillic module-name sweep

### DIFF
--- a/apps/mobile/src/core/settings/NotificationsSection.test.tsx
+++ b/apps/mobile/src/core/settings/NotificationsSection.test.tsx
@@ -79,9 +79,9 @@ describe("NotificationsSection", () => {
     });
 
     expect(getByText("Push-сповіщення")).toBeTruthy();
-    expect(getByText("Звички (Рутина)")).toBeTruthy();
+    expect(getByText("Рутина (звички)")).toBeTruthy();
     expect(getByText("Нагадування про звички")).toBeTruthy();
-    expect(getByText("Тренування (Фізрук)")).toBeTruthy();
+    expect(getByText("Фізрук (тренування)")).toBeTruthy();
     expect(
       getByText(
         "Нагадування про тренування підключаться з портом модуля Фізрук (Phase 6).",

--- a/apps/mobile/src/core/settings/NotificationsSection.tsx
+++ b/apps/mobile/src/core/settings/NotificationsSection.tsx
@@ -221,7 +221,7 @@ export function NotificationsSection() {
         ) : null}
       </Card>
 
-      <SettingsSubGroup title="Звички (Рутина)">
+      <SettingsSubGroup title="Рутина (звички)">
         <ToggleRow
           label="Нагадування про звички"
           description="Спрацьовує у встановлений в кожній звичці час. Повноцінне планування нагадувань підключиться з портом модуля Рутина (Phase 5) — зараз значення зберігається і буде підхоплено автоматично."
@@ -240,7 +240,7 @@ export function NotificationsSection() {
           the Fizruk module is ported — reminderEnabled + reminderHour /
           reminderMinute picker, analogue to web `NotificationsSection`
           Фізрук sub-group. */}
-      <SettingsSubGroup title="Тренування (Фізрук)">
+      <SettingsSubGroup title="Фізрук (тренування)">
         <DeferredNotice>
           Нагадування про тренування підключаться з портом модуля Фізрук (Phase
           6).

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -26,7 +26,22 @@
       "@sergeant/finyk-domain": ["../../packages/finyk-domain/src/index.ts"],
       "@sergeant/finyk-domain/*": ["../../packages/finyk-domain/src/*"],
       "@sergeant/db-schema": ["../../packages/db-schema/src/index.ts"],
-      "@sergeant/db-schema/*": ["../../packages/db-schema/src/*/index.ts"],
+      "@sergeant/db-schema/sqlite": [
+        "../../packages/db-schema/src/sqlite/index.ts"
+      ],
+      "@sergeant/db-schema/sqlite/migrations": [
+        "../../packages/db-schema/src/sqlite/migrations/index.ts"
+      ],
+      "@sergeant/db-schema/migrate": [
+        "../../packages/db-schema/src/migrate/index.ts"
+      ],
+      "@sergeant/db-schema/migrate/runner": [
+        "../../packages/db-schema/src/migrate/runner.ts"
+      ],
+      "@sergeant/db-schema/migrate/sqlite": [
+        "../../packages/db-schema/src/migrate/adapters/sqlite.ts"
+      ],
+      "@sergeant/db-schema/*": ["../../packages/db-schema/src/*"],
       "@sergeant/design-tokens": ["../../packages/design-tokens/index.d.ts"],
       "@sergeant/design-tokens/tokens": [
         "../../packages/design-tokens/index.d.ts"

--- a/apps/web/src/core/app/WelcomeScreen.tsx
+++ b/apps/web/src/core/app/WelcomeScreen.tsx
@@ -8,10 +8,16 @@ import { trackEvent, ANALYTICS_EVENTS } from "../observability/analytics";
 // `/welcome`. Renders a 2×2 bento grid matching `HubDashboard`'s module
 // cards so the blurred silhouette under the splash accurately teases the
 // real dashboard layout new users are about to see.
+//
+// PR-06 — canonical Cyrillic without emoji. Module labels are bare brand
+// names (`Фінік / Фізрук / Рутина / Харчування`) — the colored module-icon
+// bubble already carries the visual association, so emoji prefixed to the
+// text was duplicative and broke uniformity vs the hub bottom-nav and
+// settings groups.
 const PEEK_CARDS = [
   {
     id: "finyk",
-    label: "💰 Фінік",
+    label: "Фінік",
     cardBg: "bg-finyk-soft/40 dark:bg-finyk-surface-dark/8",
     iconClass: "bg-finyk-soft text-finyk dark:bg-finyk-surface-dark/15",
     icon: "credit-card",
@@ -20,7 +26,7 @@ const PEEK_CARDS = [
   },
   {
     id: "fizruk",
-    label: "💪 Фізрук",
+    label: "Фізрук",
     cardBg: "bg-fizruk-soft/40 dark:bg-fizruk-surface-dark/8",
     iconClass: "bg-fizruk-soft text-fizruk dark:bg-fizruk-surface-dark/15",
     icon: "dumbbell",
@@ -29,7 +35,7 @@ const PEEK_CARDS = [
   },
   {
     id: "routine",
-    label: "✅ Рутина",
+    label: "Рутина",
     cardBg: "bg-routine-surface/40 dark:bg-routine-surface-dark/8",
     iconClass:
       "bg-routine-surface text-routine dark:bg-routine-surface-dark/15",
@@ -39,7 +45,7 @@ const PEEK_CARDS = [
   },
   {
     id: "nutrition",
-    label: "🥗 Харчування",
+    label: "Харчування",
     cardBg: "bg-nutrition-soft/40 dark:bg-nutrition-surface-dark/8",
     iconClass:
       "bg-nutrition-soft text-nutrition dark:bg-nutrition-surface-dark/15",

--- a/apps/web/src/core/hub/HubReports.tsx
+++ b/apps/web/src/core/hub/HubReports.tsx
@@ -421,7 +421,7 @@ export function HubReports() {
 
       <div className="grid grid-cols-1 gap-3">
         <StatCard
-          title="Тренування (Фізрук)"
+          title="Фізрук (тренування)"
           icon="🏋️"
           storageKey="hub_reports_collapsed_v1:workouts"
           current={data.workouts.cur.count}
@@ -440,7 +440,7 @@ export function HubReports() {
         />
 
         <StatCard
-          title="Витрати (Фінік)"
+          title="Фінік (витрати)"
           icon="💳"
           storageKey="hub_reports_collapsed_v1:spending"
           current={data.spending.cur.total}
@@ -459,7 +459,7 @@ export function HubReports() {
         />
 
         <StatCard
-          title="Виконання звичок (Рутина)"
+          title="Рутина (виконання звичок)"
           icon="✅"
           storageKey="hub_reports_collapsed_v1:habits"
           current={data.habits.cur.pct}
@@ -479,7 +479,7 @@ export function HubReports() {
         />
 
         <StatCard
-          title="Середньо ккал/день (Харчування)"
+          title="Харчування (ккал/день)"
           icon="🥗"
           storageKey="hub_reports_collapsed_v1:kcal"
           current={data.kcal.cur.avg}

--- a/apps/web/src/core/settings/NotificationsSection.tsx
+++ b/apps/web/src/core/settings/NotificationsSection.tsx
@@ -150,7 +150,7 @@ export function NotificationsSection() {
 
       <PushNotificationToggle className="p-3 rounded-xl bg-bg border border-line" />
 
-      <SettingsSubGroup title="Звички (Рутина)" defaultOpen>
+      <SettingsSubGroup title="Рутина (звички)" defaultOpen>
         <ToggleRow
           label="Нагадування про звички"
           description="Спрацьовує у встановлений в кожній звичці час, навіть коли застосунок закрито."
@@ -159,7 +159,7 @@ export function NotificationsSection() {
         />
       </SettingsSubGroup>
 
-      <SettingsSubGroup title="Тренування (Фізрук)" defaultOpen>
+      <SettingsSubGroup title="Фізрук (тренування)" defaultOpen>
         <ToggleRow
           label="Нагадування про тренування"
           description="Надсилається о вказаній годині, якщо на сьогодні призначено тренування."

--- a/apps/web/src/modules/fizruk/hooks/useFizrukWorkoutReminder.ts
+++ b/apps/web/src/modules/fizruk/hooks/useFizrukWorkoutReminder.ts
@@ -81,7 +81,7 @@ export function useFizrukWorkoutReminder({
         if ("serviceWorker" in navigator) {
           navigator.serviceWorker.ready
             .then((reg) => {
-              reg.showNotification("🏋️ Фізрук — тренування", {
+              reg.showNotification("Фізрук — тренування", {
                 body: "Заплановане тренування на сьогодні. Відкрий застосунок, щоб стартувати.",
                 tag: `fizruk-plan-${dayStr}`,
                 icon: "/icon-192.png",
@@ -91,13 +91,13 @@ export function useFizrukWorkoutReminder({
               });
             })
             .catch(() => {
-              new Notification("🏋️ Фізрук — тренування", {
+              new Notification("Фізрук — тренування", {
                 body: "Заплановане тренування на сьогодні. Відкрий застосунок, щоб стартувати.",
                 tag: "fizruk-plan",
               });
             });
         } else {
-          new Notification("🏋️ Фізрук — тренування", {
+          new Notification("Фізрук — тренування", {
             body: "Заплановане тренування на сьогодні. Відкрий застосунок, щоб стартувати.",
             tag: "fizruk-plan",
           });

--- a/apps/web/src/modules/nutrition/hooks/useNutritionReminders.ts
+++ b/apps/web/src/modules/nutrition/hooks/useNutritionReminders.ts
@@ -59,7 +59,7 @@ export function useNutritionReminders(prefs: NutritionReminderPrefs): void {
         if ("serviceWorker" in navigator) {
           navigator.serviceWorker.ready
             .then((reg) => {
-              reg.showNotification("🥗 Харчування", {
+              reg.showNotification("Харчування", {
                 body: "Час записати прийоми їжі.",
                 tag: `nutrition-reminder-${key}`,
                 icon: "/icon-192.png",
@@ -69,12 +69,12 @@ export function useNutritionReminders(prefs: NutritionReminderPrefs): void {
               });
             })
             .catch(() => {
-              new Notification("🥗 Харчування", {
+              new Notification("Харчування", {
                 body: "Час записати прийоми їжі.",
               });
             });
         } else {
-          new Notification("🥗 Харчування", {
+          new Notification("Харчування", {
             body: "Час записати прийоми їжі.",
           });
         }

--- a/apps/web/src/shared/lib/modules/moduleLabels.test.ts
+++ b/apps/web/src/shared/lib/modules/moduleLabels.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { MODULE_LABELS, type HubModuleId } from "./moduleLabels";
+
+// PR-06 — canonical Cyrillic naming sweep. The four module display
+// names are the single SSOT for «Фінік / Фізрук / Рутина / Харчування».
+// Drift across surfaces (welcome peek, settings, notifications,
+// reports) was the visible symptom we observed before PR-06.
+describe("MODULE_LABELS — canonical Cyrillic without emoji (PR-06)", () => {
+  it("each module exposes the canonical Cyrillic label", () => {
+    expect(MODULE_LABELS.finyk).toBe("Фінік");
+    expect(MODULE_LABELS.fizruk).toBe("Фізрук");
+    expect(MODULE_LABELS.routine).toBe("Рутина");
+    expect(MODULE_LABELS.nutrition).toBe("Харчування");
+  });
+
+  it("no label leaks an emoji prefix or suffix", () => {
+    // The Cyrillic-block range covers Ukrainian letters; we forbid any
+    // codepoint outside the Cyrillic-block + space + parenthesis. This
+    // is the explicit guardrail that catches future regressions like
+    // `"💰 Фінік"` or `"Фінік 💳"` slipping back in.
+    const allowed = /^[А-Яа-яЁёІіЇїЄєҐґ \-()]+$/u;
+    for (const id of Object.keys(MODULE_LABELS) as HubModuleId[]) {
+      expect(MODULE_LABELS[id], `module=${id}`).toMatch(allowed);
+    }
+  });
+});

--- a/apps/web/src/sw/reminders.ts
+++ b/apps/web/src/sw/reminders.ts
@@ -85,9 +85,17 @@ function habitScheduledOnDateSW(h: SwRoutineHabit, dk: string) {
     return Array.isArray(h.weekdays) && h.weekdays.includes(wd);
   }
   if (rec === "monthly") {
-    const startDay = h.startDate ? parseInt(h.startDate.split("-")[2], 10) : 1;
-    const dkDay = parseInt(dk.split("-")[2], 10);
-    const [y, m] = dk.split("-").map(Number);
+    // `?? "01"` / `?? 0` defaults are unreachable — both `dk` and
+    // `h.startDate` are produced by `todayKey()` / ISO-date inputs,
+    // so the `YYYY-MM-DD` split always has 3 parts. They exist only
+    // to satisfy `noUncheckedIndexedAccess: true` in the host
+    // tsconfig that the staged pre-commit typecheck walks up to
+    // (the SW build itself uses the looser `tsconfig.sw.json`).
+    const startDay = h.startDate
+      ? parseInt(h.startDate.split("-")[2] ?? "01", 10)
+      : 1;
+    const dkDay = parseInt(dk.split("-")[2] ?? "01", 10);
+    const [y = 0, m = 0] = dk.split("-").map(Number);
     const lastDay = new Date(y, m, 0).getDate();
     return startDay > lastDay ? dkDay === lastDay : dkDay === startDay;
   }
@@ -166,7 +174,7 @@ function checkFizrukReminders() {
   recordNotified(storageKey);
 
   self.registration
-    .showNotification("🏋️ Фізрук — тренування", {
+    .showNotification("Фізрук — тренування", {
       body: "Заплановане тренування на сьогодні. Відкрий застосунок, щоб стартувати.",
       tag: storageKey,
       icon: "/icon-192.png",
@@ -194,7 +202,7 @@ function checkNutritionReminders() {
   recordNotified(storageKey);
 
   self.registration
-    .showNotification("🥗 Харчування", {
+    .showNotification("Харчування", {
       body: "Час відмітити прийом їжі! Відкрий застосунок.",
       tag: storageKey,
       icon: "/icon-192.png",


### PR DESCRIPTION
## Summary

PR-06 (Wave 1 — Quick wins). Standardise the four module names (Фінік / Фізрук / Рутина / Харчування) on the canonical-Cyrillic-without-emoji form across all user-facing surfaces. Module labels were drifting between the welcome peek (`💰 Фінік`), notifications (`🏋️ Фізрук — тренування`, `🥗 Харчування`), settings sub-groups (`Звички (Рутина)`) and hub reports (`Тренування (Фізрук)`) — same module, four different labels in the same flow.

Display strings only — Latin code identifiers (paths, vars, types, telemetry events, persistence keys) are intentionally untouched per master tracker §7 SSOT decision.

- **Welcome peek (`apps/web`).** Drop emoji prefix from `PEEK_CARDS` labels in `WelcomeScreen.tsx`; the colored module-icon bubble already carries the visual association.
- **Notifications (`apps/web`).** Drop emoji prefix from `showNotification` / `new Notification` titles in `useFizrukWorkoutReminder.ts`, `useNutritionReminders.ts`, and the service-worker `sw/reminders.ts` (Fizruk + Nutrition).
- **Settings sub-groups (`apps/web` + `apps/mobile`).** Flip `Звички (Рутина)` → `Рутина (звички)` and `Тренування (Фізрук)` → `Фізрук (тренування)` so brand name comes first per `moduleLabels.ts` SSOT decision; mobile snapshot test updated to match.
- **Hub reports (`apps/web`).** Flip the four `StatCard` titles to brand-first form: `Фізрук (тренування)`, `Фінік (витрати)`, `Рутина (виконання звичок)`, `Харчування (ккал/день)`.
- **Guard test.** Add `apps/web/src/shared/lib/modules/moduleLabels.test.ts` enforcing the canonical Cyrillic values + a regex denylist that catches any future emoji-prefix / suffix regression on the four module names.

Incidental tooling fixes required to land the sweep:
- `apps/mobile/tsconfig.json`: mirror `apps/web`'s explicit `@sergeant/db-schema/{sqlite,sqlite/migrations,migrate,migrate/runner,migrate/sqlite}` path entries and switch the wildcard from `../../packages/db-schema/src/*/index.ts` to `../../packages/db-schema/src/*`. The old wildcard could not resolve leaf modules like `@sergeant/db-schema/migrate/sqlite` (a flat `.ts` file, not a directory with `index.ts`), so any staged pre-commit typecheck of an `apps/mobile` file whose import graph reaches that module fell over with TS2307. The mobile `tsc` build itself was unaffected because the production build does not run through `tsc-files`.
- `apps/web/src/sw/reminders.ts`: add unreachable `?? "01"` / `?? 0` defaults on the monthly-recurrence date split so the file passes the staged pre-commit typecheck under the strict `apps/web/tsconfig.json` (the SW build itself uses the looser `tsconfig.sw.json`, so these never ran in practice). Defaults are unreachable at runtime — `dk` and `h.startDate` are always `YYYY-MM-DD` strings produced by `todayKey()` / ISO-date inputs.

## Governing Skill

- Primary skill: `docs/skills/ftux/wave-1-quick-wins.md` — one-PR-per-row, no audit doc, ≤ 200 LOC.
- Secondary skill (if truly needed): n/a.

## Playbook

- Primary playbook: `docs/playbooks/ui-label-sweep.md` (canonical-naming sweep — display-strings only, Latin codenames preserved).
- Why this playbook: the sweep follows the `moduleLabels.ts` SSOT for canonical brand names + the master tracker §7 decision that production code identifiers stay Latin while user-facing strings stay Cyrillic.
- If no playbook matched, why: n/a — playbook above covers this row directly.

## Verification

```bash
pnpm --filter @sergeant/web lint
pnpm --filter @sergeant/web typecheck
pnpm --filter @sergeant/web test -- moduleLabels.test
pnpm --filter @sergeant/web test -- HubReports
pnpm --filter @sergeant/web test -- NotificationsSection
pnpm --filter @sergeant/mobile test -- NotificationsSection
node scripts/staged-typecheck.mjs \
  apps/web/src/core/app/WelcomeScreen.tsx \
  apps/web/src/core/hub/HubReports.tsx \
  apps/web/src/core/settings/NotificationsSection.tsx \
  apps/web/src/modules/fizruk/hooks/useFizrukWorkoutReminder.ts \
  apps/web/src/modules/nutrition/hooks/useNutritionReminders.ts \
  apps/web/src/sw/reminders.ts \
  apps/mobile/src/core/settings/NotificationsSection.tsx \
  apps/mobile/src/core/settings/NotificationsSection.test.tsx \
  apps/web/src/shared/lib/modules/moduleLabels.test.ts
```

All green: lint clean, web typecheck clean, all tests passing (incl. the new `moduleLabels` guard suite), staged-typecheck clean across all 9 touched files.

Additional checks:

- [x] Local smoke / manual validation completed (web `WelcomeScreen` + `HubReports` + web/mobile `NotificationsSection` render the new labels)
- [x] Surface-specific checks completed (web `lint` + `typecheck`, mobile `NotificationsSection.test.tsx` snapshot)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. — Display-strings-only sweep; the `moduleLabels.ts` SSOT was already documented in `docs/launch/product-os/ftux-master-tracker.md` §7. No docs changes required.
- [x] I checked whether `AGENTS.md` needed an update. — No.
- [x] I checked whether a playbook or skill needed an update. — No (the sweep is the playbook in action).
- [x] I checked whether governance docs or review docs needed an update. — No.

Updated docs:

- n/a — display-strings sweep only.

## Risk and Rollout

- User-visible risk: **Very low.** Only the four module display strings change form (`emoji + brand` → `brand`, or `descriptor (brand)` → `brand (descriptor)`). No behavioural changes, no telemetry-key changes, no persistence-key changes. The `moduleLabels` guard test prevents emoji-prefix regression.
- Rollout / deploy order: ship with the next regular Vercel deploy from `main`; no migrations, no flag flips.
- Backout plan: revert the merge commit; the sweep is purely textual and the `tsconfig.json` / `sw/reminders.ts` tooling fixes are independently safe to keep.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files. The only new file is `apps/web/src/shared/lib/modules/moduleLabels.test.ts` — a unit-test guard, not a doc.

## Reviewer Notes

- **Display-strings only.** Latin code identifiers (paths, vars, types, persistence keys, telemetry event names) are intentionally untouched. If you spot a Latin codename you wish was Ukrainian, flag it for a separate sweep — this PR is scoped to the four user-facing module labels per `moduleLabels.ts`.
- **`apps/mobile/tsconfig.json` change** is a pre-existing path-mapping bug surfaced by the staged-typecheck running over the mobile `NotificationsSection.tsx` edit. The fix mirrors `apps/web/tsconfig.json` exactly and is the minimum needed to land the mobile string change. Mobile production `tsc` build was unaffected before and after.
- **`apps/web/src/sw/reminders.ts`** got two unreachable nullish-coalescing defaults purely so the staged typecheck (which walks up to `apps/web/tsconfig.json`) accepts the file. The SW build itself uses the looser `tsconfig.sw.json` and never had a complaint. Defaults are unreachable at runtime; behaviour is identical.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes the four module names — Фінік, Фізрук, Рутина, Харчування — to canonical Cyrillic without emoji across web and mobile. Display strings only; Latin code identifiers stay unchanged per `moduleLabels.ts`.

- **Refactors**
  - Welcome cards: removed emoji from module labels.
  - Notifications: removed emoji from Fizruk workout and Nutrition reminder titles (web + service worker).
  - Settings: flipped subgroup titles to brand-first on web and mobile; updated mobile snapshot.
  - Hub reports: switched StatCard titles to brand-first for all four modules.
  - Added a `moduleLabels` guard test to enforce canonical labels and deny emoji.

- **Bug Fixes**
  - `apps/mobile/tsconfig.json`: added explicit paths for `@sergeant/db-schema/{sqlite,sqlite/migrations,migrate,migrate/runner,migrate/sqlite}` and fixed the wildcard to resolve flat modules during staged typecheck.
  - `apps/web/src/sw/reminders.ts`: added unreachable defaults for monthly recurrence parsing to satisfy strict typecheck; no runtime impact.

<sup>Written for commit 9b4d5e371387366612345b38c510dc027a9ccda2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

