### PR TITLE
fix(web): exempt path-based modules from StandaloneRoutes 404 fallback

### DIFF
--- a/apps/web/src/core/app/StandaloneRoutes.test.tsx
+++ b/apps/web/src/core/app/StandaloneRoutes.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderStandaloneRoute } from "./StandaloneRoutes";
+import type { useAuth } from "../auth/AuthContext";
+
+type AuthUser = ReturnType<typeof useAuth>["user"];
+
+vi.mock("../onboarding/OnboardingWizard", () => ({
+  shouldShowOnboarding: () => false,
+}));
+
+const noop = () => {};
+
+function callRoute(pathname: string, user: AuthUser = null) {
+  return renderStandaloneRoute({
+    pathname,
+    user,
+    authLoading: false,
+    onLeaveAuth: noop,
+    onLeaveWelcome: noop,
+    onOpenAuth: noop,
+    onAssistantClose: noop,
+  });
+}
+
+describe("renderStandaloneRoute()", () => {
+  it("returns `null` for `/` so the App shell renders the hub home", () => {
+    expect(callRoute("/")).toBeNull();
+  });
+
+  it("returns `null` for path-based module roots (regression: BUG #2132 follow-up)", () => {
+    // `/finyk` and `/nutrition` are owned by `useHubNavigation` →
+    // `<ActiveModuleView />`, NOT by `renderStandaloneRoute`. Returning
+    // a non-null value here short-circuits the App shell into the 404
+    // page (the user-reported "Сторінку не знайдено" symptom from
+    // initiative 0006 Phase 2).
+    expect(callRoute("/finyk")).toBeNull();
+    expect(callRoute("/nutrition")).toBeNull();
+  });
+
+  it("returns `null` for nested path-based module URLs", () => {
+    // Sub-routes (`/finyk/budgets`, `/nutrition/log`) must also fall
+    // through to the active-module shell — they're handled by the
+    // domain-local routers (`useFinykRoute`, `useNutritionRoute`).
+    expect(callRoute("/finyk/budgets")).toBeNull();
+    expect(callRoute("/finyk/cards")).toBeNull();
+    expect(callRoute("/nutrition/log")).toBeNull();
+    expect(callRoute("/nutrition/pantry/shopping")).toBeNull();
+  });
+
+  it("returns the 404 surface for genuinely unknown paths", () => {
+    // A path that's neither in `KNOWN_PATHS` nor a path-based-module
+    // root must still 404 — that's the original guard intent.
+    const result = callRoute("/some-random-bogus-path");
+    expect(result).not.toBeNull();
+  });
+
+  it("returns the 404 surface for prefix-aliased pseudo-modules (boundary check)", () => {
+    // `/finykfoo` and `/nutritionish` are NOT path-based modules —
+    // they should still 404, matching the boundary in
+    // `isPathBasedModulePath()`.
+    expect(callRoute("/finykfoo")).not.toBeNull();
+    expect(callRoute("/nutritionish")).not.toBeNull();
+  });
+});

--- a/apps/web/src/core/app/StandaloneRoutes.tsx
+++ b/apps/web/src/core/app/StandaloneRoutes.tsx
@@ -14,6 +14,7 @@ import {
   RESET_PASSWORD_PATH,
   SIGN_IN_PATH,
   WELCOME_PATH,
+  isPathBasedModulePath,
 } from "./appPaths";
 import type { useAuth } from "../auth/AuthContext";
 
@@ -169,7 +170,16 @@ export function renderStandaloneRoute(args: StandaloneRouteArgs): ReactNode {
   }
 
   // Unknown paths get a 404 instead of silently showing the dashboard.
-  if (!KNOWN_PATHS.has(pathname)) {
+  // Exception: paths owned by a migrated path-based module (`/finyk`,
+  // `/nutrition`, plus their nested URLs like `/finyk/budgets` or
+  // `/nutrition/log`) — those are handled by `useHubNavigation` →
+  // `<ActiveModuleView />` further down the App shell, **not** by
+  // `renderStandaloneRoute`. Without this exemption, every entry into
+  // a migrated module short-circuits into `<NotFoundPage />` (regression
+  // introduced together with `KNOWN_PATHS`-as-allowlist + 0006 Phase 2
+  // when path-based modules were not added to the standalone-route
+  // surface map).
+  if (!KNOWN_PATHS.has(pathname) && !isPathBasedModulePath(pathname)) {
     return (
       <Suspense fallback={<PageLoader />}>
         <NotFoundPage />

--- a/apps/web/src/core/app/appPaths.test.ts
+++ b/apps/web/src/core/app/appPaths.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  KNOWN_PATHS,
+  PATH_BASED_MODULE_IDS,
+  isPathBasedModulePath,
+} from "./appPaths";
+
+describe("PATH_BASED_MODULE_IDS", () => {
+  it("includes the modules migrated to path-based URLs (initiative 0006 Phase 2)", () => {
+    // The set is the cross-cutting source of truth for `useHubNavigation`
+    // (router-side) and `StandaloneRoutes` (404 fallback). Whenever a new
+    // module migrates, this expectation is updated and both consumers
+    // pick it up automatically.
+    expect(PATH_BASED_MODULE_IDS.has("nutrition")).toBe(true);
+    expect(PATH_BASED_MODULE_IDS.has("finyk")).toBe(true);
+  });
+
+  it("does not include modules still on the legacy `?module=<id>` URL contract", () => {
+    expect(PATH_BASED_MODULE_IDS.has("fizruk")).toBe(false);
+    expect(PATH_BASED_MODULE_IDS.has("routine")).toBe(false);
+  });
+});
+
+describe("isPathBasedModulePath()", () => {
+  it("matches the bare module root (`/finyk`, `/nutrition`)", () => {
+    expect(isPathBasedModulePath("/finyk")).toBe(true);
+    expect(isPathBasedModulePath("/nutrition")).toBe(true);
+  });
+
+  it("matches nested module URLs (`/finyk/budgets`, `/nutrition/log`)", () => {
+    expect(isPathBasedModulePath("/finyk/budgets")).toBe(true);
+    expect(isPathBasedModulePath("/finyk/budgets?cat=smoking")).toBe(true);
+    expect(isPathBasedModulePath("/nutrition/log")).toBe(true);
+    expect(isPathBasedModulePath("/nutrition/pantry/shopping")).toBe(true);
+  });
+
+  it("does not match modules that have not migrated yet", () => {
+    expect(isPathBasedModulePath("/fizruk")).toBe(false);
+    expect(isPathBasedModulePath("/routine")).toBe(false);
+    expect(isPathBasedModulePath("/fizruk/exercise/12")).toBe(false);
+  });
+
+  it("does not match prefix-aliased URLs (boundary check)", () => {
+    // `/finykfoo` is a different surface and must not be aliased to
+    // finyk — same boundary `parsePathnameModule()` enforces in
+    // `useHubNavigation.ts`.
+    expect(isPathBasedModulePath("/finykprofile")).toBe(false);
+    expect(isPathBasedModulePath("/nutritionish")).toBe(false);
+  });
+
+  it("does not match the root or other surfaces", () => {
+    expect(isPathBasedModulePath("/")).toBe(false);
+    expect(isPathBasedModulePath("/sign-in")).toBe(false);
+    expect(isPathBasedModulePath("/welcome")).toBe(false);
+    expect(isPathBasedModulePath("/profile")).toBe(false);
+  });
+
+  it("rejects malformed input defensively", () => {
+    expect(isPathBasedModulePath("")).toBe(false);
+    expect(isPathBasedModulePath("finyk")).toBe(false); // missing leading "/"
+    // Cast to bypass the type guard — runtime input from `useLocation()`
+    // is always a string, but the function is defensive about it.
+    expect(isPathBasedModulePath(null as unknown as string)).toBe(false);
+    expect(isPathBasedModulePath(undefined as unknown as string)).toBe(false);
+  });
+
+  it("does not consider path-based-module paths members of KNOWN_PATHS", () => {
+    // Sanity check on the StandaloneRoutes contract: KNOWN_PATHS owns
+    // standalone surfaces only, and the path-based-module exemption
+    // is what keeps `/finyk` etc. from short-circuiting into the 404.
+    expect(KNOWN_PATHS.has("/finyk")).toBe(false);
+    expect(KNOWN_PATHS.has("/nutrition")).toBe(false);
+  });
+});

--- a/apps/web/src/core/app/appPaths.ts
+++ b/apps/web/src/core/app/appPaths.ts
@@ -37,7 +37,8 @@ export const PROFILE_PATH = "/profile";
 export const DESIGN_PATH = "/design";
 export const PRICING_PATH = "/pricing";
 
-// All URL paths the app handles. Anything outside this set gets a 404
+// All URL paths the app handles. Anything outside this set **and** not
+// owned by a path-based module (`isPathBasedModulePath`) gets a 404
 // instead of silently falling through to the dashboard.
 export const KNOWN_PATHS: ReadonlySet<string> = new Set([
   "/",
@@ -50,3 +51,41 @@ export const KNOWN_PATHS: ReadonlySet<string> = new Set([
   CHAT_PATH,
   WELCOME_PATH,
 ]);
+
+/**
+ * Modules that have graduated from `/?module=<id>` to a top-level
+ * `/<id>/...` path-based URL contract (initiative 0006 §Phase 2).
+ *
+ * Single source of truth: both `useHubNavigation` (router-side
+ * pathname → activeModule mapping + URL emission) and
+ * `renderStandaloneRoute` (404 fallback exemption) read from this
+ * set. When a new module migrates, add it here once; both consumers
+ * pick it up automatically.
+ *
+ * Order: nutrition (PR #2104), finyk (PR #2108); fizruk + routine
+ * are still on `?module=<id>` until later 0006 PRs.
+ */
+export const PATH_BASED_MODULE_IDS: ReadonlySet<string> = new Set([
+  "nutrition",
+  "finyk",
+]);
+
+/**
+ * Returns true when `pathname` is owned by a path-based module
+ * (`/<id>` or `/<id>/...`). Used by `renderStandaloneRoute` to skip
+ * the unknown-paths 404 for module-owned URLs — without this, the
+ * App shell renders `<NotFoundPage />` for `/finyk` / `/nutrition`
+ * before `useHubNavigation` gets a chance to set `activeModule`.
+ *
+ * Boundary: `/finykfoo` is **not** a finyk path (would otherwise
+ * alias `/finykprofile` → finyk). The check splits on `/` to require
+ * an exact first-segment match, mirroring `parsePathnameModule()` in
+ * `useHubNavigation.ts`.
+ */
+export function isPathBasedModulePath(pathname: string): boolean {
+  if (typeof pathname !== "string" || pathname.length < 2) return false;
+  if (!pathname.startsWith("/")) return false;
+  const firstSegment = pathname.slice(1).split("/", 1)[0] ?? "";
+  if (!firstSegment) return false;
+  return PATH_BASED_MODULE_IDS.has(firstSegment);
+}

--- a/apps/web/src/core/hooks/useHubNavigation.ts
+++ b/apps/web/src/core/hooks/useHubNavigation.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import type { ModuleAccent } from "@sergeant/design-tokens";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { recordModuleOpen } from "../lib/recentModules";
+import { PATH_BASED_MODULE_IDS } from "../app/appPaths";
 
 const VALID_MODULES = new Set(["finyk", "fizruk", "routine", "nutrition"]);
 
@@ -12,12 +13,11 @@ const VALID_MODULES = new Set(["finyk", "fizruk", "routine", "nutrition"]);
  * `activeModule = id` and (b) emit clean `/<id>` URLs from
  * `openModule(id, { hash })` instead of `/?module=<id>#<hash>`.
  *
- * When a module migrates in a later 0006 PR, add its id here and ensure
- * `apps/web/src/modules/<id>/route.tsx` exists and is wired into
- * `core/app/router.tsx` **before** the catch-all. Order: nutrition (PR
- * #2104), finyk (this PR), then fizruk, routine.
+ * Single source of truth lives in `core/app/appPaths.ts` so the App
+ * shell's standalone-route 404 fallback (`renderStandaloneRoute`) and
+ * this hook agree on which URLs are owned by a module.
  */
-const PATH_BASED_MODULES = new Set<HubModuleId>(["nutrition", "finyk"]);
+const PATH_BASED_MODULES = PATH_BASED_MODULE_IDS;
 
 export type HubModuleId = ModuleAccent;
 


### PR DESCRIPTION
## Summary

Fixes user-reported "Сторінку не знайдено" 404 page that appeared when selecting **Фінік** or **Харчування** from the hub.

**Root cause** — initiative 0006 Phase 2 (PRs #2104, #2108) migrated `/nutrition/*` and `/finyk/*` to top-level data-router routes, but the App-shell standalone-route fallback in `core/app/StandaloneRoutes.tsx` was not updated to know about them. Result:

1. User clicks Фінік → `openModule("finyk")` → URL becomes `/finyk`.
2. `core/app/router.tsx` matches `/finyk/*` → renders `<App />` (per `modules/finyk/route.tsx` `Component: App`).
3. Inside `<App />`, `renderStandaloneRoute({ pathname: "/finyk", ... })` is called **before** the `activeModule` check.
4. `KNOWN_PATHS` (the standalone-surface allowlist in `core/app/appPaths.ts`) does **not** contain `/finyk` → the guard short-circuits into `<NotFoundPage />`.
5. `useHubNavigation` never gets to set `activeModule = "finyk"`, so `<ActiveModuleView />` never renders.

The same path triggers for `/nutrition`, `/finyk/budgets`, `/nutrition/log`, etc.

**Fix** —
- `core/app/appPaths.ts`: extract `PATH_BASED_MODULE_IDS` (single source of truth, was previously duplicated as a private const inside `useHubNavigation.ts`) and `isPathBasedModulePath(pathname)` helper that mirrors `parsePathnameModule()`'s first-segment boundary check (so `/finykprofile` is not mis-aliased to finyk).
- `core/app/StandaloneRoutes.tsx`: the unknown-paths 404 branch now short-circuits (returns `null`) when `isPathBasedModulePath(pathname)` is true, letting the App shell fall through to `<ActiveModuleView />`.
- `core/hooks/useHubNavigation.ts`: alias the imported `PATH_BASED_MODULE_IDS` so existing `PATH_BASED_MODULES.has(...)` callsites stay untouched (zero behavioral change there).

Going forward, when a new module migrates to a path-based route in a later 0006 PR, only `PATH_BASED_MODULE_IDS` in `appPaths.ts` needs updating — both consumers pick it up automatically.

## Governing Skill

- Primary skill: `sergeant-web-ui`
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a (regression hot-fix; no recipe matched)
- Why this playbook: hot-fix for user-reported 404 — narrow, scoped, with regression tests.
- If no playbook matched, why: this is a one-off route-fallback bug introduced by a recent migration; nothing in `docs/playbooks/` covers `StandaloneRoutes` ↔ `useHubNavigation` cross-cutting state.

## Verification

```bash
pnpm exec eslint apps/web/src/core/app/StandaloneRoutes.tsx \
  apps/web/src/core/app/StandaloneRoutes.test.tsx \
  apps/web/src/core/app/appPaths.ts \
  apps/web/src/core/app/appPaths.test.ts \
  apps/web/src/core/hooks/useHubNavigation.ts
# 0 errors

pnpm --filter @sergeant/web typecheck
# tsc -p tsconfig.json --noEmit && tsc -p tsconfig.sw.json --noEmit — PASS

pnpm --filter @sergeant/web test -- --run \
  "core/app/appPaths" "core/app/StandaloneRoutes"
# Test Files  2 passed (2)
# Tests       14 passed (14)

pnpm --filter @sergeant/web test -- --run \
  modules/finyk modules/nutrition core/hooks/useHubNavigation core/app
# Test Files 49 passed (49)
# Tests      397 passed (397)
```

Additional checks:

- [x] Local smoke / manual validation completed (unit-test coverage of all reproducer paths)
- [x] Surface-specific checks completed (web vitest + tsc + eslint)

New tests:

- `apps/web/src/core/app/appPaths.test.ts` (8 cases): `PATH_BASED_MODULE_IDS` membership, `isPathBasedModulePath` happy/nested/boundary/malformed paths, `KNOWN_PATHS` disjointness.
- `apps/web/src/core/app/StandaloneRoutes.test.tsx` (6 cases): `/`, `/finyk`, `/nutrition`, nested `/finyk/budgets` & `/nutrition/log` → `null` (regression guard); `/some-bogus`, `/finykfoo`, `/nutritionish` → still 404 (boundary guard).

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. — JSDoc on `PATH_BASED_MODULE_IDS` and `isPathBasedModulePath` documents the cross-cutting contract; comment on the `StandaloneRoutes.tsx` guard records the regression and references initiative 0006 Phase 2.
- [x] I checked whether `AGENTS.md` needed an update. — No: routing surface map / hard rules unchanged.
- [x] I checked whether a playbook or skill needed an update. — No: existing `sergeant-web-ui` skill covers extraction patterns; this PR is a bug fix.
- [x] I checked whether governance docs or review docs needed an update. — No.

Updated docs:

- JSDoc inline (no Markdown changes).

## Risk and Rollout

- **User-visible risk:** Low. The fix is additive — it only extends an existing 404 guard with a known-good carve-out for two specific URL prefixes (`/nutrition`, `/finyk`). Behavior for `/`, `/sign-in`, `/welcome`, `/profile`, `/design`, `/pricing`, `/assistant`, `/chat`, and all genuinely-unknown paths is unchanged (verified by tests).
- **Rollout / deploy order:** Single-app deploy of `apps/web`. No server / DB changes. No schema / contract drift.
- **Backout plan:** `git revert <commit>` — the change is contained to 3 source files + 2 test files. The previous behavior (404 on `/nutrition`, `/finyk`) is what we want to back out _of_, so a revert would be a regression rather than an emergency stop; if needed, just remove the `&& !isPathBasedModulePath(pathname)` clause to fall back to the pre-PR-2104 behavior of falling through to the dashboard for unknown paths.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian. — n/a (only inline JSDoc in English, which is the existing convention for `apps/web/src/core/app/*`).
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

- This PR is **independent of initiative 0013 (PR #2132 LogCard.tsx decomp)** — it lives on a fresh branch off `main` because the bug was reported mid-decomposition and we wanted a clean revert path that doesn't touch the refactor.
- The deduplication of `PATH_BASED_MODULES` (was `new Set<HubModuleId>(["nutrition", "finyk"])` private to `useHubNavigation.ts`, now imported from `appPaths.ts`) is intentional — without a single source of truth, the next module migration would have to update _two_ files in lock-step or risk re-introducing this exact bug.
- 8 pre-existing CI failures on `main` (Argos quota, ADR-0053 README, governance-sync, auth E2E) carry over here too — they are **not** caused by this PR. See PR #2132 for the same list.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a regression that showed the 404 page when opening Finik or Nutrition by exempting path-based modules (`/finyk`, `/nutrition`) from the app shell’s StandaloneRoutes 404 fallback. Users now land in the correct module, including nested routes like `/finyk/budgets` and `/nutrition/log`.

- **Bug Fixes**
  - `StandaloneRoutes.tsx` now returns `null` for path-based module URLs so `<ActiveModuleView />` renders instead of 404.
  - Handles nested paths and preserves boundaries (`/finykfoo` and `/nutritionish` still 404).

- **Refactors**
  - Added `PATH_BASED_MODULE_IDS` and `isPathBasedModulePath` in `appPaths.ts` as the shared source of truth.
  - `useHubNavigation` now imports the shared set; added targeted tests for the exemption and boundaries.

<sup>Written for commit 87bf3c99af11483b7c29b0a061b6f8e9bc7fb005. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

