### PR TITLE
feat(web): drop Reports-tab reveal toast; keep bounce only (UX roast 2026-Q2 PR-21)

### DIFF
--- a/apps/web/src/core/app/HubBottomNav.test.tsx
+++ b/apps/web/src/core/app/HubBottomNav.test.tsx
@@ -2,7 +2,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { HubBottomNav } from "./HubBottomNav";
-import { ToastProvider } from "@shared/hooks/useToast";
 
 const STORAGE_KEY = "sergeant.hub.reportsTabRevealedAt";
 
@@ -18,14 +17,12 @@ function renderNav(props: {
   return {
     onChange,
     ...render(
-      <ToastProvider>
-        <HubBottomNav
-          hubView={props.hubView ?? "dashboard"}
-          onChange={onChange}
-          showReports={props.showReports ?? true}
-          showProfile={props.showProfile}
-        />
-      </ToastProvider>,
+      <HubBottomNav
+        hubView={props.hubView ?? "dashboard"}
+        onChange={onChange}
+        showReports={props.showReports ?? true}
+        showProfile={props.showProfile}
+      />,
     ),
   };
 }
@@ -111,15 +108,39 @@ describe("HubBottomNav", () => {
     expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
 
     rerender(
-      <ToastProvider>
-        <HubBottomNav
-          hubView="dashboard"
-          onChange={onChange}
-          showReports={true}
-        />
-      </ToastProvider>,
+      <HubBottomNav
+        hubView="dashboard"
+        onChange={onChange}
+        showReports={true}
+      />,
     );
     expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+  });
+
+  it("не показує ««Звіти» тепер доступні» toast при reveal-і (UX roast 2026-Q2 R1)", () => {
+    const { rerender, onChange } = renderNav({ showReports: false });
+    rerender(
+      <HubBottomNav
+        hubView="dashboard"
+        onChange={onChange}
+        showReports={true}
+      />,
+    );
+    expect(screen.queryByText(/«Звіти» тепер доступні/)).toBeNull();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("все ще запускає bounce-анімацію на «Звіти» при першому reveal-і", () => {
+    const { rerender, onChange } = renderNav({ showReports: false });
+    rerender(
+      <HubBottomNav
+        hubView="dashboard"
+        onChange={onChange}
+        showReports={true}
+      />,
+    );
+    const reports = screen.getByRole("tab", { name: /Звіти/ });
+    expect(reports.className).toContain("animate-bounce-in");
   });
 
   it("не показує toast вдруге: якщо прапор вже у localStorage", () => {

--- a/apps/web/src/core/app/HubBottomNav.tsx
+++ b/apps/web/src/core/app/HubBottomNav.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { cn } from "@shared/lib/ui/cn";
 import { Icon } from "@shared/components/ui/Icon";
-import { useToast } from "@shared/hooks/useToast";
 import { safeReadStringLS, safeWriteLS } from "@shared/lib/storage/storage";
 import type { HubView } from "../hooks/useHubUIState";
 import { messages } from "@shared/i18n/uk";
@@ -26,10 +25,13 @@ import { messages } from "@shared/i18n/uk";
  *   `ActiveWorkoutBanner` and other floating chrome must offset
  *   their `bottom:` by 76 px + safe-area-inset-bottom to sit above it.
  *
- * The reports-tab reveal behavior (animate + one-time toast) is
- * preserved from the old `HubTabs` — see comments on `safeReadStringLS`
- * usage below. Storage key is unchanged so existing users aren't
- * re-onboarded through the reveal toast.
+ * The reports-tab reveal behavior (a single bounce-in animation when
+ * the tab first appears) is preserved from the old `HubTabs` — see
+ * comments on `safeReadStringLS` usage below. The previous one-time
+ * toast was removed per UX-roast 2026-Q2 R1 (it overlapped with the
+ * Re-engagement card and the install banner that appear in the same
+ * frame and overwhelmed the FTUX). Storage key is unchanged so
+ * existing users aren't re-animated.
  */
 
 const REPORTS_TAB_REVEALED_AT_KEY = "sergeant.hub.reportsTabRevealedAt";
@@ -120,14 +122,15 @@ export function HubBottomNav({
   showProfile = false,
   onShowAuth,
 }: HubBottomNavProps) {
-  const toast = useToast();
   // Чи був перехід `showReports: false → true` в межах поточного маунту.
-  // Тільки в цьому випадку ми вмикаємо bounce-анімацію + one-time toast.
+  // Тільки в цьому випадку ми вмикаємо bounce-анімацію (без toast — див.
+  // UX-roast 2026-Q2 R1: одночасні «нова вкладка»-toast + Re-engagement
+  // card + install banner перевантажували перший запис).
   // Якщо компонент маунтиться вже з `showReports === true` без флага в
   // localStorage — це або легасі-користувач (виставлявся ще до цього
   // прапора), або повне перезавантаження після розблокування. В обох
-  // сценаріях celebrate-toast у момент перезавантаження виглядав би
-  // невчасно, тож тихо ставимо флаг і нічого не показуємо.
+  // сценаріях bounce у момент перезавантаження виглядав би невчасно,
+  // тож тихо ставимо флаг і нічого не показуємо.
   const prevShowReportsRef = useRef(showReports);
   const [animateReveal, setAnimateReveal] = useState(false);
 
@@ -139,30 +142,19 @@ export function HubBottomNav({
     if (safeReadStringLS(REPORTS_TAB_REVEALED_AT_KEY)) return;
 
     if (!prevShowReports) {
-      // Це справжнє розблокування «в реальному часі»: користувач
-      // зробив свій перший реальний запис у поточному сеансі, і
-      // `hasAnyRealEntry()` щойно flip-нув. Запускаємо bounce +
-      // показуємо нав'язливий, але дружній toast із прямою CTA на
-      // вкладку. Toast самозникає за 6с — звідси не лишається
-      // постійного chrome-у, тому ризик заглушити подальші важливі
-      // toast-и низький.
+      // Справжнє розблокування «в реальному часі»: користувач щойно
+      // зробив перший реальний запис, і `hasAnyRealEntry()` flip-нув.
+      // Bounce-анімація сама по собі звертає увагу на нову вкладку
+      // без додаткового toast.
       safeWriteLS(REPORTS_TAB_REVEALED_AT_KEY, String(Date.now()));
       setAnimateReveal(true);
-      toast.info(
-        "«Звіти» тепер доступні — короткі зведення по всіх модулях.",
-        6000,
-        {
-          label: "Відкрити",
-          onClick: () => onChange("reports"),
-        },
-      );
       return;
     }
 
     // Migration / cold-start path: tab уже мав бути розблокований
     // (минулий маунт), просто на ньому не було флага. Ставимо тихо.
     safeWriteLS(REPORTS_TAB_REVEALED_AT_KEY, String(Date.now()));
-  }, [showReports, onChange, toast]);
+  }, [showReports]);
 
   const tabs: HubBottomNavItem[] = [
     {


### PR DESCRIPTION
## Summary

Per the post-onboarding UX roast (`docs/audits/2026-05-06-ux-roast.md` §1.4, item **R1**), the Reports-tab reveal toast («Звіти» тепер доступні — короткі зведення по всіх модулях.) was firing in the same frame as the Re-engagement card and the install banner — three competing signals overwhelmed first-time users immediately after their first real entry.

- Drop the `toast.info(...)` call inside `HubBottomNav`'s reveal `useEffect`.
- Keep the bounce-in animation on the freshly-revealed «Звіти» tab — motion alone is enough to draw attention without crowding the FTUX.
- Storage key (`sergeant.hub.reportsTabRevealedAt`) and migration / cold-start logic are unchanged so legacy users aren't re-animated.
- Drop the now-unused `useToast` import from the component and the `ToastProvider` wrapper from the test.

This is the second execution PR landing from the [43-PR plan](../blob/main/docs/audits/2026-05-06-ux-roast-pr-plan.md) attached to the audit (after #2103). Closes item **R1** / §1.4 of the roast.

## Governing Skill

- Primary skill: `.agents/skills/sergeant-start-here/SKILL.md` — single-component copy/UX trim with no domain-specialist surface.
- Secondary skill (if truly needed): n/a.

## Playbook

- Primary playbook: n/a — single-component reveal-effect trim with no schema, contract, or workflow change.
- Why this playbook: scope is one effect block + comment update + test wrapper update; no playbook matches.
- If no playbook matched, why: see above.

## Verification

```bash
pnpm --filter @sergeant/web exec vitest run src/core/app/HubBottomNav.test.tsx
# Test Files 1 passed (1), Tests 13 passed (13)  — was 11 before; +2 new

pnpm --filter @sergeant/web exec tsc --noEmit
# (silent, exit 0)

pnpm exec lint-staged --concurrent false
# ESLint --fix + Prettier + staged-typecheck + bump-last-validated all green
```

Additional checks:

- [x] Local smoke / manual validation completed (the toast call was the only consumer of `useToast` inside `HubBottomNav`; verified no other callers depend on a toast firing during reveal).
- [x] Surface-specific checks completed (storage flag still set + bounce class still attached — both locked by tests).

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a in this PR. The audit doc / PR-plan / `docs/audits/README.md` will be updated in a single follow-up docs PR alongside the PR-4 follow-up (per user direction: «потім оновиш документацію за зроблену роботу»). The follow-up will mark **R1** / §1.4 as resolved and bump the `Implemented` counter.

## Risk and Rollout

- **User-visible risk:** very low. Existing users (who already have the `sergeant.hub.reportsTabRevealedAt` flag in localStorage) see no behaviour change. New users who unlock Reports during the session will see the bounce-in animation but no longer the toast.
- **Rollout / deploy order:** standard merge → main → next deploy.
- **Backout plan:** revert this PR. Pure UX trim; revert restores the previous toast and the test's `ToastProvider` wrapper.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian (no docs touched in this PR; in-code Ukrainian comments updated alongside the change).
- [x] I did not use `--no-verify`. Husky + lint-staged ran green; commitlint accepted the message.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files. No `[freeze-exception]` needed.

## Reviewer Notes

- **No `useToast` removal beyond `HubBottomNav`.** The `ToastProvider` is still mounted at the app shell — other consumers (forms, sync errors, Mono import flow, etc.) keep working unchanged.
- **Bounce kept.** The original PR-21 spec («Зберегти лише animation + (можливо) короткий tooltip над табом») leaves the `tooltip` as optional. Skipped it to keep the PR truly XS — can be added in a follow-up if A11y review prefers an explicit signal.
- **Storage-flag invariant preserved.** Test `«ставить прапор у localStorage коли reports з'являється»` still passes — legacy users do not get re-animated.
- **Git proxy fallback used.** `git push` via the standard `git-manager.devin.ai` proxy still returns 403; this branch was pushed via PAT-in-URL fallback. Already reported as a session-level operational blocker — does not affect the diff.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the Reports tab reveal toast to cut FTUX noise; kept the bounce-in animation so users still notice the new tab. Storage flag `sergeant.hub.reportsTabRevealedAt` stays the same, so existing users are unaffected and re-loads don’t re-animate.

- **Refactors**
  - Removed the `toast.info(...)` call in `HubBottomNav` reveal effect; bounce-only reveal remains.
  - Dropped `@shared/hooks/useToast` usage and the `ToastProvider` wrapper from tests.
  - Added tests to ensure no toast appears on reveal and the bounce class is applied.

<sup>Written for commit 7fd4dd30a842bd9c277aac3b7350a0ec6aded2e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Reports tab now displays a bounce animation on first reveal instead of a toast notification, providing more refined visual feedback.
  * Reveal state is now stored locally, ensuring consistent behavior across sessions and devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->