### PR TITLE
chore(web): apply prettier to syncEngine/singleton.ts

### DIFF
--- a/apps/web/src/core/syncEngine/singleton.ts
+++ b/apps/web/src/core/syncEngine/singleton.ts
@@ -59,12 +59,7 @@ async function createDefaultRuntime(): Promise<SyncEngineWriterRuntime> {
     throw new Error("sync v2 writer boot requires a browser window");
   }
 
-  const [
-    { getSqliteDb },
-    { apiClient },
-    sentry,
-    dbSchema,
-  ] = await Promise.all([
+  const [{ getSqliteDb }, { apiClient }, sentry, dbSchema] = await Promise.all([
     import("../db/sqlite"),
     import("@shared/api"),
     import("../observability/sentry"),


### PR DESCRIPTION
## Why

`pnpm check` (`format:check`) currently fails repo-wide for **every PR** because `apps/web/src/core/syncEngine/singleton.ts` was committed in `142a03a3` (`feat(web): wire sync engine writer runtime`) without prettier-formatting the new `Promise.all` destructuring. Effect: `check` job goes red on PRs that touch nothing related to sync v2 — confirmed empirically on PR-19 #1989 (docs-only paywall sketch) and PR-20 plan #1993 (also docs-only).

This chore-PR unblocks `check` for everyone.

## What

- `pnpm exec prettier --write apps/web/src/core/syncEngine/singleton.ts`
- Diff is **purely whitespace**: collapses 6-line vertical destructuring into a single line per prettier 80-col rule.

## Behavior delta

None. ESLint + tsc + vitest all pass on the file pre/post; the only change is a single-line vs. multi-line rendering of `[{ getSqliteDb }, { apiClient }, sentry, dbSchema]`.

## Verify locally

```bash
pnpm exec prettier --check apps/web/src/core/syncEngine/singleton.ts
# pass on this branch, fail on main
```

Link: discovered while triaging CI on https://github.com/Skords-01/Sergeant/pull/1989.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Formatted `apps/web/src/core/syncEngine/singleton.ts` with `prettier` to fix the repo-wide `pnpm check` (`format:check`) failure. Pure whitespace change; no behavior impact.

- **Bug Fixes**
  - Collapsed multi-line `Promise.all` destructuring to a single line per `prettier` rules.

<sup>Written for commit 87a75d11136e527e55cb98d36fdfefcbc9233596. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

