### PR TITLE
chore(web): drop LS mirror in webKVStore (SQLite-only) — PR #064

### DIFF
--- a/apps/web/src/core/db/__tests__/kvStoreBoot.test.ts
+++ b/apps/web/src/core/db/__tests__/kvStoreBoot.test.ts
@@ -17,53 +17,25 @@ import type {
   BroadcastChannelLike,
   SqliteKVStoreClient,
 } from "@sergeant/shared";
-import type { BootstrapLocalStorage } from "../kvStoreBoot";
 
 /**
- * Tests for {@link bootstrapKvStore} (Stage 9 / PR #062 of
- * `docs/planning/storage-roadmap.md`). Coverage matches the four
- * boot-stage invariants the LS-fallback gate in PR #063 leans on:
+ * Tests for {@link bootstrapKvStore} (Stage 9 / PR #062–#064 of
+ * `docs/planning/storage-roadmap.md`). Coverage matches the boot-stage
+ * invariants:
  *
  *  1. Cold boot against an empty `kv_store` populates the warm cache
  *     from a fresh scan and flips `loaded = true`.
  *  2. Re-boot is idempotent — second invocation is a no-op so HMR
- *     `main.tsx` reloads do not double-import LS keys.
- *  3. One-time LS to `kv_store` import: writes every LS key to SQLite,
- *     stamps the marker key (`kv_store_migrated_v1`), and skips the
- *     migration on the next boot.
- *  4. Failure-mode: SQLite init throw → `loaded` stays `false`,
+ *     `main.tsx` reloads do not re-scan.
+ *  3. Failure-mode: SQLite init throw → `loaded` stays `false`,
  *     `onError` fires, and the warm cache is unchanged so the LS
- *     fallback gate in `resolveStore()` (PR #063) returns the
- *     LS-backed adapter.
+ *     fallback gate in `resolveStore()` returns the LS-backed adapter.
+ *
+ * PR #064 removed the one-time LS→`kv_store` migration (4-week canary
+ * passed) and the dual-write mirror. Tests for those are dropped.
  */
 
 vi.stubGlobal("crossOriginIsolated", true);
-
-function fakeLocalStorage(
-  initial: Record<string, string> = {},
-): BootstrapLocalStorage & {
-  setItem(key: string, value: string): void;
-  removeItem(key: string): void;
-} {
-  const store = new Map<string, string>(Object.entries(initial));
-  return {
-    get length() {
-      return store.size;
-    },
-    key(index) {
-      return Array.from(store.keys())[index] ?? null;
-    },
-    getItem(key) {
-      return store.get(key) ?? null;
-    },
-    setItem(key, value) {
-      store.set(key, value);
-    },
-    removeItem(key) {
-      store.delete(key);
-    },
-  };
-}
 
 function fakeBroadcastChannel(): BroadcastChannelLike & {
   posted: unknown[];
@@ -92,10 +64,6 @@ beforeEach(() => {
     value: undefined,
     configurable: true,
   });
-  Object.defineProperty(globalThis, "localStorage", {
-    value: undefined,
-    configurable: true,
-  });
 });
 
 afterEach(() => {
@@ -105,20 +73,17 @@ afterEach(() => {
 });
 
 describe("bootstrapKvStore — cold boot against empty kv_store", () => {
-  it("flips loaded = true and leaves the warm cache empty when LS is empty", async () => {
+  it("flips loaded = true and leaves the warm cache empty on a fresh db", async () => {
     const result = await bootstrapKvStore({
-      localStorage: null,
       broadcastChannel: null,
     });
     expect(result.loaded).toBe(true);
     expect(kvStoreBoot.loaded).toBe(true);
-    // Warm cache empty: no LS migration ran (no LS), no marker stamped.
     expect(kvStoreBoot.warmCache.size).toBe(0);
   });
 
   it("returns a working SqliteKVStoreClient bound to the live SQLite handle", async () => {
     const result = await bootstrapKvStore({
-      localStorage: null,
       broadcastChannel: null,
     });
     expect(result.sqlite).not.toBeNull();
@@ -157,7 +122,6 @@ describe("bootstrapKvStore — warm cache populated from kv_store rows", () => {
     );
 
     const result = await bootstrapKvStore({
-      localStorage: null,
       broadcastChannel: null,
     });
     expect(result.loaded).toBe(true);
@@ -170,7 +134,6 @@ describe("bootstrapKvStore — warm cache populated from kv_store rows", () => {
 describe("bootstrapKvStore — re-boot idempotency", () => {
   it("returns immediately on the second call without re-scanning", async () => {
     await bootstrapKvStore({
-      localStorage: null,
       broadcastChannel: null,
     });
     expect(kvStoreBoot.loaded).toBe(true);
@@ -179,98 +142,10 @@ describe("bootstrapKvStore — re-boot idempotency", () => {
     const getDb = vi.fn();
     const result = await bootstrapKvStore({
       getDb,
-      localStorage: null,
       broadcastChannel: null,
     });
     expect(getDb).not.toHaveBeenCalled();
     expect(result.loaded).toBe(true);
-  });
-});
-
-describe("bootstrapKvStore — one-time LS to kv_store import", () => {
-  it("imports every LS key, stamps the marker, and warms the cache", async () => {
-    const ls = fakeLocalStorage({
-      hub_flags_v1: "{}",
-      fizruk_rest: '{"sec":90}',
-      nutrition_pantry_v2: "[]",
-    });
-    const now = vi.fn(() => 1_700_000_000_000);
-    const result = await bootstrapKvStore({
-      localStorage: ls,
-      broadcastChannel: null,
-      now,
-    });
-    expect(result.loaded).toBe(true);
-    expect(kvStoreBoot.warmCache.get("hub_flags_v1")).toBe("{}");
-    expect(kvStoreBoot.warmCache.get("fizruk_rest")).toBe('{"sec":90}');
-    expect(kvStoreBoot.warmCache.get("nutrition_pantry_v2")).toBe("[]");
-    expect(kvStoreBoot.warmCache.has("kv_store_migrated_v1")).toBe(true);
-
-    // Round-trip: imported rows are durable in kv_store.
-    const handle = await getSqliteDb();
-    const rows = await handle.drizzle.select().from(kvStore);
-    const byKey = new Map(rows.map((r) => [r.key, r.value]));
-    expect(byKey.get("hub_flags_v1")).toBe("{}");
-    expect(byKey.get("fizruk_rest")).toBe('{"sec":90}');
-    expect(byKey.get("nutrition_pantry_v2")).toBe("[]");
-    expect(byKey.has("kv_store_migrated_v1")).toBe(true);
-  });
-
-  it("skips the LS migration when the marker is already present in kv_store", async () => {
-    // Seed kv_store with the marker.
-    const handle = await getSqliteDb();
-    await handle.drizzle.run(
-      sql`CREATE TABLE IF NOT EXISTS kv_store (
-        key TEXT PRIMARY KEY,
-        value TEXT NOT NULL,
-        updated_at INTEGER NOT NULL DEFAULT (CAST((unixepoch() * 1000) AS INTEGER))
-      )`,
-    );
-    await handle.drizzle.run(
-      sql`INSERT INTO kv_store (key, value, updated_at) VALUES ('kv_store_migrated_v1', 'done', 100)`,
-    );
-    const ls = fakeLocalStorage({ a: "should-not-import" });
-    const result = await bootstrapKvStore({
-      localStorage: ls,
-      broadcastChannel: null,
-    });
-    expect(result.loaded).toBe(true);
-    // LS key NOT imported because the marker was already present.
-    expect(kvStoreBoot.warmCache.has("a")).toBe(false);
-  });
-
-  it("never imports the marker key itself even when LS contains it (defensive)", async () => {
-    const ls = fakeLocalStorage({
-      kv_store_migrated_v1: "lying-payload",
-      "real-key": "real-value",
-    });
-    const result = await bootstrapKvStore({
-      localStorage: ls,
-      broadcastChannel: null,
-    });
-    expect(result.loaded).toBe(true);
-    // The bootstrap stamps its own marker; it never copies the LS one.
-    expect(kvStoreBoot.warmCache.get("kv_store_migrated_v1")).not.toBe(
-      "lying-payload",
-    );
-    expect(kvStoreBoot.warmCache.get("real-key")).toBe("real-value");
-  });
-
-  it("continues the batch when a single LS key fails to upsert", async () => {
-    const ls = fakeLocalStorage({ ok: "1", bad: "2", also_ok: "3" });
-
-    const result = await bootstrapKvStore({
-      localStorage: ls,
-      broadcastChannel: null,
-    });
-    expect(result.loaded).toBe(true);
-    // All three keys made it across via the live SQLite client (no
-    // injected failures here — the test just confirms the batch runs
-    // to completion against the real handle).
-    expect(kvStoreBoot.warmCache.get("ok")).toBe("1");
-    expect(kvStoreBoot.warmCache.get("bad")).toBe("2");
-    expect(kvStoreBoot.warmCache.get("also_ok")).toBe("3");
-    expect(kvStoreBoot.warmCache.has("kv_store_migrated_v1")).toBe(true);
   });
 });
 
@@ -280,7 +155,6 @@ describe("bootstrapKvStore — failure modes", () => {
     const getDb = vi.fn(() => Promise.reject(new Error("opfs failure")));
     const result = await bootstrapKvStore({
       getDb,
-      localStorage: null,
       broadcastChannel: null,
       onError,
     });
@@ -294,7 +168,6 @@ describe("bootstrapKvStore — failure modes", () => {
     await expect(
       bootstrapKvStore({
         getDb,
-        localStorage: null,
         broadcastChannel: null,
         onError: () => {},
       }),
@@ -319,7 +192,6 @@ describe("bootstrapKvStore — failure modes", () => {
     };
     const result = await bootstrapKvStore({
       getDb: () => Promise.resolve(fakeHandle),
-      localStorage: null,
       broadcastChannel: null,
       onError,
     });
@@ -354,37 +226,18 @@ describe("bootstrapKvStore — failure modes", () => {
     };
     const result = await bootstrapKvStore({
       getDb: () => Promise.resolve(fakeHandle),
-      localStorage: null,
       broadcastChannel: null,
       onError,
     });
     expect(result.loaded).toBe(false);
     expect(onError).toHaveBeenCalledWith("kv-store-scan", expect.any(Error));
   });
-
-  it("LS migration failure is non-fatal — boot still flips loaded = true", async () => {
-    const onError = vi.fn();
-    const ls: BootstrapLocalStorage = {
-      get length(): number {
-        throw new Error("ls-property-throws");
-      },
-      key: () => null,
-      getItem: () => null,
-    };
-    const result = await bootstrapKvStore({
-      localStorage: ls,
-      broadcastChannel: null,
-      onError,
-    });
-    expect(result.loaded).toBe(true);
-    expect(onError).toHaveBeenCalledWith("ls-migration", expect.any(Error));
-  });
 });
 
 describe("bootstrapKvStore — BroadcastChannel wiring", () => {
   it("uses an injected BroadcastChannel as-is", async () => {
     const bc = fakeBroadcastChannel();
-    await bootstrapKvStore({ localStorage: null, broadcastChannel: bc });
+    await bootstrapKvStore({ broadcastChannel: bc });
     expect(getKvStoreCrossTab()).toBe(bc);
   });
 
@@ -397,7 +250,7 @@ describe("bootstrapKvStore — BroadcastChannel wiring", () => {
       configurable: true,
     });
     try {
-      await bootstrapKvStore({ localStorage: null });
+      await bootstrapKvStore({});
       expect(getKvStoreCrossTab()).toBeNull();
     } finally {
       Object.defineProperty(globalThis, "BroadcastChannel", {
@@ -423,7 +276,7 @@ describe("bootstrapKvStore — BroadcastChannel wiring", () => {
       configurable: true,
     });
     try {
-      await bootstrapKvStore({ localStorage: null });
+      await bootstrapKvStore({});
       expect(calls).toEqual([KV_STORE_BC_NAME]);
     } finally {
       Object.defineProperty(globalThis, "BroadcastChannel", {
@@ -441,7 +294,7 @@ describe("bootstrapKvStore — BroadcastChannel wiring", () => {
       configurable: true,
     });
     try {
-      const result = await bootstrapKvStore({ localStorage: null });
+      const result = await bootstrapKvStore({});
       expect(result.loaded).toBe(true);
       expect(getKvStoreCrossTab()).toBeNull();
     } finally {

--- a/apps/web/src/core/db/kvStoreBoot.ts
+++ b/apps/web/src/core/db/kvStoreBoot.ts
@@ -16,24 +16,16 @@
  *   2. Run the bundled `kv_store` migration via the shared
  *      `runMigrations()` runner (idempotent — second boot is a no-op).
  *   3. `SELECT key, value FROM kv_store` → populate `kvStoreBoot.warmCache`.
- *   4. If `kv_store` is empty AND `localStorage` has keys AND the
- *      one-time migration flag (`kv_store_migrated_v1`) is missing,
- *      bulk-import every LS key into `kv_store` (and the warm cache),
- *      then set the flag.
- *   5. Flip `kvStoreBoot.loaded = true`.
+ *   4. Flip `kvStoreBoot.loaded = true`.
  *
- * The actual swap of `webKVStore` from LS-backed to SQLite-backed lives
- * in PR #063 — this PR only installs the bootstrap pump and leaves
- * `webKVStore` LS-backed. Until PR #063 lands, `kvStoreBoot.warmCache`
- * is populated but never read; the only user-visible side-effect is
- * the one-time LS→`kv_store` import (which is also benign since LS is
- * still the source of truth).
+ * PR #064 removed the one-time LS→`kv_store` migration (the 4-week
+ * canary has passed without incidents) and the dual-write mirror in
+ * `storage.ts`. `webKVStore` is now strictly SQLite-backed with an
+ * LS-only fallback on bootstrap failure.
  *
  * Failure mode: if SQLite init throws or the migration runner fails,
  * we leave `kvStoreBoot.loaded = false`, log + Sentry-breadcrumb, and
- * the app continues with the existing LS-backed `webKVStore`. The
- * actual fallback-UI gate that PR #063 adds (`if (!boot.loaded) →
- * return webLsKv`) is what makes this safe in production.
+ * the app continues with the LS-backed fallback in `resolveStore()`.
  */
 
 import { eq } from "drizzle-orm";
@@ -56,15 +48,6 @@ import type {
 import { createSqliteKVStore } from "@sergeant/shared";
 import { addSentryBreadcrumb } from "../observability/sentry.js";
 import { getSqliteDb, type SqliteDbHandle } from "./sqlite.js";
-
-/**
- * Marker key written into `kv_store` once the one-time LS→`kv_store`
- * import has run. Stored in the same table so it survives a
- * `kv_store` reopen but disappears if a user wipes their browser
- * storage entirely (a wipe also drops `localStorage`, so re-running
- * the import is a no-op).
- */
-const LS_MIGRATION_FLAG_KEY = "kv_store_migrated_v1";
 
 /**
  * Channel name for cross-tab `kv_store` writes. Stable so `apps/web`
@@ -153,11 +136,11 @@ export function getKvStoreCrossTab(): BroadcastChannelLike | null {
  * bootstrap has not yet run, has not yet finished, or failed.
  *
  * `apps/web/src/shared/lib/storage/storage.ts :: resolveStore()` uses
- * this as the priority-1 branch in its ladder (PR #063):
+ * this as the priority-1 branch in its two-rung ladder (PR #064):
  *
  * ```ts
  * const sqlite = getActiveSqliteKvStore();
- * if (sqlite) return makeDualWriteKvStore(sqlite, lsAdapter);
+ * if (sqlite) return sqlite;
  * // else fall through to LS adapter or memory
  * ```
  */
@@ -228,29 +211,17 @@ export interface BootstrapKvStoreResult {
 
 /**
  * Inputs the bootstrap helper accepts so unit tests can swap in a
- * fake SQLite handle, fake `localStorage`, and fake BroadcastChannel
- * constructor without touching globals.
+ * fake SQLite handle and fake BroadcastChannel constructor without
+ * touching globals.
  *
- * Production callers pass nothing — defaults route to {@link getSqliteDb},
- * `globalThis.localStorage`, and `globalThis.BroadcastChannel`.
+ * Production callers pass nothing — defaults route to {@link getSqliteDb}
+ * and `globalThis.BroadcastChannel`.
  */
 export interface BootstrapKvStoreOptions {
   readonly getDb?: () => Promise<SqliteDbHandle>;
-  readonly localStorage?: BootstrapLocalStorage | null;
   readonly broadcastChannel?: BroadcastChannelLike | null;
   readonly now?: () => number;
   readonly onError?: (stage: string, error: unknown) => void;
-}
-
-/**
- * Sub-set of `Storage` consumed by the LS→`kv_store` one-time
- * importer. Defined structurally so unit tests can pass a plain
- * `Map`-backed fake without polyfilling the full `Storage` interface.
- */
-export interface BootstrapLocalStorage {
-  readonly length: number;
-  key(index: number): string | null;
-  getItem(key: string): string | null;
 }
 
 /**
@@ -346,26 +317,6 @@ export async function bootstrapKvStore(
 
   const sqliteClient = makeSqliteKvStoreClient(handle);
 
-  // One-time LS→kv_store import. Skipped if the marker is already in
-  // the warm cache (or the runtime has no localStorage at all).
-  if (!kvStoreBoot.warmCache.has(LS_MIGRATION_FLAG_KEY)) {
-    const ls = resolveLocalStorage(opts.localStorage);
-    if (ls) {
-      try {
-        await migrateLocalStorageToKvStore({
-          ls,
-          sqliteClient,
-          warmCache: kvStoreBoot.warmCache,
-          now: opts.now ?? Date.now,
-        });
-      } catch (err) {
-        // Migration failure is non-fatal — the boot continues with
-        // whatever rows we did manage to import.
-        onError("ls-migration", err);
-      }
-    }
-  }
-
   kvStoreBoot.loaded = true;
   activeSqliteClient = sqliteClient;
   activeSqliteKvStore = createSqliteKVStore({
@@ -393,83 +344,6 @@ export async function bootstrapKvStore(
     sqlite: sqliteClient,
     loaded: true,
   };
-}
-
-/**
- * Bulk-import every key currently in localStorage into `kv_store` +
- * the warm cache, then write the migration marker so a subsequent
- * boot is a no-op.
- *
- * Order:
- *  1. Walk `localStorage` once and snapshot every (key, value) pair.
- *     We snapshot up-front because a write-back into `kv_store`
- *     itself (when PR #063 has flipped `webKVStore` → SQLite) could
- *     mutate `localStorage` mid-walk.
- *  2. Upsert each row in turn. Failures on a single key are logged
- *     via `onWriteError`-style handling but do not abort the batch —
- *     a partial migration still makes progress.
- *  3. Stamp the migration marker.
- */
-async function migrateLocalStorageToKvStore(args: {
-  readonly ls: BootstrapLocalStorage;
-  readonly sqliteClient: SqliteKVStoreClient;
-  readonly warmCache: Map<string, string>;
-  readonly now: () => number;
-}): Promise<void> {
-  const { ls, sqliteClient, warmCache, now } = args;
-
-  const pairs: { key: string; value: string }[] = [];
-  for (let i = 0; i < ls.length; i += 1) {
-    const key = ls.key(i);
-    if (key === null) continue;
-    if (key === LS_MIGRATION_FLAG_KEY) continue;
-    const value = ls.getItem(key);
-    if (value === null) continue;
-    pairs.push({ key, value });
-  }
-
-  for (const pair of pairs) {
-    try {
-      const updatedAt = now();
-      await sqliteClient.upsert({
-        key: pair.key,
-        value: pair.value,
-        updatedAt,
-      });
-      warmCache.set(pair.key, pair.value);
-    } catch (err) {
-      // Single-key failure: log and continue. Boot success does not
-      // depend on every LS key making it across — the worst case is
-      // that the next boot retries because the marker hasn't been
-      // written yet.
-
-      console.warn(
-        `[kvStoreBoot] ls-migration: skipped key "${pair.key}"`,
-        err,
-      );
-    }
-  }
-
-  const markerUpdatedAt = now();
-  await sqliteClient.upsert({
-    key: LS_MIGRATION_FLAG_KEY,
-    value: new Date(markerUpdatedAt).toISOString(),
-    updatedAt: markerUpdatedAt,
-  });
-  warmCache.set(LS_MIGRATION_FLAG_KEY, new Date(markerUpdatedAt).toISOString());
-}
-
-function resolveLocalStorage(
-  override: BootstrapLocalStorage | null | undefined,
-): BootstrapLocalStorage | null {
-  if (override !== undefined) return override;
-  try {
-    const ls = (globalThis as { localStorage?: BootstrapLocalStorage })
-      .localStorage;
-    return ls ?? null;
-  } catch {
-    return null;
-  }
 }
 
 interface BroadcastChannelCtor {

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -97,17 +97,15 @@ function ErrorFallback({ error, resetError }: ErrorFallbackProps) {
   );
 }
 
-// PR #063 boot wiring: kick off SQLite warm-cache, then run the storage-dependent
-// boot steps (demo seed, `storageManager` migrations, demo cleanup,
-// sync-engine writer boot) and finally mount React. We **await** bootstrap
-// before any writes happen so there is no race window between the
-// LS-only adapter (pre-bootstrap) and the SQLite-backed adapter
-// (post-bootstrap) — every write done after this point fans out to
-// BOTH stores via {@link makeDualWriteKvStore}, and no key written
-// here is visible only in LS.
+// PR #063–#064 boot wiring: kick off SQLite warm-cache, then run the
+// storage-dependent boot steps (demo seed, `storageManager` migrations,
+// demo cleanup, sync-engine writer boot) and finally mount React. We
+// **await** bootstrap before any writes happen so there is no race
+// window between the LS-only adapter (pre-bootstrap) and the
+// SQLite-backed adapter (post-bootstrap).
 //
 // `bootstrapKvStore` is documented as never-throwing: every failure
-// path (SQLite init, migration runner, scan, LS import) leaves
+// path (SQLite init, migration runner, scan) leaves
 // `kvStoreBoot.loaded = false` and surfaces through `onError`, so the
 // IIFE's `try/catch` is belt-and-suspenders against future bugs.
 void (async () => {

--- a/apps/web/src/shared/lib/storage/storage.dualwrite.test.ts
+++ b/apps/web/src/shared/lib/storage/storage.dualwrite.test.ts
@@ -1,30 +1,25 @@
 /**
- * Stage 9 / PR #063 — `webKVStore` dual-write ladder.
+ * Stage 9 / PR #064 — `webKVStore` resolve ladder (post-dual-write).
  *
- * Covers the three-rung priority ladder in `resolveStore()`:
+ * PR #063 introduced a dual-write mirror so `localStorage` stayed
+ * populated during a 4-week canary. PR #064 dropped the mirror —
+ * `resolveStore()` now returns the SQLite adapter directly when
+ * available, with no LS fan-out.
+ *
+ * Covers the two-rung + memory-fallback ladder in `resolveStore()`:
  *
  *   1. SQLite-backed adapter wins when `getActiveSqliteKvStore()`
- *      returns non-null AND `localStorage` is also available — every
- *      write fans out to BOTH, reads come from SQLite only.
- *   2. SQLite-backed adapter wins alone when `localStorage` is not
- *      available (memory-only mode, e.g. SSR or private mode without
- *      DOM Storage).
- *   3. LS-backed adapter wins when `getActiveSqliteKvStore()` returns
+ *      returns non-null — reads and writes go to SQLite only, no
+ *      LS mirror.
+ *   2. LS-backed adapter wins when `getActiveSqliteKvStore()` returns
  *      `null` (pre-bootstrap, on bootstrap failure, or in
  *      environments without SQLite-WASM).
- *   4. In-memory fallback wins when both rungs above are unavailable.
- *
- * Mirror writes are wrapped in try/catch so a quota-exceeded error
- * in `localStorage` never escapes a primary-store call site —
- * `setString` / `remove` always succeed if the SQLite primary
- * succeeds.
+ *   3. In-memory fallback wins when both rungs above are unavailable.
  *
  * Resolution is lazy on every method call. A test that sets a
  * SQLite-backed return value via `__setActiveSqliteKvStore` AFTER
  * the module is imported still gets the SQLite adapter on the next
- * `webKVStore.getString` / `setString` call. This is critical
- * because `apps/web/src/main.tsx` mounts React BEFORE the
- * BroadcastChannel-driven `kvStoreBoot` finishes its scan.
+ * `webKVStore.getString` / `setString` call.
  */
 import {
   describe,
@@ -109,7 +104,7 @@ function uninstallFakeLocalStorage(): void {
   });
 }
 
-describe("webKVStore dual-write ladder", () => {
+describe("webKVStore resolve ladder (post-dual-write)", () => {
   beforeEach(() => {
     getActiveSqliteKvStoreMock.mockReset();
     getActiveSqliteKvStoreMock.mockReturnValue(null);
@@ -119,7 +114,7 @@ describe("webKVStore dual-write ladder", () => {
     uninstallFakeLocalStorage();
   });
 
-  describe("rung 3 — LS-only (pre-bootstrap)", () => {
+  describe("rung 2 — LS-only (pre-bootstrap)", () => {
     it("reads / writes via localStorage when SQLite adapter is null", () => {
       installFakeLocalStorage();
 
@@ -140,9 +135,8 @@ describe("webKVStore dual-write ladder", () => {
     });
   });
 
-  describe("rung 4 — memory fallback (no SQLite, no LS)", () => {
+  describe("rung 3 — memory fallback (no SQLite, no LS)", () => {
     it("survives across calls within the same process", () => {
-      // No localStorage installed, no SQLite adapter.
       uninstallFakeLocalStorage();
       getActiveSqliteKvStoreMock.mockReturnValue(null);
 
@@ -154,15 +148,13 @@ describe("webKVStore dual-write ladder", () => {
     });
   });
 
-  describe("rung 1 — SQLite + LS dual-write", () => {
+  describe("rung 1 — SQLite (no LS mirror)", () => {
     it("reads from SQLite primary only", () => {
       installFakeLocalStorage();
       const sqlite = makeFakeKvStore();
       sqlite.getString.mockImplementation((k) =>
         k === "from-sqlite" ? "sqlite-value" : null,
       );
-      // Even though LS has a different value for the same key, the
-      // dual-write read path must hit SQLite only.
       localStorage.setItem("from-sqlite", "ls-value");
       getActiveSqliteKvStoreMock.mockReturnValue(sqlite);
 
@@ -170,7 +162,7 @@ describe("webKVStore dual-write ladder", () => {
       expect(sqlite.getString).toHaveBeenCalledWith("from-sqlite");
     });
 
-    it("writes fan out to BOTH SQLite and LS", () => {
+    it("writes go to SQLite only — LS is NOT mirrored", () => {
       installFakeLocalStorage();
       const sqlite = makeFakeKvStore();
       getActiveSqliteKvStoreMock.mockReturnValue(sqlite);
@@ -178,11 +170,11 @@ describe("webKVStore dual-write ladder", () => {
       webKVStore.setString("k", "v");
 
       expect(sqlite.setString).toHaveBeenCalledWith("k", "v");
-      // Mirror write goes through createWebKVStore → localStorage.setItem.
-      expect(localStorage.getItem("k")).toBe("v");
+      // No mirror write — LS must NOT receive the value.
+      expect(localStorage.getItem("k")).toBeNull();
     });
 
-    it("removes fan out to BOTH SQLite and LS", () => {
+    it("removes go to SQLite only — LS is NOT mirrored", () => {
       installFakeLocalStorage();
       localStorage.setItem("doomed", "stale");
       const sqlite = makeFakeKvStore();
@@ -191,14 +183,12 @@ describe("webKVStore dual-write ladder", () => {
       webKVStore.remove("doomed");
 
       expect(sqlite.remove).toHaveBeenCalledWith("doomed");
-      expect(localStorage.getItem("doomed")).toBeNull();
+      // LS key untouched — no mirror remove.
+      expect(localStorage.getItem("doomed")).toBe("stale");
     });
 
-    it("listKeys is sourced from SQLite primary, not LS mirror", () => {
+    it("listKeys is sourced from SQLite primary, not LS", () => {
       installFakeLocalStorage();
-      // LS has 'orphan' that SQLite does not — listKeys must NOT
-      // surface it because the SQLite warm-cache is the source of
-      // truth post-bootstrap.
       localStorage.setItem("orphan", "stale");
       const sqlite = makeFakeKvStore();
       sqlite.listKeys.mockReturnValue(["sqlite-key"]);
@@ -223,7 +213,7 @@ describe("webKVStore dual-write ladder", () => {
     });
   });
 
-  describe("rung 2 — SQLite without LS mirror", () => {
+  describe("SQLite without LS available", () => {
     it("returns SQLite primary as-is when localStorage is unavailable", () => {
       uninstallFakeLocalStorage();
       const sqlite = makeFakeKvStore();
@@ -234,45 +224,6 @@ describe("webKVStore dual-write ladder", () => {
 
       webKVStore.setString("k", "v");
       expect(sqlite.setString).toHaveBeenCalledWith("k", "v");
-      // No mirror write happens — there is no LS to mirror into.
-    });
-  });
-
-  describe("mirror error swallowing (rung 1 robustness)", () => {
-    it("setString succeeds even when mirror throws QuotaExceededError", () => {
-      installFakeLocalStorage();
-      // Force the underlying setItem to throw so the mirror write
-      // raises a synthetic QuotaExceededError. The dual-write
-      // adapter must swallow it so the SQLite primary write still
-      // counts as a success.
-      const setItemSpy = vi
-        .spyOn(localStorage, "setItem")
-        .mockImplementation(() => {
-          throw new DOMException("Quota exceeded", "QuotaExceededError");
-        });
-      const sqlite = makeFakeKvStore();
-      getActiveSqliteKvStoreMock.mockReturnValue(sqlite);
-
-      expect(() => webKVStore.setString("k", "v")).not.toThrow();
-      expect(sqlite.setString).toHaveBeenCalledWith("k", "v");
-
-      setItemSpy.mockRestore();
-    });
-
-    it("remove succeeds even when mirror throws", () => {
-      installFakeLocalStorage();
-      const removeItemSpy = vi
-        .spyOn(localStorage, "removeItem")
-        .mockImplementation(() => {
-          throw new Error("LS remove blew up");
-        });
-      const sqlite = makeFakeKvStore();
-      getActiveSqliteKvStoreMock.mockReturnValue(sqlite);
-
-      expect(() => webKVStore.remove("k")).not.toThrow();
-      expect(sqlite.remove).toHaveBeenCalledWith("k");
-
-      removeItemSpy.mockRestore();
     });
   });
 
@@ -280,7 +231,7 @@ describe("webKVStore dual-write ladder", () => {
     it("picks up the SQLite adapter on the call AFTER bootstrap completes", () => {
       installFakeLocalStorage();
 
-      // Rung 3: LS-backed write while bootstrap is still running.
+      // Rung 2: LS-backed write while bootstrap is still running.
       webKVStore.setString("k", "ls-value");
       expect(localStorage.getItem("k")).toBe("ls-value");
 
@@ -291,8 +242,7 @@ describe("webKVStore dual-write ladder", () => {
       );
       getActiveSqliteKvStoreMock.mockReturnValue(sqlite);
 
-      // Subsequent reads route through SQLite — even though LS still
-      // has the old value, the dual-write read path returns SQLite's.
+      // Subsequent reads route through SQLite.
       expect(webKVStore.getString("k")).toBe("sqlite-value");
     });
   });

--- a/apps/web/src/shared/lib/storage/storage.ts
+++ b/apps/web/src/shared/lib/storage/storage.ts
@@ -9,8 +9,9 @@
  * Implementation: every read/write is routed through {@link webKVStore} (a
  * `KVStore` adapter from `@sergeant/shared`).
  *
- * Stage 9 / PR #063 of `docs/planning/storage-roadmap.md` introduced a
- * three-rung priority ladder in {@link resolveStore}:
+ * Stage 9 / PR #064 of `docs/planning/storage-roadmap.md` dropped the
+ * dual-write LS mirror that PR #063 introduced for the 4-week canary.
+ * {@link resolveStore} now uses a two-rung ladder:
  *
  *   1. **SQLite warm-cache** — once `bootstrapKvStore()` (PR #062) has
  *      finished, {@link getActiveSqliteKvStore} returns the
@@ -19,15 +20,11 @@
  *      and fan out to a fire-and-forget `INSERT … ON CONFLICT(key) DO
  *      UPDATE` against `kv_store`. Cross-tab `onChange` rides on
  *      `BroadcastChannel("kv-store")`.
- *   2. **`localStorage` mirror** — every SQLite write also fans out to
- *      the LS adapter via {@link makeDualWriteKvStore} so a revert of
- *      PR #063 does not lose user data. PR #064 drops this rung after
- *      a 4-week canary.
- *   3. **`localStorage`-only fallback** — pre-bootstrap, on bootstrap
+ *   2. **`localStorage`-only fallback** — pre-bootstrap, on bootstrap
  *      failure, or in environments without SQLite-WASM (SSR, very old
  *      iOS WebView, Safari Private mode). Same `createWebKVStore`
  *      adapter that backed `webKVStore` before PR #063.
- *   4. **In-memory fallback** — SSR + private mode without DOM
+ *   3. **In-memory fallback** — SSR + private mode without DOM
  *      `Storage`. Process-wide singleton so writes survive across
  *      calls within the same process.
  *
@@ -89,66 +86,9 @@ function resolveLsStore(): KVStore | null {
   }
 }
 
-/**
- * Wrap `primary` (SQLite-backed) and `mirror` (LS-backed) into a
- * single {@link KVStore} that reads from `primary` and writes to both.
- *
- * Why dual-write: PR #063 swaps `webKVStore` from LS-backed to
- * SQLite-backed, but a 4-week canary keeps `localStorage` populated
- * as a live mirror so a revert can recover user data without manual
- * intervention. PR #064 drops the mirror once the canary closes.
- *
- * Read path: SQLite warm-cache only. The mirror is intentionally
- * write-only — reading from it would re-introduce the LS-vs-SQLite
- * skew we are trying to retire.
- *
- * Subscription path: `onChange` rides on the SQLite adapter
- * (BroadcastChannel + same-tab `notify`). The LS adapter's
- * `storage`-event listeners are unused — same-tab writes already fire
- * via `notify`, and the SQLite BroadcastChannel covers cross-tab
- * (every tab post-PR-#063 holds the SQLite-backed adapter).
- *
- * Mirror writes are wrapped in try/catch so a quota-exceeded error in
- * `localStorage` (the typical failure mode after the SQLite cut-over —
- * users with multi-MB SQLite payloads still have legacy LS quotas)
- * never escapes a primary-store call site.
- */
-function makeDualWriteKvStore(primary: KVStore, mirror: KVStore): KVStore {
-  return {
-    getString(key) {
-      return primary.getString(key);
-    },
-    setString(key, value) {
-      primary.setString(key, value);
-      try {
-        mirror.setString(key, value);
-      } catch {
-        /* mirror write quota / private-mode — non-fatal. */
-      }
-    },
-    remove(key) {
-      primary.remove(key);
-      try {
-        mirror.remove(key);
-      } catch {
-        /* mirror remove failure — non-fatal. */
-      }
-    },
-    listKeys() {
-      return primary.listKeys();
-    },
-    onChange(key, listener) {
-      return primary.onChange(key, listener);
-    },
-  };
-}
-
 function resolveStore(): KVStore {
   const sqlite = getActiveSqliteKvStore();
-  if (sqlite) {
-    const mirror = resolveLsStore();
-    return mirror ? makeDualWriteKvStore(sqlite, mirror) : sqlite;
-  }
+  if (sqlite) return sqlite;
   return resolveLsStore() ?? memoryFallback;
 }
 


### PR DESCRIPTION
## Summary

Roadmap PR #064 (`docs/planning/storage-roadmap.md` Stage 9). The 4-week canary for the SQLite-backed `webKVStore` swap (PR #063 / #2165) has passed — this PR removes the dual-write `localStorage` mirror and the one-time LS→`kv_store` migration.

Concrete deletions:

- `makeDualWriteKvStore()` in `storage.ts` — `resolveStore()` now returns the SQLite adapter directly
- `migrateLocalStorageToKvStore()`, `resolveLocalStorage()`, `BootstrapLocalStorage` interface, and `LS_MIGRATION_FLAG_KEY` in `kvStoreBoot.ts`
- `localStorage` option from `BootstrapKvStoreOptions`
- All LS-migration tests in `kvStoreBoot.test.ts` and mirror-error-swallowing tests in `storage.dualwrite.test.ts`

The resolve ladder shrinks from four rungs to three: **SQLite warm-cache → LS-only fallback → in-memory fallback**.

## Governing Skill

- Primary skill: n/a (roadmap-driven deletion PR)
- Secondary skill: n/a

## Playbook

- Primary playbook: n/a
- Why this playbook: n/a
- If no playbook matched, why: Pure cleanup PR following the roadmap's canary-close checklist.

## Verification

```bash
cd apps/web && pnpm run typecheck   # ✅ clean
cd apps/web && pnpm run lint        # ✅ 0 errors (13 pre-existing warnings)
git commit                          # ✅ pre-commit hooks (eslint + staged-typecheck) passed
```

Additional checks:

- [ ] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [ ] I checked whether `AGENTS.md` needed an update.
- [ ] I checked whether a playbook or skill needed an update.
- [ ] I checked whether governance docs or review docs needed an update.

Updated docs:

- JSDoc in `storage.ts`, `kvStoreBoot.ts`, `main.tsx` (ladder description, boot-wiring comment)

## Risk and Rollout

- User-visible risk: **Low.** No user-facing behavior change — writes already went to SQLite as primary since PR #063. The only difference is LS no longer receives mirror copies.
- Rollout / deploy order: Ship after PR #063 has been live for ≥ 4 weeks (canary window).
- Backout plan: Revert this PR to restore dual-write. LS data will be stale (not updated since this PR deployed) but the LS-fallback path still works for pre-#063 keys.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

**⚠️ Test assertion inversions are the critical review item.** The dual-write tests in `storage.dualwrite.test.ts` were flipped to assert the *opposite* behavior:

| Test | Before (dual-write) | After (SQLite-only) |
|---|---|---|
| `setString` with SQLite active | LS receives mirror write | LS must be `null` |
| `remove` with SQLite active | LS key removed | LS key untouched (`"stale"`) |

Please verify these match `resolveStore()` which now returns `sqlite` directly with no `makeDualWriteKvStore` wrapper.

**Exported type removal:** `BootstrapLocalStorage` was an exported interface — confirm nothing outside `apps/web` imports it.

**Vitest was not run locally** — only lint + typecheck. CI should confirm the test suite passes.

Link to Devin session: https://app.devin.ai/sessions/2900dafeb6714acc8885559aa28de448
Requested by: @Skords-01

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `webKVStore` SQLite-only by removing the `localStorage` mirror and the one-time LS→SQLite import. The resolve ladder is now SQLite → `localStorage` → in-memory.

- **Refactors**
  - Deleted `makeDualWriteKvStore()`; `resolveStore()` now returns the SQLite adapter directly and no longer mirrors to LS.
  - Removed LS→`kv_store` bootstrap migration; dropped `BootstrapLocalStorage`, `LS_MIGRATION_FLAG_KEY`, and the `localStorage` option from bootstrap.
  - Updated tests to remove migration specs and assert no LS mirror writes/removes; kept lazy resolution semantics.
  - Updated JSDoc/comments in `storage.ts`, `kvStoreBoot.ts`, and `main.tsx`.

<sup>Written for commit 90c5626ab43ed3ec7f99b0f3528907791ed78c21. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

