### PR TITLE
feat(web): wire SQLite dual-write parity probe into Routine orchestrator (Stage 8 §3)

### DIFF
--- a/apps/web/src/modules/routine/lib/dualWrite/__tests__/parity.test.ts
+++ b/apps/web/src/modules/routine/lib/dualWrite/__tests__/parity.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from "vitest";
+import type { SqliteMigrationClient } from "@sergeant/db-schema/migrate/sqlite";
+
+import { probeRoutineParity } from "../parity.js";
+import { createTestSqlite } from "./testSqlite.js";
+
+const USER_ID = "user-1";
+
+function makeStateWithCompletions(completions: Record<string, string[]>) {
+  return {
+    schemaVersion: 1,
+    prefs: {},
+    tags: [],
+    categories: [],
+    habits: Object.keys(completions).map((id) => ({ id, name: id })),
+    completions,
+    pushupsByDate: {},
+    habitOrder: Object.keys(completions),
+    completionNotes: {},
+  };
+}
+
+async function seedEntries(
+  client: SqliteMigrationClient,
+  rows: { habitId: string; dateKey: string; deletedAt?: string | null }[],
+): Promise<void> {
+  for (const r of rows) {
+    await client.run(
+      `INSERT INTO routine_entries
+         (id, user_id, name, completed_at, created_at, updated_at, deleted_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [
+        `${r.habitId}:${r.dateKey}`,
+        USER_ID,
+        r.habitId,
+        `${r.dateKey}T00:00:00.000Z`,
+        `${r.dateKey}T00:00:00.000Z`,
+        `${r.dateKey}T00:00:00.000Z`,
+        r.deletedAt ?? null,
+      ],
+    );
+  }
+}
+
+describe("probeRoutineParity", () => {
+  it("reports match when LS and SQLite agree on the active completion set", async () => {
+    const handle = await createTestSqlite();
+    try {
+      await seedEntries(handle.client, [
+        { habitId: "h1", dateKey: "2026-05-01" },
+        { habitId: "h1", dateKey: "2026-05-02" },
+        { habitId: "h2", dateKey: "2026-05-01" },
+      ]);
+      const next = makeStateWithCompletions({
+        h1: ["2026-05-01", "2026-05-02"],
+        h2: ["2026-05-01"],
+      });
+      const out = await probeRoutineParity(handle.client, USER_ID, next);
+      expect(out.result).toBe("match");
+      expect(out.details).toEqual({ ls: 3, sqlite: 3 });
+    } finally {
+      handle.close();
+    }
+  });
+
+  it("reports match when both sides are empty", async () => {
+    const handle = await createTestSqlite();
+    try {
+      const next = makeStateWithCompletions({});
+      const out = await probeRoutineParity(handle.client, USER_ID, next);
+      expect(out.result).toBe("match");
+      expect(out.details).toEqual({ ls: 0, sqlite: 0 });
+    } finally {
+      handle.close();
+    }
+  });
+
+  it("ignores soft-deleted SQLite rows in the parity comparison", async () => {
+    const handle = await createTestSqlite();
+    try {
+      await seedEntries(handle.client, [
+        { habitId: "h1", dateKey: "2026-05-01" },
+        {
+          habitId: "h1",
+          dateKey: "2026-05-02",
+          deletedAt: "2026-05-02T10:00:00.000Z",
+        },
+      ]);
+      const next = makeStateWithCompletions({ h1: ["2026-05-01"] });
+      const out = await probeRoutineParity(handle.client, USER_ID, next);
+      expect(out.result).toBe("match");
+      expect(out.details).toEqual({ ls: 1, sqlite: 1 });
+    } finally {
+      handle.close();
+    }
+  });
+
+  it("reports mismatch with lsOnly count when SQLite is missing rows", async () => {
+    const handle = await createTestSqlite();
+    try {
+      await seedEntries(handle.client, [
+        { habitId: "h1", dateKey: "2026-05-01" },
+      ]);
+      const next = makeStateWithCompletions({
+        h1: ["2026-05-01", "2026-05-02"],
+      });
+      const out = await probeRoutineParity(handle.client, USER_ID, next);
+      expect(out.result).toBe("mismatch");
+      expect(out.details).toEqual({
+        ls: 2,
+        sqlite: 1,
+        lsOnly: 1,
+        sqliteOnly: 0,
+      });
+    } finally {
+      handle.close();
+    }
+  });
+
+  it("reports mismatch with sqliteOnly count when SQLite has stale rows", async () => {
+    const handle = await createTestSqlite();
+    try {
+      await seedEntries(handle.client, [
+        { habitId: "h1", dateKey: "2026-05-01" },
+        { habitId: "h1", dateKey: "2026-05-02" },
+        { habitId: "h2", dateKey: "2026-05-03" },
+      ]);
+      const next = makeStateWithCompletions({ h1: ["2026-05-01"] });
+      const out = await probeRoutineParity(handle.client, USER_ID, next);
+      expect(out.result).toBe("mismatch");
+      expect(out.details).toEqual({
+        ls: 1,
+        sqlite: 3,
+        lsOnly: 0,
+        sqliteOnly: 2,
+      });
+    } finally {
+      handle.close();
+    }
+  });
+
+  it("reports mismatch with both lsOnly and sqliteOnly when sets diverge symmetrically", async () => {
+    const handle = await createTestSqlite();
+    try {
+      await seedEntries(handle.client, [
+        { habitId: "h1", dateKey: "2026-05-01" },
+      ]);
+      const next = makeStateWithCompletions({ h2: ["2026-05-02"] });
+      const out = await probeRoutineParity(handle.client, USER_ID, next);
+      expect(out.result).toBe("mismatch");
+      expect(out.details).toEqual({
+        ls: 1,
+        sqlite: 1,
+        lsOnly: 1,
+        sqliteOnly: 1,
+      });
+    } finally {
+      handle.close();
+    }
+  });
+
+  it("scopes the read to user_id so other users' rows don't leak in", async () => {
+    const handle = await createTestSqlite();
+    try {
+      // Other user has 5 rows; current user has 1.
+      await handle.client.run(
+        `INSERT INTO routine_entries
+           (id, user_id, name, completed_at, created_at, updated_at, deleted_at)
+         VALUES (?, 'user-2', 'X', '2026-05-01T00:00:00.000Z',
+                 '2026-05-01T00:00:00.000Z', '2026-05-01T00:00:00.000Z', NULL)`,
+        ["other-h:2026-05-01"],
+      );
+      await seedEntries(handle.client, [
+        { habitId: "h1", dateKey: "2026-05-01" },
+      ]);
+      const next = makeStateWithCompletions({ h1: ["2026-05-01"] });
+      const out = await probeRoutineParity(handle.client, USER_ID, next);
+      expect(out.result).toBe("match");
+      expect(out.details).toEqual({ ls: 1, sqlite: 1 });
+    } finally {
+      handle.close();
+    }
+  });
+
+  it("rejects malformed SQLite ids without crashing the probe", async () => {
+    const handle = await createTestSqlite();
+    try {
+      // Insert a row whose id has no separator — should be ignored.
+      await handle.client.run(
+        `INSERT INTO routine_entries
+           (id, user_id, name, completed_at, created_at, updated_at, deleted_at)
+         VALUES (?, ?, 'X', '2026-05-01T00:00:00.000Z',
+                 '2026-05-01T00:00:00.000Z', '2026-05-01T00:00:00.000Z', NULL)`,
+        ["no-sep-id", USER_ID],
+      );
+      await seedEntries(handle.client, [
+        { habitId: "h1", dateKey: "2026-05-01" },
+      ]);
+      const next = makeStateWithCompletions({ h1: ["2026-05-01"] });
+      const out = await probeRoutineParity(handle.client, USER_ID, next);
+      expect(out.result).toBe("match");
+      expect(out.details).toEqual({ ls: 1, sqlite: 1 });
+    } finally {
+      handle.close();
+    }
+  });
+
+  it("rejects malformed dateKey values in next.completions", async () => {
+    const handle = await createTestSqlite();
+    try {
+      await seedEntries(handle.client, [
+        { habitId: "h1", dateKey: "2026-05-01" },
+      ]);
+      const next = makeStateWithCompletions({
+        h1: ["2026-05-01", "not-a-date", ""],
+      });
+      const out = await probeRoutineParity(handle.client, USER_ID, next);
+      expect(out.result).toBe("match");
+      expect(out.details).toEqual({ ls: 1, sqlite: 1 });
+    } finally {
+      handle.close();
+    }
+  });
+});

--- a/apps/web/src/modules/routine/lib/dualWrite/index.ts
+++ b/apps/web/src/modules/routine/lib/dualWrite/index.ts
@@ -1,13 +1,18 @@
 import type { RoutineState } from "@sergeant/routine-domain";
 import type { SqliteMigrationClient } from "@sergeant/db-schema/migrate/sqlite";
 
-import { recordDualWriteOutcome } from "../../../../core/observability/dualWriteTelemetry.js";
+import {
+  recordDualWriteOutcome,
+  recordParityCheck,
+  recordReadFallback,
+} from "../../../../core/observability/dualWriteTelemetry.js";
 import {
   applyRoutineDualWriteOps,
   type ApplyDualWriteResult,
   type DualWriteLogger,
 } from "./adapter.js";
 import { diffRoutineDualWriteOps } from "./diff.js";
+import { probeRoutineParity } from "./parity.js";
 
 /**
  * Orchestrator for the routine dual-write layer.
@@ -160,6 +165,24 @@ async function runDualWriteRoutineState(
     clientTs: ctx.getNow(),
     logger: ctx.logger,
   });
+
+  // Stage 8 parity probe — best-effort: never throws, never disturbs
+  // the dual-write outcome. A failed probe-read is tagged distinctly
+  // (`recordReadFallback`) so triage can tell `SELECT failing` apart
+  // from a real LS↔SQLite divergence (`recordParityCheck("…",
+  // "mismatch", …)`).
+  try {
+    const parity = await probeRoutineParity(client, userId, next);
+    recordParityCheck("routine", parity.result, parity.details);
+  } catch (err) {
+    recordReadFallback(
+      "routine",
+      err instanceof Error
+        ? `parity-probe-failed: ${err.message}`
+        : "parity-probe-failed",
+    );
+  }
+
   return { status: "applied", result };
 }
 

--- a/apps/web/src/modules/routine/lib/dualWrite/parity.ts
+++ b/apps/web/src/modules/routine/lib/dualWrite/parity.ts
@@ -1,0 +1,121 @@
+import type { RoutineState } from "@sergeant/routine-domain";
+import type { SqliteMigrationClient } from "@sergeant/db-schema/migrate/sqlite";
+
+/**
+ * Parity probe for the Routine SQLite dual-write layer.
+ *
+ * Stage 8 §3 of `docs/planning/storage-roadmap.md` defines a
+ * `<module>.sqlite.dualwrite.parity` decision-gate metric: whenever
+ * the LS-derived state and the SQLite-derived state should be
+ * identical (which is the steady-state invariant once the dual-write
+ * `applied` outcome returns success), they are compared and a
+ * `recordParityCheck` tick is emitted on the global Sentry scope.
+ *
+ * The orchestrator (`./index.ts`) calls this helper after every
+ * successful `applyRoutineDualWriteOps` apply. Routine SQLite holds
+ * only the `routine_entries` table today — habits / tags / categories /
+ * prefs / pushups / habitOrder / completionNotes still live in LS and
+ * migrate in later PRs (`storage-roadmap.md` Stage 8). The probe
+ * therefore compares **only** the (habitId, dateKey) completion set
+ * — that is the only field that actually round-trips through SQLite
+ * at this stage.
+ *
+ * The probe is best-effort: it must NEVER throw, and any read failure
+ * is surfaced as a `read.fallback` — distinct from a real parity
+ * mismatch — so triage can tell `SELECT failing` apart from `LS and
+ * SQLite genuinely disagree on completions`. The orchestrator
+ * implements that distinction.
+ */
+
+interface ParityProbeOutcome {
+  result: "match" | "mismatch";
+  details: Record<string, unknown>;
+}
+
+/**
+ * Read the active Routine completion set from SQLite for `userId` and
+ * compare it to the LS-derived `next.completions`. The two are
+ * expected to be byte-identical right after a successful dual-write
+ * apply — any divergence is a Stage 8 decision-gate signal.
+ *
+ * The function may throw if the SQLite read itself fails. The caller
+ * is expected to catch and route that to `recordReadFallback` rather
+ * than `recordParityCheck("…", "mismatch", …)` — see `./index.ts`.
+ */
+export async function probeRoutineParity(
+  client: SqliteMigrationClient,
+  userId: string,
+  next: RoutineState,
+): Promise<ParityProbeOutcome> {
+  const rows = await client.all<{ id: string }>(
+    `SELECT id FROM routine_entries
+       WHERE user_id = ? AND deleted_at IS NULL`,
+    [userId],
+  );
+
+  // Build the SQLite-side `(habitId, dateKey)` set, mirroring the row
+  // id convention from `buildCompletionRowId` in `./diff.ts`.
+  const sqliteSet = new Set<string>();
+  let sqliteRows = 0;
+  for (const row of rows) {
+    const sep = row.id.indexOf(":");
+    if (sep <= 0 || sep === row.id.length - 1) continue;
+    const dateKey = row.id.slice(sep + 1);
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(dateKey)) continue;
+    sqliteSet.add(row.id);
+    sqliteRows += 1;
+  }
+
+  const lsSet = buildExpectedSet(next.completions);
+
+  if (lsSet.size === sqliteSet.size) {
+    let allMatch = true;
+    for (const key of lsSet) {
+      if (!sqliteSet.has(key)) {
+        allMatch = false;
+        break;
+      }
+    }
+    if (allMatch) {
+      return {
+        result: "match",
+        details: { ls: lsSet.size, sqlite: sqliteRows },
+      };
+    }
+  }
+
+  // Mismatch: surface the symmetric-difference cardinality so triage
+  // can read the bucket without a follow-up query. We deliberately
+  // do NOT include the actual ids — habit ids are user-data and
+  // Sentry breadcrumbs leak into events.
+  let lsOnly = 0;
+  let sqliteOnly = 0;
+  for (const key of lsSet) if (!sqliteSet.has(key)) lsOnly += 1;
+  for (const key of sqliteSet) if (!lsSet.has(key)) sqliteOnly += 1;
+
+  return {
+    result: "mismatch",
+    details: {
+      ls: lsSet.size,
+      sqlite: sqliteRows,
+      lsOnly,
+      sqliteOnly,
+    },
+  };
+}
+
+function buildExpectedSet(
+  completions: Record<string, string[]> | undefined,
+): Set<string> {
+  const out = new Set<string>();
+  if (!completions || typeof completions !== "object") return out;
+  for (const [habitId, dateKeys] of Object.entries(completions)) {
+    if (!Array.isArray(dateKeys)) continue;
+    for (const dk of dateKeys) {
+      if (typeof dk !== "string" || dk.length === 0) continue;
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(dk)) continue;
+      out.add(`${habitId}:${dk}`);
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

Closes the gap between the Stage 8 telemetry sink (`ff92dbb4`, `apps/web/src/core/observability/dualWriteTelemetry.ts`) and the Routine dual-write orchestrator. `recordParityCheck("routine", …)` was exported but never called — the recorder API was complete and the Sentry tag plumbing was live, but **no `dualwrite.routine.parity_*` telemetry was being emitted in production**.

This PR:

- Adds `probeRoutineParity(client, userId, next)` in a new `apps/web/src/modules/routine/lib/dualWrite/parity.ts`. It re-reads the active `routine_entries` set for `userId` and compares the `(habitId, dateKey)` set to `next.completions`.
- Hooks it into `runDualWriteRoutineState` after a successful `applyRoutineDualWriteOps` apply. Best-effort — never throws, never disturbs the dual-write outcome. A failed read is tagged distinctly via `recordReadFallback("routine", "parity-probe-failed: …")` so triage can tell `SELECT failing` apart from a real LS↔SQLite divergence.
- Mismatch breadcrumbs include only set-cardinality and symmetric-difference counts (`{ ls, sqlite, lsOnly, sqliteOnly }`); habit ids are user data and Sentry breadcrumbs leak into events.

Stage 8 §3 of `docs/planning/storage-roadmap.md` names `<module>.sqlite.dualwrite.parity` as a decision-gate metric for re-rolling out `feature.routine.sqlite_v2.read_sqlite` (the #055r2 family that was paused after #2181 / `2735fa75`). Routine is the next re-rollout candidate, so it lands first; Fizruk / Nutrition / Finyk each have a different state shape and follow in subsequent focused PRs.

## Governing Skill

- Primary skill: n/a (no matched skill — small focused production-code change)
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a
- Why this playbook: n/a
- If no playbook matched, why: This is a focused observability wire-up inside an existing Stage 8 framework. The framework (`dualWriteTelemetry.ts`, the orchestrator pattern) is already established and tested; this PR just connects an unused exported function to its intended call-site.

## Verification

```bash
# from apps/web
pnpm exec vitest run src/modules/routine/lib/dualWrite
#   Test Files  4 passed (4)
#        Tests  40 passed (40)   ← 9 new parity cases + 31 pre-existing pass

pnpm exec eslint src/modules/routine/lib/dualWrite/parity.ts \
                  src/modules/routine/lib/dualWrite/index.ts \
                  src/modules/routine/lib/dualWrite/__tests__/parity.test.ts
#   clean

pnpm exec prettier --check src/modules/routine/lib/dualWrite/parity.ts \
                            src/modules/routine/lib/dualWrite/index.ts \
                            src/modules/routine/lib/dualWrite/__tests__/parity.test.ts
#   All matched files use Prettier code style!

pnpm typecheck
#   Pre-existing errors in src/core/security/useAppLock.test.ts:94,104
#   (verified present on main at a3b9e52c — unrelated to this PR's diff)
```

Additional checks:

- [x] Local smoke (vitest 9 new cases — match / empty / soft-delete / lsOnly / sqliteOnly / symmetric-diff / user-scope / malformed-id / malformed-dateKey)
- [ ] Production smoke not possible from a PR — telemetry verification is "after deploy: are `dualwrite.routine.parity_match` / `parity_mismatch` tag distributions populating in Sentry within 24-48h of merge?"

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. — N/A: the parity gate is already documented in `docs/planning/storage-roadmap.md` Stage 8 §3 (just refreshed in #2241). No new behavior to document.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a

## Risk and Rollout

- **User-visible risk:** None directly. The probe is fire-and-forget, runs only when the dual-write `applied` outcome is reached, and never propagates errors to the caller. It does add **one extra `SELECT id FROM routine_entries WHERE user_id = ? AND deleted_at IS NULL`** per successful Routine dual-write apply — bounded by `# habits × ~365 days`, single user-id index hit, runs after the LS write has already returned to the UI.
- **Rollout / deploy order:** Standard merge → web deploy. No flag, no migration, no infra change. Telemetry tags will start populating within the first user-session after deploy.
- **Backout plan:** Revert this commit. The wire-up is a single try/catch block in `runDualWriteRoutineState`; removing it returns the orchestrator to its pre-PR shape.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian. — N/A: no docs touched in this PR. Code comments follow the existing English convention of neighboring files (`diff.ts`, `adapter.ts`, `dualWriteTelemetry.ts`).
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

Things worth a closer look:

1. **Probe semantics on partial-apply errors.** When `applyRoutineDualWriteOps` returns `{ applied: 0, errored: N }` (e.g., the `boom`-throwing client in `integration.test.ts:180`), the parity probe still runs and will emit `mismatch` because LS has the new state but SQLite does not. That is technically correct (LS↔SQLite *do* disagree), but the cause is a write error, not a parity-layer drift. The Stage 8 gate already cross-references `dualwrite.routine.error_rate` against `dualwrite.routine.parity_mismatch`, so this is not blocking — just be aware that mismatches will be slightly correlated with the error_rate bucket. Acceptable in my read; flagging in case you want a `result.errored > 0` early-return.

2. **Probe does not catch pre-existing drift.** It only checks the post-apply state. If SQLite was already drifted before the dual-write fired, this probe still reports `match` as long as `next.completions` lines up with whatever is now in `routine_entries`. That's the intended scope (Stage 8 is a dual-write gate, not a backfill audit), but worth being explicit about.

3. **No comparison of `habits[].name`.** `habit-rename` ops *are* mirrored to SQLite (`name` column on `routine_entries`) but the parity probe ignores them. Same scope reasoning — Stage 8 only blocks on completion-set parity for the read-cut-over decision; rename parity matters only for PR #055r2 read-tail, not the gate itself.

4. **Pre-existing setup gap (not fixed here):** running `pnpm exec vitest` against `apps/web/src/modules/routine/lib/dualWrite/` requires `@sergeant/db-schema/sqlite/migrations` to be built first (`pnpm --filter @sergeant/db-schema build`). This affects every test in this directory, not just the new ones — left for a separate setup PR.

5. **Other modules not wired here.** Fizruk / Nutrition / Finyk parity probes intentionally NOT in this PR — each has a meaningfully different state shape (workouts/exercises/measurements vs meals/pantries/recipes vs ~14 finyk slot types) and benefits from per-module review. Routine is the next re-rollout candidate (#055r2), so it ships first.

Related context: the doc-PR that landed the Stage 8 reality-check (#2241) flagged this exact gap in its drift register — "Telemetry sink (`ff92dbb4`) not having a parity caller". This PR closes drift item #4 from that audit.

Link to Devin session: https://app.devin.ai/sessions/cb346b769efd4198a4d64dca7fa2caef
Requested by: @Skords-01

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires a best‑effort parity probe into the Routine dual‑write orchestrator to emit Stage 8 gate telemetry. This compares LS `next.completions` to SQLite `routine_entries` and reports via `recordParityCheck`, enabling `<module>.sqlite.dualwrite.parity` for the Routine re‑rollout.

- **New Features**
  - Added `probeRoutineParity(client, userId, next)` in `apps/web/src/modules/routine/lib/dualWrite/parity.ts` to compare `(habitId, dateKey)` sets between LS and SQLite (user‑scoped, ignores soft‑deleted rows, validates keys).
  - Hooked into the orchestrator in `index.ts` after a successful `applyRoutineDualWriteOps`; emits `recordParityCheck("routine", …)` or `recordReadFallback("routine", "parity-probe-failed: …")`; never throws or alters the dual‑write outcome.
  - Added tests in `__tests__/parity.test.ts` covering match/mismatch cases, soft‑delete, symmetric diff, user scoping, and malformed ids/dateKeys.

<sup>Written for commit 4ea2c952b4a4754a7098cc9bcf6480926f785044. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

