### PR TITLE
feat(server): declarative body-size policy + ESLint guard (stack-pulse PR-07)

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -8,6 +8,7 @@ import type {
 } from "express";
 
 import { pool } from "./db.js";
+import { applyBodySizePolicy } from "./http/bodySizePolicy.js";
 import {
   apiCorsMiddleware,
   apiHelmetMiddleware,
@@ -126,68 +127,12 @@ export function createApp({
   app.use(apiVersionRewrite);
   app.use(apiHelmetMiddleware({ servesFrontend }));
 
-  // Body-size policy: tight default, explicit loosening on routes that
-  // legitimately carry large payloads.
-  //
-  // Контекст. Раніше глобально стояв `express.json({ limit: "12mb" })`, що
-  // робило будь-який POST-ендпоінт потенційним каналом для 12MB сміття
-  // (OOM-amplifier, повільний парс, зайва RSS на Railway-інстансі з
-  // скромним лімітом пам'яті). 99% наших ендпоінтів обмінюються пейлоадами
-  // <4KB — дефолт 128KB дає комфортний запас навіть під великий textarea
-  // і одразу закриває 413 до того, як handler/zod навіть побачать тіло.
-  //
-  // Порядок важливий. Mount-и на конкретні шляхи мусять іти ПЕРЕД
-  // глобальним мініатюрним, інакше 128KB-парсер спрацює першим і вб'є
-  // великий legit-payload. `express.json()` no-op-ить, якщо body вже
-  // розпарсене, тож другий виклик на тому самому request-і безпечний.
-  //
-  // Ліміти підібрані: schema-level max + невеликий запас під JSON-оверхед:
-  //   analyze-photo / refine-photo : 10mb (schema допускає base64 до ~7MB)
-  //   backup-upload                : 4mb  (internal cap 2.5MB post-stringify)
-  //   sync push/pull               : 6mb  (MAX_BLOB_SIZE = 5MB)
-  //   coach memory                 : 6mb  (той самий MAX_BLOB_SIZE)
-  //   chat                         : 1mb  (ChatRequestSchema: context 40KB +
-  //                                        50 messages × 8KB + 20 tool_results ×
-  //                                        8KB + 20 tool_calls_raw ≈ до ~1MB
-  //                                        на активній сесії з tool-calling)
-  app.use("/api/nutrition/analyze-photo", express.json({ limit: "10mb" }));
-  app.use("/api/nutrition/refine-photo", express.json({ limit: "10mb" }));
-  app.use("/api/nutrition/backup-upload", express.json({ limit: "4mb" }));
-  app.use("/api/sync", express.json({ limit: "6mb" }));
-  app.use("/api/coach/memory", express.json({ limit: "6mb" }));
-  app.use("/api/chat", express.json({ limit: "1mb" }));
-  app.use("/api/mono/webhook", express.json({ limit: "32kb" }));
-  app.use(
-    "/api/billing/stripe-webhook",
-    express.raw({ type: "application/json", limit: "128kb" }),
-  );
-  // M12 — web-vitals beacon legitimately ships ≤10 metrics × ~120B JSON ≈ 2KB
-  // у нормі. 10kb cap дає 5×запас від легітимного payload-у і одразу б'є 413
-  // на спроби пхнути великі об'єкти (raw JS-помилка з stacktrace, PII, інше
-  // сміття) у анонімний sessionless endpoint. Mount-имо ПЕРЕД глобальним
-  // 128kb-парсером — порядок mount-ів у Express важливий.
-  app.use("/api/metrics/web-vitals", express.json({ limit: "10kb" }));
-  // CSP-violation reports come from browsers with non-default content-types
-  // (`application/csp-report` for legacy `report-uri`, `application/reports+json`
-  // for the modern Reporting-API). Mount type-aware parsers ahead of the
-  // global `express.json({ limit: "128kb" })` so the report body lands in
-  // `req.body` regardless of which wire format the browser chose. The 16kb
-  // ceiling matches Sentry's own CSP-ingest limit and is well above any
-  // legitimate single-violation payload (~1–2kb in practice).
-  app.use(
-    "/api/csp-report",
-    express.json({ type: "application/csp-report", limit: "16kb" }),
-  );
-  app.use(
-    "/api/csp-report",
-    express.json({ type: "application/reports+json", limit: "16kb" }),
-  );
-  app.use("/api/csp-report", express.json({ limit: "16kb" }));
-  // Voice transcription: raw audio blob, NOT JSON. Mount раніше за глобальний
-  // `express.json({ limit: "128kb" })`, щоб 10mb-блоб не різався 128KB-парсером
-  // (хоч `express.json()` no-op-ить на не-JSON, явний raw-парсер чіткіший).
-  app.use("/api/transcribe", express.raw({ type: "audio/*", limit: "10mb" }));
-  app.use(express.json({ limit: "128kb" }));
+  // Body-size policy: declarative table в `http/bodySizePolicy.ts` — єдине
+  // джерело правди про per-route ліміти. ESLint-rule
+  // `sergeant-design/no-inline-body-size-limit` блокує inline
+  // `express.json({ limit })` поза тим файлом, щоб новий route випадково
+  // не обійшов policy і не зламав specificity-order.
+  applyBodySizePolicy(app);
 
   // Global CORS for the whole /api surface. Individual handlers may re-set
   // headers (e.g. to widen allow-headers) — `setCorsHeaders` is idempotent.

--- a/apps/server/src/http/bodySizePolicy.test.ts
+++ b/apps/server/src/http/bodySizePolicy.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+import express from "express";
+import request from "supertest";
+
+import {
+  BODY_SIZE_POLICY,
+  applyBodySizePolicy,
+  type BodySizeRule,
+} from "./bodySizePolicy.js";
+
+/**
+ * Контракт `bodySizePolicy.ts` — єдине джерело правди для per-route
+ * `express.json/raw({ limit })` mount-ів.
+ *
+ *   1. Policy-таблиця має валідні rule-и (всі ключі заповнені, kind
+ *      коректний, raw-rule має `type`).
+ *   2. У таблиці є явний default-rule (prefix "/") — без нього будь-який
+ *      незарестрований route ходив би БЕЗ json-парсера.
+ *   3. `applyBodySizePolicy()` дотримує contract:
+ *      - Великі payload-и на route з підвищеним лімітом — приймає (200).
+ *      - Перевищення route-ліміту — 413 PayloadTooLargeError.
+ *      - Перевищення global default (128KB) — 413.
+ *      - Дефолтний "малий" payload (≤128KB) — 200 на будь-якому route.
+ *      - Type-aware mount-и `/api/csp-report` спрацьовують для кастомних
+ *        content-type-ів.
+ */
+
+function makeApp() {
+  const app = express();
+  applyBodySizePolicy(app);
+  app.all("*", (req, res) => {
+    res.status(200).json({
+      receivedKeys: Object.keys((req.body as Record<string, unknown>) ?? {})
+        .length,
+      bodyType: typeof req.body,
+    });
+  });
+  return app;
+}
+
+function buildJsonPayload(approxBytes: number): Record<string, string> {
+  // Pad with a single string field so the payload size is predictable; JSON
+  // overhead (`{"data":"..."}`) is ~12B, accounted for in the caller.
+  return { data: "x".repeat(Math.max(0, approxBytes - 12)) };
+}
+
+describe("BODY_SIZE_POLICY (declarative table)", () => {
+  it("кожен rule заповнений: pathPrefix, kind, limit, reason", () => {
+    for (const rule of BODY_SIZE_POLICY) {
+      expect(rule.pathPrefix).toMatch(/^\//);
+      expect(rule.limit).toMatch(/^\d+(?:b|kb|mb|gb)$/i);
+      expect(rule.reason.length).toBeGreaterThan(8);
+      expect(["json", "raw"]).toContain(rule.kind);
+      if (rule.kind === "raw") {
+        expect(rule.type).toBeTruthy();
+      }
+    }
+  });
+
+  it("має explicit default-rule (prefix `/`) — інакше будь-який route без явної policy лишається без json-парсера", () => {
+    const defaults = BODY_SIZE_POLICY.filter(
+      (r: BodySizeRule) => r.pathPrefix === "/",
+    );
+    expect(defaults.length).toBe(1);
+    expect(defaults[0]!.kind).toBe("json");
+    expect(defaults[0]!.limit).toBe("128kb");
+  });
+
+  it("specific-route правила НЕ повторюються випадково (крім multi-content-type на /api/csp-report)", () => {
+    const seen = new Map<string, BodySizeRule[]>();
+    for (const rule of BODY_SIZE_POLICY) {
+      const list = seen.get(rule.pathPrefix) ?? [];
+      list.push(rule);
+      seen.set(rule.pathPrefix, list);
+    }
+    for (const [prefix, list] of seen) {
+      if (list.length > 1) {
+        // Дублі дозволені тільки коли кожен rule має унікальний `type`-matcher.
+        const types = new Set(list.map((r: BodySizeRule) => r.type ?? "*"));
+        expect(
+          types.size,
+          `prefix ${prefix} має дублі без унікального type`,
+        ).toBe(list.length);
+      }
+    }
+  });
+});
+
+describe("applyBodySizePolicy — payload acceptance", () => {
+  it("default route приймає малий JSON ≤128KB", async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .post("/api/something-default")
+      .set("Content-Type", "application/json")
+      .send({ hello: "world" });
+    expect(res.status).toBe(200);
+    expect(res.body.receivedKeys).toBe(1);
+  });
+
+  it("default route 413 при перевищенні 128KB", async () => {
+    const app = makeApp();
+    const big = buildJsonPayload(200 * 1024); // 200KB
+    const res = await request(app)
+      .post("/api/something-default")
+      .set("Content-Type", "application/json")
+      .send(big);
+    expect(res.status).toBe(413);
+  });
+
+  it("/api/sync приймає 5.5MB (під лімітом 6MB)", async () => {
+    const app = makeApp();
+    const big = buildJsonPayload(5.5 * 1024 * 1024);
+    const res = await request(app)
+      .post("/api/sync/push")
+      .set("Content-Type", "application/json")
+      .send(big);
+    expect(res.status).toBe(200);
+  });
+
+  it("/api/sync 413 при перевищенні 6MB", async () => {
+    const app = makeApp();
+    const tooBig = buildJsonPayload(7 * 1024 * 1024);
+    const res = await request(app)
+      .post("/api/sync/push")
+      .set("Content-Type", "application/json")
+      .send(tooBig);
+    expect(res.status).toBe(413);
+  });
+
+  it("/api/chat приймає до ~900KB (під лімітом 1MB)", async () => {
+    const app = makeApp();
+    const big = buildJsonPayload(900 * 1024);
+    const res = await request(app)
+      .post("/api/chat")
+      .set("Content-Type", "application/json")
+      .send(big);
+    expect(res.status).toBe(200);
+  });
+
+  it("/api/chat 413 при перевищенні 1MB", async () => {
+    const app = makeApp();
+    const tooBig = buildJsonPayload(1.5 * 1024 * 1024);
+    const res = await request(app)
+      .post("/api/chat")
+      .set("Content-Type", "application/json")
+      .send(tooBig);
+    expect(res.status).toBe(413);
+  });
+
+  it("/api/metrics/web-vitals — жорсткий 10KB cap", async () => {
+    const app = makeApp();
+    const tooBig = buildJsonPayload(20 * 1024);
+    const res = await request(app)
+      .post("/api/metrics/web-vitals")
+      .set("Content-Type", "application/json")
+      .send(tooBig);
+    expect(res.status).toBe(413);
+  });
+
+  it("/api/csp-report приймає браузерні `application/csp-report` payload-и", async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .post("/api/csp-report")
+      .set("Content-Type", "application/csp-report")
+      .send(JSON.stringify({ "csp-report": { violatedDirective: "img-src" } }));
+    expect(res.status).toBe(200);
+    expect(res.body.bodyType).toBe("object");
+  });
+
+  it("/api/csp-report приймає Reporting-API `application/reports+json`", async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .post("/api/csp-report")
+      .set("Content-Type", "application/reports+json")
+      .send(JSON.stringify([{ type: "csp-violation", body: {} }]));
+    expect(res.status).toBe(200);
+  });
+
+  it("/api/billing/stripe-webhook — raw-парсер, body Buffer-ом доходить до handler", async () => {
+    // Окремо інстансимо app, щоб додати handler, який перевіряє type body-а.
+    const app = express();
+    applyBodySizePolicy(app);
+    app.post("/api/billing/stripe-webhook", (req, res) => {
+      // express.raw → req.body це Buffer (а не object).
+      res.status(200).json({ isBuffer: Buffer.isBuffer(req.body) });
+    });
+    const res = await request(app)
+      .post("/api/billing/stripe-webhook")
+      .set("Content-Type", "application/json")
+      .send('{"type":"checkout.session.completed"}');
+    expect(res.status).toBe(200);
+    expect(res.body.isBuffer).toBe(true);
+  });
+});

--- a/apps/server/src/http/bodySizePolicy.ts
+++ b/apps/server/src/http/bodySizePolicy.ts
@@ -1,0 +1,187 @@
+import express, { type Express, type RequestHandler } from "express";
+
+/**
+ * Декларативна політика лімітів body-парсера.
+ *
+ * Контекст. Раніше у `app.ts` стояло ~14 inline-викликів
+ * `app.use("/path", express.json({ limit: ... }))` — порядок mount-ів був
+ * критичним (specific-shrут мусить mount-итись ДО глобального дефолтного,
+ * бо Express bodyParser, що першим спрацює, виграє). Один zero-думаний
+ * рефакторинг — і `/api/nutrition/analyze-photo` починає 413-итись на
+ * легітимні 9MB upload-и. Цей файл — єдине джерело правди: усі ліміти
+ * описані в `BODY_SIZE_POLICY`, а `applyBodySizePolicy(app)` сама
+ * проставляє правильний порядок (longest-prefix-first), щоб руки
+ * не плуталися.
+ *
+ * Контракт ESLint-rule `sergeant-design/no-inline-body-size-limit`
+ * блокує `express.json({ limit })` / `express.raw({ ..., limit })` поза
+ * цим файлом — щоб новий route не випадково отримав inline-mount, який
+ * обходить policy і ламає specificity-order.
+ */
+export type BodySizeRule =
+  | {
+      readonly pathPrefix: string;
+      readonly kind: "json";
+      readonly limit: string;
+      readonly reason: string;
+      /**
+       * Optional `Content-Type` filter (forwarded to `express.json({ type })`).
+       * Дозволяє mount-ити кілька парсерів на однаковому шляху з різними
+       * type-matcher-ами — як `/api/csp-report` (CSP-violation reports
+       * приходять з нестандартними `application/csp-report` /
+       * `application/reports+json`).
+       */
+      readonly type?: string;
+    }
+  | {
+      readonly pathPrefix: string;
+      readonly kind: "raw";
+      readonly limit: string;
+      readonly reason: string;
+      readonly type: string;
+    };
+
+/**
+ * Один список — два призначення:
+ *   1. `applyBodySizePolicy()` чітко проставляє mount-и у Express app.
+ *   2. Тести читають той самий список, щоб перевірити, що жоден
+ *      route не залишився без явного ліміту і що default-правило
+ *      реально mount-иться останнім.
+ *
+ * Обчислені ліміти (schema-level max + запас під JSON-оверхед):
+ *   nutrition/analyze-photo / refine-photo : 10mb (schema до ~7MB base64)
+ *   nutrition/backup-upload                : 4mb  (internal cap 2.5MB)
+ *   sync push/pull                         : 6mb  (MAX_BLOB_SIZE = 5MB)
+ *   coach memory                           : 6mb  (той самий MAX_BLOB_SIZE)
+ *   chat                                   : 1mb  (ChatRequestSchema active session)
+ *   mono webhook                           : 32kb (Monobank payload)
+ *   billing stripe-webhook                 : 128kb raw (Stripe-signature)
+ *   csp-report                             : 16kb (Sentry CSP-ingest cap)
+ *   metrics/web-vitals                     : 10kb (≤10 metrics × ~120B JSON)
+ *   transcribe                             : 10mb raw audio
+ *   default                                : 128kb (99% endpoint-ів <4KB JSON)
+ */
+export const BODY_SIZE_POLICY: ReadonlyArray<BodySizeRule> = [
+  {
+    pathPrefix: "/api/nutrition/analyze-photo",
+    kind: "json",
+    limit: "10mb",
+    reason: "User photo upload (nutrition vision pipeline)",
+  },
+  {
+    pathPrefix: "/api/nutrition/refine-photo",
+    kind: "json",
+    limit: "10mb",
+    reason: "Photo refinement second-pass",
+  },
+  {
+    pathPrefix: "/api/nutrition/backup-upload",
+    kind: "json",
+    limit: "4mb",
+    reason: "Manual nutrition backup blob",
+  },
+  {
+    pathPrefix: "/api/sync",
+    kind: "json",
+    limit: "6mb",
+    reason: "CloudSync push/pull (MAX_BLOB_SIZE = 5MB)",
+  },
+  {
+    pathPrefix: "/api/coach/memory",
+    kind: "json",
+    limit: "6mb",
+    reason: "Coach long-term memory blob",
+  },
+  {
+    pathPrefix: "/api/chat",
+    kind: "json",
+    limit: "1mb",
+    reason: "ChatRequestSchema (context + 50 msg + 20 tool_results)",
+  },
+  {
+    pathPrefix: "/api/mono/webhook",
+    kind: "json",
+    limit: "32kb",
+    reason: "Monobank webhook payload",
+  },
+  {
+    pathPrefix: "/api/billing/stripe-webhook",
+    kind: "raw",
+    limit: "128kb",
+    reason: "Stripe webhook (signature verification on raw bytes)",
+    type: "application/json",
+  },
+  {
+    pathPrefix: "/api/metrics/web-vitals",
+    kind: "json",
+    limit: "10kb",
+    reason: "Web-vitals beacon (≤10 metrics × ~120B JSON)",
+  },
+  {
+    pathPrefix: "/api/csp-report",
+    kind: "json",
+    limit: "16kb",
+    reason: "Legacy CSP report-uri (application/csp-report)",
+    type: "application/csp-report",
+  },
+  {
+    pathPrefix: "/api/csp-report",
+    kind: "json",
+    limit: "16kb",
+    reason: "Modern Reporting-API (application/reports+json)",
+    type: "application/reports+json",
+  },
+  {
+    pathPrefix: "/api/csp-report",
+    kind: "json",
+    limit: "16kb",
+    reason: "CSP report fallback (default content-type)",
+  },
+  {
+    pathPrefix: "/api/transcribe",
+    kind: "raw",
+    limit: "10mb",
+    reason: "Voice transcription (audio blob, not JSON)",
+    type: "audio/*",
+  },
+  {
+    pathPrefix: "/",
+    kind: "json",
+    limit: "128kb",
+    reason: "Default API body cap — 99% endpoints exchange <4KB JSON",
+  },
+];
+
+/**
+ * Обираємо middleware-фабрику з config-rule. Винесено у helper, щоб
+ * `applyBodySizePolicy` лишалась маленьким і щоб тестам було легко
+ * перевірити маппінг rule → middleware-options без mount-у в Express.
+ */
+function buildMiddleware(rule: BodySizeRule): RequestHandler {
+  if (rule.kind === "json") {
+    if (rule.type !== undefined) {
+      return express.json({ limit: rule.limit, type: rule.type });
+    }
+    return express.json({ limit: rule.limit });
+  }
+  return express.raw({ limit: rule.limit, type: rule.type });
+}
+
+/**
+ * Mount-ить тіло-парсери у Express-app у порядку specificity-descending
+ * (longest-prefix-first). Сортування стабільне — при однаковій довжині
+ * prefix-у оригінальний порядок збережено (важливо для multi-parser
+ * шляхів типу `/api/csp-report`, де три rule-и з різними `type`-матчерами).
+ *
+ * `express.json()` no-op-ить, якщо body вже розпарсений, тому
+ * специфічний парсер виграє, а глобальний дефолтний (`/`) спокійно
+ * mount-иться останнім без ризику зрізати legit-payload.
+ */
+export function applyBodySizePolicy(app: Express): void {
+  const ordered = [...BODY_SIZE_POLICY].sort(
+    (a, b) => b.pathPrefix.length - a.pathPrefix.length,
+  );
+  for (const rule of ordered) {
+    app.use(rule.pathPrefix, buildMiddleware(rule));
+  }
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -284,6 +284,19 @@ export default [
       "sergeant-design/no-flat-shared-lib": "error",
     },
   },
+  // Stack-pulse PR-07 — body-size declarative policy.
+  // Inline `express.json({ limit })` / `express.raw({ ..., limit })`
+  // у server-коді (поза `apps/server/src/http/bodySizePolicy.ts`)
+  // обходить декларативну `BODY_SIZE_POLICY`-таблицю — додавай rule
+  // у policy замість того, щоб mount-ити inline-парсер. Скоупимо
+  // виключно у `apps/server/**`, бо лише там Express body-парсери
+  // мають значення (web/mobile не мають Express-сервера).
+  {
+    files: ["apps/server/**/*.{ts,js,mjs}"],
+    rules: {
+      "sergeant-design/no-inline-body-size-limit": "error",
+    },
+  },
   // Mobile-shell sunset guardrail — initiative 0002 (mobile platform
   // decision). `apps/mobile-shell/` is on the locked-in deprecation
   // schedule defined in ADR-0010 § Sunset schedule (T₀ 2026-09-01,

--- a/packages/eslint-plugin-sergeant-design/__tests__/no-inline-body-size-limit.test.mjs
+++ b/packages/eslint-plugin-sergeant-design/__tests__/no-inline-body-size-limit.test.mjs
@@ -1,0 +1,166 @@
+/**
+ * Unit tests for `sergeant-design/no-inline-body-size-limit` rule
+ * (stack-pulse PR-07 — Body-size declarative policy).
+ *
+ * Контракт. ВСЕ inline-mount-и `express.json({ limit })` /
+ * `express.raw({ ..., limit })` мусять жити у
+ * `apps/server/src/http/bodySizePolicy.ts`. Поза тим файлом rule
+ * блокує такі виклики, бо вони обходять декларативну
+ * `BODY_SIZE_POLICY`-таблицю і ламають specificity-order при mount-і.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { Linter } from "eslint";
+import path from "node:path";
+import plugin from "../index.js";
+
+const linter = new Linter();
+const RULE_ID = "sergeant-design/no-inline-body-size-limit";
+
+function abs(p) {
+  return path.resolve(process.cwd(), p);
+}
+
+function lint(code, filename) {
+  return linter.verify(
+    code,
+    {
+      files: ["**/*.{js,mjs,cjs,ts,tsx}"],
+      plugins: { "sergeant-design": plugin },
+      rules: { [RULE_ID]: "error" },
+      languageOptions: {
+        ecmaVersion: "latest",
+        sourceType: "module",
+      },
+    },
+    { filename },
+  );
+}
+
+// ── BAD: inline `express.json({ limit })` поза policy-файлом ─────────────
+
+describe("no-inline-body-size-limit — flags inline express.json/raw with `limit`", () => {
+  it("flags `express.json({ limit })` у app.ts", () => {
+    const messages = lint(
+      `import express from "express";
+       const app = express();
+       app.use("/api/foo", express.json({ limit: "10mb" }));`,
+      abs("apps/server/src/app.ts"),
+    );
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].ruleId, RULE_ID);
+    assert.match(messages[0].message, /bodySizePolicy\.ts/);
+    assert.match(messages[0].message, /BODY_SIZE_POLICY/);
+  });
+
+  it("flags `express.raw({ type, limit })` у домінному router-і", () => {
+    const messages = lint(
+      `import express from "express";
+       const router = express.Router();
+       router.use(express.raw({ type: "application/json", limit: "128kb" }));`,
+      abs("apps/server/src/routes/billing.ts"),
+    );
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].ruleId, RULE_ID);
+  });
+
+  it("flags bare `json({ limit })` після destructured-import", () => {
+    const messages = lint(
+      `import { json } from "express";
+       const app = createApp();
+       app.use("/api/sync", json({ limit: "6mb" }));`,
+      abs("apps/server/src/routes/sync.ts"),
+    );
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].ruleId, RULE_ID);
+  });
+
+  it("flags декілька викликів у тому самому файлі (each separately)", () => {
+    const messages = lint(
+      `import express from "express";
+       const app = express();
+       app.use("/api/a", express.json({ limit: "10mb" }));
+       app.use("/api/b", express.raw({ type: "audio/*", limit: "10mb" }));
+       app.use(express.json({ limit: "128kb" }));`,
+      abs("apps/server/src/app.ts"),
+    );
+    assert.equal(messages.length, 3);
+    for (const m of messages) {
+      assert.equal(m.ruleId, RULE_ID);
+    }
+  });
+});
+
+// ── GOOD: rule не штрафує валідні patterns ───────────────────────────────
+
+describe("no-inline-body-size-limit — leaves clean code alone", () => {
+  it("ignores `express.json()` без `limit`", () => {
+    const messages = lint(
+      `import express from "express";
+       const app = express();
+       app.use(express.json());`,
+      abs("apps/server/src/app.ts"),
+    );
+    assert.equal(messages.length, 0);
+  });
+
+  it("ignores `express.json({ strict: false })` без `limit` ключа", () => {
+    const messages = lint(
+      `import express from "express";
+       const app = express();
+       app.use(express.json({ strict: false }));`,
+      abs("apps/server/src/app.ts"),
+    );
+    assert.equal(messages.length, 0);
+  });
+
+  it("ignores `applyBodySizePolicy(app)` (canonical entrypoint)", () => {
+    const messages = lint(
+      `import { applyBodySizePolicy } from "./http/bodySizePolicy.js";
+       const app = createApp();
+       applyBodySizePolicy(app);`,
+      abs("apps/server/src/app.ts"),
+    );
+    assert.equal(messages.length, 0);
+  });
+
+  it("ignores сторонні method calls названі json/raw з `limit` поза express", () => {
+    // Наша rule навмисно ширше hits будь-яке `.json({ limit })` —
+    // у Sergeant-кодбазі немає легітимних callsite-ів з такою формою
+    // поза body-парсером, тож false-positive ризик мінімальний. Це
+    // тест-документація поведінки: якщо хтось десь напише
+    // `someThing.json({ limit: 1 })` — rule зловить, хай і false-pos.
+    // Тоді або переіменовуємо callsite, або вузить-ся scope правила.
+    const messages = lint(
+      `class Fake { json(o) { return o; } }
+       const x = new Fake();
+       x.json({ limit: 1 });`,
+      abs("apps/server/src/app.ts"),
+    );
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].ruleId, RULE_ID);
+  });
+});
+
+// ── ALLOWED: bodySizePolicy.ts і його тест — єдині exempt-и ─────────────
+
+describe("no-inline-body-size-limit — bodySizePolicy.ts is exempt", () => {
+  it("ignores самого `bodySizePolicy.ts`", () => {
+    const messages = lint(
+      `import express from "express";
+       export const m = express.json({ limit: "128kb" });`,
+      abs("apps/server/src/http/bodySizePolicy.ts"),
+    );
+    assert.equal(messages.length, 0);
+  });
+
+  it("ignores `bodySizePolicy.test.ts`", () => {
+    const messages = lint(
+      `import express from "express";
+       const app = express();
+       app.use(express.json({ limit: "1mb" }));`,
+      abs("apps/server/src/http/bodySizePolicy.test.ts"),
+    );
+    assert.equal(messages.length, 0);
+  });
+});

--- a/packages/eslint-plugin-sergeant-design/index.js
+++ b/packages/eslint-plugin-sergeant-design/index.js
@@ -3418,6 +3418,130 @@ const preferDataState = {
   },
 };
 
+// ─── no-inline-body-size-limit ──────────────────────────────────────────
+//
+// Stack-pulse PR-07 (Body-size declarative policy). Усі route-specific
+// `express.json({ limit })` / `express.raw({ ..., limit })` mount-и мусять
+// жити у `apps/server/src/http/bodySizePolicy.ts` як декларативна
+// `BODY_SIZE_POLICY`-таблиця. Inline-mount у `app.ts` чи доменному
+// router-і — це регресія: порядок mount-ів стає крихким (specific-shrут
+// мусить йти ДО глобального дефолтного), а сам ліміт перестає бути
+// auditable з одного місця. Rule ловить використання `.json({ limit })`
+// та `.raw({ ..., limit })` поза policy-файлом.
+//
+// File-scope: rule НЕ срацьовує у самому `bodySizePolicy.ts` і його
+// тесті (єдині легітимні місця, де inline-options валідні). Усе інше
+// під забороною.
+
+const NO_INLINE_BODY_SIZE_LIMIT_MESSAGE =
+  "Inline `express.{{method}}({ limit })` is not allowed outside `apps/server/src/http/bodySizePolicy.ts`. Add a rule to `BODY_SIZE_POLICY` instead — that file is the single source of truth, and `applyBodySizePolicy()` mounts everything in specificity-descending order. ESLint guard from stack-pulse PR-07.";
+
+const BODY_SIZE_POLICY_PATH_RE =
+  /(?:^|\/)apps\/server\/src\/http\/bodySizePolicy(?:\.test)?\.ts$/;
+
+// Розмір тіла у body-парсерах express завжди записується або
+// рядком формату `"<число><b|kb|mb|gb>"` (canonical), або голим
+// числом байтів. Рядкове `result.limit` у Response.json-payload-і
+// (відповідь сервера типу `{ limit: 200 }`) НЕ підпадає під цей
+// формат — тому такого виду перевірка вузить scope без false-positive.
+const BODY_SIZE_LIMIT_LITERAL_RE = /^\d+\s*(?:b|kb|mb|gb)$/i;
+
+function isBodySizeLimitValue(valueNode) {
+  if (!valueNode) return false;
+  if (
+    valueNode.type === "Literal" &&
+    typeof valueNode.value === "string" &&
+    BODY_SIZE_LIMIT_LITERAL_RE.test(valueNode.value)
+  ) {
+    return true;
+  }
+  if (valueNode.type === "Literal" && typeof valueNode.value === "number") {
+    // Numeric byte-count form (legacy, але body-парсери приймають number).
+    return true;
+  }
+  if (
+    valueNode.type === "TemplateLiteral" &&
+    valueNode.quasis.length === 1 &&
+    typeof valueNode.quasis[0].value.cooked === "string" &&
+    BODY_SIZE_LIMIT_LITERAL_RE.test(valueNode.quasis[0].value.cooked)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function isLimitedBodyParserCall(node) {
+  // node — CallExpression. Ми очікуємо callee на кшталт
+  // `express.json({ limit })` або `express.raw({ ..., limit })`. Без
+  // обов'язкового імені модуля `express`, бо хтось може робити
+  // `import { json } from "express"` і потім `json({ limit })`.
+  if (node.type !== "CallExpression") return null;
+  const args = node.arguments;
+  if (!args.length || args[0].type !== "ObjectExpression") return null;
+  const limitProp = args[0].properties.find(
+    (p) =>
+      p.type === "Property" &&
+      !p.computed &&
+      ((p.key.type === "Identifier" && p.key.name === "limit") ||
+        (p.key.type === "Literal" && p.key.value === "limit")),
+  );
+  if (!limitProp) return null;
+  // Звужуємо: значення `limit` мусить виглядати як body-size, інакше
+  // це Response.json-payload (`res.status(429).json({ limit: x })`),
+  // де `limit` — це поле бізнес-помилки (квота, ліміт суми, etc.),
+  // а не body-парсер.
+  if (!isBodySizeLimitValue(limitProp.value)) return null;
+
+  // Match `express.json(...)` / `express.raw(...)`.
+  const callee = node.callee;
+  if (
+    callee.type === "MemberExpression" &&
+    !callee.computed &&
+    callee.property.type === "Identifier" &&
+    (callee.property.name === "json" || callee.property.name === "raw")
+  ) {
+    return callee.property.name;
+  }
+
+  // Match bare `json({...})` / `raw({...})` after a destructured import.
+  if (
+    callee.type === "Identifier" &&
+    (callee.name === "json" || callee.name === "raw")
+  ) {
+    return callee.name;
+  }
+
+  return null;
+}
+
+const noInlineBodySizeLimit = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Forbid inline `express.json({ limit })` / `express.raw({ ..., limit })` outside `apps/server/src/http/bodySizePolicy.ts`. Mount through `applyBodySizePolicy()` instead.",
+    },
+    schema: [],
+    messages: { inline: NO_INLINE_BODY_SIZE_LIMIT_MESSAGE },
+  },
+  create(context) {
+    const filename = context.filename ?? context.getFilename?.() ?? "";
+    const norm = filename.replace(/\\/g, "/");
+    if (BODY_SIZE_POLICY_PATH_RE.test(norm)) return {};
+    return {
+      CallExpression(node) {
+        const method = isLimitedBodyParserCall(node);
+        if (!method) return;
+        context.report({
+          node,
+          messageId: "inline",
+          data: { method },
+        });
+      },
+    };
+  },
+};
+
 const plugin = {
   rules: {
     "no-eyebrow-drift": noEyebrowDrift,
@@ -3447,6 +3571,7 @@ const plugin = {
     "no-legacy-telegram-parse-mode": noLegacyTelegramParseMode,
     "require-stories-for-ui-components": requireStoriesForUiComponents,
     "prefer-data-state": preferDataState,
+    "no-inline-body-size-limit": noInlineBodySizeLimit,
   },
 };
 


### PR DESCRIPTION
## Summary

stack-pulse-2026-05 PR-07 — declarative body-size policy with ESLint guard.

- New `apps/server/src/http/bodySizePolicy.ts` — single source of truth for per-route `express.json/raw({ limit })`. `BODY_SIZE_POLICY` (14 rules, longest-prefix-first sort) + `applyBodySizePolicy(app)`.
- Refactored `apps/server/src/app.ts` to call `applyBodySizePolicy()` in place of ~40 lines of inline middleware mounts.
- New ESLint rule `sergeant-design/no-inline-body-size-limit` — forbids inline `express.json({ limit })` / `express.raw({ ..., limit })` outside `bodySizePolicy.ts`. Narrows to literal body-size values (`<n>(b|kb|mb|gb)` or numeric byte counts) to avoid false-positives on `Response.json` payloads with a `limit` field.
- Tests:
  - `apps/server/src/http/bodySizePolicy.test.ts` — 13 tests (supertest + vitest) verify 413 behaviour, route overrides, raw parser for Stripe webhooks, type-aware mounting for CSP reports.
  - `packages/eslint-plugin-sergeant-design/__tests__/no-inline-body-size-limit.test.mjs` — 10 RuleTester cases.

## Acceptance criteria (from plan)

- [x] `BODY_SIZE_POLICY` is the single source of truth for per-route limits.
- [x] No inline `express.json({ limit })` in `apps/server/src/app.ts`.
- [x] ESLint rule prevents new inline limits, exempts `bodySizePolicy.ts`.
- [x] Unit tests verify 413 behaviour at route boundaries.

Refs: `docs/initiatives/stack-pulse-2026-05/pr-07-body-size-declarative-policy.md`.

---
This PR was assisted by Devin (https://app.devin.ai/sessions/5196c4f46db34e4eb1c05c498e54f52d). Requested by @Skords-01.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a declarative per-route body-size policy and an ESLint guard to block inline limits. Replaces scattered `express` body-parser mounts with a single source of truth and adds tests for 413 behavior and special routes.

- **New Features**
  - Added `BODY_SIZE_POLICY` and `applyBodySizePolicy(app)` in `apps/server/src/http/bodySizePolicy.ts` (14 rules, longest-prefix-first).
  - New ESLint rule `sergeant-design/no-inline-body-size-limit` forbids inline `express.json({ limit })` / `express.raw({ ..., limit })` outside `bodySizePolicy.ts` (literal size values only; policy files exempt).
  - Tests with `supertest` + `vitest` cover defaults, route overrides, Stripe raw body, and CSP content-types.

- **Refactors**
  - Replaced inline body-parser mounts in `apps/server/src/app.ts` with `applyBodySizePolicy(app)`.
  - Enabled the ESLint rule for `apps/server/**` in `eslint.config.js`.

<sup>Written for commit 2eb70e17a6aab3e0db0e296ad3eafdea4de24ac3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

