### PR TITLE
fix(web): remove header scroll-hide behavior, keep greeting always visible

### DIFF
--- a/apps/web/src/core/app/HubHeader.tsx
+++ b/apps/web/src/core/app/HubHeader.tsx
@@ -2,7 +2,6 @@ import { useMemo } from "react";
 import { cn } from "@shared/lib/ui/cn";
 import { Icon } from "@shared/components/ui/Icon";
 import { Tooltip } from "@shared/components/ui/Tooltip";
-import { useScrollHeader } from "@shared/hooks/useScrollHeader";
 import { BrandLogo } from "./BrandLogo";
 import { DarkModeToggle } from "./DarkModeToggle";
 import type { User } from "@sergeant/shared";
@@ -63,12 +62,6 @@ export function HubHeader({
   onToggleDark,
   hideAuthButton = false,
 }: HubHeaderProps) {
-  const { isHidden, isShrunk, hasBlur } = useScrollHeader({
-    shrinkThreshold: 40,
-    hideThreshold: 120,
-    minDelta: 8,
-  });
-
   const greetingText = useMemo(() => {
     const tod = getTimeOfDay();
     const base = GREETINGS[tod];
@@ -82,22 +75,11 @@ export function HubHeader({
     <header
       className={cn(
         "px-5 max-w-lg mx-auto w-full",
-        "sticky top-0 z-40",
-        "transition-all duration-300 ease-out",
-        // Progressive header states
-        isHidden && "-translate-y-full",
-        isShrunk ? "pt-2 pb-2" : "pt-6 pb-2.5",
-        hasBlur && "bg-bg/80 backdrop-blur-md border-b border-line/50",
+        "shrink-0 z-40",
+        "pt-6 pb-2.5",
       )}
       style={{
-        // Prefer the OS-reported safe-area inset on devices that have one
-        // (notched/dynamic-island phones, PWA standalone with status-bar);
-        // fall back to a tighter 1.5rem (24px) baseline on the web instead
-        // of the previous 2.5rem (40px), which ate ~16px of dashboard
-        // real estate on every cold start without serving any system chrome.
-        paddingTop: isShrunk
-          ? undefined
-          : "max(1.5rem, env(safe-area-inset-top))",
+        paddingTop: "max(1.5rem, env(safe-area-inset-top))",
       }}
     >
       {/* ── Row 1: Mark + Wordmark + Action icons ─────────────── */}
@@ -163,13 +145,7 @@ export function HubHeader({
       {/* greeting+date, бо це справжній сигнальний шар (час доби, */}
       {/* персональне звернення), а тег «оперативний центр» — */}
       {/* брендовий шум, який забирав вертикальний простір. */}
-      <p
-        className={cn(
-          "mt-1.5 ml-[3px] text-sm leading-snug text-muted truncate",
-          "transition-all duration-300",
-          isShrunk && "opacity-0 h-0 mt-0 overflow-hidden",
-        )}
-      >
+      <p className="mt-1.5 ml-[3px] text-sm leading-snug text-muted truncate">
         {greetingText}
         {dateStr && (
           <>


### PR DESCRIPTION
## Summary

Removes the scroll-aware header behavior that was hiding the greeting text ("Доброго дня") and causing the bottom navigation to be clipped.

## Changes

- **`apps/web/src/core/app/HubHeader.tsx`**: Removed `useScrollHeader` hook and all scroll-dependent CSS classes. Header is now static (`shrink-0`) instead of `sticky top-0` with translate/shrink/blur transitions. The greeting + date row is always visible.

## What was wrong

1. The header used `useScrollHeader` to shrink and hide on scroll — this hid the "Доброго дня" greeting and date.
2. The `sticky` + dynamic height changes caused the bottom nav footer to be partially clipped on mobile.

## Fix

- Header is now a static flex item (`shrink-0`) that always shows the full greeting.
- Bottom nav is no longer affected by header height changes since the header no longer changes height.

Link to Devin session: https://app.devin.ai/sessions/6288e6d0b6a14b1588f562e7a5b36533

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the header scroll-hide behavior so the greeting and date are always visible. This also fixes the mobile bottom nav being clipped.

- **Bug Fixes**
  - Removed `useScrollHeader` and scroll-dependent classes from `HubHeader.tsx`.
  - Made the header static (`shrink-0`) with fixed padding (`max(1.5rem, env(safe-area-inset-top))`).
  - Dropped shrink/blur/translate transitions that changed header height.

<sup>Written for commit 6f09b69df3723465277f2419186d2394f3d82963. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

