### PR TITLE
refactor(web): centralise FTUX hero state into shared store (PR-12)

### DIFF
--- a/apps/web/src/core/hub/HubDashboard.tsx
+++ b/apps/web/src/core/hub/HubDashboard.tsx
@@ -45,12 +45,8 @@ import {
   getFirstRealEntryModule,
 } from "../onboarding/firstRealEntry";
 import { CrossModulePreview } from "./CrossModulePreview";
-import {
-  getSessionDays,
-  isFirstActionPending,
-  isSoftAuthDismissed,
-  recordSessionDay,
-} from "../onboarding/vibePicks";
+import { getSessionDays, recordSessionDay } from "../onboarding/vibePicks";
+import { useOnboardingState } from "../onboarding/useOnboardingState";
 import { useFirstEntryCelebration } from "../onboarding/useFirstEntryCelebration";
 import { CelebrationModal } from "../onboarding/CelebrationModal";
 import { DailyNudge } from "../onboarding/DailyNudge";
@@ -182,10 +178,6 @@ export function HubDashboard({
   const density = useDashboardDensity();
   useMondayAutoDigest();
 
-  const [firstActionVisible, setFirstActionVisible] = useState(() =>
-    isFirstActionPending(),
-  );
-
   const hasRealEntry = detectFirstRealEntry();
   const celebration = useFirstEntryCelebration(hasRealEntry);
   const [sessionDays, setSessionDays] = useState(-1);
@@ -196,25 +188,7 @@ export function HubDashboard({
   useEffect(() => {
     setSessionDays(recordSessionDay() || getSessionDays());
   }, []);
-  const SOFT_AUTH_SESSION_DAYS_THRESHOLD = 3;
-  // Скільки сеансів-днів має минути після першого реального запису, перш
-  // ніж показати SoftAuth. `1` означає «не на тому ж дні»: користувач,
-  // що щойно завершив `FirstActionHeroCard` → `CelebrationModal`, не
-  // отримує одразу прохання створити акаунт. Картка чекає наступного
-  // повернення (sessionDays ≥ 2). Це зберігає «win-момент» цілим, а
-  // самій картці дає вищий signal-to-noise: якщо юзер повернувся —
-  // він уже залучений.
-  const SOFT_AUTH_AFTER_ENTRY_MIN_SESSION_DAYS = 2;
-  const [softAuthDismissed, setSoftAuthDismissed] = useState(() =>
-    isSoftAuthDismissed(),
-  );
   const entryCount = useMemo(() => countRealEntries(localStorageStore), []);
-  const showSoftAuth =
-    !user &&
-    !softAuthDismissed &&
-    typeof onShowAuth === "function" &&
-    ((hasRealEntry && sessionDays >= SOFT_AUTH_AFTER_ENTRY_MIN_SESSION_DAYS) ||
-      sessionDays >= SOFT_AUTH_SESSION_DAYS_THRESHOLD);
 
   const [reengagement, setReengagement] = useState(() =>
     shouldShowReengagement(localStorageStore),
@@ -222,6 +196,30 @@ export function HubDashboard({
   useEffect(() => {
     recordLastActiveDate(localStorageStore);
   }, []);
+
+  // Single source of truth for the FTUX hero slot (PR-12). Wraps the
+  // pure `resolveOnboardingHero` resolver from `@sergeant/shared` and
+  // owns the `firstActionVisible` / `softAuthDismissed` storage flags
+  // that used to be inline `useState`s here. Behavioural contract is
+  // identical to the previous `if/else` ladder; the gain is that the
+  // single-hero invariant lives in one tested place and mobile can
+  // share the resolver in PR-21 (FTUX parity sweep).
+  //
+  // The `useDashboardFocus()` hook is invoked further below — we
+  // re-call it inline to read `focus !== null` for the resolver and
+  // then destructure once more after the hook so we keep variable
+  // names stable. Both calls share the same memoised state because
+  // `useLocalStorageState` is keyed by the dismissed-map storage key
+  // (`hub_recs_dismissed_v1`).
+  const focusProbe = useDashboardFocus();
+  const onboardingState = useOnboardingState({
+    user,
+    hasRealEntry,
+    sessionDays,
+    todayFocusAvailable: focusProbe.focus !== null,
+    reengagementEligible: reengagement.show,
+    onShowAuth,
+  });
 
   // Cross-module preview (S6.4) — one-shot post-first-entry promo.
   // Snapshotted at mount: source module is taken from `getFirstRealEntryModule`
@@ -278,7 +276,7 @@ export function HubDashboard({
     [order, activeModules, hideInactive],
   );
 
-  const { focus, rest, dismiss } = useDashboardFocus();
+  const { focus, rest, dismiss } = focusProbe;
 
   // Insights з deep-link (`actionHash`) повинні відкрити модуль рівно
   // на потрібній вкладці/елементі — не на дефолтному Огляді. Якщо
@@ -447,19 +445,24 @@ export function HubDashboard({
     | "nutrition"
     | undefined;
   const showChecklist =
-    primaryModule && hasRealEntry && !firstActionVisible && sessionDays <= 7;
+    primaryModule &&
+    hasRealEntry &&
+    !onboardingState.showFirstAction &&
+    sessionDays <= 7;
 
-  // ONE-HERO RULE
+  // ONE-HERO RULE — the resolver in `useOnboardingState` already
+  // narrowed the candidates to a single winner. We just dispatch on
+  // its `show*` flags and let the resolver carry the priority logic.
   let hero: React.ReactNode;
-  if (firstActionVisible) {
+  if (onboardingState.showFirstAction) {
     hero = (
-      <FirstActionHeroCard onDismiss={() => setFirstActionVisible(false)} />
+      <FirstActionHeroCard onDismiss={onboardingState.dismissFirstAction} />
     );
-  } else if (showSoftAuth) {
+  } else if (onboardingState.showSoftAuth) {
     hero = (
       <SoftAuthPromptCard
         onOpenAuth={onShowAuth}
-        onDismiss={() => setSoftAuthDismissed(true)}
+        onDismiss={onboardingState.dismissSoftAuth}
         entryCount={entryCount}
         sessionDays={sessionDays}
       />
@@ -523,7 +526,8 @@ export function HubDashboard({
                * the hero card produced the «card avalanche» the IA pass
                * is fixing — streak still re-appears once the hero falls
                * back to TodayFocus or the default state. */}
-              {!firstActionVisible && !showSoftAuth && <StreakIndicator />}
+              {!onboardingState.showFirstAction &&
+                !onboardingState.showSoftAuth && <StreakIndicator />}
               {hero}
               {showChecklist && primaryModule && (
                 <ModuleChecklist

--- a/apps/web/src/core/onboarding/useOnboardingState.test.ts
+++ b/apps/web/src/core/onboarding/useOnboardingState.test.ts
@@ -1,0 +1,251 @@
+/** @vitest-environment jsdom */
+/**
+ * Tests for the `useOnboardingState` React hook (PR-12). The pure
+ * `resolveOnboardingHero` resolver is covered separately in
+ * `packages/shared/src/lib/onboardingHero.test.ts`; this file focuses
+ * on the React-glue behaviour:
+ *
+ *   • storage flags read once on mount via lazy initialisers
+ *   • dismissals flip the in-render flag and persist via injected
+ *     storage adapter
+ *   • soft-auth threshold logic matches the legacy `HubDashboard`
+ *     derivation byte-for-byte
+ */
+
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  SOFT_AUTH_AFTER_ENTRY_MIN_SESSION_DAYS,
+  SOFT_AUTH_SESSION_DAYS_THRESHOLD,
+  useOnboardingState,
+  type OnboardingStateStorage,
+  type UseOnboardingStateOptions,
+} from "./useOnboardingState";
+
+function makeStorage(
+  overrides: Partial<OnboardingStateStorage> = {},
+): OnboardingStateStorage {
+  return {
+    isFirstActionPending: vi.fn(() => false),
+    isSoftAuthDismissed: vi.fn(() => false),
+    clearFirstActionPending: vi.fn(),
+    ...overrides,
+  };
+}
+
+const BASE: UseOnboardingStateOptions = {
+  user: null,
+  hasRealEntry: false,
+  sessionDays: 0,
+  todayFocusAvailable: false,
+  reengagementEligible: false,
+  onShowAuth: () => {},
+};
+
+describe("useOnboardingState", () => {
+  it("reads storage flags exactly once on mount", () => {
+    const storage = makeStorage({
+      isFirstActionPending: vi.fn(() => true),
+      isSoftAuthDismissed: vi.fn(() => false),
+    });
+
+    const { rerender } = renderHook(
+      (props: UseOnboardingStateOptions) => useOnboardingState(props, storage),
+      { initialProps: BASE },
+    );
+
+    rerender({ ...BASE, sessionDays: 5 });
+    rerender({ ...BASE, sessionDays: 7 });
+
+    expect(storage.isFirstActionPending).toHaveBeenCalledTimes(1);
+    expect(storage.isSoftAuthDismissed).toHaveBeenCalledTimes(1);
+  });
+
+  it("promotes first-action when FTUX is pending", () => {
+    const storage = makeStorage({
+      isFirstActionPending: vi.fn(() => true),
+    });
+
+    const { result } = renderHook(() =>
+      useOnboardingState({ ...BASE, todayFocusAvailable: true }, storage),
+    );
+
+    expect(result.current.hero).toBe("first-action");
+    expect(result.current.showFirstAction).toBe(true);
+    expect(result.current.showSoftAuth).toBe(false);
+    expect(result.current.showTodayFocus).toBe(false);
+  });
+
+  it("dismissFirstAction clears storage and flips the flag in-render", () => {
+    const storage = makeStorage({
+      isFirstActionPending: vi.fn(() => true),
+    });
+
+    const { result } = renderHook(() =>
+      useOnboardingState({ ...BASE, todayFocusAvailable: true }, storage),
+    );
+
+    expect(result.current.showFirstAction).toBe(true);
+
+    act(() => {
+      result.current.dismissFirstAction();
+    });
+
+    expect(storage.clearFirstActionPending).toHaveBeenCalledTimes(1);
+    expect(result.current.showFirstAction).toBe(false);
+    // Today-focus takes the slot in the same tick.
+    expect(result.current.hero).toBe("today-focus");
+  });
+
+  it("suppresses soft-auth when user is signed in", () => {
+    const { result } = renderHook(() =>
+      useOnboardingState(
+        {
+          ...BASE,
+          user: {
+            id: "u1",
+            email: "u@example.com",
+            name: null,
+            image: null,
+            emailVerified: false,
+            createdAt: new Date().toISOString(),
+          },
+          hasRealEntry: true,
+          sessionDays: 5,
+        },
+        makeStorage(),
+      ),
+    );
+
+    expect(result.current.showSoftAuth).toBe(false);
+  });
+
+  it("suppresses soft-auth when user has dismissed it", () => {
+    const storage = makeStorage({
+      isSoftAuthDismissed: vi.fn(() => true),
+    });
+
+    const { result } = renderHook(() =>
+      useOnboardingState(
+        {
+          ...BASE,
+          hasRealEntry: true,
+          sessionDays: SOFT_AUTH_SESSION_DAYS_THRESHOLD,
+        },
+        storage,
+      ),
+    );
+
+    expect(result.current.showSoftAuth).toBe(false);
+  });
+
+  it("suppresses soft-auth when onShowAuth is missing", () => {
+    const { result } = renderHook(() =>
+      useOnboardingState(
+        {
+          ...BASE,
+          hasRealEntry: false,
+          sessionDays: SOFT_AUTH_SESSION_DAYS_THRESHOLD,
+          onShowAuth: undefined,
+        },
+        makeStorage(),
+      ),
+    );
+
+    expect(result.current.showSoftAuth).toBe(false);
+  });
+
+  it("fires soft-auth for cold users at the cold threshold", () => {
+    const { result } = renderHook(() =>
+      useOnboardingState(
+        {
+          ...BASE,
+          hasRealEntry: false,
+          sessionDays: SOFT_AUTH_SESSION_DAYS_THRESHOLD,
+        },
+        makeStorage(),
+      ),
+    );
+
+    expect(result.current.showSoftAuth).toBe(true);
+    expect(result.current.reason).toBe("soft-auth-due");
+  });
+
+  it("fires soft-auth earlier for post-first-entry users", () => {
+    const { result } = renderHook(() =>
+      useOnboardingState(
+        {
+          ...BASE,
+          hasRealEntry: true,
+          sessionDays: SOFT_AUTH_AFTER_ENTRY_MIN_SESSION_DAYS,
+        },
+        makeStorage(),
+      ),
+    );
+
+    expect(result.current.showSoftAuth).toBe(true);
+  });
+
+  it("dismissSoftAuth clears the slot in-render", () => {
+    const { result } = renderHook(() =>
+      useOnboardingState(
+        {
+          ...BASE,
+          hasRealEntry: true,
+          sessionDays: SOFT_AUTH_AFTER_ENTRY_MIN_SESSION_DAYS,
+          todayFocusAvailable: true,
+        },
+        makeStorage(),
+      ),
+    );
+
+    expect(result.current.showSoftAuth).toBe(true);
+
+    act(() => {
+      result.current.dismissSoftAuth();
+    });
+
+    expect(result.current.showSoftAuth).toBe(false);
+    expect(result.current.hero).toBe("today-focus");
+  });
+
+  it("reengagement wins over every other candidate", () => {
+    const storage = makeStorage({
+      isFirstActionPending: vi.fn(() => true),
+    });
+
+    const { result } = renderHook(() =>
+      useOnboardingState(
+        {
+          ...BASE,
+          reengagementEligible: true,
+          hasRealEntry: true,
+          sessionDays: SOFT_AUTH_SESSION_DAYS_THRESHOLD,
+          todayFocusAvailable: true,
+        },
+        storage,
+      ),
+    );
+
+    expect(result.current.hero).toBe("reengagement");
+    expect(result.current.showReengagement).toBe(true);
+    // All four contenders should still be reported.
+    expect(result.current.candidates).toEqual([
+      "reengagement",
+      "first-action",
+      "soft-auth",
+      "today-focus",
+    ]);
+  });
+
+  it("returns hero=null when no candidate is eligible", () => {
+    const { result } = renderHook(() =>
+      useOnboardingState(BASE, makeStorage()),
+    );
+
+    expect(result.current.hero).toBeNull();
+    expect(result.current.reason).toBe("none");
+    expect(result.current.candidates).toEqual([]);
+  });
+});

--- a/apps/web/src/core/onboarding/useOnboardingState.ts
+++ b/apps/web/src/core/onboarding/useOnboardingState.ts
@@ -1,0 +1,212 @@
+/**
+ * `useOnboardingState` — React state machine for the FTUX hero slot
+ * (PR-12). Wraps the pure `resolveOnboardingHero` resolver from
+ * `@sergeant/shared` and adds the storage / lifecycle plumbing the
+ * dashboard previously kept inline.
+ *
+ * Why this lives in `apps/web` rather than `packages/shared`:
+ * `useState`, `useCallback`, and the `vibePicks` storage helpers all
+ * depend on web-specific bindings (`localStorage` / `webKVStore`).
+ * The reusable bits — priority order, single-hero invariant, reason
+ * vocabulary — already live in `packages/shared/src/lib/onboardingHero.ts`,
+ * so the mobile port (PR-21 — "FTUX parity sweep") can re-use that
+ * resolver while wiring its own MMKV-backed hook.
+ *
+ * Behavioural contract preserved 1:1 from `HubDashboard`:
+ *   • FTUX hero hides as soon as the user dismisses (storage flag
+ *     cleared + in-render boolean flipped) so the next priority
+ *     winner takes the slot in the same render.
+ *   • Soft-auth thresholds: 3 session-days for cold users, 2 session-
+ *     days minimum after the first real entry so the celebration
+ *     modal is not immediately followed by an auth nag.
+ *   • TodayFocus availability is a caller-supplied boolean — the
+ *     dashboard already owns `useDashboardFocus()` and we don't want
+ *     to re-couple to it here.
+ */
+
+import { useCallback, useState } from "react";
+
+import {
+  resolveOnboardingHero,
+  type OnboardingHeroId,
+  type OnboardingHeroReason,
+  type User,
+} from "@sergeant/shared";
+
+import {
+  clearFirstActionPending,
+  isFirstActionPending,
+  isSoftAuthDismissed,
+} from "./vibePicks";
+
+/**
+ * Days the user must have visited the dashboard before the soft-auth
+ * nag fires for a *cold* user (no real entry yet). Mirrors the legacy
+ * `SOFT_AUTH_SESSION_DAYS_THRESHOLD` constant from `HubDashboard.tsx`
+ * before this refactor — exported so tests can reference it without
+ * duplicating the magic number.
+ */
+export const SOFT_AUTH_SESSION_DAYS_THRESHOLD = 3;
+
+/**
+ * Minimum session-days the *post-first-entry* user must have before
+ * the soft-auth nag fires. The lower threshold (vs. cold users) is
+ * intentional — engaged users tolerate the nag earlier — but it is
+ * still ≥ 2 so we never collide the auth prompt with the celebration
+ * modal that fires on the first-entry session itself.
+ */
+export const SOFT_AUTH_AFTER_ENTRY_MIN_SESSION_DAYS = 2;
+
+export interface UseOnboardingStateOptions {
+  /** Current user record (or `null`/`undefined` if anonymous). When
+   *  truthy, suppresses the soft-auth nag. */
+  user: User | null | undefined;
+  /** `detectFirstRealEntry()` resolved to `true`. Drives the cold-vs-
+   *  post-first-entry split for the soft-auth threshold. */
+  hasRealEntry: boolean;
+  /** Number of distinct calendar-days the user has visited the hub.
+   *  Use the `-1` sentinel during the first render (before
+   *  `recordSessionDay()` resolves) so all FTUX gates stay closed. */
+  sessionDays: number;
+  /** `useDashboardFocus()` returned a non-null `focus` rec. The
+   *  dashboard already computes this — passing it in keeps the hook
+   *  decoupled from the focus implementation. */
+  todayFocusAvailable: boolean;
+  /** `nudges.ts:shouldShowReengagement(...)` resolved to `true`. */
+  reengagementEligible: boolean;
+  /** Optional auth-modal opener. The soft-auth nag is suppressed
+   *  when this is missing — the card is useless without a way to
+   *  open the modal it nags toward. */
+  onShowAuth?: () => void;
+}
+
+export interface UseOnboardingStateResult {
+  /** Resolved hero id from `resolveOnboardingHero`. `null` means
+   *  no candidate is eligible (post-FTUX without focus rec, etc.). */
+  hero: OnboardingHeroId | null;
+  /** Why `hero` won — fed into `hub_hero_resolved` analytics if/when
+   *  the dashboard fires the event. */
+  reason: OnboardingHeroReason;
+  /** All eligible candidates in priority order. The dashboard can
+   *  use this to assert the single-hero invariant in dev or to
+   *  surface conflict-rate analytics. */
+  candidates: readonly OnboardingHeroId[];
+  /** True when the FTUX hero is the slot winner. Cheaper to read
+   *  than `hero === "first-action"` at the call site, and lets
+   *  ancillary toggles (streak chip suppression, checklist gating)
+   *  reference the same source of truth. */
+  showFirstAction: boolean;
+  /** True when the soft-auth nag is the slot winner. */
+  showSoftAuth: boolean;
+  /** True when the TodayFocus card is the slot winner (default). */
+  showTodayFocus: boolean;
+  /** True when the re-engagement card is the slot winner — note this
+   *  card replaces the entire hero block on web, so the dashboard
+   *  branches on this flag at a higher level. */
+  showReengagement: boolean;
+  /** Dismiss the FTUX hero. Clears `hub_first_action_pending_v1`
+   *  (storage) and flips the in-render flag so the next-priority
+   *  candidate (soft-auth or today-focus) takes the slot in the
+   *  same render. */
+  dismissFirstAction: () => void;
+  /** Dismiss the soft-auth nag. Persists to storage so subsequent
+   *  sessions also skip the card. */
+  dismissSoftAuth: () => void;
+}
+
+/**
+ * Compute soft-auth eligibility from the same inputs the legacy
+ * `HubDashboard.showSoftAuth` derivation used.
+ */
+function computeSoftAuthEligible(
+  user: User | null | undefined,
+  softAuthDismissed: boolean,
+  hasRealEntry: boolean,
+  sessionDays: number,
+  onShowAuth?: () => void,
+): boolean {
+  return (
+    !user &&
+    !softAuthDismissed &&
+    typeof onShowAuth === "function" &&
+    ((hasRealEntry && sessionDays >= SOFT_AUTH_AFTER_ENTRY_MIN_SESSION_DAYS) ||
+      sessionDays >= SOFT_AUTH_SESSION_DAYS_THRESHOLD)
+  );
+}
+
+/**
+ * Pluggable storage hooks for tests. `useOnboardingState` always
+ * defaults to the production `vibePicks.ts` helpers; tests inject
+ * deterministic mocks via the second argument.
+ */
+export interface OnboardingStateStorage {
+  isFirstActionPending: () => boolean;
+  isSoftAuthDismissed: () => boolean;
+  clearFirstActionPending: () => void;
+}
+
+const DEFAULT_STORAGE: OnboardingStateStorage = {
+  isFirstActionPending,
+  isSoftAuthDismissed,
+  clearFirstActionPending,
+};
+
+export function useOnboardingState(
+  options: UseOnboardingStateOptions,
+  storage: OnboardingStateStorage = DEFAULT_STORAGE,
+): UseOnboardingStateResult {
+  const {
+    user,
+    hasRealEntry,
+    sessionDays,
+    todayFocusAvailable,
+    reengagementEligible,
+    onShowAuth,
+  } = options;
+
+  // Lazy initialisers: storage reads run once on mount, not on every
+  // render. The booleans flip only via the explicit `dismiss*`
+  // callbacks below.
+  const [firstActionVisible, setFirstActionVisible] = useState(() =>
+    storage.isFirstActionPending(),
+  );
+  const [softAuthDismissed, setSoftAuthDismissed] = useState(() =>
+    storage.isSoftAuthDismissed(),
+  );
+
+  const softAuthEligible = computeSoftAuthEligible(
+    user,
+    softAuthDismissed,
+    hasRealEntry,
+    sessionDays,
+    onShowAuth,
+  );
+
+  const resolution = resolveOnboardingHero({
+    reengagementEligible,
+    firstActionVisible,
+    softAuthEligible,
+    todayFocusAvailable,
+  });
+
+  const dismissFirstAction = useCallback(() => {
+    storage.clearFirstActionPending();
+    setFirstActionVisible(false);
+  }, [storage]);
+
+  const dismissSoftAuth = useCallback(() => {
+    setSoftAuthDismissed(true);
+  }, []);
+
+  return {
+    hero: resolution.hero,
+    reason: resolution.reason,
+    candidates: resolution.candidates,
+    showFirstAction: resolution.hero === "first-action",
+    showSoftAuth: resolution.hero === "soft-auth",
+    showTodayFocus: resolution.hero === "today-focus",
+    showReengagement: resolution.hero === "reengagement",
+    dismissFirstAction,
+    dismissSoftAuth,
+  };
+}

--- a/docs/launch/product-os/ftux-master-tracker.md
+++ b/docs/launch/product-os/ftux-master-tracker.md
@@ -138,7 +138,9 @@
 | **PR-13** | feat(experiments): goal-first wizard variant (S5.1) | ~250 | PR-11        | D7 retention за goal-first arm vs current ≥ +5pp    |
 | **PR-14** | feat(observability): FTUX SLO + dashboard + alert   | ~100 | —            | Self-referential — alert fires when SLO breaches    |
 
-> **PR-11 status (2026-05-06):** in-flight як [#1991](https://github.com/Skords-01/Sergeant/pull/1991) — додав `rankFirstActionCandidates`, vibe-pick-order tie-break серед goal-set picks та `primary_reason` faceting field у `onboarding_first_action_*` події (Sentry/PostHog). Static fallback (без goals) — байт-в-байт як до S2.1.
+> **PR-11 status (2026-05-06):** ✅ [Merged #1991](https://github.com/Skords-01/Sergeant/pull/1991) — додав `rankFirstActionCandidates`, vibe-pick-order tie-break серед goal-set picks та `primary_reason` faceting field у `onboarding_first_action_*` події (Sentry/PostHog). Static fallback (без goals) — байт-в-байт як до S2.1.
+>
+> **PR-12 status (2026-05-06):** in-flight як [#2014](https://github.com/Skords-01/Sergeant/pull/2014) — `resolveOnboardingHero` (shared, pure) + `useOnboardingState` (web hook) + `HubDashboard` рефакторинг. 4-tier priority ladder (`reengagement > first-action > soft-auth > today-focus`) централізує single-hero rule в одному tested місці; mobile parity — Wave 4 PR-21.
 
 ### 3.3. Хвиля 3 — Platform parity (Week 3-4, 4 PR)
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -56,6 +56,7 @@ export * from "./lib/onboarding";
 
 // Onboarding goal-setting (multi-step v2).
 export * from "./lib/onboardingGoals";
+export * from "./lib/onboardingHero";
 
 // Pre-first-entry value-promise bars (S3.3 shared logic — used by
 // the web `<ValueProgressBar>` and the mobile RN port).

--- a/packages/shared/src/lib/onboardingHero.test.ts
+++ b/packages/shared/src/lib/onboardingHero.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ONBOARDING_HERO_PRIORITY,
+  resolveOnboardingHero,
+  type OnboardingHeroInputs,
+} from "./onboardingHero";
+
+const NONE: OnboardingHeroInputs = {
+  reengagementEligible: false,
+  firstActionVisible: false,
+  softAuthEligible: false,
+  todayFocusAvailable: false,
+};
+
+describe("resolveOnboardingHero (PR-12)", () => {
+  it("returns null hero with reason='none' when no candidate is eligible", () => {
+    expect(resolveOnboardingHero(NONE)).toEqual({
+      hero: null,
+      reason: "none",
+      candidates: [],
+    });
+  });
+
+  it("promotes today-focus when it's the only candidate", () => {
+    expect(
+      resolveOnboardingHero({ ...NONE, todayFocusAvailable: true }),
+    ).toEqual({
+      hero: "today-focus",
+      reason: "today-focus",
+      candidates: ["today-focus"],
+    });
+  });
+
+  it("promotes first-action over today-focus during FTUX", () => {
+    const result = resolveOnboardingHero({
+      ...NONE,
+      firstActionVisible: true,
+      todayFocusAvailable: true,
+    });
+    expect(result.hero).toBe("first-action");
+    expect(result.reason).toBe("ftux-pending");
+    expect(result.candidates).toEqual(["first-action", "today-focus"]);
+  });
+
+  it("promotes soft-auth over today-focus when FTUX is done", () => {
+    const result = resolveOnboardingHero({
+      ...NONE,
+      softAuthEligible: true,
+      todayFocusAvailable: true,
+    });
+    expect(result.hero).toBe("soft-auth");
+    expect(result.reason).toBe("soft-auth-due");
+  });
+
+  it("first-action wins over soft-auth when both are eligible", () => {
+    // Defensive: storage flags should never both be true at the same
+    // time, but the resolver needs to produce a deterministic winner
+    // anyway so the hero slot does not flicker between renders.
+    const result = resolveOnboardingHero({
+      ...NONE,
+      firstActionVisible: true,
+      softAuthEligible: true,
+    });
+    expect(result.hero).toBe("first-action");
+  });
+
+  it("reengagement wins over every other candidate", () => {
+    const result = resolveOnboardingHero({
+      reengagementEligible: true,
+      firstActionVisible: true,
+      softAuthEligible: true,
+      todayFocusAvailable: true,
+    });
+    expect(result.hero).toBe("reengagement");
+    expect(result.reason).toBe("reengagement-active");
+    // All four candidates should be reported so the dashboard / tests
+    // can detect the conflict.
+    expect(result.candidates).toEqual([
+      "reengagement",
+      "first-action",
+      "soft-auth",
+      "today-focus",
+    ]);
+  });
+
+  it("preserves priority ordering in candidates", () => {
+    // soft-auth + first-action: candidates should still be reported in
+    // priority order, not in input order.
+    const result = resolveOnboardingHero({
+      ...NONE,
+      softAuthEligible: true,
+      firstActionVisible: true,
+    });
+    expect(result.candidates).toEqual(["first-action", "soft-auth"]);
+  });
+
+  it("ONBOARDING_HERO_PRIORITY exposes the canonical ordering", () => {
+    // Hard-coded so analytics / docs can rely on the order without
+    // having to re-derive it from the resolver behaviour.
+    expect([...ONBOARDING_HERO_PRIORITY]).toEqual([
+      "reengagement",
+      "first-action",
+      "soft-auth",
+      "today-focus",
+    ]);
+  });
+});

--- a/packages/shared/src/lib/onboardingHero.ts
+++ b/packages/shared/src/lib/onboardingHero.ts
@@ -1,0 +1,157 @@
+/**
+ * Pure resolver for the FTUX hero slot's "single-hero rule" (PR-12).
+ *
+ * Web `HubDashboard` (and, eventually, mobile `HubDashboard`) renders a
+ * single primary card at the top of the dashboard chrome. Across the
+ * onboarding journey this slot is contended by four very different
+ * surfaces, each with its own copy / CTA / dismissal semantics:
+ *
+ *   1. `ReEngagementCard`  — fired when the user has been inactive for
+ *      ≥ `REENGAGEMENT_INACTIVE_DAYS` (see `nudges.ts`). Treat as the
+ *      ultimate hero: a returning-user nudge wins over any FTUX/auth
+ *      framing because we want the comeback acknowledged before
+ *      anything else.
+ *   2. `FirstActionHeroCard` — pre-first-real-entry FTUX hero. Drives
+ *      the "tap once to your first real entry" flow.
+ *   3. `SoftAuthPromptCard` — anonymous user, post-FTUX, eligible
+ *      session-day window. Cheap account-creation nudge that should
+ *      not collide with FTUX (`firstActionVisible` win).
+ *   4. `TodayFocusCard`     — the default daily card; visible whenever
+ *      the dashboard has a focus rec to surface and no higher-priority
+ *      contender is asking for the slot.
+ *
+ * Before this resolver, the priority chain was an ad-hoc `if/else`
+ * ladder inside `HubDashboard` that was duplicated almost verbatim on
+ * mobile. Every new hero candidate forced an `if` insertion in two
+ * files and a coordinated review to keep tie-breaking consistent.
+ * Centralising the rule here lets the dashboards stay declarative
+ * (`state.activeHero === "first-action"` vs the previous `if (foo)
+ * else if (bar) else …`) and lets the `single-hero` invariant be
+ * asserted once for both platforms — exactly what the FTUX master
+ * tracker §3.2 / PR-12 metric expects ("≤1 prompt-card одночасно").
+ */
+
+/**
+ * Identifier for a candidate hero card. Matches the React component
+ * names from `apps/web/src/core/hub/HubDashboard.tsx`. New hero
+ * candidates must be inserted into `ONBOARDING_HERO_PRIORITY` in the
+ * order they should win the slot.
+ */
+export type OnboardingHeroId =
+  | "reengagement"
+  | "first-action"
+  | "soft-auth"
+  | "today-focus";
+
+/**
+ * Eligibility flags for each candidate. Callers compute these from
+ * their own state (storage, useEffect-tracked flags, derived booleans)
+ * and pass them through; the resolver itself stays pure so it is
+ * trivial to unit-test and to re-run on every render without worrying
+ * about side effects.
+ */
+export interface OnboardingHeroInputs {
+  /** `nudges.ts:shouldShowReengagement(...)` resolved to `true`. */
+  reengagementEligible: boolean;
+  /** `vibePicks.ts:isFirstActionPending(...)` resolved to `true` and
+   *  the user has not yet dismissed the FTUX hero in this render. */
+  firstActionVisible: boolean;
+  /** Composite eligibility for the soft-auth nag — anonymous user,
+   *  not previously dismissed, callable `onShowAuth` available, and
+   *  `sessionDays` past the configured threshold. The resolver does
+   *  not crack this composite open because every input has its own
+   *  tested predicate already. */
+  softAuthEligible: boolean;
+  /** `useDashboardFocus()` returned a non-null `focus` rec. The
+   *  TodayFocus card is otherwise empty and would never be a real
+   *  hero candidate, so we filter it out at the resolver level. */
+  todayFocusAvailable: boolean;
+}
+
+/**
+ * Why the given `hero` won. Mirrors `OnboardingHeroId` so dashboards
+ * can fire one-shot analytics events when the slot flips, e.g.
+ * `hub_hero_resolved` with `reason: "ftux-pending"`. Keeping the
+ * vocabulary tight (one tag per hero) means PostHog can compute
+ * "hero conflict rate" as `count(distinct(reason) per session) > 1`.
+ */
+export type OnboardingHeroReason =
+  | "reengagement-active"
+  | "ftux-pending"
+  | "soft-auth-due"
+  | "today-focus"
+  | "none";
+
+export interface OnboardingHeroResolution {
+  /** Winning hero id, or `null` when no candidate is eligible — in
+   *  that case the dashboard should render nothing in the hero slot
+   *  (post-FTUX without a focus rec is the canonical "empty" path). */
+  hero: OnboardingHeroId | null;
+  /** Reason matching the winner (for analytics). `none` when
+   *  `hero === null`. */
+  reason: OnboardingHeroReason;
+  /** All eligible candidates in priority order. Lets the dashboard
+   *  assert the single-hero invariant in dev (`candidates.length <=
+   *  1` after deduping) and lets tests inspect tie-break behaviour
+   *  without re-running the resolver multiple times. */
+  candidates: OnboardingHeroId[];
+}
+
+/**
+ * Single-hero priority order. Higher-priority candidates eat lower-
+ * priority ones. Re-engagement wins everything — a returning user is
+ * a stronger signal than any FTUX framing. FTUX wins next so we never
+ * overlay a soft-auth nag on top of an unfinished first-action flow.
+ * Soft-auth then wins the remaining slot, and today-focus is the
+ * default fallback when no special nudge is due.
+ */
+export const ONBOARDING_HERO_PRIORITY: readonly OnboardingHeroId[] = [
+  "reengagement",
+  "first-action",
+  "soft-auth",
+  "today-focus",
+] as const;
+
+const REASON_BY_HERO: Record<OnboardingHeroId, OnboardingHeroReason> = {
+  reengagement: "reengagement-active",
+  "first-action": "ftux-pending",
+  "soft-auth": "soft-auth-due",
+  "today-focus": "today-focus",
+};
+
+/**
+ * Resolve the single hero for the dashboard's hero slot.
+ *
+ * - When zero candidates are eligible, returns `{ hero: null, reason:
+ *   "none", candidates: [] }`. Callers should render nothing in the
+ *   slot (or a no-op skeleton) — falling back to one of the cards
+ *   anyway would re-introduce the "two heroes at once" bug we are
+ *   fixing.
+ * - Otherwise returns the highest-priority eligible candidate plus
+ *   the full `candidates` list so callers can verify the single-hero
+ *   invariant or fire conflict analytics.
+ *
+ * The function is intentionally pure and synchronous — no storage
+ * access, no `useState`, no React imports — so it can be re-evaluated
+ * on every render without a memoisation hop, and so it is trivially
+ * tested via the table-driven cases in `onboardingHero.test.ts`.
+ */
+export function resolveOnboardingHero(
+  inputs: OnboardingHeroInputs,
+): OnboardingHeroResolution {
+  const eligibility: Record<OnboardingHeroId, boolean> = {
+    reengagement: inputs.reengagementEligible,
+    "first-action": inputs.firstActionVisible,
+    "soft-auth": inputs.softAuthEligible,
+    "today-focus": inputs.todayFocusAvailable,
+  };
+
+  const candidates = ONBOARDING_HERO_PRIORITY.filter((id) => eligibility[id]);
+
+  if (candidates.length === 0) {
+    return { hero: null, reason: "none", candidates: [] };
+  }
+
+  const hero = candidates[0]!;
+  return { hero, reason: REASON_BY_HERO[hero], candidates };
+}


### PR DESCRIPTION
## Summary

Implements **PR-12** from the FTUX master tracker §3.2 — _OnboardingState shared store_.

The FTUX hero slot in `HubDashboard` (web) is contended by four very different cards (`ReEngagementCard`, `FirstActionHeroCard`, `SoftAuthPromptCard`, `TodayFocusCard`), each with its own state and dismissal semantics. Before this PR the priority chain was an ad-hoc `if/else` ladder with `firstActionVisible` / `softAuthDismissed` / `showSoftAuth` derivations strewn across `HubDashboard.tsx`. Every new hero candidate forced a coordinated edit to keep tie-breaking consistent.

This PR centralises the rule into:

- **`packages/shared/src/lib/onboardingHero.ts`** — pure `resolveOnboardingHero(inputs)` resolver with a 4-tier priority ladder (`reengagement > first-action > soft-auth > today-focus`), discriminated reason enum (`reengagement-active | ftux-pending | soft-auth-due | today-focus | none`), and the canonical `ONBOARDING_HERO_PRIORITY` constant. No React, no storage, easily table-tested.
- **`apps/web/src/core/onboarding/useOnboardingState.ts`** — React hook that wraps the resolver and owns the `firstActionVisible` / `softAuthDismissed` storage flags via an injectable `OnboardingStateStorage` adapter (deterministic in tests). Exposes typed dismissal callbacks (`dismissFirstAction()`, `dismissSoftAuth()`) and convenience flags (`showFirstAction`, `showSoftAuth`, `showTodayFocus`, `showReengagement`).
- **`apps/web/src/core/hub/HubDashboard.tsx`** — replaces the if/else hero ladder + scattered state with a single `useOnboardingState({...})` call. The downstream `StreakIndicator` suppression and `showChecklist` derivation now read from the hook flags. Behavioural contract is identical to the previous implementation.

### Single-hero invariant

The metric called out in the master tracker is _"≤1 prompt-card одночасно"_. The resolver always returns at most one `hero`; the `candidates` array (in priority order) is exposed so the dashboard can assert the invariant in dev or fire conflict-rate analytics. Soft-auth thresholds (`SOFT_AUTH_SESSION_DAYS_THRESHOLD = 3`, `SOFT_AUTH_AFTER_ENTRY_MIN_SESSION_DAYS = 2`) are exported from the hook module so tests reference the same constants.

### Tests

- `packages/shared/src/lib/onboardingHero.test.ts` — 8 cases covering all priority paths, conflict reporting, and the canonical ordering.
- `apps/web/src/core/onboarding/useOnboardingState.test.ts` — 11 cases covering lazy-init storage reads, dismissal side-effects, soft-auth eligibility forks (cold vs post-entry), and reengagement priority.
- Existing `HubDashboard.test.tsx` (8/8) still passes — behavioural contract unchanged.

### Mobile parity

The pure resolver is shared, so the mobile `HubDashboard` (PR-21 — _FTUX parity sweep_ in the master tracker) can reuse it with its own MMKV-backed hook wrapper.

## Linked

- FTUX master tracker §3.2 → PR-12
- Builds on top of PR-11 (#1991, goal-aware first-action priority)

## Verification

- `pnpm lint` ✓
- `pnpm typecheck` ✓
- `pnpm --filter @sergeant/shared test` — 557/557 ✓ (incl. 8 new resolver tests)
- `pnpm --filter @sergeant/web test -- src/core/` — 1234/1234 ✓ (incl. 11 new hook tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes the FTUX hero slot into a shared resolver and a small web hook so the dashboard enforces the “single-hero” rule (≤1 prompt-card) consistently. Implements PR-12 (FTUX master tracker §3.2) with a 4-tier priority: reengagement > first-action > soft-auth > today-focus.

- **Refactors**
  - Added `packages/shared/src/lib/onboardingHero.ts`: pure `resolveOnboardingHero` with reasons and `candidates`; exported via `packages/shared/src/index.ts`.
  - Added `apps/web/src/core/onboarding/useOnboardingState.ts`: wraps the resolver; lazily reads `firstActionVisible`/`softAuthDismissed`; computes soft-auth thresholds; exposes `show*` flags and `dismiss*` callbacks; exports `SOFT_AUTH_SESSION_DAYS_THRESHOLD` and `SOFT_AUTH_AFTER_ENTRY_MIN_SESSION_DAYS`.
  - Updated `apps/web/src/core/hub/HubDashboard.tsx` to use `useOnboardingState`; streak/checklist gating now read from the hook; hero rendering dispatches on `show*` flags.
  - Tests: `packages/shared/src/lib/onboardingHero.test.ts` (priority + invariant) and `apps/web/src/core/onboarding/useOnboardingState.test.ts` (storage reads, dismissals, soft-auth forks, reengagement wins).
  - Docs: FTUX master tracker now marks PR-11 (#1991) as merged and PR-12 (#2014) as in-flight.

<sup>Written for commit 0c62d7d3c4af3c7b8732c5bb4edd8800eb3d9f69. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

