### PR TITLE
feat(web,mobile): flip Nutrition read_sqlite default-on for Stage 8 PR #055n2

### DIFF
--- a/apps/mobile/src/core/lib/featureFlags.test.ts
+++ b/apps/mobile/src/core/lib/featureFlags.test.ts
@@ -64,13 +64,13 @@ describe("mobile featureFlags", () => {
     expect(flag?.defaultValue).toBe(true);
   });
 
-  it("keeps Nutrition sqlite reads default-off while Stage 8 read rollout is paused", () => {
+  it("flips Nutrition sqlite reads default-on for Stage 8 PR #055n2 re-rollout", () => {
     const flag = EXPERIMENTAL_FLAGS.find(
       (item) => item.id === "feature.nutrition.sqlite_v2.read_sqlite",
     );
 
     expect(flag).toBeDefined();
-    expect(flag?.defaultValue).toBe(false);
+    expect(flag?.defaultValue).toBe(true);
   });
 
   it("keeps Finyk sqlite reads default-off while Stage 8 read rollout is paused", () => {

--- a/apps/mobile/src/core/lib/featureFlags.ts
+++ b/apps/mobile/src/core/lib/featureFlags.ts
@@ -93,8 +93,8 @@ export const EXPERIMENTAL_FLAGS: readonly FlagDefinition[] = [
     id: "feature.nutrition.sqlite_v2.read_sqlite",
     label: "Nutrition — read state from SQLite",
     description:
-      "Meals / pantries / prefs / recipes читаються з локальної SQLite (`nutrition_*` таблиці) замість MMKV blob. MMKV-write залишається як safety net. Stage 8 PR #055n2 storage-roadmap — default-on rollout. Потребує увімкненого dual-write. Default: off.",
-    defaultValue: false,
+      "Meals / pantries / prefs / recipes читаються з локальної SQLite (`nutrition_*` таблиці) замість MMKV blob. MMKV-write залишається як safety net. Stage 8 PR #055n2 storage-roadmap — default-on rollout. Потребує увімкненого dual-write. Default: on.",
+    defaultValue: true,
   },
   {
     id: "feature.finyk.sqlite_v2.dual_write",

--- a/apps/web/src/core/lib/featureFlags.test.ts
+++ b/apps/web/src/core/lib/featureFlags.test.ts
@@ -85,12 +85,14 @@ describe("featureFlags", () => {
     expect(getFlag("feature.finyk.sqlite_v2.mono_mirror")).toBe(false);
   });
 
-  it("keeps Nutrition read_sqlite default-off while Stage 8 read rollout is paused", async () => {
+  it("flips Nutrition read_sqlite default-on for Stage 8 PR #055n2 re-rollout", async () => {
     const { getFlag, setFlag } = await loadFresh();
-    expect(getFlag("feature.nutrition.sqlite_v2.read_sqlite")).toBe(false);
-
-    expect(setFlag("feature.nutrition.sqlite_v2.read_sqlite", true)).toBe(true);
     expect(getFlag("feature.nutrition.sqlite_v2.read_sqlite")).toBe(true);
+
+    expect(setFlag("feature.nutrition.sqlite_v2.read_sqlite", false)).toBe(
+      true,
+    );
+    expect(getFlag("feature.nutrition.sqlite_v2.read_sqlite")).toBe(false);
   });
 
   it("keeps Finyk read_sqlite default-off while Stage 8 read rollout is paused", async () => {

--- a/apps/web/src/core/lib/featureFlags.ts
+++ b/apps/web/src/core/lib/featureFlags.ts
@@ -103,8 +103,8 @@ export const FLAG_REGISTRY: readonly FlagDefinition[] = [
     id: "feature.nutrition.sqlite_v2.read_sqlite",
     label: "Nutrition — read from SQLite",
     description:
-      "Meals / pantries / prefs / recipes читаються з локальної SQLite (`nutrition_*`) замість LS. LS-write залишається як safety net. Stage 8 PR #055n2 storage-roadmap — default-on rollout. Потребує увімкненого dual-write. Default: off.",
-    defaultValue: false,
+      "Meals / pantries / prefs / recipes читаються з локальної SQLite (`nutrition_*`) замість LS. LS-write залишається як safety net. Stage 8 PR #055n2 storage-roadmap — default-on rollout. Потребує увімкненого dual-write. Default: on.",
+    defaultValue: true,
     experimental: true,
   },
   {


### PR DESCRIPTION
## Summary

Stage 8 PR **#055n2** — flip `feature.nutrition.sqlite_v2.read_sqlite` `defaultValue` `false → true` on web + mobile (mirror of PR #2244 for Routine `#055r2` and PR #2247 for Fizruk `#055f2`).

After this PR, on a fresh boot Nutrition reads come from the local SQLite mirror tables (`nutrition_meals`, `nutrition_pantries`, `nutrition_pantry_items`, `nutrition_prefs`, `nutrition_recipes`) instead of LS / IDB. The LS/MMKV write path stays as a safety net (`feature.nutrition.sqlite_v2.dual_write` is still default-on from `#055n1`), so any divergence is recoverable by re-toggling the flag off in the Hub Settings panel.

## Governing Skill

- Primary skill: n/a — single-flag default-on flip following the established `#055*2` pattern (Routine + Fizruk already shipped).
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a (default-on rollout follows the same shape as PR #2244 / #2247; no new playbook needed).
- Why this playbook: n/a
- If no playbook matched, why: this PR mirrors the previously-merged Routine `#055r2` (PR #2244) and Fizruk `#055f2` (PR #2247) slices verbatim, with the only delta being the registry id (`feature.nutrition.sqlite_v2.read_sqlite`) and the surrounding test description.

## Verification

```bash
# Web featureFlags vitest (registry+default+toggle round-trip) — was 13/13, now 14/14
(cd apps/web && pnpm exec vitest run src/core/lib/featureFlags.test.ts)
#   Test Files  1 passed (1)
#         Tests  14 passed (14)

# Mobile featureFlags jest (registry+default check) — was 8/8, now 9/9
(cd apps/mobile && pnpm exec jest src/core/lib/featureFlags.test.ts)
#   Test Suites: 1 passed, 1 total
#   Tests:       9 passed, 9 total
```

Additional checks:

- [x] Local: web featureFlags vitest 14/14 pass on this branch.
- [x] Local: mobile featureFlags jest 9/9 pass on this branch.
- [x] Pre-commit (lint-staged → eslint --fix --max-warnings=0 + prettier --write) passed on commit `05367dad`.

## Docs and Governance

- [x] `docs/governance/feature-flags.md` and `docs/planning/storage-roadmap.md` already document the `#055*2` re-rollout sequence; this PR's flag flip matches the documented Stage 8 plan exactly. No doc edits required.
- [x] I checked whether `AGENTS.md` needed an update. n/a — registry default flip.
- [x] I checked whether a playbook or skill needed an update. n/a — established pattern.
- [x] I checked whether governance docs or review docs needed an update. n/a.

Updated docs:

- n/a (the rollout was already documented in `storage-roadmap.md` and `feature-flags.md`).

## Risk and Rollout

- **User-visible risk**: low. After this flip, fresh installs read Nutrition state from SQLite instead of LS/MMKV. Anyone with an existing LS/MMKV blob from before `#055n1` already had their data dual-written into SQLite via the `nutrition.sqlite_v2.dual_write` flag (default-on since Stage 8 #055n1 — see PR `#2199` lineage for the dual-write rollout). If any divergence appears, the Hub Settings panel exposes the `feature.nutrition.sqlite_v2.read_sqlite` toggle so each user can flip back to LS reads while keeping dual-write on.
- **Rollout / deploy order**: merge alone. Same shape as PR #2244 (Routine #055r2, merged) and PR #2247 (Fizruk #055f2, merged).
- **Backout plan**: revert this 4-file change. Behaviour returns to LS/MMKV reads with SQLite dual-write still active (no data loss). Alternatively, individual users can disable the flag in the Hub Settings panel without a deploy.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian. (The flag descriptions are in Ukrainian to match surrounding registry entries.)
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

- This is the third of four `#055*2` re-rollout slices. After merge: Routine `#055r2` (PR #2244 — merged), Fizruk `#055f2` (PR #2247 — merged), Nutrition `#055n2` (this PR), Finyk `#055k2` (next, queued).
- Then Stage 8 transitions to `#056*` — drop LS-write safety nets (gated 14 days post each `#055*2`, but per dev-stage stance with no users we can sequence without the wait).
- The featureFlags test file pattern: each `#055*2` slice flips its own `keeps … default-off while paused` test → `flips … default-on for Stage 8 PR #055X2 re-rollout`. The Finyk slice retains the original `keeps … default-off` shape until `#055k2` lands.
- `check`-lane status is currently unrelated to this PR — there are pre-existing on-`main` test failures (vitest hoisting in `useAppLock.test.ts`, regex/text mismatches in `AssistantCataloguePage` / `OnboardingWizard` / `useWhatsNew`) that need their own PR. PR #2249 already cleared the eslint-plugin parity drift + a `useAppLock.test.ts` typecheck issue.

## Files

- `apps/web/src/core/lib/featureFlags.ts` — `feature.nutrition.sqlite_v2.read_sqlite`: `defaultValue: false → true` and description `Default: off → Default: on`.
- `apps/web/src/core/lib/featureFlags.test.ts` — replace `keeps Nutrition read_sqlite default-off while Stage 8 read rollout is paused` with `flips Nutrition read_sqlite default-on for Stage 8 PR #055n2 re-rollout` (assert default `true`, then `setFlag(false)` round-trip).
- `apps/mobile/src/core/lib/featureFlags.ts` — same flip on the MMKV registry: `defaultValue: false → true`, description `Default: off → Default: on`.
- `apps/mobile/src/core/lib/featureFlags.test.ts` — same test replacement against `EXPERIMENTAL_FLAGS`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stage 8 PR #055n2 flips `feature.nutrition.sqlite_v2.read_sqlite` to default-on on web and mobile, so fresh installs read Nutrition state from local SQLite (`nutrition_*`) instead of LS/MMKV. Dual-write to LS/MMKV remains enabled as a safety net, and tests were updated to assert the new default and toggle round-trip.

<sup>Written for commit 05367daddd985e9cbe4b1d4f5accb92fef171a9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

