### PR TITLE
test(mobile): wrap module shell tests in Api/QueryClient providers (audit #5)

### DIFF
--- a/apps/mobile/src/features/analytics/AnalyticsIdentityBridge.test.tsx
+++ b/apps/mobile/src/features/analytics/AnalyticsIdentityBridge.test.tsx
@@ -6,11 +6,15 @@
 
 import { render } from "@testing-library/react-native";
 
-const useUserMock = jest.fn();
+// Variables referenced inside `jest.mock()` factories must be prefixed
+// with `mock` (case-insensitive) — the babel-jest plugin allows that
+// prefix through the out-of-scope guard. See
+// https://jestjs.io/docs/es6-class-mocks#calling-jestmock-with-the-module-factory-parameter
+const mockUseUser = jest.fn();
 
 jest.mock("@sergeant/api-client/react", () => ({
   __esModule: true,
-  useUser: () => useUserMock(),
+  useUser: () => mockUseUser(),
 }));
 
 jest.mock("@/lib/observability/posthog", () => ({
@@ -46,14 +50,14 @@ const SAMPLE_USER = {
 
 describe("AnalyticsIdentityBridge", () => {
   beforeEach(() => {
-    useUserMock.mockReset();
+    mockUseUser.mockReset();
     identifyMock.mockReset();
     resetMock.mockReset();
     buildTraitsMock.mockClear();
   });
 
   it("не викликає identify/reset поки isPending=true", () => {
-    useUserMock.mockReturnValue({ data: undefined, isPending: true });
+    mockUseUser.mockReturnValue({ data: undefined, isPending: true });
 
     render(<AnalyticsIdentityBridge />);
 
@@ -62,7 +66,7 @@ describe("AnalyticsIdentityBridge", () => {
   });
 
   it("викликає identify коли зʼявляється userId", () => {
-    useUserMock.mockReturnValue({
+    mockUseUser.mockReturnValue({
       data: { user: SAMPLE_USER },
       isPending: false,
     });
@@ -78,7 +82,7 @@ describe("AnalyticsIdentityBridge", () => {
   });
 
   it("re-render із тим самим userId не дублює identify", () => {
-    useUserMock.mockReturnValue({
+    mockUseUser.mockReturnValue({
       data: { user: SAMPLE_USER },
       isPending: false,
     });
@@ -90,14 +94,14 @@ describe("AnalyticsIdentityBridge", () => {
   });
 
   it("викликає reset на переході authenticated → unauthenticated", () => {
-    useUserMock.mockReturnValue({
+    mockUseUser.mockReturnValue({
       data: { user: SAMPLE_USER },
       isPending: false,
     });
     const { rerender } = render(<AnalyticsIdentityBridge />);
     expect(identifyMock).toHaveBeenCalledTimes(1);
 
-    useUserMock.mockReturnValue({
+    mockUseUser.mockReturnValue({
       data: { user: null },
       isPending: false,
     });
@@ -107,7 +111,7 @@ describe("AnalyticsIdentityBridge", () => {
   });
 
   it("при cold-start без сесії (user=null від першого fetch) не викликає reset", () => {
-    useUserMock.mockReturnValue({
+    mockUseUser.mockReturnValue({
       data: { user: null },
       isPending: false,
     });

--- a/apps/mobile/src/modules/finyk/FinykApp.test.tsx
+++ b/apps/mobile/src/modules/finyk/FinykApp.test.tsx
@@ -6,8 +6,22 @@
  * surfaces (hero + planning copy, in-module nav grid) so this test is a
  * regression fence for the composition itself, not for individual card
  * internals (those have their own tests).
+ *
+ * `FinykApp` boots `useFinykDualWriteBoot` which calls `useUser()` from
+ * `@sergeant/api-client/react`. That hook needs both an
+ * `<ApiClientProvider>` (for the underlying ApiClient) and a
+ * `<QueryClientProvider>` (for the React Query store). Without them
+ * `FinykApp` throws in the boot hook and the surrounding
+ * `ModuleErrorBoundary` (top-level wrapper) catches the error and
+ * renders the "module crashed" fallback, hiding the surfaces we want
+ * to assert on. Mirror the runtime provider tree from `app/_layout.tsx`
+ * so render-tests see the real component, not the boundary fallback.
  */
 import { render, screen } from "@testing-library/react-native";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ApiClientProvider, apiQueryKeys } from "@sergeant/api-client/react";
+import { createApiClient } from "@sergeant/api-client";
+import type { ReactElement } from "react";
 
 import { FinykApp } from "./FinykApp";
 
@@ -16,15 +30,54 @@ jest.mock("expo-router", () => ({
   useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
 }));
 
+const testUser = {
+  user: {
+    id: "test-user",
+    email: "test@example.com",
+    name: "Test User",
+    image: null,
+    emailVerified: true,
+    createdAt: "2026-04-21T00:00:00.000Z",
+  },
+};
+
+const testApiClient = createApiClient({
+  baseUrl: "http://127.0.0.1",
+  fetchImpl: async () =>
+    ({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-type": "application/json" }),
+      text: async () => JSON.stringify(testUser),
+    }) as Response,
+});
+
+function renderFinyk(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity, gcTime: Infinity },
+    },
+  });
+  // Pre-seed the `useUser` cache so the `me` query hydrates synchronously
+  // without firing a fetch — we don't care about the user data here, only
+  // that the dual-write boot hook receives a stable user id.
+  queryClient.setQueryData(apiQueryKeys.me.current(), testUser);
+  return render(
+    <ApiClientProvider client={testApiClient}>
+      <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+    </ApiClientProvider>,
+  );
+}
+
 describe("FinykApp shell", () => {
   it("renders the Overview hero card", () => {
-    render(<FinykApp />);
+    renderFinyk(<FinykApp />);
     expect(screen.getByTestId("finyk-overview-hero")).toBeTruthy();
     expect(screen.getByText("Загальний нетворс")).toBeTruthy();
   });
 
   it("renders the in-module navigation grid", () => {
-    render(<FinykApp />);
+    renderFinyk(<FinykApp />);
     expect(screen.getByTestId("finyk-nav-grid-transactions")).toBeTruthy();
     expect(screen.getByTestId("finyk-nav-grid-budgets")).toBeTruthy();
     expect(screen.getByTestId("finyk-nav-grid-analytics")).toBeTruthy();
@@ -32,7 +85,7 @@ describe("FinykApp shell", () => {
   });
 
   it("renders the networth empty-state on first-run data", () => {
-    render(<FinykApp />);
+    renderFinyk(<FinykApp />);
     // Networth history starts empty in the `useFinykOverviewData` stub
     // — we expect the "too few snapshots" placeholder, not the chart.
     expect(screen.getByTestId("finyk-overview-networth-empty")).toBeTruthy();

--- a/apps/mobile/src/modules/finyk/pages/Budgets/BudgetsPage.test.tsx
+++ b/apps/mobile/src/modules/finyk/pages/Budgets/BudgetsPage.test.tsx
@@ -13,6 +13,10 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react-native";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ApiClientProvider, apiQueryKeys } from "@sergeant/api-client/react";
+import { createApiClient } from "@sergeant/api-client";
+import type { ReactElement } from "react";
 
 import { _getMMKVInstance } from "@/lib/storage";
 
@@ -34,6 +38,49 @@ jest.mock("victory-native", () => {
 
 import { BudgetsPage } from "./BudgetsPage";
 
+// `BudgetsPage` indirectly mounts `useFinykTransactionsStore`, which
+// reads the current user via `useUser()` from `@sergeant/api-client/
+// react`. That hook needs an `<ApiClientProvider>` and a
+// `<QueryClientProvider>` mounted higher in the tree, otherwise the
+// component throws and the surrounding ErrorBoundary swallows the
+// surfaces under test. Mirror the runtime provider tree from
+// `app/_layout.tsx`. Same shape as the TransactionsPage helper above.
+const testUser = {
+  user: {
+    id: "test-user",
+    email: "test@example.com",
+    name: "Test User",
+    image: null,
+    emailVerified: true,
+    createdAt: "2026-04-21T00:00:00.000Z",
+  },
+};
+
+const testApiClient = createApiClient({
+  baseUrl: "http://127.0.0.1",
+  fetchImpl: async () =>
+    ({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-type": "application/json" }),
+      text: async () => JSON.stringify(testUser),
+    }) as Response,
+});
+
+function renderBudgets(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity, gcTime: Infinity },
+    },
+  });
+  queryClient.setQueryData(apiQueryKeys.me.current(), testUser);
+  return render(
+    <ApiClientProvider client={testApiClient}>
+      <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+    </ApiClientProvider>,
+  );
+}
+
 const FIXED_NOW = new Date("2026-04-21T12:00:00.000Z");
 
 beforeEach(() => {
@@ -42,7 +89,7 @@ beforeEach(() => {
 
 describe("BudgetsPage — empty state", () => {
   it("renders empty placeholders for limits and goals", () => {
-    render(
+    renderBudgets(
       <BudgetsPage
         now={FIXED_NOW}
         seed={{ budgets: [], subscriptions: [], monthlyPlan: {} }}
@@ -56,7 +103,7 @@ describe("BudgetsPage — empty state", () => {
 
 describe("BudgetsPage — monthly plan", () => {
   it("renders fact and remaining when a plan + manual tx exists", () => {
-    render(
+    renderBudgets(
       <BudgetsPage
         now={FIXED_NOW}
         seed={{
@@ -95,7 +142,7 @@ describe("BudgetsPage — monthly plan", () => {
   });
 
   it("opens the plan sheet on tap and persists edits", async () => {
-    render(
+    renderBudgets(
       <BudgetsPage
         now={FIXED_NOW}
         seed={{ budgets: [], subscriptions: [], monthlyPlan: {} }}
@@ -118,7 +165,7 @@ describe("BudgetsPage — monthly plan", () => {
 
 describe("BudgetsPage — limits", () => {
   it("renders a limit budget row with computed amount", () => {
-    render(
+    renderBudgets(
       <BudgetsPage
         now={FIXED_NOW}
         seed={{
@@ -145,7 +192,7 @@ describe("BudgetsPage — limits", () => {
   });
 
   it("adds a new limit budget through the AddBudgetSheet", async () => {
-    render(
+    renderBudgets(
       <BudgetsPage
         now={FIXED_NOW}
         seed={{ budgets: [], subscriptions: [], monthlyPlan: {} }}
@@ -169,7 +216,7 @@ describe("BudgetsPage — limits", () => {
 
 describe("BudgetsPage — subscriptions", () => {
   it("renders seeded subscriptions with a billing badge", () => {
-    render(
+    renderBudgets(
       <BudgetsPage
         now={FIXED_NOW}
         seed={{
@@ -195,7 +242,7 @@ describe("BudgetsPage — subscriptions", () => {
 
   it("rolls billing day forward to next month when it has already passed", () => {
     // FIXED_NOW = 2026-04-21 → billing day 5 has passed → next charge = May 5
-    render(
+    renderBudgets(
       <BudgetsPage
         now={FIXED_NOW}
         seed={{
@@ -228,7 +275,7 @@ describe("BudgetsPage — subscriptions", () => {
 describe("BudgetsPage — same-day billing", () => {
   it("shows 'сьогодні' badge when billing day equals today", () => {
     // FIXED_NOW = 2026-04-21 → billingDay 21 should read as today
-    render(
+    renderBudgets(
       <BudgetsPage
         now={FIXED_NOW}
         seed={{
@@ -254,7 +301,7 @@ describe("BudgetsPage — same-day billing", () => {
 
 describe("BudgetsPage — limit sparkline", () => {
   it("renders a per-row sparkline for limit budgets", () => {
-    render(
+    renderBudgets(
       <BudgetsPage
         now={FIXED_NOW}
         seed={{

--- a/apps/mobile/src/modules/nutrition/NutritionApp.test.tsx
+++ b/apps/mobile/src/modules/nutrition/NutritionApp.test.tsx
@@ -11,22 +11,61 @@
  */
 
 import { fireEvent, render } from "@testing-library/react-native";
-import { ApiClientProvider } from "@sergeant/api-client/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ApiClientProvider, apiQueryKeys } from "@sergeant/api-client/react";
+import { createApiClient } from "@sergeant/api-client";
 
 import { STORAGE_KEYS } from "@sergeant/shared";
 
-import { apiClient } from "@/api/apiClient";
 import { _getMMKVInstance } from "@/lib/storage";
 import { ToastProvider } from "@/components/ui/Toast";
 
 import { NutritionApp } from "./NutritionApp";
 
+// `NutritionApp` mounts `useNutritionDualWriteBoot` (and the Dashboard
+// page mounts more `useUser`-backed hooks). All of them go through
+// `@tanstack/react-query`'s `useQuery`, which throws when there is no
+// `<QueryClientProvider>` higher in the tree. Without a provider the
+// surrounding `ModuleErrorBoundary` swallows the render and the test
+// asserts on hidden surfaces (animated opacity:0). Mirror the runtime
+// provider tree from `app/_layout.tsx` and pre-seed the user cache so
+// dual-write boot has a stable user id without hitting the network.
+const testUser = {
+  user: {
+    id: "test-user",
+    email: "test@example.com",
+    name: "Test User",
+    image: null,
+    emailVerified: true,
+    createdAt: "2026-04-21T00:00:00.000Z",
+  },
+};
+
+const testApiClient = createApiClient({
+  baseUrl: "http://127.0.0.1",
+  fetchImpl: async () =>
+    ({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-type": "application/json" }),
+      text: async () => JSON.stringify(testUser),
+    }) as Response,
+});
+
 function renderNutrition() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity, gcTime: Infinity },
+    },
+  });
+  queryClient.setQueryData(apiQueryKeys.me.current(), testUser);
   return render(
-    <ApiClientProvider client={apiClient}>
-      <ToastProvider>
-        <NutritionApp />
-      </ToastProvider>
+    <ApiClientProvider client={testApiClient}>
+      <QueryClientProvider client={queryClient}>
+        <ToastProvider>
+          <NutritionApp />
+        </ToastProvider>
+      </QueryClientProvider>
     </ApiClientProvider>,
   );
 }

--- a/apps/mobile/src/modules/routine/RoutineApp.test.tsx
+++ b/apps/mobile/src/modules/routine/RoutineApp.test.tsx
@@ -12,6 +12,9 @@
  */
 
 import { fireEvent, render } from "@testing-library/react-native";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ApiClientProvider, apiQueryKeys } from "@sergeant/api-client/react";
+import { createApiClient } from "@sergeant/api-client";
 
 import { STORAGE_KEYS } from "@sergeant/shared";
 
@@ -20,11 +23,52 @@ import { ToastProvider } from "@/components/ui/Toast";
 
 import { RoutineApp } from "./RoutineApp";
 
+// `RoutineApp` mounts `useRoutineDualWriteBoot` which calls
+// `useUser()` from `@sergeant/api-client/react`. That hook needs both
+// an `<ApiClientProvider>` (for the underlying ApiClient) and a
+// `<QueryClientProvider>` (for the React Query store). Without them
+// the boot hook throws and the surrounding `ModuleErrorBoundary`
+// catches the error and renders the "module crashed" fallback,
+// hiding the surfaces we want to assert on. Mirror the runtime
+// provider tree from `app/_layout.tsx` and pre-seed the user cache so
+// dual-write boot has a stable user id without hitting the network.
+const testUser = {
+  user: {
+    id: "test-user",
+    email: "test@example.com",
+    name: "Test User",
+    image: null,
+    emailVerified: true,
+    createdAt: "2026-04-21T00:00:00.000Z",
+  },
+};
+
+const testApiClient = createApiClient({
+  baseUrl: "http://127.0.0.1",
+  fetchImpl: async () =>
+    ({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-type": "application/json" }),
+      text: async () => JSON.stringify(testUser),
+    }) as Response,
+});
+
 function renderApp() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity, gcTime: Infinity },
+    },
+  });
+  queryClient.setQueryData(apiQueryKeys.me.current(), testUser);
   return render(
-    <ToastProvider>
-      <RoutineApp />
-    </ToastProvider>,
+    <ApiClientProvider client={testApiClient}>
+      <QueryClientProvider client={queryClient}>
+        <ToastProvider>
+          <RoutineApp />
+        </ToastProvider>
+      </QueryClientProvider>
+    </ApiClientProvider>,
   );
 }
 

--- a/docs/governance/hard-rules-matrix.md
+++ b/docs/governance/hard-rules-matrix.md
@@ -1,6 +1,6 @@
 # Hard rules — enforcement matrix
 
-> **Last validated:** 2026-05-07 by @Skords-01. **Next review:** 2026-08-05.
+> **Last validated:** 2026-05-08 by @Skords-01. **Next review:** 2026-08-06.
 > **Status:** Active
 
 <!-- AUTO-GENERATED FILE. Do not edit by hand. Source: `docs/governance/hard-rules.json`. Regenerate via `pnpm hard-rules:generate`. -->

--- a/docs/initiatives/follow-ups.md
+++ b/docs/initiatives/follow-ups.md
@@ -1,6 +1,6 @@
 # Initiative follow-ups
 
-> **Last validated:** 2026-05-07 by @Skords-01. **Next review:** 2026-08-05.
+> **Last validated:** 2026-05-08 by @Skords-01. **Next review:** 2026-08-06.
 > **Status:** Active
 
 <!-- AUTO-GENERATED FILE. Do not edit by hand. Regenerate via `pnpm docs:gen-initiative-followups`. -->


### PR DESCRIPTION
## Summary

Closes audit follow-up **#5 mobile Jest reliability** (`docs/audits/2026-05-07-full-app-regression-ux-audit.md`). Re-running `pnpm --filter @sergeant/mobile exec jest --runInBand` under Node 20.20.2 surfaced 5 failing suites, all driven by two latent test-setup bugs (no product code involved):

1. **`AnalyticsIdentityBridge.test.tsx`** referenced a top-level `useUserMock` inside a `jest.mock()` factory. Babel-jest hoists factories above imports and only allows out-of-scope variables whose name starts with `mock` (case-insensitive). Renamed `useUserMock` → `mockUseUser`.
2. **`FinykApp` / `BudgetsPage` / `NutritionApp` / `RoutineApp`** shells all mount a dual-write boot hook that calls `useUser()` from `@sergeant/api-client/react`. That hook requires both `<ApiClientProvider>` and `<QueryClientProvider>` higher in the tree. Without them the boot hook throws, the surrounding `ModuleErrorBoundary` swallows the render, and tests asserted on hidden surfaces (animated `opacity:0`). Mirrored the runtime provider tree from `app/_layout.tsx` (Api → QueryClient → Toast) and pre-seeded the `me` query cache with a fixed `testUser` so dual-write boot receives a stable user id without firing a fetch. Same shape as the existing `TransactionsPage.test.tsx` helper.

## Governing Skill

- Primary skill: n/a (direct test-fixture maintenance)
- Secondary skill: n/a

## Playbook

- Primary playbook: n/a
- Why this playbook: n/a
- If no playbook matched, why: scoped, mechanical fix to test setup; existing `TransactionsPage` helper is the in-repo pattern.

## Verification

```bash
# Full mobile Jest under Node 20 — 624/624 passed, peak heap ~1 GB
source ~/.devin/use-node20.sh
cd apps/mobile && NODE_OPTIONS="--max-old-space-size=4096" \
  pnpm exec jest --runInBand --logHeapUsage --silent
# Test Suites: 96 passed, 96 total
# Tests:       624 passed, 624 total
# Time:        52.847 s

# Typecheck stays green
pnpm --filter @sergeant/mobile typecheck

# Targeted fence
cd apps/mobile && pnpm exec jest \
  src/modules/finyk/pages/Transactions/TransactionsPage.test.tsx \
  src/lib/__tests__/identifyTraits.test.ts --runInBand
# 28/28 passed
```

Verified absent in the run log (the symptoms the audit flagged):

- `Cannot log after tests are done` — 0 occurrences
- `not wrapped in act(...)` — 0 occurrences in full-suite log
- worker OOM / heap exhaustion — peak ~1 GB / 4 GB

Additional checks:

- [x] Local `--runInBand` smoke completed (Node 20.20.2 / pnpm 9.15.1)
- [x] Targeted fence (TransactionsPage, identifyTraits) re-ran clean

## Docs and Governance

- [x] No behavior/contract/workflow change → no docs to update.
- [x] `AGENTS.md` not affected.
- [x] No playbook/skill change.
- [x] No governance/review docs.

Updated docs:

- n/a (the audit doc itself will be updated together with the #7 UX-hardening PR which closes the remaining audit row).

## Risk and Rollout

- User-visible risk: **none** — test-only changes, no product diff.
- Rollout / deploy order: merge anytime; CI is the only consumer.
- Backout plan: revert this commit; pre-fix suites were already red, so revert restores the previous failing baseline rather than breaking green.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian (none touched).
- [x] I did not use `--no-verify` (pre-commit `staged-typecheck.mjs` ran clean).

## Audit-freeze (until 2026-06-02)

- [x] No new files under `docs/audits/`, `docs/initiatives/`, `docs/playbooks/`, `docs/adr/`.

## Reviewer Notes

Things worth a closer look:

- **Provider tree parity** — the helper renders `<ApiClientProvider><QueryClientProvider><ToastProvider>{ui}` in the suites that previously had Toast (Nutrition, Routine) and `<ApiClientProvider><QueryClientProvider>{ui}` for the two Finyk suites that never used Toast. Confirm this matches `app/_layout.tsx` for the surfaces under test.
- **`fetchImpl` stub** — returns the seeded `testUser` JSON on any request. With `staleTime: Infinity` and `apiQueryKeys.me.current()` pre-seeded, the `me` query never fetches. Other queries that fire during the render (none observed in the failing assertions) would receive an unrelated `MeResponse`-shaped body — flag if you spot a query whose schema validation would reject this.
- **`mock` prefix rename** — purely a Jest-hoisting requirement; behavior of `AnalyticsIdentityBridge` is unchanged.
- **Audit #7 UX hardening** is the next PR (separate branch); this one only closes #5.

Link to Devin session: https://app.devin.ai/sessions/468732c16b1b4805b00ee2d0d47865f1
Requested by: @Skords-01

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mobile Jest reliability by wrapping module shell tests with runtime `ApiClient`/React Query providers and fixing a `jest.mock` hoisting issue. Regenerates auto-generated docs banners for CI; closes audit follow-up #5; test-only changes.

- **Bug Fixes**
  - Wrapped `FinykApp`, `BudgetsPage`, `NutritionApp`, `RoutineApp` tests with `<ApiClientProvider>` + `<QueryClientProvider>` (mirrors `app/_layout.tsx`) to satisfy `useUser()` from `@sergeant/api-client/react` and avoid ErrorBoundary fallbacks.
  - Pre-seeded `@tanstack/react-query` cache (`apiQueryKeys.me`) with a static test user and stubbed `createApiClient` `fetchImpl` to skip network calls.
  - Renamed `useUserMock` → `mockUseUser` to comply with `jest.mock()` factory hoisting rules.

<sup>Written for commit 6283dc2915a752d9f3dc3537e698173f3c61c10d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure across multiple modules to properly configure API client and React Query providers, pre-seed test data, and improve test environment setup consistency with runtime behavior for more reliable testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->