### PR TITLE
feat(web): unify zod-каталог під «Введи X» / «Обери X» (PR-31, §C6)

### DIFF
--- a/apps/web/src/modules/finyk/components/CategorySelector.tsx
+++ b/apps/web/src/modules/finyk/components/CategorySelector.tsx
@@ -21,7 +21,8 @@ function CategorySelectorComponent({
   onChange,
   categories = [],
   className,
-  placeholder = "Оберіть категорію",
+  // PR-31 / §C6 — узгоджено з `validation.categoryRequired`.
+  placeholder = "Обери категорію",
 }: CategorySelectorProps) {
   return (
     <select

--- a/apps/web/src/modules/finyk/components/budgets/AddBudgetForm.test.tsx
+++ b/apps/web/src/modules/finyk/components/budgets/AddBudgetForm.test.tsx
@@ -37,7 +37,7 @@ describe("AddBudgetForm — useApiForm + zod (Item #8 round-13)", () => {
 
   it("submits a valid limit budget with normalized number value", async () => {
     const { onSubmit } = setup();
-    fireEvent.change(screen.getByDisplayValue("Вибери категорію"), {
+    fireEvent.change(screen.getByDisplayValue("Обери категорію"), {
       target: { value: "food" },
     });
     fireEvent.change(screen.getByLabelText("Ліміт"), {
@@ -61,14 +61,14 @@ describe("AddBudgetForm — useApiForm + zod (Item #8 round-13)", () => {
     fireEvent.submit(screen.getByRole("form", { name: "Новий ліміт бюджету" }));
 
     await waitFor(() => {
-      expect(screen.getByText("Оберіть категорію")).toBeInTheDocument();
+      expect(screen.getByText("Обери категорію")).toBeInTheDocument();
     });
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
   it("flags non-positive limit amount via aria-invalid + zod refine", async () => {
     const { onSubmit } = setup();
-    fireEvent.change(screen.getByDisplayValue("Вибери категорію"), {
+    fireEvent.change(screen.getByDisplayValue("Обери категорію"), {
       target: { value: "food" },
     });
     fireEvent.change(screen.getByLabelText("Ліміт"), {
@@ -82,7 +82,7 @@ describe("AddBudgetForm — useApiForm + zod (Item #8 round-13)", () => {
         "true",
       );
     });
-    expect(screen.getByText("Вкажіть ліміт більше 0")).toBeInTheDocument();
+    expect(screen.getByText("Введи ліміт більше 0")).toBeInTheDocument();
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
@@ -91,7 +91,7 @@ describe("AddBudgetForm — useApiForm + zod (Item #8 round-13)", () => {
       { id: "b1", type: "limit", categoryId: "food", limit: 1000 },
     ];
     const { onSubmit } = setup(existing);
-    fireEvent.change(screen.getByDisplayValue("Вибери категорію"), {
+    fireEvent.change(screen.getByDisplayValue("Обери категорію"), {
       target: { value: "food" },
     });
     fireEvent.change(screen.getByLabelText("Ліміт"), {
@@ -149,7 +149,7 @@ describe("AddBudgetForm — useApiForm + zod (Item #8 round-13)", () => {
     fireEvent.submit(screen.getByRole("form", { name: "Нова ціль бюджету" }));
 
     await waitFor(() => {
-      expect(screen.getByText("Вкажіть назву цілі")).toBeInTheDocument();
+      expect(screen.getByText("Введи назву цілі")).toBeInTheDocument();
     });
     expect(onSubmit).not.toHaveBeenCalled();
   });

--- a/apps/web/src/modules/finyk/components/budgets/AddBudgetForm.tsx
+++ b/apps/web/src/modules/finyk/components/budgets/AddBudgetForm.tsx
@@ -235,7 +235,6 @@ function AddBudgetFormComponent({
                 })
               }
               categories={expenseCategoryList.filter((c) => c.id !== "income")}
-              placeholder="Вибери категорію"
             />
             {limitCategoryError && (
               <p

--- a/apps/web/src/shared/i18n/uk.ts
+++ b/apps/web/src/shared/i18n/uk.ts
@@ -77,6 +77,12 @@ export const messages = {
     // Іменування — за призначенням, не за рядком. Якщо в майбутньому буде
     // змінено формулювання чи довжину пароля, зміна торкнеться лише
     // value-у тут.
+    // PR-31 / §C6 — `fieldRequired` deprecated. Безособове «Поле
+    // обовʼязкове» виграло від уніфікації під 1-у особу («Введи X»
+    // / «Обери X»). Лишаємо до follow-up міграції design-showcase
+    // demo (`core/designShowcase/sections/Forms.tsx`); прохід через
+    // production-форми вже не звертається до цього key-а.
+    /** @deprecated PR-31: use `<entity>Required` ключі замість безособового. */
     fieldRequired: "Поле обовʼязкове.",
     emailRequired: "Введи email",
     emailInvalid: "Некоректний формат email",
@@ -95,12 +101,18 @@ export const messages = {
     noteMax200: "Не більше 200 символів",
     sleepHoursRange: "Сон має бути від 0 до 24 годин",
     weightKgRange: "Вага має бути від 20 до 300 кг",
-    tagNameRequired: "Назва тега не може бути порожньою",
-    goalNameRequired: "Вкажіть назву цілі",
-    goalAmountRequired: "Вкажіть суму цілі більше 0",
+    // PR-31 / §C6 — уніфікація під 1-у особу «Введи X» / «Обери X».
+    // Раніше каталог змішував чотири стилі (`Поле обовʼязкове`,
+    // `Назва тега не може бути порожньою`, `Вкажіть назву`, `Введи`).
+    // Тримаємо стиль одним: для input-полів — «Введи …», для select-ів
+    // — «Обери …». Snapshot-и `AddBudgetForm.test.tsx` оновлюються
+    // разом з цим (тести закривають user-facing copy contract).
+    tagNameRequired: "Введи назву тега",
+    goalNameRequired: "Введи назву цілі",
+    goalAmountRequired: "Введи суму цілі більше 0",
     goalSavedNonNegative: "Відкладена сума не може бути від'ємною",
-    limitAmountRequired: "Вкажіть ліміт більше 0",
-    categoryRequired: "Оберіть категорію",
+    limitAmountRequired: "Введи ліміт більше 0",
+    categoryRequired: "Обери категорію",
     passwordResetMin10: "Пароль має бути мінімум 10 символів.",
     // Дві варіації паролі-не-збігаються тримаємо роздільно — крапка є
     // частиною snapshot-ів і existing-копірайту (`ResetPasswordPage` на


### PR DESCRIPTION
## Summary

**PR-31 / §C6** з [`docs/audits/2026-05-06-ux-roast-pr-plan.md`](../blob/main/docs/audits/2026-05-06-ux-roast-pr-plan.md).

Раніше `messages.validation` мікс-ʼивав чотири стилі для одного й того ж required-field кейсу (`Поле обовʼязкове`, `Назва тега не може бути порожньою`, `Вкажіть назву`, `Введи email`). Тримаємо стиль одним: input-полі — `Введи X`, select — `Обери X`.

### Diff

| key | before | after |
|---|---|---|
| `tagNameRequired` | `Назва тега не може бути порожньою` | `Введи назву тега` |
| `goalNameRequired` | `Вкажіть назву цілі` | `Введи назву цілі` |
| `goalAmountRequired` | `Вкажіть суму цілі більше 0` | `Введи суму цілі більше 0` |
| `limitAmountRequired` | `Вкажіть ліміт більше 0` | `Введи ліміт більше 0` |
| `categoryRequired` | `Оберіть категорію` | `Обери категорію` |
| `fieldRequired` | (kept) | marked `@deprecated` |

### Touch-points

- `apps/web/src/shared/i18n/uk.ts` — 5 рядків + deprecation tag.
- `apps/web/src/modules/finyk/components/CategorySelector.tsx` — placeholder default тепер `Обери категорію`.
- `apps/web/src/modules/finyk/components/budgets/AddBudgetForm.tsx` — drop inline override `Вибери категорію`.
- `apps/web/src/modules/finyk/components/budgets/AddBudgetForm.test.tsx` — оновлено 6 user-facing assertion-ів.

### Out of scope

- `apps/mobile/**` мають власні inline-копії (`GoalEditSheet`, `LimitEditSheet`) — не ділять каталог. Follow-up міграція.
- Design-showcase demo `core/designShowcase/sections/Forms.tsx` лишається з literal-ом `Поле обов'язкове`.

## Test plan

- `pnpm --filter @sergeant/web typecheck` ✅
- `pnpm --filter @sergeant/web lint` ✅ (0 errors, 13 pre-existing warnings)
- `pnpm --filter @sergeant/web test src/modules/finyk/components/budgets src/modules/routine/components/settings` ✅ (13/13)

## Source

- Plan: `docs/audits/2026-05-06-ux-roast-pr-plan.md` § PR-31
- Symptom: `2026-05-06-ux-roast.md` § 4.4 (C6) — Form validation tone-of-voice.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies validation copy to a single voice: inputs use "Введи X", selects use "Обери X". Deprecates `messages.validation.fieldRequired`, updates i18n keys, default select placeholder, and tests.

- **Refactors**
  - i18n: updated `tagNameRequired`, `goalNameRequired`, `goalAmountRequired`, `limitAmountRequired`, `categoryRequired`; marked `fieldRequired` as deprecated.
  - UI: `CategorySelector` default placeholder is now "Обери категорію"; removed inline override in `AddBudgetForm`.
  - Tests: adjusted 6 assertions in `AddBudgetForm.test.tsx` to match the new copy.

<sup>Written for commit fb0d80c26361335b78be8d069e719c878281800e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

