### PR TITLE
fix(mobile): unify db-schema/migrate import to /migrate/runner

### DIFF
--- a/apps/mobile/src/core/db/kvStoreBoot.ts
+++ b/apps/mobile/src/core/db/kvStoreBoot.ts
@@ -36,7 +36,13 @@ import {
   createSqliteAdapter,
   type SqliteMigrationClient,
 } from "@sergeant/db-schema/migrate/sqlite";
-import { runMigrations } from "@sergeant/db-schema/migrate";
+// Import the runner from the dedicated `./migrate/runner` sub-path
+// rather than `./migrate`. The umbrella `./migrate` entry re-exports
+// `loadMigrationFiles` from `./files.js`, which top-level imports
+// `node:fs` / `node:path` and would break the mobile bundle if Metro
+// ever stopped tree-shaking the unused export. The runner itself is
+// dialect- and platform-free.
+import { runMigrations } from "@sergeant/db-schema/migrate/runner";
 import type {
   KVStore,
   SqliteKVStoreBoot,

--- a/apps/mobile/src/modules/finyk/lib/clientMigrate.ts
+++ b/apps/mobile/src/modules/finyk/lib/clientMigrate.ts
@@ -2,7 +2,12 @@ import {
   FINYK_CLIENT_MIGRATIONS,
   FINYK_MIGRATIONS_TABLE,
 } from "@sergeant/db-schema/sqlite/migrations";
-import { runMigrations } from "@sergeant/db-schema/migrate";
+// Import the runner from the dedicated `./migrate/runner` sub-path —
+// the umbrella `./migrate` re-exports `loadMigrationFiles` from
+// `./files.js`, which top-level imports `node:fs` / `node:path` and
+// would break the mobile bundle if Metro ever stopped tree-shaking
+// the unused export.
+import { runMigrations } from "@sergeant/db-schema/migrate/runner";
 import {
   createSqliteAdapter,
   type SqliteMigrationClient,

--- a/apps/mobile/src/modules/fizruk/lib/clientMigrate.ts
+++ b/apps/mobile/src/modules/fizruk/lib/clientMigrate.ts
@@ -2,7 +2,12 @@ import {
   FIZRUK_CLIENT_MIGRATIONS,
   FIZRUK_MIGRATIONS_TABLE,
 } from "@sergeant/db-schema/sqlite/migrations";
-import { runMigrations } from "@sergeant/db-schema/migrate";
+// Import the runner from the dedicated `./migrate/runner` sub-path —
+// the umbrella `./migrate` re-exports `loadMigrationFiles` from
+// `./files.js`, which top-level imports `node:fs` / `node:path` and
+// would break the mobile bundle if Metro ever stopped tree-shaking
+// the unused export.
+import { runMigrations } from "@sergeant/db-schema/migrate/runner";
 import {
   createSqliteAdapter,
   type SqliteMigrationClient,

--- a/apps/mobile/src/modules/nutrition/lib/clientMigrate.ts
+++ b/apps/mobile/src/modules/nutrition/lib/clientMigrate.ts
@@ -2,7 +2,12 @@ import {
   NUTRITION_CLIENT_MIGRATIONS,
   NUTRITION_MIGRATIONS_TABLE,
 } from "@sergeant/db-schema/sqlite/migrations";
-import { runMigrations } from "@sergeant/db-schema/migrate";
+// Import the runner from the dedicated `./migrate/runner` sub-path —
+// the umbrella `./migrate` re-exports `loadMigrationFiles` from
+// `./files.js`, which top-level imports `node:fs` / `node:path` and
+// would break the mobile bundle if Metro ever stopped tree-shaking
+// the unused export.
+import { runMigrations } from "@sergeant/db-schema/migrate/runner";
 import {
   createSqliteAdapter,
   type SqliteMigrationClient,

--- a/apps/mobile/src/modules/routine/lib/clientMigrate.ts
+++ b/apps/mobile/src/modules/routine/lib/clientMigrate.ts
@@ -2,7 +2,12 @@ import {
   ROUTINE_SPIKE_CLIENT_MIGRATIONS,
   ROUTINE_SPIKE_MIGRATIONS_TABLE,
 } from "@sergeant/db-schema/sqlite/migrations";
-import { runMigrations } from "@sergeant/db-schema/migrate";
+// Import the runner from the dedicated `./migrate/runner` sub-path —
+// the umbrella `./migrate` re-exports `loadMigrationFiles` from
+// `./files.js`, which top-level imports `node:fs` / `node:path` and
+// would break the mobile bundle if Metro ever stopped tree-shaking
+// the unused export.
+import { runMigrations } from "@sergeant/db-schema/migrate/runner";
 import {
   createSqliteAdapter,
   type SqliteMigrationClient,


### PR DESCRIPTION
## Why

Web already mostly migrated away from the umbrella `@sergeant/db-schema/migrate` subpath (which top-level imports `node:fs` via `./files.ts`). Mobile did **not** — 5 mobile files still used the umbrella. Metro currently does not detonate (it tree-shakes `loadMigrationFiles` because it's unused), but this is a "fragility debt" mine: the moment any code-path transitively pulls a `./files.ts` export, the production mobile bundle breaks.

This is the latent dzerkalny (mirror) of PR-01's web-side hotfix.

## Audit reference

`docs/audits/2026-05-07-app-audit.md` §8 — "Latent — ще 5 однакових bombs у mobile (дзеркало #1)":

> 5 мобільних споживачів `db-schema/migrate` umbrella — латентний дзеркальний #1. Привести усі 6 (1 web + 5 mobile) до `/migrate/runner`.

## Files changed (exhaustive list from audit §8)

```
apps/mobile/src/core/db/kvStoreBoot.ts                          (line ~39)
apps/mobile/src/modules/finyk/lib/clientMigrate.ts              (line ~5)
apps/mobile/src/modules/fizruk/lib/clientMigrate.ts             (line ~5)
apps/mobile/src/modules/nutrition/lib/clientMigrate.ts          (line ~5)
apps/mobile/src/modules/routine/lib/clientMigrate.ts            (line ~5)
```

Each replaces:

```diff
-import { runMigrations } from "@sergeant/db-schema/migrate";
+import { runMigrations } from "@sergeant/db-schema/migrate/runner";
```

A brief docstring is mirrored next to each new import (similar to the existing one in `apps/web/src/modules/routine/lib/clientMigrate.ts`) so future readers see why the umbrella is avoided.

## Out of scope

- The same fix in `apps/web/src/core/db/kvStoreBoot.ts` — that's PR-01.
- Dropping the umbrella from `packages/db-schema/package.json` exports — follow-up PR (depends on this and PR-01 landing first).
- ESLint guard — separate PR.

## Verification

- `pnpm install --frozen-lockfile` — passed.
- `pnpm --filter @sergeant/mobile typecheck` — **passed**.
- `pnpm --filter @sergeant/mobile test` — running; pre-existing failures from §4 are noted in the audit and unrelated to this change. (Will append result.)
- Mobile native build (`expo export` / etc.) not run locally — Metro should be unaffected since the runner sub-path exposes the same `runMigrations` symbol.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch mobile imports to `@sergeant/db-schema/migrate/runner` to avoid bundling `node:fs`/`node:path` via the umbrella `@sergeant/db-schema/migrate`. This removes a fragile path that could break Metro builds.

- **Bug Fixes**
  - Replaced `runMigrations` imports in five mobile files with `@sergeant/db-schema/migrate/runner`.
  - Added brief comments near each import to document why the umbrella path is avoided.

<sup>Written for commit 7a2bbb6a6442c886c90587ce73f790dbd6dc703f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

