### PR TITLE
fix(web): restore Finyk Overview/Budgets scroll after DataState refactor

### DIFF
--- a/apps/web/src/modules/finyk/pages/Overview.tsx
+++ b/apps/web/src/modules/finyk/pages/Overview.tsx
@@ -414,7 +414,19 @@ export function Overview({
   });
 
   return (
-    <DataState query={overviewQuery} skeleton={overviewLoadingSkeleton}>
+    // `className` propagates to the wrapper `<div>` `<DataState>` puts
+    // around its children. FinykApp's tab body is a vertical flex
+    // (`flex-1 flex flex-col min-h-0 overflow-hidden`) and the inner
+    // scroll container below relies on `flex-1` against that flex chain
+    // — without these classes here, DataState's plain `<div>` breaks the
+    // flex chain and `overflow-y-auto` collapses → the page becomes
+    // unscrollable (regression from PR `9bd7b4f0`, "adopt <DataState>
+    // in finyk Mono panels").
+    <DataState
+      query={overviewQuery}
+      skeleton={overviewLoadingSkeleton}
+      className="flex-1 flex flex-col min-h-0"
+    >
       {() => (
         <div className="flex-1 overflow-y-auto overscroll-contain">
           <div className="px-4 pt-4 page-tabbar-pad space-y-4 max-w-4xl mx-auto">

--- a/apps/web/src/modules/finyk/pages/budgets/Budgets.tsx
+++ b/apps/web/src/modules/finyk/pages/budgets/Budgets.tsx
@@ -314,7 +314,16 @@ export function Budgets({
   );
 
   return (
-    <DataState query={budgetsQuery} skeleton={budgetsLoadingSkeleton}>
+    // See comment in Overview.tsx — FinykApp's tab body is a vertical
+    // flex chain, so `<DataState>`'s wrapper div needs to participate in
+    // it (`flex-1 flex flex-col min-h-0`) for the inner `flex-1
+    // overflow-y-auto` scroller to size against the viewport. Without
+    // these classes the page becomes unscrollable on Budgets too.
+    <DataState
+      query={budgetsQuery}
+      skeleton={budgetsLoadingSkeleton}
+      className="flex-1 flex flex-col min-h-0"
+    >
       {() => (
         <div className="flex-1 overflow-y-auto">
           <div className="max-w-4xl mx-auto px-4 pt-4 page-tabbar-pad space-y-4">


### PR DESCRIPTION
## Summary

Fixes user-reported "скрол на сторінці огляд у фініку не працює" — content past the viewport on Finyk's **Overview** and **Budgets** pages was clipped and unreachable on both desktop and mobile.

**Root cause** — PR #1979 (`9bd7b4f0 refactor(web): adopt <DataState> in finyk Mono panels`, merged 2026-05-04) wrapped both page bodies in `<DataState>` but did not pass any `className` to the wrapper. `DataState` renders `<div className={className}>{children(data)}</div>` (see `apps/web/src/shared/components/ui/DataState.tsx:224`). With no `className`, this is a plain `<div>` that **breaks the FinykApp tab-body flex chain**.

The surrounding chain looks like:

```
<div className="flex-1 overflow-hidden flex flex-col min-h-0 ...">  ← FinykApp tab body
  <DataState>                                                       ← refactor renders this
    <div>                                                           ← DataState wrapper (NO flex)
      <div className="flex-1 overflow-y-auto overscroll-contain">   ← scroll container
```

The inner `flex-1 overflow-y-auto` relies on its parent being a `flex flex-col` container with `min-h-0`. When `DataState`'s wrapper is a plain `<div>`, the inner `flex-1` cannot constrain height → `overflow-y-auto` has nothing to overflow against → content extends past viewport → FinykApp's outer `overflow-hidden` clips it → no scroll anywhere.

**Fix** — pass `className="flex-1 flex flex-col min-h-0"` to `<DataState>` in both `Overview.tsx` and `Budgets.tsx`. The wrapper now participates in the flex chain and the inner scroller sizes correctly against the viewport. The loading-skeleton branch in `DataState` is `<div className={cn('min-h-0', className)}>{skeleton}</div>` — same `className` therefore propagates there too, so first-paint sizing is also correct.

## Governing Skill

- Primary skill: `sergeant-web-ui`
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a (regression hot-fix; no recipe matched)
- Why this playbook: scoped 2-line className fix in two pages; same root cause, same fix applied to both.
- If no playbook matched, why: this is the second `<DataState>` regression in two days (after the routing 404, fixed in #2139 with the same shape: a refactor missed a class-chain dependency). The pattern of "DataState wrapper className forwarding" is now documented in inline comments on both files; consider promoting to a stricter `DataState` API in a follow-up if more callsites hit this.

## Verification

```bash
pnpm exec eslint \
  apps/web/src/modules/finyk/pages/Overview.tsx \
  apps/web/src/modules/finyk/pages/budgets/Budgets.tsx
# 0 errors

pnpm --filter @sergeant/web typecheck
# tsc -p tsconfig.json --noEmit && tsc -p tsconfig.sw.json --noEmit — PASS

pnpm --filter @sergeant/web test -- --run \
  modules/finyk/pages/Overview \
  modules/finyk/pages/budgets
# Test Files  2 passed (2)
# Tests       16 passed (16)
```

Additional checks:

- [x] Local smoke / manual validation completed — flex-chain reasoning verified against `apps/web/src/shared/components/ui/DataState.tsx:202` (skeleton branch) and `:224` (success branch); class additions confirmed to satisfy the inner `flex-1 overflow-y-auto` parent contract.
- [x] Surface-specific checks completed (web vitest + tsc + eslint)

## Docs and Governance

- [x] Inline comments on both pages explain the wrapper-className contract and reference `9bd7b4f0` so a future refactor doesn't re-introduce the same regression.
- [x] I checked whether `AGENTS.md` needed an update. — No.
- [x] I checked whether a playbook or skill needed an update. — No (this is a one-off fix; if a third callsite hits the same issue, promote the rule to the `DataState` skill).
- [x] I checked whether governance docs or review docs needed an update. — No.

Updated docs:

- Inline (no Markdown changes).

## Risk and Rollout

- **User-visible risk:** Very low. The fix only adds layout utilities to a wrapper `<div>` whose previous classlist was empty; behavior with no children, with skeleton-only render, and with full content all flow through the same path. Tested with both finyk page test files.
- **Rollout / deploy order:** Single-app deploy of `apps/web`. No server / DB changes.
- **Backout plan:** `git revert` — the change is contained to 2 source files. Reverting restores the broken-scroll behavior.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian. — n/a (only inline JSDoc-style comments in English, the existing convention for `apps/web/src/modules/finyk/pages/*`).
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

- Same shape as #2139 (path-based module 404 fallback): a recent refactor introduced a regression because a class-chain / contract dependency was implicit and not enforced by types or tests.
- The 8 pre-existing CI failures on `main` (Argos quota, ADR-0053 README, governance-sync, auth E2E) carry over here too — they are **not** caused by this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores scrolling on Finyk Overview and Budgets by fixing a flex-chain break introduced when wrapping content with `DataState`. Adds the needed flex classes so the inner scroll container sizes to the viewport on desktop and mobile.

- Bug Fixes
  - Passes `className="flex-1 flex flex-col min-h-0"` to `DataState` in `Overview.tsx` and `budgets/Budgets.tsx`, rejoining the tab-body flex chain and re-enabling `overflow-y-auto`.
  - The loading skeleton path inherits the same classes via `DataState`, so first-paint sizing and scroll are correct.

<sup>Written for commit a1cbc44a733185d53cbc0933305fa6f3e931cdc6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

