### PR TITLE
fix(web): block clicks on inactive Bento cards, route to Hub Settings

### DIFF
--- a/apps/web/src/core/app/useAppEffects.ts
+++ b/apps/web/src/core/app/useAppEffects.ts
@@ -1,7 +1,10 @@
 import { useEffect } from "react";
 import type { NavigateFunction } from "react-router-dom";
 import { onHubBus } from "@shared/lib/modules/hubBus";
-import { HUB_OPEN_MODULE_EVENT } from "@shared/lib/modules/hubNav";
+import {
+  HUB_OPEN_MODULE_EVENT,
+  HUB_OPEN_SETTINGS_EVENT,
+} from "@shared/lib/modules/hubNav";
 import {
   REQUEST_PULL_EVENT,
   emitCloudPullComplete,
@@ -137,4 +140,29 @@ export function useAppEffects(deps: AppEffectsDeps): void {
     window.addEventListener(HUB_OPEN_MODULE_EVENT, onHubOpen);
     return () => window.removeEventListener(HUB_OPEN_MODULE_EVENT, onHubOpen);
   }, [openModule, setPwaAction, validActions]);
+
+  // Cross-cutting signal: switch to the Settings tab and (optionally)
+  // scroll to a named section. Used by surfaces that need to send the
+  // user to Hub Settings without prop-drilling react-router through the
+  // tree — most notably the inactive-module Bento card whose tap should
+  // open Hub Settings → Дашборд → "Модулі дашборду" instead of the
+  // (disabled) module itself.
+  const setHubViewStable = ui.setHubView;
+  useEffect(() => {
+    const onSettingsOpen = (ev: Event) => {
+      const detail = (ev as CustomEvent<{ section?: string }>).detail || {};
+      const section = (detail.section ?? "").trim();
+      // Always flip the in-memory tab state immediately so the Settings
+      // tabpanel mounts even before the URL change is observed via
+      // `useLocation().search` — keeps the redirect feeling instant.
+      setHubViewStable("settings");
+      const target = section
+        ? `/?tab=settings#settings-${section}`
+        : `/?tab=settings`;
+      navigate(target);
+    };
+    window.addEventListener(HUB_OPEN_SETTINGS_EVENT, onSettingsOpen);
+    return () =>
+      window.removeEventListener(HUB_OPEN_SETTINGS_EVENT, onSettingsOpen);
+  }, [navigate, setHubViewStable]);
 }

--- a/apps/web/src/core/hub/HubDashboard.test.tsx
+++ b/apps/web/src/core/hub/HubDashboard.test.tsx
@@ -38,6 +38,7 @@ const mocks = vi.hoisted(() => ({
   digestFresh: false,
   openHubModule: vi.fn(),
   openHubModuleWithAction: vi.fn(),
+  openHubSettingsSection: vi.fn(),
   // Capture refs for the latest sensor wiring + DndContext callbacks so
   // PR-12 (UX-roast 2026-Q2 / A9) can assert KeyboardSensor registration
   // and aria-live announcements without booting full pointer simulation.
@@ -109,6 +110,8 @@ vi.mock("@shared/lib/modules/hubNav", () => ({
   openHubModule: (...args: unknown[]) => mocks.openHubModule(...args),
   openHubModuleWithAction: (...args: unknown[]) =>
     mocks.openHubModuleWithAction(...args),
+  openHubSettingsSection: (...args: unknown[]) =>
+    mocks.openHubSettingsSection(...args),
 }));
 
 vi.mock("../insights/TodayFocusCard", () => ({
@@ -328,6 +331,7 @@ describe("HubDashboard", () => {
     mocks.digestFresh = false;
     mocks.openHubModule.mockClear();
     mocks.openHubModuleWithAction.mockClear();
+    mocks.openHubSettingsSection.mockClear();
     mocks.announce.mockClear();
     mocks.dndCapture.sensors = undefined;
     mocks.dndCapture.onDragStart = undefined;
@@ -465,6 +469,40 @@ describe("HubDashboard", () => {
         name: new RegExp(DASHBOARD_MODULE_LABELS.fizruk),
       }),
     ).toBeNull();
+  });
+
+  it("routes taps on inactive bento cards to Hub Settings → Дашборд instead of opening the module", () => {
+    // Only `finyk` is in vibe picks → fizruk/routine/nutrition cards
+    // render greyed-out. The card's copy promises «Неактивний —
+    // увімкнути в налаштуваннях» and the quick-add affordance is
+    // suppressed; tapping the card body must follow the same intent
+    // and dispatch `HUB_OPEN_SETTINGS_EVENT` for section "dashboard"
+    // (which scrolls to the «Модулі дашборду» toggle list) instead of
+    // calling `onOpenModule(id)` for a module the user explicitly did
+    // not opt into.
+    localStorage.setItem(VIBE_PICKS_KEY, JSON.stringify(["finyk"]));
+    const onOpenModule = vi.fn();
+
+    renderDashboard({ onOpenModule });
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: new RegExp(DASHBOARD_MODULE_LABELS.fizruk),
+      }),
+    );
+
+    expect(onOpenModule).not.toHaveBeenCalled();
+    expect(mocks.openHubSettingsSection).toHaveBeenCalledTimes(1);
+    expect(mocks.openHubSettingsSection).toHaveBeenCalledWith("dashboard");
+
+    // Active modules keep their normal "open the module" tap target —
+    // the inactive guard must not regress the happy path.
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: new RegExp(DASHBOARD_MODULE_LABELS.finyk),
+      }),
+    );
+    expect(onOpenModule).toHaveBeenCalledWith("finyk");
   });
 
   it("routes hero and insight callbacks to the correct dashboard actions", () => {

--- a/apps/web/src/core/hub/dashboard/BentoCard.tsx
+++ b/apps/web/src/core/hub/dashboard/BentoCard.tsx
@@ -3,6 +3,7 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { cn } from "@shared/lib/ui/cn";
 import { Icon } from "@shared/components/ui/Icon";
+import { openHubSettingsSection } from "@shared/lib/modules/hubNav";
 import { getModulePrefetchProps } from "../../lib/intentPrefetch";
 import {
   MODULE_CONFIGS,
@@ -377,7 +378,19 @@ export const SortableCard = memo(function SortableCard({
     [editMode, dndProps, intentProps],
   );
 
-  const handleClick = useCallback(() => onOpenModule(id), [onOpenModule, id]);
+  // Inactive cards route the user to Hub Settings → Дашборд → "Модулі
+  // дашборду" instead of opening the module itself. The card's copy
+  // already promises «Неактивний — увімкнути в налаштуваннях» and the
+  // quick-add affordance is suppressed for the same reason; navigating
+  // back to the toggle list is the affordance the user is being told
+  // about. See HubSettingsPage.tsx for the `#settings-dashboard` anchor.
+  const handleClick = useCallback(() => {
+    if (inactive) {
+      openHubSettingsSection("dashboard");
+      return;
+    }
+    onOpenModule(id);
+  }, [inactive, onOpenModule, id]);
 
   const cfg = MODULE_CONFIGS[id];
   if (!cfg) return null;

--- a/apps/web/src/shared/lib/modules/hubNav.test.ts
+++ b/apps/web/src/shared/lib/modules/hubNav.test.ts
@@ -4,7 +4,9 @@ import type { Mock } from "vitest";
 import {
   openHubModule,
   openHubModuleWithAction,
+  openHubSettingsSection,
   HUB_OPEN_MODULE_EVENT,
+  HUB_OPEN_SETTINGS_EVENT,
 } from "./hubNav";
 
 // Vitest 4 widened the default `Mock` to `Mock<Procedure | Constructable>`,
@@ -65,6 +67,37 @@ describe("openHubModuleWithAction", () => {
   it("не диспатчить для невалідної дії", () => {
     // @ts-expect-error тестуємо runtime guard
     openHubModuleWithAction("finyk", "invalid_action");
+    expect(listener).not.toHaveBeenCalled();
+  });
+});
+
+describe("openHubSettingsSection", () => {
+  let listener: EventSpy;
+
+  beforeEach(() => {
+    listener = vi.fn<(event: Event) => void>();
+    window.addEventListener(HUB_OPEN_SETTINGS_EVENT, listener);
+  });
+  afterEach(() => {
+    window.removeEventListener(HUB_OPEN_SETTINGS_EVENT, listener);
+  });
+
+  it("диспатчить CustomEvent з section", () => {
+    openHubSettingsSection("dashboard");
+    expect(listener).toHaveBeenCalledTimes(1);
+    const detail = (listener.mock.calls[0]![0] as CustomEvent).detail;
+    expect(detail).toEqual({ section: "dashboard" });
+  });
+
+  it("без аргументу — section порожній рядок (відкрити Settings без скролу)", () => {
+    openHubSettingsSection();
+    expect(listener).toHaveBeenCalledTimes(1);
+    const detail = (listener.mock.calls[0]![0] as CustomEvent).detail;
+    expect(detail.section).toBe("");
+  });
+
+  it("не диспатчить для невалідної section", () => {
+    openHubSettingsSection("not-a-real-section");
     expect(listener).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/shared/lib/modules/hubNav.ts
+++ b/apps/web/src/shared/lib/modules/hubNav.ts
@@ -79,3 +79,54 @@ export function openHubModuleWithAction(
     /* noop */
   }
 }
+
+export const HUB_OPEN_SETTINGS_EVENT = "hub:open-settings";
+
+export interface HubOpenSettingsDetail {
+  /**
+   * Settings section id to scroll to (matches the `#settings-<id>` anchor
+   * emitted by `HubSettingsPage`). Empty string opens the Settings tab
+   * without scrolling to any specific section.
+   */
+  section: string;
+}
+
+// Mirrors the section list in `HubSettingsPage.tsx`. Kept defensive at
+// runtime so a typo in a caller can't navigate the user to an
+// unscrollable hash, but the source of truth is HubSettingsPage.
+const VALID_SETTINGS_SECTIONS = new Set<string>([
+  "",
+  "dashboard",
+  "general",
+  "notifications",
+  "ai",
+  "assistant",
+  "routine",
+  "fizruk",
+  "finyk",
+  "nutrition",
+  "privacy",
+  "pwa",
+  "dataExport",
+  "experimental",
+]);
+
+/**
+ * Перемкнути Hub на вкладку «Налаштування» з опційним скролом до секції.
+ *
+ * Використовується, напр., у Bento-картці неактивного модуля: тап по
+ * сірій картці має вести користувача в Hub Settings → Дашборд →
+ * "Модулі дашборду", а не відкривати сам неактивний модуль.
+ */
+export function openHubSettingsSection(section: string = ""): void {
+  if (!VALID_SETTINGS_SECTIONS.has(section)) return;
+  try {
+    window.dispatchEvent(
+      new CustomEvent<HubOpenSettingsDetail>(HUB_OPEN_SETTINGS_EVENT, {
+        detail: { section },
+      }),
+    );
+  } catch {
+    /* noop — SSR / disabled CustomEvent */
+  }
+}


### PR DESCRIPTION
## Summary

Before this PR, tapping a greyed-out (inactive) Bento card on the Hub dashboard still opened the underlying module — even though the card already promises «Неактивний — увімкнути в налаштуваннях», sets `aria-label` to «… увімкнути в налаштуваннях Hub», and suppresses its quick-add affordance for the same reason. Display said one thing, click did another.

This PR makes the click match the copy: tapping an inactive card now routes the user to **Hub Settings → Дашборд** (the «Модулі дашборду» toggle list), which is exactly where they need to be to re-activate the module they just tapped. Active modules are unchanged.

Files touched:

- `apps/web/src/shared/lib/modules/hubNav.ts` — new `HUB_OPEN_SETTINGS_EVENT` + `openHubSettingsSection(section?)` helper. Mirrors the existing `HUB_OPEN_MODULE_EVENT` / `openHubModule(id)` pattern, so we don't prop-drill react-router through the dashboard tree. Defensive `VALID_SETTINGS_SECTIONS` set prevents typos from navigating to non-existent anchors.
- `apps/web/src/core/app/useAppEffects.ts` — listener that responds to `HUB_OPEN_SETTINGS_EVENT` by switching the in-memory `hubView` to `"settings"` and navigating to `/?tab=settings#settings-{section}` (or `/?tab=settings` if `section` is empty). Sits next to the existing `HUB_OPEN_MODULE_EVENT` listener for symmetry.
- `apps/web/src/core/hub/dashboard/BentoCard.tsx` — `SortableCard.handleClick` now guards on `inactive` and dispatches `openHubSettingsSection("dashboard")` instead of calling `onOpenModule(id)`. Active cards keep the existing tap target.
- `apps/web/src/shared/lib/modules/hubNav.test.ts` — three new unit tests for `openHubSettingsSection`.
- `apps/web/src/core/hub/HubDashboard.test.tsx` — integration test asserting the inactive-tap → settings flow + a regression guard that active taps still call `onOpenModule(id)`.

## Governing Skill

- Primary skill: web/hub/dashboard — Bento card interaction patterns and the inactive-vs-active module contract (copy ↔ behaviour parity).
- Secondary skill (if truly needed): web/cross-cutting — `CustomEvent`-based hub navigation signals (`HUB_OPEN_*_EVENT` family) wired through `useAppEffects`.

## Playbook

- Primary playbook: «UX consistency: visual affordance must match interaction». Card already showed disabled state (opacity-60 + grayscale + «Неактивний — увімкнути в налаштуваннях») and suppressed its quick-add affordance — but the click still opened the module. Bring the click in line.
- Why this playbook: the prior copy + suppressed affordance proves the team's intent was «click is no-op / leads to settings», not «click opens disabled module». No new design decision required, only execution to match what the card already told the user.
- If no playbook matched, why: n/a.

## Verification

Local commands run before push:

```bash
pnpm --filter @sergeant/web exec vitest run
# 18/18 passed (incl. 3 new in hubNav.test.ts + 1 new in HubDashboard.test.tsx)

pnpm --filter @sergeant/web exec eslint --quiet \
  src/shared/lib/modules/hubNav.ts \
  src/shared/lib/modules/hubNav.test.ts \
  src/core/app/useAppEffects.ts \
  src/core/hub/dashboard/BentoCard.tsx \
  src/core/hub/HubDashboard.test.tsx
# 0 errors

pnpm --filter @sergeant/web exec tsc --noEmit
# Only pre-existing TS2769 errors in apps/web/src/.../useAppLock.test.ts
# (verified those exist on `main` via `git stash` round-trip — unrelated)
```

Additional checks:

- [x] Local smoke / manual validation completed — opened the dashboard with a single-pick `VIBE_PICKS_KEY` (only `finyk`) and verified inactive cards (`fizruk`, `routine`, `nutrition`) route to Hub Settings → Дашборд instead of opening the module; active card still opens the module.
- [x] Surface-specific checks completed — added `HubDashboard.test.tsx` integration test that asserts both inactive→settings and active→`onOpenModule(id)` paths, so the regression is locked.

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a — no public-facing contract changed. The new `HUB_OPEN_SETTINGS_EVENT` is internal to the Hub surface and self-documenting via JSDoc on `openHubSettingsSection` (`hubNav.ts`) and on the matching listener in `useAppEffects.ts`.

## Risk and Rollout

- User-visible risk: very low. Only a single bound `onClick` on a greyed-out tile changes behaviour; everything else (active cards, drag-sort, quick-add, accent system, locked-card overlay) is untouched. The new behaviour matches what the card's copy and `aria-label` were already promising, so no user expectation is broken.
- Rollout / deploy order: ships with the next `apps/web` deploy, no migration / feature-flag / coordination required.
- Backout plan: revert this single commit. The change is contained to three product files (`hubNav.ts`, `useAppEffects.ts`, `BentoCard.tsx`) plus two test files; no schema, no API, no shared package, no external dependency.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

- The PR was opened via the GitHub REST API with a temporary user-supplied PAT instead of the standard `git_create_pr` Devin tool, because the `git-manager.devin.ai/proxy` returned `403` consistently for ~30 minutes during this session — `git_create_pr` could not see the pushed branch. Branch was pushed directly to `github.com`. A blocker has been reported. The diff itself is unaffected.
- Mirrors the existing `openHubModule` / `HUB_OPEN_MODULE_EVENT` pattern used by `openClawIntegration` etc., not a new architectural shape — kept on purpose to stay consistent with the rest of the Hub navigation signals.
- The `VALID_SETTINGS_SECTIONS` set is duplicated from `HubSettingsPage` section ids on purpose — the source of truth is `HubSettingsPage`, this set is a defensive guard so a typo in a future caller can't navigate the user to an unscrollable hash. Easy to drop if a stronger type-level binding gets added later.