### PR TITLE
fix(web): route typedStore writes through webKVStore for SQLite consistency

### DIFF
--- a/apps/web/src/shared/lib/storage/typedStore.ts
+++ b/apps/web/src/shared/lib/storage/typedStore.ts
@@ -25,7 +25,6 @@
 
 import type { ZodType } from "zod";
 import { webKVStore } from "./storage";
-import { safeJsonSet } from "./storageQuota";
 
 type Listener<T> = (value: T) => void;
 
@@ -212,9 +211,17 @@ export function createTypedStore<T>(
       return true;
     }
     const envelope: Envelope<T> = { __v: version, data: result.data };
-    const res = safeJsonSet(key, envelope);
-    if (!res || !res.ok) {
-      report("write", res?.reason || res?.error || "unknown");
+    let serialized: string;
+    try {
+      serialized = JSON.stringify(envelope);
+    } catch (err) {
+      report("write", err);
+      return false;
+    }
+    try {
+      webKVStore.setString(key, serialized);
+    } catch (err) {
+      report("write", err);
       return false;
     }
     notify(result.data);


### PR DESCRIPTION
## Summary

`typedStore.set()` wrote values via `safeJsonSet()` which routes to raw `localStorage.setItem()`. However, `typedStore.readFromStorage()` reads via `webKVStore.getString()` which resolves to SQLite warm-cache post-boot. This write/read path mismatch caused all `typedStore` consumers (including `hub_flags_v1` / feature flags) to lose persisted values on page reload when SQLite is active.

Fix: route `set()` writes through `webKVStore.setString()` so both reads and writes use the same store resolution.

User-visible symptom: App Lock PIN toggle resets on page reload / app restart; PIN is never requested.

## Governing Skill

- Primary skill: n/a (bug fix in shared storage layer)
- Secondary skill: n/a

## Playbook

- Primary playbook: n/a
- Why this playbook: n/a
- If no playbook matched, why: This is a targeted storage-layer bug fix, no playbook covers this specific area.

## Verification

```bash
pnpm lint
pnpm typecheck
```

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a (no doc changes needed for this internal bug fix)

## Risk and Rollout

- User-visible risk: Low — fixes existing broken behavior. All `typedStore` writes now route through `webKVStore` (SQLite when active, localStorage fallback). No API change.
- Rollout / deploy order: Standard web deploy.
- Backout plan: Revert this commit; flag persistence reverts to broken pre-SQLite behavior.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

This fix affects **all** `typedStore` consumers, not just feature flags. The `safeJsonSet` import is removed from `typedStore.ts` since writes now go through `webKVStore.setString()`. The quota-check from `safeJsonSet` is not replicated — the envelope payloads are small JSON objects well under the 4MB limit.