### PR TITLE
docs(patches): add README + freshness-gate script (M4 / PR-20)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,14 @@ jobs:
         # scripts/check-codeowners-coverage.mjs.
         run: pnpm lint:codeowners
 
+      - name: patches/ freshness gate (PR-20 / M4)
+        # Fails when patches/*.patch files are not documented in
+        # patches/README.md (or rows have empty Owner / Drop-when /
+        # Upstream cells), or when pnpm.patchedDependencies in
+        # package.json is out of sync with patches/ on disk. Source of
+        # truth: scripts/check-patches-doc.mjs.
+        run: pnpm lint:patches
+
       - name: Drizzle schema ↔ SQL migration drift (PR-11)
         # Static analysis: verifies that every table/column in
         # packages/db-schema/src/pg/ is present in the SQL migrations under

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:analyze": "pnpm --filter @sergeant/web build:analyze",
     "build:check-size": "node scripts/check-bundle-size.mjs",
     "preview": "pnpm --filter @sergeant/web preview",
-    "lint": "turbo run lint && node scripts/check-imports.mjs && node tools/tsconfig-guard/check.mjs && pnpm lint:plugins && pnpm lint:skills && pnpm lint:playbook-language && pnpm lint:tech-debt-freshness && pnpm lint:initiative-status-sync && pnpm lint:localstorage-allowlist && pnpm lint:env-single-source && pnpm lint:discoverability && pnpm api:check-openapi && pnpm api:check-openapi-types",
+    "lint": "turbo run lint && node scripts/check-imports.mjs && node tools/tsconfig-guard/check.mjs && pnpm lint:plugins && pnpm lint:skills && pnpm lint:playbook-language && pnpm lint:tech-debt-freshness && pnpm lint:initiative-status-sync && pnpm lint:localstorage-allowlist && pnpm lint:env-single-source && pnpm lint:discoverability && pnpm lint:patches && pnpm api:check-openapi && pnpm api:check-openapi-types",
     "lint:imports": "node scripts/check-imports.mjs",
     "lint:migrations": "node scripts/lint-migrations.mjs",
     "ops:n8n:validate": "node scripts/n8n/validate-n8n-workflows.mjs",
@@ -80,6 +80,7 @@
     "lint:ai-legacy": "node scripts/check-ai-legacy.mjs --check",
     "ai-legacy:dashboard": "node scripts/check-ai-legacy.mjs --dashboard dist/ai-legacy-dashboard.html",
     "lint:codeowners": "node scripts/check-codeowners-coverage.mjs",
+    "lint:patches": "node scripts/check-patches-doc.mjs",
     "lint:pnpm-overrides": "node scripts/check-pnpm-overrides.mjs",
     "ci:validate-pr-body": "node scripts/ci/validate-pr-body.mjs"
   },

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,58 @@
+# patches/
+
+> **Last reviewed:** 2026-05-07 by Devin. **Next review:** 2026-08-05.
+
+This directory contains pnpm-managed patches applied to upstream packages
+via `pnpm patch <pkg>` → `pnpm patch-commit <path>`. Each row in the table
+below is enforced by `scripts/check-patches-doc.mjs` (`pnpm lint:patches`),
+which fails CI when a patch is missing a row, has empty mandatory cells,
+or when `pnpm.patchedDependencies` in root `package.json` references a
+patch file that does not exist on disk.
+
+Closes [PR-20](../docs/initiatives/stack-pulse-2026-05/pr-20-patches-readme.md)
+(stack-pulse-2026-05 / M4).
+
+## Active patches
+
+<!-- LINT:patches:table:start -->
+
+| Patch                      | Reason                                                                                                                                                                                                                                                    | Upstream                                                                                                                                                                             | Drop when                                                                                                                                                                            | Owner        |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------ |
+| `@expo__cli@0.22.28.patch` | tar v7 ships ESM with `__esModule=true` + no `default` export → `_tar().default.extract` is undefined and `expo prebuild` crashes. Patch wraps the `require("tar")` result so `.default` points back at the module namespace, restoring the v6 behaviour. | <https://github.com/chatwoot/chatwoot-mobile-app/pull/1045> (mirror context — root cause is upstream `tar` v7 + Babel `_interopRequireDefault` interaction in older Expo CLI builds) | Expo CLI ≥ 0.23.x lands the upstream-side fix (or downgrade to `tar` v6 transitively). PR-22 (Expo SDK 53 upgrade) will drop this patch automatically — verify after Expo SDK 53 GA. | `@Skords-01` |
+
+<!-- LINT:patches:table:end -->
+
+## Schema (enforced by `pnpm lint:patches`)
+
+Every row inside the `LINT:patches:table` markers must have:
+
+- **Patch** — exact filename matching `patches/*.patch` and a key in
+  `pnpm.patchedDependencies` (root `package.json`).
+- **Reason** — non-empty bug description.
+- **Upstream** — link to upstream issue/PR/release-notes (or
+  `n/a — internal patch` with a reason).
+- **Drop when** — concrete condition (version, ADR, release date) under
+  which the patch becomes obsolete.
+- **Owner** — GitHub handle (e.g. `@Skords-01`) accountable for re-validating
+  this patch on the next quarterly review.
+
+The check runs in `pnpm lint` and as a dedicated `lint:patches` step in
+`.github/workflows/ci.yml`.
+
+## Adding or removing a patch
+
+1. `pnpm patch <pkg>@<exact-version>` → modify in the temp dir → `pnpm
+patch-commit <temp-path>`. pnpm writes the diff to `patches/` and
+   updates `pnpm.patchedDependencies` for you.
+2. Add / update / remove the corresponding row in this README between the
+   `LINT:patches:table` markers.
+3. Run `pnpm lint:patches` locally — it must pass before push.
+4. Commit the patch file, the README change, and the
+   `pnpm.patchedDependencies` update together.
+
+## Why a freshness gate?
+
+Patches are silent tech debt — nothing reminds the team that the upstream
+fix has shipped. The gate forces a documented "Drop when" condition next
+to every patch so the next contributor seeing a `pnpm install` patch
+warning has a clear "is it safe to remove?" answer.

--- a/scripts/__tests__/check-patches-doc.test.mjs
+++ b/scripts/__tests__/check-patches-doc.test.mjs
@@ -1,0 +1,298 @@
+// scripts/__tests__/check-patches-doc.test.mjs
+//
+// Unit tests for the `patches/` freshness-gate (PR-20 / M4).
+// Run with: node --test scripts/__tests__/check-patches-doc.test.mjs
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  extractPatchedDeps,
+  patchKeyToFilename,
+  extractTableBlock,
+  parseTable,
+  unwrapCode,
+  validate,
+} from "../check-patches-doc.mjs";
+
+// ── extractPatchedDeps ───────────────────────────────────────────────────────
+
+describe("extractPatchedDeps", () => {
+  it("returns sorted keys when present", () => {
+    const pkg = {
+      pnpm: {
+        patchedDependencies: {
+          "react@18.2.0": "patches/react.patch",
+          "@expo/cli@0.22.28": "patches/@expo__cli@0.22.28.patch",
+        },
+      },
+    };
+    assert.deepEqual(extractPatchedDeps(pkg), [
+      "@expo/cli@0.22.28",
+      "react@18.2.0",
+    ]);
+  });
+
+  it("returns [] when pnpm.patchedDependencies is missing", () => {
+    assert.deepEqual(extractPatchedDeps({}), []);
+    assert.deepEqual(extractPatchedDeps({ pnpm: {} }), []);
+  });
+});
+
+// ── patchKeyToFilename ───────────────────────────────────────────────────────
+
+describe("patchKeyToFilename", () => {
+  it("converts pnpm keys to on-disk filenames", () => {
+    assert.equal(
+      patchKeyToFilename("@expo/cli@0.22.28"),
+      "@expo__cli@0.22.28.patch",
+    );
+    assert.equal(patchKeyToFilename("react@18.2.0"), "react@18.2.0.patch");
+    assert.equal(
+      patchKeyToFilename("@scope/sub/inner@1.0.0"),
+      "@scope__sub__inner@1.0.0.patch",
+    );
+  });
+});
+
+// ── extractTableBlock ────────────────────────────────────────────────────────
+
+describe("extractTableBlock", () => {
+  it("extracts content between LINT markers", () => {
+    const readme = [
+      "# Title",
+      "intro",
+      "<!-- LINT:patches:table:start -->",
+      "table content",
+      "<!-- LINT:patches:table:end -->",
+      "outro",
+    ].join("\n");
+    assert.equal(extractTableBlock(readme), "table content");
+  });
+
+  it("returns null when markers are missing", () => {
+    assert.equal(extractTableBlock("# Title\n"), null);
+  });
+
+  it("returns null when markers are reversed", () => {
+    const readme = [
+      "<!-- LINT:patches:table:end -->",
+      "x",
+      "<!-- LINT:patches:table:start -->",
+    ].join("\n");
+    assert.equal(extractTableBlock(readme), null);
+  });
+});
+
+// ── parseTable ───────────────────────────────────────────────────────────────
+
+describe("parseTable", () => {
+  it("parses a well-formed table into row objects", () => {
+    const block = [
+      "| Patch | Reason | Owner |",
+      "| --- | --- | --- |",
+      "| `a.patch` | bug | @x |",
+      "| `b.patch` | other | @y |",
+    ].join("\n");
+    const t = parseTable(block);
+    assert.deepEqual(t.header, ["Patch", "Reason", "Owner"]);
+    assert.equal(t.rows.length, 2);
+    assert.equal(t.rows[0].Patch, "`a.patch`");
+    assert.equal(t.rows[1].Owner, "@y");
+  });
+
+  it("returns null for blocks with no separator row", () => {
+    const block = ["| Patch | Reason |", "| `a.patch` | bug |"].join("\n");
+    assert.equal(parseTable(block), null);
+  });
+
+  it("flags a malformed row with __malformed marker", () => {
+    const block = [
+      "| Patch | Reason | Owner |",
+      "| --- | --- | --- |",
+      "| `a.patch` | bug |", // missing Owner cell
+    ].join("\n");
+    const t = parseTable(block);
+    assert.equal(t.rows.length, 1);
+    assert.ok(t.rows[0].__malformed);
+  });
+
+  it("returns null for empty input", () => {
+    assert.equal(parseTable(""), null);
+    assert.equal(parseTable(null), null);
+  });
+});
+
+// ── unwrapCode ───────────────────────────────────────────────────────────────
+
+describe("unwrapCode", () => {
+  it("strips wrapping backticks", () => {
+    assert.equal(unwrapCode("`a.patch`"), "a.patch");
+  });
+
+  it("returns the original when no backticks", () => {
+    assert.equal(unwrapCode("a.patch"), "a.patch");
+  });
+
+  it("returns empty string for falsy input", () => {
+    assert.equal(unwrapCode(""), "");
+    assert.equal(unwrapCode(undefined), "");
+    assert.equal(unwrapCode(null), "");
+  });
+});
+
+// ── validate ─────────────────────────────────────────────────────────────────
+
+describe("validate (integration of all three checks)", () => {
+  const happyTable = parseTable(
+    [
+      "| Patch | Reason | Upstream | Drop when | Owner |",
+      "| --- | --- | --- | --- | --- |",
+      "| `@expo__cli@0.22.28.patch` | tar v7 ESM crash | https://example/issue/1 | Expo CLI 0.23.x | @Skords-01 |",
+    ].join("\n"),
+  );
+
+  it("passes when patches/, package.json, and README are all in sync", () => {
+    const result = validate({
+      patchFiles: ["@expo__cli@0.22.28.patch"],
+      patchedDeps: ["@expo/cli@0.22.28"],
+      table: happyTable,
+    });
+    assert.equal(result.ok, true, JSON.stringify(result.errors));
+    assert.deepEqual(result.errors, []);
+  });
+
+  it("fails when a patch file has no documented row", () => {
+    const result = validate({
+      patchFiles: ["@expo__cli@0.22.28.patch", "react@18.2.0.patch"],
+      patchedDeps: ["@expo/cli@0.22.28", "react@18.2.0"],
+      table: happyTable,
+    });
+    assert.equal(result.ok, false);
+    assert.ok(
+      result.errors.some((e) =>
+        e.includes('no row found for patch file "react@18.2.0.patch"'),
+      ),
+      JSON.stringify(result.errors),
+    );
+  });
+
+  it("fails when a row has an empty mandatory cell (Owner)", () => {
+    const t = parseTable(
+      [
+        "| Patch | Reason | Upstream | Drop when | Owner |",
+        "| --- | --- | --- | --- | --- |",
+        "| `@expo__cli@0.22.28.patch` | tar v7 ESM crash | https://example/issue/1 | Expo CLI 0.23.x |  |",
+      ].join("\n"),
+    );
+    const result = validate({
+      patchFiles: ["@expo__cli@0.22.28.patch"],
+      patchedDeps: ["@expo/cli@0.22.28"],
+      table: t,
+    });
+    assert.equal(result.ok, false);
+    assert.ok(
+      result.errors.some((e) => e.includes('empty "Owner" cell')),
+      JSON.stringify(result.errors),
+    );
+  });
+
+  it("fails when README block markers are missing (table === null)", () => {
+    const result = validate({
+      patchFiles: ["@expo__cli@0.22.28.patch"],
+      patchedDeps: ["@expo/cli@0.22.28"],
+      table: null,
+    });
+    assert.equal(result.ok, false);
+    assert.ok(
+      result.errors.some((e) =>
+        e.includes("missing or malformed LINT:patches:table block"),
+      ),
+      JSON.stringify(result.errors),
+    );
+  });
+
+  it("fails when pnpm.patchedDependencies references a missing patch file", () => {
+    const result = validate({
+      patchFiles: ["@expo__cli@0.22.28.patch"],
+      patchedDeps: ["@expo/cli@0.22.28", "react@18.2.0"],
+      table: happyTable,
+    });
+    assert.equal(result.ok, false);
+    assert.ok(
+      result.errors.some(
+        (e) =>
+          e.includes('"react@18.2.0.patch"') && e.includes("does not exist"),
+      ),
+      JSON.stringify(result.errors),
+    );
+  });
+
+  it("fails when an orphan patch file is not in pnpm.patchedDependencies", () => {
+    const result = validate({
+      patchFiles: ["@expo__cli@0.22.28.patch", "stale.patch"],
+      patchedDeps: ["@expo/cli@0.22.28"],
+      // Add a row for the orphan so we don't hit "no row" error first.
+      table: parseTable(
+        [
+          "| Patch | Reason | Upstream | Drop when | Owner |",
+          "| --- | --- | --- | --- | --- |",
+          "| `@expo__cli@0.22.28.patch` | x | y | z | @a |",
+          "| `stale.patch` | x | y | z | @a |",
+        ].join("\n"),
+      ),
+    });
+    assert.equal(result.ok, false);
+    assert.ok(
+      result.errors.some(
+        (e) => e.includes("orphan patch") && e.includes("stale.patch"),
+      ),
+      JSON.stringify(result.errors),
+    );
+  });
+
+  it("fails when a documented row points to a non-existent patch file", () => {
+    const t = parseTable(
+      [
+        "| Patch | Reason | Upstream | Drop when | Owner |",
+        "| --- | --- | --- | --- | --- |",
+        "| `ghost.patch` | x | y | z | @a |",
+      ].join("\n"),
+    );
+    const result = validate({
+      patchFiles: [],
+      patchedDeps: [],
+      table: t,
+    });
+    assert.equal(result.ok, false);
+    assert.ok(
+      result.errors.some(
+        (e) =>
+          e.includes('"ghost.patch"') && e.includes("does not exist on disk"),
+      ),
+      JSON.stringify(result.errors),
+    );
+  });
+
+  it("fails when a required column is missing from the header", () => {
+    const t = parseTable(
+      [
+        "| Patch | Reason | Owner |",
+        "| --- | --- | --- |",
+        "| `a.patch` | x | @a |",
+      ].join("\n"),
+    );
+    const result = validate({
+      patchFiles: ["a.patch"],
+      patchedDeps: [],
+      table: t,
+    });
+    assert.equal(result.ok, false);
+    assert.ok(
+      result.errors.some((e) =>
+        e.includes('missing required column "Upstream"'),
+      ),
+      JSON.stringify(result.errors),
+    );
+  });
+});

--- a/scripts/check-patches-doc.mjs
+++ b/scripts/check-patches-doc.mjs
@@ -1,0 +1,316 @@
+#!/usr/bin/env node
+// scripts/check-patches-doc.mjs
+//
+// CI guard for `patches/README.md` (closes PR-20 / M4).
+//
+// Why this guard exists:
+//   `patches/` is silent tech debt. Nothing reminds the team that an
+//   upstream fix has shipped, so patches accumulate and rebase pain
+//   compounds during framework upgrades (e.g. Expo SDK bumps). This
+//   script forces every `patches/*.patch` to carry a documented
+//   "Drop when" condition + Owner alongside it.
+//
+// Three checks, each fatal:
+//   1. Every `patches/*.patch` file has a row in `patches/README.md`'s
+//      `LINT:patches:table` block, and every row's mandatory cells
+//      (Patch, Reason, Upstream, Drop when, Owner) are non-empty.
+//   2. Every patch file is referenced from
+//      `package.json -> pnpm.patchedDependencies`, and every key in
+//      `pnpm.patchedDependencies` has a matching patch file on disk
+//      (no stale orphans).
+//   3. Every row in the table refers to an existing patch file (the
+//      table cannot describe ghosts).
+//
+// Usage:
+//   pnpm lint:patches
+//   node scripts/check-patches-doc.mjs
+//
+// Exit code: 0 on success, 1 on any violation. The runner is purely
+// path-based (no `pnpm install` required) so it stays cheap on PR-CI.
+
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, "..");
+
+const TABLE_START = "<!-- LINT:patches:table:start -->";
+const TABLE_END = "<!-- LINT:patches:table:end -->";
+const REQUIRED_COLUMNS = ["Patch", "Reason", "Upstream", "Drop when", "Owner"];
+
+// ── Pure helpers (exported for tests) ────────────────────────────────────────
+
+/**
+ * List `*.patch` filenames in the given directory. Returns sorted
+ * basenames (no path prefix). Throws on missing directory.
+ */
+export function listPatchFiles(patchesDir, fs = { readdirSync }) {
+  const entries = fs.readdirSync(patchesDir);
+  return entries.filter((f) => f.endsWith(".patch")).sort();
+}
+
+/**
+ * Read a JSON file and return its parsed contents. Returns `null` on
+ * ENOENT and rethrows other errors.
+ */
+export function loadJSON(filePath, fs = { readFileSync }) {
+  try {
+    const raw = fs.readFileSync(filePath, "utf8");
+    return JSON.parse(raw);
+  } catch (e) {
+    if (e?.code === "ENOENT") return null;
+    throw e;
+  }
+}
+
+/**
+ * Extract the keys of `pnpm.patchedDependencies` from a parsed
+ * `package.json` object. Returns a sorted string array. Falls back to
+ * an empty array when the field is missing.
+ */
+export function extractPatchedDeps(pkgJson) {
+  const map = pkgJson?.pnpm?.patchedDependencies ?? {};
+  return Object.keys(map).sort();
+}
+
+/**
+ * Convert a `patchedDependencies` key (e.g. `@expo/cli@0.22.28`) into
+ * its canonical patch-file basename (e.g. `@expo__cli@0.22.28.patch`)
+ * — pnpm replaces `/` with `__` when materialising a patch on disk.
+ *
+ * The reverse direction is NOT 1:1 (multiple keys can map to the same
+ * filename only on case-folded filesystems, which we don't support),
+ * so the test set treats this as authoritative.
+ */
+export function patchKeyToFilename(key) {
+  return `${key.replace(/\//g, "__")}.patch`;
+}
+
+/**
+ * Locate the table block inside README content and return its raw
+ * inner markdown (lines between the markers). Returns `null` when the
+ * markers are missing or out of order.
+ */
+export function extractTableBlock(readme) {
+  const startIdx = readme.indexOf(TABLE_START);
+  const endIdx = readme.indexOf(TABLE_END);
+  if (startIdx === -1 || endIdx === -1 || endIdx < startIdx) return null;
+  return readme.slice(startIdx + TABLE_START.length, endIdx).trim();
+}
+
+/**
+ * Parse a GitHub-flavoured markdown table from `block` (the content
+ * between the LINT markers, NOT the whole README). Returns an array
+ * of objects keyed by column header. Cells are trimmed; leading /
+ * trailing pipe characters and the separator row (`| --- |`) are
+ * skipped. Returns `null` when no header row is found.
+ */
+export function parseTable(block) {
+  if (!block) return null;
+  const lines = block
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0 && l.startsWith("|"));
+  if (lines.length < 2) return null;
+
+  const splitRow = (row) =>
+    row
+      .replace(/^\|/, "")
+      .replace(/\|$/, "")
+      .split("|")
+      .map((cell) => cell.trim());
+
+  const header = splitRow(lines[0]);
+  // Separator row: `| --- | :---: | ---: |` etc.
+  const separator = splitRow(lines[1]);
+  if (!separator.every((c) => /^:?-{3,}:?$/.test(c))) return null;
+
+  const rows = [];
+  for (let i = 2; i < lines.length; i++) {
+    const cells = splitRow(lines[i]);
+    if (cells.length !== header.length) {
+      // Mismatch is significant — surface as a malformed row that
+      // downstream validation flags via missing required columns.
+      const obj = Object.fromEntries(header.map((h) => [h, ""]));
+      obj.__malformed = lines[i];
+      rows.push(obj);
+      continue;
+    }
+    rows.push(Object.fromEntries(header.map((h, j) => [h, cells[j]])));
+  }
+  return { header, rows };
+}
+
+/**
+ * Strip the inline-code backticks pnpm uses around the patch filename
+ * (e.g. `` `@expo__cli@0.22.28.patch` `` → `@expo__cli@0.22.28.patch`).
+ * Returns the original string when no wrapping backticks are present.
+ */
+export function unwrapCode(value) {
+  if (!value) return "";
+  const m = value.match(/^`(.+)`$/);
+  return m ? m[1] : value;
+}
+
+/**
+ * Run all three guards against pre-loaded inputs (mockable for tests).
+ *
+ * Returns `{ ok, errors }` where `errors` is a string array. The CLI
+ * runner formats / prints them.
+ */
+export function validate({ patchFiles, patchedDeps, table }) {
+  const errors = [];
+
+  if (table === null) {
+    errors.push(
+      `patches/README.md: missing or malformed LINT:patches:table block ` +
+        `(expected ${TABLE_START} … ${TABLE_END}).`,
+    );
+    return { ok: false, errors };
+  }
+
+  // Header coverage.
+  for (const col of REQUIRED_COLUMNS) {
+    if (!table.header.includes(col)) {
+      errors.push(
+        `patches/README.md: table is missing required column "${col}". ` +
+          `Required columns: ${REQUIRED_COLUMNS.join(", ")}.`,
+      );
+    }
+  }
+
+  // Build patch-row lookup keyed by filename.
+  const rowByPatch = new Map();
+  for (const row of table.rows) {
+    if (row.__malformed) {
+      errors.push(
+        `patches/README.md: malformed row (column count mismatch): "${row.__malformed}".`,
+      );
+      continue;
+    }
+    const patchCell = unwrapCode(row.Patch ?? "");
+    if (!patchCell) {
+      errors.push(`patches/README.md: row has empty Patch cell.`);
+      continue;
+    }
+    if (rowByPatch.has(patchCell)) {
+      errors.push(`patches/README.md: duplicate row for "${patchCell}".`);
+    }
+    rowByPatch.set(patchCell, row);
+
+    for (const col of REQUIRED_COLUMNS) {
+      const cell = (row[col] ?? "").trim();
+      if (!cell) {
+        errors.push(
+          `patches/README.md: row "${patchCell}" has empty "${col}" cell.`,
+        );
+      }
+    }
+  }
+
+  // Check 1: every patch file in patches/ has a documented row.
+  for (const file of patchFiles) {
+    if (!rowByPatch.has(file)) {
+      errors.push(
+        `patches/README.md: no row found for patch file "${file}". ` +
+          `Add a row inside the LINT:patches:table block.`,
+      );
+    }
+  }
+
+  // Check 2: pnpm.patchedDependencies ↔ patches/ filesystem parity.
+  const expectedFilenames = new Set(patchedDeps.map(patchKeyToFilename));
+  const actualFilenames = new Set(patchFiles);
+  for (const expected of expectedFilenames) {
+    if (!actualFilenames.has(expected)) {
+      errors.push(
+        `package.json: pnpm.patchedDependencies references "${expected}" ` +
+          `but patches/${expected} does not exist.`,
+      );
+    }
+  }
+  for (const actual of actualFilenames) {
+    if (!expectedFilenames.has(actual)) {
+      errors.push(
+        `patches/${actual}: file exists but is not referenced from ` +
+          `package.json -> pnpm.patchedDependencies (orphan patch).`,
+      );
+    }
+  }
+
+  // Check 3: every documented row maps to a real patch file.
+  for (const documented of rowByPatch.keys()) {
+    if (!actualFilenames.has(documented)) {
+      errors.push(
+        `patches/README.md: row "${documented}" describes a patch file ` +
+          `that does not exist on disk.`,
+      );
+    }
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────────────
+
+function main() {
+  const patchesDir = path.join(REPO_ROOT, "patches");
+  const readmePath = path.join(patchesDir, "README.md");
+  const pkgPath = path.join(REPO_ROOT, "package.json");
+
+  let patchFiles;
+  try {
+    patchFiles = listPatchFiles(patchesDir);
+  } catch (e) {
+    console.error(`[patches] failed to read ${patchesDir}: ${e.message}`);
+    process.exit(1);
+  }
+
+  const pkgJson = loadJSON(pkgPath);
+  if (pkgJson === null) {
+    console.error(`[patches] package.json missing at ${pkgPath}.`);
+    process.exit(1);
+  }
+  const patchedDeps = extractPatchedDeps(pkgJson);
+
+  let readme;
+  try {
+    readme = readFileSync(readmePath, "utf8");
+  } catch (e) {
+    if (e?.code === "ENOENT") {
+      console.error(
+        `[patches] patches/README.md is missing. Document each patch in ` +
+          `a LINT:patches:table block with columns: ${REQUIRED_COLUMNS.join(", ")}.`,
+      );
+    } else {
+      console.error(`[patches] failed to read README: ${e.message}`);
+    }
+    process.exit(1);
+  }
+
+  const block = extractTableBlock(readme);
+  const table = parseTable(block);
+
+  const { ok, errors } = validate({ patchFiles, patchedDeps, table });
+
+  if (!ok) {
+    console.error("[patches] freshness check failed:\n");
+    for (const err of errors) console.error(`  ❌ ${err}`);
+    console.error(
+      `\n[patches] re-read patches/README.md, fix the rows, and re-run ` +
+        `\`pnpm lint:patches\`.`,
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `[patches] OK: ${patchFiles.length} patch(es) documented and in sync ` +
+      `with pnpm.patchedDependencies.`,
+  );
+}
+
+if (process.argv[1] === __filename) {
+  main();
+}


### PR DESCRIPTION
Closes M4 in stack-pulse-2026-05: patches/ silent tech debt has no README, no ownership, and no reminder when upstream fixes ship.

Adds:
- patches/README.md: table (Patch / Reason / Upstream / Drop when / Owner)
  + 'Last reviewed' freshness marker. Single existing patch (@expo/cli@0.22.28) documented with link to upstream tracking issue.
- scripts/check-patches-doc.mjs: three-check gate 1) every patches/*.patch has a documented row with non-empty mandatory cells 2) pnpm.patchedDependencies <-> patches/ filesystem parity (no orphans) 3) every documented row maps to a real patch file (no ghosts)
- scripts/__tests__/check-patches-doc.test.mjs: 21 unit tests covering all three checks + edge cases (missing markers, ghost rows, empty cells, etc.)
- package.json: 'lint:patches' script added to main 'lint' chain
- .github/workflows/ci.yml: 'patches/ freshness gate' step in 'check' job after CODEOWNERS coverage.

## Summary

<!-- What changed in one tight paragraph or a short flat list. -->

## Governing Skill

- Primary skill:
- Secondary skill (if truly needed):

## Playbook

- Primary playbook:
- Why this playbook:
- If no playbook matched, why:

## Verification

<!-- Paste the exact commands you ran and the key result. -->

```bash
pnpm lint
pnpm typecheck
```

Additional checks:

- [ ] Local smoke / manual validation completed
- [ ] Surface-specific checks completed

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [ ] I checked whether `AGENTS.md` needed an update.
- [ ] I checked whether a playbook or skill needed an update.
- [ ] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a

## Risk and Rollout

- User-visible risk:
- Rollout / deploy order:
- Backout plan:

## Hard Rule #15

- [ ] I read `AGENTS.md` before coding.
- [ ] Internal docs I touched are in Ukrainian.
- [ ] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

<!-- Per `docs/governance/audit-freeze-2026-05-05.md`. New files under
docs/audits/, docs/initiatives/, docs/playbooks/, docs/adr/ trigger a
non-blocking CI warning. If this PR adds such a file, add `[skip-freeze]`
or `[freeze-exception]` to the PR title and explain below. Otherwise leave
this section as-is or remove. -->

- [ ] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

<!-- Flag migrations, env changes, HubChat tools, auth, or anything else that deserves extra reviewer attention. -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a docs-and-CI freshness gate for `patches/` so every `pnpm` patch is documented, owned, and kept in sync with `pnpm.patchedDependencies`. Documents the current `@expo/cli@0.22.28` patch and fails CI if docs, files, or config drift.

- **New Features**
  - `patches/README.md` with enforced table (Patch, Reason, Upstream, Drop when, Owner) guarded by `LINT:patches:table` markers; includes “Last reviewed” and a row for `@expo__cli@0.22.28.patch` (tar v7 ESM crash).
  - `scripts/check-patches-doc.mjs` runs 3 checks: non-empty required cells; `patches/*.patch` ↔ `package.json` parity; no docs-to-file ghosts.
  - 21 unit tests for the checker.
  - Adds `lint:patches`; runs in `pnpm lint` and as a CI “patches/ freshness gate” step.

<sup>Written for commit bf3b3e67a78e5781fd92538180dd3fdc93dd97eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

