### PR TITLE
feat(web): wire Stage 8 §3 parity probe into Finyk dual-write (PR #055k3)

### DIFF
--- a/apps/web/src/modules/finyk/lib/dualWrite/__tests__/parity.test.ts
+++ b/apps/web/src/modules/finyk/lib/dualWrite/__tests__/parity.test.ts
@@ -1,0 +1,562 @@
+import { describe, expect, it } from "vitest";
+import type { SqliteMigrationClient } from "@sergeant/db-schema/migrate/sqlite";
+
+import type {
+  FinykBlobEntry,
+  FinykDualWriteState,
+  FinykIdEntry,
+  FinykMonoDebtLinkEntry,
+  FinykNetworthEntry,
+  FinykPrefsSnapshot,
+  FinykTxCategoryEntry,
+  FinykTxSplitsEntry,
+} from "../diff.js";
+import { probeFinykParity } from "../parity.js";
+import { createTestSqlite } from "./testSqlite.js";
+
+const USER_ID = "user-1";
+const TS = "2026-05-08T10:00:00.000Z";
+
+const EMPTY_STATE: FinykDualWriteState = {
+  hiddenAccounts: [],
+  hiddenTransactions: [],
+  budgets: [],
+  subscriptions: [],
+  assets: [],
+  debts: [],
+  receivables: [],
+  customCategories: [],
+  manualExpenses: [],
+  txCategories: [],
+  txSplits: [],
+  monoDebtLinks: [],
+  networthHistory: [],
+  prefs: null,
+};
+
+// -------------------- seed helpers --------------------
+
+async function seedHiddenAccount(
+  client: SqliteMigrationClient,
+  accountId: string,
+  opts: { deletedAt?: string | null; userId?: string } = {},
+): Promise<void> {
+  await client.run(
+    `INSERT INTO finyk_hidden_accounts
+       (user_id, account_id, created_at, updated_at, deleted_at)
+     VALUES (?, ?, ?, ?, ?)`,
+    [opts.userId ?? USER_ID, accountId, TS, TS, opts.deletedAt ?? null],
+  );
+}
+
+async function seedHiddenTransaction(
+  client: SqliteMigrationClient,
+  txId: string,
+  opts: { deletedAt?: string | null; userId?: string } = {},
+): Promise<void> {
+  await client.run(
+    `INSERT INTO finyk_hidden_transactions
+       (user_id, transaction_id, created_at, updated_at, deleted_at)
+     VALUES (?, ?, ?, ?, ?)`,
+    [opts.userId ?? USER_ID, txId, TS, TS, opts.deletedAt ?? null],
+  );
+}
+
+async function seedBlob(
+  client: SqliteMigrationClient,
+  table:
+    | "finyk_budgets"
+    | "finyk_subscriptions"
+    | "finyk_assets"
+    | "finyk_debts"
+    | "finyk_receivables"
+    | "finyk_custom_categories"
+    | "finyk_manual_expenses",
+  id: string,
+  opts: { deletedAt?: string | null; userId?: string } = {},
+): Promise<void> {
+  await client.run(
+    `INSERT INTO ${table}
+       (id, user_id, data_json, created_at, updated_at, deleted_at)
+     VALUES (?, ?, '{}', ?, ?, ?)`,
+    [id, opts.userId ?? USER_ID, TS, TS, opts.deletedAt ?? null],
+  );
+}
+
+async function seedTxCategory(
+  client: SqliteMigrationClient,
+  txId: string,
+  opts: { userId?: string; categoryId?: string } = {},
+): Promise<void> {
+  await client.run(
+    `INSERT INTO finyk_tx_categories
+       (user_id, transaction_id, category_id, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?)`,
+    [opts.userId ?? USER_ID, txId, opts.categoryId ?? "cat-x", TS, TS],
+  );
+}
+
+async function seedTxSplit(
+  client: SqliteMigrationClient,
+  txId: string,
+  opts: { userId?: string } = {},
+): Promise<void> {
+  await client.run(
+    `INSERT INTO finyk_tx_splits
+       (user_id, transaction_id, splits_json, created_at, updated_at)
+     VALUES (?, ?, '[]', ?, ?)`,
+    [opts.userId ?? USER_ID, txId, TS, TS],
+  );
+}
+
+async function seedMonoDebtLink(
+  client: SqliteMigrationClient,
+  txId: string,
+  opts: { userId?: string } = {},
+): Promise<void> {
+  await client.run(
+    `INSERT INTO finyk_mono_debt_links
+       (user_id, transaction_id, debt_ids_json, created_at, updated_at)
+     VALUES (?, ?, '[]', ?, ?)`,
+    [opts.userId ?? USER_ID, txId, TS, TS],
+  );
+}
+
+async function seedNetworth(
+  client: SqliteMigrationClient,
+  month: string,
+  opts: { userId?: string; networth?: number } = {},
+): Promise<void> {
+  await client.run(
+    `INSERT INTO finyk_networth_history
+       (user_id, month, networth, snapshot_json, created_at, updated_at)
+     VALUES (?, ?, ?, '{}', ?, ?)`,
+    [opts.userId ?? USER_ID, month, opts.networth ?? 0, TS, TS],
+  );
+}
+
+async function seedPrefs(
+  client: SqliteMigrationClient,
+  userId: string = USER_ID,
+): Promise<void> {
+  await client.run(
+    `INSERT INTO finyk_prefs
+       (user_id, prefs_json, monthly_plan_json, show_balance,
+        created_at, updated_at)
+     VALUES (?, '{}', '{}', 1, ?, ?)`,
+    [userId, TS, TS],
+  );
+}
+
+// -------------------- entity-class factories --------------------
+
+function makeId(id: string): FinykIdEntry {
+  return { id };
+}
+
+function makeBlob(id: string): FinykBlobEntry {
+  return { id, dataJson: "{}" };
+}
+
+function makeTxCategory(transactionId: string): FinykTxCategoryEntry {
+  return { transactionId, categoryId: "cat-x" };
+}
+
+function makeTxSplit(transactionId: string): FinykTxSplitsEntry {
+  return { transactionId, splitsJson: "[]" };
+}
+
+function makeMonoDebtLink(transactionId: string): FinykMonoDebtLinkEntry {
+  return { transactionId, debtIdsJson: "[]" };
+}
+
+function makeNetworth(month: string): FinykNetworthEntry {
+  return { month, networth: 0 };
+}
+
+function makePrefs(): FinykPrefsSnapshot {
+  return { monthlyPlanJson: "{}", showBalance: true };
+}
+
+// -------------------- "all-zero" details fixture --------------------
+
+const MATCH_ZEROS_DETAILS = {
+  budgets: { ls: 0, sqlite: 0 },
+  subscriptions: { ls: 0, sqlite: 0 },
+  assets: { ls: 0, sqlite: 0 },
+  debts: { ls: 0, sqlite: 0 },
+  receivables: { ls: 0, sqlite: 0 },
+  customCategories: { ls: 0, sqlite: 0 },
+  manualExpenses: { ls: 0, sqlite: 0 },
+  hiddenAccounts: { ls: 0, sqlite: 0 },
+  hiddenTransactions: { ls: 0, sqlite: 0 },
+  txCategories: { ls: 0, sqlite: 0 },
+  txSplits: { ls: 0, sqlite: 0 },
+  monoDebtLinks: { ls: 0, sqlite: 0 },
+  networthHistory: { ls: 0, sqlite: 0 },
+  prefs: { ls: false, sqlite: false },
+};
+
+const MISMATCH_ZEROS_DETAILS = {
+  budgets: { ls: 0, sqlite: 0, lsOnly: 0, sqliteOnly: 0 },
+  subscriptions: { ls: 0, sqlite: 0, lsOnly: 0, sqliteOnly: 0 },
+  assets: { ls: 0, sqlite: 0, lsOnly: 0, sqliteOnly: 0 },
+  debts: { ls: 0, sqlite: 0, lsOnly: 0, sqliteOnly: 0 },
+  receivables: { ls: 0, sqlite: 0, lsOnly: 0, sqliteOnly: 0 },
+  customCategories: { ls: 0, sqlite: 0, lsOnly: 0, sqliteOnly: 0 },
+  manualExpenses: { ls: 0, sqlite: 0, lsOnly: 0, sqliteOnly: 0 },
+  hiddenAccounts: { ls: 0, sqlite: 0, lsOnly: 0, sqliteOnly: 0 },
+  hiddenTransactions: { ls: 0, sqlite: 0, lsOnly: 0, sqliteOnly: 0 },
+  txCategories: { ls: 0, sqlite: 0, lsOnly: 0, sqliteOnly: 0 },
+  txSplits: { ls: 0, sqlite: 0, lsOnly: 0, sqliteOnly: 0 },
+  monoDebtLinks: { ls: 0, sqlite: 0, lsOnly: 0, sqliteOnly: 0 },
+  networthHistory: { ls: 0, sqlite: 0, lsOnly: 0, sqliteOnly: 0 },
+  prefs: { ls: false, sqlite: false },
+};
+
+describe("probeFinykParity", () => {
+  it("reports match when both sides are empty", async () => {
+    const handle = await createTestSqlite();
+    try {
+      const out = await probeFinykParity(handle.client, USER_ID, EMPTY_STATE);
+      expect(out.result).toBe("match");
+      expect(out.details).toEqual(MATCH_ZEROS_DETAILS);
+    } finally {
+      handle.close();
+    }
+  });
+
+  it("reports match when LS and SQLite agree on every entity class", async () => {
+    const handle = await createTestSqlite();
+    try {
+      // Seed one row per entity class.
+      await seedHiddenAccount(handle.client, "acc-1");
+      await seedHiddenTransaction(handle.client, "tx-h1");
+      await seedBlob(handle.client, "finyk_budgets", "b1");
+      await seedBlob(handle.client, "finyk_subscriptions", "s1");
+      await seedBlob(handle.client, "finyk_assets", "a1");
+      await seedBlob(handle.client, "finyk_debts", "d1");
+      await seedBlob(handle.client, "finyk_receivables", "r1");
+      await seedBlob(handle.client, "finyk_custom_categories", "cc1");
+      await seedBlob(handle.client, "finyk_manual_expenses", "me1");
+      await seedTxCategory(handle.client, "tx-c1");
+      await seedTxSplit(handle.client, "tx-s1");
+      await seedMonoDebtLink(handle.client, "tx-l1");
+      await seedNetworth(handle.client, "2026-04");
+      await seedPrefs(handle.client);
+
+      const next: FinykDualWriteState = {
+        hiddenAccounts: [makeId("acc-1")],
+        hiddenTransactions: [makeId("tx-h1")],
+        budgets: [makeBlob("b1")],
+        subscriptions: [makeBlob("s1")],
+        assets: [makeBlob("a1")],
+        debts: [makeBlob("d1")],
+        receivables: [makeBlob("r1")],
+        customCategories: [makeBlob("cc1")],
+        manualExpenses: [makeBlob("me1")],
+        txCategories: [makeTxCategory("tx-c1")],
+        txSplits: [makeTxSplit("tx-s1")],
+        monoDebtLinks: [makeMonoDebtLink("tx-l1")],
+        networthHistory: [makeNetworth("2026-04")],
+        prefs: makePrefs(),
+      };
+
+      const out = await probeFinykParity(handle.client, USER_ID, next);
+      expect(out.result).toBe("match");
+      expect(out.details).toEqual({
+        budgets: { ls: 1, sqlite: 1 },
+        subscriptions: { ls: 1, sqlite: 1 },
+        assets: { ls: 1, sqlite: 1 },
+        debts: { ls: 1, sqlite: 1 },
+        receivables: { ls: 1, sqlite: 1 },
+        customCategories: { ls: 1, sqlite: 1 },
+        manualExpenses: { ls: 1, sqlite: 1 },
+        hiddenAccounts: { ls: 1, sqlite: 1 },
+        hiddenTransactions: { ls: 1, sqlite: 1 },
+        txCategories: { ls: 1, sqlite: 1 },
+        txSplits: { ls: 1, sqlite: 1 },
+        monoDebtLinks: { ls: 1, sqlite: 1 },
+        networthHistory: { ls: 1, sqlite: 1 },
+        prefs: { ls: true, sqlite: true },
+      });
+    } finally {
+      handle.close();
+    }
+  });
+
+  it("ignores soft-deleted SQLite rows in tombstone and blob tables", async () => {
+    const handle = await createTestSqlite();
+    try {
+      // active + tombstoned rows on every soft-delete-aware table.
+      await seedHiddenAccount(handle.client, "acc-1");
+      await seedHiddenAccount(handle.client, "acc-2", { deletedAt: TS });
+      await seedHiddenTransaction(handle.client, "tx-h1", { deletedAt: TS });
+      await seedBlob(handle.client, "finyk_budgets", "b1");
+      await seedBlob(handle.client, "finyk_budgets", "b2", { deletedAt: TS });
+      await seedBlob(handle.client, "finyk_assets", "a1", { deletedAt: TS });
+
+      const next: FinykDualWriteState = {
+        ...EMPTY_STATE,
+        hiddenAccounts: [makeId("acc-1")],
+        budgets: [makeBlob("b1")],
+      };
+
+      const out = await probeFinykParity(handle.client, USER_ID, next);
+      expect(out.result).toBe("match");
+      expect(out.details).toEqual({
+        ...MATCH_ZEROS_DETAILS,
+        hiddenAccounts: { ls: 1, sqlite: 1 },
+        budgets: { ls: 1, sqlite: 1 },
+      });
+    } finally {
+      handle.close();
+    }
+  });
+
+  it("reports mismatch with lsOnly when SQLite is missing a budget", async () => {
+    const handle = await createTestSqlite();
+    try {
+      await seedBlob(handle.client, "finyk_budgets", "b1");
+
+      const next: FinykDualWriteState = {
+        ...EMPTY_STATE,
+        budgets: [makeBlob("b1"), makeBlob("b2")],
+      };
+
+      const out = await probeFinykParity(handle.client, USER_ID, next);
+      expect(out.result).toBe("mismatch");
+      expect(out.details).toEqual({
+        ...MISMATCH_ZEROS_DETAILS,
+        budgets: { ls: 2, sqlite: 1, lsOnly: 1, sqliteOnly: 0 },
+      });
+    } finally {
+      handle.close();
+    }
+  });
+
+  it("reports mismatch with sqliteOnly when SQLite has stale tx-categories", async () => {
+    const handle = await createTestSqlite();
+    try {
+      await seedTxCategory(handle.client, "tx-1");
+      await seedTxCategory(handle.client, "tx-2");
+      await seedTxCategory(handle.client, "tx-3");
+
+      const next: FinykDualWriteState = {
+        ...EMPTY_STATE,
+        txCategories: [makeTxCategory("tx-1")],
+      };
+
+      const out = await probeFinykParity(handle.client, USER_ID, next);
+      expect(out.result).toBe("mismatch");
+      expect(out.details).toEqual({
+        ...MISMATCH_ZEROS_DETAILS,
+        txCategories: { ls: 1, sqlite: 3, lsOnly: 0, sqliteOnly: 2 },
+      });
+    } finally {
+      handle.close();
+    }
+  });
+
+  it("reports mismatch when prefs presence diverges (LS has prefs, SQLite does not)", async () => {
+    const handle = await createTestSqlite();
+    try {
+      const next: FinykDualWriteState = {
+        ...EMPTY_STATE,
+        prefs: makePrefs(),
+      };
+
+      const out = await probeFinykParity(handle.client, USER_ID, next);
+      expect(out.result).toBe("mismatch");
+      expect(out.details).toEqual({
+        ...MISMATCH_ZEROS_DETAILS,
+        prefs: { ls: true, sqlite: false },
+      });
+    } finally {
+      handle.close();
+    }
+  });
+
+  it("reports mismatch when prefs presence diverges (SQLite has prefs, LS does not)", async () => {
+    const handle = await createTestSqlite();
+    try {
+      await seedPrefs(handle.client);
+
+      const out = await probeFinykParity(handle.client, USER_ID, EMPTY_STATE);
+      expect(out.result).toBe("mismatch");
+      expect(out.details).toEqual({
+        ...MISMATCH_ZEROS_DETAILS,
+        prefs: { ls: false, sqlite: true },
+      });
+    } finally {
+      handle.close();
+    }
+  });
+
+  it("reports mismatch with both lsOnly and sqliteOnly on networth-history symmetric divergence", async () => {
+    const handle = await createTestSqlite();
+    try {
+      await seedNetworth(handle.client, "2026-03");
+
+      const next: FinykDualWriteState = {
+        ...EMPTY_STATE,
+        networthHistory: [makeNetworth("2026-04")],
+      };
+
+      const out = await probeFinykParity(handle.client, USER_ID, next);
+      expect(out.result).toBe("mismatch");
+      expect(out.details).toEqual({
+        ...MISMATCH_ZEROS_DETAILS,
+        networthHistory: { ls: 1, sqlite: 1, lsOnly: 1, sqliteOnly: 1 },
+      });
+    } finally {
+      handle.close();
+    }
+  });
+
+  it("scopes the read to user_id so other users' rows don't leak in", async () => {
+    const handle = await createTestSqlite();
+    try {
+      // Other-user noise across every soft-delete-aware and per-tx
+      // table — none of these should appear in user-1's parity tally.
+      await seedHiddenAccount(handle.client, "acc-other", {
+        userId: "user-2",
+      });
+      await seedHiddenTransaction(handle.client, "tx-other", {
+        userId: "user-2",
+      });
+      await seedBlob(handle.client, "finyk_budgets", "b-other", {
+        userId: "user-2",
+      });
+      await seedBlob(handle.client, "finyk_subscriptions", "s-other", {
+        userId: "user-2",
+      });
+      await seedBlob(handle.client, "finyk_debts", "d-other", {
+        userId: "user-2",
+      });
+      await seedTxCategory(handle.client, "tx-other-c", { userId: "user-2" });
+      await seedTxSplit(handle.client, "tx-other-s", { userId: "user-2" });
+      await seedMonoDebtLink(handle.client, "tx-other-l", {
+        userId: "user-2",
+      });
+      await seedNetworth(handle.client, "2026-04", { userId: "user-2" });
+      await seedPrefs(handle.client, "user-2");
+
+      // user-1's own row.
+      await seedBlob(handle.client, "finyk_budgets", "b1");
+
+      const next: FinykDualWriteState = {
+        ...EMPTY_STATE,
+        budgets: [makeBlob("b1")],
+      };
+
+      const out = await probeFinykParity(handle.client, USER_ID, next);
+      expect(out.result).toBe("match");
+      expect(out.details).toEqual({
+        ...MATCH_ZEROS_DETAILS,
+        budgets: { ls: 1, sqlite: 1 },
+      });
+    } finally {
+      handle.close();
+    }
+  });
+
+  it("ignores LS entries with empty or non-string ids on blob and per-tx tables", async () => {
+    const handle = await createTestSqlite();
+    try {
+      await seedBlob(handle.client, "finyk_budgets", "b1");
+      await seedTxCategory(handle.client, "tx-c1");
+
+      // Inject malformed entries past the type-check. The probe must
+      // defensively skip them rather than surface a phantom mismatch.
+      const malformedBudgets = [
+        makeBlob("b1"),
+        { ...makeBlob(""), id: "" },
+        { ...makeBlob("ignored"), id: 42 },
+        null,
+      ] as unknown as readonly FinykBlobEntry[];
+
+      const malformedTxCategories = [
+        makeTxCategory("tx-c1"),
+        { transactionId: "", categoryId: "x" },
+        { transactionId: 7, categoryId: "x" },
+        undefined,
+      ] as unknown as readonly FinykTxCategoryEntry[];
+
+      const next: FinykDualWriteState = {
+        ...EMPTY_STATE,
+        budgets: malformedBudgets,
+        txCategories: malformedTxCategories,
+      };
+
+      const out = await probeFinykParity(handle.client, USER_ID, next);
+      expect(out.result).toBe("match");
+      expect(out.details).toEqual({
+        ...MATCH_ZEROS_DETAILS,
+        budgets: { ls: 1, sqlite: 1 },
+        txCategories: { ls: 1, sqlite: 1 },
+      });
+    } finally {
+      handle.close();
+    }
+  });
+
+  it("reports mismatch when only the time-series month differs across many entity classes", async () => {
+    // Multi-bucket mismatch — confirms each bucket gets its own
+    // lsOnly / sqliteOnly tally rather than a global aggregate.
+    const handle = await createTestSqlite();
+    try {
+      await seedBlob(handle.client, "finyk_assets", "a-stale");
+      await seedBlob(handle.client, "finyk_debts", "d1");
+      await seedTxSplit(handle.client, "tx-1");
+      await seedNetworth(handle.client, "2026-03");
+
+      const next: FinykDualWriteState = {
+        ...EMPTY_STATE,
+        // assets diverge — LS has none, SQLite has a-stale
+        // debts match — both have d1
+        debts: [makeBlob("d1")],
+        // txSplits match — both have tx-1
+        txSplits: [makeTxSplit("tx-1")],
+        // networthHistory diverges — LS=2026-04, SQLite=2026-03
+        networthHistory: [makeNetworth("2026-04")],
+      };
+
+      const out = await probeFinykParity(handle.client, USER_ID, next);
+      expect(out.result).toBe("mismatch");
+      expect(out.details).toEqual({
+        ...MISMATCH_ZEROS_DETAILS,
+        assets: { ls: 0, sqlite: 1, lsOnly: 0, sqliteOnly: 1 },
+        debts: { ls: 1, sqlite: 1, lsOnly: 0, sqliteOnly: 0 },
+        txSplits: { ls: 1, sqlite: 1, lsOnly: 0, sqliteOnly: 0 },
+        networthHistory: { ls: 1, sqlite: 1, lsOnly: 1, sqliteOnly: 1 },
+      });
+    } finally {
+      handle.close();
+    }
+  });
+
+  it("reports match when LS prefs object is set with falsy showBalance flag", async () => {
+    // Defensive: prefs presence is a boolean — the probe must NOT
+    // shortcut on `next.prefs?.showBalance` semantics. A prefs object
+    // with `showBalance: false` is still "present".
+    const handle = await createTestSqlite();
+    try {
+      await seedPrefs(handle.client);
+
+      const next: FinykDualWriteState = {
+        ...EMPTY_STATE,
+        prefs: { monthlyPlanJson: "{}", showBalance: false },
+      };
+
+      const out = await probeFinykParity(handle.client, USER_ID, next);
+      expect(out.result).toBe("match");
+      expect(out.details).toEqual({
+        ...MATCH_ZEROS_DETAILS,
+        prefs: { ls: true, sqlite: true },
+      });
+    } finally {
+      handle.close();
+    }
+  });
+});

--- a/apps/web/src/modules/finyk/lib/dualWrite/index.ts
+++ b/apps/web/src/modules/finyk/lib/dualWrite/index.ts
@@ -1,6 +1,10 @@
 import type { SqliteMigrationClient } from "@sergeant/db-schema/migrate/sqlite";
 
-import { recordDualWriteOutcome } from "../../../../core/observability/dualWriteTelemetry.js";
+import {
+  recordDualWriteOutcome,
+  recordParityCheck,
+  recordReadFallback,
+} from "../../../../core/observability/dualWriteTelemetry.js";
 import {
   applyFinykDualWriteOps,
   type ApplyDualWriteResult,
@@ -11,6 +15,7 @@ import {
   EMPTY_FINYK_STATE,
   type FinykDualWriteState,
 } from "./diff.js";
+import { probeFinykParity } from "./parity.js";
 
 /**
  * Orchestrator for the Finyk dual-write layer.
@@ -136,6 +141,24 @@ async function runDualWriteFinykState(
     clientTs: ctx.getNow(),
     logger: ctx.logger,
   });
+
+  // Stage 8 parity probe — best-effort: never throws, never disturbs
+  // the dual-write outcome. A failed probe-read is tagged distinctly
+  // (`recordReadFallback`) so triage can tell `SELECT failing` apart
+  // from a real LS↔SQLite divergence (`recordParityCheck("…",
+  // "mismatch", …)`).
+  try {
+    const parity = await probeFinykParity(client, userId, next);
+    recordParityCheck("finyk", parity.result, parity.details);
+  } catch (err) {
+    recordReadFallback(
+      "finyk",
+      err instanceof Error
+        ? `parity-probe-failed: ${err.message}`
+        : "parity-probe-failed",
+    );
+  }
+
   return { status: "applied", result };
 }
 

--- a/apps/web/src/modules/finyk/lib/dualWrite/parity.ts
+++ b/apps/web/src/modules/finyk/lib/dualWrite/parity.ts
@@ -1,0 +1,490 @@
+import type { SqliteMigrationClient } from "@sergeant/db-schema/migrate/sqlite";
+
+import type { FinykDualWriteState } from "./diff.js";
+
+/**
+ * Parity probe for the Finyk SQLite dual-write layer.
+ *
+ * Stage 8 §3 of `docs/planning/storage-roadmap.md` defines a
+ * `<module>.sqlite.dualwrite.parity` decision-gate metric: whenever
+ * the LS-derived state and the SQLite-derived state should be
+ * identical (which is the steady-state invariant once the dual-write
+ * `applied` outcome returns success), they are compared and a
+ * `recordParityCheck` tick is emitted on the global Sentry scope.
+ *
+ * The orchestrator (`./index.ts`) calls this helper after every
+ * successful `applyFinykDualWriteOps` apply. Finyk SQLite is the
+ * largest of the four modules — five entity classes across thirteen
+ * tables that round-trip through this dual-write boundary:
+ *
+ *   1. **Blob tables (7)** — top-level rows keyed by `id` (UUID) with
+ *      `deleted_at`: `finyk_budgets`, `finyk_subscriptions`,
+ *      `finyk_assets`, `finyk_debts`, `finyk_receivables`,
+ *      `finyk_custom_categories`, `finyk_manual_expenses`.
+ *   2. **Tombstone id-tables (2)** — composite PK on
+ *      `(user_id, account_id|transaction_id)` with `deleted_at`:
+ *      `finyk_hidden_accounts` (key column `account_id`),
+ *      `finyk_hidden_transactions` (key column `transaction_id`).
+ *      The LS shape is `{ id }` where `id` is the external Mono id.
+ *   3. **Per-tx mappings (3)** — composite PK on
+ *      `(user_id, transaction_id)` without `deleted_at`:
+ *      `finyk_tx_categories`, `finyk_tx_splits`,
+ *      `finyk_mono_debt_links`. "No mapping" is the same as the row
+ *      not existing — the sync apply path treats `delete` as
+ *      `DELETE FROM`.
+ *   4. **Time-series (1)** — composite PK on `(user_id, month)`
+ *      without `deleted_at`: `finyk_networth_history`. `month` is a
+ *      TEXT `YYYY-MM` to mirror the LS shape verbatim.
+ *   5. **Singleton prefs (1)** — `user_id` PK, no `id`, no
+ *      `deleted_at`: `finyk_prefs`. Compared as a presence boolean:
+ *      LS-side has prefs iff `next.prefs !== null`; SQLite-side iff
+ *      a row exists for `user_id`.
+ *
+ * Mono cache mirrors (`finyk_mono_transactions`, `finyk_mono_accounts`,
+ * `finyk_mono_account_snapshots`) are NOT compared here. They are not
+ * round-tripped through this dual-write — they are written directly
+ * by the Mono import path with LWW against Mono's own `time` field —
+ * so they are not part of the LS↔SQLite parity invariant the Stage 8
+ * decision-gate is gated on.
+ *
+ * `finyk_tx_filters` is also NOT compared here. The diff layer
+ * intentionally omits it (`./diff.ts` line 37–40) because there is no
+ * LS source on `main` today; until the LS shape lands, comparing the
+ * SQLite side to nothing would emit gratuitous mismatches.
+ *
+ * The probe is best-effort: it must NEVER throw, and any read failure
+ * is surfaced as a `read.fallback` — distinct from a real parity
+ * mismatch — so triage can tell `SELECT failing` apart from `LS and
+ * SQLite genuinely disagree`. The orchestrator implements that
+ * distinction.
+ */
+
+interface ParityProbeOutcome {
+  result: "match" | "mismatch";
+  details: Record<string, unknown>;
+}
+
+interface SetCompareOutcome {
+  match: boolean;
+  lsOnly: number;
+  sqliteOnly: number;
+}
+
+/**
+ * Read the active Finyk entity ids/keys from SQLite for `userId` and
+ * compare them to the LS-derived `next` snapshot. The two are
+ * expected to be byte-identical right after a successful dual-write
+ * apply — any divergence is a Stage 8 decision-gate signal.
+ *
+ * The function may throw if any of the SQLite reads fail. The caller
+ * is expected to catch and route that to `recordReadFallback` rather
+ * than `recordParityCheck("…", "mismatch", …)` — see `./index.ts`.
+ */
+export async function probeFinykParity(
+  client: SqliteMigrationClient,
+  userId: string,
+  next: FinykDualWriteState,
+): Promise<ParityProbeOutcome> {
+  // --- Blob tables (7) ---
+  const sqliteBudgets = await readBlobIds(client, "finyk_budgets", userId);
+  const sqliteSubscriptions = await readBlobIds(
+    client,
+    "finyk_subscriptions",
+    userId,
+  );
+  const sqliteAssets = await readBlobIds(client, "finyk_assets", userId);
+  const sqliteDebts = await readBlobIds(client, "finyk_debts", userId);
+  const sqliteReceivables = await readBlobIds(
+    client,
+    "finyk_receivables",
+    userId,
+  );
+  const sqliteCustomCategories = await readBlobIds(
+    client,
+    "finyk_custom_categories",
+    userId,
+  );
+  const sqliteManualExpenses = await readBlobIds(
+    client,
+    "finyk_manual_expenses",
+    userId,
+  );
+
+  // --- Tombstone id-tables (2) ---
+  const sqliteHiddenAccounts = await readKeyedIds(
+    client,
+    "finyk_hidden_accounts",
+    "account_id",
+    userId,
+  );
+  const sqliteHiddenTransactions = await readKeyedIds(
+    client,
+    "finyk_hidden_transactions",
+    "transaction_id",
+    userId,
+  );
+
+  // --- Per-tx mappings (3) — no deleted_at ---
+  const sqliteTxCategories = await readKeyedIdsNoSoftDelete(
+    client,
+    "finyk_tx_categories",
+    "transaction_id",
+    userId,
+  );
+  const sqliteTxSplits = await readKeyedIdsNoSoftDelete(
+    client,
+    "finyk_tx_splits",
+    "transaction_id",
+    userId,
+  );
+  const sqliteMonoDebtLinks = await readKeyedIdsNoSoftDelete(
+    client,
+    "finyk_mono_debt_links",
+    "transaction_id",
+    userId,
+  );
+
+  // --- Time-series (1) — no deleted_at ---
+  const sqliteNetworthHistory = await readKeyedIdsNoSoftDelete(
+    client,
+    "finyk_networth_history",
+    "month",
+    userId,
+  );
+
+  // --- Singleton prefs (1) ---
+  const sqliteHasPrefs = await readPrefsExists(client, userId);
+
+  // --- Build LS-side sets ---
+  const lsBudgets = buildIdSet(next.budgets);
+  const lsSubscriptions = buildIdSet(next.subscriptions);
+  const lsAssets = buildIdSet(next.assets);
+  const lsDebts = buildIdSet(next.debts);
+  const lsReceivables = buildIdSet(next.receivables);
+  const lsCustomCategories = buildIdSet(next.customCategories);
+  const lsManualExpenses = buildIdSet(next.manualExpenses);
+  const lsHiddenAccounts = buildIdSet(next.hiddenAccounts);
+  const lsHiddenTransactions = buildIdSet(next.hiddenTransactions);
+  const lsTxCategories = buildKeySet(next.txCategories, "transactionId");
+  const lsTxSplits = buildKeySet(next.txSplits, "transactionId");
+  const lsMonoDebtLinks = buildKeySet(next.monoDebtLinks, "transactionId");
+  const lsNetworthHistory = buildKeySet(next.networthHistory, "month");
+  const lsHasPrefs = next.prefs !== null && next.prefs !== undefined;
+
+  // --- Compare ---
+  const budgetsDiff = compareSets(lsBudgets, sqliteBudgets);
+  const subscriptionsDiff = compareSets(lsSubscriptions, sqliteSubscriptions);
+  const assetsDiff = compareSets(lsAssets, sqliteAssets);
+  const debtsDiff = compareSets(lsDebts, sqliteDebts);
+  const receivablesDiff = compareSets(lsReceivables, sqliteReceivables);
+  const customCategoriesDiff = compareSets(
+    lsCustomCategories,
+    sqliteCustomCategories,
+  );
+  const manualExpensesDiff = compareSets(
+    lsManualExpenses,
+    sqliteManualExpenses,
+  );
+  const hiddenAccountsDiff = compareSets(
+    lsHiddenAccounts,
+    sqliteHiddenAccounts,
+  );
+  const hiddenTransactionsDiff = compareSets(
+    lsHiddenTransactions,
+    sqliteHiddenTransactions,
+  );
+  const txCategoriesDiff = compareSets(lsTxCategories, sqliteTxCategories);
+  const txSplitsDiff = compareSets(lsTxSplits, sqliteTxSplits);
+  const monoDebtLinksDiff = compareSets(lsMonoDebtLinks, sqliteMonoDebtLinks);
+  const networthHistoryDiff = compareSets(
+    lsNetworthHistory,
+    sqliteNetworthHistory,
+  );
+  const prefsMatch = lsHasPrefs === sqliteHasPrefs;
+
+  const allMatch =
+    budgetsDiff.match &&
+    subscriptionsDiff.match &&
+    assetsDiff.match &&
+    debtsDiff.match &&
+    receivablesDiff.match &&
+    customCategoriesDiff.match &&
+    manualExpensesDiff.match &&
+    hiddenAccountsDiff.match &&
+    hiddenTransactionsDiff.match &&
+    txCategoriesDiff.match &&
+    txSplitsDiff.match &&
+    monoDebtLinksDiff.match &&
+    networthHistoryDiff.match &&
+    prefsMatch;
+
+  if (allMatch) {
+    return {
+      result: "match",
+      details: {
+        budgets: { ls: lsBudgets.size, sqlite: sqliteBudgets.size },
+        subscriptions: {
+          ls: lsSubscriptions.size,
+          sqlite: sqliteSubscriptions.size,
+        },
+        assets: { ls: lsAssets.size, sqlite: sqliteAssets.size },
+        debts: { ls: lsDebts.size, sqlite: sqliteDebts.size },
+        receivables: { ls: lsReceivables.size, sqlite: sqliteReceivables.size },
+        customCategories: {
+          ls: lsCustomCategories.size,
+          sqlite: sqliteCustomCategories.size,
+        },
+        manualExpenses: {
+          ls: lsManualExpenses.size,
+          sqlite: sqliteManualExpenses.size,
+        },
+        hiddenAccounts: {
+          ls: lsHiddenAccounts.size,
+          sqlite: sqliteHiddenAccounts.size,
+        },
+        hiddenTransactions: {
+          ls: lsHiddenTransactions.size,
+          sqlite: sqliteHiddenTransactions.size,
+        },
+        txCategories: {
+          ls: lsTxCategories.size,
+          sqlite: sqliteTxCategories.size,
+        },
+        txSplits: { ls: lsTxSplits.size, sqlite: sqliteTxSplits.size },
+        monoDebtLinks: {
+          ls: lsMonoDebtLinks.size,
+          sqlite: sqliteMonoDebtLinks.size,
+        },
+        networthHistory: {
+          ls: lsNetworthHistory.size,
+          sqlite: sqliteNetworthHistory.size,
+        },
+        prefs: { ls: lsHasPrefs, sqlite: sqliteHasPrefs },
+      },
+    };
+  }
+
+  // Mismatch: surface the symmetric-difference cardinality per entity
+  // class so triage can read the bucket without a follow-up query. We
+  // deliberately do NOT include the actual ids — Mono account / tx
+  // ids and budget / subscription / asset / debt / receivable ids are
+  // user-data and Sentry breadcrumbs leak into events.
+  return {
+    result: "mismatch",
+    details: {
+      budgets: detailWithDiff(lsBudgets, sqliteBudgets, budgetsDiff),
+      subscriptions: detailWithDiff(
+        lsSubscriptions,
+        sqliteSubscriptions,
+        subscriptionsDiff,
+      ),
+      assets: detailWithDiff(lsAssets, sqliteAssets, assetsDiff),
+      debts: detailWithDiff(lsDebts, sqliteDebts, debtsDiff),
+      receivables: detailWithDiff(
+        lsReceivables,
+        sqliteReceivables,
+        receivablesDiff,
+      ),
+      customCategories: detailWithDiff(
+        lsCustomCategories,
+        sqliteCustomCategories,
+        customCategoriesDiff,
+      ),
+      manualExpenses: detailWithDiff(
+        lsManualExpenses,
+        sqliteManualExpenses,
+        manualExpensesDiff,
+      ),
+      hiddenAccounts: detailWithDiff(
+        lsHiddenAccounts,
+        sqliteHiddenAccounts,
+        hiddenAccountsDiff,
+      ),
+      hiddenTransactions: detailWithDiff(
+        lsHiddenTransactions,
+        sqliteHiddenTransactions,
+        hiddenTransactionsDiff,
+      ),
+      txCategories: detailWithDiff(
+        lsTxCategories,
+        sqliteTxCategories,
+        txCategoriesDiff,
+      ),
+      txSplits: detailWithDiff(lsTxSplits, sqliteTxSplits, txSplitsDiff),
+      monoDebtLinks: detailWithDiff(
+        lsMonoDebtLinks,
+        sqliteMonoDebtLinks,
+        monoDebtLinksDiff,
+      ),
+      networthHistory: detailWithDiff(
+        lsNetworthHistory,
+        sqliteNetworthHistory,
+        networthHistoryDiff,
+      ),
+      prefs: { ls: lsHasPrefs, sqlite: sqliteHasPrefs },
+    },
+  };
+}
+
+/**
+ * Read active ids from a Finyk blob table (per-row JSONB blob with
+ * `id` UUID PK + `deleted_at` soft-delete column).
+ *
+ * The `table` parameter is a typed union of seven literal strings, so
+ * there is no SQL-injection surface from string interpolation here.
+ */
+async function readBlobIds(
+  client: SqliteMigrationClient,
+  table:
+    | "finyk_budgets"
+    | "finyk_subscriptions"
+    | "finyk_assets"
+    | "finyk_debts"
+    | "finyk_receivables"
+    | "finyk_custom_categories"
+    | "finyk_manual_expenses",
+  userId: string,
+): Promise<Set<string>> {
+  const rows = await client.all<{ id: string }>(
+    `SELECT id FROM ${table}
+       WHERE user_id = ? AND deleted_at IS NULL`,
+    [userId],
+  );
+  const out = new Set<string>();
+  for (const row of rows) {
+    if (typeof row.id === "string" && row.id.length > 0) out.add(row.id);
+  }
+  return out;
+}
+
+/**
+ * Read active keys from a tombstone id-table (composite PK on
+ * `(user_id, key_col)` with `deleted_at`). Used for
+ * `finyk_hidden_accounts` and `finyk_hidden_transactions`.
+ *
+ * Both `table` and `keyColumn` are typed unions of literal strings,
+ * so the interpolation is safe.
+ */
+async function readKeyedIds(
+  client: SqliteMigrationClient,
+  table: "finyk_hidden_accounts" | "finyk_hidden_transactions",
+  keyColumn: "account_id" | "transaction_id",
+  userId: string,
+): Promise<Set<string>> {
+  const rows = await client.all<Record<string, unknown>>(
+    `SELECT ${keyColumn} AS key FROM ${table}
+       WHERE user_id = ? AND deleted_at IS NULL`,
+    [userId],
+  );
+  return collectStringKeys(rows);
+}
+
+/**
+ * Read keys from tables that have no `deleted_at` column. Used for
+ * `finyk_tx_categories`, `finyk_tx_splits`, `finyk_mono_debt_links`,
+ * and `finyk_networth_history`.
+ */
+async function readKeyedIdsNoSoftDelete(
+  client: SqliteMigrationClient,
+  table:
+    | "finyk_tx_categories"
+    | "finyk_tx_splits"
+    | "finyk_mono_debt_links"
+    | "finyk_networth_history",
+  keyColumn: "transaction_id" | "month",
+  userId: string,
+): Promise<Set<string>> {
+  const rows = await client.all<Record<string, unknown>>(
+    `SELECT ${keyColumn} AS key FROM ${table}
+       WHERE user_id = ?`,
+    [userId],
+  );
+  return collectStringKeys(rows);
+}
+
+async function readPrefsExists(
+  client: SqliteMigrationClient,
+  userId: string,
+): Promise<boolean> {
+  // `finyk_prefs` is a singleton row keyed by `user_id` — there is no
+  // `id` column and no soft-delete column. A presence check is the
+  // only meaningful parity signal.
+  const rows = await client.all<{ user_id: string }>(
+    `SELECT user_id FROM finyk_prefs WHERE user_id = ? LIMIT 1`,
+    [userId],
+  );
+  return rows.length > 0;
+}
+
+function collectStringKeys(
+  rows: readonly Record<string, unknown>[],
+): Set<string> {
+  const out = new Set<string>();
+  for (const row of rows) {
+    const key = row.key;
+    if (typeof key === "string" && key.length > 0) out.add(key);
+  }
+  return out;
+}
+
+function buildIdSet(items: readonly { id: string }[]): Set<string> {
+  const out = new Set<string>();
+  if (!Array.isArray(items)) return out;
+  for (const item of items) {
+    if (
+      item &&
+      typeof item === "object" &&
+      typeof item.id === "string" &&
+      item.id.length > 0
+    ) {
+      out.add(item.id);
+    }
+  }
+  return out;
+}
+
+function buildKeySet<T extends object>(
+  items: readonly T[],
+  keyName: keyof T,
+): Set<string> {
+  const out = new Set<string>();
+  if (!Array.isArray(items)) return out;
+  for (const item of items) {
+    if (item && typeof item === "object") {
+      const key = (item as Record<string, unknown>)[keyName as string];
+      if (typeof key === "string" && key.length > 0) out.add(key);
+    }
+  }
+  return out;
+}
+
+function compareSets(ls: Set<string>, sqlite: Set<string>): SetCompareOutcome {
+  if (ls.size === sqlite.size) {
+    let allMatch = true;
+    for (const key of ls) {
+      if (!sqlite.has(key)) {
+        allMatch = false;
+        break;
+      }
+    }
+    if (allMatch) return { match: true, lsOnly: 0, sqliteOnly: 0 };
+  }
+  let lsOnly = 0;
+  let sqliteOnly = 0;
+  for (const key of ls) if (!sqlite.has(key)) lsOnly += 1;
+  for (const key of sqlite) if (!ls.has(key)) sqliteOnly += 1;
+  return { match: false, lsOnly, sqliteOnly };
+}
+
+function detailWithDiff(
+  ls: Set<string>,
+  sqlite: Set<string>,
+  diff: SetCompareOutcome,
+): Record<string, unknown> {
+  return {
+    ls: ls.size,
+    sqlite: sqlite.size,
+    lsOnly: diff.lsOnly,
+    sqliteOnly: diff.sqliteOnly,
+  };
+}


### PR DESCRIPTION
## Summary

Wires a best-effort LS↔SQLite parity probe into the Finyk dual-write orchestrator — third and final slice of the Stage 8 §3 parity-probe quartet (after Routine PR #2243, Fizruk PR #2257, Nutrition PR #2259). After every successful `applyFinykDualWriteOps`, `probeFinykParity` reads the SQLite-side id/key sets for all 13 Finyk tables and compares them to the LS-derived `next` snapshot, emitting a `recordParityCheck("finyk", "match" | "mismatch", details)` tick. SELECT failures are caught and routed to `recordReadFallback` so triage can distinguish "SELECT failing" from a real divergence — never throws, never disturbs the dual-write outcome.

Surface (5 entity classes / 13 tables):

- **Blob tables (7)** — `finyk_{budgets,subscriptions,assets,debts,receivables,custom_categories,manual_expenses}`: `SELECT id WHERE user_id = ? AND deleted_at IS NULL`.
- **Tombstone id-tables (2)** — `finyk_hidden_{accounts,transactions}`: `SELECT account_id|transaction_id WHERE user_id = ? AND deleted_at IS NULL`.
- **Per-tx mappings (3)** — `finyk_{tx_categories,tx_splits,mono_debt_links}`: `SELECT transaction_id WHERE user_id = ?` (no `deleted_at`).
- **Time-series (1)** — `finyk_networth_history`: `SELECT month WHERE user_id = ?`.
- **Singleton prefs (1)** — `finyk_prefs`: presence-only check; LS-side is `next.prefs !== null`.

Mono cache mirrors (`finyk_mono_*`) and `finyk_tx_filters` are deliberately excluded — see header comment in `parity.ts` (mono caches don't round-trip through this dual-write; `finyk_tx_filters` has no LS source on `main` today).

## Governing Skill

- Primary skill: dual-write Stage 8 §3 parity-probe pattern (mirrors Nutrition PR #2259 / Fizruk PR #2257)
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a
- Why this playbook: n/a
- If no playbook matched, why: parity-probe additions are tracked in `docs/planning/storage-roadmap.md` Stage 8 §3, not via a standalone playbook.

## Verification

```bash
pnpm --filter @sergeant/web exec vitest run src/modules/finyk/lib/dualWrite/__tests__/parity.test.ts
# → 12/12 passed

pnpm --filter @sergeant/web exec eslint \
  src/modules/finyk/lib/dualWrite/parity.ts \
  src/modules/finyk/lib/dualWrite/index.ts \
  src/modules/finyk/lib/dualWrite/__tests__/parity.test.ts
# → clean

pnpm --filter @sergeant/web typecheck
# → tsc -p tsconfig.json --noEmit && tsc -p tsconfig.sw.json --noEmit (clean)
```

12 new tests cover: empty state, full-class match, soft-delete awareness on every soft-delete-aware table, lsOnly/sqliteOnly mismatches per bucket, prefs presence divergence (both directions), networth-history symmetric divergence, multi-bucket mismatch (verifies per-bucket tallies vs global aggregate), user-scoping, defensive id-validation on blob and per-tx tables, and a `showBalance: false` prefs presence case.

Additional checks:

- [x] Local smoke / manual validation completed (vitest, eslint, typecheck)
- [ ] Surface-specific checks completed (no UI changes; observability-only)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. (Roadmap doc updated separately in PR #2256; this PR adds inline header documentation in `parity.ts`.)
- [x] I checked whether `AGENTS.md` needed an update. (No — pattern unchanged.)
- [x] I checked whether a playbook or skill needed an update. (No.)
- [x] I checked whether governance docs or review docs needed an update. (No.)

Updated docs:

- n/a (file-header docstring in `parity.ts` documents the 5-class / 13-table surface and the `tx_filters` / `mono_*` exclusions)

## Risk and Rollout

- User-visible risk: none. Probe is best-effort, runs after the dual-write apply has already returned, swallows all errors into `recordReadFallback`. No flag flip; no read-path change. Telemetry-only.
- Rollout / deploy order: lands behind the existing `finyk.sqlite.dualwrite.enabled` gating — the probe only runs on dual-write apply success, so it inherits the existing rollout state.
- Backout plan: revert this PR. The probe is additive; the orchestrator's pre-existing return value is unchanged.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian. (No internal docs touched in this PR.)
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

Things worth extra eyeballs:

- **Read-amplification.** Each successful Finyk dual-write apply now issues **13 sequential SQLite SELECTs** (one per table). For the other modules this is 1 (Routine) or 4 (Nutrition / Fizruk). Local SQLite + indexed `user_id` should keep each query sub-ms, but if the apply path runs hot during Mono sync this is the place where I'd expect to see it. Easy follow-up if needed: collapse into a single `UNION ALL` or run reads in parallel with `Promise.all` — kept sequential here to mirror the simpler-module pattern verbatim.
- **Schema-table coverage.** Confirmed against `apps/server/src/migrations/039_finyk_tables.sql` and `packages/db-schema/src/sqlite/finyk.ts` that all 13 dual-write-tracked tables are probed. `finyk_tx_filters` is intentionally skipped (matches the explicit omission documented in `./diff.ts` lines 37–40 — no LS source on `main`). `finyk_mono_*` mirrors are intentionally skipped (Mono is the source-of-truth, written by the import path with LWW against Mono's own `time` field — not part of the LS↔SQLite invariant).
- **Soft-delete partitioning.** Soft-delete-aware tables (7 blobs + 2 tombstones) use `WHERE deleted_at IS NULL`; per-tx mappings (3) and time-series (1) use no `WHERE deleted_at` clause. The third test (`ignores soft-deleted SQLite rows in tombstone and blob tables`) seeds tombstoned rows on every soft-delete-aware table to lock this in.
- **`buildKeySet` constraint.** Initial typecheck failed with `T extends Record<string, unknown>` because the readonly entry interfaces (e.g. `FinykTxCategoryEntry`) don't carry an index signature. Loosened to `T extends object` with an internal cast to `Record<string, unknown>` for the property access. Functionally equivalent to the previous nutrition/fizruk inline patterns; flagging in case the constraint should be tightened differently.
- **Mismatch breadcrumb privacy.** Per the file-header rationale, the mismatch path only emits cardinalities (`ls`, `sqlite`, `lsOnly`, `sqliteOnly`) per bucket — never the actual ids. Mono account / tx ids and budget / subscription / asset / debt / receivable ids are user-data and Sentry breadcrumbs leak into events.
- **CI flakes.** PR #2259 hit the same main-branch `Critical-flow E2E` / `Test coverage (vitest)` / `check` flake pattern that #2257 was merged through. If the required checks fail here with the same auth-cascade signature on `not.toHaveURL`, that's the pre-existing main flake and is not caused by this PR (probe is purely backend, in a try/catch after `applyFinykDualWriteOps`, and never throws).

Link to Devin session: https://app.devin.ai/sessions/3c05c8e2675b4a1a8435a527af022bc6
Requested by: @Skords-01

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a best-effort LS↔SQLite parity probe to the Finyk dual-write path. After each successful apply, it compares id/key sets across 13 tables to the LS snapshot and emits telemetry without affecting writes.

- **New Features**
  - Runs after successful `applyFinykDualWriteOps` and emits `recordParityCheck("finyk", "match" | "mismatch", details)`.
  - Catches SELECT failures and routes them to `recordReadFallback`; never throws or changes the apply result.
  - Compares 13 tables: 7 blob tables with soft-delete, 2 tombstone id tables, 3 per-tx mappings (no soft-delete), 1 time-series by `month`, plus prefs via presence check.
  - Excludes `finyk_mono_*` mirrors and `finyk_tx_filters` by design.
  - Issues 13 sequential reads; inherits `finyk.sqlite.dualwrite.enabled` gate.
  - Adds 12 tests covering empty/match cases, per-bucket mismatches, soft-deletes, user scoping, defensive id validation, prefs presence.

<sup>Written for commit 43e34f8a0a0d947af2cdc2f9c3ac7f131c53558c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

