### PR TITLE
refactor(web): decompose Workouts.tsx 744→567 LOC (0013 sprint 1 PR #1)

### DIFF
--- a/apps/web/eslint.i18n-allowlist.json
+++ b/apps/web/eslint.i18n-allowlist.json
@@ -156,6 +156,8 @@
   "apps/web/src/modules/fizruk/components/workouts/WorkoutItemsList.tsx",
   "apps/web/src/modules/fizruk/components/workouts/WorkoutJournalSection.tsx",
   "apps/web/src/modules/fizruk/components/workouts/WorkoutTimeEditor.tsx",
+  "apps/web/src/modules/fizruk/components/workouts/WorkoutsConfirmDialogs.tsx",
+  "apps/web/src/modules/fizruk/components/workouts/WorkoutsHeader.tsx",
   "apps/web/src/modules/fizruk/components/workouts/WorkoutsHome.tsx",
   "apps/web/src/modules/fizruk/pages/Atlas.tsx",
   "apps/web/src/modules/fizruk/pages/Body.tsx",

--- a/apps/web/src/modules/fizruk/components/workouts/WorkoutsConfirmDialogs.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/WorkoutsConfirmDialogs.tsx
@@ -1,0 +1,61 @@
+import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
+import type { WorkoutTemplate } from "../../hooks/useWorkoutTemplates";
+
+export interface WorkoutsConfirmDialogsProps {
+  /** Open flag for the "delete catalog exercise" confirm. */
+  deleteExerciseConfirm: boolean;
+  onDeleteExerciseConfirm: () => void;
+  onDeleteExerciseCancel: () => void;
+
+  /**
+   * Holds the template to start when the user confirms the
+   * "muscles still recovering" warning. `null` keeps the dialog
+   * closed.
+   */
+  riskyTemplate: WorkoutTemplate | null;
+  onRiskyTemplateConfirm: () => void;
+  onRiskyTemplateCancel: () => void;
+}
+
+/**
+ * Bottom-of-page confirmation dialogs for the Workouts page. The
+ * "Delete active workout" `ConfirmDialog` was removed in favour of
+ * the unified soft-delete flow (`onDeleteWorkout` in
+ * `WorkoutJournalSection`) that calls `deleteWorkout` immediately
+ * and surfaces a 5 s undo toast via `showUndoToast`. Per the
+ * unified-undo policy, only non-reversible flows (e.g. exercise
+ * removal that detaches the catalog entry) keep an explicit
+ * confirmation step.
+ */
+export function WorkoutsConfirmDialogs({
+  deleteExerciseConfirm,
+  onDeleteExerciseConfirm,
+  onDeleteExerciseCancel,
+  riskyTemplate,
+  onRiskyTemplateConfirm,
+  onRiskyTemplateCancel,
+}: WorkoutsConfirmDialogsProps) {
+  return (
+    <>
+      <ConfirmDialog
+        open={deleteExerciseConfirm}
+        title="Видалити вправу?"
+        description="Вправу буде видалено з каталогу. Записи в тренуваннях залишаться."
+        confirmLabel="Видалити"
+        onConfirm={onDeleteExerciseConfirm}
+        onCancel={onDeleteExerciseCancel}
+      />
+
+      <ConfirmDialog
+        open={!!riskyTemplate}
+        title="М'язи ще відновлюються"
+        description="У шаблоні є вправи на групи м'язів, які ще не відновились. Почати тренування все одно?"
+        confirmLabel="Так, почати"
+        cancelLabel="Скасувати"
+        danger={false}
+        onConfirm={onRiskyTemplateConfirm}
+        onCancel={onRiskyTemplateCancel}
+      />
+    </>
+  );
+}

--- a/apps/web/src/modules/fizruk/components/workouts/WorkoutsHeader.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/WorkoutsHeader.tsx
@@ -1,0 +1,74 @@
+import { Button } from "@shared/components/ui/Button";
+import type { Workout } from "@sergeant/fizruk-domain";
+import type { WorkoutsView } from "../../pages/Workouts.types";
+
+export interface WorkoutsHeaderProps {
+  view: WorkoutsView;
+  activeWorkout: Workout | null;
+  finishedCount: number;
+  onBack: () => void;
+  onAddCatalog: () => void;
+}
+
+/**
+ * Top header bar for the Workouts page. Renders a back-to-home button
+ * for non-home subviews, the contextual title + subtitle, and the
+ * "+ Додати" action which is only visible while the catalog is
+ * focused.
+ */
+export function WorkoutsHeader({
+  view,
+  activeWorkout,
+  finishedCount,
+  onBack,
+  onAddCatalog,
+}: WorkoutsHeaderProps) {
+  const title =
+    view === "catalog"
+      ? "Каталог вправ"
+      : view === "templates"
+        ? "Шаблони"
+        : view === "log"
+          ? activeWorkout && !activeWorkout.endedAt
+            ? "Активне тренування"
+            : "Журнал"
+          : "Тренування";
+
+  const homeSubtitle =
+    activeWorkout && !activeWorkout.endedAt
+      ? `Активне · ${(activeWorkout.items || []).length} вправ`
+      : finishedCount > 0
+        ? `Завершено: ${finishedCount}`
+        : "Перше тренування — попереду";
+
+  return (
+    <div className="flex items-center gap-3 mb-3">
+      {view !== "home" ? (
+        <button
+          type="button"
+          className="w-9 h-9 -ml-1 rounded-xl flex items-center justify-center text-text/80 hover:bg-surface-2"
+          onClick={onBack}
+          aria-label="Повернутись до тренувань"
+        >
+          ‹
+        </button>
+      ) : null}
+      <div className="flex-1">
+        <h1 className="text-style-title text-text">{title}</h1>
+        {view === "home" ? (
+          <p className="text-xs text-subtle mt-0.5">{homeSubtitle}</p>
+        ) : null}
+      </div>
+      {view === "catalog" ? (
+        <Button
+          size="sm"
+          className="h-9 min-h-[44px] px-4"
+          onClick={onAddCatalog}
+          aria-label="Додати вправу в каталог"
+        >
+          + Додати
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/modules/fizruk/hooks/useWorkoutsLifecycle.ts
+++ b/apps/web/src/modules/fizruk/hooks/useWorkoutsLifecycle.ts
@@ -1,0 +1,108 @@
+import { useEffect } from "react";
+import type { Dispatch, SetStateAction } from "react";
+import { safeRemoveLS, safeWriteLS } from "@shared/lib/storage/storage";
+import { ACTIVE_WORKOUT_KEY, type Workout } from "@sergeant/fizruk-domain";
+import type { RestTimerState } from "./useFizrukRestSound";
+import type { WorkoutsView } from "../pages/Workouts.types";
+
+const VIEW_FROM_SESSION_KEY = "fizruk_workouts_mode";
+
+/**
+ * Persist `activeWorkoutId` into local storage so a refresh keeps the
+ * user inside the same session. Set-to-`null` removes the key.
+ */
+export function useActiveWorkoutIdPersistence(
+  activeWorkoutId: string | null,
+): void {
+  useEffect(() => {
+    if (!activeWorkoutId) safeRemoveLS(ACTIVE_WORKOUT_KEY);
+    else safeWriteLS(ACTIVE_WORKOUT_KEY, activeWorkoutId);
+  }, [activeWorkoutId]);
+}
+
+/**
+ * Clear a stale `activeWorkoutId` that no longer matches any workout
+ * (e.g. the workout was deleted on another device before sync).
+ */
+export function useStaleActiveWorkoutCleanup(
+  workoutsLoaded: boolean,
+  workouts: readonly Workout[],
+  activeWorkoutId: string | null,
+  setActiveWorkoutId: Dispatch<SetStateAction<string | null>>,
+): void {
+  useEffect(() => {
+    if (!workoutsLoaded || !activeWorkoutId) return;
+    if (!workouts.some((w) => w.id === activeWorkoutId)) {
+      setActiveWorkoutId(null);
+    }
+  }, [workoutsLoaded, activeWorkoutId, workouts, setActiveWorkoutId]);
+}
+
+/**
+ * Restore `view` from a one-shot `sessionStorage` flag set by other
+ * surfaces ("open Templates" / "open Journal" deep-links). The flag
+ * is consumed (cleared) on read so a refresh reverts to "home".
+ */
+export function useWorkoutsViewFromSession(
+  setView: (v: WorkoutsView) => void,
+): void {
+  useEffect(() => {
+    try {
+      const m = sessionStorage.getItem(VIEW_FROM_SESSION_KEY);
+      if (m === "templates") {
+        setView("templates");
+        sessionStorage.removeItem(VIEW_FROM_SESSION_KEY);
+      } else if (m === "log") {
+        setView("log");
+        sessionStorage.removeItem(VIEW_FROM_SESSION_KEY);
+      }
+    } catch {}
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only; setView identity is stable
+  }, []);
+}
+
+/**
+ * Tick the rest timer once per second; when `remaining` reaches 0
+ * call `markCompletedNaturally` so the rest-sound hook can play the
+ * end-cue, then clear the timer.
+ */
+export function useRestTimerCountdown(
+  restTimer: RestTimerState | null,
+  setRestTimer: Dispatch<SetStateAction<RestTimerState | null>>,
+  markCompletedNaturally: () => void,
+): void {
+  useEffect(() => {
+    if (!restTimer || restTimer.remaining <= 0) return;
+    const id = setInterval(() => {
+      setRestTimer((r) => {
+        if (!r || r.remaining <= 1) {
+          markCompletedNaturally();
+          return null;
+        }
+        return { ...r, remaining: r.remaining - 1 };
+      });
+    }, 1000);
+    return () => clearInterval(id);
+  }, [restTimer, markCompletedNaturally, setRestTimer]);
+}
+
+/**
+ * Re-render the active-workout duration once per second while the
+ * session is unfinished. Re-subscribes only when the active workout
+ * `id` or its `endedAt` changes — full workout-object churn (set
+ * edits, etc.) doesn't restart the interval.
+ */
+export function useLiveWorkoutTick(
+  activeWorkout: Workout | null,
+  setNow: Dispatch<SetStateAction<number>>,
+): void {
+  useEffect(
+    () => {
+      if (!activeWorkout || activeWorkout.endedAt) return;
+      const id = setInterval(() => setNow(Date.now()), 1000);
+      return () => clearInterval(id);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- достатньо id/endedAt; повний об’єкт workout змінюється часто
+    [activeWorkout?.id, activeWorkout?.endedAt],
+  );
+}

--- a/apps/web/src/modules/fizruk/pages/Workouts.helpers.ts
+++ b/apps/web/src/modules/fizruk/pages/Workouts.helpers.ts
@@ -1,0 +1,127 @@
+import type { Workout } from "@sergeant/fizruk-domain";
+import type { RawExerciseDef } from "@sergeant/fizruk-domain/data";
+import type { LastExerciseItem } from "./Workouts.types";
+
+/**
+ * Render order for primary muscle groups in the catalog browser.
+ * Anything not in the list falls to the end alphabetically — see
+ * `buildGroupedExercises` below.
+ */
+export const MUSCLE_GROUP_ORDER: readonly string[] = [
+  "chest",
+  "back",
+  "shoulders",
+  "biceps",
+  "triceps",
+  "forearms",
+  "core",
+  "quadriceps",
+  "hamstrings",
+  "calves",
+  "glutes",
+  "full_body",
+  "cardio",
+];
+
+export interface GroupedExercises {
+  id: string;
+  label: string;
+  items: RawExerciseDef[];
+  total: number;
+}
+
+/**
+ * Group an exercise list by `primaryGroup`, preserving the canonical
+ * `MUSCLE_GROUP_ORDER`. Each bucket is capped at 80 items in the
+ * rendered slice (the `total` count keeps the original size visible).
+ */
+export function buildGroupedExercises(
+  list: readonly RawExerciseDef[],
+  equipmentFilter: readonly string[],
+  primaryGroupsUk: Record<string, string>,
+): GroupedExercises[] {
+  const eqSet = equipmentFilter.length > 0 ? new Set(equipmentFilter) : null;
+  const pool = eqSet
+    ? list.filter((ex) => (ex.equipment ?? []).some((e) => eqSet.has(e)))
+    : list;
+  const m = new Map<string, RawExerciseDef[]>();
+  for (const ex of pool) {
+    const gid = ex.primaryGroup || "full_body";
+    const bucket = m.get(gid);
+    if (bucket) bucket.push(ex);
+    else m.set(gid, [ex]);
+  }
+  const entries = Array.from(m.entries()).sort((a, b) => {
+    const ai = MUSCLE_GROUP_ORDER.indexOf(a[0]);
+    const bi = MUSCLE_GROUP_ORDER.indexOf(b[0]);
+    return (
+      (ai === -1 ? 999 : ai) - (bi === -1 ? 999 : bi) ||
+      a[0].localeCompare(b[0])
+    );
+  });
+  return entries.map(([gid, items]) => ({
+    id: gid,
+    label: primaryGroupsUk[gid] || gid,
+    items: items.slice(0, 80),
+    total: items.length,
+  }));
+}
+
+/**
+ * Walk all completed (non-active) workouts and pick the most recent
+ * occurrence of every exercise. The resulting map is keyed by
+ * `exerciseId` and lets the catalog show "last weight × reps" hints.
+ */
+export function collectLastByExerciseId(
+  workouts: readonly Workout[],
+  activeWorkoutId: string | null,
+): Record<string, LastExerciseItem> {
+  const out: Record<string, LastExerciseItem> = {};
+  for (const w of workouts || []) {
+    if (w.id === activeWorkoutId) continue;
+    for (const it of w.items || []) {
+      const exId = it.exerciseId;
+      if (!exId) continue;
+      const existing = out[exId];
+      if (
+        !existing ||
+        (w.startedAt || "").localeCompare(existing._startedAt || "") > 0
+      ) {
+        out[exId] = { ...it, _startedAt: w.startedAt };
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Format active-workout duration as `mm:ss`. Returns `null` when the
+ * timestamps are missing/invalid (so the caller can render a blank
+ * instead of `NaN:NaN`). `endedAt` is optional — when missing, `now`
+ * (a live tick from `Date.now()`) is used so the UI keeps updating.
+ */
+export function formatActiveDuration(
+  startedAt: string | null | undefined,
+  endedAt: string | null | undefined,
+  now: number,
+): string | null {
+  if (!startedAt) return null;
+  const start = Date.parse(startedAt);
+  const end = endedAt ? Date.parse(endedAt) : now;
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end < start)
+    return null;
+  const sec = Math.floor((end - start) / 1000);
+  const mm = String(Math.floor(sec / 60)).padStart(2, "0");
+  const ss = String(sec % 60).padStart(2, "0");
+  return `${mm}:${ss}`;
+}
+
+/**
+ * Default retro-workout date — today's calendar date in `YYYY-MM-DD`
+ * form, computed from the local time zone (Kyiv-day boundary follows
+ * the device clock).
+ */
+export function todayLocalDateString(): string {
+  const x = new Date();
+  return `${x.getFullYear()}-${String(x.getMonth() + 1).padStart(2, "0")}-${String(x.getDate()).padStart(2, "0")}`;
+}

--- a/apps/web/src/modules/fizruk/pages/Workouts.tsx
+++ b/apps/web/src/modules/fizruk/pages/Workouts.tsx
@@ -1,13 +1,7 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
-import {
-  safeReadStringLS,
-  safeWriteLS,
-  safeRemoveLS,
-} from "@shared/lib/storage/storage";
+import { useCallback, useMemo, useState } from "react";
+import { safeReadStringLS } from "@shared/lib/storage/storage";
 import { requestCloudPull } from "@shared/lib/modules/cloudPullRequest";
 import { PullToRefresh } from "@shared/components/ui/PullToRefresh";
-import { Button } from "@shared/components/ui/Button";
-import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
 import { Skeleton } from "@shared/components/ui/Skeleton";
 import {
   DataState,
@@ -26,54 +20,39 @@ import { ExerciseDetailSheet } from "../components/workouts/ExerciseDetailSheet"
 import { WorkoutJournalSection } from "../components/workouts/WorkoutJournalSection";
 import { WorkoutCatalogSection } from "../components/workouts/WorkoutCatalogSection";
 import { QuickStartSheet } from "../components/workouts/QuickStartSheet";
+import { WorkoutsHome } from "../components/workouts/WorkoutsHome";
+import { WorkoutsHeader } from "../components/workouts/WorkoutsHeader";
+import { WorkoutsConfirmDialogs } from "../components/workouts/WorkoutsConfirmDialogs";
 import { useExerciseCatalog } from "../hooks/useExerciseCatalog";
-import {
-  useFizrukRestSound,
-  type RestTimerState,
-} from "../hooks/useFizrukRestSound";
+import { useFizrukRestSound } from "../hooks/useFizrukRestSound";
+import type { RestTimerState } from "../hooks/useFizrukRestSound";
 import { useRecovery } from "../hooks/useRecovery";
 import {
   useWorkoutTemplates,
   type WorkoutTemplate,
 } from "../hooks/useWorkoutTemplates";
 import { useWorkouts } from "../hooks/useWorkouts";
+import {
+  useActiveWorkoutIdPersistence,
+  useLiveWorkoutTick,
+  useRestTimerCountdown,
+  useStaleActiveWorkoutCleanup,
+  useWorkoutsViewFromSession,
+} from "../hooks/useWorkoutsLifecycle";
 import { recoveryConflictsForExercise } from "@sergeant/fizruk-domain";
 import type { RawExerciseDef } from "@sergeant/fizruk-domain/data";
-import type {
-  Workout,
-  WorkoutFinishSummary,
-  WorkoutGroup,
-  WorkoutItem,
-} from "@sergeant/fizruk-domain";
+import type { Workout, WorkoutGroup } from "@sergeant/fizruk-domain";
 import {
   ACTIVE_WORKOUT_KEY,
   summarizeWorkoutForFinish,
 } from "@sergeant/fizruk-domain";
-import { WorkoutsHome } from "../components/workouts/WorkoutsHome";
-
-type WorkoutsView = "home" | "catalog" | "log" | "templates";
-
-/**
- * Mirrors `FinishFlashState` in `WorkoutJournalSection` / consumed by
- * `WorkoutFinishSheets`. Owned here so the `useState` setter can be
- * passed across both sheets without re-deriving the shape twice.
- */
-interface FinishFlashState extends WorkoutFinishSummary {
-  step: "wellbeing" | "summary";
-  collapsed: boolean;
-  workoutId: string;
-  energy: number | null;
-  mood: number | null;
-  savedWellbeing?: { energy?: number | null; mood?: number | null } | null;
-}
-
-/**
- * The catalog `WorkoutItem` carries the workout `startedAt` when
- * resolved as the most recent occurrence of an exercise. We only attach
- * a single extra field, so widen the canonical domain item rather than
- * lying via `any`.
- */
-type LastExerciseItem = WorkoutItem & { _startedAt?: string };
+import type { FinishFlashState, WorkoutsView } from "./Workouts.types";
+import {
+  buildGroupedExercises,
+  collectLastByExerciseId,
+  formatActiveDuration,
+  todayLocalDateString,
+} from "./Workouts.helpers";
 
 export function Workouts() {
   const toast = useToast();
@@ -154,10 +133,7 @@ export function Workouts() {
   const [now, setNow] = useState(Date.now());
   const [retroOpen, setRetroOpen] = useState(false);
   const [quickStartOpen, setQuickStartOpen] = useState(false);
-  const [retroDate, setRetroDate] = useState(() => {
-    const x = new Date();
-    return `${x.getFullYear()}-${String(x.getMonth() + 1).padStart(2, "0")}-${String(x.getDate()).padStart(2, "0")}`;
-  });
+  const [retroDate, setRetroDate] = useState(() => todayLocalDateString());
   const [retroTime, setRetroTime] = useState("18:00");
   const [form, setForm] = useState<AddExerciseForm>(() => ({
     nameUk: "",
@@ -168,73 +144,31 @@ export function Workouts() {
     description: "",
   }));
   const list = useMemo(() => search(q), [search, q]);
-  const activeWorkout = workouts.find((w) => w.id === activeWorkoutId) || null;
+  const activeWorkout: Workout | null =
+    workouts.find((w) => w.id === activeWorkoutId) || null;
 
-  const activeDuration = useMemo(() => {
-    if (!activeWorkout?.startedAt) return null;
-    const start = Date.parse(activeWorkout.startedAt);
-    const end = activeWorkout.endedAt ? Date.parse(activeWorkout.endedAt) : now;
-    if (!Number.isFinite(start) || !Number.isFinite(end) || end < start)
-      return null;
-    const sec = Math.floor((end - start) / 1000);
-    const mm = String(Math.floor(sec / 60)).padStart(2, "0");
-    const ss = String(sec % 60).padStart(2, "0");
-    return `${mm}:${ss}`;
-  }, [activeWorkout?.startedAt, activeWorkout?.endedAt, now]);
+  const activeDuration = useMemo(
+    () =>
+      formatActiveDuration(
+        activeWorkout?.startedAt,
+        activeWorkout?.endedAt,
+        now,
+      ),
+    [activeWorkout?.startedAt, activeWorkout?.endedAt, now],
+  );
 
-  useEffect(() => {
-    if (!activeWorkoutId) safeRemoveLS(ACTIVE_WORKOUT_KEY);
-    else safeWriteLS(ACTIVE_WORKOUT_KEY, activeWorkoutId);
-  }, [activeWorkoutId]);
-
-  // Clear a stale activeWorkoutId that no longer matches any workout
-  // (e.g. the workout was deleted on another device before sync).
-  useEffect(() => {
-    if (!workoutsLoaded || !activeWorkoutId) return;
-    if (!workouts.some((w) => w.id === activeWorkoutId)) {
-      setActiveWorkoutId(null);
-    }
-  }, [workoutsLoaded, activeWorkoutId, workouts]);
-
-  useEffect(() => {
-    try {
-      const m = sessionStorage.getItem("fizruk_workouts_mode");
-      if (m === "templates") {
-        setView("templates");
-        sessionStorage.removeItem("fizruk_workouts_mode");
-      } else if (m === "log") {
-        setView("log");
-        sessionStorage.removeItem("fizruk_workouts_mode");
-      }
-    } catch {}
-  }, []);
+  useActiveWorkoutIdPersistence(activeWorkoutId);
+  useStaleActiveWorkoutCleanup(
+    workoutsLoaded,
+    workouts,
+    activeWorkoutId,
+    setActiveWorkoutId,
+  );
+  useWorkoutsViewFromSession(setView);
 
   const { markCompletedNaturally } = useFizrukRestSound(restTimer);
-
-  useEffect(() => {
-    if (!restTimer || restTimer.remaining <= 0) return;
-    const id = setInterval(() => {
-      setRestTimer((r) => {
-        if (!r || r.remaining <= 1) {
-          markCompletedNaturally();
-          return null;
-        }
-        return { ...r, remaining: r.remaining - 1 };
-      });
-    }, 1000);
-    return () => clearInterval(id);
-  }, [restTimer, markCompletedNaturally]);
-
-  // Live timer tick — only when there is an active, unfinished workout
-  useEffect(
-    () => {
-      if (!activeWorkout || activeWorkout.endedAt) return;
-      const id = setInterval(() => setNow(Date.now()), 1000);
-      return () => clearInterval(id);
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- достатньо id/endedAt; повний об’єкт workout змінюється часто
-    [activeWorkout?.id, activeWorkout?.endedAt],
-  );
+  useRestTimerCountdown(restTimer, setRestTimer, markCompletedNaturally);
+  useLiveWorkoutTick(activeWorkout, setNow);
 
   const addExerciseToActive = useCallback(
     (ex: RawExerciseDef) => {
@@ -368,67 +302,15 @@ export function Workouts() {
     setRetroOpen(false);
   }, [retroDate, retroTime, createWorkoutWithTimes]);
 
-  const lastByExerciseId = useMemo(() => {
-    const out: Record<string, LastExerciseItem> = {};
-    for (const w of workouts || []) {
-      if (w.id === activeWorkoutId) continue;
-      for (const it of w.items || []) {
-        const exId = it.exerciseId;
-        if (!exId) continue;
-        const existing = out[exId];
-        if (
-          !existing ||
-          (w.startedAt || "").localeCompare(existing._startedAt || "") > 0
-        ) {
-          out[exId] = { ...it, _startedAt: w.startedAt };
-        }
-      }
-    }
-    return out;
-  }, [workouts, activeWorkoutId]);
+  const lastByExerciseId = useMemo(
+    () => collectLastByExerciseId(workouts, activeWorkoutId),
+    [workouts, activeWorkoutId],
+  );
 
-  const grouped = useMemo(() => {
-    const eqSet = equipmentFilter.length > 0 ? new Set(equipmentFilter) : null;
-    const pool = eqSet
-      ? list.filter((ex) => (ex.equipment ?? []).some((e) => eqSet.has(e)))
-      : list;
-    const m = new Map<string, RawExerciseDef[]>();
-    for (const ex of pool) {
-      const gid = ex.primaryGroup || "full_body";
-      const bucket = m.get(gid);
-      if (bucket) bucket.push(ex);
-      else m.set(gid, [ex]);
-    }
-    const order = [
-      "chest",
-      "back",
-      "shoulders",
-      "biceps",
-      "triceps",
-      "forearms",
-      "core",
-      "quadriceps",
-      "hamstrings",
-      "calves",
-      "glutes",
-      "full_body",
-      "cardio",
-    ];
-    const entries = Array.from(m.entries()).sort((a, b) => {
-      const ai = order.indexOf(a[0]);
-      const bi = order.indexOf(b[0]);
-      return (
-        (ai === -1 ? 999 : ai) - (bi === -1 ? 999 : bi) ||
-        a[0].localeCompare(b[0])
-      );
-    });
-    return entries.map(([gid, items]) => ({
-      id: gid,
-      label: primaryGroupsUk[gid] || gid,
-      items: items.slice(0, 80),
-      total: items.length,
-    }));
-  }, [list, equipmentFilter, primaryGroupsUk]);
+  const grouped = useMemo(
+    () => buildGroupedExercises(list, equipmentFilter, primaryGroupsUk),
+    [list, equipmentFilter, primaryGroupsUk],
+  );
 
   const finishedCount = useMemo(
     () => (workouts || []).filter((w) => w.endedAt).length,
@@ -481,50 +363,13 @@ export function Workouts() {
   return (
     <PullToRefresh onRefresh={handlePullRefresh} variant="fizruk">
       <div className="max-w-4xl mx-auto px-4 pt-4 page-tabbar-pad">
-        <div className="flex items-center gap-3 mb-3">
-          {view !== "home" ? (
-            <button
-              type="button"
-              className="w-9 h-9 -ml-1 rounded-xl flex items-center justify-center text-text/80 hover:bg-surface-2"
-              onClick={() => setView("home")}
-              aria-label="Повернутись до тренувань"
-            >
-              ‹
-            </button>
-          ) : null}
-          <div className="flex-1">
-            <h1 className="text-style-title text-text">
-              {view === "catalog"
-                ? "Каталог вправ"
-                : view === "templates"
-                  ? "Шаблони"
-                  : view === "log"
-                    ? activeWorkout && !activeWorkout.endedAt
-                      ? "Активне тренування"
-                      : "Журнал"
-                    : "Тренування"}
-            </h1>
-            {view === "home" ? (
-              <p className="text-xs text-subtle mt-0.5">
-                {activeWorkout && !activeWorkout.endedAt
-                  ? `Активне · ${(activeWorkout.items || []).length} вправ`
-                  : finishedCount > 0
-                    ? `Завершено: ${finishedCount}`
-                    : "Перше тренування — попереду"}
-              </p>
-            ) : null}
-          </div>
-          {view === "catalog" ? (
-            <Button
-              size="sm"
-              className="h-9 min-h-[44px] px-4"
-              onClick={() => setAddOpen(true)}
-              aria-label="Додати вправу в каталог"
-            >
-              + Додати
-            </Button>
-          ) : null}
-        </div>
+        <WorkoutsHeader
+          view={view}
+          activeWorkout={activeWorkout}
+          finishedCount={finishedCount}
+          onBack={() => setView("home")}
+          onAddCatalog={() => setAddOpen(true)}
+        />
 
         {view === "home" ? (
           <WorkoutsHome
@@ -692,23 +537,9 @@ export function Workouts() {
         />
       </div>
 
-      {/*
-        Confirmation dialogs.
-
-        The "Delete active workout" `ConfirmDialog` was removed in favour
-        of the unified soft-delete flow (`onDeleteWorkout` in
-        `WorkoutJournalSection`) that calls `deleteWorkout` immediately
-        and surfaces a 5 s undo toast via `showUndoToast`. Per the
-        unified-undo policy, only non-reversible flows (e.g. exercise
-        removal that detaches the catalog entry) keep an explicit
-        confirmation step.
-      */}
-      <ConfirmDialog
-        open={deleteExerciseConfirm}
-        title="Видалити вправу?"
-        description="Вправу буде видалено з каталогу. Записи в тренуваннях залишаться."
-        confirmLabel="Видалити"
-        onConfirm={() => {
+      <WorkoutsConfirmDialogs
+        deleteExerciseConfirm={deleteExerciseConfirm}
+        onDeleteExerciseConfirm={() => {
           if (selected) {
             const snapshot = selected;
             if (removeExercise(snapshot.id)) {
@@ -721,23 +552,15 @@ export function Workouts() {
           }
           setDeleteExerciseConfirm(false);
         }}
-        onCancel={() => setDeleteExerciseConfirm(false)}
-      />
-
-      <ConfirmDialog
-        open={!!riskyTemplateConfirm}
-        title="М'язи ще відновлюються"
-        description="У шаблоні є вправи на групи м'язів, які ще не відновились. Почати тренування все одно?"
-        confirmLabel="Так, почати"
-        cancelLabel="Скасувати"
-        danger={false}
-        onConfirm={() => {
+        onDeleteExerciseCancel={() => setDeleteExerciseConfirm(false)}
+        riskyTemplate={riskyTemplateConfirm}
+        onRiskyTemplateConfirm={() => {
           const tpl = riskyTemplateConfirm;
           setRiskyTemplateConfirm(null);
           if (!tpl) return;
           executeTemplateStart(tpl);
         }}
-        onCancel={() => setRiskyTemplateConfirm(null)}
+        onRiskyTemplateCancel={() => setRiskyTemplateConfirm(null)}
       />
     </PullToRefresh>
   );

--- a/apps/web/src/modules/fizruk/pages/Workouts.types.ts
+++ b/apps/web/src/modules/fizruk/pages/Workouts.types.ts
@@ -1,0 +1,28 @@
+import type {
+  WorkoutFinishSummary,
+  WorkoutItem,
+} from "@sergeant/fizruk-domain";
+
+export type WorkoutsView = "home" | "catalog" | "log" | "templates";
+
+/**
+ * Mirrors `FinishFlashState` in `WorkoutJournalSection` / consumed by
+ * `WorkoutFinishSheets`. Owned here so the `useState` setter can be
+ * passed across both sheets without re-deriving the shape twice.
+ */
+export interface FinishFlashState extends WorkoutFinishSummary {
+  step: "wellbeing" | "summary";
+  collapsed: boolean;
+  workoutId: string;
+  energy: number | null;
+  mood: number | null;
+  savedWellbeing?: { energy?: number | null; mood?: number | null } | null;
+}
+
+/**
+ * The catalog `WorkoutItem` carries the workout `startedAt` when
+ * resolved as the most recent occurrence of an exercise. We only attach
+ * a single extra field, so widen the canonical domain item rather than
+ * lying via `any`.
+ */
+export type LastExerciseItem = WorkoutItem & { _startedAt?: string };

--- a/docs/initiatives/0013-module-decomposition-round-2.md
+++ b/docs/initiatives/0013-module-decomposition-round-2.md
@@ -1,7 +1,7 @@
 # 0013 — Module decomposition round 2 (`apps/web` allowlist drain)
 
-> **Last validated:** 2026-05-05 by @Skords-01. **Next review:** 2026-08-03.
-> **Status:** Proposed
+> **Last validated:** 2026-05-06 by @Skords-01. **Next review:** 2026-08-03.
+> **Status:** In progress (Sprint 1 — 1/4 PR-ів)
 > **Priority:** P2 (subordinate to 0010-revenue-first-launch scope-freeze; pre-launch work паралельно лише на adjacent-touch — див. § Чому зараз)
 > **Owner:** `@Skords-01`
 > **ETA:** 3 sprints (≈3 тижні), **8–11 PR-ів** (по 1 PR на файл, плюс finalize-PR з drop-allowlist)
@@ -129,3 +129,24 @@ PR-и:
 - [`eslint.config.js`](../../eslint.config.js) — поточний `overrides` allowlist (≈11 entries з deadline-коментарями, що цілять у цю ініціативу).
 - [`scripts/check-bundle-size.mjs`](../../scripts/check-bundle-size.mjs) — bundle-gate, який перевіряє delta після decomp-у.
 - [`docs/initiatives/0010-revenue-first-launch.md`](./0010-revenue-first-launch.md) — paralleling scope-freeze, що визначає коли robо `FinykApp.tsx` дозволено.
+
+## Outcome
+
+### Sprint 1 — PR #1 `decomp-r2-workouts` (in flight, 2026-05-06)
+
+`apps/web/src/modules/fizruk/pages/Workouts.tsx` декомпозовано **744 → 567 LOC**
+(нижче 600-LOC гарду; рядок видалено з allowlist у `eslint.config.js`).
+
+Виокремлено в нові файли (поряд з існуючими `components/workouts/*`):
+
+- `pages/Workouts.types.ts` (25 LOC) — `WorkoutsView`, `FinishFlashState`, `LastExerciseItem`.
+- `pages/Workouts.helpers.ts` (127 LOC) — `MUSCLE_GROUP_ORDER`, `buildGroupedExercises`, `collectLastByExerciseId`, `formatActiveDuration`, `todayLocalDateString`.
+- `hooks/useWorkoutsLifecycle.ts` (111 LOC) — `useActiveWorkoutIdPersistence`, `useStaleActiveWorkoutCleanup`, `useWorkoutsViewFromSession`, `useRestTimerCountdown`, `useLiveWorkoutTick`.
+- `components/workouts/WorkoutsHeader.tsx` (74 LOC) — back-button + контекстуальний title/subtitle + «+ Додати».
+- `components/workouts/WorkoutsConfirmDialogs.tsx` (61 LOC) — «Видалити вправу» + «Risky-template start» діалоги.
+
+Verify:
+
+- `pnpm lint` — зелений (0 errors); попередні warnings на cyrillic-JSX літерали перенесено разом зі стрічками без змін поведінки.
+- `pnpm --filter @sergeant/web typecheck` — зелений.
+- `pnpm --filter @sergeant/web test` — `223 / 223` test-files, `2247 / 2247` tests passed (тести `dualWrite/*` запрацювали після `pnpm --filter @sergeant/db-schema build` — pre-existing setup-крок, не пов’язаний з цим PR-ом).

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1054,7 +1054,6 @@ export default [
   {
     files: [
       "apps/web/src/modules/nutrition/components/LogCard.tsx",
-      "apps/web/src/modules/fizruk/pages/Workouts.tsx",
       "apps/web/src/modules/fizruk/pages/Progress.tsx",
       "apps/web/src/modules/nutrition/NutritionApp.tsx",
       "apps/web/src/core/lib/hubChatContext.ts",


### PR DESCRIPTION
Sprint 1 PR #1 of [0013-module-decomposition-round-2](https://github.com/Skords-01/Sergeant/blob/main/docs/initiatives/0013-module-decomposition-round-2.md). Drains `apps/web/src/modules/fizruk/pages/Workouts.tsx` out of the `max-lines:600` ESLint allowlist.

## What

`Workouts.tsx` decomposed **744 → 567 LOC** by extracting cohesive sub-modules — strict refactor, no behaviour changes:

- `pages/Workouts.types.ts` — `WorkoutsView`, `FinishFlashState`, `LastExerciseItem`.
- `pages/Workouts.helpers.ts` — `MUSCLE_GROUP_ORDER`, `buildGroupedExercises`, `collectLastByExerciseId`, `formatActiveDuration`, `todayLocalDateString`.
- `hooks/useWorkoutsLifecycle.ts` — `useActiveWorkoutIdPersistence`, `useStaleActiveWorkoutCleanup`, `useWorkoutsViewFromSession`, `useRestTimerCountdown`, `useLiveWorkoutTick`.
- `components/workouts/WorkoutsHeader.tsx` — back-button + contextual title/subtitle + «+ Додати».
- `components/workouts/WorkoutsConfirmDialogs.tsx` — delete-exercise + risky-template confirm dialogs.

`Workouts.tsx` removed from `eslint.config.js` `max-lines` allowlist. The two new JSX components were added to `apps/web/eslint.i18n-allowlist.json` (the cyrillic literals just moved across files; messages-catalog migration is the separate i18n burndown workstream).

## Verify

- `pnpm lint` — green (0 errors).
- `pnpm --filter @sergeant/web typecheck` — green.
- `pnpm --filter @sergeant/web test` — `223/223` files, `2247/2247` tests passed (after `pnpm --filter @sergeant/db-schema build` to materialize `dist/sqlite/migrations` — pre-existing setup step, unrelated to this PR).

## Out of scope

- Migrating extracted dialog/header strings to `apps/web/src/shared/i18n/uk.ts` — see [docs/i18n/readiness.md § Burndown](https://github.com/Skords-01/Sergeant/blob/main/docs/i18n/readiness.md).
- Bundle-size delta — measured later in `decomp-r2-finalize` after the rest of sprint 1 lands.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decomposed the `Workouts.tsx` page into focused hooks, helpers, types, and small UI components to cut size 744→567 LOC with no behavior changes. Removes `Workouts.tsx` from the ESLint 600-line allowlist as part of initiative 0013.

- **Refactors**
  - Extracted types to `pages/Workouts.types.ts` and helpers to `pages/Workouts.helpers.ts` (e.g., `buildGroupedExercises`, `collectLastByExerciseId`, `formatActiveDuration`).
  - Added lifecycle hooks in `hooks/useWorkoutsLifecycle.ts` (`useActiveWorkoutIdPersistence`, `useRestTimerCountdown`, etc.).
  - Introduced `components/workouts/WorkoutsHeader.tsx` and `components/workouts/WorkoutsConfirmDialogs.tsx`.
  - Removed `apps/web/src/modules/fizruk/pages/Workouts.tsx` from the max-lines allowlist; added new JSX files to `apps/web/eslint.i18n-allowlist.json`.
  - Updated `docs/initiatives/0013-module-decomposition-round-2.md`.
  - Lint, typecheck, and tests pass.

<sup>Written for commit 61a8afffee2e2e80aef03926950e62b6ac195623. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

