### PR TITLE
feat(db-schema): add kv_store SQLite table + client migration (PR #060)

### DIFF
--- a/docs/planning/storage-roadmap.md
+++ b/docs/planning/storage-roadmap.md
@@ -2911,7 +2911,7 @@ updated_at: Date.now() })`. Async-write enqueue-ується через
 
 **PR plan.**
 
-#### **PR #060 — `feat(db-schema): add kv_store SQLite table + client migration`** 📋 ROADMAP
+#### **PR #060 — `feat(db-schema): add kv_store SQLite table + client migration`** 🚧 IN FLIGHT ([#2155](https://github.com/Skords-01/Sergeant/pull/2155))
 
 - Drizzle SQLite schema у `packages/db-schema/src/sqlite/kvStore.ts`:
   ```ts

--- a/packages/db-schema/src/__tests__/sqlite-kv-store-snapshot.test.ts
+++ b/packages/db-schema/src/__tests__/sqlite-kv-store-snapshot.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import type { Database as BetterSqliteDatabase } from "better-sqlite3";
+import { getTableConfig } from "drizzle-orm/sqlite-core";
+import { kvStore } from "../sqlite/kvStore.js";
+import {
+  KV_STORE_CLIENT_MIGRATIONS,
+  KV_STORE_MIGRATIONS_TABLE,
+} from "../sqlite/migrations/index.js";
+import { runMigrations } from "../migrate/runner.js";
+import {
+  createSqliteAdapter,
+  type SqliteMigrationClient,
+} from "../migrate/adapters/sqlite.js";
+
+/**
+ * Snapshot tests for the per-device `kv_store` SQLite schema and the
+ * single bundled migration that creates it. Stage 9 / PR #060 of
+ * `docs/planning/storage-roadmap.md`.
+ *
+ * Coverage:
+ *   - column ordering, names, dataType + nullability + hasDefault on
+ *     the Drizzle schema in `sqlite/kvStore.ts`;
+ *   - the bundled migration manifest entry name + DDL anchors;
+ *   - end-to-end migrate-on-`:memory:` smoke + insert/select
+ *     round-trip + idempotent re-run.
+ *
+ * Why no Postgres counterpart: per the storage-roadmap §3 Stage 9
+ * decision note, `kv_store` is purely a per-device key-value table —
+ * its contents never round-trip through op-log push/pull, so there is
+ * no `apps/server/src/migrations/` companion. The corresponding
+ * snapshot test file under `pg-*-snapshot.test.ts` is intentionally
+ * absent.
+ */
+
+function syncClient(db: BetterSqliteDatabase): SqliteMigrationClient {
+  return {
+    exec(sql) {
+      db.exec(sql);
+    },
+    run(sql, params) {
+      db.prepare(sql).run(...(params as unknown[]));
+    },
+    all<R extends Record<string, unknown>>(
+      sql: string,
+      params?: readonly unknown[],
+    ): R[] {
+      const stmt = db.prepare(sql);
+      const result = params ? stmt.all(...(params as unknown[])) : stmt.all();
+      return result as R[];
+    },
+  };
+}
+
+describe("sqlite/kvStore schema snapshot", () => {
+  const config = getTableConfig(kvStore);
+
+  it("has the canonical table name", () => {
+    expect(config.name).toBe("kv_store");
+  });
+
+  it("declares all expected columns in migration order", () => {
+    const columnNames = config.columns.map((c) => c.name);
+    expect(columnNames).toEqual(["key", "value", "updated_at"]);
+  });
+
+  it("declares column types matching `001_kv_store.sql`", () => {
+    const columnMap = Object.fromEntries(
+      config.columns.map((c) => [c.name, c]),
+    );
+
+    // key TEXT PRIMARY KEY
+    expect(columnMap["key"]!.dataType).toBe("string");
+    expect(columnMap["key"]!.columnType).toBe("SQLiteText");
+    expect(columnMap["key"]!.primary).toBe(true);
+    expect(columnMap["key"]!.notNull).toBe(true);
+
+    // value TEXT NOT NULL — JSON-encoded payload, but storage layer
+    // is opaque to the schema (the warm-cache passes strings through).
+    expect(columnMap["value"]!.dataType).toBe("string");
+    expect(columnMap["value"]!.columnType).toBe("SQLiteText");
+    expect(columnMap["value"]!.notNull).toBe(true);
+
+    // updated_at INTEGER (timestamp_ms) NOT NULL — Date round-trip
+    // via Drizzle's `mode: "timestamp_ms"`. Numeric-sortable so the
+    // PR #061 warm-cache eviction heuristic can ORDER BY updated_at.
+    expect(columnMap["updated_at"]!.dataType).toBe("date");
+    expect(columnMap["updated_at"]!.columnType).toBe("SQLiteTimestamp");
+    expect(columnMap["updated_at"]!.notNull).toBe(true);
+    expect(columnMap["updated_at"]!.hasDefault).toBe(true);
+  });
+
+  it("has no extra indexes (PRIMARY KEY on `key` is the only access path)", () => {
+    expect(config.indexes).toHaveLength(0);
+  });
+});
+
+describe("sqlite/kv_store migrations exports", () => {
+  it("exports a single 001_kv_store.sql migration", () => {
+    expect(KV_STORE_CLIENT_MIGRATIONS).toHaveLength(1);
+    expect(KV_STORE_CLIENT_MIGRATIONS[0]!.name).toBe("001_kv_store.sql");
+  });
+
+  it("DDL creates the kv_store table with the expected column shape", () => {
+    const sql = KV_STORE_CLIENT_MIGRATIONS[0]!.sql;
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS kv_store/);
+    expect(sql).toMatch(/key\s+TEXT PRIMARY KEY/);
+    expect(sql).toMatch(/value\s+TEXT NOT NULL/);
+    expect(sql).toMatch(/updated_at\s+INTEGER NOT NULL/);
+    // Numeric SQL default so raw-SQL inserts (tests, future migrations)
+    // don't have to specify updated_at — Drizzle's $defaultFn covers
+    // ORM-driven inserts but the SQL fallback keeps the table usable
+    // from outside Drizzle too.
+    expect(sql).toMatch(
+      /DEFAULT \(CAST\(\(unixepoch\(\) \* 1000\) AS INTEGER\)\)/,
+    );
+  });
+
+  it("uses a separate `__kv_store_migrations` ledger table", () => {
+    expect(KV_STORE_MIGRATIONS_TABLE).toBe("__kv_store_migrations");
+  });
+});
+
+describe("KV_STORE_CLIENT_MIGRATIONS apply roundtrip", () => {
+  let db: BetterSqliteDatabase;
+  let client: SqliteMigrationClient;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    client = syncClient(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("applies the bundled migration end-to-end and creates the kv_store table", async () => {
+    const result = await runMigrations({
+      adapter: createSqliteAdapter(client),
+      files: KV_STORE_CLIENT_MIGRATIONS,
+      tableName: KV_STORE_MIGRATIONS_TABLE,
+    });
+    expect(result.applied).toEqual(["001_kv_store.sql"]);
+    expect(result.skipped).toEqual([]);
+
+    const tables = db
+      .prepare(
+        `SELECT name FROM sqlite_master
+         WHERE type='table' AND name NOT LIKE 'sqlite_%'
+         ORDER BY name`,
+      )
+      .all() as { name: string }[];
+    expect(tables.map((r) => r.name)).toEqual([
+      "__kv_store_migrations",
+      "kv_store",
+    ]);
+
+    const cols = db
+      .prepare("SELECT name FROM pragma_table_info('kv_store')")
+      .all() as { name: string }[];
+    expect(cols.map((c) => c.name)).toEqual(["key", "value", "updated_at"]);
+
+    const pk = db
+      .prepare("SELECT name FROM pragma_table_info('kv_store') WHERE pk != 0")
+      .all() as { name: string }[];
+    expect(pk.map((r) => r.name)).toEqual(["key"]);
+  });
+
+  it("re-running is a no-op (idempotent migrations ledger)", async () => {
+    const adapter = createSqliteAdapter(client);
+    await runMigrations({
+      adapter,
+      files: KV_STORE_CLIENT_MIGRATIONS,
+      tableName: KV_STORE_MIGRATIONS_TABLE,
+    });
+    const second = await runMigrations({
+      adapter,
+      files: KV_STORE_CLIENT_MIGRATIONS,
+      tableName: KV_STORE_MIGRATIONS_TABLE,
+    });
+    expect(second.applied).toEqual([]);
+    expect(second.skipped).toEqual(["001_kv_store.sql"]);
+  });
+
+  it("supports insert + select roundtrips and SQL default for updated_at", async () => {
+    await runMigrations({
+      adapter: createSqliteAdapter(client),
+      files: KV_STORE_CLIENT_MIGRATIONS,
+      tableName: KV_STORE_MIGRATIONS_TABLE,
+    });
+
+    const before = Date.now();
+    db.prepare(`INSERT INTO kv_store (key, value) VALUES (?, ?)`).run(
+      "hub_flags_v1",
+      JSON.stringify({ hub_command_palette: true }),
+    );
+    const after = Date.now();
+
+    const row = db
+      .prepare(
+        "SELECT key, value, updated_at FROM kv_store WHERE key = 'hub_flags_v1'",
+      )
+      .get() as { key: string; value: string; updated_at: number };
+    expect(row.key).toBe("hub_flags_v1");
+    expect(JSON.parse(row.value)).toEqual({ hub_command_palette: true });
+    expect(typeof row.updated_at).toBe("number");
+    // SQL default `(unixepoch() * 1000)` fires when the caller omits
+    // `updated_at`; should land within the wall-clock window of the
+    // INSERT statement (some leeway for clock granularity).
+    expect(row.updated_at).toBeGreaterThanOrEqual(before - 1000);
+    expect(row.updated_at).toBeLessThanOrEqual(after + 1000);
+  });
+
+  it("PRIMARY KEY on `key` rejects duplicate inserts", async () => {
+    await runMigrations({
+      adapter: createSqliteAdapter(client),
+      files: KV_STORE_CLIENT_MIGRATIONS,
+      tableName: KV_STORE_MIGRATIONS_TABLE,
+    });
+
+    db.prepare(`INSERT INTO kv_store (key, value) VALUES (?, ?)`).run(
+      "shared_key",
+      "first",
+    );
+    expect(() =>
+      db
+        .prepare(`INSERT INTO kv_store (key, value) VALUES (?, ?)`)
+        .run("shared_key", "second"),
+    ).toThrow();
+  });
+
+  it("INSERT ON CONFLICT(key) DO UPDATE upserts value + bumps updated_at", async () => {
+    await runMigrations({
+      adapter: createSqliteAdapter(client),
+      files: KV_STORE_CLIENT_MIGRATIONS,
+      tableName: KV_STORE_MIGRATIONS_TABLE,
+    });
+
+    // The PR #061 warm-cache will use ON CONFLICT upserts as its
+    // sole write path — pin that the SQL surface the schema exposes
+    // supports them with the column shape we declared.
+    db.prepare(
+      `INSERT INTO kv_store (key, value, updated_at)
+       VALUES (?, ?, ?)
+       ON CONFLICT(key) DO UPDATE SET
+         value = excluded.value,
+         updated_at = excluded.updated_at`,
+    ).run("session_seen_at", "0", 1_700_000_000_000);
+
+    db.prepare(
+      `INSERT INTO kv_store (key, value, updated_at)
+       VALUES (?, ?, ?)
+       ON CONFLICT(key) DO UPDATE SET
+         value = excluded.value,
+         updated_at = excluded.updated_at`,
+    ).run("session_seen_at", "1", 1_700_000_000_500);
+
+    const row = db
+      .prepare(
+        "SELECT value, updated_at FROM kv_store WHERE key = 'session_seen_at'",
+      )
+      .get() as { value: string; updated_at: number };
+    expect(row).toEqual({ value: "1", updated_at: 1_700_000_000_500 });
+  });
+});

--- a/packages/db-schema/src/sqlite/index.ts
+++ b/packages/db-schema/src/sqlite/index.ts
@@ -59,6 +59,8 @@ export {
   NUTRITION_MIGRATIONS_TABLE,
   FINYK_CLIENT_MIGRATIONS,
   FINYK_MIGRATIONS_TABLE,
+  KV_STORE_CLIENT_MIGRATIONS,
+  KV_STORE_MIGRATIONS_TABLE,
 } from "./migrations/index.js";
 export {
   fizrukWorkouts,

--- a/packages/db-schema/src/sqlite/kvStore.ts
+++ b/packages/db-schema/src/sqlite/kvStore.ts
@@ -1,0 +1,41 @@
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+/**
+ * SQLite schema for the per-device `kv_store` table.
+ *
+ * Stage 9 / PR #060 of `docs/planning/storage-roadmap.md`. Hosts the
+ * SQLite-backed replacement for the LocalStorage-backed `webKVStore`
+ * primitive that today serves typedStore (`hub_flags_v1`, hidden-account
+ * blobs, etc.) on web, and the `react-native-mmkv`-backed mobile
+ * counterpart. Schema-only — no consumers swap onto this table until
+ * PR #061 (`createSqliteKVStore` + warm-cache), PR #062 (bootstrap +
+ * one-time LS→`kv_store` migration), and PR #063 (`webKVStore` impl
+ * swap) land.
+ *
+ * Why purely client-local: the contents are per-device key-value (UI
+ * prefs, last-seen timestamps, expandable feature flags, …). For
+ * cross-device prefs we rely on the normalized module tables
+ * (`nutrition_prefs`, `finyk_prefs`); `kv_store` deliberately does NOT
+ * round-trip through op-log push/pull, so there is no Postgres
+ * counterpart in `apps/server/src/migrations/`.
+ *
+ * Differences from the routine/fizruk/nutrition/finyk pattern:
+ *   - `updated_at` is INTEGER (Unix epoch milliseconds via Drizzle's
+ *     `mode: "timestamp_ms"`) rather than TEXT ISO-8601. The warm-cache
+ *     in PR #061 needs a sortable numeric timestamp for cache-eviction
+ *     heuristics, and LWW comparisons happen entirely client-local —
+ *     there is no server apply-path that needs offset-aware ISO-8601
+ *     byte alignment.
+ *   - No `_lite`-suffixed indexes: the table is not mirrored
+ *     server-side, so there is no name-collision risk against PG
+ *     migrations. The PRIMARY KEY on `key` is the only access path the
+ *     warm-cache uses (full-table scan once at boot, point lookups
+ *     thereafter).
+ */
+export const kvStore = sqliteTable("kv_store", {
+  key: text().primaryKey(),
+  value: text().notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+});

--- a/packages/db-schema/src/sqlite/migrations/index.ts
+++ b/packages/db-schema/src/sqlite/migrations/index.ts
@@ -800,3 +800,56 @@ export const FINYK_CLIENT_MIGRATIONS: readonly MigrationFile[] = [
  * modules' migration histories stay independent.
  */
 export const FINYK_MIGRATIONS_TABLE = "__finyk_migrations";
+
+// ---------------------------------------------------------------------------
+// KV store — Stage 9 / PR #060
+//
+// Per-device key-value table that backs the SQLite swap of the
+// LocalStorage-backed `webKVStore` primitive (and its MMKV mobile
+// counterpart). Schema-only at this PR — `createSqliteKVStore` +
+// warm-cache (PR #061), bootstrap + LS→kv_store one-time migration
+// (PR #062), and the `webKVStore` impl swap (PR #063) follow in
+// later PRs of `docs/planning/storage-roadmap.md` Stage 9.
+//
+// Differences from the routine/fizruk/nutrition/finyk pattern:
+//   - `updated_at` is INTEGER (Unix epoch ms) rather than TEXT ISO-8601.
+//     Warm-cache eviction heuristics need a sortable numeric timestamp,
+//     and LWW comparisons happen entirely client-local — there is no
+//     server apply-path that needs offset-aware ISO-8601 byte alignment.
+//   - No `_lite`-suffixed indexes. The table is not mirrored
+//     server-side (no Postgres counterpart) and the warm-cache hits
+//     only the PRIMARY KEY on `key`, so additional indexes would be
+//     dead weight.
+// ---------------------------------------------------------------------------
+
+const KV_STORE_001_SQL = `
+CREATE TABLE IF NOT EXISTS kv_store (
+  key        TEXT PRIMARY KEY,
+  value      TEXT NOT NULL,
+  updated_at INTEGER NOT NULL DEFAULT (CAST((unixepoch() * 1000) AS INTEGER))
+);
+`;
+
+/**
+ * Ordered list of bundled client migrations for the per-device
+ * `kv_store` table. Pass this directly to `runMigrations` from
+ * `@sergeant/db-schema/migrate`.
+ *
+ * The `kv_store` module uses its own ledger table
+ * (`__kv_store_migrations`) so the warm-cache bootstrap (PR #061+)
+ * can run independently of the routine / fizruk / nutrition / finyk
+ * module migrations — each module's history stays independent so
+ * canary rollouts and rollbacks don't interlock.
+ */
+export const KV_STORE_CLIENT_MIGRATIONS: readonly MigrationFile[] = [
+  { name: "001_kv_store.sql", sql: KV_STORE_001_SQL },
+] as const;
+
+/**
+ * Stable ledger table name used by the `kv_store` SQLite module.
+ * Separate from `__migrations` (routine), `__fizruk_migrations`
+ * (fizruk), `__nutrition_migrations` (nutrition), and
+ * `__finyk_migrations` (finyk) so all five modules' migration
+ * histories stay independent.
+ */
+export const KV_STORE_MIGRATIONS_TABLE = "__kv_store_migrations";


### PR DESCRIPTION
## Summary

Stage 9 / PR #060 of `docs/planning/storage-roadmap.md`. Adds the per-device `kv_store` schema that backs the Stage 9 swap of the LocalStorage-backed `webKVStore` primitive (and its MMKV mobile counterpart) onto SQLite. **Schema-only change** — no consumers swap onto this table until PR #061 (`createSqliteKVStore` + warm-cache), PR #062 (bootstrap + one-time LS→`kv_store` migration), and PR #063 (`webKVStore` impl swap) follow.

## What changed

- `packages/db-schema/src/sqlite/kvStore.ts` — Drizzle table:
  - `key TEXT PRIMARY KEY`
  - `value TEXT NOT NULL`
  - `updated_at INTEGER` (timestamp_ms via Drizzle’s `mode: "timestamp_ms"`) `NOT NULL` with `$defaultFn(() => new Date())`.
- `packages/db-schema/src/sqlite/migrations/index.ts` — `KV_STORE_CLIENT_MIGRATIONS` (single `001_kv_store.sql` entry) + `KV_STORE_MIGRATIONS_TABLE = "__kv_store_migrations"` (separate ledger from the four module ledgers so the warm-cache bootstrap can run independently).
- `packages/db-schema/src/sqlite/index.ts` — re-export the new schema + migrations constants.
- `packages/db-schema/src/__tests__/sqlite-kv-store-snapshot.test.ts` — column-shape snapshot, manifest assertions, end-to-end migrate-on-`:memory:` smoke, idempotent re-run, PRIMARY KEY duplicate rejection, and `INSERT … ON CONFLICT(key) DO UPDATE` upsert roundtrip.

## Why no Postgres counterpart

Per storage-roadmap §3 Stage 9, `kv_store` is purely a per-device key-value table — its contents never round-trip through op-log push/pull (cross-device prefs use the normalised module tables `nutrition_prefs`, `finyk_prefs`, etc.), so there is no `apps/server/src/migrations/` companion.

## Tests

```
pnpm --filter @sergeant/db-schema test
  Test Files  22 passed (22)
  Tests       377 passed (377)
pnpm --filter @sergeant/db-schema lint
pnpm --filter @sergeant/db-schema typecheck
```

## Out of scope

No changes to `webKVStore` impl, no consumer migrations, no bootstrap wiring — those land in PR #061-#063.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a per-device `kv_store` SQLite table and client migration to prepare swapping the LocalStorage/MMKV-backed KV store to SQLite; roadmap docs now mark this PR as in flight. Schema-only; no consumers switch in this PR.

- **New Features**
  - Added Drizzle table `kv_store` with `key TEXT PRIMARY KEY`, `value TEXT NOT NULL`, and `updated_at INTEGER NOT NULL` (epoch ms, defaulted via Drizzle `timestamp_ms`).
  - Introduced `KV_STORE_CLIENT_MIGRATIONS` (includes `001_kv_store.sql`) and a dedicated ledger `KV_STORE_MIGRATIONS_TABLE` = `__kv_store_migrations`; re-exported from `@sergeant/db-schema/sqlite`.
  - Added tests for schema shape, migration apply/idempotence, PK uniqueness, and `INSERT … ON CONFLICT(key) DO UPDATE` upserts.
  - No Postgres migration (client-local data; not synced).

<sup>Written for commit a8462eca3781c0dc66c7a1a6db79a0fbb0f3b4a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

