### PR TITLE
feat(web): app-lock base PIN flow — PR-1a UX-roast 2026-Q2

### DIFF
--- a/apps/web/src/core/App.tsx
+++ b/apps/web/src/core/App.tsx
@@ -12,6 +12,9 @@ import {
 } from "@shared/components/ui/KeyboardShortcutsModal";
 
 import { AuthProvider, useAuth } from "./auth/AuthContext";
+import { AppLock } from "./security/AppLock";
+import { AppLockProvider, useAppLockContext } from "./security/AppLockContext";
+import { setFlag } from "./lib/featureFlags";
 import { ActiveModuleView } from "./app/ActiveModuleView";
 import { HubHomeView } from "./app/HubHomeView";
 import { RedirectTo } from "./app/RedirectTo";
@@ -57,12 +60,33 @@ export default function App() {
         <ScreenReaderAnnouncerProvider>
           <ApiClientProvider client={apiClient}>
             <AuthProvider>
-              <AppInner />
+              <AppLockProvider>
+                <AppInnerWithLock />
+              </AppLockProvider>
             </AuthProvider>
           </ApiClientProvider>
         </ScreenReaderAnnouncerProvider>
       </ToastProvider>
     </ShortcutRegistryProvider>
+  );
+}
+
+function AppInnerWithLock() {
+  const appLock = useAppLockContext();
+  return (
+    <>
+      <AppLock
+        state={appLock.state}
+        onUnlock={appLock.unlock}
+        onSetupDone={appLock.finishSetup}
+        onSetupCancel={() => {
+          // If user cancels setup, turn the flag off so the toggle reverts.
+          setFlag("app-lock-enabled", false);
+          appLock.finishSetup();
+        }}
+      />
+      <AppInner />
+    </>
   );
 }
 

--- a/apps/web/src/core/hub/HubSettingsPage.tsx
+++ b/apps/web/src/core/hub/HubSettingsPage.tsx
@@ -13,6 +13,7 @@ import { FizrukSection } from "../settings/FizrukSection";
 import { GeneralSection } from "../settings/GeneralSection";
 import { NotificationsSection } from "../settings/NotificationsSection";
 import { NutritionSection } from "../settings/NutritionSection";
+import { PrivacySection } from "../settings/PrivacySection";
 import { PWASection } from "../settings/PWASection";
 import { RoutineSection } from "../settings/RoutineSection";
 
@@ -40,7 +41,7 @@ const GROUPS = [
   {
     id: "advanced",
     label: "Додатково",
-    sections: ["pwa", "dataExport", "experimental"],
+    sections: ["privacy", "pwa", "dataExport", "experimental"],
   },
 ] as const;
 
@@ -137,6 +138,13 @@ export function HubSettingsPage({ user }: HubSettingsPageProps) {
         keywords:
           "харчування їжа nutrition meals food kбжу калорії kcal білки жири вуглеводи вода комора pantry скан штрихкод barcode",
         render: () => <NutritionSection />,
+      },
+      {
+        id: "privacy",
+        title: "Конфіденційність",
+        keywords:
+          "конфіденційність блокування pin пін lock security безпека захист",
+        render: () => <PrivacySection />,
       },
       {
         id: "pwa",

--- a/apps/web/src/core/lib/featureFlags.ts
+++ b/apps/web/src/core/lib/featureFlags.ts
@@ -36,6 +36,14 @@ export interface FlagDefinition {
 
 export const FLAG_REGISTRY: readonly FlagDefinition[] = [
   {
+    id: "app-lock-enabled",
+    label: "Блокування додатку (PIN)",
+    description:
+      "Захищає дані PIN-кодом. При увімкненні — встановлюй PIN у Конфіденційність → Блокування. PR-1a UX-roast 2026-Q2.",
+    defaultValue: false,
+    experimental: true,
+  },
+  {
     id: "finyk_subscriptions_category",
     label: "Категорія «Підписки» у швидкому додаванні",
     description:

--- a/apps/web/src/core/security/AppLock.tsx
+++ b/apps/web/src/core/security/AppLock.tsx
@@ -1,0 +1,319 @@
+import { useEffect, useRef, useState } from "react";
+import { useDialogFocusTrap } from "@shared/hooks/useDialogFocusTrap";
+import { Button } from "@shared/components/ui/Button";
+import { Icon } from "@shared/components/ui/Icon";
+import { messages } from "@shared/i18n/uk";
+import { type LockState } from "./useAppLock";
+import { savePinHash } from "./lockStorage";
+
+const m = messages.privacy.lock;
+
+// PIN length constraints
+const PIN_MIN = 4;
+const PIN_MAX = 6;
+
+interface PinPadProps {
+  value: string;
+  onChange: (v: string) => void;
+  maxLength: number;
+  error?: string;
+  focusOnMount?: boolean;
+}
+
+function PinDisplay({ length, filled }: { length: number; filled: number }) {
+  return (
+    <div className="flex gap-3 justify-center my-4" aria-hidden>
+      {Array.from({ length }).map((_, i) => (
+        <div
+          key={i}
+          className={`w-3 h-3 rounded-full border-2 transition-colors ${
+            i < filled ? "bg-brand border-brand" : "bg-transparent border-line"
+          }`}
+        />
+      ))}
+    </div>
+  );
+}
+
+function PinPad({
+  value,
+  onChange,
+  maxLength,
+  error,
+  focusOnMount,
+}: PinPadProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (focusOnMount) inputRef.current?.focus();
+  }, [focusOnMount]);
+
+  return (
+    <div className="flex flex-col items-center gap-2 w-full">
+      {/* Hidden numeric input — used on desktop / non-touch */}
+      <input
+        ref={inputRef}
+        type="password"
+        inputMode="numeric"
+        pattern="[0-9]*"
+        maxLength={maxLength}
+        value={value}
+        onChange={(e) => {
+          const digits = e.target.value.replace(/\D/g, "").slice(0, maxLength);
+          onChange(digits);
+        }}
+        aria-label="PIN"
+        className="sr-only"
+      />
+
+      <PinDisplay length={maxLength} filled={value.length} />
+
+      {/* On-screen numpad (primary on mobile) */}
+      <div className="grid grid-cols-3 gap-3 mt-2">
+        {["1", "2", "3", "4", "5", "6", "7", "8", "9", "", "0", "⌫"].map(
+          (key) => {
+            if (key === "") {
+              return <div key="spacer" aria-hidden />;
+            }
+            const isBackspace = key === "⌫";
+            return (
+              <button
+                key={key}
+                type="button"
+                aria-label={isBackspace ? m.deleteDigit : key}
+                className="w-16 h-16 rounded-full bg-panel border border-line text-style-title text-text hover:bg-panelHi active:scale-95 transition-all select-none"
+                onClick={() => {
+                  if (isBackspace) {
+                    onChange(value.slice(0, -1));
+                  } else if (value.length < maxLength) {
+                    onChange(value + key);
+                  }
+                }}
+              >
+                {key}
+              </button>
+            );
+          },
+        )}
+      </div>
+
+      {error && (
+        <p role="alert" className="text-sm text-danger text-center mt-2">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ---- Setup / Change flow (two-step: enter then confirm) ------------------
+
+interface PinSetupFlowProps {
+  onDone: () => void;
+  onCancel: () => void;
+}
+
+function PinSetupFlow({ onDone, onCancel }: PinSetupFlowProps) {
+  const [step, setStep] = useState<"enter" | "confirm">("enter");
+  const [first, setFirst] = useState("");
+  const [second, setSecond] = useState("");
+  const [error, setError] = useState("");
+
+  const handleFirstNext = () => {
+    if (first.length < PIN_MIN) {
+      setError(m.pinTooShort);
+      return;
+    }
+    setError("");
+    setStep("confirm");
+  };
+
+  const handleConfirm = async () => {
+    if (second !== first) {
+      setError(m.pinMismatch);
+      setSecond("");
+      return;
+    }
+    await savePinHash(first);
+    onDone();
+  };
+
+  if (step === "enter") {
+    return (
+      <div className="flex flex-col items-center gap-2 w-full">
+        <p className="text-sm text-muted">{m.setupSubtitle}</p>
+        <PinPad
+          value={first}
+          onChange={setFirst}
+          maxLength={PIN_MAX}
+          error={error}
+          focusOnMount
+        />
+        <Button
+          variant="primary"
+          size="md"
+          className="w-full mt-2"
+          disabled={first.length < PIN_MIN}
+          onClick={handleFirstNext}
+        >
+          {m.next}
+        </Button>
+        <Button variant="ghost" size="sm" onClick={onCancel}>
+          {messages.actions.cancel}
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-2 w-full">
+      <p className="text-sm text-muted">{m.confirmSubtitle}</p>
+      <PinPad
+        value={second}
+        onChange={setSecond}
+        maxLength={PIN_MAX}
+        error={error}
+        focusOnMount
+      />
+      <Button
+        variant="primary"
+        size="md"
+        className="w-full mt-2"
+        disabled={second.length < PIN_MIN}
+        onClick={handleConfirm}
+      >
+        {messages.actions.confirm}
+      </Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => {
+          setStep("enter");
+          setSecond("");
+          setError("");
+        }}
+      >
+        {m.back}
+      </Button>
+    </div>
+  );
+}
+
+// ---- Unlock screen -------------------------------------------------------
+
+interface UnlockScreenProps {
+  onUnlock: (pin: string) => Promise<boolean>;
+}
+
+function UnlockScreen({ onUnlock }: UnlockScreenProps) {
+  const [pin, setPin] = useState("");
+  const [error, setError] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const handleSubmit = async (candidate: string) => {
+    if (candidate.length < PIN_MIN) return;
+    setBusy(true);
+    const ok = await onUnlock(candidate);
+    if (!ok) {
+      setError(m.pinWrong);
+      setPin("");
+    }
+    setBusy(false);
+  };
+
+  const handlePinChange = (v: string) => {
+    setPin(v);
+    setError("");
+    if (v.length === PIN_MAX) {
+      handleSubmit(v);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-2 w-full">
+      <p className="text-sm text-muted">{m.unlockSubtitle}</p>
+      <PinPad
+        value={pin}
+        onChange={handlePinChange}
+        maxLength={PIN_MAX}
+        error={error}
+        focusOnMount
+      />
+      <Button
+        variant="primary"
+        size="md"
+        className="w-full mt-2"
+        disabled={pin.length < PIN_MIN || busy}
+        onClick={() => handleSubmit(pin)}
+      >
+        {m.open}
+      </Button>
+      <p className="text-xs text-subtle text-center mt-2">{m.recoveryHint}</p>
+    </div>
+  );
+}
+
+// ---- Top-level overlay ---------------------------------------------------
+
+export interface AppLockProps {
+  state: LockState;
+  onUnlock: (pin: string) => Promise<boolean>;
+  onSetupDone: () => void;
+  onSetupCancel: () => void;
+}
+
+export function AppLock({
+  state,
+  onUnlock,
+  onSetupDone,
+  onSetupCancel,
+}: AppLockProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const visible = state === "locked" || state === "setup" || state === "change";
+
+  // ESC intentionally disabled on locked — user cannot bypass with keyboard.
+  useDialogFocusTrap(visible, panelRef, {
+    onEscape: state === "locked" ? undefined : onSetupCancel,
+  });
+
+  if (!visible) return null;
+
+  const title =
+    state === "locked"
+      ? m.unlockTitle
+      : state === "change"
+        ? m.changeTitle
+        : m.setupTitle;
+
+  return (
+    <div
+      className="fixed inset-0 z-[200] flex items-center justify-center p-6 bg-bg/95 backdrop-blur-md motion-safe:animate-fade-in"
+      role="presentation"
+    >
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="app-lock-title"
+        className="w-full max-w-xs flex flex-col items-center gap-4"
+      >
+        <div className="w-14 h-14 rounded-2xl bg-brand/10 flex items-center justify-center mb-2">
+          <Icon name="lock" size={28} className="text-brand" />
+        </div>
+
+        <h2
+          id="app-lock-title"
+          className="text-style-title text-text text-center"
+        >
+          {title}
+        </h2>
+
+        {state === "locked" ? (
+          <UnlockScreen onUnlock={onUnlock} />
+        ) : (
+          <PinSetupFlow onDone={onSetupDone} onCancel={onSetupCancel} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/core/security/AppLockContext.tsx
+++ b/apps/web/src/core/security/AppLockContext.tsx
@@ -1,0 +1,20 @@
+import { createContext, useContext, type ReactNode } from "react";
+import { useAppLock, type UseAppLockReturn } from "./useAppLock";
+
+const AppLockContext = createContext<UseAppLockReturn | null>(null);
+
+export function AppLockProvider({ children }: { children: ReactNode }) {
+  const appLock = useAppLock();
+  return (
+    <AppLockContext.Provider value={appLock}>
+      {children}
+    </AppLockContext.Provider>
+  );
+}
+
+export function useAppLockContext(): UseAppLockReturn {
+  const ctx = useContext(AppLockContext);
+  if (!ctx)
+    throw new Error("useAppLockContext must be used inside AppLockProvider");
+  return ctx;
+}

--- a/apps/web/src/core/security/lockStorage.test.ts
+++ b/apps/web/src/core/security/lockStorage.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { IDBFactory } from "fake-indexeddb";
+
+import { clearPinHash, hasPinSet, savePinHash, verifyPin } from "./lockStorage";
+
+const originalIndexedDB = (globalThis as { indexedDB?: unknown }).indexedDB;
+
+function installFakeIDB(): IDBFactory {
+  const factory = new IDBFactory();
+  (globalThis as { indexedDB?: IDBFactory }).indexedDB = factory;
+  return factory;
+}
+
+function uninstallIDB() {
+  (globalThis as { indexedDB?: unknown }).indexedDB = originalIndexedDB;
+}
+
+describe("lockStorage", () => {
+  beforeEach(() => {
+    installFakeIDB();
+  });
+
+  afterEach(async () => {
+    // Wipe the fake DB so each test starts clean.
+    await clearPinHash().catch(() => {});
+    uninstallIDB();
+  });
+
+  it("hasPinSet returns false when no PIN has been saved", async () => {
+    expect(await hasPinSet()).toBe(false);
+  });
+
+  it("savePinHash + hasPinSet returns true", async () => {
+    await savePinHash("1234");
+    expect(await hasPinSet()).toBe(true);
+  });
+
+  it("verifyPin succeeds with the correct PIN", async () => {
+    await savePinHash("9876");
+    expect(await verifyPin("9876")).toBe(true);
+  });
+
+  it("verifyPin fails with a wrong PIN", async () => {
+    await savePinHash("9876");
+    expect(await verifyPin("0000")).toBe(false);
+  });
+
+  it("verifyPin returns false when no PIN is set", async () => {
+    expect(await verifyPin("1234")).toBe(false);
+  });
+
+  it("clearPinHash removes the stored credential", async () => {
+    await savePinHash("5555");
+    await clearPinHash();
+    expect(await hasPinSet()).toBe(false);
+  });
+
+  it("two saves with the same PIN still verify correctly (different salts)", async () => {
+    await savePinHash("1234");
+    // Overwrite — should still verify with the same PIN.
+    await savePinHash("1234");
+    expect(await verifyPin("1234")).toBe(true);
+  });
+});

--- a/apps/web/src/core/security/lockStorage.ts
+++ b/apps/web/src/core/security/lockStorage.ts
@@ -1,0 +1,106 @@
+// App-lock credential store — SubtleCrypto PBKDF2 hash in IndexedDB.
+//
+// Why IndexedDB instead of localStorage: IDB survives PWA cache clears, has
+// a larger quota, and is not accessible from other-origin service workers.
+// The hash (not the PIN) is stored so brute-force requires running PBKDF2
+// locally — no plaintext anywhere.
+//
+// IDB schema: db "sergeant_app_lock" / store "lock_cred" / key "v1"
+//   value: { salt: Uint8Array, hash: Uint8Array }
+
+const DB_NAME = "sergeant_app_lock";
+const STORE = "lock_cred";
+const KEY = "v1";
+
+interface LockCred {
+  salt: Uint8Array;
+  hash: Uint8Array;
+}
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, 1);
+    req.onupgradeneeded = () => {
+      req.result.createObjectStore(STORE);
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function deriveHash(pin: string, salt: Uint8Array): Promise<Uint8Array> {
+  const enc = new TextEncoder();
+  const keyMaterial = await crypto.subtle.importKey(
+    "raw",
+    enc.encode(pin),
+    "PBKDF2",
+    false,
+    ["deriveBits"],
+  );
+  const bits = await crypto.subtle.deriveBits(
+    {
+      name: "PBKDF2",
+      salt: salt.buffer as ArrayBuffer,
+      iterations: 200_000,
+      hash: "SHA-256",
+    },
+    keyMaterial,
+    256,
+  );
+  return new Uint8Array(bits);
+}
+
+function timingSafeEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= (a[i] ?? 0) ^ (b[i] ?? 0);
+  return diff === 0;
+}
+
+export async function savePinHash(pin: string): Promise<void> {
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const hash = await deriveHash(pin, salt);
+  const db = await openDb();
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(STORE, "readwrite");
+    tx.objectStore(STORE).put({ salt, hash }, KEY);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+  db.close();
+}
+
+export async function verifyPin(pin: string): Promise<boolean> {
+  const cred = await loadCred();
+  if (!cred) return false;
+  const candidate = await deriveHash(pin, cred.salt);
+  return timingSafeEqual(candidate, cred.hash);
+}
+
+export async function hasPinSet(): Promise<boolean> {
+  const cred = await loadCred();
+  return cred !== null;
+}
+
+export async function clearPinHash(): Promise<void> {
+  const db = await openDb();
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(STORE, "readwrite");
+    tx.objectStore(STORE).delete(KEY);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+  db.close();
+}
+
+async function loadCred(): Promise<LockCred | null> {
+  const db = await openDb();
+  const cred = await new Promise<LockCred | null>((resolve, reject) => {
+    const tx = db.transaction(STORE, "readonly");
+    const req = tx.objectStore(STORE).get(KEY);
+    req.onsuccess = () => resolve(req.result ?? null);
+    req.onerror = () => reject(req.error);
+  });
+  db.close();
+  return cred;
+}

--- a/apps/web/src/core/security/useAppLock.test.ts
+++ b/apps/web/src/core/security/useAppLock.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockInstance,
+} from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { IDBFactory } from "fake-indexeddb";
+
+// Mock the posthog transport so tests don't need a real PostHog key.
+vi.mock("../observability/posthog", () => ({
+  capturePostHogEvent: vi.fn(),
+}));
+
+// Mock featureFlags — start with the flag disabled; individual tests override.
+vi.mock("../lib/featureFlags", () => ({
+  useFlag: vi.fn().mockReturnValue(false),
+  setFlag: vi.fn(),
+}));
+
+import { useFlag } from "../lib/featureFlags";
+import { savePinHash, clearPinHash } from "./lockStorage";
+import { useAppLock } from "./useAppLock";
+
+const mockUseFlag = useFlag as unknown as MockInstance;
+
+const originalIndexedDB = (globalThis as { indexedDB?: unknown }).indexedDB;
+
+function installFakeIDB() {
+  (globalThis as { indexedDB?: IDBFactory }).indexedDB = new IDBFactory();
+}
+
+describe("useAppLock", () => {
+  beforeEach(() => {
+    installFakeIDB();
+    mockUseFlag.mockReturnValue(false);
+  });
+
+  afterEach(async () => {
+    await clearPinHash().catch(() => {});
+    (globalThis as { indexedDB?: unknown }).indexedDB = originalIndexedDB;
+    vi.clearAllMocks();
+  });
+
+  it("returns 'idle' when flag is disabled", () => {
+    const { result } = renderHook(() => useAppLock());
+    expect(result.current.state).toBe("idle");
+  });
+
+  it("returns 'idle' when flag enabled but no PIN set", async () => {
+    mockUseFlag.mockReturnValue(true);
+    const { result } = renderHook(() => useAppLock());
+    // hasPinSet() is async — give it a tick
+    await act(async () => {});
+    expect(result.current.state).toBe("idle");
+  });
+
+  it("returns 'locked' when flag enabled and PIN is stored", async () => {
+    await savePinHash("1234");
+    mockUseFlag.mockReturnValue(true);
+    const { result } = renderHook(() => useAppLock());
+    await waitFor(() => expect(result.current.state).toBe("locked"));
+  });
+
+  it("transitions to 'setup' on startSetup()", () => {
+    const { result } = renderHook(() => useAppLock());
+    act(() => result.current.startSetup());
+    expect(result.current.state).toBe("setup");
+  });
+
+  it("transitions to 'change' on startChange()", () => {
+    const { result } = renderHook(() => useAppLock());
+    act(() => result.current.startChange());
+    expect(result.current.state).toBe("change");
+  });
+
+  it("transitions back to 'idle' on finishSetup()", () => {
+    const { result } = renderHook(() => useAppLock());
+    act(() => result.current.startSetup());
+    act(() => result.current.finishSetup());
+    expect(result.current.state).toBe("idle");
+  });
+
+  it("unlock() with correct PIN transitions to 'idle' and returns true", async () => {
+    await savePinHash("9876");
+    mockUseFlag.mockReturnValue(true);
+    const { result } = renderHook(() => useAppLock());
+    await waitFor(() => expect(result.current.state).toBe("locked"));
+
+    let ok = false;
+    await act(async () => {
+      ok = await result.current.unlock("9876");
+    });
+    expect(ok).toBe(true);
+    expect(result.current.state).toBe("idle");
+  });
+
+  it("unlock() with wrong PIN keeps 'locked' and returns false", async () => {
+    await savePinHash("9876");
+    mockUseFlag.mockReturnValue(true);
+    const { result } = renderHook(() => useAppLock());
+    await waitFor(() => expect(result.current.state).toBe("locked"));
+
+    let ok = true;
+    await act(async () => {
+      ok = await result.current.unlock("0000");
+    });
+    expect(ok).toBe(false);
+    expect(result.current.state).toBe("locked");
+  });
+
+  it("lock() forces state to 'locked'", async () => {
+    const { result } = renderHook(() => useAppLock());
+    act(() => result.current.lock());
+    expect(result.current.state).toBe("locked");
+  });
+});

--- a/apps/web/src/core/security/useAppLock.ts
+++ b/apps/web/src/core/security/useAppLock.ts
@@ -1,0 +1,125 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ANALYTICS_EVENTS } from "@sergeant/shared";
+import { capturePostHogEvent } from "../observability/posthog";
+import { useFlag } from "../lib/featureFlags";
+import { hasPinSet, verifyPin } from "./lockStorage";
+
+export type LockState = "idle" | "locked" | "setup" | "change";
+
+// How long (ms) without pointer/keyboard activity before auto-lock.
+const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+
+export interface UseAppLockReturn {
+  state: LockState;
+  /** Begin the PIN-setup flow (called by PrivacySection when enabling lock). */
+  startSetup: () => void;
+  /** Begin the change-PIN flow (called by PrivacySection). */
+  startChange: () => void;
+  /** Called by AppLock when the user submits a PIN in the unlock screen. */
+  unlock: (pin: string) => Promise<boolean>;
+  /** Called after setup/change is complete. */
+  finishSetup: () => void;
+  /** Force-lock immediately (e.g. from PrivacySection "Lock now"). */
+  lock: () => void;
+}
+
+export function useAppLock(): UseAppLockReturn {
+  const enabled = useFlag("app-lock-enabled");
+  const [state, setState] = useState<LockState>("idle");
+  const idleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // On mount (and whenever the flag is toggled on) check if a PIN is already
+  // configured — if yes, lock immediately (cold-start protection).
+  useEffect(() => {
+    if (!enabled) {
+      setState("idle");
+      return;
+    }
+    let cancelled = false;
+    hasPinSet().then((has) => {
+      if (!cancelled && has) setState("locked");
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled]);
+
+  // visibilitychange → lock when tab returns to foreground while a PIN is set.
+  useEffect(() => {
+    if (!enabled) return;
+    const handleVisibility = () => {
+      if (document.visibilityState !== "visible") return;
+      hasPinSet().then((has) => {
+        if (has) setState("locked");
+      });
+    };
+    document.addEventListener("visibilitychange", handleVisibility);
+    return () =>
+      document.removeEventListener("visibilitychange", handleVisibility);
+  }, [enabled]);
+
+  // Idle timer — reset on any user interaction; lock after IDLE_TIMEOUT_MS.
+  const resetIdleTimer = useCallback(() => {
+    if (!enabled) return;
+    if (idleTimer.current) clearTimeout(idleTimer.current);
+    idleTimer.current = setTimeout(() => {
+      hasPinSet().then((has) => {
+        if (has) setState("locked");
+      });
+    }, IDLE_TIMEOUT_MS);
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const events: (keyof DocumentEventMap)[] = [
+      "pointerdown",
+      "keydown",
+      "scroll",
+      "touchstart",
+    ];
+    events.forEach((e) => document.addEventListener(e, resetIdleTimer, true));
+    resetIdleTimer();
+    return () => {
+      events.forEach((e) =>
+        document.removeEventListener(e, resetIdleTimer, true),
+      );
+      if (idleTimer.current) clearTimeout(idleTimer.current);
+    };
+  }, [enabled, resetIdleTimer]);
+
+  const lock = useCallback(() => {
+    setState("locked");
+  }, []);
+
+  const startSetup = useCallback(() => {
+    setState("setup");
+    capturePostHogEvent(ANALYTICS_EVENTS.APP_LOCK_SETUP_STARTED, {});
+  }, []);
+
+  const startChange = useCallback(() => {
+    setState("change");
+    capturePostHogEvent(ANALYTICS_EVENTS.APP_LOCK_SETUP_STARTED, {});
+  }, []);
+
+  const finishSetup = useCallback(() => {
+    setState("idle");
+    capturePostHogEvent(ANALYTICS_EVENTS.APP_LOCK_SETUP_COMPLETED, {});
+  }, []);
+
+  const unlock = useCallback(
+    async (pin: string): Promise<boolean> => {
+      const ok = await verifyPin(pin);
+      if (ok) {
+        setState("idle");
+        capturePostHogEvent(ANALYTICS_EVENTS.APP_LOCK_UNLOCK_SUCCESS, {});
+        resetIdleTimer();
+      } else {
+        capturePostHogEvent(ANALYTICS_EVENTS.APP_LOCK_UNLOCK_FAILED, {});
+      }
+      return ok;
+    },
+    [resetIdleTimer],
+  );
+
+  return { state, startSetup, startChange, unlock, finishSetup, lock };
+}

--- a/apps/web/src/core/settings/PrivacySection.tsx
+++ b/apps/web/src/core/settings/PrivacySection.tsx
@@ -1,0 +1,76 @@
+import { useState } from "react";
+import { Button } from "@shared/components/ui/Button";
+import { messages } from "@shared/i18n/uk";
+import { useFlag, setFlag } from "../lib/featureFlags";
+import { clearPinHash, hasPinSet } from "../security/lockStorage";
+import { useAppLockContext } from "../security/AppLockContext";
+import { ConfirmModal, SettingsGroup, ToggleRow } from "./SettingsPrimitives";
+
+const m = messages.privacy.lock;
+
+export function PrivacySection() {
+  const appLock = useAppLockContext();
+  const flagEnabled = useFlag("app-lock-enabled");
+  const [disableConfirmOpen, setDisableConfirmOpen] = useState(false);
+
+  const handleToggle = async (checked: boolean) => {
+    if (checked) {
+      setFlag("app-lock-enabled", true);
+      const has = await hasPinSet();
+      if (!has) {
+        appLock.startSetup();
+      }
+    } else {
+      // Require confirmation before clearing the PIN
+      setDisableConfirmOpen(true);
+    }
+  };
+
+  const handleDisableConfirm = async () => {
+    setDisableConfirmOpen(false);
+    setFlag("app-lock-enabled", false);
+    await clearPinHash();
+  };
+
+  return (
+    <SettingsGroup title={m.sectionTitle} emoji="🔒">
+      <ToggleRow
+        label={m.enableLabel}
+        description={m.enableDescription}
+        checked={flagEnabled}
+        onChange={handleToggle}
+      />
+
+      {flagEnabled && (
+        <div className="flex flex-col gap-3 pt-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={appLock.startChange}
+            className="self-start text-brand"
+          >
+            {m.changePin}
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={appLock.lock}
+            className="self-start text-muted"
+          >
+            {m.lockNow}
+          </Button>
+        </div>
+      )}
+
+      <ConfirmModal
+        open={disableConfirmOpen}
+        title={m.disableConfirmTitle}
+        body={m.disableConfirmBody}
+        confirmLabel={m.disableConfirmButton}
+        danger
+        onConfirm={handleDisableConfirm}
+        onCancel={() => setDisableConfirmOpen(false)}
+      />
+    </SettingsGroup>
+  );
+}

--- a/apps/web/src/shared/i18n/uk.ts
+++ b/apps/web/src/shared/i18n/uk.ts
@@ -362,6 +362,38 @@ export const messages = {
     addLimitOrGoal: "+ Додати ліміт або ціль",
   },
 
+  // App-lock / Privacy settings (PR-1a UX-roast 2026-Q2).
+  privacy: {
+    lock: {
+      sectionTitle: "Конфіденційність",
+      enableLabel: "Блокування додатку",
+      enableDescription:
+        "Захисти дані PIN-кодом. Додаток заблокується при переключенні або після 5 хвилин бездіяльності.",
+      setupTitle: "Встановити PIN",
+      setupSubtitle: "Введи 4–6 цифр",
+      changeTitle: "Змінити PIN",
+      confirmTitle: "Підтвердь PIN",
+      confirmSubtitle: "Введи PIN ще раз для підтвердження",
+      unlockTitle: "Введи PIN",
+      unlockSubtitle: "Введи PIN, щоб розблокувати",
+      pinMismatch: "PIN-коди не збігаються. Спробуй ще раз.",
+      pinWrong: "Невірний PIN. Спробуй ще раз.",
+      pinTooShort: "PIN має містити від 4 до 6 цифр.",
+      lockNow: "Заблокувати зараз",
+      changePin: "Змінити PIN",
+      disableLabel: "Вимкнути блокування",
+      disableConfirmTitle: "Вимкнути блокування?",
+      disableConfirmBody:
+        "Додаток більше не буде запитувати PIN при відкритті.",
+      disableConfirmButton: "Вимкнути",
+      recoveryHint: "Забув PIN? Скинь через відновлення акаунту.",
+      next: "Далі",
+      back: "Назад",
+      open: "Відкрити",
+      deleteDigit: "Видалити",
+    },
+  },
+
   // What's new modal (PR-18 у `docs/launch/product-os/ftux-master-tracker.md`
   // §3.3). UI-копія обмежена — release-specific копія (title / summary /
   // items / CTA label) живе у TS-таблиці `apps/web/src/core/whatsNew/


### PR DESCRIPTION
## Summary

- **`lockStorage.ts`** — SubtleCrypto PBKDF2 (200k iterations, SHA-256, random 16-byte salt per save) stores only the hash in IndexedDB `sergeant_app_lock`. Public API: `savePinHash`, `verifyPin`, `hasPinSet`, `clearPinHash`. Timing-safe comparison via XOR accumulator.
- **`useAppLock.ts`** — hook/state-machine (`idle | locked | setup | change`). Locks on cold-start (PIN set → `locked`), on `visibilitychange`, and after 5 min of idle (pointer/keyboard/scroll/touch events). Fires `ANALYTICS_EVENTS.APP_LOCK_*` registered in PR-0.
- **`AppLock.tsx`** — full-screen overlay (`z-[200]`, `fixed inset-0`, `bg-bg/95 backdrop-blur-md`). On-screen numpad + hidden `sr-only` text input for desktop. Two-step setup flow (enter → confirm). `useDialogFocusTrap` for keyboard nav; ESC **intentionally disabled** on locked screen (user cannot bypass with keyboard, per spec).
- **`AppLockContext.tsx`** — React context wrapping `useAppLock()` so the overlay in `AppInnerWithLock` and `PrivacySection` (3 component levels deep) share one instance.
- **`PrivacySection.tsx`** — Settings → Додатково → Конфіденційність: toggle enable/disable, "Змінити PIN", "Заблокувати зараз"; danger-confirm modal before disabling (clears hash from IDB).
- **`HubSettingsPage.tsx`** — `privacy` section added to `advanced` group; `sections` entry with UA search keywords.
- **`featureFlags.ts`** — `app-lock-enabled` flag (`defaultValue: false`, `experimental: true`).
- **`uk.ts`** — 26 new keys under `messages.privacy.lock.*` (Hard Rule #15 satisfied).

## Governing Skill

`apps/web` — `@shared` component system, feature-flag pattern, `useDialogFocusTrap`, settings section pattern.

## Playbook

`docs/playbooks/README.md` — no specific app-lock playbook exists; followed settings-section pattern from `ExperimentalSection` / `PrivacySection` design in `docs/audits/2026-05-06-ux-roast-pr-plan.md` PR-1a spec.

## Verification

- `pnpm vitest run apps/web/src/core/security/` → 16/16 pass
- `pnpm tsc --noEmit` (apps/web) → clean
- `eslint --max-warnings=0 src/core/security/ src/core/settings/PrivacySection.tsx` → clean
- Manual smoke (flag off): settings page unchanged, no lock overlay
- Manual smoke (flag on, PIN set): app locks on tab switch and after 5 min idle; correct PIN unlocks; wrong PIN shows error; "Заблокувати зараз" works; disable PIN requires confirmation

## Docs and Governance

- Feature gated behind `app-lock-enabled` (default off) — no user-visible change until flag is toggled
- Hard Rule #15 satisfied: all UA string literals in `messages.privacy.lock.*`
- ADR-0054 (`docs/adr/0054-ux-roast-2026-Q2.md`) covers architectural decisions for this flow (PIN in IndexedDB, biometric opt-in deferred to PR-1b)
- Follow-up: PR-1b adds biometric (WebAuthn) on top of this base

## Risk and Rollout

- **Risk low** — default-off feature flag; zero production impact until enabled
- **Storage** — IndexedDB `sergeant_app_lock` is isolated from the main `sergeant-db`; clear via `clearPinHash()` if needed
- **Recovery** — no recovery flow in this PR (spec: email magic-link / account password reset); noted in `m.recoveryHint`
- **Rollback** — flip `app-lock-enabled` default to `false` in `featureFlags.ts` (already is)

## Hard Rule #15

All Ukrainian string literals added to `apps/web/src/shared/i18n/uk.ts` under `messages.privacy.lock.*`. No bare Cyrillic in JSX.

https://claude.ai/code/session_01QZNU4uzdWzMoxtZLjuwNPQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QZNU4uzdWzMoxtZLjuwNPQ)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the base app-lock PIN flow behind the `app-lock-enabled` flag. When enabled, the app locks on cold start (if a PIN exists), on tab switch, and after 5 minutes idle with a full-screen PIN UI.

- **New Features**
  - IndexedDB credential store with PBKDF2-SHA-256 (200k, 16-byte salt); API: `savePinHash`, `verifyPin`, `hasPinSet`, `clearPinHash`.
  - `useAppLock` state machine (`idle | locked | setup | change`) with PostHog events.
  - `AppLock` overlay: on-screen numpad, 2-step setup/confirm; ESC disabled when locked.
  - Settings → Advanced → Privacy: toggle enable/disable, “Change PIN”, “Lock now”; disabling asks for confirmation and clears the hash.
  - `AppLockProvider` context wires the overlay and settings; canceling setup turns the flag off.
  - Registers `app-lock-enabled` (default off, experimental) and adds UA copies under `messages.privacy.lock.*`.

- **Migration**
  - Default is off; enable `app-lock-enabled` to try it.
  - Set or change PIN in Settings → Advanced → Privacy.
  - Canceling setup reverts the toggle; disabling clears stored credentials.
  - To roll back, disable the flag.

<sup>Written for commit 63c2858fdcab2752aee46fe0c8256b65126d225b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

