### PR TITLE
fix(web): tag sync_op_outbox boot outcome in Sentry

### DIFF
--- a/apps/web/src/core/observability/sentry.test.ts
+++ b/apps/web/src/core/observability/sentry.test.ts
@@ -18,6 +18,7 @@ const setTag = vi.fn();
 const browserTracingIntegration = vi.fn(() => ({ name: "tracing" }));
 const replayIntegration = vi.fn(() => ({ name: "replay" }));
 const captureException = vi.fn();
+const addBreadcrumb = vi.fn();
 
 vi.mock("@sentry/react", () => ({
   init: sentryInit,
@@ -25,6 +26,7 @@ vi.mock("@sentry/react", () => ({
   browserTracingIntegration,
   replayIntegration,
   captureException,
+  addBreadcrumb,
 }));
 
 const isCapacitorMock = vi.fn<() => boolean>();
@@ -49,6 +51,7 @@ beforeEach(() => {
   browserTracingIntegration.mockClear();
   replayIntegration.mockClear();
   captureException.mockReset();
+  addBreadcrumb.mockReset();
   isCapacitorMock.mockReset().mockReturnValue(false);
   getPlatformMock.mockReset().mockReturnValue("web");
   vi.stubEnv("VITE_SENTRY_DSN", "https://public@sentry.example/1");
@@ -98,6 +101,47 @@ describe("initSentry", () => {
     // Старе поле має бути відсутнє — інакше Sentry приоритезує статичний
     // rate і ігнорує sampler.
     expect(cfg.tracesSampleRate).toBeUndefined();
+  });
+});
+
+describe("setSentryTag", () => {
+  it("forwards to Sentry.setTag once the SDK is initialised", async () => {
+    const sentry = await import("./sentry");
+    await sentry.initSentry();
+
+    setTag.mockClear();
+    sentry.setSentryTag("outbox.boot.outcome", "repaired");
+
+    expect(setTag).toHaveBeenCalledWith("outbox.boot.outcome", "repaired");
+  });
+
+  it("is a silent no-op before init (no DSN, SDK never loaded)", async () => {
+    vi.stubEnv("VITE_SENTRY_DSN", "");
+
+    const sentry = await import("./sentry");
+    await sentry.initSentry();
+
+    sentry.setSentryTag("outbox.boot.outcome", "failed");
+
+    expect(setTag).not.toHaveBeenCalled();
+  });
+
+  it("swallows underlying SDK exceptions so callers stay unconditional", async () => {
+    const sentry = await import("./sentry");
+    // `initSentry` itself calls `setTag` for `platform` / `is_capacitor`,
+    // so install the throwing mock *after* init succeeds — otherwise we
+    // assert the wrong code path. The interesting contract is that
+    // `setSentryTag` (the public, lazy-forward wrapper) never re-throws
+    // its caller, even when the SDK is faulty.
+    await sentry.initSentry();
+
+    setTag.mockImplementation(() => {
+      throw new Error("sentry exploded");
+    });
+
+    expect(() =>
+      sentry.setSentryTag("outbox.boot.outcome", "fresh"),
+    ).not.toThrow();
   });
 });
 

--- a/apps/web/src/core/observability/sentry.ts
+++ b/apps/web/src/core/observability/sentry.ts
@@ -140,3 +140,26 @@ export function addSentryBreadcrumb(
     /* noop */
   }
 }
+
+/**
+ * Lazy-forward `Sentry.setTag`. No-op until the SDK is loaded so the
+ * sync-engine boot path can record `outbox.boot.outcome` (and similar
+ * Stage 8 triage tags) unconditionally — the call costs nothing on
+ * cold-start and the actual tag is attached the moment the SDK
+ * finishes lazy-loading via `requestIdleCallback`.
+ *
+ * Using global tags (rather than `withScope`) is intentional: every
+ * subsequent event in the session inherits the tag so a saved search
+ * like `outbox.boot.outcome:failed` finds the boot failure *and* any
+ * downstream errors caused by it (e.g. the periodic drain surfacing
+ * `no such table: sync_op_outbox`). That is the SERGEANT-WEB-A
+ * shape we want to remain queryable if the regression ever recurs.
+ */
+export function setSentryTag(key: string, value: string): void {
+  if (!sentryModule) return;
+  try {
+    sentryModule.setTag(key, value);
+  } catch {
+    /* noop */
+  }
+}

--- a/apps/web/src/core/syncEngine/outboxBoot.test.ts
+++ b/apps/web/src/core/syncEngine/outboxBoot.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyOutboxBootOutcome } from "./outboxBoot";
+
+describe("classifyOutboxBootOutcome", () => {
+  it("returns 'repaired' when the self-heal helper recovered the table", () => {
+    // `repairPartialOutboxMigration` only returns `recovered: true`
+    // on the post-002 corrupted shape (no live `sync_op_outbox`,
+    // `sync_op_outbox_legacy` present). So `hadOutbox` is necessarily
+    // `false` in this branch — but we encode the priority explicitly
+    // in case the helper's contract ever loosens.
+    expect(
+      classifyOutboxBootOutcome({ hadOutbox: false, recovered: true }),
+    ).toBe("repaired");
+  });
+
+  it("returns 'already_present' on a previously-converged DB", () => {
+    expect(
+      classifyOutboxBootOutcome({ hadOutbox: true, recovered: false }),
+    ).toBe("already_present");
+  });
+
+  it("returns 'fresh' when the table did not exist and was created by the runner", () => {
+    expect(
+      classifyOutboxBootOutcome({ hadOutbox: false, recovered: false }),
+    ).toBe("fresh");
+  });
+
+  it("prioritises 'repaired' over 'already_present' when both flags are set", () => {
+    // Defence-in-depth: a future repair helper that leaves the
+    // legacy table renamed back *and* somehow flags `hadOutbox`
+    // (e.g. by snapshotting after repair) should still be tagged
+    // as a recovery, not a healthy boot.
+    expect(
+      classifyOutboxBootOutcome({ hadOutbox: true, recovered: true }),
+    ).toBe("repaired");
+  });
+});

--- a/apps/web/src/core/syncEngine/outboxBoot.ts
+++ b/apps/web/src/core/syncEngine/outboxBoot.ts
@@ -1,0 +1,42 @@
+/**
+ * Pure classifier for the routine-module sync outbox boot path.
+ *
+ * The boot path in `singleton.ts → createDefaultRuntime` does three
+ * things in order: snapshot the on-disk schema, run
+ * `repairPartialOutboxMigration` (idempotent self-heal for the
+ * SERGEANT-WEB-A / post-002 corruption shape), then run
+ * `ROUTINE_CLIENT_MIGRATIONS`. The runtime can therefore land in one
+ * of three healthy outcomes — and we want each surfaced as a Sentry
+ * tag (`outbox.boot.outcome`) so the saved-search filter stays
+ * grep-able if the regression ever recurs.
+ *
+ * This helper is pure on purpose: the real boot is hard to unit-test
+ * (it lazy-imports half a dozen modules and depends on a live
+ * sqlite-wasm DB), but the classification logic is the bit most
+ * likely to drift, so it sits in its own file with its own tests.
+ */
+export type OutboxBootOutcome =
+  | "fresh"
+  | "already_present"
+  | "repaired"
+  | "failed";
+
+export interface ClassifyOutboxBootArgs {
+  /** `sync_op_outbox` was visible in `sqlite_master` *before* repair. */
+  readonly hadOutbox: boolean;
+  /** `repairPartialOutboxMigration` returned `recovered: true`. */
+  readonly recovered: boolean;
+}
+
+/**
+ * Classify the post-success boot path. Failures are tagged
+ * `"failed"` by the catch arm in `createDefaultRuntime` directly —
+ * this helper is only ever called once we know migrations converged.
+ */
+export function classifyOutboxBootOutcome(
+  args: ClassifyOutboxBootArgs,
+): Exclude<OutboxBootOutcome, "failed"> {
+  if (args.recovered) return "repaired";
+  if (args.hadOutbox) return "already_present";
+  return "fresh";
+}

--- a/apps/web/src/core/syncEngine/singleton.ts
+++ b/apps/web/src/core/syncEngine/singleton.ts
@@ -1,5 +1,6 @@
 import type { RecoverDeadLetterSelector } from "@sergeant/db-schema/sqlite";
 
+import { classifyOutboxBootOutcome } from "./outboxBoot";
 import {
   createSyncEngineWriterRuntime,
   type SyncEngineWriterRuntime,
@@ -95,40 +96,81 @@ async function createDefaultRuntime(): Promise<SyncEngineWriterRuntime> {
   // (`sync_op_outbox_legacy` лишився, `sync_op_outbox` зник). Звичайний
   // re-run runner-а на такому DB вилітає на першому ALTER 002-ї.
   // Helper — idempotent: на здоровій або свіжій БД — no-op.
-  const repaired = await dbSchema.repairPartialOutboxMigration(client, {
-    ledgerTable: dbSchema.ROUTINE_MIGRATIONS_TABLE,
-  });
-  if (repaired.recovered) {
-    sentry.addSentryBreadcrumb({
-      category: "storage",
-      level: "warning",
-      message: "sqlite: recovered sync_op_outbox from partial 002 migration",
-    });
-  }
+  //
+  // Кожен boot тегує `outbox.boot.outcome` у Sentry
+  // (`fresh|already_present|repaired|failed`) + `outbox.boot.legacy_seen`
+  // — це робить регресію SERGEANT-WEB-A прямо filter-able у saved
+  // search-і навіть якщо помилка прилітає не у самому boot-у, а
+  // через 30 секунд у періодичному drain-і (тег глобальний, тож
+  // успадковується усіма наступними events у сесії).
 
-  await runMigrations({
-    adapter: createSqliteAdapter(client),
-    files: dbSchema.ROUTINE_CLIENT_MIGRATIONS,
-    tableName: dbSchema.ROUTINE_MIGRATIONS_TABLE,
-  });
-
-  // Post-migration smoke check: if `sync_op_outbox` is still missing
-  // after the runner returned, something deeper than the
-  // post-002 corruption is wrong (e.g. a brand-new failure mode in
-  // sqlite-wasm). Throw a typed error here so the
-  // `bootSyncEngineWriter`-owy catch-all routes it to Sentry with a
-  // breadcrumb instead of letting the periodic drain surface a raw
-  // `SQLITE_ERROR: no such table` 30s later (the original WEB-A
-  // shape).
-  const presentTables = await client.all<{ name: string }>(
-    `SELECT name FROM sqlite_master
-       WHERE type = 'table' AND name = 'sync_op_outbox'`,
-  );
-  if (presentTables.length === 0) {
-    throw new Error(
-      "sync_op_outbox missing after running ROUTINE_CLIENT_MIGRATIONS — " +
-        "client SQLite did not converge on the expected schema",
+  // Pre-state snapshot: перед першим write-ом у схему фіксуємо що
+  // саме було на диску. Розрізняємо "вже-мігрована БД" vs "свіжий
+  // user" vs "post-002 corruption" — інакше всі три зливаються
+  // в один тег і diagnostic value губиться.
+  let hadLegacy = false;
+  try {
+    const initialTables = await client.all<{ name: string }>(
+      `SELECT name FROM sqlite_master
+         WHERE type = 'table'
+           AND name IN ('sync_op_outbox', 'sync_op_outbox_legacy')`,
     );
+    const hadOutbox = initialTables.some((r) => r.name === "sync_op_outbox");
+    hadLegacy = initialTables.some((r) => r.name === "sync_op_outbox_legacy");
+
+    const repaired = await dbSchema.repairPartialOutboxMigration(client, {
+      ledgerTable: dbSchema.ROUTINE_MIGRATIONS_TABLE,
+    });
+    if (repaired.recovered) {
+      sentry.addSentryBreadcrumb({
+        category: "storage",
+        level: "warning",
+        message: "sqlite: recovered sync_op_outbox from partial 002 migration",
+      });
+    }
+
+    await runMigrations({
+      adapter: createSqliteAdapter(client),
+      files: dbSchema.ROUTINE_CLIENT_MIGRATIONS,
+      tableName: dbSchema.ROUTINE_MIGRATIONS_TABLE,
+    });
+
+    // Post-migration smoke check: if `sync_op_outbox` is still missing
+    // after the runner returned, something deeper than the
+    // post-002 corruption is wrong (e.g. a brand-new failure mode in
+    // sqlite-wasm). Throw a typed error here so the
+    // `bootSyncEngineWriter`-owy catch-all routes it to Sentry with a
+    // breadcrumb instead of letting the periodic drain surface a raw
+    // `SQLITE_ERROR: no such table` 30s later (the original WEB-A
+    // shape).
+    const presentTables = await client.all<{ name: string }>(
+      `SELECT name FROM sqlite_master
+         WHERE type = 'table' AND name = 'sync_op_outbox'`,
+    );
+    if (presentTables.length === 0) {
+      throw new Error(
+        "sync_op_outbox missing after running ROUTINE_CLIENT_MIGRATIONS — " +
+          "client SQLite did not converge on the expected schema",
+      );
+    }
+
+    sentry.setSentryTag(
+      "outbox.boot.outcome",
+      classifyOutboxBootOutcome({ hadOutbox, recovered: repaired.recovered }),
+    );
+    sentry.setSentryTag("outbox.boot.legacy_seen", String(hadLegacy));
+  } catch (err) {
+    // Tagging *before* re-throwing is intentional: the
+    // `bootSyncEngineWriter` catch arm forwards to
+    // `captureException`, and the global tag we set here ends up on
+    // that event (and any later events in the same session). Saved
+    // search `outbox.boot.outcome:failed` therefore catches both the
+    // direct boot exception and any downstream
+    // `no such table: sync_op_outbox` surfaced by callers that ran
+    // before this boot resolved.
+    sentry.setSentryTag("outbox.boot.outcome", "failed");
+    sentry.setSentryTag("outbox.boot.legacy_seen", String(hadLegacy));
+    throw err;
   }
 
   return createSyncEngineWriterRuntime({


### PR DESCRIPTION
## Summary

Hardening on top of the already-shipped `sync_op_outbox` race fix (PRs #2192 / #2199) so the SERGEANT-WEB-A regression stays observable if it ever recurs:

- Adds a lazy-forward `setSentryTag(key, value)` wrapper to `apps/web/src/core/observability/sentry.ts`, mirroring the existing `addSentryBreadcrumb` pattern (no-op until SDK loads, swallows SDK throws).
- Wires it into `bootSyncEngineWriter → createDefaultRuntime` to record two **global** Sentry tags on every routine-module sync boot:
  - `outbox.boot.outcome` ∈ `fresh | already_present | repaired | failed`
  - `outbox.boot.legacy_seen` (`"true"` / `"false"`)
- Snapshots `sqlite_master` for `sync_op_outbox` / `sync_op_outbox_legacy` *before* `repairPartialOutboxMigration` runs, so the three healthy shapes stay distinguishable from the post-002 corruption shape.
- Wraps the migration + smoke-check block in `try/catch`; the catch arm tags `failed` then re-throws so the existing `captureException` arm in `bootSyncEngineWriter` keeps owning the boot-error path unchanged.
- Extracts the classification rule into a pure `outboxBoot.ts` helper with its own unit test (the real boot is hard to unit-test — lazy imports + sqlite-wasm — so the bit most likely to drift gets isolated coverage).

Tags are global (not scoped) on purpose: a saved search like `outbox.boot.outcome:failed` then catches both the direct boot exception and any downstream `no such table: sync_op_outbox` that lands 30s later in the periodic drain.

## Governing Skill

- Primary skill: n/a — observability hardening, no rollout / migration / UI surface guarded by a skill.
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a
- Why this playbook: —
- If no playbook matched, why: This is a small Sentry-instrumentation hardening on an already-merged race fix. No playbook in the repo covers "add a Sentry tag to an existing boot path"; the change touches no governance surfaces (no rollout flag, no schema migration, no API contract).

## Verification

```bash
cd apps/web
pnpm exec eslint src/core/syncEngine/outboxBoot.ts src/core/syncEngine/outboxBoot.test.ts \
                 src/core/syncEngine/singleton.ts \
                 src/core/observability/sentry.ts src/core/observability/sentry.test.ts
# clean, 0 warnings

pnpm exec vitest run src/core/syncEngine/outboxBoot.test.ts \
                     src/core/syncEngine/singleton.test.ts \
                     src/core/observability/sentry.test.ts
# Test Files  3 passed (3)
# Tests       17 passed (17)

pnpm exec tsc -p tsconfig.json --noEmit
# Clean for the files touched here. Two pre-existing errors in
# src/core/security/useAppLock.test.ts(94,7) and (104,7) reproduce on
# `main` with this branch's changes stashed — not introduced by this PR.
```

Additional checks:

- [x] Local smoke / manual validation completed (unit tests above + verified pre-existing typecheck errors are on main with `git stash` repro).
- [ ] Surface-specific checks completed — no UI / a11y / visual surface touched.

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. (No external contract change — Sentry tags are an internal triage signal; the relevant rollout doc is `docs/planning/storage-roadmap.md` Stage 8 §3 which already enumerates these decision-gate metrics; this PR does not advance the rollout.)
- [x] I checked whether `AGENTS.md` needed an update. (No — no governance change.)
- [x] I checked whether a playbook or skill needed an update. (No — see *Playbook* above.)
- [x] I checked whether governance docs or review docs needed an update. (No.)

Updated docs:

- n/a

## Risk and Rollout

- **User-visible risk:** None. No UI, schema, or API contract touched. The only runtime side-effects are: (1) one extra `SELECT name FROM sqlite_master WHERE name IN (...)` per boot (cheap), and (2) two global `Sentry.setTag` calls per boot (lazy, no-op until SDK loaded).
- **Rollout / deploy order:** Standard `apps/web` Vercel deploy. No flag, no migration, no order dependency.
- **Backout plan:** Plain revert of the single commit. Tags are additive; removing them does not break any existing search/dashboard (none consume them yet).

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian. (Inline comments in `singleton.ts` follow the existing Ukrainian-with-anglicisms style of the surrounding block; English used only for the catch-arm comment to match the existing `// Post-migration smoke check…` block style above it.)
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files. Only `apps/web/src/...` source + tests touched.

## Reviewer Notes

Things most worth a careful look:

1. **Global tag semantics.** `Sentry.setTag` (not `withScope`) means `outbox.boot.outcome:failed` ends up on **every subsequent event in the same browser session**. That is the explicit design — it's how a 30s-delayed `no such table` drain error gets correlated back to the boot — but please sanity-check that's the desired triage shape vs. a scoped tag on a single boot event.
2. **Smoke-check throw is now under the `failed` umbrella.** The post-migration "table still missing" `throw new Error(...)` used to be a bare throw; it is now inside the new `try`, so it tags `outbox.boot.outcome:failed` rather than a more specific `missing_after_migration`. The error *message* still carries that distinction, so triage isn't lost — but if you want a separate tag value for that shape, let me know.
3. **Integration coverage.** `singleton.test.ts` injects a fake `createRuntime`, so the real outbox boot path (with the new try/catch + tagging) is not exercised by a unit test. Coverage is split: `outboxBoot.test.ts` covers the classifier, `sentry.test.ts` covers the lazy-forward wrapper. The wiring between them lives in the real `createDefaultRuntime` and is verified manually + by deployed Sentry events post-deploy.
4. **Pre-existing typecheck errors** in `src/core/security/useAppLock.test.ts` reproduce on `main` with this branch stashed (verified locally); not introduced by this PR.
5. **No tag value on `failed`-then-recovered.** If the boot transiently fails on a session and a subsequent boot succeeds in the same session, the second boot will overwrite the tag with `repaired`/`already_present`/`fresh`. That's the correct outcome (latest wins), but called out in case it confuses a search hit later.

Link to Devin session: https://app.devin.ai/sessions/b5a5bf561f7f4c5e8d1f225f59527c56
Requested by: @Skords-01

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds global Sentry tagging for the outbox boot path so SERGEANT-WEB-A (“no such table: sync_op_outbox”) stays searchable across the session. Adds a lazy `setSentryTag` and emits `outbox.boot.outcome` and `outbox.boot.legacy_seen` on each boot.

- **New Features**
  - Added lazy-forward `setSentryTag` (no-op before SDK; swallows SDK errors).
  - Boot now snapshots schema pre-repair and sets global tags:
    - `outbox.boot.outcome` ∈ `fresh | already_present | repaired | failed`
    - `outbox.boot.legacy_seen` (`"true"` / `"false"`)
  - Wrapped repair + migrations in try/catch; on error tags `failed` then rethrows to preserve existing error handling.
  - Extracted outcome classifier to `outboxBoot.ts` with unit tests.

<sup>Written for commit ce4fb14518e9819f3cabc0423c0f6e297cc46aff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

