### PR TITLE
fix: bug review — XSS, analytics conflation, silent failures, invalid date keys

### DIFF
--- a/apps/server/src/modules/openclaw/store.ts
+++ b/apps/server/src/modules/openclaw/store.ts
@@ -64,7 +64,9 @@ export async function openInvocation(
   // BIGINT → string у pg-driver default; coerce-ять до number для зручного
   // використання у app-коді. Hard-rule #1 (BIGINT serialization safety):
   // у Phase 1 у нас точно <2^53 invocations.
-  return Number(result.rows[0]?.id ?? 0);
+  const row = result.rows[0];
+  if (!row) throw new Error("openInvocation: INSERT RETURNING returned no rows");
+  return Number(row.id);
 }
 
 export interface FinalizeInvocationInput {
@@ -190,7 +192,10 @@ export async function insertDecision(
       JSON.stringify(input.metadata ?? {}),
     ],
   );
-  return Number(result.rows[0]?.id ?? 0);
+  const decisionRow = result.rows[0];
+  if (!decisionRow)
+    throw new Error("insertDecision: INSERT RETURNING returned no rows");
+  return Number(decisionRow.id);
 }
 
 /**
@@ -369,7 +374,10 @@ export async function recordWriteAudit(
       JSON.stringify(input.metadata ?? {}),
     ],
   );
-  return Number(result.rows[0]?.id ?? 0);
+  const auditRow = result.rows[0];
+  if (!auditRow)
+    throw new Error("recordWriteAudit: INSERT RETURNING returned no rows");
+  return Number(auditRow.id);
 }
 
 export interface ListWriteAuditFilters {

--- a/apps/web/src/core/components/AssistantMessageBody.tsx
+++ b/apps/web/src/core/components/AssistantMessageBody.tsx
@@ -6,21 +6,30 @@ interface AssistantMessageBodyProps {
   text: string;
 }
 
+/** Allow only safe URL schemes — blocks javascript:, data:, vbscript:, etc. */
+function isSafeHref(href: string | undefined): boolean {
+  if (!href) return false;
+  return /^(https?:\/\/|\/|#)/i.test(href);
+}
+
 function AssistantMessageBodyImpl({ text }: AssistantMessageBodyProps) {
   return (
     <ReactMarkdown
       className="text-sm leading-relaxed [&_strong]:font-semibold [&_em]:italic [&_ul]:list-disc [&_ul]:pl-4 [&_ol]:list-decimal [&_ol]:pl-4 [&_p]:my-1 [&_li]:my-0.5 [&_a]:text-primary [&_a]:underline [&_h3]:text-base [&_h3]:font-bold [&_h3]:mt-2 [&_h3]:mb-1 [&_h4]:text-sm [&_h4]:font-semibold [&_h4]:mt-3 [&_h4]:mb-1 [&_h4]:text-text [&_blockquote]:border-l-2 [&_blockquote]:border-primary [&_blockquote]:pl-3 [&_blockquote]:mt-3 [&_blockquote]:text-subtle [&_blockquote]:italic [&_code]:bg-surface [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded [&_code]:text-xs"
       components={{
-        a: ({ href, children }: { href?: string; children?: ReactNode }) => (
-          <a
-            href={href}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-primary underline"
-          >
-            {children}
-          </a>
-        ),
+        a: ({ href, children }: { href?: string; children?: ReactNode }) =>
+          isSafeHref(href) ? (
+            <a
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary underline"
+            >
+              {children}
+            </a>
+          ) : (
+            <span className="text-primary underline">{children}</span>
+          ),
       }}
     >
       {text}

--- a/apps/web/src/core/security/useAppLock.ts
+++ b/apps/web/src/core/security/useAppLock.ts
@@ -93,12 +93,16 @@ export function useAppLock(): UseAppLockReturn {
 
   const startSetup = useCallback(() => {
     setState("setup");
-    capturePostHogEvent(ANALYTICS_EVENTS.APP_LOCK_SETUP_STARTED, {});
+    capturePostHogEvent(ANALYTICS_EVENTS.APP_LOCK_SETUP_STARTED, {
+      mode: "setup",
+    });
   }, []);
 
   const startChange = useCallback(() => {
     setState("change");
-    capturePostHogEvent(ANALYTICS_EVENTS.APP_LOCK_SETUP_STARTED, {});
+    capturePostHogEvent(ANALYTICS_EVENTS.APP_LOCK_SETUP_STARTED, {
+      mode: "change",
+    });
   }, []);
 
   const finishSetup = useCallback(() => {

--- a/packages/routine-domain/src/dateKeys.test.ts
+++ b/packages/routine-domain/src/dateKeys.test.ts
@@ -52,4 +52,10 @@ describe("routine-domain/dateKeys", () => {
     expect(isoWeekdayFromDateKey("2026-01-05")).toBe(0); // Mon
     expect(isoWeekdayFromDateKey("2026-01-11")).toBe(6); // Sun
   });
+
+  it("parseDateKey throws on malformed key", () => {
+    expect(() => parseDateKey("")).toThrow(/invalid date key/);
+    expect(() => parseDateKey("not-a-date")).toThrow(/invalid date key/);
+    expect(() => parseDateKey("2026-13-01")).not.toThrow(); // JS Date handles overflow
+  });
 });

--- a/packages/routine-domain/src/dateKeys.ts
+++ b/packages/routine-domain/src/dateKeys.ts
@@ -19,7 +19,10 @@ export function dateKeyFromDate(d: Date): string {
 
 export function parseDateKey(key: string): Date {
   const [y, m, day] = key.split("-").map(Number);
-  return new Date(y || 1970, (m || 1) - 1, day || 1);
+  if (!y || !m || !day || isNaN(y) || isNaN(m) || isNaN(day)) {
+    throw new Error(`parseDateKey: invalid date key "${key}"`);
+  }
+  return new Date(y, m - 1, day);
 }
 
 export function enumerateDateKeys(startKey: string, endKey: string): string[] {


### PR DESCRIPTION
## Summary

Full-stack bug review (backend + frontend + domain packages). Four confirmed issues fixed:

### 1. Security — XSS via unvalidated `href` in `AssistantMessageBody`
**File:** `apps/web/src/core/components/AssistantMessageBody.tsx`

LLM-generated markdown links had no URL scheme validation. If an AI response contained `[text](javascript:alert(1))` or a `data:` URI, the raw `href` was passed straight to `<a>`. React 16.9+ blocks `javascript:` but **not** `data:` or `vbscript:`. Added `isSafeHref()` — only `https?://`, `/`, `#` pass through; unsafe URLs render the link text as a plain `<span>` instead.

### 2. Logic — `startChange()` fires wrong analytics event in `useAppLock`
**File:** `apps/web/src/core/security/useAppLock.ts`

Both `startSetup()` and `startChange()` fired `APP_LOCK_SETUP_STARTED` with an empty `{}` payload, making it impossible to distinguish "user setting up PIN for the first time" from "user changing existing PIN" in PostHog. Fixed by passing `{ mode: "setup" | "change" }` so both flows are observable.

### 3. Server — `openclaw/store.ts` INSERT RETURNING silently returns `id: 0`
**File:** `apps/server/src/modules/openclaw/store.ts`

Three functions (`openInvocation`, `insertDecision`, `recordWriteAudit`) used `result.rows[0]?.id ?? 0` on INSERT … RETURNING queries. If the result somehow contained no rows, callers received a phantom `id: 0`, which is a valid-looking primary key — downstream `finalizeInvocation(0, ...)` or `attachDecisionPrUrl(0, ...)` would silently UPDATE 0 rows. All three now throw an explicit error so failures surface immediately.

### 4. Domain — `parseDateKey` silently falls back to `1970-01-01` on bad input
**File:** `packages/routine-domain/src/dateKeys.ts`

`const [y, m, day] = key.split("-").map(Number)` followed by `y || 1970` masked NaN/undefined values from malformed keys (e.g. empty string, garbage data from corrupted storage). Habits/streaks built on an invisible `1970-01-01` would silently corrupt the calendar. Now throws with a clear message. Test updated to assert throw behavior for invalid inputs.

## Test plan

- [ ] `AssistantMessageBody`: render a message with `[click](javascript:alert(1))` — should render as plain text, no `<a>` tag
- [ ] `AssistantMessageBody`: render `[link](https://example.com)` — should render as `<a href="https://example.com">`
- [ ] `useAppLock`: call `startSetup()` → PostHog event has `{ mode: "setup" }`; call `startChange()` → event has `{ mode: "change" }`
- [ ] `openclaw/store.ts`: verify that an INSERT failure now surfaces as a thrown error (unit test or integration test)
- [ ] `parseDateKey("")` / `parseDateKey("bad")` → throws `invalid date key`; `parseDateKey("2026-03-14")` still works

https://claude.ai/code/session_01NiXNRSkaAkCtwCUCveN5aa

---
_Generated by [Claude Code](https://claude.ai/code/session_01NiXNRSkaAkCtwCUCveN5aa)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four user-impacting bugs: blocks unsafe markdown links, separates setup vs change analytics, surfaces failed INSERTs, and validates date keys to avoid silent corruption.

- **Bug Fixes**
  - AssistantMessageBody: validate link `href`; allow only http/https, `/`, `#`; unsafe links render as text.
  - useAppLock: `startChange()` sends `APP_LOCK_SETUP_STARTED` with `{ mode: "change" }`; setup uses `{ mode: "setup" }` for accurate PostHog data.
  - Server openclaw: `openInvocation`, `insertDecision`, `recordWriteAudit` now throw if INSERT RETURNING yields no rows; no more `id: 0` phantom updates.
  - `routine-domain`: `parseDateKey` throws on malformed keys; added tests.

<sup>Written for commit 95b2fc059a9e698919bffe6e686eb76b82bf3374. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

