### PR TITLE
test(web): stable FTUX seed/dismiss helper + visual matrix coverage (audit #7)

### DIFF
--- a/apps/web/tests/a11y/ds-visual-qa.spec.ts
+++ b/apps/web/tests/a11y/ds-visual-qa.spec.ts
@@ -1,114 +1,129 @@
 import { test, type Page } from "@playwright/test";
 import { argosScreenshot } from "@argos-ci/playwright";
 
+import {
+  ALL_FTUX_MODULES,
+  type FtuxModuleId,
+  type FtuxSeedMode,
+  type FtuxTheme,
+  seedFTUX,
+} from "../utils/seedFTUX";
+
 /**
- * Design-system visual regression.
+ * Design-system visual regression — full viewport / theme / surface
+ * matrix exercised by audit follow-up #7
+ * (`docs/audits/2026-05-07-full-app-regression-ux-audit.md` §7).
  *
- * Baselines cover the activation-critical surfaces (welcome, pre-FTUX
- * hub, post-FTUX hub) plus the module shells across light/dark mode and
- * the requested mobile/desktop sizes.
+ * Coverage
+ * --------
+ * Viewports — 1440 / 768 / 390 / 320 (audit-required widths) plus
+ * legacy 1280 mid-desktop kept for continuity with the previous
+ * baseline. Themes — light + dark. Surfaces:
+ *
+ *   - welcome              → cold-start, `<WelcomeScreen />`
+ *   - auth                 → `/sign-in`, `<AuthPage />`
+ *   - hub-pre-ftux         → `/`, FTUX hero pending (one-tap card)
+ *   - hub                  → `/`, post-FTUX dashboard
+ *   - finyk / fizruk /
+ *     routine / nutrition  → module shells, post-FTUX
+ *   - finyk-first-run /    → `<ModuleFirstRunGoalSheet />` («Налаштуй
+ *     nutrition-first-run    Фінік / Харчування») surfaces specifically
+ *                            seeded by audit #7 — these are the most
+ *                            common bottom-sheet collisions in the
+ *                            manual UX pass.
+ *   - hub-chat             → `/chat`, `<HubChatPage />`
+ *
+ * All seeding goes through `tests/utils/seedFTUX.ts` so the welcome /
+ * first-action / module-first-run / what's-new gates are dismissed
+ * (or armed, in the targeted first-run case) deterministically before
+ * navigation. Adding a new gate? Update `seedFTUX.ts` once and every
+ * surface here picks the change up automatically.
  */
 
 const VIEWPORTS = [
-  { name: "mobile-375", width: 375, height: 812 },
-  { name: "mobile-414", width: 414, height: 900 },
-  { name: "tablet-768", width: 768, height: 900 },
+  { name: "mobile-320", width: 320, height: 568 },
+  { name: "mobile-390", width: 390, height: 844 },
+  { name: "tablet-768", width: 768, height: 1024 },
   { name: "desktop-1280", width: 1280, height: 800 },
+  { name: "desktop-1440", width: 1440, height: 900 },
 ] as const;
-const THEMES = ["light", "dark"] as const;
 
-const POST_FTUX_SEED = "post-ftux" as const;
-const PRE_FTUX_SEED = "pre-ftux" as const;
+const THEMES = ["light", "dark"] as const satisfies readonly FtuxTheme[];
 
-const SURFACES: Array<{
+interface SurfaceSpec {
   name: string;
   path: string;
-  seed: typeof POST_FTUX_SEED | typeof PRE_FTUX_SEED | null;
-}> = [
-  { name: "welcome", path: "/welcome", seed: null },
-  { name: "hub-pre-ftux", path: "/", seed: PRE_FTUX_SEED },
-  { name: "hub", path: "/", seed: POST_FTUX_SEED },
-  { name: "finyk", path: "/?module=finyk", seed: POST_FTUX_SEED },
-  { name: "fizruk", path: "/?module=fizruk", seed: POST_FTUX_SEED },
-  { name: "routine", path: "/?module=routine", seed: POST_FTUX_SEED },
-  { name: "nutrition", path: "/?module=nutrition", seed: POST_FTUX_SEED },
-];
-
-function buildSeed(
-  theme: "light" | "dark",
-  mode: typeof POST_FTUX_SEED | typeof PRE_FTUX_SEED,
-): Record<string, string> {
-  const now = Date.now();
-  const seed: Record<string, string> = {
-    hub_onboarding_done_v1: "1",
-    finyk_manual_only_v1: "1",
-    hub_dark_mode_v1: theme === "dark" ? "1" : "0",
-    hub_onboarding_vibes_v1: JSON.stringify([
-      "finyk",
-      "fizruk",
-      "nutrition",
-      "routine",
-    ]),
-    hub_vibe_picks_v1: JSON.stringify({
-      picks: ["finyk", "fizruk", "nutrition", "routine"],
-      firstActionPending: mode === PRE_FTUX_SEED ? "finyk" : null,
-      firstActionStartedAt: mode === PRE_FTUX_SEED ? now : null,
-      firstRealEntryAt: mode === POST_FTUX_SEED ? now : null,
-      updatedAt: now,
-    }),
-  };
-
-  if (mode === POST_FTUX_SEED) {
-    seed.hub_first_real_entry_done_v1 = "1";
-  } else {
-    seed.hub_first_action_pending_v1 = "1";
-    seed.hub_first_action_started_at_v1 = String(now);
-  }
-
-  return seed;
+  mode: FtuxSeedMode;
+  /** Required when `mode === "module-first-run"`. */
+  moduleId?: FtuxModuleId;
+  /** Spec-specific localStorage entries layered on top of the base seed. */
+  extra?: Record<string, string>;
 }
 
-async function seedLocalStorage(
-  page: Page,
-  theme: "light" | "dark",
-  mode: typeof POST_FTUX_SEED | typeof PRE_FTUX_SEED | null,
-) {
-  if (!mode) {
-    await page.addInitScript((dark: boolean) => {
-      try {
-        window.localStorage.setItem("hub_dark_mode_v1", dark ? "1" : "0");
-      } catch {
-        /* ignore */
-      }
-    }, theme === "dark");
-    return;
-  }
+const FINYK_MANUAL_ONLY: Record<string, string> = { finyk_manual_only_v1: "1" };
 
-  await page.addInitScript(
-    (entries: Record<string, string>) => {
-      try {
-        for (const [k, v] of Object.entries(entries)) {
-          window.localStorage.setItem(k, v);
-        }
-      } catch {
-        /* ignore */
-      }
-    },
-    buildSeed(theme, mode),
-  );
+const SURFACES: readonly SurfaceSpec[] = [
+  { name: "welcome", path: "/welcome", mode: "cold" },
+  { name: "auth", path: "/sign-in", mode: "cold" },
+  {
+    name: "hub-pre-ftux",
+    path: "/",
+    mode: "pre-ftux",
+    extra: FINYK_MANUAL_ONLY,
+  },
+  { name: "hub", path: "/", mode: "post-ftux", extra: FINYK_MANUAL_ONLY },
+  ...ALL_FTUX_MODULES.map<SurfaceSpec>((id) => ({
+    name: id,
+    path: `/?module=${id}`,
+    mode: "post-ftux",
+    extra: id === "finyk" ? FINYK_MANUAL_ONLY : undefined,
+  })),
+  {
+    name: "finyk-first-run",
+    path: "/?module=finyk",
+    mode: "module-first-run",
+    moduleId: "finyk",
+    extra: FINYK_MANUAL_ONLY,
+  },
+  {
+    name: "nutrition-first-run",
+    path: "/?module=nutrition",
+    mode: "module-first-run",
+    moduleId: "nutrition",
+  },
+  {
+    name: "hub-chat",
+    path: "/chat",
+    mode: "post-ftux",
+    extra: FINYK_MANUAL_ONLY,
+  },
+];
+
+async function applySeed(
+  page: Page,
+  theme: FtuxTheme,
+  surface: SurfaceSpec,
+): Promise<void> {
+  await seedFTUX(page, surface.mode, {
+    theme,
+    moduleId: surface.moduleId,
+    extra: surface.extra,
+  });
 }
 
 for (const theme of THEMES) {
   for (const viewport of VIEWPORTS) {
-    for (const { name, path: routePath, seed } of SURFACES) {
-      test(`visual: ${theme} ${viewport.name} ${name}`, async ({ page }) => {
+    for (const surface of SURFACES) {
+      test(`visual: ${theme} ${viewport.name} ${surface.name}`, async ({
+        page,
+      }) => {
         await page.setViewportSize({
           width: viewport.width,
           height: viewport.height,
         });
-        await seedLocalStorage(page, theme, seed);
+        await applySeed(page, theme, surface);
 
-        await page.goto(routePath, { waitUntil: "domcontentloaded" });
+        await page.goto(surface.path, { waitUntil: "domcontentloaded" });
         await page
           .waitForLoadState("networkidle", { timeout: 15_000 })
           .catch(() => {
@@ -118,12 +133,19 @@ for (const theme of THEMES) {
           .locator("main, #root > *")
           .first()
           .waitFor({ state: "visible", timeout: 10_000 });
+        // Module-first-run sheets fade in — give the Sheet animation
+        // enough time to settle before snapshotting. 800 ms keeps
+        // parity with the previous baseline timing.
         await page.waitForTimeout(800);
 
-        await argosScreenshot(page, `${theme}/${viewport.name}/${name}`, {
-          fullPage: true,
-          animations: "disabled",
-        });
+        await argosScreenshot(
+          page,
+          `${theme}/${viewport.name}/${surface.name}`,
+          {
+            fullPage: true,
+            animations: "disabled",
+          },
+        );
       });
     }
   }

--- a/apps/web/tests/utils/seedFTUX.ts
+++ b/apps/web/tests/utils/seedFTUX.ts
@@ -1,0 +1,287 @@
+/**
+ * Stable seed/dismiss helpers for the FTUX surfaces (PR-7 of audit
+ * `2026-05-07-full-app-regression-ux-audit.md`).
+ *
+ * Why this module exists
+ * ----------------------
+ * The web app has three independent FTUX overlays that all auto-open
+ * on cold start and that all must be dismissed before any meaningful
+ * Hub / module surface is visible:
+ *
+ *   1. `/welcome` cold-start splash (`<WelcomeScreen />`, gated by
+ *      `shouldShowOnboarding()` → `hub_onboarding_done_v1`).
+ *   2. `<FirstActionHeroCard />` — the "one tap to your first real
+ *      entry" card on the Hub dashboard. Gated by
+ *      `hub_first_action_pending_v1` (set by the wizard, cleared by
+ *      `dismissFirstAction` / `markFirstRealEntryDone`).
+ *   3. `<ModuleFirstRunGoalSheet />` — the per-module bottom sheet
+ *      («Налаштуй Фінік», «Налаштуй Харчування», «Налаштуй Рутину»,
+ *      «Налаштуй Фізрук»). Gated by
+ *      `sergeant.onboarding.module_first_seen.<moduleId>.v1`.
+ *
+ * Plus `<WhatsNewModal />` which auto-shows ~2.5 s after dashboard mount
+ * unless `sergeant.whatsNew.lastSeenId.v1` already matches `RELEASES[0]`.
+ *
+ * Before this helper, every smoke / visual spec inlined a slightly
+ * different copy of the seed map: `bottom-nav.spec.ts` covered the
+ * module-first-run + whats-new keys, `dashboard-health.spec.ts` only
+ * covered the wizard + vibe-picks, and `ds-visual-qa.spec.ts` covered
+ * the FTUX hero but not the module sheets — meaning the visual matrix
+ * had a non-deterministic «Налаштуй …» overlay over the module
+ * baselines. The audit (#7) called this out as a manual UX-pass
+ * stability issue; centralising the seed contract here is the fix.
+ *
+ * Single source of truth
+ * ----------------------
+ * Storage keys are imported from the canonical packages where they
+ * live (`@sergeant/shared`, `apps/web/src/core/onboarding/...`,
+ * `apps/web/src/core/whatsNew/...`) so that a key rename in source
+ * cannot silently break the seed contract.
+ *
+ * Usage
+ * -----
+ *   await seedFTUX(page, "post-ftux", { theme: "dark" });
+ *   await page.goto("/?module=finyk");
+ *
+ * Modes:
+ *   - "cold"             — only theme set, nothing dismissed. Welcome
+ *                          splash takes over `/`. Use this for `/welcome`
+ *                          screenshots.
+ *   - "pre-ftux"         — onboarding done, FTUX hero pending,
+ *                          module-first-seen flags marked, what's-new
+ *                          dismissed. Use for the pre-FTUX dashboard
+ *                          baseline.
+ *   - "post-ftux"        — onboarding done, FTUX hero dismissed, real
+ *                          entry recorded, all module-first-seen flags
+ *                          marked, what's-new dismissed. Use for the
+ *                          steady-state Hub + module shells.
+ *   - "module-first-run" — like `post-ftux` but the named module's
+ *                          first-seen flag is left absent so
+ *                          `<ModuleFirstRunGoalSheet />` auto-opens.
+ *                          Used by visual baselines that specifically
+ *                          want the «Налаштуй …» sheet on screen.
+ */
+
+import type { Page } from "@playwright/test";
+
+import {
+  FIRST_ACTION_PENDING_KEY,
+  FIRST_ACTION_STARTED_AT_KEY,
+  FIRST_REAL_ENTRY_KEY,
+  ONBOARDING_DONE_KEY,
+  SOFT_AUTH_DISMISSED_KEY,
+  VIBE_PICKS_KEY,
+  type DashboardModuleId,
+} from "@sergeant/shared";
+
+import { RELEASES } from "../../src/core/whatsNew/releases";
+import { WHATS_NEW_LAST_SEEN_KEY } from "../../src/core/whatsNew/storage";
+
+/** Mirrors the constant in `useDarkMode.ts` (private inside the hook). */
+const DARK_MODE_KEY = "hub_dark_mode_v1";
+
+/** Legacy «first action done» flag still read by some surfaces. */
+const FIRST_ACTION_DONE_LEGACY_KEY = "hub_first_action_done_v1";
+
+/**
+ * Mirrors `FIRST_SEEN_KEY_PREFIX/SUFFIX` in
+ * `apps/web/src/core/onboarding/ModuleFirstRunGoalSheet.tsx`. Marking
+ * this flag suppresses the «Налаштуй <module>» bottom sheet that auto-
+ * opens on first module mount.
+ */
+const MODULE_FIRST_SEEN_KEY_PREFIX = "sergeant.onboarding.module_first_seen.";
+const MODULE_FIRST_SEEN_KEY_SUFFIX = ".v1";
+
+export const ALL_FTUX_MODULES = [
+  "finyk",
+  "fizruk",
+  "routine",
+  "nutrition",
+] as const satisfies readonly DashboardModuleId[];
+
+export type FtuxModuleId = (typeof ALL_FTUX_MODULES)[number];
+
+export function moduleFirstSeenKey(moduleId: FtuxModuleId): string {
+  return `${MODULE_FIRST_SEEN_KEY_PREFIX}${moduleId}${MODULE_FIRST_SEEN_KEY_SUFFIX}`;
+}
+
+export type FtuxTheme = "light" | "dark";
+
+export type FtuxSeedMode =
+  | "cold"
+  | "pre-ftux"
+  | "post-ftux"
+  | "module-first-run";
+
+export interface SeedFTUXOptions {
+  /** Theme to apply via `hub_dark_mode_v1`. Defaults to `"light"`. */
+  theme?: FtuxTheme;
+  /**
+   * Module whose first-run sheet should be left armed. Required for
+   * `mode === "module-first-run"`, ignored otherwise.
+   */
+  moduleId?: FtuxModuleId;
+  /**
+   * Extra localStorage entries to merge after the canonical FTUX seed.
+   * Use this for spec-specific keys (e.g. `finyk_manual_only_v1`)
+   * without forking the helper.
+   */
+  extra?: Record<string, string>;
+}
+
+/** All keys this helper writes — exported so cleanup specs can wipe
+ *  the world if they need to (e.g. a returning-user spec that wants
+ *  to start from a truly empty `localStorage`). */
+export const FTUX_SEED_KEYS: readonly string[] = [
+  DARK_MODE_KEY,
+  ONBOARDING_DONE_KEY,
+  FIRST_ACTION_DONE_LEGACY_KEY,
+  FIRST_ACTION_PENDING_KEY,
+  FIRST_ACTION_STARTED_AT_KEY,
+  FIRST_REAL_ENTRY_KEY,
+  SOFT_AUTH_DISMISSED_KEY,
+  VIBE_PICKS_KEY,
+  "hub_vibe_picks_v1",
+  WHATS_NEW_LAST_SEEN_KEY,
+  ...ALL_FTUX_MODULES.map(moduleFirstSeenKey),
+];
+
+interface InitScriptPayload {
+  toSet: Record<string, string>;
+  toRemove: readonly string[];
+}
+
+function buildPayload(
+  mode: FtuxSeedMode,
+  options: SeedFTUXOptions,
+): InitScriptPayload {
+  const theme = options.theme ?? "light";
+  const now = Date.now();
+  const set: Record<string, string> = {
+    [DARK_MODE_KEY]: theme === "dark" ? "1" : "0",
+  };
+  const remove: string[] = [];
+
+  if (mode === "cold") {
+    // Welcome splash should take over `/`. Strip every other gate so
+    // the spec can verify the cold-start surface deterministically.
+    remove.push(
+      ONBOARDING_DONE_KEY,
+      FIRST_ACTION_DONE_LEGACY_KEY,
+      FIRST_ACTION_PENDING_KEY,
+      FIRST_ACTION_STARTED_AT_KEY,
+      FIRST_REAL_ENTRY_KEY,
+      SOFT_AUTH_DISMISSED_KEY,
+      VIBE_PICKS_KEY,
+      "hub_vibe_picks_v1",
+      WHATS_NEW_LAST_SEEN_KEY,
+      ...ALL_FTUX_MODULES.map(moduleFirstSeenKey),
+    );
+    return { toSet: { ...set, ...(options.extra ?? {}) }, toRemove: remove };
+  }
+
+  // Onboarding wizard finished — `<WelcomeScreen />` redirects away
+  // from `/welcome` once this flag is "1".
+  set[ONBOARDING_DONE_KEY] = "1";
+
+  // Vibe picks — pin all four modules so the dashboard renders the
+  // full bento grid rather than the empty-state. The shared key
+  // (`VIBE_PICKS_KEY = "hub_onboarding_vibes_v1"`) is the canonical
+  // one; the legacy `hub_vibe_picks_v1` blob is also written so any
+  // surface still reading the older shape (FirstActionHeroCard,
+  // analytics) sees consistent state.
+  const allModules: readonly FtuxModuleId[] = ALL_FTUX_MODULES;
+  set[VIBE_PICKS_KEY] = JSON.stringify(allModules);
+  set["hub_vibe_picks_v1"] = JSON.stringify({
+    picks: allModules,
+    firstActionPending: mode === "pre-ftux" ? "finyk" : null,
+    firstActionStartedAt: mode === "pre-ftux" ? now : null,
+    firstRealEntryAt: mode === "pre-ftux" ? null : now,
+    updatedAt: now,
+  });
+
+  if (mode === "pre-ftux") {
+    set[FIRST_ACTION_PENDING_KEY] = "1";
+    set[FIRST_ACTION_STARTED_AT_KEY] = String(now);
+    remove.push(FIRST_REAL_ENTRY_KEY, FIRST_ACTION_DONE_LEGACY_KEY);
+  } else {
+    // post-ftux + module-first-run — first-action hero is dismissed,
+    // first-real-entry recorded so the soft-auth nag does not fire.
+    set[FIRST_REAL_ENTRY_KEY] = "1";
+    set[FIRST_ACTION_DONE_LEGACY_KEY] = "1";
+    remove.push(FIRST_ACTION_PENDING_KEY, FIRST_ACTION_STARTED_AT_KEY);
+  }
+
+  // Suppress the soft-auth nag — the visual matrix is anonymous and
+  // the nag would fire ~2 session-days in. Idempotent: writing "1" is
+  // safe even when the key is absent.
+  set[SOFT_AUTH_DISMISSED_KEY] = "1";
+
+  // Suppress the «What's new» modal. `<useWhatsNew />` calls
+  // `pickRelease(lastSeenId)` which returns `null` when `lastSeenId
+  // === RELEASES[0].id`, so the modal never auto-opens.
+  const latestRelease = RELEASES[0];
+  if (latestRelease) {
+    set[WHATS_NEW_LAST_SEEN_KEY] = latestRelease.id;
+  }
+
+  // Mark every module's first-run sheet as already seen — except the
+  // single module the caller wants to capture. `module-first-run`
+  // therefore gives a deterministic single-sheet screenshot.
+  const skip = mode === "module-first-run" ? options.moduleId : null;
+  for (const id of ALL_FTUX_MODULES) {
+    if (id === skip) {
+      remove.push(moduleFirstSeenKey(id));
+    } else {
+      set[moduleFirstSeenKey(id)] = "1";
+    }
+  }
+
+  return { toSet: { ...set, ...(options.extra ?? {}) }, toRemove: remove };
+}
+
+/**
+ * Seed `localStorage` so the FTUX surfaces match `mode` *before* the
+ * page navigates. Must be called before `page.goto(...)` — uses
+ * `addInitScript` so the seed is in place before any app code runs.
+ *
+ * Idempotent: calling twice does not double-write keys, and unknown
+ * mode/module combinations throw at boot rather than at assertion
+ * time.
+ */
+export async function seedFTUX(
+  page: Page,
+  mode: FtuxSeedMode,
+  options: SeedFTUXOptions = {},
+): Promise<void> {
+  if (mode === "module-first-run" && !options.moduleId) {
+    throw new Error(
+      'seedFTUX("module-first-run") requires options.moduleId — pick the module whose first-run sheet should auto-open.',
+    );
+  }
+  const payload = buildPayload(mode, options);
+  await page.addInitScript((p: InitScriptPayload) => {
+    try {
+      for (const k of p.toRemove) {
+        window.localStorage.removeItem(k);
+      }
+      for (const [k, v] of Object.entries(p.toSet)) {
+        window.localStorage.setItem(k, v);
+      }
+    } catch {
+      /* ignore — incognito storage quotas, etc. */
+    }
+  }, payload);
+}
+
+/**
+ * Convenience wrapper for the most common case: post-FTUX dashboard
+ * with a known theme. Equivalent to
+ * `seedFTUX(page, "post-ftux", { theme })`.
+ */
+export async function seedHub(
+  page: Page,
+  theme: FtuxTheme = "light",
+): Promise<void> {
+  await seedFTUX(page, "post-ftux", { theme });
+}


### PR DESCRIPTION
## Summary

Closes audit follow-up #7 from `docs/audits/2026-05-07-full-app-regression-ux-audit.md` (manual UX-pass hardening). Two changes:

- **New `apps/web/tests/utils/seedFTUX.ts`** — a single helper that seeds/dismisses every FTUX gate the web app exposes (`/welcome` splash, `<FirstActionHeroCard />`, `<ModuleFirstRunGoalSheet />`, `<WhatsNewModal />`) plus theme. Storage keys are imported from `@sergeant/shared` and from the source modules (`whatsNew/storage`, `whatsNew/releases`) so a key rename in source cannot silently break the seed contract. Four modes: `cold`, `pre-ftux`, `post-ftux`, `module-first-run` (the last one arms exactly one bottom sheet for deterministic screenshots).
- **`ds-visual-qa.spec.ts` rewired onto the helper.** Surface set grew from 7 → 11 (added `auth` at `/sign-in`, `hub-chat` at `/chat`, `finyk-first-run`, `nutrition-first-run`). Viewport set grew from 4 → 5 (audit-required 320 / 390 / 768 / 1440 plus the legacy 1280 mid-desktop kept for continuity). Total Argos baselines: **110** (was 56).

No product code changes; tests + helper only.

## Governing Skill

- Primary skill: n/a — direct implementation against an audit follow-up
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a
- Why this playbook: n/a
- If no playbook matched, why: this is targeted test infra hardening tied to an existing audit doc; no playbook covers visual-matrix expansion specifically.

## Verification

```bash
# Typecheck (whole web app)
pnpm --filter @sergeant/web exec tsc --noEmit
# → exit 0, no diagnostics

# ESLint on changed files
pnpm --filter @sergeant/web exec eslint tests/utils/seedFTUX.ts tests/a11y/ds-visual-qa.spec.ts
# → exit 0

# Test discovery (confirms 110 tests)
PW_SKIP_WEBSERVER=1 pnpm --filter @sergeant/web exec playwright test \
  -c playwright.visual.config.ts --list
# → "Total: 110 tests in 1 file"

# Pre-commit (lint-staged) ran on commit and passed.
```

Additional checks:

- [x] Typecheck passes
- [x] Lint passes on changed files
- [x] Playwright test discovery confirms 110 tests
- [ ] Full visual matrix run end-to-end — deferred to CI / Argos baseline review

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. — n/a (test infra only)
- [x] I checked whether `AGENTS.md` needed an update. — no
- [x] I checked whether a playbook or skill needed an update. — no
- [x] I checked whether governance docs or review docs needed an update. — no

Updated docs: n/a. Audit doc (`docs/audits/2026-05-07-full-app-regression-ux-audit.md`) will be updated in a follow-up commit once the new Argos baselines are accepted.

## Risk and Rollout

- **User-visible risk:** none — test-only change.
- **Rollout / deploy order:** merge after Argos baselines are reviewed and accepted (the new surfaces and viewports will register as new baselines, not regressions).
- **Backout plan:** revert this PR. The previous `seedLocalStorage` + 7-surface matrix is fully self-contained in this single commit.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian. — n/a (no doc changes; user-facing strings in JSDoc are Ukrainian where they reference UI copy, e.g. «Налаштуй Фінік»).
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

Things worth a careful look:

1. **Argos baselines.** This PR roughly doubles the baseline set (56 → 110). The four genuinely new surfaces (`auth`, `hub-chat`, `finyk-first-run`, `nutrition-first-run`) and the new viewports (320, 390, 1440) will register as new baselines in Argos and need to be accepted manually. The seven previously-existing surfaces should look effectively unchanged, but the inner-frame timing changes (animations + 800 ms wait are unchanged) should be verified visually for any unintended diffs.
2. **Viewport list kept 1280 in addition to the audit-required 1440.** Audit spec line 247 lists "1440 / 768 / 390 / 320" — I kept 1280 to avoid invalidating the existing mid-desktop baseline. Happy to drop 1280 if you'd prefer the matrix to match the audit exactly (saves 22 baselines).
3. **`module-first-run` mode for `finyk` includes `finyk_manual_only_v1`** (suppresses the bank-import CTA so the bottom sheet is the only overlay). The `nutrition` first-run does not need that flag. Confirm this matches how you want the «Налаштуй …» surfaces captured.
4. **Storage key sources.** `DARK_MODE_KEY` and `FIRST_ACTION_DONE_LEGACY_KEY` are duplicated as string literals in `seedFTUX.ts` because their canonical sources don't export them (they're private inside `useDarkMode.ts` and not exported anywhere as a constant respectively). If we want strict SSOT, those would need a small product-side export — flag if you'd like that as a follow-up.
5. **`FTUX_SEED_KEYS` export is currently unused** internally — it's there for future cleanup specs (e.g. a returning-user smoke that wants to wipe `localStorage` to a known state). Remove if you'd prefer no dead exports.
6. **No audit-doc update in this PR.** I deferred updating `docs/audits/2026-05-07-full-app-regression-ux-audit.md` until the new baselines land in Argos so the evidence link points at a real run; happy to fold the doc update in here if you'd rather not split it.
7. **End-to-end matrix not run locally.** Local verification was typecheck + lint + Playwright `--list`. The full 110-test run depends on a Vite preview server and the Argos token — both available on CI. If you'd like a local dry run before review, I can run it against a local preview server and post the HTML report.

Link to Devin session: https://app.devin.ai/sessions/468732c16b1b4805b00ee2d0d47865f1
Requested by: @Skords-01

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a stable FTUX seed/dismiss helper for web tests and expands the visual QA matrix per audit follow-up #7. Test-only; makes first‑run sheets deterministic and increases Argos baselines to 110.

- **New Features**
  - Added `apps/web/tests/utils/seedFTUX.ts` to seed/dismiss welcome, first-action, module-first-run, and what’s new, plus theme. Keys come from `@sergeant/shared` and the source modules to avoid drift. Includes a targeted `module-first-run` mode.
  - Rewired `ds-visual-qa.spec.ts` to use the helper and cover 11 surfaces (welcome, auth, hub pre/post‑FTUX, all modules, finyk/nutrition first‑run, hub-chat) across 5 viewports (320, 390, 768, 1280, 1440) and both themes — 110 Argos baselines.

<sup>Written for commit f0929a3df2b250b236303d2e1ba23f72d15b0aaf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

