### PR TITLE
fix(web): search exercise catalog, collapse reports, presets dropdown, pantry idle form

### DIFF
--- a/apps/web/src/core/hub/HubReports.tsx
+++ b/apps/web/src/core/hub/HubReports.tsx
@@ -238,9 +238,16 @@ function StatCard({
   chart,
   storageKey,
 }: StatCardProps) {
+  // Звіти за замовчуванням згорнуті — користувач у фідбеку 2026-05
+  // (UX-roast) скаржився, що з 4-х розгорнутих карток на одному екрані
+  // важко швидко окинути всі цифри. Згорнутий режим показує заголовок,
+  // велике число + дельту в одному рядку (~32px), що дає overview за 1
+  // погляд. Розгортаємо лише ту картку, в яку користувач явно тицьнув —
+  // стан зберігається в `useLocalStorageState`, так що його вибір
+  // персистить.
   const [collapsed, setCollapsed] = useLocalStorageState<boolean>(
     storageKey,
-    false,
+    true,
     { validate: (v): v is boolean => typeof v === "boolean" },
   );
   const formattedCurrent =

--- a/apps/web/src/core/hub/search/searchSources.ts
+++ b/apps/web/src/core/hub/search/searchSources.ts
@@ -1,3 +1,4 @@
+import { FizrukData } from "@sergeant/fizruk-domain";
 import { formatMoney, formatMoneyFromKopecks } from "@sergeant/shared";
 import { safeReadStringLS } from "@shared/lib/storage/storage";
 import { tokenize } from "../hubSearchEngine";
@@ -80,6 +81,58 @@ function searchFinyk(tokens: string[]): Hit[] {
 
 function searchFizruk(tokens: string[]): Hit[] {
   const results: Hit[] = [];
+
+  // Built-in catalogue from `@sergeant/fizruk-domain` — користувач шукав
+  // «жим» (Жим лежачи) і не знаходив, бо раніше ми проходили лише по
+  // `fizruk_custom_exercises_v1` (порожньому до першої кастомної вправи)
+  // та по логах тренувань. Тепер проганяємо ще й вбудований каталог,
+  // щоб глобальний пошук відповідав тому, що показує `useExerciseCatalog`
+  // у Фізрука. Беремо невеликий ліміт, бо це не основний фокус —
+  // користувацькі вправи + тренування мають пріоритет вище.
+  for (const ex of FizrukData.EXERCISES) {
+    if (!ex || typeof ex !== "object") continue;
+    const nameUk = ex.name?.uk;
+    if (!nameUk) continue;
+    const groupUk =
+      (ex.primaryGroup &&
+        FizrukData.PRIMARY_GROUPS_UK[ex.primaryGroup as string]) ||
+      ex.primaryGroupUk ||
+      ex.primaryGroup ||
+      "";
+    const aliases = Array.isArray(ex.aliases) ? ex.aliases.join(" ") : "";
+    const stop = pushScored(
+      results,
+      {
+        id: `fizruk_cat_${ex.id}`,
+        module: "fizruk",
+        moduleLabel: "Фізрук",
+        title: nameUk,
+        // subtitle включає aliases та англійську назву — щоб scoreMatch
+        // ловив запит «bench», «жим лежа» тощо. Перед рендером ми
+        // повертаємо короткий subtitle (lookup по id у мапі нижче).
+        subtitle: `${groupUk} · ${ex.name?.en ?? ""} ${aliases}`.trim(),
+        icon: "💪",
+        target: { kind: "module", moduleId: "fizruk" },
+      },
+      tokens,
+      8,
+    );
+    if (stop) break;
+  }
+  // Заміняємо subtitle на коротку версію (без aliases) перед рендером —
+  // довгий список синонімів був корисний для скорінгу, але в UI хочеться
+  // лише примарну м'язову групу.
+  for (const r of results) {
+    const ex = FizrukData.EXERCISES.find((e) => `fizruk_cat_${e?.id}` === r.id);
+    if (!ex) continue;
+    const groupUk =
+      (ex.primaryGroup &&
+        FizrukData.PRIMARY_GROUPS_UK[ex.primaryGroup as string]) ||
+      ex.primaryGroupUk ||
+      ex.primaryGroup ||
+      "Вправа";
+    r.subtitle = `${groupUk} · з каталогу Фізрука`;
+  }
 
   const workouts = parseFizrukWorkouts(
     safeReadStringLS("fizruk_workouts_v1", null),

--- a/apps/web/src/modules/nutrition/components/DailyPlanCard.tsx
+++ b/apps/web/src/modules/nutrition/components/DailyPlanCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import { chartHex } from "@sergeant/design-tokens/tokens";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
@@ -205,6 +205,83 @@ function MacroKcalWarning({ prefs, setPrefs, busy }: MacroKcalWarningProps) {
           )}
         >
           Скинути макро
+        </button>
+      </div>
+    </div>
+  );
+}
+
+interface MissingMacrosHintProps {
+  prefs: NutritionPrefs;
+  setPrefs: Dispatch<SetStateAction<NutritionPrefs>>;
+  busy?: boolean;
+}
+
+/**
+ * Користувач у фідбеку 2026-05 (UX-roast §3.3): «коли вводить ккал
+ * воно підставляло середні стартові значення для макросів, а юзер
+ * потім редачив». Тут — м'яка підказка з кнопкою «Підставити середні»,
+ * яка з'являється тільки коли вже задано ккал, але макросів ще немає.
+ * Дефолти: 1.6 г білка / 1 г жиру на кг ваги (типові безпечні старт-
+ * рекомендації); вуглеводи добираються залишком ккал. Ваги ми не
+ * знаємо в цій картці, тому стартуємо з macro-сплітом 30/25/45 від
+ * заданих ккал — це одночасно дає валідні цифри й не претендує на
+ * точність (її користувач уточнить вручну).
+ */
+function MissingMacrosHint({ prefs, setPrefs, busy }: MissingMacrosHintProps) {
+  const kcal = prefs.dailyTargetKcal ?? 0;
+  if (kcal <= 0) return null;
+  const hasAnyMacro =
+    (prefs.dailyTargetProtein_g ?? 0) > 0 ||
+    (prefs.dailyTargetFat_g ?? 0) > 0 ||
+    (prefs.dailyTargetCarbs_g ?? 0) > 0;
+  if (hasAnyMacro) return null;
+
+  // 30 % білок · 25 % жир · 45 % вуглеводи від цільових ккал → грами.
+  const suggestedProtein = Math.round((kcal * 0.3) / 4);
+  const suggestedFat = Math.round((kcal * 0.25) / 9);
+  const suggestedCarbs = Math.round((kcal * 0.45) / 4);
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={cn(
+        "mt-3 rounded-xl border border-warn/40 bg-warn/10 px-3 py-2.5",
+        "text-xs space-y-2",
+      )}
+      data-testid="missing-macros-hint"
+    >
+      <div className="flex items-start gap-2">
+        <span className="shrink-0 font-bold text-warn" aria-hidden>
+          ℹ
+        </span>
+        <p className="text-text leading-snug">
+          Задано лише <strong>{kcal} ккал</strong>, але без макро AI не зрозуміє
+          що тобі важливо — білок, жир чи вуглеводи. Підстав середні стартові
+          значення й відредагуй під себе.
+        </p>
+      </div>
+      <div className="flex flex-wrap gap-2 pl-5">
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() =>
+            setPrefs((p) => ({
+              ...p,
+              dailyTargetProtein_g: suggestedProtein,
+              dailyTargetFat_g: suggestedFat,
+              dailyTargetCarbs_g: suggestedCarbs,
+            }))
+          }
+          className={cn(
+            "inline-flex items-center gap-1 rounded-xl border px-2 py-1",
+            "border-line/60 bg-bg/60 text-text hover:bg-panelHi",
+            "disabled:opacity-50 transition-colors",
+          )}
+        >
+          Підставити середні · Б{suggestedProtein} · Ж{suggestedFat} · В
+          {suggestedCarbs}
         </button>
       </div>
     </div>
@@ -428,7 +505,12 @@ export function DailyPlanCard({
   weekPlanBusy,
   fetchWeekPlan,
 }: DailyPlanCardProps) {
-  const [showManual, setShowManual] = useState(false);
+  // UX-roast 2026-05 §3.3: користувач хотів, аби пресети «Схуднення /
+  // Підтримка / Набір» не були первинним фокусом, а виглядали як
+  // підказка, бо їх рідко обирають дослівно. Тепер дефолт — чотири
+  // інпути (ккал/Б/Ж/В), а пресети сховані за випадайкою.
+  const [presetMenuOpen, setPresetMenuOpen] = useState(false);
+  const presetMenuRef = useRef<HTMLDivElement | null>(null);
 
   const activePreset = PRESETS.find(
     (p) =>
@@ -446,7 +528,28 @@ export function DailyPlanCard({
       dailyTargetFat_g: preset.fat_g,
       dailyTargetCarbs_g: preset.carbs_g,
     }));
+    setPresetMenuOpen(false);
   };
+
+  // Закривати випадайку пресетів по тапу/кліку поза нею. Користуємось
+  // mousedown — щоб закриття відбулось до того, як саме поле забере
+  // фокус (інакше виходить «миготіння» меню при тапі по інпуту).
+  useEffect(() => {
+    if (!presetMenuOpen) return;
+    const onPointer = (e: MouseEvent | TouchEvent) => {
+      const root = presetMenuRef.current;
+      if (!root) return;
+      const target = e.target as Node | null;
+      if (target && root.contains(target)) return;
+      setPresetMenuOpen(false);
+    };
+    document.addEventListener("mousedown", onPointer);
+    document.addEventListener("touchstart", onPointer);
+    return () => {
+      document.removeEventListener("mousedown", onPointer);
+      document.removeEventListener("touchstart", onPointer);
+    };
+  }, [presetMenuOpen]);
 
   const hasTargets = prefs.dailyTargetKcal != null;
 
@@ -468,137 +571,150 @@ export function DailyPlanCard({
 
       <div className="mt-4 space-y-4">
         <div>
-          <div className="text-xs text-subtle mb-2">Пресет або ручні цілі</div>
-          <div className="flex gap-2 flex-wrap">
-            {PRESETS.map((preset) => (
+          <div className="flex items-center justify-between gap-2 mb-2">
+            <div className="text-xs text-subtle">Цілі на день</div>
+            <div ref={presetMenuRef} className="relative">
               <button
-                key={preset.id}
                 type="button"
-                onClick={() => applyPreset(preset)}
+                onClick={() => setPresetMenuOpen((v) => !v)}
                 disabled={busy || dayPlanBusy}
+                aria-haspopup="menu"
+                aria-expanded={presetMenuOpen}
                 className={cn(
-                  "flex-1 min-w-[90px] py-2 px-3 rounded-xl text-xs font-semibold border transition-[background-color,border-color,color,opacity]",
-                  activePreset?.id === preset.id
-                    ? "bg-nutrition-strong text-white border-nutrition"
-                    : "border-line text-text hover:border-nutrition/50 hover:bg-nutrition/5",
+                  "inline-flex items-center gap-1 rounded-xl border px-2.5 py-1 text-xs font-semibold",
+                  "border-line/70 text-subtle hover:text-text hover:border-nutrition/50",
+                  "disabled:opacity-50 transition-colors",
                 )}
               >
-                <div>{preset.label}</div>
-                <div className="text-2xs opacity-70 mt-0.5">
-                  ~{preset.kcal} ккал
-                </div>
+                {activePreset
+                  ? `Пресет: ${activePreset.label}`
+                  : "Підказати з пресету"}
+                <span aria-hidden className="text-2xs">
+                  ▾
+                </span>
               </button>
-            ))}
-            <button
-              type="button"
-              onClick={() => setShowManual((v) => !v)}
-              disabled={busy || dayPlanBusy}
-              className={cn(
-                "flex-1 min-w-[90px] py-2 px-3 rounded-xl text-xs font-semibold border transition-[background-color,border-color,color,opacity]",
-                showManual && !activePreset
-                  ? "bg-panel border-nutrition text-text"
-                  : "border-line text-subtle hover:border-nutrition/50 hover:text-text",
+              {presetMenuOpen && (
+                <div
+                  role="menu"
+                  className={cn(
+                    "absolute right-0 top-full mt-1 z-10 min-w-[200px]",
+                    "rounded-xl border border-line bg-bg shadow-lg overflow-hidden",
+                  )}
+                >
+                  {PRESETS.map((preset) => (
+                    <button
+                      key={preset.id}
+                      type="button"
+                      role="menuitem"
+                      onClick={() => applyPreset(preset)}
+                      disabled={busy || dayPlanBusy}
+                      className={cn(
+                        "w-full text-left px-3 py-2 border-b border-line last:border-0",
+                        "hover:bg-panelHi disabled:opacity-50 transition-colors",
+                        activePreset?.id === preset.id &&
+                          "bg-nutrition/10 text-nutrition-strong dark:text-nutrition",
+                      )}
+                    >
+                      <div className="text-style-label">{preset.label}</div>
+                      <div className="text-2xs text-subtle mt-0.5">
+                        {preset.kcal} ккал · Б{preset.protein_g} · Ж
+                        {preset.fat_g} · В{preset.carbs_g}
+                      </div>
+                    </button>
+                  ))}
+                </div>
               )}
-            >
-              Свої цілі
-            </button>
+            </div>
           </div>
 
-          {showManual && (
-            <div className="mt-3 grid grid-cols-2 gap-2">
-              {(
-                [
-                  {
-                    key: "dailyTargetKcal",
-                    label: "Ккал/день",
-                    unit: "",
-                    color: null,
-                  },
-                  {
-                    key: "dailyTargetProtein_g",
-                    label: "Білки",
-                    unit: "г",
-                    color: "text-blue-400",
-                  },
-                  {
-                    key: "dailyTargetFat_g",
-                    label: "Жири",
-                    unit: "г",
-                    color: "text-yellow-400",
-                  },
-                  {
-                    key: "dailyTargetCarbs_g",
-                    label: "Вуглеводи",
-                    unit: "г",
-                    color: "text-green-400",
-                  },
-                ] as const
-              ).map(({ key, label, unit, color }) => (
-                <div key={key}>
-                  <div
-                    className={cn(
-                      "text-xs mb-1 font-semibold",
-                      color ?? "text-subtle",
-                    )}
-                  >
-                    {label}
-                    {unit && ` (${unit})`}
-                  </div>
-                  <Input
-                    type="number"
-                    inputMode="numeric"
-                    value={prefs[key] != null ? String(prefs[key]) : ""}
-                    onChange={(e) => {
-                      const raw = e.target.value;
-                      const v =
-                        raw === ""
-                          ? null
-                          : Number(raw) > 0
-                            ? Number(raw)
-                            : null;
-                      setPrefs((p) => {
-                        const next = { ...p, [key]: v };
-                        // Авто-перерахунок Ккал лише коли користувач явно не
-                        // задав ціль (kcal === null) або коли вона дорівнює
-                        // попередньому авто-значенню. Інакше тиха перезапис
-                        // з'їдала кастомні значення (M7 з аудиту).
-                        if (key !== "dailyTargetKcal") {
-                          const prevProt = p.dailyTargetProtein_g ?? 0;
-                          const prevFat = p.dailyTargetFat_g ?? 0;
-                          const prevCarb = p.dailyTargetCarbs_g ?? 0;
-                          const prevCalc = Math.round(
-                            prevProt * 4 + prevFat * 9 + prevCarb * 4,
-                          );
-                          const isAutoKcal =
-                            p.dailyTargetKcal == null ||
-                            p.dailyTargetKcal === prevCalc;
-                          if (isAutoKcal) {
-                            const prot =
-                              key === "dailyTargetProtein_g" ? v : prevProt;
-                            const fat =
-                              key === "dailyTargetFat_g" ? v : prevFat;
-                            const carb =
-                              key === "dailyTargetCarbs_g" ? v : prevCarb;
-                            const calc = Math.round(
-                              (prot || 0) * 4 +
-                                (fat || 0) * 9 +
-                                (carb || 0) * 4,
-                            );
-                            next.dailyTargetKcal = calc > 0 ? calc : null;
-                          }
-                        }
-                        return next;
-                      });
-                    }}
-                    placeholder="—"
-                    disabled={busy || dayPlanBusy}
-                  />
+          <div className="grid grid-cols-2 gap-2">
+            {(
+              [
+                {
+                  key: "dailyTargetKcal",
+                  label: "Ккал/день",
+                  unit: "",
+                  color: null,
+                },
+                {
+                  key: "dailyTargetProtein_g",
+                  label: "Білки",
+                  unit: "г",
+                  color: "text-blue-400",
+                },
+                {
+                  key: "dailyTargetFat_g",
+                  label: "Жири",
+                  unit: "г",
+                  color: "text-yellow-400",
+                },
+                {
+                  key: "dailyTargetCarbs_g",
+                  label: "Вуглеводи",
+                  unit: "г",
+                  color: "text-green-400",
+                },
+              ] as const
+            ).map(({ key, label, unit, color }) => (
+              <div key={key}>
+                <div
+                  className={cn(
+                    "text-xs mb-1 font-semibold",
+                    color ?? "text-subtle",
+                  )}
+                >
+                  {label}
+                  {unit && ` (${unit})`}
                 </div>
-              ))}
-            </div>
-          )}
+                <Input
+                  type="number"
+                  inputMode="numeric"
+                  value={prefs[key] != null ? String(prefs[key]) : ""}
+                  onChange={(e) => {
+                    const raw = e.target.value;
+                    const v =
+                      raw === "" ? null : Number(raw) > 0 ? Number(raw) : null;
+                    setPrefs((p) => {
+                      const next = { ...p, [key]: v };
+                      // Авто-перерахунок Ккал лише коли користувач явно не
+                      // задав ціль (kcal === null) або коли вона дорівнює
+                      // попередньому авто-значенню. Інакше тиха перезапис
+                      // з'їдала кастомні значення (M7 з аудиту).
+                      if (key !== "dailyTargetKcal") {
+                        const prevProt = p.dailyTargetProtein_g ?? 0;
+                        const prevFat = p.dailyTargetFat_g ?? 0;
+                        const prevCarb = p.dailyTargetCarbs_g ?? 0;
+                        const prevCalc = Math.round(
+                          prevProt * 4 + prevFat * 9 + prevCarb * 4,
+                        );
+                        const isAutoKcal =
+                          p.dailyTargetKcal == null ||
+                          p.dailyTargetKcal === prevCalc;
+                        if (isAutoKcal) {
+                          const prot =
+                            key === "dailyTargetProtein_g" ? v : prevProt;
+                          const fat = key === "dailyTargetFat_g" ? v : prevFat;
+                          const carb =
+                            key === "dailyTargetCarbs_g" ? v : prevCarb;
+                          const calc = Math.round(
+                            (prot || 0) * 4 + (fat || 0) * 9 + (carb || 0) * 4,
+                          );
+                          next.dailyTargetKcal = calc > 0 ? calc : null;
+                        }
+                      }
+                      return next;
+                    });
+                  }}
+                  placeholder="—"
+                  disabled={busy || dayPlanBusy}
+                />
+              </div>
+            ))}
+          </div>
 
           <MacroRatioBar prefs={prefs} />
+
+          <MissingMacrosHint prefs={prefs} setPrefs={setPrefs} busy={busy} />
 
           <MacroKcalWarning prefs={prefs} setPrefs={setPrefs} busy={busy} />
 

--- a/apps/web/src/modules/nutrition/components/PantryManagerSheet.test.tsx
+++ b/apps/web/src/modules/nutrition/components/PantryManagerSheet.test.tsx
@@ -2,10 +2,19 @@
 //
 // PR-37 ux-roast 2026-Q3 / §3.2 — у формі редагування назви складу
 // destructive «Видалити» поряд із «Зберегти» хибно зчитувалось як
-// скасування. Тут перевіряємо новий контракт:
-//   • поряд зі «Зберегти» стоїть «Скасувати», що закриває sheet;
-//   • видалення активного складу живе в окремій «Небезпечній зоні»
-//     і ховається, коли склад залишився єдиний (UX-guard).
+// скасування. Контракт:
+//   • поряд зі «Зберегти/Створити» стоїть «Скасувати»;
+//   • видалення активного складу живе в окремому розділі «Інше →
+//     Небезпечна зона» і ховається, коли склад залишився єдиний.
+//
+// UX-roast 2026-05 §3.4 — додаємо `idle`-режим форми. У цьому стані
+// інпут «Назва складу» взагалі не показано, доки користувач явно не
+// натиснув «+ Новий склад» / «Перейменувати активний». Перевіряємо:
+//   • в `idle` форма прихована;
+//   • у режимі `create` поряд зі «Створити» стоїть «Скасувати», а не
+//     «Видалити»;
+//   • небезпечна зона з'являється лише після натиску на роздільник
+//     «Інше».
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { Pantry } from "@sergeant/nutrition-domain";
@@ -17,7 +26,10 @@ function makeProps(overrides: {
   activePantryId: string;
   onClose?: () => void;
   onBeginDelete?: () => void;
-  onSavePantryForm?: (name: string, mode: PantryForm["mode"]) => void;
+  onSavePantryForm?: (
+    name: string,
+    mode: Exclude<PantryForm["mode"], "idle">,
+  ) => void;
   pantryForm?: PantryForm;
 }) {
   return {
@@ -41,8 +53,8 @@ afterEach(() => {
   cleanup();
 });
 
-describe("PantryManagerSheet (PR-37 / §3.2)", () => {
-  it("offers Cancel next to Save in the form, not Delete", () => {
+describe("PantryManagerSheet (PR-37 / §3.2 + 2026-05 §3.4)", () => {
+  it("offers Cancel next to Save in rename mode, not Delete", () => {
     render(
       <PantryManagerSheet
         {...makeProps({
@@ -63,8 +75,7 @@ describe("PantryManagerSheet (PR-37 / §3.2)", () => {
     ).toBeNull();
   });
 
-  it("invokes onClose when Cancel is clicked", () => {
-    const onClose = vi.fn();
+  it("offers Create + Cancel pair in create mode", () => {
     render(
       <PantryManagerSheet
         {...makeProps({
@@ -73,16 +84,64 @@ describe("PantryManagerSheet (PR-37 / §3.2)", () => {
             { id: "work", name: "Робота", items: [], text: "" },
           ],
           activePantryId: "home",
-          onClose,
+          pantryForm: { mode: "create", name: "", err: "" },
         })}
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Скасувати" }));
-    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("button", { name: "Створити" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Скасувати" })).toBeTruthy();
   });
 
-  it("renders danger-zone delete button when more than one pantry exists", () => {
+  it("hides the form entirely in idle mode", () => {
+    render(
+      <PantryManagerSheet
+        {...makeProps({
+          pantries: [
+            { id: "home", name: "Дім", items: [], text: "" },
+            { id: "work", name: "Робота", items: [], text: "" },
+          ],
+          activePantryId: "home",
+          pantryForm: { mode: "idle", name: "", err: "" },
+        })}
+      />,
+    );
+
+    // No Save / Create / Cancel buttons until the user picks a mode.
+    expect(screen.queryByRole("button", { name: "Зберегти" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Створити" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Скасувати" })).toBeNull();
+    // The action triggers (still visible) confirm the sheet is interactive.
+    expect(screen.getByRole("button", { name: "+ Новий склад" })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Перейменувати активний" }),
+    ).toBeTruthy();
+  });
+
+  it("invokes setPantryForm with idle when Cancel is clicked", () => {
+    const setPantryForm = vi.fn();
+    render(
+      <PantryManagerSheet
+        {...makeProps({
+          pantries: [
+            { id: "home", name: "Дім", items: [], text: "" },
+            { id: "work", name: "Робота", items: [], text: "" },
+          ],
+          activePantryId: "home",
+        })}
+        setPantryForm={setPantryForm}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Скасувати" }));
+    expect(setPantryForm).toHaveBeenCalledWith({
+      mode: "idle",
+      name: "",
+      err: "",
+    });
+  });
+
+  it("hides danger-zone behind 'Інше' until expanded", () => {
     const onBeginDelete = vi.fn();
     render(
       <PantryManagerSheet
@@ -97,6 +156,15 @@ describe("PantryManagerSheet (PR-37 / §3.2)", () => {
       />,
     );
 
+    // Collapsed by default — danger zone copy/button is not rendered yet.
+    expect(screen.queryByText(/Небезпечна зона/)).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: /Видалити активний склад/ }),
+    ).toBeNull();
+
+    // Expand the «Інше» section.
+    fireEvent.click(screen.getByRole("button", { name: /Інше/ }));
+
     const deleteBtn = screen.getByRole("button", {
       name: /Видалити активний склад/,
     });
@@ -105,7 +173,7 @@ describe("PantryManagerSheet (PR-37 / §3.2)", () => {
     expect(onBeginDelete).toHaveBeenCalledTimes(1);
   });
 
-  it("hides danger-zone delete when only one pantry remains", () => {
+  it("hides 'Інше' / danger-zone affordance when only one pantry remains", () => {
     render(
       <PantryManagerSheet
         {...makeProps({
@@ -115,6 +183,7 @@ describe("PantryManagerSheet (PR-37 / §3.2)", () => {
       />,
     );
 
+    expect(screen.queryByRole("button", { name: /Інше/ })).toBeNull();
     expect(screen.queryByText(/Небезпечна зона/)).toBeNull();
     expect(
       screen.queryByRole("button", { name: /Видалити активний склад/ }),

--- a/apps/web/src/modules/nutrition/components/PantryManagerSheet.tsx
+++ b/apps/web/src/modules/nutrition/components/PantryManagerSheet.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Input } from "@shared/components/ui/Input";
@@ -8,13 +9,21 @@ import type { Pantry } from "@sergeant/nutrition-domain";
 
 /**
  * Modes a pantry form can be in:
+ * - `idle`: form is hidden, sheet шows тільки список + кнопки дій.
  * - `create`: input is the name of a brand-new склад to add.
  * - `rename`: input is the new name for the active склад.
  *
  * Defined as an explicit union so call-sites and state shapes stay aligned
  * (`PantryManagerSheet`, `useNutritionPantries`, `NutritionOverlays`).
+ *
+ * UX-roast 2026-05 §3.4: Раніше форма за замовчуванням стояла у `create`
+ * mode і інпут «Назва складу» одразу був видимий. Користувач натискав
+ * «+ Новий склад» — нічого візуально не змінювалось, бо форма вже й
+ * так в стані створення. Тепер додаємо `idle`, у який фолбекаємось
+ * між діями: натиск кнопки «+ Новий склад» гарантовано показує форму
+ * і фокусує інпут (бо ми переходимо з `idle` → `create`).
  */
-export type PantryFormMode = "create" | "rename";
+export type PantryFormMode = "idle" | "create" | "rename";
 
 export interface PantryForm {
   mode: PantryFormMode;
@@ -31,7 +40,10 @@ interface PantryManagerSheetProps {
   pantryForm: PantryForm;
   setPantryForm: Dispatch<SetStateAction<PantryForm>>;
   busy?: boolean;
-  onSavePantryForm: (name: string, mode: PantryFormMode) => void;
+  onSavePantryForm: (
+    name: string,
+    mode: Exclude<PantryFormMode, "idle">,
+  ) => void;
   onBeginCreate: () => void;
   onBeginRename: () => void;
   onBeginDelete: () => void;
@@ -55,10 +67,53 @@ export function PantryManagerSheet({
   const activePantry =
     safePantries.find((p) => p.id === activePantryId) ?? null;
   const activeName = activePantry?.name?.trim() || "Склад";
-  // Гарантуємо хоча б один склад: останній не показуємо в «Небезпечній зоні»,
-  // бо `onConfirmDeletePantry` для нього no-op (щоб не залишити користувача
-  // зовсім без сховища).
+  // Гарантуємо хоча б один склад: останній не показуємо в розділі
+  // «Інше → Видалити», бо `onConfirmDeletePantry` для нього no-op
+  // (щоб не залишити користувача зовсім без сховища).
   const canDeleteActive = safePantries.length > 1 && activePantry !== null;
+
+  // UX-roast 2026-05 §3.4: «Видалити активний» — небезпечна дія, що
+  // майже ніколи не потрібна. Сховали її за роздільником «Інше», який
+  // користувач має явно розкрити, щоб уникнути випадкового тапу
+  // одразу після створення/перейменування. Стан розкриття — local UI,
+  // не персистимо.
+  const [moreOpen, setMoreOpen] = useState(false);
+
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const isFormVisible =
+    pantryForm.mode === "create" || pantryForm.mode === "rename";
+
+  // Коли форма відкрилась (mode != idle) — фокусуємось у інпут одразу,
+  // щоб користувач міг почати друкувати без додаткового тапу. Це і є
+  // те видиме «щось сталося», якого бракувало раніше.
+  useEffect(() => {
+    if (!open) return;
+    if (!isFormVisible) return;
+    const id = window.setTimeout(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }, 50);
+    return () => window.clearTimeout(id);
+  }, [open, isFormVisible, pantryForm.mode]);
+
+  // При закритті sheet — повертаємо форму в `idle`, щоб наступне
+  // відкриття було без застряглого минулого стану.
+  useEffect(() => {
+    if (open) return;
+    setMoreOpen(false);
+    setPantryForm((f) =>
+      f.mode === "idle" ? f : { mode: "idle", name: "", err: "" },
+    );
+  }, [open, setPantryForm]);
+
+  const formTitle =
+    pantryForm.mode === "rename"
+      ? `Перейменувати «${activeName}»`
+      : "Новий склад";
+  const formHint =
+    pantryForm.mode === "rename"
+      ? "Введи нову назву та збережи."
+      : "Введи назву нового складу та натисни «Створити».";
 
   return (
     <Sheet
@@ -101,7 +156,11 @@ export function PantryManagerSheet({
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 mb-4">
         <Button
           type="button"
-          className="h-12 min-h-[44px] bg-nutrition-strong text-white hover:bg-nutrition-hover"
+          aria-pressed={pantryForm.mode === "create"}
+          className={cn(
+            "h-12 min-h-[44px] bg-nutrition-strong text-white hover:bg-nutrition-hover",
+            pantryForm.mode === "create" && "ring-2 ring-nutrition/60",
+          )}
           onClick={onBeginCreate}
         >
           + Новий склад
@@ -109,90 +168,138 @@ export function PantryManagerSheet({
         <Button
           type="button"
           variant="ghost"
-          className="h-12 min-h-[44px]"
+          aria-pressed={pantryForm.mode === "rename"}
+          className={cn(
+            "h-12 min-h-[44px]",
+            pantryForm.mode === "rename" &&
+              "border border-nutrition text-text bg-panelHi",
+          )}
           onClick={onBeginRename}
         >
           Перейменувати активний
         </Button>
       </div>
 
-      <div className="rounded-2xl border border-line bg-panelHi p-4">
-        <SectionHeading as="div" size="xs">
-          {pantryForm.mode === "rename" ? "Нова назва" : "Назва складу"}
-        </SectionHeading>
-        <div className="mt-2">
-          <Input
-            value={pantryForm.name}
-            onChange={(e) =>
-              setPantryForm((f) => ({
-                ...f,
-                name: e.target.value,
-                err: "",
-              }))
-            }
-            placeholder="напр. Дім"
-            disabled={busy}
-            aria-label="Назва складу"
-          />
-          {pantryForm.err ? (
-            <div className="text-xs text-danger mt-2">{pantryForm.err}</div>
-          ) : null}
-        </div>
-        {/*
-         * PR-37 ux-roast 2026-Q3 / §3.2: «Видалити активний» поряд із «Зберегти»
-         * читалося як парна destructive-дія до збереження назви — користувачі
-         * хибно очікували, що це скасує редагування. Тепер тут пара
-         * Зберегти / Скасувати, а видалення складу винесено в окремий
-         * блок «Небезпечна зона» нижче.
-         */}
-        <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-2">
-          <Button
-            type="button"
-            className="h-12 min-h-[44px] bg-nutrition-strong text-white hover:bg-nutrition-hover"
-            onClick={() => {
-              const name = String(pantryForm.name || "").trim();
-              if (!name) {
-                setPantryForm((f) => ({ ...f, err: "Вкажи назву." }));
-                return;
+      {isFormVisible && (
+        <div className="rounded-2xl border border-nutrition/40 bg-panelHi p-4">
+          <SectionHeading as="div" size="xs">
+            {formTitle}
+          </SectionHeading>
+          <p className="text-xs text-subtle leading-relaxed mt-1">{formHint}</p>
+          <div className="mt-3">
+            <Input
+              ref={inputRef}
+              value={pantryForm.name}
+              onChange={(e) =>
+                setPantryForm((f) => ({
+                  ...f,
+                  name: e.target.value,
+                  err: "",
+                }))
               }
-              onSavePantryForm(name, pantryForm.mode);
-            }}
-          >
-            Зберегти
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            className="h-12 min-h-[44px]"
-            onClick={onClose}
-            disabled={busy}
-          >
-            Скасувати
-          </Button>
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  const name = String(pantryForm.name || "").trim();
+                  if (!name) {
+                    setPantryForm((f) => ({ ...f, err: "Вкажи назву." }));
+                    return;
+                  }
+                  if (pantryForm.mode === "idle") return;
+                  onSavePantryForm(name, pantryForm.mode);
+                }
+              }}
+              placeholder={
+                pantryForm.mode === "rename"
+                  ? "Нова назва"
+                  : "напр. Дім, Робота, Дача"
+              }
+              disabled={busy}
+              aria-label={
+                pantryForm.mode === "rename" ? "Нова назва" : "Назва складу"
+              }
+            />
+            {pantryForm.err ? (
+              <div className="text-xs text-danger mt-2">{pantryForm.err}</div>
+            ) : null}
+          </div>
+          {/*
+           * PR-37 ux-roast 2026-Q3 / §3.2 + 2026-05 / §3.4: пара
+           * «Зберегти / Скасувати». «Скасувати» згортає форму назад в
+           * `idle`-стан замість закриття всього sheet, щоб користувач
+           * міг одразу натиснути іншу дію (наприклад, перейменувати).
+           */}
+          <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-2">
+            <Button
+              type="button"
+              className="h-12 min-h-[44px] bg-nutrition-strong text-white hover:bg-nutrition-hover"
+              onClick={() => {
+                const name = String(pantryForm.name || "").trim();
+                if (!name) {
+                  setPantryForm((f) => ({ ...f, err: "Вкажи назву." }));
+                  return;
+                }
+                if (pantryForm.mode === "idle") return;
+                onSavePantryForm(name, pantryForm.mode);
+              }}
+            >
+              {pantryForm.mode === "rename" ? "Зберегти" : "Створити"}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              className="h-12 min-h-[44px]"
+              onClick={() => setPantryForm({ mode: "idle", name: "", err: "" })}
+              disabled={busy}
+            >
+              Скасувати
+            </Button>
+          </div>
         </div>
-      </div>
+      )}
 
       {canDeleteActive && (
-        <div className="mt-4 rounded-2xl border border-line/60 bg-bg/40 p-4">
-          <SectionHeading as="div" size="xs">
-            Небезпечна зона
-          </SectionHeading>
-          <p className="text-xs text-subtle leading-relaxed mt-1">
-            Видалить активний склад «{activeName}» разом з усіма продуктами в
-            ньому. Дію не можна відмінити.
-          </p>
+        <div className="mt-4">
           <button
             type="button"
-            onClick={onBeginDelete}
-            disabled={busy}
+            onClick={() => setMoreOpen((v) => !v)}
             className={cn(
-              "mt-3 inline-flex items-center gap-1.5 text-xs font-semibold",
-              "text-danger hover:text-danger/80 disabled:opacity-50",
-              "transition-colors",
+              "w-full flex items-center justify-between gap-2",
+              "text-xs text-subtle hover:text-text transition-colors",
+              "py-2 border-t border-line/60",
             )}
+            aria-expanded={moreOpen}
+            aria-controls="pantry-more-actions"
           >
-            🗑 Видалити активний склад
+            <span>Інше</span>
+            <span aria-hidden>{moreOpen ? "▴" : "▾"}</span>
           </button>
+          {moreOpen && (
+            <div
+              id="pantry-more-actions"
+              className="rounded-2xl border border-line/60 bg-bg/40 p-4 mt-2"
+            >
+              <SectionHeading as="div" size="xs">
+                Небезпечна зона
+              </SectionHeading>
+              <p className="text-xs text-subtle leading-relaxed mt-1">
+                Видалить активний склад «{activeName}» разом з усіма продуктами
+                в ньому. Дію не можна відмінити.
+              </p>
+              <button
+                type="button"
+                onClick={onBeginDelete}
+                disabled={busy}
+                className={cn(
+                  "mt-3 inline-flex items-center gap-1.5 text-xs font-semibold",
+                  "text-danger hover:text-danger/80 disabled:opacity-50",
+                  "transition-colors",
+                )}
+              >
+                🗑 Видалити активний склад
+              </button>
+            </div>
+          )}
         </div>
       )}
     </Sheet>

--- a/apps/web/src/modules/nutrition/hooks/useNutritionPantries.ts
+++ b/apps/web/src/modules/nutrition/hooks/useNutritionPantries.ts
@@ -88,8 +88,11 @@ export function useNutritionPantries({
 
   const [pantryManagerOpen, setPantryManagerOpen] = useState(false);
 
+  // UX-roast 2026-05 §3.4: дефолтний mode `idle` — поле «Назва складу»
+  // не показується, доки користувач явно не натиснув «+ Новий склад»
+  // або «Перейменувати». Це робить ці кнопки видимо реактивними.
   const [pantryForm, setPantryForm] = useState<PantryForm>(() => ({
-    mode: "create",
+    mode: "idle",
     name: "",
     err: "",
   }));
@@ -218,7 +221,10 @@ export function useNutritionPantries({
     setConfirmDeleteOpen(true);
   };
 
-  const onSavePantryForm = (name: string, mode: PantryFormMode) => {
+  const onSavePantryForm = (
+    name: string,
+    mode: Exclude<PantryFormMode, "idle">,
+  ) => {
     if (mode === "rename") {
       setPantries((cur) =>
         updatePantry(cur, activePantryId, (p) => ({ ...p, name })),
@@ -231,6 +237,7 @@ export function useNutritionPantries({
       ]);
       setActivePantryId(id);
     }
+    setPantryForm({ mode: "idle", name: "", err: "" });
     setPantryManagerOpen(false);
   };
 


### PR DESCRIPTION
## Summary

UX-roast 2026-05 від користувача — чотири точкові фікси у застосунку Sergeant без зміни доменних контрактів і RQ-ключів:

1. Глобальний пошук тепер сканує і вбудований каталог вправ Фізрука (запит «жим» / «bench» знаходить «Жим лежачи»).
2. Картки KPI на сторінці «Звіти» згорнуті за замовчуванням; стан розгортання per-card зберігається в localStorage.
3. У `DailyPlanCard` дефолт — manual entry (4 інпути ккал/Б/Ж/В); пресети «Схуднення/Підтримка/Набір» сховано за випадайкою «Підказати з пресету»; soft-hint `MissingMacrosHint` пропонує підставити середні макро (30/25/45 split), коли заданий лише ккал.
4. У `PantryManagerSheet` доданий `idle` mode — інпут «Назва складу» прихований, доки користувач явно не натиснув «+ Новий склад» / «Перейменувати» (тоді інпут одразу показується + фокусується + selectAll'ається). Кнопка «Видалити активний» згорнута під розкривний розділ «Інше → Небезпечна зона», на її місці тепер — звичайне «Скасувати».

## Governing Skill

- Primary skill: web-frontend (apps/web — UI components, search, hub)
- Secondary skill (if truly needed): nutrition (DailyPlanCard, PantryManagerSheet — UI-only changes; домен/міграцій не зачіпали)

## Playbook

- Primary playbook: ui-ux-fix
- Why this playbook: всі чотири пункти — це frontend-only UX правки (видимість/скоупи/дефолтні стани) без міграцій, нових RQ-ключів чи зміни сервер-контрактів.
- If no playbook matched, why: n/a

## Verification

```bash
pnpm lint                                  # проганяємо staged-lint у pre-commit hook (eslint --fix --max-warnings=0) — pass
pnpm --filter @sergeant/web test -- src/modules/nutrition/components/PantryManagerSheet.test.tsx
# 6 tests passed (idle/create/cancel/danger-zone)
```

Additional checks:

- [x] Local smoke / manual validation completed (lint + targeted tests)
- [x] Surface-specific checks completed (PantryManagerSheet.test.tsx: idle/create/rename/cancel/danger-zone)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. — n/a, чисто UI-зміни без публічного контракту.
- [x] I checked whether `AGENTS.md` needed an update. — не потрібно.
- [x] I checked whether a playbook or skill needed an update. — не потрібно.
- [x] I checked whether governance docs or review docs needed an update. — не потрібно.

Updated docs:

- n/a

## Risk and Rollout

- User-visible risk: дефолтний стан карток звітів змінено на згорнутий — користувачі побачать інакший layout при першому заході; стан персистить per-card. Дефолт мак-цілей тепер manual замість пресета — старі збережені значення `dailyTarget*` не торкаємось.
- Rollout / deploy order: звичайний релізний цикл `apps/web`. Не вимагає flag-flip-у або міграцій.
- Backout plan: revert цього коміту → деплой попередньої версії; localStorage-ключі не змінювали (`workout_report_collapsed_*`, `nutrition_prefs_v1`, `nutrition_pantries_v1` залишились як були).

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

- `git_create_pr` tool у середовищі повертав `Internal error` 6× поспіль, тож PR створено через GitHub REST API з PAT за згодою користувача (звідси й перший рев'юверський сюрприз — описова частина PR оновлена окремим API-викликом, а не одночасно з створенням).
- Три CI-чеки `Test coverage (vitest)` / `Critical-flow E2E (Playwright)` / `check` падають і на `main` (`b71487ab`) — pre-existing infrastructure failures, не пов'язані з цим PR. Локальний smoke-тест зачеплених модулів (PantryManagerSheet) — зелений.
- Зачеплені файли:
  - `apps/web/src/core/hub/search/searchSources.ts`
  - `apps/web/src/core/hub/HubReports.tsx`
  - `apps/web/src/modules/nutrition/components/DailyPlanCard.tsx`
  - `apps/web/src/modules/nutrition/components/PantryManagerSheet.tsx`
  - `apps/web/src/modules/nutrition/components/PantryManagerSheet.test.tsx`
  - `apps/web/src/modules/nutrition/hooks/useNutritionPantries.ts`
