### PR TITLE
feat(web): pwa reset cache → variant=danger + confirm modal [A11]

### DIFF
--- a/apps/web/src/core/settings/PWASection.tsx
+++ b/apps/web/src/core/settings/PWASection.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Button } from "@shared/components/ui/Button";
+import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
 import { useToast } from "@shared/hooks/useToast";
 import {
   swClearCaches,
@@ -11,6 +12,23 @@ import { SettingsGroup } from "./SettingsPrimitives";
 export function PWASection() {
   const toast = useToast();
   const [swBusy, setSwBusy] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const performClearCaches = async () => {
+    setConfirmOpen(false);
+    setSwBusy(true);
+    try {
+      const res = await swClearCaches();
+      console.log("[sw] caches cleared", res);
+      toast.success("Кеш PWA скинуто. Перезавантажуємо…", 4000);
+      setTimeout(() => window.location.reload(), 300);
+    } catch (err) {
+      toast.error("Не вдалося скинути кеш PWA");
+      console.warn("[sw] clear caches failed", err);
+    } finally {
+      setSwBusy(false);
+    }
+  };
 
   return (
     <SettingsGroup title="PWA та офлайн" emoji="📡">
@@ -44,28 +62,25 @@ export function PWASection() {
         </Button>
         <Button
           type="button"
-          variant="ghost"
+          variant="danger"
           size="sm"
           className="h-10 flex-1"
           disabled={swBusy || !("serviceWorker" in navigator)}
-          onClick={async () => {
-            setSwBusy(true);
-            try {
-              const res = await swClearCaches();
-              console.log("[sw] caches cleared", res);
-              toast.success("Кеш PWA скинуто. Перезавантажуємо…", 4000);
-              setTimeout(() => window.location.reload(), 300);
-            } catch (err) {
-              toast.error("Не вдалося скинути кеш PWA");
-              console.warn("[sw] clear caches failed", err);
-            } finally {
-              setSwBusy(false);
-            }
-          }}
+          onClick={() => setConfirmOpen(true)}
         >
           Скинути кеш PWA
         </Button>
       </div>
+      <ConfirmDialog
+        open={confirmOpen}
+        title="Скинути кеш PWA?"
+        description="Service Worker очистить локальні кеші, після чого сторінка перезавантажиться. Несинхронізовані зміни в офлайн-черзі можуть бути втрачені."
+        confirmLabel="Скинути та перезавантажити"
+        cancelLabel="Скасувати"
+        danger
+        onConfirm={performClearCaches}
+        onCancel={() => setConfirmOpen(false)}
+      />
     </SettingsGroup>
   );
 }

--- a/docs/tech-debt/frontend.md
+++ b/docs/tech-debt/frontend.md
@@ -87,7 +87,7 @@ try/catch крашить на quota exceeded, corrupted storage або private b
 chatActions / insights / recommendations / `useDarkMode` / `perf` /
 `useActiveFizrukWorkout`) → 6 (PR #054a — drop стейлових
 cloudSync v1 entry-їв після PR #052b/#052c видалили engine tree;
-PR #053a видалив `apps/web/src/core/cloudSync/enqueue.ts` no-op shim
+PR #053a видалив `apps/web/src/core/cloudSync/enqueue` no-op shim
 
 - web `syncedKV` фасад) → 0 (PR #054 final — переписали 6 storage-
   primitive файлів так, щоб делегували у `webKVStore` з


### PR DESCRIPTION
## Summary

Робить кнопку «Скинути кеш PWA» в `PWASection` свідомо «небезпечною» — щоб неможливо було випадково очистити cache + перезавантажити сторінку одним тапом.

- **Variant:** `ghost` → `danger` (red soft, `text-danger-strong` за палітрою design-tokens). Візуально вирівнюється з рештою destructive-flow-ів («Видалити», «Skip onboarding»).
- **Confirm-modal:** перед `swClearCaches()` + `window.location.reload()` показуємо `<ConfirmDialog>` з пояснювальним описом. Жоден pointerdown по самій кнопці тепер не запускає очистку — потрібен другий навмисний тап на «Скинути та перезавантажити».
- **Опис у модалці** попереджає про можливу втрату несинхронізованих змін в офлайн-черзі (cloudSync queue) — це справжній risk дії.

PR-33 з [`docs/audits/2026-05-06-ux-roast-pr-plan.md`](../blob/main/docs/audits/2026-05-06-ux-roast-pr-plan.md) (§A11 / §6.4, розмір **XS**, без залежностей).

Включає cherry-pick fix-CI commit з PR #2112 (`docs(tech-debt): unbreak governance-sync — drop dangling enqueue.ts ref`), щоб governance-sync чек на цьому PR теж зелений.

## Governing Skill

- Primary skill: `.agents/skills/sergeant-start-here/SKILL.md`
- Secondary skill (if truly needed): n/a — single-file UX-стиль + confirm-flow

## Playbook

- Primary playbook: n/a — single-file UI зміна
- Why this playbook: жоден playbook не цільовий під danger-confirm flow
- If no playbook matched, why: XS-зміна, повністю описана в audit-плані

## Verification

```bash
cd apps/web && pnpm exec eslint src/core/settings/PWASection.tsx
cd apps/web && pnpm exec tsc -p tsconfig.json --noEmit
node scripts/check-governance-sync.mjs
```

Усі — зелені.

`ConfirmDialog` уже існує (`apps/web/src/shared/components/ui/ConfirmDialog.tsx`) і вживається в інших destructive flow-ах — це стандартний bottom-sheet з focus-trap + swipe-to-dismiss + Escape, тож не вводимо новий patterned-UI компонент.

Additional checks:

- [x] Local smoke / manual validation completed (lint + typecheck + governance-sync)
- [x] Surface-specific checks completed (`useApiForm` / Toast / SW logic — без змін, обернуто тільки render-trigger)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- `docs/tech-debt/frontend.md` — cherry-pick fix з PR #2112 (drop dangling `.ts` extension)

## Risk and Rollout

- User-visible risk: низький — одна кнопка змінює variant + потребує підтвердження. Існуючий toast-feedback / reload-логіка незмінні. Edge case: попереднє reflexive-tap за м'язовою пам'яттю тепер не очищає кеш одразу — це й є whole point.
- Rollout / deploy order: стандартний Vercel preview → main merge.
- Backout plan: revert одного функціонального коміту (cherry-pick fix-CI лишається — корисний сам по собі).

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

- `variant="danger"` ≠ `variant="destructive"` — `danger` це м'якша «warning»-кнопка (soft-bg + danger-border), `destructive` це повністю заповнена червона (для незворотних дій типу «Видалити акаунт»). Cache-clear не є незворотним (cache відбудується автоматично при першому fetch), тому `danger` адекватний рівень.
- Текст модалки: «Service Worker очистить локальні кеші, після чого сторінка перезавантажиться. Несинхронізовані зміни в офлайн-черзі можуть бути втрачені.» — навмисно конкретний (cloudSync queue може мати unsubmitted requests) замість generic «ви впевнені?».
- `setConfirmOpen(false)` робиться першим у `performClearCaches()`, щоб модалка зникла одразу при тапі, ще до того як `swClearCaches()` завершиться (~100-300ms).


Link to Devin session: https://app.devin.ai/sessions/8a11930378b3465fa7df339923dcf52d
Requested by: @Skords-01

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the "Reset PWA cache" action intentional and safer. The button is now `danger` and opens a confirm modal, so clearing Service Worker caches and reloading only happens after explicit confirmation; the dialog warns about possible loss of unsynced offline changes.

- **Bug Fixes**
  - Fix governance-sync by updating `docs/tech-debt/frontend.md` to drop a dangling reference to `apps/web/src/core/cloudSync/enqueue.ts`.

<sup>Written for commit cf4daa634ff95ad8c6b1e60910fbdcbbef1c182c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

