### PR TITLE
chore(ci): add vite build smoke for apps/web as a hard gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,71 @@ jobs:
               });
             }
 
+  web-build-smoke:
+    name: Vite build smoke (apps/web)
+    runs-on: ubuntu-latest
+    # Hard gate that catches Node-only imports leaking into the browser
+    # bundle (e.g. `node:fs`, `node:path`) before they reach `main`.
+    #
+    # Why this gate exists: see
+    # docs/audits/2026-05-07-app-audit.md §9 (process gap — `pnpm build`
+    # for apps/web wasn't running on PRs, so the umbrella `node:fs`
+    # import in kvStoreBoot.ts shipped to prod) and §11.1 (recommendation
+    # — add `pnpm --filter @sergeant/web build` as a hard CI gate so
+    # regressions of this class fail PR-time, not at deploy/runtime).
+    #
+    # `pnpm typecheck` and `pnpm test` both pass for this regression
+    # class: the imports are typed, and `runMigrations` is mocked in
+    # tests. Only the actual Vite production build surfaces the
+    # "Module 'node:X' has been externalized for browser compatibility"
+    # warning that breaks the page at runtime.
+    steps:
+      # actions/checkout v6.0.2 (SHA-pinned for supply-chain hardening)
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      # pnpm/action-setup v6.0.3 (SHA-pinned for supply-chain hardening)
+      # Version is read from packageManager in root package.json.
+      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d
+
+      # actions/setup-node v6.4.0 (SHA-pinned for supply-chain hardening)
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "20"
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Build apps/web (Vite)
+        # Hard gate. Failure here blocks the PR.
+        # Captures stderr+stdout so the next step can grep for the
+        # browser-externalized warning and fail on it specifically.
+        run: |
+          set -o pipefail
+          pnpm --filter @sergeant/web build 2>&1 | tee /tmp/web-build.log
+
+      - name: Assert no Node-only imports in browser bundle
+        # Bonus targeted regression assertion (audit §11.1). Vite emits
+        # `vite-browser-external:node:` shim modules and a runtime
+        # "Module 'node:X' has been externalized for browser
+        # compatibility" warning whenever Node-only modules (`node:fs`,
+        # `node:path`, `node:crypto`, …) leak into the client bundle.
+        # We fail the job on either signal so the regression class
+        # cannot ship even if Vite kept exit-code 0.
+        run: |
+          set -euo pipefail
+          if grep -q 'vite-browser-external:node:' /tmp/web-build.log; then
+            echo "::error::Node built-in module externalized into browser bundle (see audit §1)."
+            grep 'vite-browser-external:node:' /tmp/web-build.log || true
+            exit 1
+          fi
+          if grep -q 'has been externalized for browser compatibility' /tmp/web-build.log; then
+            echo "::error::Vite externalized a Node-only module for browser compatibility (see audit §1)."
+            grep 'has been externalized for browser compatibility' /tmp/web-build.log || true
+            exit 1
+          fi
+          echo "OK: no Node-only imports detected in apps/web bundle."
+
   coverage:
     name: Test coverage (vitest)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

The web blocker in [`docs/audits/2026-05-07-app-audit.md` §1](../blob/main/docs/audits/2026-05-07-app-audit.md) (umbrella `node:fs` import in `kvStoreBoot.ts`) reached `main` because **no PR-time CI hard gate runs `pnpm --filter @sergeant/web build`**. `pnpm typecheck` and `pnpm test` both pass for that regression class — types are valid and `runMigrations` is mocked in tests — so only the actual Vite production build surfaces the runtime breakage:

```
Module "node:fs" has been externalized for browser compatibility.
  ...packages/db-schema/src/migrate/files.ts:1:31
```

Quoting the audit:

> **§9 — Чому процес ревʼю не зловив блокер #1**
>
> 1. `pnpm typecheck` не дивиться на runtime-сумісність бандлу.
> 2. `pnpm test` для `@sergeant/web` ніколи не виконує real bootstrap (`runMigrations` замокано).
> 3. **`pnpm build` для apps/web не запускається в CI.** (Якщо запускався би, Vite би скрипнув: `Module "node:fs" externalized for browser`.)
> 4. Smoke E2E на staging — відсутній/не блокує.
>
> **§11.1 — Рекомендації по CI / процесу**
>
> Додати smoke-build для apps/web у CI: `pnpm --filter @sergeant/web build` як hard gate. Це би зловило цей блокер ще на PR #062.

## What

Adds a new top-level job **`web-build-smoke` / “Vite build smoke (apps/web)”** to `.github/workflows/ci.yml`:

- Runs on every `pull_request` and `push` (same triggers as the rest of `ci.yml`).
- `pnpm install --frozen-lockfile` (reuses the existing `cache: pnpm` key on `actions/setup-node`, so install cost is shared across the matrix).
- **Hard gate:** `pnpm --filter @sergeant/web build` — failure blocks the PR.
- **Bonus targeted regression assertion (audit §11.1):** after the build, the job `grep`s the captured build log for both `vite-browser-external:node:` shim modules and the `"... has been externalized for browser compatibility"` Vite warning, and fails the job on either signal so the regression class cannot ship even if `vite build` itself returned exit-code 0.
- All actions are SHA-pinned, matching the existing supply-chain hardening convention in the file.

No app-code changes; surface is CI workflow only.

## Out of scope (separate PRs)

- The actual `kvStoreBoot.ts` source fix → PR-01.
- ESLint `no-restricted-imports` rule for `@sergeant/db-schema/migrate` → separate PR.
- CI for mobile builds, server builds, e2e — unchanged here.

## Verification

The new gate **may fail on this PR's own CI** if PR-01 (the `kvStoreBoot.ts` fix) has not yet landed on `main` — that is expected and is the proof the gate works (it catches the §1 regression class). Once PR-01 merges, this gate passes on a clean `main`.

If the run on this PR fails specifically on:

```
Module "node:fs" has been externalized for browser compatibility.
```

…that is the §1 umbrella bug, **not** a regression introduced by this PR. The point of this PR is exactly that the gate now catches it at PR time instead of letting it ship.

## Audit references

- `docs/audits/2026-05-07-app-audit.md` §9 (process gap)
- `docs/audits/2026-05-07-app-audit.md` §11.1 (recommendation)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI hard gate that runs a Vite production build for `@sergeant/web` to catch Node-only imports before merge. It runs on PRs and pushes, executes `pnpm --filter @sergeant/web build`, and fails if the logs contain `vite-browser-external:node:` or "has been externalized for browser compatibility".

<sup>Written for commit 8108ce6e5caf7478f7fe425ea7e45528959873d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

