### PR TITLE
fix(shared,web): repair check-lane (HUB_BIOMETRICS parity + useAppLock typecheck)

### DIFF
--- a/apps/web/src/core/security/useAppLock.test.ts
+++ b/apps/web/src/core/security/useAppLock.test.ts
@@ -91,7 +91,7 @@ describe("useAppLock", () => {
     act(() => result.current.startSetup());
     act(() => result.current.finishSetup());
     const completedCall = capturePostHogEvent.mock.calls.find(
-      ([name]: [string]) => name === "app_lock_setup_completed",
+      ([name]) => name === "app_lock_setup_completed",
     );
     expect(completedCall?.[1]).toEqual({ mode: "setup" });
   });
@@ -101,7 +101,7 @@ describe("useAppLock", () => {
     act(() => result.current.startChange());
     act(() => result.current.finishSetup());
     const completedCall = capturePostHogEvent.mock.calls.find(
-      ([name]: [string]) => name === "app_lock_setup_completed",
+      ([name]) => name === "app_lock_setup_completed",
     );
     expect(completedCall?.[1]).toEqual({ mode: "change" });
   });

--- a/packages/eslint-plugin-sergeant-design/index.js
+++ b/packages/eslint-plugin-sergeant-design/index.js
@@ -205,7 +205,13 @@ const TRACKED_STORAGE_KEY_NAMES = new Set([
   // profile (web-only payload — `USER_PROFILE` does not exist in MMKV,
   // but listing it here keeps the cross-platform registry symmetric so
   // mobile sync no longer null-overwrites the server blob).
+  // `HUB_BIOMETRICS` (added alongside `USER_PROFILE` in PR #2245 — the
+  // hub-level biometric parameters store, height/birth-date/sex/
+  // activity-level/current-weight, used by the nutrition Mifflin-St
+  // Jeor TDEE calculator). Synced via `SYNC_MODULES.profile` (LWW),
+  // same path as the user-profile blob.
   "USER_PROFILE",
+  "HUB_BIOMETRICS",
 ]);
 
 const TRACKED_STORAGE_KEY_VALUES = new Set([
@@ -218,8 +224,9 @@ const TRACKED_STORAGE_KEY_VALUES = new Set([
   // PR #026).
   // nutrition — see TRACKED_STORAGE_KEY_NAMES comment above (retired
   // in PR #034).
-  // profile (see USER_PROFILE comment above).
+  // profile (see USER_PROFILE / HUB_BIOMETRICS comments above).
   "hub_user_profile_v1",
+  "hub_biometrics_v1",
 ]);
 
 const RAW_TRACKED_STORAGE_MESSAGE =


### PR DESCRIPTION
## Summary

Fixes **two pre-existing failures on the `check` CI lane** that have been red on `main` since their respective introducing PRs and are blocking every Stage 8 PR. Bundled into one PR because both are scope-of-one-line "make `check` lane green" fixes:

1. **eslint-plugin parity drift — `HUB_BIOMETRICS`.** Adds `HUB_BIOMETRICS` / `hub_biometrics_v1` to the parity sets in `packages/eslint-plugin-sergeant-design/index.js` (`TRACKED_STORAGE_KEY_NAMES` + `TRACKED_STORAGE_KEY_VALUES`) so the dedicated parity test in `packages/eslint-plugin-sergeant-design/__tests__/no-raw-tracked-storage.parity.test.mjs` (which reads `packages/shared/src/sync/modules.ts` + `packages/shared/src/lib/storageKeys.ts` directly) passes again. Drift dates back to PR [#2245](https://github.com/Skords-01/Sergeant/pull/2245), where `STORAGE_KEYS.HUB_BIOMETRICS` was added and registered under `SYNC_MODULES.profile` alongside `STORAGE_KEYS.USER_PROFILE`, but the eslint-plugin's local mirror of those tracked sets was not updated in the same PR.

2. **`apps/web` typecheck — `useAppLock.test.ts` TS2769.** `find(([name]: [string]) => …)` over a `vi.fn()` mock's `.mock.calls` (typed `any[][]`) was rejected by tsc 5.x because the destructure annotation `[string]` is a 1-tuple but `any[]` may have fewer elements. Drops the unnecessary explicit annotation and lets TS infer the parameter type.

Verified **both** failures reproduce on `origin/main` with no local changes — i.e., neither was introduced by this branch.

## Governing Skill

- Primary skill: n/a (registry sync + one-line type-annotation fix; no behavior change)
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a
- Why this playbook: n/a
- If no playbook matched, why: parity-only registry sync + tsc fix. The parity test itself spells out the required edit verbatim ("Update packages/eslint-plugin-sergeant-design/index.js to match.") and the typecheck error message points at the exact line.

## Verification

```bash
# 1) Parity test (was failing) — now 3/3 pass
node --test packages/eslint-plugin-sergeant-design/__tests__/no-raw-tracked-storage.parity.test.mjs
#   # tests 3
#   # pass 3
#   # fail 0

# 2) apps/web typecheck (was failing) — now clean
(cd apps/web && pnpm exec tsc -p tsconfig.json --noEmit && pnpm exec tsc -p tsconfig.sw.json --noEmit)
#   (no output = success)
```

Additional checks:

- [x] Local: parity test 3/3 pass on this branch.
- [x] Local: `apps/web` typecheck (both `tsconfig.json` and `tsconfig.sw.json`) passes on this branch.
- [x] Pre-commit (lint-staged → eslint --fix --max-warnings=0 + prettier --write) passed on commits `e90920b9` + `9bd3b54a`.

## Docs and Governance

- [x] No docs needed — both fixes are CI-lane-only with zero behavior change visible to users or other consumers.
- [x] I checked whether `AGENTS.md` needed an update. n/a — registry sync + tsc fix.
- [x] I checked whether a playbook or skill needed an update. n/a.
- [x] I checked whether governance docs or review docs needed an update. n/a.

Updated docs:

- n/a

## Risk and Rollout

- **User-visible risk**: zero on both fixes.
  - Parity-set edit: the eslint plugin's runtime behavior changes only insofar as `useLocalStorage("hub_biometrics_v1", …)` and `useLocalStorage(STORAGE_KEYS.HUB_BIOMETRICS, …)` will now be flagged with the existing `RAW_TRACKED_STORAGE_MESSAGE` directing authors to `useSyncedStorage` instead. Repo audit (`grep useLocalStorage hub_biometrics_v1`) shows zero existing call-sites — the biometrics store already uses the synced wrapper. No `--max-warnings=0` regression risk.
  - useAppLock test edit: same runtime / same assertion semantics; only the destructure parameter's *static type* changes (from too-narrow `[string]` to inferred `any[]`).
- **Rollout / deploy order**: merge this PR alone; no migration, no flag flip.
- **Backout plan**: revert this two-file change. Both `check`-lane failures will re-appear, but no runtime / user-visible side effect.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian. (Comments in `index.js` are in English to match surrounding plugin comments — Hard Rule #15 covers `docs/**` and `.agents/skills/**`, not source-file comments.)
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

- The parity test (`__tests__/no-raw-tracked-storage.parity.test.mjs`) is the source of truth: it reads `SYNC_MODULES` keys via regex from `packages/shared/src/sync/modules.ts` and `STORAGE_KEYS` values from `packages/shared/src/lib/storageKeys.ts` and asserts the rule's two `Set`s match exactly. Any future drift will surface there.
- The comment block in `TRACKED_STORAGE_KEY_NAMES` was updated to mention `HUB_BIOMETRICS` with a link back to `SYNC_MODULES.profile` so future maintainers see the rationale alongside the entry.
- This unblocks PR [#2247](https://github.com/Skords-01/Sergeant/pull/2247) (Stage 8 PR #055f2 — Fizruk read_sqlite default-on), which was blocked by the `check` lane on these pre-existing-on-main failures.

## Files

- `packages/eslint-plugin-sergeant-design/index.js` — add `"HUB_BIOMETRICS"` to `TRACKED_STORAGE_KEY_NAMES`, `"hub_biometrics_v1"` to `TRACKED_STORAGE_KEY_VALUES`, and a comment block tying back to `SYNC_MODULES.profile`.
- `apps/web/src/core/security/useAppLock.test.ts` — drop overly-narrow `[string]` tuple annotation on two `mock.calls.find(…)` callbacks; inferred `any[]` is sufficient and matches the actual `vi.fn().mock.calls` type.
