### PR TITLE
fix(web): hotfix kvStoreBoot import + ESLint guard against db-schema/migrate umbrella

### DIFF
--- a/apps/mobile/jest.config.js
+++ b/apps/mobile/jest.config.js
@@ -28,12 +28,15 @@ module.exports = {
     // (`/sqlite`, `/pg`, `/shared`) and the package root onto
     // `packages/db-schema/src/...`.
     "^@sergeant/db-schema$": "<rootDir>/../../packages/db-schema/src/index.ts",
-    // `migrate/pg` and `migrate/sqlite` are single files, not directories;
-    // map them explicitly before the catch-all that appends `/index.ts`.
+    // `migrate/pg`, `migrate/sqlite` and `migrate/runner` are single files,
+    // not directories; map them explicitly before the catch-all that
+    // appends `/index.ts`.
     "^@sergeant/db-schema/migrate/pg$":
       "<rootDir>/../../packages/db-schema/src/migrate/pg.ts",
     "^@sergeant/db-schema/migrate/sqlite$":
       "<rootDir>/../../packages/db-schema/src/migrate/sqlite.ts",
+    "^@sergeant/db-schema/migrate/runner$":
+      "<rootDir>/../../packages/db-schema/src/migrate/runner.ts",
     "^@sergeant/db-schema/(.*)$":
       "<rootDir>/../../packages/db-schema/src/$1/index.ts",
     // `@sergeant/design-tokens` ships its `exports` map with `types`

--- a/apps/mobile/src/core/db/kvStoreBoot.ts
+++ b/apps/mobile/src/core/db/kvStoreBoot.ts
@@ -36,7 +36,13 @@ import {
   createSqliteAdapter,
   type SqliteMigrationClient,
 } from "@sergeant/db-schema/migrate/sqlite";
-import { runMigrations } from "@sergeant/db-schema/migrate";
+// Mirror of the web fix: import the runner from the dedicated
+// `./migrate/runner` sub-path. The umbrella `./migrate` entry
+// re-exports `loadMigrationFiles` from `./files.js`, which top-level
+// imports `node:fs` / `node:path`. Metro tolerates that today, but
+// the umbrella is banned by the `no-restricted-imports` guard so
+// every client surface stays bundler-portable.
+import { runMigrations } from "@sergeant/db-schema/migrate/runner";
 import type {
   KVStore,
   SqliteKVStoreBoot,

--- a/apps/mobile/src/modules/finyk/lib/clientMigrate.ts
+++ b/apps/mobile/src/modules/finyk/lib/clientMigrate.ts
@@ -2,7 +2,7 @@ import {
   FINYK_CLIENT_MIGRATIONS,
   FINYK_MIGRATIONS_TABLE,
 } from "@sergeant/db-schema/sqlite/migrations";
-import { runMigrations } from "@sergeant/db-schema/migrate";
+import { runMigrations } from "@sergeant/db-schema/migrate/runner";
 import {
   createSqliteAdapter,
   type SqliteMigrationClient,

--- a/apps/mobile/src/modules/fizruk/lib/clientMigrate.ts
+++ b/apps/mobile/src/modules/fizruk/lib/clientMigrate.ts
@@ -2,7 +2,7 @@ import {
   FIZRUK_CLIENT_MIGRATIONS,
   FIZRUK_MIGRATIONS_TABLE,
 } from "@sergeant/db-schema/sqlite/migrations";
-import { runMigrations } from "@sergeant/db-schema/migrate";
+import { runMigrations } from "@sergeant/db-schema/migrate/runner";
 import {
   createSqliteAdapter,
   type SqliteMigrationClient,

--- a/apps/mobile/src/modules/nutrition/lib/clientMigrate.ts
+++ b/apps/mobile/src/modules/nutrition/lib/clientMigrate.ts
@@ -2,7 +2,7 @@ import {
   NUTRITION_CLIENT_MIGRATIONS,
   NUTRITION_MIGRATIONS_TABLE,
 } from "@sergeant/db-schema/sqlite/migrations";
-import { runMigrations } from "@sergeant/db-schema/migrate";
+import { runMigrations } from "@sergeant/db-schema/migrate/runner";
 import {
   createSqliteAdapter,
   type SqliteMigrationClient,

--- a/apps/mobile/src/modules/routine/lib/clientMigrate.ts
+++ b/apps/mobile/src/modules/routine/lib/clientMigrate.ts
@@ -2,7 +2,7 @@ import {
   ROUTINE_SPIKE_CLIENT_MIGRATIONS,
   ROUTINE_SPIKE_MIGRATIONS_TABLE,
 } from "@sergeant/db-schema/sqlite/migrations";
-import { runMigrations } from "@sergeant/db-schema/migrate";
+import { runMigrations } from "@sergeant/db-schema/migrate/runner";
 import {
   createSqliteAdapter,
   type SqliteMigrationClient,

--- a/apps/web/src/core/db/kvStoreBoot.ts
+++ b/apps/web/src/core/db/kvStoreBoot.ts
@@ -38,7 +38,13 @@ import {
   createSqliteAdapter,
   type SqliteMigrationClient,
 } from "@sergeant/db-schema/migrate/sqlite";
-import { runMigrations } from "@sergeant/db-schema/migrate";
+// Import the runner from the dedicated `./migrate/runner` sub-path
+// rather than `./migrate`. The umbrella `./migrate` entry re-exports
+// `loadMigrationFiles` from `./files.js`, which top-level imports
+// `node:fs` / `node:path` and breaks Vite's browser bundle (white
+// screen on boot). The runner itself is dialect- and platform-free.
+// See routine/lib/clientMigrate.ts for the same pattern.
+import { runMigrations } from "@sergeant/db-schema/migrate/runner";
 import type {
   BroadcastChannelLike,
   KVStore,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -601,6 +601,15 @@ export default [
   // web app except `authClient.ts`, which is the one legitimate adapter
   // module — it owns the Better Auth client and intentionally does NOT
   // re-export `useSession` (see the note in that file).
+  //
+  // Same block also bans the `@sergeant/db-schema/migrate` umbrella entry —
+  // that re-exports `loadMigrationFiles` from `./files.js`, which top-level
+  // imports `node:fs` / `node:path` and breaks Vite's browser bundle (white
+  // screen on boot — see audit `docs/audits/2026-05-07-app-audit.md` §1).
+  // Browser-side callers must use one of the saner sub-segments:
+  // `@sergeant/db-schema/migrate/runner` (dialect-free runner),
+  // `@sergeant/db-schema/migrate/sqlite` (sqlite adapter),
+  // `@sergeant/db-schema/migrate/pg`     (pg adapter — Node-only callers).
   {
     files: ["apps/web/src/**/*.{js,jsx,ts,tsx}"],
     ignores: ["apps/web/src/core/auth/authClient.ts"],
@@ -614,6 +623,31 @@ export default [
               importNames: ["useSession"],
               message:
                 "Use `useAuth()` from `core/auth/AuthContext` (backed by `useUser()` from `@sergeant/api-client/react` → GET /api/v1/me). `useSession` from Better Auth is only for the actions layer inside `core/auth/authClient.ts`.",
+            },
+            {
+              name: "@sergeant/db-schema/migrate",
+              message:
+                "Import the runner from `@sergeant/db-schema/migrate/runner` (or the dialect-specific sub-segment `…/migrate/sqlite` / `…/migrate/pg`). The umbrella `…/migrate` re-exports `loadMigrationFiles` from `./files.js`, which top-level imports `node:fs`/`node:path` and breaks Vite's browser bundle. See `docs/audits/2026-05-07-app-audit.md` §1.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  // Mirror of the web umbrella ban for the mobile app — Metro tolerates
+  // `node:fs` shims today, but the latent dual breakage (audit §8) means
+  // we lock all client-side surfaces to the safe sub-segments.
+  {
+    files: ["apps/mobile/src/**/*.{js,jsx,ts,tsx}"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "@sergeant/db-schema/migrate",
+              message:
+                "Import the runner from `@sergeant/db-schema/migrate/runner` (or the dialect-specific sub-segment `…/migrate/sqlite` / `…/migrate/pg`). The umbrella `…/migrate` re-exports `loadMigrationFiles` from `./files.js`, which top-level imports `node:fs`/`node:path`. See `docs/audits/2026-05-07-app-audit.md` §1.",
             },
           ],
         },


### PR DESCRIPTION
## Summary

Hotfix for audit [`docs/audits/2026-05-07-app-audit.md` §1](docs/audits/2026-05-07-app-audit.md) — web app boot was crashing on every URL (white screen, React never mounting) because `apps/web/src/core/db/kvStoreBoot.ts` imported `runMigrations` from the umbrella `@sergeant/db-schema/migrate`, which re-exports `loadMigrationFiles` → top-level `node:fs` / `node:path` → Vite browser-externalized → throw at module-parse time.

- Switch the import to the dialect/platform-free `@sergeant/db-schema/migrate/runner` sub-segment (same pattern that `routine/fizruk/finyk/nutrition` `clientMigrate.ts` already use).
- Add a `no-restricted-imports` ESLint guard on `apps/web/src/**` and `apps/mobile/src/**` that bans the bare umbrella so this regression cannot drift back. Only the safe sub-segments (`/runner`, `/sqlite`, `/pg`) are allowed in client code.
- Cascade-fix the 5 mobile callers the new lint rule would otherwise flag (audit §8 latent mirror): `apps/mobile/src/core/db/kvStoreBoot.ts` + the 4 module `clientMigrate.ts` files.

Server-side imports are untouched — `apps/server` legitimately needs `loadMigrationFiles`, the umbrella, and Node `fs`.

## Governing Skill

- Primary skill: n/a (1-line hotfix following the audit's recommended fix verbatim)

## Playbook

- Primary playbook: n/a — direct execution of audit §1 "Запропонований фікс" + Гард option 2.
- If no playbook matched, why: the audit document itself prescribes the fix and the lint-guard option to use.

## Verification

```bash
# 1. lint guard fires on the umbrella import (synthetic test file)
echo 'import { runMigrations } from "@sergeant/db-schema/migrate";' \
  > apps/web/src/_eslint_guard_check.ts
pnpm exec eslint apps/web/src/_eslint_guard_check.ts
#   → error  '@sergeant/db-schema/migrate' import is restricted...
rm apps/web/src/_eslint_guard_check.ts

# 2. lint clean on touched files + on apps/web/src + apps/mobile/src
pnpm exec eslint apps/web/src apps/mobile/src --quiet
#   → exit 0

# 3. typecheck
pnpm --filter @sergeant/web typecheck   # → exit 0
pnpm --filter @sergeant/mobile typecheck # → exit 0

# 4. production web build no longer ships `node:fs` / `node:path`
#    or `vite-browser-external` shim references in the JS bundle
pnpm --filter @sergeant/web build
grep -rn "node:fs\|node:path\|vite-browser-external" \
  apps/server/dist/assets/*.js
#   → no matches
```

Additional checks:

- [x] `pnpm --filter @sergeant/web build` succeeds; bundle scan clean of `node:fs` / `vite-browser-external`.
- [x] Synthetic lint check confirms the new `no-restricted-imports` rule fires on the umbrella.
- [ ] Live browser smoke (`/welcome?demo=1` no longer white-screens) — pending; please run `pnpm dev:web` locally or wait for the Vercel preview to confirm.

## Docs and Governance

- [x] I read the audit before coding.
- [x] No `AGENTS.md` change needed — this is enforcement of an existing implicit convention.
- [x] No playbook/skill change needed.
- [x] No governance/review docs change needed. The audit doc itself stays untouched (it is the source of truth for the regression).

Updated docs:

- n/a

## Risk and Rollout

- **User-visible risk:** very low. Web users currently see a 100% white screen on every URL — any code path that succeeds is strictly an improvement. The runner sub-segment is exactly the same `runMigrations` function the umbrella was re-exporting; behavior is identical, only the dependency graph is smaller.
- **Rollout / deploy order:** standard — Vercel auto-preview on this PR, prod deploy on merge to `main`.
- **Backout plan:** revert this commit; restores the white-screen state (worse than before-merge, equivalent to current `main`). No data migrations or schema changes involved.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] No internal docs touched (Ukrainian-language requirement N/A).
- [x] I did not use `--no-verify` (Husky `pre-commit` + `commit-msg` ran cleanly; `staged-typecheck.mjs` passed).

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

- **ESLint flat-config rule precedence:** the existing `apps/web/src/**` block already had a `no-restricted-imports` for `better-auth/react#useSession`. Flat-config rule options don't merge — later configs replace earlier ones. I therefore folded the new umbrella ban into that **same** block (combined `paths` array), so `useSession` enforcement is preserved. Mobile gets a separate block (no auth concern there). Worth a careful look at the `no-restricted-imports` diff in `eslint.config.js` to confirm both restrictions still apply on web.
- **Mobile cascade fix:** I touched 5 mobile files even though Metro tolerates the umbrella today. The audit §8 calls them a latent dual of §1 and the new lint rule would flag them. If you'd rather keep mobile untouched in this PR, I can split it.
- **What I did NOT do:** I did not pursue audit option 1 (CI bundle-smoke check for `vite-browser-external:node:` strings) or option 3 (drop the umbrella entry from `packages/db-schema/package.json` exports). Option 2 (lint guard) was chosen per the audit's "increasing strictness" ladder. If you want belt-and-suspenders, option 1 can be a tiny CI step in a follow-up.
- **Other audit items:** §2 (mobile orphan test), §3 (5 hard-rule lint overflow), §4 (mobile test failures), §6/§7 (server warnings), §A1/§A2 (production Sentry events) are all out of scope here — they will need separate PRs.

Link to Devin session: https://app.devin.ai/sessions/2995ab449f1f4cd2b8d7635ac1582592

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a web boot white-screen by replacing `@sergeant/db-schema/migrate` with the browser-safe `@sergeant/db-schema/migrate/runner`. Adds an ESLint guard and a mobile Jest mapping to keep client code bundler-safe and tests passing.

- **Bug Fixes**
  - Switched `runMigrations` in `apps/web/src/core/db/kvStoreBoot.ts` to `@sergeant/db-schema/migrate/runner`, removing `node:fs`/`node:path` from the browser bundle.
  - Added `no-restricted-imports` for `apps/web/src/**` and `apps/mobile/src/**` to ban `@sergeant/db-schema/migrate`; use `…/migrate/runner`, `…/migrate/sqlite`, or `…/migrate/pg`.
  - Updated `apps/mobile/src/core/db/kvStoreBoot.ts` and 4 `clientMigrate.ts` files to use `…/migrate/runner`, and mapped `@sergeant/db-schema/migrate/runner` in `apps/mobile/jest.config.js` to fix test module resolution.
  - Rebased with `main` and aligned inline comments in mobile migrators to reference the new guard (no functional changes).

<sup>Written for commit 8200c0a526d6a18a346383a1a197ac0664e47ba0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

