### PR TITLE
feat(web): password-strength entropy estimator (PR-15, §C8)

### DIFF
--- a/apps/web/src/core/auth/AuthPage.tsx
+++ b/apps/web/src/core/auth/AuthPage.tsx
@@ -8,6 +8,7 @@ import { useCelebration } from "@shared/components/ui/CelebrationModal";
 import { useToast } from "@shared/hooks/useToast";
 import { useApiForm } from "@shared/forms/useApiForm";
 import { messages } from "@shared/i18n/uk";
+import { estimatePasswordStrength } from "@shared/lib/auth/passwordStrength";
 import { BrandLogo } from "../app/BrandLogo";
 import { useAuth } from "./AuthContext";
 
@@ -49,8 +50,11 @@ type RegisterValues = z.infer<typeof registerSchema>;
 
 function PasswordStrengthBar({ password }: { password: string }) {
   if (!password) return null;
-  const len = password.length;
-  const level = len < 6 ? 0 : len < 10 ? 1 : 2;
+  // PR-15 / §C8 — entropy-aware ladder. Замінює naive довжина-only оцінку,
+  // що однаково вважала надійним і `aaaaaaaaaa`, і `Aa1!Aa1!Aa`. Лейбли —
+  // bare-string (rule scope: тільки JSX-літерали), окремий i18n-namespace
+  // не виправдано для трьох коротких токенів.
+  const { level } = estimatePasswordStrength(password);
   const widths = ["w-1/3", "w-2/3", "w-full"];
   const colors = ["bg-error", "bg-amber-400", "bg-brand-500"];
   const labels = ["Слабкий", "Середній", "Надійний"];

--- a/apps/web/src/shared/lib/auth/passwordStrength.test.ts
+++ b/apps/web/src/shared/lib/auth/passwordStrength.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { estimatePasswordStrength } from "./passwordStrength";
+
+describe("estimatePasswordStrength", () => {
+  it("returns weak/zero for empty string", () => {
+    const r = estimatePasswordStrength("");
+    expect(r.level).toBe(0);
+    expect(r.score).toBe(0);
+    expect(r.classCount).toBe(0);
+    expect(r.uniqueChars).toBe(0);
+    expect(r.uniqueRatio).toBe(0);
+  });
+
+  it("rates `aaaaaaaaaa` (10 chars, 1 unique, 1 class) as weak", () => {
+    // PR-15 acceptance criterion #1.
+    const r = estimatePasswordStrength("aaaaaaaaaa");
+    expect(r.classCount).toBe(1);
+    expect(r.uniqueChars).toBe(1);
+    expect(r.level).toBe(0);
+  });
+
+  it("rates `Aa1!Aa1!Aa` (10 chars, 4 classes) as strong", () => {
+    // PR-15 acceptance criterion #2 — повний 4-class набір з достатньою
+    // довжиною.
+    const r = estimatePasswordStrength("Aa1!Aa1!Aa");
+    expect(r.classCount).toBe(4);
+    expect(r.level).toBe(2);
+  });
+
+  it("rates 10-char two-class word at most medium", () => {
+    // `password11` — 9 unique chars, але лише digit + lowercase classes;
+    // 2-class cap не дозволяє strong.
+    const r = estimatePasswordStrength("password11");
+    expect(r.classCount).toBe(2);
+    expect(r.level).toBeLessThan(2);
+  });
+
+  it("rates pure long lowercase password as weak (single-class cap)", () => {
+    // `qwertyuiop` має 10 unique chars, але лише 1 клас → forced weak.
+    const r = estimatePasswordStrength("qwertyuiop");
+    expect(r.classCount).toBe(1);
+    expect(r.level).toBe(0);
+  });
+
+  it("rates a long mixed password as strong", () => {
+    const r = estimatePasswordStrength("CorrectHorseBattery!9");
+    expect(r.classCount).toBeGreaterThanOrEqual(3);
+    expect(r.level).toBe(2);
+  });
+
+  it("rates a 6-char mixed password as not-strong", () => {
+    // Класи всі 4, але length занадто мала для strong.
+    const r = estimatePasswordStrength("Ab1!Ab");
+    expect(r.classCount).toBe(4);
+    expect(r.level).toBeLessThan(2);
+  });
+
+  it("uses Cyrillic uppercase/lowercase as separate classes", () => {
+    const r = estimatePasswordStrength("Привіт1!Привіт");
+    expect(r.classCount).toBe(4);
+    expect(r.level).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/shared/lib/auth/passwordStrength.ts
+++ b/apps/web/src/shared/lib/auth/passwordStrength.ts
@@ -1,0 +1,93 @@
+/**
+ * Password-strength heuristic для register/reset форм.
+ *
+ * PR-15 / §C8 з docs/audits/2026-05-06-ux-roast-pr-plan.md.
+ *
+ * Замінює naive довжина-only ладдер (`< 6 / < 10 / >= 10`), який давав
+ * однакову «надійну» оцінку і `aaaaaaaaaa`, і `Aa1!Aa1!Aa1!`. Нова
+ * метрика враховує:
+ *
+ *   - довжину (`len`),
+ *   - кількість унікальних символів (`uniqueChars`),
+ *   - кількість char-classes (lowercase, uppercase, digit, symbol).
+ *
+ * `score = len * uniqueChars * (classCount / 4)`.
+ *
+ * Класовий cap: щоб одно-классові паролі (`aaaaaaaaaa`, `qwertyuiop`)
+ * не отримували helper-у через довжину, ми обмежуємо:
+ *
+ *   - `classCount === 1` → завжди weak (level 0), незалежно від score.
+ *   - `classCount === 2` → не вище за medium (level 1).
+ *   - `classCount >= 3` → повний ladder за score: `<8` weak, `<30`
+ *     medium, `>=30` strong.
+ *
+ * Це не криптографічний bit-entropy estimator; це product-level
+ * heuristic, який без залежностей дає user-у відчутну різницю між
+ * `aaaaa` і `Aa1!Aa1!Aa`.
+ */
+
+export type PasswordStrengthLevel = 0 | 1 | 2;
+
+export interface PasswordStrength {
+  /** Числова оцінка (`Math.round`-ed для зручності тестів). */
+  score: number;
+  /** 0 = weak, 1 = medium, 2 = strong. */
+  level: PasswordStrengthLevel;
+  /** Скільки char-classes присутні: 0..4. */
+  classCount: number;
+  /** Кількість унікальних символів. */
+  uniqueChars: number;
+  /** Ratio унікальних chars до total chars (0..1). */
+  uniqueRatio: number;
+}
+
+const LOWERCASE = /[a-zа-яёіїєґ]/;
+const UPPERCASE = /[A-ZА-ЯЁІЇЄҐ]/;
+const DIGIT = /[0-9]/;
+const SYMBOL = /[^A-Za-zА-Яа-яЁёІіЇїЄєҐґ0-9\s]/;
+
+function countCharClasses(password: string): number {
+  let count = 0;
+  if (LOWERCASE.test(password)) count += 1;
+  if (UPPERCASE.test(password)) count += 1;
+  if (DIGIT.test(password)) count += 1;
+  if (SYMBOL.test(password)) count += 1;
+  return count;
+}
+
+function countUniqueChars(password: string): number {
+  if (password.length === 0) return 0;
+  const unique = new Set<string>();
+  for (const ch of password) unique.add(ch);
+  return unique.size;
+}
+
+function levelFor(score: number, classCount: number): PasswordStrengthLevel {
+  if (classCount <= 1) return 0;
+  if (classCount === 2) return score < 30 ? 0 : 1;
+  return score < 8 ? 0 : score < 30 ? 1 : 2;
+}
+
+/**
+ * Оцінити силу пароля. Повертає score, level (0..2) і breakdown
+ * для дебага/UI-tooltip-ів.
+ */
+export function estimatePasswordStrength(password: string): PasswordStrength {
+  if (!password) {
+    return {
+      score: 0,
+      level: 0,
+      classCount: 0,
+      uniqueChars: 0,
+      uniqueRatio: 0,
+    };
+  }
+  const len = password.length;
+  const uniqueChars = countUniqueChars(password);
+  const uniqueRatio = uniqueChars / len;
+  const classCount = countCharClasses(password);
+  const rawScore = len * uniqueChars * (classCount / 4);
+  const score = Math.round(rawScore);
+  const level = levelFor(score, classCount);
+  return { score, level, classCount, uniqueChars, uniqueRatio };
+}


### PR DESCRIPTION
## Summary

**PR-15 / §C8** з [`docs/audits/2026-05-06-ux-roast-pr-plan.md`](../blob/main/docs/audits/2026-05-06-ux-roast-pr-plan.md).

Замінює naive довжина-only ladder (`<6 / <10 / >=10`) у `PasswordStrengthBar`, у якому `aaaaaaaaaa` і `Aa1!Aa1!Aa` отримували однакову «надійну» оцінку.

### Метрика

```
score = len * uniqueChars * (classCount / 4)
```

з class-cap-ladder:

- `classCount === 1` → завжди weak
- `classCount === 2` → max medium
- `classCount >= 3` → ladder за score: `<8 weak`, `<30 medium`, `>=30 strong`

### Acceptance (з плану)

- [x] `aaaaaaaaaa` → weak (раніше strong)
- [x] `Aa1!Aa1!Aa` → strong
- [x] Cyrillic upper/lower трактуються окремими класами

### Files

- `apps/web/src/shared/lib/auth/passwordStrength.ts` (new)
- `apps/web/src/shared/lib/auth/passwordStrength.test.ts` (new, 8 cases)
- `apps/web/src/core/auth/AuthPage.tsx` — `PasswordStrengthBar` тепер дергає `estimatePasswordStrength()`.

### Out of scope

- Локалізовані лейбли (`Слабкий/Середній/Надійний`) лишаються inline-string. Rule `no-cyrillic-jsx-literal` діє лише на JSX-literals, окремий i18n-namespace для трьох слів-індикаторів не виправдано в цьому PR.
- `password-strength bit-entropy` (zxcvbn) — heavier dep, відкладено.

## Test plan

- `pnpm --filter @sergeant/web typecheck` ✅
- `pnpm --filter @sergeant/web lint` ✅ (0 errors, 13 pre-existing warnings)
- `pnpm --filter @sergeant/web test src/shared/lib/auth/passwordStrength src/core/auth` ✅ (49 / 49)

## Source

- Plan: [`docs/audits/2026-05-06-ux-roast-pr-plan.md` § PR-15](../blob/main/docs/audits/2026-05-06-ux-roast-pr-plan.md)
- Symptom: `2026-05-03-web-deep-dive` § C8 — Password-strength bar misleading.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the length-only password strength bar with an entropy-aware estimator for clearer, more accurate feedback. Example: `aaaaaaaaaa` is now weak; `Aa1!Aa1!Aa` is strong.

- **New Features**
  - Added `estimatePasswordStrength` with score: len * uniqueChars * (classCount / 4).
  - Class caps: 1 class → weak; 2 classes → max medium; 3+ classes → thresholds (<8 weak, <30 medium, ≥30 strong).
  - Integrated into `PasswordStrengthBar` in `AuthPage.tsx`.
  - Added tests (8 cases), including Cyrillic upper/lower as separate classes.

<sup>Written for commit 8ef7ff3902d3f52fcdb0a503d10aeff5d8215b2d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

