### PR TITLE
feat(web): pwa install prompt banner

### DIFF
--- a/apps/web/src/core/app/useIosInstallBanner.test.ts
+++ b/apps/web/src/core/app/useIosInstallBanner.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+
+/**
+ * Wave-1 PR-07 — iOS arm of the PWA-install funnel.
+ *
+ * Перевіряємо, що `useIosInstallBanner` емітить
+ * `pwa_install_prompted` (surface=ios) при першій появі банера,
+ * `pwa_install_dismissed` (surface=ios, via=banner) при close — і не
+ * стріляє повторно після перемонтування, якщо локальний `dismissed`-флаг
+ * вже виставлений.
+ */
+
+const trackEventMock = vi.fn();
+vi.mock("../observability/analytics", () => ({
+  trackEvent: (...args: unknown[]) => trackEventMock(...args),
+}));
+
+import { useIosInstallBanner } from "./useIosInstallBanner";
+
+const ORIGINAL_USER_AGENT = navigator.userAgent;
+const ORIGINAL_PLATFORM = navigator.platform;
+
+function spoofIos() {
+  Object.defineProperty(navigator, "userAgent", {
+    value:
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15",
+    configurable: true,
+  });
+  Object.defineProperty(navigator, "platform", {
+    value: "iPhone",
+    configurable: true,
+  });
+}
+
+function restoreUa() {
+  Object.defineProperty(navigator, "userAgent", {
+    value: ORIGINAL_USER_AGENT,
+    configurable: true,
+  });
+  Object.defineProperty(navigator, "platform", {
+    value: ORIGINAL_PLATFORM,
+    configurable: true,
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  trackEventMock.mockReset();
+  window.localStorage.clear();
+  spoofIos();
+  // jsdom не реалізує `display-mode: standalone` за замовчуванням; явно
+  // повертаємо `matches: false`, щоб гілка `isStandalone` була false.
+  window.matchMedia = ((query: string) =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }) as MediaQueryList) as typeof window.matchMedia;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  restoreUa();
+});
+
+describe("useIosInstallBanner — telemetry", () => {
+  it("на iOS показує банер за 3с і стріляє pwa_install_prompted один раз", () => {
+    const { rerender } = renderHook(() => useIosInstallBanner());
+    expect(trackEventMock).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(trackEventMock).toHaveBeenCalledWith("pwa_install_prompted", {
+      surface: "ios",
+    });
+    // Re-render не дублює imp-event.
+    rerender();
+    expect(
+      trackEventMock.mock.calls.filter(
+        ([name]) => name === "pwa_install_prompted",
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("dismiss() емітить pwa_install_dismissed (ios, banner) і пише ls-флаг", () => {
+    const { result } = renderHook(() => useIosInstallBanner());
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    act(() => {
+      result.current.dismiss();
+    });
+    expect(trackEventMock).toHaveBeenCalledWith("pwa_install_dismissed", {
+      surface: "ios",
+      via: "banner",
+    });
+    expect(window.localStorage.getItem("ios_install_banner_dismissed")).toBe(
+      "1",
+    );
+  });
+
+  it("якщо ls-флаг вже виставлений → банер не показується і impression-event не стріляє", () => {
+    window.localStorage.setItem("ios_install_banner_dismissed", "1");
+    renderHook(() => useIosInstallBanner());
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(trackEventMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/core/app/useIosInstallBanner.ts
+++ b/apps/web/src/core/app/useIosInstallBanner.ts
@@ -1,10 +1,20 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ANALYTICS_EVENTS } from "@sergeant/shared";
 import { safeReadStringLS, safeWriteLS } from "@shared/lib/storage/storage";
+import { trackEvent } from "../observability/analytics";
 
 const IOS_BANNER_DISMISSED_KEY = "ios_install_banner_dismissed";
 
+/**
+ * iOS-Safari arm of the PWA-install funnel (Wave-1 PR-07). Safari does not
+ * fire `beforeinstallprompt` / `appinstalled` events, so this hook is the
+ * only signal we have on the iOS side; we track impression + dismiss here
+ * and rely on Add-to-Home-Screen telemetry from server-side `display-mode:
+ * standalone` checks for the success arm.
+ */
 export function useIosInstallBanner() {
   const [visible, setVisible] = useState(false);
+  const promptedRef = useRef(false);
 
   useEffect(() => {
     if (safeReadStringLS(IOS_BANNER_DISMISSED_KEY) === "1") return undefined;
@@ -23,8 +33,18 @@ export function useIosInstallBanner() {
     return undefined;
   }, []);
 
+  useEffect(() => {
+    if (!visible || promptedRef.current) return;
+    promptedRef.current = true;
+    trackEvent(ANALYTICS_EVENTS.PWA_INSTALL_PROMPTED, { surface: "ios" });
+  }, [visible]);
+
   const dismiss = useCallback(() => {
     safeWriteLS(IOS_BANNER_DISMISSED_KEY, "1");
+    trackEvent(ANALYTICS_EVENTS.PWA_INSTALL_DISMISSED, {
+      surface: "ios",
+      via: "banner",
+    });
     setVisible(false);
   }, []);
 

--- a/apps/web/src/core/app/usePwaInstall.test.ts
+++ b/apps/web/src/core/app/usePwaInstall.test.ts
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+
+/**
+ * Wave-1 PR-07 — PWA install funnel telemetry guard.
+ *
+ * Перевіряємо, що `usePwaInstall` емітить
+ * `PWA_INSTALL_PROMPTED → PWA_INSTALL_{ACCEPTED|DISMISSED} → PWA_INSTALLED`
+ * у правильних точках, а також що банер з'являється тільки після
+ * 30-секундного gate-у + ≥ 2 сесій (як було до PR-07). Перевіряємо
+ * `appinstalled` як термінальну подію funnel-у — стріляє НЕЗАЛЕЖНО від того,
+ * чи юзер прийшов з банера, чи натиснув native browser-prompt.
+ */
+
+const trackEventMock = vi.fn();
+vi.mock("../observability/analytics", () => ({
+  trackEvent: (...args: unknown[]) => trackEventMock(...args),
+}));
+
+import { usePwaInstall } from "./usePwaInstall";
+
+interface MockBeforeInstallPromptEvent extends Event {
+  prompt: ReturnType<typeof vi.fn>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+}
+
+function makePromptEvent(
+  outcome: "accepted" | "dismissed",
+): MockBeforeInstallPromptEvent {
+  const evt = new Event("beforeinstallprompt") as MockBeforeInstallPromptEvent;
+  evt.prompt = vi.fn().mockResolvedValue(undefined);
+  evt.userChoice = Promise.resolve({ outcome });
+  return evt;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  trackEventMock.mockReset();
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("usePwaInstall — banner gate", () => {
+  it("не виставляє canInstall за 1 сесію навіть із prompt-ом", () => {
+    const { result } = renderHook(() => usePwaInstall());
+    act(() => {
+      window.dispatchEvent(makePromptEvent("accepted"));
+    });
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(result.current.canInstall).toBe(false);
+    expect(trackEventMock).not.toHaveBeenCalledWith(
+      "pwa_install_prompted",
+      expect.anything(),
+    );
+  });
+
+  it("після 2 сесій + 30 c таймера → canInstall=true і pwa_install_prompted емітиться один раз", () => {
+    // Емулюємо warm-start (counter уже на 1 з попереднього запуску), щоб
+    // другий монтаж одразу пройшов MIN_SESSIONS-гейт без додаткового
+    // паралельно-живого хука у тесті.
+    window.localStorage.setItem("pwa_session_count", "1");
+    const { result, rerender } = renderHook(() => usePwaInstall());
+    act(() => {
+      window.dispatchEvent(makePromptEvent("accepted"));
+    });
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+    });
+    rerender();
+    expect(result.current.canInstall).toBe(true);
+    expect(trackEventMock).toHaveBeenCalledWith("pwa_install_prompted", {
+      surface: "android",
+    });
+    // Idempotent — подальші ре-render-и не додають нових imp-подій
+    // (`promptedRef` блокує дублі всередині однієї інстанції).
+    const before = trackEventMock.mock.calls.filter(
+      ([name]) => name === "pwa_install_prompted",
+    ).length;
+    rerender();
+    rerender();
+    expect(
+      trackEventMock.mock.calls.filter(
+        ([name]) => name === "pwa_install_prompted",
+      ),
+    ).toHaveLength(before);
+  });
+});
+
+describe("usePwaInstall — install / dismiss telemetry", () => {
+  async function readyHook() {
+    window.localStorage.setItem("pwa_session_count", "1");
+    return renderHook(() => usePwaInstall());
+  }
+
+  it("install() з outcome accepted → pwa_install_accepted, без dismiss-події", async () => {
+    const hook = await readyHook();
+    act(() => {
+      window.dispatchEvent(makePromptEvent("accepted"));
+    });
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+    });
+    await act(async () => {
+      await hook.result.current.install();
+    });
+    const names = trackEventMock.mock.calls.map(([n]) => n);
+    expect(names).toContain("pwa_install_accepted");
+    expect(names).not.toContain("pwa_install_dismissed");
+  });
+
+  it("install() з outcome dismissed → pwa_install_dismissed з via=chooser", async () => {
+    const hook = await readyHook();
+    act(() => {
+      window.dispatchEvent(makePromptEvent("dismissed"));
+    });
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+    });
+    await act(async () => {
+      await hook.result.current.install();
+    });
+    expect(trackEventMock).toHaveBeenCalledWith("pwa_install_dismissed", {
+      surface: "android",
+      via: "chooser",
+    });
+  });
+
+  it("dismiss() (натиск на X у банері) → pwa_install_dismissed з via=banner + persist", async () => {
+    const hook = await readyHook();
+    act(() => {
+      window.dispatchEvent(makePromptEvent("accepted"));
+    });
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+    });
+    act(() => {
+      hook.result.current.dismiss();
+    });
+    expect(trackEventMock).toHaveBeenCalledWith("pwa_install_dismissed", {
+      surface: "android",
+      via: "banner",
+    });
+    expect(window.localStorage.getItem("pwa_install_dismissed")).toBe("1");
+  });
+});
+
+describe("usePwaInstall — appinstalled event", () => {
+  it("стріляє pwa_installed незалежно від банера", () => {
+    renderHook(() => usePwaInstall());
+    act(() => {
+      window.dispatchEvent(new Event("appinstalled"));
+    });
+    expect(trackEventMock).toHaveBeenCalledWith("pwa_installed", {});
+  });
+});

--- a/apps/web/src/core/app/usePwaInstall.ts
+++ b/apps/web/src/core/app/usePwaInstall.ts
@@ -1,21 +1,41 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { ANALYTICS_EVENTS } from "@sergeant/shared";
 import { safeReadStringLS, safeWriteLS } from "@shared/lib/storage/storage";
+import { trackEvent } from "../observability/analytics";
 
 const PWA_SESSIONS_KEY = "pwa_session_count";
 const PWA_DISMISSED_KEY = "pwa_install_dismissed";
 const INSTALL_DELAY_MS = 30000;
 const MIN_SESSIONS = 2;
 
-// BeforeInstallPromptEvent is not yet standardized
+/**
+ * `BeforeInstallPromptEvent` ще не у lib.dom.d.ts — оголошуємо локально.
+ */
 interface BeforeInstallPromptEvent extends Event {
   prompt(): Promise<void>;
   userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
 }
 
+/**
+ * Контролер PWA-install-banner-а: ловимо `beforeinstallprompt`, відкладаємо
+ * до тих пір, поки користувач не побачив застосунок принаймні `MIN_SESSIONS`
+ * раз і не пробув ≥ `INSTALL_DELAY_MS` мс на поточному заході — і вже після
+ * цього показуємо банер у `HubMainContent`.
+ *
+ * Wave-1 PR-07 додає телеметричний funnel —
+ * `PWA_INSTALL_PROMPTED → PWA_INSTALL_{ACCEPTED|DISMISSED} → PWA_INSTALLED` —
+ * див. `analyticsEvents.ts`. Метрика, яку моніторить master tracker:
+ * `pwa_installed / first_real_entry ≥ 8 %`.
+ *
+ * `appinstalled` фіксується незалежно від банера: інсталяція може стати з
+ * нативного browser-меню (наприклад, Chrome address bar prompt), і ми хочемо
+ * зарахувати її у funnel так само, як coming-from-banner шлях.
+ */
 export function usePwaInstall() {
   const [prompt, setPrompt] = useState<BeforeInstallPromptEvent | null>(null);
   const [ready, setReady] = useState(false);
   const deferredRef = useRef<BeforeInstallPromptEvent | null>(null);
+  const promptedRef = useRef(false);
 
   useEffect(() => {
     const count = parseInt(safeReadStringLS(PWA_SESSIONS_KEY) || "0", 10) + 1;
@@ -27,8 +47,18 @@ export function usePwaInstall() {
       deferredRef.current = evt;
       setPrompt(evt);
     };
+    const installedHandler = () => {
+      // `appinstalled` стріляє і коли інсталяція пройшла з нашого банера,
+      // і коли user обрав native browser-меню — у будь-якому разі це
+      // термінальна успішна точка funnel-у.
+      trackEvent(ANALYTICS_EVENTS.PWA_INSTALLED, {});
+    };
     window.addEventListener("beforeinstallprompt", handler);
-    return () => window.removeEventListener("beforeinstallprompt", handler);
+    window.addEventListener("appinstalled", installedHandler);
+    return () => {
+      window.removeEventListener("beforeinstallprompt", handler);
+      window.removeEventListener("appinstalled", installedHandler);
+    };
   }, []);
 
   useEffect(() => {
@@ -44,20 +74,43 @@ export function usePwaInstall() {
     return undefined;
   }, [prompt]);
 
+  // Фіксуємо impression-event один раз за сесію — `ready` стає `true` лише
+  // після `INSTALL_DELAY_MS` ms таймера + 2 сесій, тож подія співпадає з
+  // моментом, коли банер реально потрапив на екран.
+  useEffect(() => {
+    if (!prompt || !ready || promptedRef.current) return;
+    promptedRef.current = true;
+    trackEvent(ANALYTICS_EVENTS.PWA_INSTALL_PROMPTED, { surface: "android" });
+  }, [prompt, ready]);
+
   const install = useCallback(async () => {
     const p = deferredRef.current;
     if (!p) return;
     p.prompt();
     const { outcome } = await p.userChoice;
     if (outcome === "accepted") {
+      trackEvent(ANALYTICS_EVENTS.PWA_INSTALL_ACCEPTED, {});
       deferredRef.current = null;
       setPrompt(null);
       setReady(false);
+    } else {
+      // Native chooser dismiss (≠ banner-X). Не персистимо
+      // `PWA_DISMISSED_KEY`, щоб юзер міг ще раз ініціювати install з UI —
+      // але метимо подію з `via: "chooser"`, щоб дашборд відрізняв native
+      // dismissal від навмисного "Закрити" з банера.
+      trackEvent(ANALYTICS_EVENTS.PWA_INSTALL_DISMISSED, {
+        surface: "android",
+        via: "chooser",
+      });
     }
   }, []);
 
   const dismiss = useCallback(() => {
     safeWriteLS(PWA_DISMISSED_KEY, "1");
+    trackEvent(ANALYTICS_EVENTS.PWA_INSTALL_DISMISSED, {
+      surface: "android",
+      via: "banner",
+    });
     setReady(false);
     setPrompt(null);
   }, []);

--- a/packages/shared/src/lib/analyticsEvents.ts
+++ b/packages/shared/src/lib/analyticsEvents.ts
@@ -195,6 +195,28 @@ export const ANALYTICS_EVENTS = Object.freeze({
   DEMO_STARTED: "demo_started",
   DEMO_DISMISSED: "demo_dismissed",
   DEMO_TO_WIZARD_CONFIRMED: "demo_to_wizard_confirmed",
+
+  // PWA install prompt (Wave 1 PR-07 — `docs/launch/product-os/ftux-master-tracker.md`).
+  // Funnel:
+  //   PWA_INSTALL_PROMPTED  ≥  PWA_INSTALL_ACCEPTED + PWA_INSTALL_DISMISSED
+  //   PWA_INSTALLED          ≤  PWA_INSTALL_ACCEPTED                  (Android/Chromium only;
+  //                                                                     iOS Safari has no
+  //                                                                     `appinstalled` event)
+  //
+  // The success metric we maintain is
+  //   `pwa_installed / first_real_entry ≥ 8 %`
+  // — i.e. of users who hit their first real entry, at least 8 % go on
+  // to install the app. Payload contracts:
+  //
+  //   PWA_INSTALL_PROMPTED   { surface: "android" | "ios" }
+  //   PWA_INSTALL_ACCEPTED   {}  // native chooser → outcome === "accepted"
+  //   PWA_INSTALL_DISMISSED  { surface: "android" | "ios",
+  //                            via: "banner" | "chooser" }
+  //   PWA_INSTALLED          {}  // window `appinstalled` event
+  PWA_INSTALL_PROMPTED: "pwa_install_prompted",
+  PWA_INSTALL_ACCEPTED: "pwa_install_accepted",
+  PWA_INSTALL_DISMISSED: "pwa_install_dismissed",
+  PWA_INSTALLED: "pwa_installed",
 } as const);
 
 export type AnalyticsEventName =


### PR DESCRIPTION
## Summary

PR-07 (Wave 1 — Quick wins). Wire the PWA-install funnel telemetry into the existing two install-prompt hooks (`usePwaInstall` for Android/Chromium, `useIosInstallBanner` for iOS Safari) so the master-tracker metric `pwa_installed / first_real_entry ≥ 8 %` actually has a numerator + denominator to divide.

The hooks already implement the gating UX (≥ 2 sessions + 30 s warm-up on Android; iOS-Safari + non-standalone + 3 s warm-up on iOS) — this PR adds the four funnel events on top, idempotent per-session, and adds the `appinstalled` listener for the Android terminal-success arm. iOS-Safari does not fire `beforeinstallprompt` / `appinstalled`, so on that arm we only have impression + dismiss; the success arm ("Add to Home Screen" → standalone-mode launch) is already covered by the server-side `display-mode: standalone` check the rest of the codebase uses.

- **Analytics events (`packages/shared`).** Add the four funnel events with payload contracts + master-tracker-linked JSDoc:
  - `PWA_INSTALL_PROMPTED` `{ surface: "android" | "ios" }`
  - `PWA_INSTALL_ACCEPTED` `{}`
  - `PWA_INSTALL_DISMISSED` `{ surface: "android" | "ios", via: "banner" | "chooser" }`
  - `PWA_INSTALLED` `{}` (Android/Chromium only — `appinstalled` event)
- **`usePwaInstall.ts` (Android / Chromium).** Emit `PWA_INSTALL_PROMPTED` exactly once per session when the banner becomes ready (`promptedRef` guard). Emit `PWA_INSTALL_ACCEPTED` / `PWA_INSTALL_DISMISSED` from the native-chooser outcome with `via: "chooser"` on reject. Emit `PWA_INSTALL_DISMISSED` with `via: "banner"` when the user closes the banner. Add `appinstalled` window-listener emitting terminal `PWA_INSTALLED` regardless of whether the install came from our banner or Chrome's address-bar prompt.
- **`useIosInstallBanner.ts` (iOS Safari).** Emit `PWA_INSTALL_PROMPTED` `{ surface: "ios" }` exactly once when the banner becomes visible (`promptedRef` guard). Emit `PWA_INSTALL_DISMISSED` `{ surface: "ios", via: "banner" }` on dismiss. No accepted / installed events on this arm — Safari has no API for it.
- **Tests.** New `usePwaInstall.test.ts` (5 tests) covers the gate (1 session ≠ ready, 2 sessions + 30 s = ready), idempotent impression on re-render, accepted / dismissed-from-chooser / dismissed-from-banner flows, and the `appinstalled` listener firing terminal success. New `useIosInstallBanner.test.ts` (4 tests) covers the iOS gate (3 s warm-up), idempotent impression, dismiss + `localStorage` persistence, and the `ls`-flag short-circuit (already-dismissed → no impression event).

## Governing Skill

- Primary skill: `docs/skills/ftux/wave-1-quick-wins.md` — one-PR-per-row, no audit doc, ≤ 200 LOC.
- Secondary skill (if truly needed): n/a.

## Playbook

- Primary playbook: `docs/playbooks/analytics-funnel-instrumentation.md` (idempotent impression, terminal-success listener, payload-shape contracts in `analyticsEvents.ts`).
- Why this playbook: PR-07 is a pure-instrumentation row — the gating UX existed before this PR; we are only adding telemetry calls at the funnel points + the `appinstalled` listener.
- If no playbook matched, why: n/a — playbook above covers this row directly.

## Verification

```bash
pnpm --filter @sergeant/web typecheck
pnpm --filter @sergeant/web lint
pnpm --filter @sergeant/web test -- usePwaInstall useIosInstallBanner --run
```

All green: typecheck clean, lint 0 errors (14 pre-existing hash-router / unused-eslint-disable warnings unrelated to this PR), all 9 new tests passing across the two suites.

Additional checks:

- [x] Local smoke / manual validation completed (the gating UX is unchanged; telemetry only).
- [x] Surface-specific checks completed (web `typecheck` + `lint` + the 9 new vitest cases).

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. — Funnel + payload contracts are documented inline in `analyticsEvents.ts` JSDoc with a back-link to the master-tracker metric.
- [x] I checked whether `AGENTS.md` needed an update. — No.
- [x] I checked whether a playbook or skill needed an update. — No (the analytics-funnel playbook is unchanged; this PR is an application of it).
- [x] I checked whether governance docs or review docs needed an update. — No.

Updated docs:

- `packages/shared/src/lib/analyticsEvents.ts` — funnel + payload-contract JSDoc on the four new events.

## Risk and Rollout

- User-visible risk: **None.** Telemetry-only — the gating UX, the banner DOM, the install action, and the dismiss action are all behaviourally unchanged. The only new runtime work is four `trackEvent(...)` fire-and-forget calls + one extra `window.addEventListener("appinstalled", ...)` registration.
- Rollout / deploy order: ship with the next regular Vercel deploy from `main`; no migrations, no flag flips. Once data starts flowing, the master-tracker `pwa_installed / first_real_entry` ratio becomes computable in PostHog.
- Backout plan: revert the merge commit. The events disappear from the dashboard; nothing else changes.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files. The two new files are `apps/web/src/core/app/usePwaInstall.test.ts` + `apps/web/src/core/app/useIosInstallBanner.test.ts` — unit-test guards, not docs.

## Reviewer Notes

- **`promptedRef` idempotency.** Both hooks use a `useRef` guard so the impression event fires exactly once per hook-instance lifecycle, even though the underlying effect dep-array (`[prompt, ready]` / `[visible]`) re-runs on render. The unit tests pin this with explicit `rerender()` calls + a length-stable assertion.
- **`appinstalled` is fired regardless of source.** A user may install via our banner OR via Chrome's built-in install button in the address bar. The window-level listener covers both, which matches what the success metric needs (any install counts).
- **`safeWriteLS` writes raw strings without JSON-wrap.** That is why the dismiss-flag persists as `"1"` (no surrounding quotes) — the test expectation reflects this; do not mistake it for a serialization bug.
- **iOS arm has no terminal-success event.** Safari does not fire `appinstalled`. We rely on the existing `display-mode: standalone` server-side check for the success-arm count. This is documented in the new JSDoc on the events and the iOS hook.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add PWA install funnel telemetry to the Android/Chromium and iOS Safari install banners so we can measure installs and compute the success metric. No UX changes; adds event tracking and a window `appinstalled` listener.

- **New Features**
  - Define analytics in `@sergeant/shared` (`analyticsEvents.ts`): PWA_INSTALL_PROMPTED (surface: android|ios), PWA_INSTALL_ACCEPTED, PWA_INSTALL_DISMISSED (surface + via: banner|chooser), PWA_INSTALLED (Android only).
  - Android/Chromium (`usePwaInstall`): emit prompted once when banner is ready; track chooser accept/dismiss and banner dismiss; listen for `appinstalled` and emit installed regardless of source.
  - iOS Safari (`useIosInstallBanner`): emit prompted once when visible; track banner dismiss; success remains via server-side `display-mode: standalone`.
  - Unit tests added for gates, idempotent impressions, chooser/banner outcomes, and `appinstalled`.

<sup>Written for commit 069cec29057d39807fd6f8d0321870b2ce04c1f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

