### PR TITLE
chore(web,mobile): drop Nutrition LS-write + LS-read for Stage 8 PR #057n-tombstone

### DIFF
--- a/apps/mobile/src/modules/nutrition/hooks/useNutritionLog.ts
+++ b/apps/mobile/src/modules/nutrition/hooks/useNutritionLog.ts
@@ -1,15 +1,15 @@
 /**
- * `useNutritionLog` — MMKV-backed React hook над журналом прийомів їжі
- * для mobile. Mirror `apps/web/src/modules/nutrition/hooks/useNutritionLog.ts`
+ * `useNutritionLog` — SQLite-cache-backed React hook над журналом
+ * прийомів їжі для mobile. Mirror `apps/web/src/modules/nutrition/hooks/useNutritionLog.ts`
  * але без photo-thumbnail-GC, query-invalidation і storage-error-banner
  * (ті блоки специфічні для web або прилітають у пізніших PR-ах).
  *
- * Action-surface цього PR-а (PR-4 — read-only UI):
- * - `log` + `selectedDate` + `setSelectedDate`
- * - мутатори (`addMeal`, `removeMeal`, `updateMeal`) повертають void;
- *   після мутації значення вже у MMKV, далі op-log v2 push підхопить.
- *
- * AddMealSheet / PhotoAnalyze / AI-фічі — PR-5+.
+ * Stage 8 PR #057n-tombstone: initial state reads `loadNutritionLog`
+ * which now hits the SQLite warm cache (empty pre-boot). The MMKV
+ * value-changed listener was removed because `nutrition_log_v1` is
+ * tombstoned — cross-consumer notifications now flow through
+ * `useNutritionSqliteReadTick` (the dual-write orchestrator bumps
+ * the tick after every successful apply).
  */
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -21,9 +21,7 @@ import {
   type Meal,
   type NutritionLog,
 } from "@sergeant/nutrition-domain";
-import { STORAGE_KEYS, toLocalISODate } from "@sergeant/shared";
-
-import { _getMMKVInstance } from "@/lib/storage";
+import { toLocalISODate } from "@sergeant/shared";
 
 import { loadNutritionLog, saveNutritionLog } from "../lib/nutritionStore";
 import { getCachedNutritionSqliteState } from "../lib/sqliteReader";
@@ -59,17 +57,11 @@ export function useNutritionLog(): UseNutritionLogResult {
     setNutritionLog(loadNutritionLog());
   }, []);
 
-  useEffect(() => {
-    const mmkv = _getMMKVInstance();
-    const sub = mmkv.addOnValueChangedListener((changedKey) => {
-      if (changedKey === STORAGE_KEYS.NUTRITION_LOG) refresh();
-    });
-    return () => sub.remove();
-  }, [refresh]);
-
-  // Stage 4 PR #033 + Stage 8 PR #057n: overlay the meal log from
-  // the local SQLite cache once it's warm. MMKV first-paint read
-  // above stays as a synchronous fallback.
+  // Stage 4 PR #033 + Stage 8 PR #057n-tombstone: overlay the meal log
+  // from the local SQLite cache once it's warm. The MMKV value-changed
+  // listener was dropped because `nutrition_log_v1` no longer exists —
+  // cache-tick is now the only "value changed" signal, and the
+  // dual-write orchestrator bumps it after every successful apply.
   const sqliteCacheTick = useNutritionSqliteReadTick();
   useEffect(() => {
     const cache = getCachedNutritionSqliteState();

--- a/apps/mobile/src/modules/nutrition/hooks/useNutritionPrefs.ts
+++ b/apps/mobile/src/modules/nutrition/hooks/useNutritionPrefs.ts
@@ -1,16 +1,15 @@
 /**
- * `useNutritionPrefs` — MMKV-backed read/write hook для nutrition prefs
- * (денні цілі КБЖВ, водна ціль, reminder-опції).
+ * `useNutritionPrefs` — SQLite-cache-backed read/write hook for
+ * nutrition prefs (денні цілі КБЖВ, водна ціль, reminder-опції).
  *
- * PR-4 використовує це лише для читання (денні targets у Dashboard).
- * Запис prefs-форми через реальний settings-екран прилітає з PR-7/8.
+ * Stage 8 PR #057n-tombstone: initial state reads from the SQLite
+ * warm cache. The MMKV value-changed listener was removed because
+ * `nutrition_prefs_v1` is tombstoned — cross-consumer notifications
+ * now flow through `useNutritionSqliteReadTick`.
  */
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { type NutritionPrefs } from "@sergeant/nutrition-domain";
-import { STORAGE_KEYS } from "@sergeant/shared";
-
-import { _getMMKVInstance } from "@/lib/storage";
 
 import { loadNutritionPrefs, saveNutritionPrefs } from "../lib/nutritionStore";
 import { getCachedNutritionSqliteState } from "../lib/sqliteReader";
@@ -32,20 +31,11 @@ export function useNutritionPrefs(): UseNutritionPrefsResult {
     prefsRef.current = prefs;
   }, [prefs]);
 
-  useEffect(() => {
-    const mmkv = _getMMKVInstance();
-    const sub = mmkv.addOnValueChangedListener((changedKey) => {
-      if (changedKey === STORAGE_KEYS.NUTRITION_PREFS) {
-        setPrefsState(loadNutritionPrefs());
-      }
-    });
-    return () => sub.remove();
-  }, []);
-
-  // Stage 4 PR #033 + Stage 8 PR #057n: overlay nutrition prefs from
-  // the local SQLite cache once it's warm. The MMKV first-paint read
-  // above stays as a synchronous fallback so the first paint never
-  // blocks on SQLite.
+  // Stage 4 PR #033 + Stage 8 PR #057n-tombstone: overlay nutrition
+  // prefs from the local SQLite cache once it's warm. The MMKV
+  // value-changed listener was dropped — `nutrition_prefs_v1` no
+  // longer exists, the cache-tick is the single source of "value
+  // changed" notifications.
   const sqliteCacheTick = useNutritionSqliteReadTick();
   useEffect(() => {
     const cache = getCachedNutritionSqliteState();

--- a/apps/mobile/src/modules/nutrition/lib/__tests__/nutritionStore.test.ts
+++ b/apps/mobile/src/modules/nutrition/lib/__tests__/nutritionStore.test.ts
@@ -1,10 +1,12 @@
 /**
- * Phase 7 / PR 3 — mobile nutrition storage foundation.
+ * Phase 7 / PR 3 — mobile nutrition storage foundation, rewired for
+ * Stage 8 PR #057n-tombstone (`docs/planning/storage-roadmap.md`).
  *
- * Verifies that every `load*` / `save*` helper in `nutritionStore.ts`
- * routes through `safeReadLS` / `safeWriteLS` (→ MMKV) and delegates
- * normalization to `@sergeant/nutrition-domain`. Storage primitives
- * are mocked so the suite stays pure — we never touch real MMKV.
+ * The Nutrition `load*` / `save*` helpers no longer touch MMKV. The
+ * suite now seeds the SQLite warm cache via
+ * `__setNutritionSqliteCacheForTests` and verifies that `save*` calls
+ * fan out through `triggerNutritionDualWrite(prev, next)` instead of
+ * `safeWriteLS`. Water and shopping helpers keep their MMKV path.
  */
 const mockSafeReadLS = jest.fn();
 const mockSafeReadStringLS = jest.fn();
@@ -16,14 +18,22 @@ jest.mock("@/lib/storage", () => ({
   safeWriteLS: (...args: unknown[]) => mockSafeWriteLS(...args),
 }));
 
+const mockTriggerDualWrite = jest.fn();
+const mockIsRegistered = jest.fn();
+
+jest.mock("../dualWrite", () => ({
+  triggerNutritionDualWrite: (...args: unknown[]) =>
+    mockTriggerDualWrite(...args),
+  isNutritionDualWriteRegistered: () => mockIsRegistered(),
+}));
+
 import {
-  NUTRITION_ACTIVE_PANTRY_KEY,
-  NUTRITION_LOG_KEY,
-  NUTRITION_PANTRIES_KEY,
-  NUTRITION_PREFS_KEY,
   SHOPPING_LIST_KEY,
   WATER_LOG_KEY,
+  defaultNutritionPrefs,
+  type NutritionLog,
 } from "@sergeant/nutrition-domain";
+
 import {
   loadActivePantryId,
   loadNutritionLog,
@@ -38,122 +48,173 @@ import {
   saveShoppingList,
   saveWaterLog,
 } from "../nutritionStore";
+import {
+  __setNutritionSqliteCacheForTests,
+  clearNutritionSqliteCache,
+} from "../sqliteReader";
 
 beforeEach(() => {
   mockSafeReadLS.mockReset().mockReturnValue(null);
   mockSafeReadStringLS.mockReset().mockReturnValue(null);
   mockSafeWriteLS.mockReset().mockReturnValue(true);
+  mockTriggerDualWrite.mockReset();
+  // Default: dual-write is registered → save paths actually fire the
+  // trigger. Individual tests flip this to `false` when they want to
+  // verify the early-return guard.
+  mockIsRegistered.mockReset().mockReturnValue(true);
+  clearNutritionSqliteCache();
 });
 
 describe("mobile nutritionStore — log", () => {
-  it("loadNutritionLog normalises missing data into an empty log", () => {
-    const out = loadNutritionLog();
-    expect(mockSafeReadLS).toHaveBeenCalledWith(NUTRITION_LOG_KEY, null);
-    expect(out).toEqual({});
+  it("loadNutritionLog returns an empty log when the cache is cold", () => {
+    expect(loadNutritionLog()).toEqual({});
+    // No MMKV reads — the cache is the only source.
+    expect(mockSafeReadLS).not.toHaveBeenCalled();
   });
 
-  it("loadNutritionLog normalises one well-formed day", () => {
-    mockSafeReadLS.mockReturnValueOnce({
+  it("loadNutritionLog reads from the SQLite warm cache", () => {
+    const seeded: NutritionLog = {
       "2024-01-15": {
-        meals: [{ id: "m1", name: "Сніданок", mealType: "breakfast" }],
+        meals: [
+          {
+            id: "m1",
+            name: "Сніданок",
+            mealType: "breakfast",
+            time: "08:00",
+            label: "",
+            source: "manual",
+            macroSource: "manual",
+            macros: null,
+          },
+        ],
       },
-    });
+    } as unknown as NutritionLog;
+    __setNutritionSqliteCacheForTests({ log: seeded });
     const out = loadNutritionLog();
     expect(out["2024-01-15"]!.meals).toHaveLength(1);
     expect(out["2024-01-15"]!.meals[0]!.id).toBe("m1");
   });
 
-  it("saveNutritionLog writes to the canonical key", () => {
-    saveNutritionLog({ "2024-01-15": { meals: [] } });
-    expect(mockSafeWriteLS).toHaveBeenCalledWith(NUTRITION_LOG_KEY, {
-      "2024-01-15": { meals: [] },
-    });
+  it("saveNutritionLog dispatches a dual-write op and never touches MMKV", () => {
+    const payload: NutritionLog = {
+      "2024-01-15": {
+        meals: [
+          {
+            id: "m1",
+            name: "Сніданок",
+            mealType: "breakfast",
+            time: "08:00",
+            label: "",
+            source: "manual",
+            macroSource: "manual",
+            macros: null,
+          },
+        ],
+      },
+    } as unknown as NutritionLog;
+    saveNutritionLog(payload);
+    expect(mockSafeWriteLS).not.toHaveBeenCalled();
+    expect(mockTriggerDualWrite).toHaveBeenCalledTimes(1);
+    const [, next] = mockTriggerDualWrite.mock.calls[0]!;
+    expect(next.meals).toHaveLength(1);
+    expect(next.meals[0]).toMatchObject({ id: "m1", dateKey: "2024-01-15" });
   });
 
-  it("saveNutritionLog with null writes an empty object (not null)", () => {
+  it("saveNutritionLog with null sends an empty meals array", () => {
     saveNutritionLog(null);
-    expect(mockSafeWriteLS).toHaveBeenCalledWith(NUTRITION_LOG_KEY, {});
+    expect(mockTriggerDualWrite).toHaveBeenCalledTimes(1);
+    const [, next] = mockTriggerDualWrite.mock.calls[0]!;
+    expect(next.meals).toEqual([]);
+  });
+
+  it("saveNutritionLog is a no-op when dual-write is not registered", () => {
+    mockIsRegistered.mockReturnValue(false);
+    expect(saveNutritionLog({ "2024-01-15": { meals: [] } })).toBe(true);
+    expect(mockTriggerDualWrite).not.toHaveBeenCalled();
+    expect(mockSafeWriteLS).not.toHaveBeenCalled();
   });
 });
 
 describe("mobile nutritionStore — prefs", () => {
-  it("loadNutritionPrefs returns defaults for missing input", () => {
+  it("loadNutritionPrefs returns defaults for an empty cache", () => {
     const out = loadNutritionPrefs();
-    expect(mockSafeReadLS).toHaveBeenCalledWith(NUTRITION_PREFS_KEY, null);
     expect(out.goal).toBe("balanced");
     expect(out.waterGoalMl).toBe(2000);
+    expect(mockSafeReadLS).not.toHaveBeenCalled();
   });
 
-  it("loadNutritionPrefs normalises custom water goal", () => {
-    mockSafeReadLS.mockReturnValueOnce({ waterGoalMl: 2500 });
+  it("loadNutritionPrefs reads custom values from the cache", () => {
+    __setNutritionSqliteCacheForTests({
+      prefs: { ...defaultNutritionPrefs(), waterGoalMl: 2500 },
+    });
     expect(loadNutritionPrefs().waterGoalMl).toBe(2500);
   });
 
-  it("saveNutritionPrefs persists provided prefs", () => {
-    const prefs = { goal: "cut" } as Parameters<typeof saveNutritionPrefs>[0];
+  it("saveNutritionPrefs dispatches a dual-write op", () => {
+    const prefs = defaultNutritionPrefs();
     saveNutritionPrefs(prefs);
-    expect(mockSafeWriteLS).toHaveBeenCalledWith(NUTRITION_PREFS_KEY, prefs);
+    expect(mockSafeWriteLS).not.toHaveBeenCalled();
+    expect(mockTriggerDualWrite).toHaveBeenCalledTimes(1);
+    const [, next] = mockTriggerDualWrite.mock.calls[0]!;
+    expect(next.prefs?.prefsJson).toBe(JSON.stringify(prefs));
   });
 });
 
 describe("mobile nutritionStore — pantries", () => {
-  it("loadActivePantryId defaults to `home` when nothing is stored", () => {
+  it("loadActivePantryId defaults to `home` when the cache is cold", () => {
     expect(loadActivePantryId()).toBe("home");
-    expect(mockSafeReadStringLS).toHaveBeenCalledWith(
-      NUTRITION_ACTIVE_PANTRY_KEY,
-      null,
-    );
+    expect(mockSafeReadStringLS).not.toHaveBeenCalled();
   });
 
-  it("loadActivePantryId returns stored id", () => {
-    mockSafeReadStringLS.mockReturnValueOnce("work");
+  it("loadActivePantryId returns the cached id", () => {
+    __setNutritionSqliteCacheForTests({ activePantryId: "work" });
     expect(loadActivePantryId()).toBe("work");
   });
 
-  it("saveActivePantryId persists under the active key", () => {
+  it("saveActivePantryId dispatches a dual-write op with the new id", () => {
     saveActivePantryId("work");
-    expect(mockSafeWriteLS).toHaveBeenCalledWith(
-      NUTRITION_ACTIVE_PANTRY_KEY,
-      "work",
-    );
+    expect(mockTriggerDualWrite).toHaveBeenCalledTimes(1);
+    const [, next] = mockTriggerDualWrite.mock.calls[0]!;
+    expect(next.prefs?.activePantryId).toBe("work");
   });
 
-  it("loadPantries seeds the default pantry on first launch", () => {
+  it("loadPantries returns an in-memory default pantry on a cold cache", () => {
     const out = loadPantries();
     expect(out).toHaveLength(1);
     expect(out[0]!.id).toBe("home");
-    // Seeded default also writes the active pointer.
-    expect(mockSafeWriteLS).toHaveBeenCalledWith(
-      NUTRITION_ACTIVE_PANTRY_KEY,
-      "home",
-    );
+    // No MMKV write for the seed default — Stage 8 PR #057n-tombstone
+    // promotes pantry creation to the dual-write path.
+    expect(mockSafeWriteLS).not.toHaveBeenCalled();
   });
 
-  it("loadPantries normalises existing pantries", () => {
-    mockSafeReadLS.mockReturnValueOnce([
-      { id: "home", name: "Дім", items: [], text: "" },
-      { id: "work", name: "Робота", items: [], text: "" },
-    ]);
+  it("loadPantries reads existing pantries from the cache", () => {
+    __setNutritionSqliteCacheForTests({
+      pantries: [
+        { id: "home", name: "Дім", items: [], text: "" },
+        { id: "work", name: "Робота", items: [], text: "" },
+      ],
+    });
     const out = loadPantries();
     expect(out.map((p) => p.id)).toEqual(["home", "work"]);
   });
 
-  it("savePantries writes pantries + optional active id", () => {
+  it("savePantries dispatches a dual-write op with snapshots + active id", () => {
     savePantries([{ id: "home", name: "Дім", items: [], text: "" }], "home");
-    expect(mockSafeWriteLS).toHaveBeenCalledWith(NUTRITION_PANTRIES_KEY, [
-      { id: "home", name: "Дім", items: [], text: "" },
+    expect(mockSafeWriteLS).not.toHaveBeenCalled();
+    expect(mockTriggerDualWrite).toHaveBeenCalledTimes(1);
+    const [, next] = mockTriggerDualWrite.mock.calls[0]!;
+    expect(next.pantries).toEqual([
+      expect.objectContaining({ id: "home", name: "Дім" }),
     ]);
-    expect(mockSafeWriteLS).toHaveBeenCalledWith(
-      NUTRITION_ACTIVE_PANTRY_KEY,
-      "home",
-    );
+    expect(next.prefs?.activePantryId).toBe("home");
   });
 
-  it("savePantries skips active-id write when none provided", () => {
-    savePantries([{ id: "home", name: "Дім", items: [], text: "" }]);
-    const writtenKeys = mockSafeWriteLS.mock.calls.map((c) => c[0]);
-    expect(writtenKeys).toContain(NUTRITION_PANTRIES_KEY);
-    expect(writtenKeys).not.toContain(NUTRITION_ACTIVE_PANTRY_KEY);
+  it("savePantries is a no-op when dual-write is not registered", () => {
+    mockIsRegistered.mockReturnValue(false);
+    expect(
+      savePantries([{ id: "home", name: "Дім", items: [], text: "" }]),
+    ).toBe(true);
+    expect(mockTriggerDualWrite).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/mobile/src/modules/nutrition/lib/dualWrite/index.ts
+++ b/apps/mobile/src/modules/nutrition/lib/dualWrite/index.ts
@@ -1,5 +1,7 @@
 import type { SqliteMigrationClient } from "@sergeant/db-schema/migrate/sqlite";
 
+import { refreshNutritionSqliteState } from "../sqliteReader";
+import { notifyNutritionSqliteCacheRefresh } from "../sqliteReadGate";
 import {
   applyNutritionDualWriteOps,
   type ApplyDualWriteResult,
@@ -90,6 +92,21 @@ export async function dualWriteNutritionState(
     clientTs: ctx.getNow(),
     logger: ctx.logger,
   });
+
+  // Stage 8 PR #057n-tombstone: refresh the SQLite warm cache so
+  // subsequent reads (overlay effects in hooks, `peek` in
+  // `dualWriteState`) reflect what we just wrote. Best-effort —
+  // a failed refresh is logged but does not disturb the dual-write
+  // outcome.
+  try {
+    await refreshNutritionSqliteState(client, userId);
+    notifyNutritionSqliteCacheRefresh();
+  } catch (err) {
+    logSafe(ctx, "warn", "dual-write cache-refresh failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
   return { status: "applied", result };
 }
 

--- a/apps/mobile/src/modules/nutrition/lib/dualWriteState.ts
+++ b/apps/mobile/src/modules/nutrition/lib/dualWriteState.ts
@@ -2,8 +2,9 @@
  * Snapshot extractor for the mobile Nutrition dual-write layer.
  *
  * Stage 4 PR #032 of `docs/planning/storage-roadmap.md`. Reads the
- * MMKV slices that map to `nutrition_*` SQLite tables and produces
- * a `NutritionDualWriteState` blob that the diff layer can compare.
+ * SQLite warm cache (Stage 8 PR #057n-tombstone — was MMKV before)
+ * and produces a `NutritionDualWriteState` blob that the diff layer
+ * can compare.
  *
  * Lives in its own file (instead of next to either store) to break
  * the otherwise-circular import between `nutritionStore.ts` and
@@ -12,14 +13,11 @@
  */
 
 import {
-  NUTRITION_ACTIVE_PANTRY_KEY,
-  NUTRITION_PANTRIES_KEY,
-  normalizePantries,
+  defaultNutritionPrefs,
   type NutritionLog,
+  type NutritionPrefs,
   type Pantry,
 } from "@sergeant/nutrition-domain";
-
-import { safeReadLS, safeReadStringLS } from "@/lib/storage";
 
 import {
   isNutritionDualWriteRegistered,
@@ -30,27 +28,22 @@ import type {
   NutritionPantrySnapshot,
   NutritionRecipeSnapshot,
 } from "./dualWrite/diff";
-import { loadNutritionLog, loadNutritionPrefs } from "./nutritionStore";
 import { loadSavedRecipes, type SavedRecipe } from "./recipeBookStore";
+import { getCachedNutritionSqliteState } from "./sqliteReader";
 
 export function peekNutritionDualWriteState(): NutritionDualWriteState | null {
   if (!isNutritionDualWriteRegistered()) return null;
   try {
-    const log = loadNutritionLog();
-    const pantries = normalizePantries(
-      safeReadLS<unknown>(NUTRITION_PANTRIES_KEY, null),
-    );
-    const activePantryRaw = safeReadStringLS(NUTRITION_ACTIVE_PANTRY_KEY, null);
-    const activePantryId = activePantryRaw ? String(activePantryRaw) : null;
-    const prefs = loadNutritionPrefs();
+    const cache = getCachedNutritionSqliteState();
+    const prefs: NutritionPrefs = cache.prefs ?? defaultNutritionPrefs();
     const recipes = loadSavedRecipes();
 
     return {
-      meals: extractMealSnapshots(log),
-      pantries: extractPantrySnapshots(pantries),
+      meals: extractMealSnapshots(cache.log),
+      pantries: extractPantrySnapshots(cache.pantries),
       prefs: {
         prefsJson: JSON.stringify(prefs),
-        activePantryId,
+        activePantryId: cache.activePantryId,
       },
       recipes: extractRecipeSnapshots(recipes),
     };

--- a/apps/mobile/src/modules/nutrition/lib/nutritionStore.ts
+++ b/apps/mobile/src/modules/nutrition/lib/nutritionStore.ts
@@ -2,30 +2,20 @@
  * MMKV-backed storage adapter for the mobile Nutrition module.
  *
  * Mirrors the shape of `apps/web/src/modules/nutrition/lib/*Storage.ts`
- * (Phase 7 / PR 2) but on top of MMKV via `@/lib/storage`. All
- * normalization / mutation logic is delegated to
+ * (Phase 7 / PR 2). All normalization / mutation logic is delegated to
  * `@sergeant/nutrition-domain` so mobile and web share the exact same
  * `NutritionLog` / `Pantry` / `WaterLog` / `ShoppingList` / `Prefs`
  * semantics — one domain change, both platforms updated.
  *
- * Scope of this file (Phase 7 / PR 3 — Mobile storage foundation):
- *  - `load*` / `save*` functions for every nutrition LS-key
- *  - No hooks, no UI, no AI — those ship with the actual RN screens in
- *    Phase 7 / PR 4+. This PR only stands up the storage plumbing so
- *    upcoming UI PR-s can `import {load*, save*}` without touching
- *    MMKV directly.
- *
- * Cloud-sync note: writes go through `safeWriteLS` directly. With the
- * v1 cloudSync engine sunset (PR #052c) and the mobile sync shim
- * dropped (PR #053c), MMKV mutations are picked up by the per-module
- * SQLite dual-write adapter (`triggerNutritionDualWrite`) which feeds
- * the op-log v2 writer. No manual `enqueueChange` is required.
+ * Stage 8 PR #057n-tombstone (`docs/planning/storage-roadmap.md`): the
+ * `load*` / `save*` helpers for nutrition log / prefs / pantries no
+ * longer touch MMKV. Reads come from the SQLite warm cache populated
+ * at boot by `useNutritionSqliteReadBoot`, and writes go through the
+ * dual-write pipeline (`triggerNutritionDualWrite`) which mirrors to
+ * SQLite and bumps the cache. The MMKV-resident water and shopping
+ * stores are unchanged — they still live in MMKV.
  */
 import {
-  NUTRITION_ACTIVE_PANTRY_KEY,
-  NUTRITION_LOG_KEY,
-  NUTRITION_PANTRIES_KEY,
-  NUTRITION_PREFS_KEY,
   SHOPPING_LIST_KEY,
   WATER_LOG_KEY,
   defaultNutritionPrefs,
@@ -42,68 +32,99 @@ import {
   type WaterLog,
 } from "@sergeant/nutrition-domain";
 
-import { safeReadLS, safeReadStringLS, safeWriteLS } from "@/lib/storage";
-import { triggerNutritionDualWrite } from "./dualWrite";
+import { safeReadLS, safeWriteLS } from "@/lib/storage";
+
+import {
+  triggerNutritionDualWrite,
+  type NutritionDualWriteState,
+} from "./dualWrite";
+import type {
+  NutritionMealSnapshot,
+  NutritionPantrySnapshot,
+} from "./dualWrite/diff";
 import { peekNutritionDualWriteState } from "./dualWriteState";
+import { getCachedNutritionSqliteState } from "./sqliteReader";
 
 // ── Log ─────────────────────────────────────────────────────────────
 
 export function loadNutritionLog(): NutritionLog {
-  return normalizeNutritionLog(safeReadLS<unknown>(NUTRITION_LOG_KEY, null));
+  // Stage 8 PR #057n-tombstone: read from the SQLite warm cache. Pre-boot
+  // the cache returns `EMPTY_CACHE.log = {}` (empty object); the hook
+  // overlay re-renders once the cache warms via `useNutritionSqliteReadTick`.
+  const cache = getCachedNutritionSqliteState();
+  return normalizeNutritionLog(cache.log);
 }
 
 export function saveNutritionLog(
   log: NutritionLog | null | undefined,
 ): boolean {
   const prev = peekNutritionDualWriteState();
-  const ok = safeWriteLS(NUTRITION_LOG_KEY, log || {});
-  if (ok && prev !== null) {
-    triggerNutritionDualWrite(prev, peekNutritionDualWriteState() ?? prev);
-  }
-  return ok;
+  if (prev === null) return true;
+  const next: NutritionDualWriteState = {
+    ...prev,
+    meals: extractMealSnapshots(normalizeNutritionLog(log ?? {})),
+  };
+  triggerNutritionDualWrite(prev, next);
+  return true;
 }
 
 // ── Prefs ───────────────────────────────────────────────────────────
 
 export function loadNutritionPrefs(): NutritionPrefs {
-  return normalizeNutritionPrefs(
-    safeReadLS<unknown>(NUTRITION_PREFS_KEY, null),
-  );
+  // Stage 8 PR #057n-tombstone: read from the SQLite warm cache.
+  const cache = getCachedNutritionSqliteState();
+  return cache.prefs
+    ? normalizeNutritionPrefs(cache.prefs)
+    : defaultNutritionPrefs();
 }
 
 export function saveNutritionPrefs(
   prefs: NutritionPrefs | null | undefined,
 ): boolean {
   const prev = peekNutritionDualWriteState();
-  const ok = safeWriteLS(NUTRITION_PREFS_KEY, prefs || defaultNutritionPrefs());
-  if (ok && prev !== null) {
-    triggerNutritionDualWrite(prev, peekNutritionDualWriteState() ?? prev);
-  }
-  return ok;
+  if (prev === null) return true;
+  const next: NutritionDualWriteState = {
+    ...prev,
+    prefs: {
+      prefsJson: JSON.stringify(prefs || defaultNutritionPrefs()),
+      activePantryId: prev.prefs?.activePantryId ?? null,
+    },
+  };
+  triggerNutritionDualWrite(prev, next);
+  return true;
 }
 
 // ── Pantries ────────────────────────────────────────────────────────
 
 export function loadActivePantryId(): string {
-  const v = safeReadStringLS(NUTRITION_ACTIVE_PANTRY_KEY, null);
-  return v ? String(v) : "home";
+  // Stage 8 PR #057n-tombstone: read from the SQLite warm cache.
+  const cache = getCachedNutritionSqliteState();
+  return cache.activePantryId ?? "home";
 }
 
 export function saveActivePantryId(id: string): boolean {
-  return safeWriteLS(NUTRITION_ACTIVE_PANTRY_KEY, String(id || "home"));
+  const prev = peekNutritionDualWriteState();
+  if (prev === null) return true;
+  const next: NutritionDualWriteState = {
+    ...prev,
+    prefs: {
+      prefsJson:
+        prev.prefs?.prefsJson ?? JSON.stringify(defaultNutritionPrefs()),
+      activePantryId: String(id || "home"),
+    },
+  };
+  triggerNutritionDualWrite(prev, next);
+  return true;
 }
 
 export function loadPantries(): Pantry[] {
-  const parsed = safeReadLS<unknown>(NUTRITION_PANTRIES_KEY, null);
-  const normalized = normalizePantries(parsed);
-  if (normalized.length > 0) return normalized;
-  // No pantries yet — seed with default so the UI has something to
-  // render on first launch. Matches web behaviour (see
-  // `apps/web/src/modules/nutrition/lib/nutritionStorage.ts →
-  // loadPantries`).
-  const fallback = makeDefaultPantry();
-  safeWriteLS(NUTRITION_ACTIVE_PANTRY_KEY, fallback.id);
-  return [fallback];
+  // Stage 8 PR #057n-tombstone: read from the SQLite warm cache. When
+  // the cache is empty (fresh user, or boot not yet complete) return a
+  // single in-memory default pantry so the UI has something to render —
+  // the first user mutation will dual-write it via `savePantries`.
+  const cache = getCachedNutritionSqliteState();
+  if (cache.pantries.length > 0) return cache.pantries;
+  return [makeDefaultPantry()];
 }
 
 export function savePantries(
@@ -111,18 +132,68 @@ export function savePantries(
   activeId?: string | null,
 ): boolean {
   const prev = peekNutritionDualWriteState();
-  const a = safeWriteLS(
-    NUTRITION_PANTRIES_KEY,
-    Array.isArray(pantries) ? pantries : [],
-  );
-  const b = activeId
-    ? safeWriteLS(NUTRITION_ACTIVE_PANTRY_KEY, String(activeId))
-    : true;
-  const ok = a && b;
-  if (ok && prev !== null) {
-    triggerNutritionDualWrite(prev, peekNutritionDualWriteState() ?? prev);
+  if (prev === null) return true;
+  const nextPantries: Pantry[] = Array.isArray(pantries) ? pantries : [];
+  const nextActive: string | null = activeId ? String(activeId) : null;
+  const next: NutritionDualWriteState = {
+    ...prev,
+    pantries: extractPantrySnapshots(nextPantries),
+    prefs: {
+      prefsJson:
+        prev.prefs?.prefsJson ?? JSON.stringify(defaultNutritionPrefs()),
+      activePantryId: nextActive ?? prev.prefs?.activePantryId ?? null,
+    },
+  };
+  triggerNutritionDualWrite(prev, next);
+  return true;
+}
+
+// Suppress unused-import warning — still re-exported for type-only callers.
+export type { NutritionDualWriteState };
+
+// ── Snapshot extractors (private; mirror `nutritionStorage.ts` web) ──
+
+function extractMealSnapshots(log: NutritionLog): NutritionMealSnapshot[] {
+  const out: NutritionMealSnapshot[] = [];
+  for (const [dateKey, day] of Object.entries(log)) {
+    const meals = Array.isArray(day?.meals) ? day.meals : [];
+    for (const m of meals) {
+      if (!m || typeof m !== "object" || !m.id) continue;
+      out.push({
+        id: String(m.id),
+        dateKey,
+        time: typeof m.time === "string" ? m.time : "",
+        mealType: typeof m.mealType === "string" ? m.mealType : "snack",
+        name: typeof m.name === "string" ? m.name : "",
+        label: typeof m.label === "string" ? m.label : "",
+        macros: m.macros ?? null,
+        source: typeof m.source === "string" ? m.source : "manual",
+        macroSource:
+          typeof m.macroSource === "string" ? m.macroSource : "manual",
+        amountG: typeof m.amount_g === "number" ? m.amount_g : null,
+        foodId: typeof m.foodId === "string" ? m.foodId : null,
+        isDemo: m.demo === true,
+      });
+    }
   }
-  return ok;
+  return out;
+}
+
+function extractPantrySnapshots(
+  pantries: readonly Pantry[],
+): NutritionPantrySnapshot[] {
+  return normalizePantries(pantries).map((p) => ({
+    id: p.id,
+    name: p.name,
+    text: p.text,
+    items: (p.items ?? []).map((it, idx) => ({
+      id: `${p.id}::${idx}::${it.name ?? ""}`,
+      name: it.name,
+      qty: typeof it.qty === "number" ? it.qty : null,
+      unit: typeof it.unit === "string" ? it.unit : null,
+      notes: typeof it.notes === "string" ? it.notes : null,
+    })),
+  }));
 }
 
 // ── Water ───────────────────────────────────────────────────────────

--- a/apps/mobile/src/modules/nutrition/lib/residualImport.ts
+++ b/apps/mobile/src/modules/nutrition/lib/residualImport.ts
@@ -1,0 +1,224 @@
+/**
+ * Boot-time residual-import helper for the mobile Nutrition MMKV keys.
+ *
+ * Stage 8 PR #057n-tombstone of `docs/planning/storage-roadmap.md`
+ * (mobile parity for `apps/web/src/modules/nutrition/lib/residualImport.ts`).
+ * Reads any leftover values from the now-deprecated MMKV keys
+ * (`nutrition_log_v1`, `nutrition_pantries_v1`,
+ * `nutrition_active_pantry_v1`, `nutrition_prefs_v1`), imports them
+ * into the local `nutrition_*` SQLite tables (idempotent + LWW-safe),
+ * and then deletes the MMKV entries. Subsequent boots no-op because
+ * the MMKV keys are gone.
+ *
+ * The import uses a deliberately stale `clientTs` (epoch zero) so the
+ * adapter's LWW guard always lets existing SQLite rows win — we never
+ * clobber newer SQLite data with a stale MMKV snapshot.
+ */
+
+import type { SqliteMigrationClient } from "@sergeant/db-schema/migrate/sqlite";
+import {
+  NUTRITION_ACTIVE_PANTRY_KEY,
+  NUTRITION_LOG_KEY,
+  NUTRITION_PANTRIES_KEY,
+  NUTRITION_PREFS_KEY,
+  defaultNutritionPrefs,
+  normalizeNutritionLog,
+  normalizeNutritionPrefs,
+  normalizePantries,
+  type NutritionLog,
+  type NutritionPrefs,
+  type Pantry,
+} from "@sergeant/nutrition-domain";
+
+import { safeReadLS, safeReadStringLS, safeRemoveLS } from "@/lib/storage";
+
+import { applyNutritionDualWriteOps } from "./dualWrite/adapter";
+import {
+  diffNutritionDualWriteOps,
+  type NutritionDualWriteState,
+  type NutritionMealSnapshot,
+  type NutritionPantrySnapshot,
+} from "./dualWrite/diff";
+
+const STALE_TIMESTAMP = "1970-01-01T00:00:00.000Z";
+
+const EMPTY_STATE: NutritionDualWriteState = {
+  meals: [],
+  pantries: [],
+  prefs: null,
+  recipes: [],
+};
+
+export interface ResidualImportResult {
+  /** `true` when at least one MMKV key had data that was imported. */
+  readonly imported: boolean;
+  /** `true` when MMKV keys were present and have been deleted. */
+  readonly cleaned: boolean;
+}
+
+/**
+ * Import any residual Nutrition MMKV data into SQLite, then delete the
+ * MMKV entries. Always returns successfully — failures fall back to a
+ * no-op so the boot path can keep going.
+ */
+export async function importNutritionResidualFromMmkv(
+  client: SqliteMigrationClient,
+  userId: string,
+): Promise<ResidualImportResult> {
+  const log = readLogFromMmkv();
+  const pantries = readPantriesFromMmkv();
+  const activePantryId = readActivePantryFromMmkv();
+  const prefs = readPrefsFromMmkv();
+
+  const hasAny =
+    log !== null ||
+    pantries !== null ||
+    activePantryId !== null ||
+    prefs !== null;
+  if (!hasAny) return { imported: false, cleaned: false };
+
+  // Build a NutritionDualWriteState from whatever was found in MMKV.
+  // Slots that are missing fall back to the empty / default value so
+  // the diff against `EMPTY_STATE` only emits ops for slots we have.
+  const next: NutritionDualWriteState = {
+    meals: log ? extractMealSnapshots(normalizeNutritionLog(log)) : [],
+    pantries: pantries
+      ? extractPantrySnapshots(normalizePantries(pantries))
+      : [],
+    prefs:
+      prefs !== null || activePantryId !== null
+        ? {
+            prefsJson: JSON.stringify(
+              prefs ? normalizeNutritionPrefs(prefs) : defaultNutritionPrefs(),
+            ),
+            activePantryId,
+          }
+        : null,
+    recipes: [],
+  };
+
+  const ops = diffNutritionDualWriteOps(EMPTY_STATE, next);
+
+  if (ops.length > 0) {
+    try {
+      await applyNutritionDualWriteOps(client, ops, {
+        userId,
+        clientTs: STALE_TIMESTAMP,
+      });
+    } catch (err) {
+      console.warn(
+        "[nutrition.residualImport] apply failed; MMKV keys retained",
+        err instanceof Error ? err.message : err,
+      );
+      return { imported: false, cleaned: false };
+    }
+  }
+
+  // Delete the MMKV keys after a successful import. Done unconditionally
+  // (i.e. even when ops.length === 0, e.g. MMKV held only an empty `{}`)
+  // so a half-cleared MMKV state can't keep retriggering the import on
+  // every boot.
+  safeRemoveLS(NUTRITION_LOG_KEY);
+  safeRemoveLS(NUTRITION_PANTRIES_KEY);
+  safeRemoveLS(NUTRITION_ACTIVE_PANTRY_KEY);
+  safeRemoveLS(NUTRITION_PREFS_KEY);
+
+  return { imported: ops.length > 0, cleaned: true };
+}
+
+// -----------------------------------------------------------------------
+// MMKV readers — defensive: any throw collapses to `null` so the import
+// proceeds with whatever else was readable.
+// -----------------------------------------------------------------------
+
+function readLogFromMmkv(): unknown | null {
+  try {
+    return safeReadLS<unknown>(NUTRITION_LOG_KEY, null);
+  } catch {
+    return null;
+  }
+}
+
+function readPantriesFromMmkv(): unknown | null {
+  try {
+    return safeReadLS<unknown>(NUTRITION_PANTRIES_KEY, null);
+  } catch {
+    return null;
+  }
+}
+
+function readActivePantryFromMmkv(): string | null {
+  try {
+    const raw = safeReadStringLS(NUTRITION_ACTIVE_PANTRY_KEY, null);
+    return raw === null ? null : String(raw);
+  } catch {
+    return null;
+  }
+}
+
+function readPrefsFromMmkv(): unknown | null {
+  try {
+    return safeReadLS<unknown>(NUTRITION_PREFS_KEY, null);
+  } catch {
+    return null;
+  }
+}
+
+// -----------------------------------------------------------------------
+// Snapshot extractors — copies of the helpers that previously lived in
+// `dualWriteState.ts` (private). The MMKV-read path that owned them is
+// gone; the residual-import is the last consumer of the MMKV layout.
+// -----------------------------------------------------------------------
+
+function extractMealSnapshots(log: NutritionLog): NutritionMealSnapshot[] {
+  const out: NutritionMealSnapshot[] = [];
+  for (const [dateKey, day] of Object.entries(log)) {
+    const meals = Array.isArray(day?.meals) ? day.meals : [];
+    for (const m of meals) {
+      if (!m || typeof m !== "object" || !m.id) continue;
+      out.push({
+        id: String(m.id),
+        dateKey,
+        time: typeof m.time === "string" ? m.time : "",
+        mealType: typeof m.mealType === "string" ? m.mealType : "snack",
+        name: typeof m.name === "string" ? m.name : "",
+        label: typeof m.label === "string" ? m.label : "",
+        macros: m.macros ?? null,
+        source: typeof m.source === "string" ? m.source : "manual",
+        macroSource:
+          typeof m.macroSource === "string" ? m.macroSource : "manual",
+        amountG: typeof m.amount_g === "number" ? m.amount_g : null,
+        foodId: typeof m.foodId === "string" ? m.foodId : null,
+        isDemo: m.demo === true,
+      });
+    }
+  }
+  return out;
+}
+
+function extractPantrySnapshots(
+  pantries: readonly Pantry[],
+): NutritionPantrySnapshot[] {
+  return pantries.map((p) => ({
+    id: p.id,
+    name: p.name,
+    text: p.text,
+    items: (p.items ?? []).map((it, idx) => ({
+      id: `${p.id}::${idx}::${it.name ?? ""}`,
+      name: it.name,
+      qty: typeof it.qty === "number" ? it.qty : null,
+      unit: typeof it.unit === "string" ? it.unit : null,
+      notes: typeof it.notes === "string" ? it.notes : null,
+    })),
+  }));
+}
+
+// Internal exports for tests.
+export const __testing = {
+  STALE_TIMESTAMP,
+  extractMealSnapshots,
+  extractPantrySnapshots,
+};
+
+// Tell TS we use NutritionPrefs in the doc comment scope.
+export type { NutritionPrefs };

--- a/apps/mobile/src/modules/nutrition/lib/sqliteReadBoot.ts
+++ b/apps/mobile/src/modules/nutrition/lib/sqliteReadBoot.ts
@@ -8,19 +8,26 @@
  *  1. Resolves a `SqliteMigrationClient` from the singleton expo-sqlite
  *     handle.
  *  2. Runs the nutrition SQLite migrations so the tables exist.
- *  3. Performs the initial `refreshNutritionSqliteState()` so the cache
+ *  3. Stage 8 PR #057n-tombstone: imports any residual MMKV values
+ *     (`nutrition_log_v1`, `nutrition_pantries_v1`,
+ *     `nutrition_active_pantry_v1`, `nutrition_prefs_v1`) into the
+ *     SQLite tables and deletes the MMKV keys. Idempotent; subsequent
+ *     boots no-op once the MMKV keys are gone.
+ *  4. Performs the initial `refreshNutritionSqliteState()` so the cache
  *     is warm before the first overlay read.
  *
  * Stage 8 PR #057n dropped `feature.nutrition.sqlite_v2.read_sqlite` —
  * the boot is unconditional once a `userId` is available.
  *
  * Fail-soft: any thrown error is caught, logged via `console.warn` and
- * surfaces as `false` so consumers can keep reading from MMKV.
+ * surfaces as `false` so consumers can keep reading from the empty
+ * cache (and MMKV residue, until residual-import lands).
  */
 
 import { getSqliteMigrationClient } from "@/core/db/sqlite";
 
 import { migrateNutrition } from "./clientMigrate";
+import { importNutritionResidualFromMmkv } from "./residualImport";
 import { refreshNutritionSqliteState } from "./sqliteReader";
 
 /**
@@ -40,6 +47,10 @@ export async function bootNutritionSqliteReadPath(
   try {
     const client = await getSqliteMigrationClient();
     await migrateNutrition(client);
+    // Stage 8 PR #057n-tombstone: opportunistic, fail-soft. The
+    // helper itself catches and logs any apply error so a hostile
+    // MMKV blob can't block the rest of the boot.
+    await importNutritionResidualFromMmkv(client, userId);
     await refreshNutritionSqliteState(client, userId);
     return true;
   } catch (err) {

--- a/apps/mobile/src/modules/nutrition/lib/sqliteReader.ts
+++ b/apps/mobile/src/modules/nutrition/lib/sqliteReader.ts
@@ -305,3 +305,22 @@ export async function refreshNutritionSqliteState(
 export function clearNutritionSqliteCache(): void {
   cache = { ...EMPTY_CACHE };
 }
+
+/**
+ * Test helper: seed the cache directly without running migrations / SQLite
+ * queries. The provided fields override the empty defaults and the cache
+ * is marked as refreshed (`refreshedAt`) so consumers treat it as warm.
+ *
+ * Stage 8 PR #057n-tombstone — used by `nutritionStore.test.ts` and the
+ * hook tests now that the load/save surface reads from this cache
+ * instead of MMKV.
+ */
+export function __setNutritionSqliteCacheForTests(
+  partial: Partial<SqliteNutritionCache>,
+): void {
+  cache = {
+    ...EMPTY_CACHE,
+    refreshedAt: new Date().toISOString(),
+    ...partial,
+  };
+}

--- a/apps/web/src/core/App.tsx
+++ b/apps/web/src/core/App.tsx
@@ -31,6 +31,8 @@ import { useHubUIState } from "./hooks/useHubUIState";
 import { usePwaActions } from "./hooks/usePwaActions";
 import { shouldShowOnboarding } from "./onboarding/OnboardingWizard";
 import { PageviewTracker } from "./observability/PageviewTracker";
+import { useNutritionDualWriteBoot } from "../modules/nutrition/hooks/useNutritionDualWriteBoot";
+import { useNutritionSqliteReadBoot } from "../modules/nutrition/hooks/useNutritionSqliteReadBoot";
 
 export default function App() {
   return (
@@ -146,6 +148,17 @@ function AppInner() {
   const { visible: iosVisible, dismiss: iosDismiss } = useIosInstallBanner();
   const { updateAvailable, applyUpdate } = useSWUpdate();
   const { user, isLoading: authLoading } = useAuth();
+
+  // Stage 8 PR #057n-tombstone: hoist the Nutrition dual-write +
+  // SQLite-read boots from `NutritionApp` into the app shell so cross-
+  // module callers (`core/settings/NotificationsSection`,
+  // `core/settings/NutritionSection`, `nutritionBackup`) read the
+  // SQLite warm cache and dual-write to the SQLite tables even when
+  // the user has never opened the Nutrition module in this session.
+  // Both hooks are idempotent — they latch on `userId` and the
+  // module-level `booted` flag in `bootNutritionSqliteReadPath`.
+  useNutritionDualWriteBoot();
+  useNutritionSqliteReadBoot();
 
   useAppEffects({
     user,

--- a/apps/web/src/modules/nutrition/domain/nutritionBackup.test.ts
+++ b/apps/web/src/modules/nutrition/domain/nutritionBackup.test.ts
@@ -1,14 +1,29 @@
-import { beforeEach, describe, expect, it } from "vitest";
+/**
+ * Stage 8 PR #057n-tombstone — backup apply no longer writes to LS;
+ * `persist*` from `../lib/nutritionStorage` now fires
+ * `triggerNutritionDualWrite`. The test mocks the dual-write trigger
+ * and verifies it receives the restored payload.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const triggerSpy = vi.fn();
+
+vi.mock("../lib/dualWrite/index", async () => {
+  const actual = await vi.importActual<typeof import("../lib/dualWrite/index")>(
+    "../lib/dualWrite/index",
+  );
+  return {
+    ...actual,
+    triggerNutritionDualWrite: (...args: unknown[]) => triggerSpy(...args),
+    isNutritionDualWriteRegistered: () => true,
+  };
+});
+
 import {
   applyNutritionBackupPayload,
   buildNutritionBackupPayload,
   NUTRITION_BACKUP_KIND,
 } from "./nutritionBackup";
-import {
-  NUTRITION_ACTIVE_PANTRY_KEY,
-  NUTRITION_PANTRIES_KEY,
-  NUTRITION_PREFS_KEY,
-} from "../lib/nutritionStorage";
 
 function createLocalStorageMock() {
   const store = new Map<string, string>();
@@ -24,6 +39,7 @@ function createLocalStorageMock() {
 
 beforeEach(() => {
   globalThis.localStorage = createLocalStorageMock() as Storage;
+  triggerSpy.mockReset();
 });
 
 describe("nutrition backup", () => {
@@ -34,7 +50,7 @@ describe("nutrition backup", () => {
     expect(p.data.prefs).toBeTruthy();
   });
 
-  it("apply persists keys", () => {
+  it("apply dispatches dual-write ops for pantries + prefs", () => {
     applyNutritionBackupPayload({
       kind: NUTRITION_BACKUP_KIND,
       schemaVersion: 1,
@@ -48,14 +64,8 @@ describe("nutrition backup", () => {
         prefs: { goal: "balanced", servings: 2, timeMinutes: 10, exclude: "" },
       },
     });
-    expect(globalThis.localStorage.getItem(NUTRITION_PANTRIES_KEY)).toContain(
-      "яйця",
-    );
-    expect(globalThis.localStorage.getItem(NUTRITION_ACTIVE_PANTRY_KEY)).toBe(
-      "home",
-    );
-    expect(globalThis.localStorage.getItem(NUTRITION_PREFS_KEY)).toContain(
-      '"servings":2',
-    );
+    // persistPantries → 1 trigger, persistNutritionPrefs → 1 trigger
+    // (no log payload supplied → no third trigger)
+    expect(triggerSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/web/src/modules/nutrition/domain/nutritionBackup.ts
+++ b/apps/web/src/modules/nutrition/domain/nutritionBackup.ts
@@ -1,17 +1,17 @@
 import {
-  safeReadLS,
-  safeReadStringLS,
-  safeWriteLS,
-} from "@shared/lib/storage/storage";
-import {
   NUTRITION_ACTIVE_PANTRY_KEY,
   NUTRITION_PANTRIES_KEY,
   NUTRITION_PREFS_KEY,
   NUTRITION_LOG_KEY,
   defaultNutritionPrefs,
-  loadNutritionPrefs,
+  loadActivePantryId,
   loadNutritionLog,
+  loadNutritionPrefs,
+  loadPantries,
   normalizeNutritionLog,
+  persistNutritionLog,
+  persistNutritionPrefs,
+  persistPantries,
   type NutritionLog,
   type NutritionPrefs,
 } from "../lib/nutritionStorage";
@@ -46,13 +46,6 @@ export interface NutritionBackupPayload {
   schemaVersion: number;
   exportedAt: string;
   data: NutritionBackupData;
-}
-
-function readJsonFromLocalStorage<T>(key: string, fallback: T): T | unknown {
-  // safeReadLS повертає `T | null` (parse-fail / quota / private mode → null),
-  // а ми зберігаємо стару семантику «fallback при порожньому ключі / збої».
-  const value = safeReadLS<unknown>(key, null);
-  return value ?? fallback;
 }
 
 function safeString(x: unknown, fallback = ""): string {
@@ -131,15 +124,19 @@ function normalizePrefs(x: unknown): NutritionPrefs {
 }
 
 export function buildNutritionBackupPayload(): NutritionBackupPayload {
-  const pantries = readJsonFromLocalStorage(NUTRITION_PANTRIES_KEY, []);
+  // Stage 8 PR #057n-tombstone: all four reads now hit the SQLite
+  // warm cache (populated at boot by `useNutritionSqliteReadBoot`),
+  // not LS. Backup is an on-demand user action so the cache is
+  // guaranteed to be warm by the time this runs.
+  const pantries = loadPantries(
+    NUTRITION_PANTRIES_KEY,
+    NUTRITION_ACTIVE_PANTRY_KEY,
+  );
   const activePantryId = safeString(
-    safeReadStringLS(NUTRITION_ACTIVE_PANTRY_KEY, ""),
+    loadActivePantryId(NUTRITION_ACTIVE_PANTRY_KEY),
     "home",
   );
-
-  // prefs завжди читаємо через loadNutritionPrefs (в ньому дефолти + нормалізація)
   const prefs = loadNutritionPrefs(NUTRITION_PREFS_KEY);
-
   const log = loadNutritionLog(NUTRITION_LOG_KEY);
 
   return {
@@ -184,14 +181,23 @@ export function applyNutritionBackupPayload(payload: unknown): void {
   const activePantryId = safeString(data.activePantryId, "home") || "home";
   const prefs = normalizePrefs(data.prefs);
 
-  // Кожен `safeWriteLS` глитає quota / private-mode помилку самостійно — це
-  // та сама `try/catch + ignore` семантика, що була inline-реалізована
-  // нижче: якщо одне поле бекапу не записалось через quota, продовжуємо
-  // зі скинутими іншими, замість обвалу всієї відновлюваної операції.
-  safeWriteLS(NUTRITION_PANTRIES_KEY, pantries);
-  safeWriteLS(NUTRITION_ACTIVE_PANTRY_KEY, activePantryId);
-  safeWriteLS(NUTRITION_PREFS_KEY, prefs);
+  // Stage 8 PR #057n-tombstone: writes go through the dual-write
+  // pipeline so the SQLite tables become the source of truth and the
+  // warm cache reflects the restored payload on next overlay tick.
+  // The previous `safeWriteLS` swallow-quota semantics is preserved
+  // because `persist*` returns a boolean — the caller already calls
+  // `window.location.reload()` so any partial failure is recovered
+  // from on the next boot via `importNutritionResidualFromLs` (no-op
+  // here since LS is no longer touched, but the dual-write happy path
+  // will have populated SQLite).
+  persistPantries(
+    NUTRITION_PANTRIES_KEY,
+    NUTRITION_ACTIVE_PANTRY_KEY,
+    pantries,
+    activePantryId,
+  );
+  persistNutritionPrefs(prefs, NUTRITION_PREFS_KEY);
   if (data.log && typeof data.log === "object" && !Array.isArray(data.log)) {
-    safeWriteLS(NUTRITION_LOG_KEY, normalizeNutritionLog(data.log));
+    persistNutritionLog(normalizeNutritionLog(data.log), NUTRITION_LOG_KEY);
   }
 }

--- a/apps/web/src/modules/nutrition/hooks/useNutritionLog.test.tsx
+++ b/apps/web/src/modules/nutrition/hooks/useNutritionLog.test.tsx
@@ -4,7 +4,12 @@ import { renderHook, act, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { useNutritionLog } from "./useNutritionLog";
-import { NUTRITION_LOG_KEY } from "../lib/nutritionStorage";
+import {
+  __setNutritionSqliteCacheForTests,
+  clearNutritionSqliteCache,
+} from "../lib/sqliteReader";
+import { notifyNutritionSqliteCacheRefresh } from "../lib/sqliteReadGate";
+import type { NutritionLog } from "@sergeant/nutrition-domain";
 import { ToastProvider } from "@shared/hooks/useToast";
 
 function makeWrapper() {
@@ -23,6 +28,7 @@ function makeWrapper() {
 describe("useNutritionLog – defensive imports", () => {
   beforeEach(() => {
     localStorage.clear();
+    clearNutritionSqliteCache();
   });
 
   it("replaceLogFromJsonText returns false and does not throw on malformed JSON", () => {
@@ -57,11 +63,16 @@ describe("useNutritionLog – defensive imports", () => {
         ],
       },
     };
-    localStorage.setItem(NUTRITION_LOG_KEY, JSON.stringify(seeded));
+    // Stage 8 PR #057n-tombstone: seed via SQLite warm cache instead of
+    // LS, then bump the cache tick so the overlay effect picks it up.
+    __setNutritionSqliteCacheForTests({
+      log: seeded as unknown as NutritionLog,
+    });
 
     const { result } = renderHook(() => useNutritionLog(), {
       wrapper: makeWrapper(),
     });
+    act(() => notifyNutritionSqliteCacheRefresh());
     await waitFor(() =>
       expect(result.current.nutritionLog["2025-01-01"]?.meals?.length).toBe(1),
     );

--- a/apps/web/src/modules/nutrition/hooks/useNutritionLog.ts
+++ b/apps/web/src/modules/nutrition/hooks/useNutritionLog.ts
@@ -39,11 +39,17 @@ function collectMealIds(log: NutritionLog): Set<string> {
 
 /**
  * Hook for managing the nutrition log and selected date.
- * Automatically persists the log to localStorage on each change.
+ *
+ * Stage 8 PR #057n-tombstone: state is initialised from the SQLite
+ * warm cache (empty `{}` until `useNutritionSqliteReadBoot` finishes)
+ * and re-overlaid whenever the cache ticks. Mutations call
+ * `persistNutritionLog`, which now triggers the dual-write
+ * orchestrator instead of writing to LS.
  */
 export function useNutritionLog() {
   const queryClient = useQueryClient();
   const toast = useToast();
+  const sqliteCacheTick = useNutritionSqliteReadTick();
   const [nutritionLog, setNutritionLog] = useState<NutritionLog>(() =>
     loadNutritionLog(NUTRITION_LOG_KEY),
   );
@@ -57,7 +63,6 @@ export function useNutritionLog() {
     Map<string, ReturnType<typeof setTimeout>>
   >(new Map());
   const didMountRef = useRef(false);
-  const sqliteCacheTick = useNutritionSqliteReadTick();
 
   useEffect(() => {
     const ok = persistNutritionLog(nutritionLog, NUTRITION_LOG_KEY);
@@ -68,10 +73,11 @@ export function useNutritionLog() {
     );
   }, [nutritionLog]);
 
-  // Stage 4 PR #033 + Stage 8 PR #057n: overlay the meal log from
-  // the local SQLite cache once it's warm. The LS read above stays
-  // as a synchronous fallback so the first paint never blocks on
-  // SQLite.
+  // Stage 4 PR #033 + Stage 8 PR #057n-tombstone: overlay the meal
+  // log from the local SQLite cache once it's warm. The next persist
+  // effect that fires with this cache snapshot diffs the SQLite cache
+  // against itself and emits zero ops, so the warm-cache hydration is
+  // a no-op for the dual-write orchestrator.
   useEffect(() => {
     const cache = getCachedNutritionSqliteState();
     if (cache.refreshedAt === null) return;

--- a/apps/web/src/modules/nutrition/hooks/useNutritionPantries.test.tsx
+++ b/apps/web/src/modules/nutrition/hooks/useNutritionPantries.test.tsx
@@ -20,11 +20,12 @@ import { nutritionApi } from "@shared/api";
 const apiParsePantry = nutritionApi.parsePantry as unknown as ReturnType<
   typeof vi.fn
 >;
+import { type Pantry } from "../lib/nutritionStorage";
 import {
-  NUTRITION_PANTRIES_KEY,
-  NUTRITION_ACTIVE_PANTRY_KEY,
-  type Pantry,
-} from "../lib/nutritionStorage";
+  __setNutritionSqliteCacheForTests,
+  clearNutritionSqliteCache,
+} from "../lib/sqliteReader";
+import { notifyNutritionSqliteCacheRefresh } from "../lib/sqliteReadGate";
 
 function makeWrapper() {
   const client = new QueryClient({
@@ -37,10 +38,18 @@ function makeWrapper() {
   };
 }
 
+// Stage 8 PR #057n-tombstone: seed the SQLite warm cache directly
+// instead of LS, since `useNutritionPantries` initial state now reads
+// from `getCachedNutritionSqliteState`. The hook's overlay effect
+// re-runs on `notifyNutritionSqliteCacheRefresh()` so we bump the tick
+// after each seed.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function seedPantries(pantries: any[], activeId: string) {
-  localStorage.setItem(NUTRITION_PANTRIES_KEY, JSON.stringify(pantries));
-  localStorage.setItem(NUTRITION_ACTIVE_PANTRY_KEY, String(activeId));
+  __setNutritionSqliteCacheForTests({
+    pantries,
+    activePantryId: String(activeId),
+  });
+  notifyNutritionSqliteCacheRefresh();
 }
 
 function renderHarness() {
@@ -57,6 +66,7 @@ function renderHarness() {
 describe("useNutritionPantries", () => {
   beforeEach(() => {
     localStorage.clear();
+    clearNutritionSqliteCache();
     vi.clearAllMocks();
   });
 

--- a/apps/web/src/modules/nutrition/lib/dualWrite/index.ts
+++ b/apps/web/src/modules/nutrition/lib/dualWrite/index.ts
@@ -5,6 +5,8 @@ import {
   recordParityCheck,
   recordReadFallback,
 } from "../../../../core/observability/dualWriteTelemetry.js";
+import { refreshNutritionSqliteState } from "../sqliteReader.js";
+import { notifyNutritionSqliteCacheRefresh } from "../sqliteReadGate.js";
 import {
   applyNutritionDualWriteOps,
   type ApplyDualWriteResult,
@@ -136,6 +138,23 @@ async function runDualWriteNutritionState(
     clientTs: ctx.getNow(),
     logger: ctx.logger,
   });
+
+  // Stage 8 PR #057n-tombstone: refresh the SQLite warm cache so
+  // subsequent reads (overlay effects in hooks, `peek` in
+  // `nutritionStorage`) reflect what we just wrote. Best-effort —
+  // a failed refresh is logged via `recordReadFallback` but does not
+  // disturb the dual-write outcome.
+  try {
+    await refreshNutritionSqliteState(client, userId);
+    notifyNutritionSqliteCacheRefresh();
+  } catch (err) {
+    recordReadFallback(
+      "nutrition",
+      err instanceof Error
+        ? `cache-refresh-failed: ${err.message}`
+        : "cache-refresh-failed",
+    );
+  }
 
   // Stage 8 parity probe — best-effort: never throws, never disturbs
   // the dual-write outcome. A failed probe-read is tagged distinctly

--- a/apps/web/src/modules/nutrition/lib/nutritionStorage.test.ts
+++ b/apps/web/src/modules/nutrition/lib/nutritionStorage.test.ts
@@ -1,4 +1,28 @@
-import { beforeEach, describe, expect, it } from "vitest";
+/**
+ * Stage 8 PR #057n-tombstone — `load*` / `persist*` no longer read from
+ * (or write to) `localStorage`. Reads come from the SQLite warm cache
+ * (`apps/web/src/modules/nutrition/lib/sqliteReader.ts`) and writes go
+ * through `triggerNutritionDualWrite`. These tests exercise the new
+ * surface using `__setNutritionSqliteCacheForTests` and a
+ * `vi.mock` of the dual-write trigger.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const triggerSpy = vi.fn();
+let dualWriteRegistered = true;
+
+vi.mock("./dualWrite/index", async () => {
+  const actual =
+    await vi.importActual<typeof import("./dualWrite/index")>(
+      "./dualWrite/index",
+    );
+  return {
+    ...actual,
+    triggerNutritionDualWrite: (...args: unknown[]) => triggerSpy(...args),
+    isNutritionDualWriteRegistered: () => dualWriteRegistered,
+  };
+});
+
 import {
   NUTRITION_ACTIVE_PANTRY_KEY,
   NUTRITION_LOG_KEY,
@@ -11,9 +35,15 @@ import {
   loadPantries,
   normalizeNutritionLog,
   normalizePantries,
+  persistNutritionLog,
+  persistNutritionPrefs,
   persistPantries,
+  type Pantry,
 } from "./nutritionStorage";
-import { storageManager } from "@shared/lib/storage/storageManager";
+import {
+  __setNutritionSqliteCacheForTests,
+  clearNutritionSqliteCache,
+} from "./sqliteReader";
 
 function createLocalStorageMock() {
   const store = new Map<string, string>();
@@ -30,64 +60,218 @@ function createLocalStorageMock() {
 
 beforeEach(() => {
   globalThis.localStorage = createLocalStorageMock() as unknown as Storage;
+  clearNutritionSqliteCache();
+  triggerSpy.mockReset();
+  dualWriteRegistered = true;
 });
 
-describe("loadActivePantryId", () => {
-  it("returns home by default", () => {
+afterEach(() => {
+  clearNutritionSqliteCache();
+});
+
+// -------------------------------------------------------------------------
+// Reads — backed by SQLite warm cache.
+// -------------------------------------------------------------------------
+
+describe("loadActivePantryId — cache-backed", () => {
+  it("returns home when cache has no active pantry", () => {
     expect(loadActivePantryId(NUTRITION_ACTIVE_PANTRY_KEY)).toBe("home");
   });
+
+  it("returns the cache value once set", () => {
+    __setNutritionSqliteCacheForTests({ activePantryId: "kitchen" });
+    expect(loadActivePantryId(NUTRITION_ACTIVE_PANTRY_KEY)).toBe("kitchen");
+  });
 });
 
-describe("loadPantries", () => {
-  it("loads stored pantries when present", () => {
-    globalThis.localStorage.setItem(
-      NUTRITION_PANTRIES_KEY,
-      JSON.stringify([{ id: "home", name: "Дім", items: [], text: "x" }]),
-    );
+describe("loadPantries — cache-backed", () => {
+  it("returns the default pantry when cache is empty", () => {
     const pantries = loadPantries(
       NUTRITION_PANTRIES_KEY,
       NUTRITION_ACTIVE_PANTRY_KEY,
     );
     expect(pantries).toHaveLength(1);
-    expect(pantries[0]!.text).toBe("x");
+    expect(pantries[0]!.id).toBe("home");
   });
 
-  it("migrates from legacy keys when new key missing", () => {
-    globalThis.localStorage.setItem(
-      "nutrition_pantry_items_v0",
-      JSON.stringify([{ name: "яйця", qty: 2, unit: "шт", notes: null }]),
-    );
-    globalThis.localStorage.setItem("nutrition_pantry_text_v0", "яйця");
-    storageManager.resetMigration("nutrition_001_migrate_legacy_pantry");
-    storageManager.runAll();
-    const pantries = loadPantries(
+  it("returns cached pantries when present", () => {
+    const pantries: Pantry[] = [
+      { id: "home", name: "Дім", items: [], text: "x" },
+      { id: "work", name: "Робота", items: [], text: "" },
+    ];
+    __setNutritionSqliteCacheForTests({ pantries });
+    const out = loadPantries(
       NUTRITION_PANTRIES_KEY,
       NUTRITION_ACTIVE_PANTRY_KEY,
     );
-    expect(pantries).toHaveLength(1);
-    expect(pantries[0]!.items).toHaveLength(1);
-    expect(pantries[0]!.text).toBe("яйця");
-    expect(globalThis.localStorage.getItem(NUTRITION_ACTIVE_PANTRY_KEY)).toBe(
-      "home",
-    );
+    expect(out).toHaveLength(2);
+    expect(out[0]!.text).toBe("x");
   });
 });
 
-describe("persistPantries", () => {
-  it("persists pantries and active id", () => {
+describe("loadNutritionLog — cache-backed", () => {
+  it("returns empty object when cache is empty", () => {
+    expect(loadNutritionLog(NUTRITION_LOG_KEY)).toEqual({});
+  });
+
+  it("normalizes the cached log", () => {
+    __setNutritionSqliteCacheForTests({
+      log: {
+        "2026-03-03": {
+          meals: [
+            {
+              id: "m1",
+              name: "Тест",
+              label: "Сніданок",
+              macros: { kcal: 1, protein_g: null, fat_g: null, carbs_g: null },
+              time: "08:00",
+              mealType: "breakfast",
+              source: "manual",
+              macroSource: "manual",
+              amount_g: null,
+              foodId: null,
+            },
+          ],
+        },
+      },
+    });
+    const log = loadNutritionLog(NUTRITION_LOG_KEY);
+    expect(log["2026-03-03"]!.meals[0]!.mealType).toBe("breakfast");
+  });
+});
+
+describe("loadNutritionPrefs — cache-backed defaults", () => {
+  it("returns defaults when cache has no prefs", () => {
+    expect(loadNutritionPrefs(NUTRITION_PREFS_KEY)).toEqual(
+      defaultNutritionPrefs(),
+    );
+  });
+
+  it("returns the cached prefs when set", () => {
+    __setNutritionSqliteCacheForTests({
+      prefs: { ...defaultNutritionPrefs(), goal: "lean", servings: 3 },
+    });
+    const prefs = loadNutritionPrefs(NUTRITION_PREFS_KEY);
+    expect(prefs.goal).toBe("lean");
+    expect(prefs.servings).toBe(3);
+    // default fields preserved by normalize
+    expect(prefs.timeMinutes).toBe(25);
+    expect(prefs.waterGoalMl).toBe(2000);
+  });
+
+  it("clamps reminderHour into [0,23]", () => {
+    __setNutritionSqliteCacheForTests({
+      prefs: {
+        ...defaultNutritionPrefs(),
+        reminderHour: 99 as unknown as number,
+      },
+    });
+    expect(loadNutritionPrefs(NUTRITION_PREFS_KEY).reminderHour).toBe(23);
+
+    __setNutritionSqliteCacheForTests({
+      prefs: {
+        ...defaultNutritionPrefs(),
+        reminderHour: -5 as unknown as number,
+      },
+    });
+    expect(loadNutritionPrefs(NUTRITION_PREFS_KEY).reminderHour).toBe(0);
+  });
+});
+
+// -------------------------------------------------------------------------
+// Writes — fire dual-write only, never touch localStorage.
+// -------------------------------------------------------------------------
+
+describe("persistPantries — dual-write only (no LS write)", () => {
+  it("does not touch localStorage", () => {
     persistPantries(
       NUTRITION_PANTRIES_KEY,
       NUTRITION_ACTIVE_PANTRY_KEY,
       [{ id: "a", name: "A", items: [], text: "" }],
       "a",
     );
-    const raw = globalThis.localStorage.getItem(NUTRITION_PANTRIES_KEY);
-    expect(JSON.parse(raw!)).toHaveLength(1);
-    expect(globalThis.localStorage.getItem(NUTRITION_ACTIVE_PANTRY_KEY)).toBe(
+    expect(globalThis.localStorage.getItem(NUTRITION_PANTRIES_KEY)).toBeNull();
+    expect(
+      globalThis.localStorage.getItem(NUTRITION_ACTIVE_PANTRY_KEY),
+    ).toBeNull();
+  });
+
+  it("triggers dual-write when context is registered", () => {
+    persistPantries(
+      NUTRITION_PANTRIES_KEY,
+      NUTRITION_ACTIVE_PANTRY_KEY,
+      [{ id: "a", name: "A", items: [], text: "" }],
       "a",
     );
+    expect(triggerSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("no-ops silently when dual-write context is not registered", () => {
+    dualWriteRegistered = false;
+    persistPantries(
+      NUTRITION_PANTRIES_KEY,
+      NUTRITION_ACTIVE_PANTRY_KEY,
+      [{ id: "a", name: "A", items: [], text: "" }],
+      "a",
+    );
+    expect(triggerSpy).not.toHaveBeenCalled();
+    expect(globalThis.localStorage.getItem(NUTRITION_PANTRIES_KEY)).toBeNull();
   });
 });
+
+describe("persistNutritionLog — dual-write only", () => {
+  it("does not touch localStorage", () => {
+    persistNutritionLog({}, NUTRITION_LOG_KEY);
+    expect(globalThis.localStorage.getItem(NUTRITION_LOG_KEY)).toBeNull();
+  });
+
+  it("triggers dual-write when context is registered and a log is provided", () => {
+    persistNutritionLog(
+      {
+        "2026-04-04": {
+          meals: [
+            {
+              id: "m1",
+              name: "Хліб",
+              time: "10:00",
+              mealType: "snack",
+              label: "",
+              macros: { kcal: 10, protein_g: 0, fat_g: 0, carbs_g: 2 },
+              source: "manual",
+              macroSource: "manual",
+              amount_g: null,
+              foodId: null,
+            },
+          ],
+        },
+      },
+      NUTRITION_LOG_KEY,
+    );
+    expect(triggerSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("persistNutritionPrefs — dual-write only", () => {
+  it("does not write to localStorage", () => {
+    persistNutritionPrefs(
+      { ...defaultNutritionPrefs(), reminderHour: 8 },
+      NUTRITION_PREFS_KEY,
+    );
+    expect(globalThis.localStorage.getItem(NUTRITION_PREFS_KEY)).toBeNull();
+  });
+
+  it("triggers dual-write when context is registered", () => {
+    persistNutritionPrefs(
+      { ...defaultNutritionPrefs(), reminderHour: 8 },
+      NUTRITION_PREFS_KEY,
+    );
+    expect(triggerSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+// -------------------------------------------------------------------------
+// Pure helpers (unchanged by tombstone — kept for regression coverage).
+// -------------------------------------------------------------------------
 
 describe("normalizeNutritionLog", () => {
   it("infers mealType from Ukrainian label", () => {
@@ -119,72 +303,6 @@ describe("normalizeNutritionLog", () => {
   });
 });
 
-describe("loadNutritionLog", () => {
-  it("normalizes stored log", () => {
-    globalThis.localStorage.setItem(
-      NUTRITION_LOG_KEY,
-      JSON.stringify({
-        "2026-03-03": {
-          meals: [{ name: "Тест", label: "Сніданок", macros: { kcal: 1 } }],
-        },
-      }),
-    );
-    const log = loadNutritionLog(NUTRITION_LOG_KEY);
-    expect(log["2026-03-03"]!.meals[0]!.mealType).toBe("breakfast");
-    expect(log["2026-03-03"]!.meals[0]!.id).toMatch(/^meal_/);
-  });
-
-  it("returns empty log when JSON is corrupted (does not crash UI)", () => {
-    globalThis.localStorage.setItem(NUTRITION_LOG_KEY, "{not json");
-    expect(loadNutritionLog(NUTRITION_LOG_KEY)).toEqual({});
-  });
-});
-
-describe("loadPantries — reload & edge cases", () => {
-  it("survives a reload — same data comes back", () => {
-    persistPantries(
-      NUTRITION_PANTRIES_KEY,
-      NUTRITION_ACTIVE_PANTRY_KEY,
-      [
-        {
-          id: "home",
-          name: "Дім",
-          items: [{ name: "Молоко", qty: 1, unit: "л", notes: null }],
-          text: "",
-        },
-      ],
-      "home",
-    );
-    const pantries = loadPantries(
-      NUTRITION_PANTRIES_KEY,
-      NUTRITION_ACTIVE_PANTRY_KEY,
-    );
-    expect(pantries).toHaveLength(1);
-    expect(pantries[0]!.items[0]!.name).toBe("Молоко");
-    expect(loadActivePantryId(NUTRITION_ACTIVE_PANTRY_KEY)).toBe("home");
-  });
-
-  it("falls back to default pantry when storage holds empty array", () => {
-    globalThis.localStorage.setItem(NUTRITION_PANTRIES_KEY, JSON.stringify([]));
-    const pantries = loadPantries(
-      NUTRITION_PANTRIES_KEY,
-      NUTRITION_ACTIVE_PANTRY_KEY,
-    );
-    expect(pantries).toHaveLength(1);
-    expect(pantries[0]!.id).toBe("home");
-  });
-
-  it("falls back to default pantry when JSON is corrupted", () => {
-    globalThis.localStorage.setItem(NUTRITION_PANTRIES_KEY, "{not json");
-    const pantries = loadPantries(
-      NUTRITION_PANTRIES_KEY,
-      NUTRITION_ACTIVE_PANTRY_KEY,
-    );
-    expect(pantries).toHaveLength(1);
-    expect(pantries[0]!.id).toBe("home");
-  });
-});
-
 describe("normalizePantries", () => {
   it("filters non-object entries and invalid items", () => {
     const out = normalizePantries([
@@ -212,88 +330,5 @@ describe("normalizePantries", () => {
     expect(normalizePantries(null)).toEqual([]);
     expect(normalizePantries({})).toEqual([]);
     expect(normalizePantries("x")).toEqual([]);
-  });
-});
-
-describe("loadNutritionPrefs — prefs survive corrupted / partial data", () => {
-  it("returns defaults when nothing is stored", () => {
-    expect(loadNutritionPrefs(NUTRITION_PREFS_KEY)).toEqual(
-      defaultNutritionPrefs(),
-    );
-  });
-
-  it("returns defaults when JSON is corrupted", () => {
-    globalThis.localStorage.setItem(NUTRITION_PREFS_KEY, "{not json");
-    expect(loadNutritionPrefs(NUTRITION_PREFS_KEY)).toEqual(
-      defaultNutritionPrefs(),
-    );
-  });
-
-  it("returns defaults when stored value is an array (type mismatch)", () => {
-    globalThis.localStorage.setItem(NUTRITION_PREFS_KEY, JSON.stringify([1]));
-    expect(loadNutritionPrefs(NUTRITION_PREFS_KEY)).toEqual(
-      defaultNutritionPrefs(),
-    );
-  });
-
-  it("merges partial prefs with defaults (prefs are not lost)", () => {
-    globalThis.localStorage.setItem(
-      NUTRITION_PREFS_KEY,
-      JSON.stringify({ goal: "lean", servings: 3 }),
-    );
-    const prefs = loadNutritionPrefs(NUTRITION_PREFS_KEY);
-    expect(prefs.goal).toBe("lean");
-    expect(prefs.servings).toBe(3);
-    // default fields preserved
-    expect(prefs.timeMinutes).toBe(25);
-    expect(prefs.waterGoalMl).toBe(2000);
-    expect(prefs.mealTemplates).toEqual([]);
-  });
-
-  it("falls back to default waterGoalMl on invalid / non-positive values", () => {
-    for (const bad of [null, "abc", -100, 0, undefined]) {
-      globalThis.localStorage.setItem(
-        NUTRITION_PREFS_KEY,
-        JSON.stringify({ waterGoalMl: bad }),
-      );
-      expect(loadNutritionPrefs(NUTRITION_PREFS_KEY).waterGoalMl).toBe(2000);
-    }
-  });
-
-  it("clamps reminderHour into [0,23]", () => {
-    globalThis.localStorage.setItem(
-      NUTRITION_PREFS_KEY,
-      JSON.stringify({ reminderHour: 99 }),
-    );
-    expect(loadNutritionPrefs(NUTRITION_PREFS_KEY).reminderHour).toBe(23);
-
-    globalThis.localStorage.setItem(
-      NUTRITION_PREFS_KEY,
-      JSON.stringify({ reminderHour: -5 }),
-    );
-    expect(loadNutritionPrefs(NUTRITION_PREFS_KEY).reminderHour).toBe(0);
-
-    globalThis.localStorage.setItem(
-      NUTRITION_PREFS_KEY,
-      JSON.stringify({ reminderHour: "nope" }),
-    );
-    expect(loadNutritionPrefs(NUTRITION_PREFS_KEY).reminderHour).toBe(12);
-  });
-
-  it("filters invalid mealTemplates entries", () => {
-    globalThis.localStorage.setItem(
-      NUTRITION_PREFS_KEY,
-      JSON.stringify({
-        mealTemplates: [
-          null,
-          { id: "1", name: "", mealType: "snack" },
-          { id: "2", name: "Омлет", mealType: "breakfast" },
-          "oops",
-        ],
-      }),
-    );
-    const prefs = loadNutritionPrefs(NUTRITION_PREFS_KEY);
-    expect(prefs.mealTemplates).toHaveLength(1);
-    expect(prefs.mealTemplates[0]!.name).toBe("Омлет");
   });
 });

--- a/apps/web/src/modules/nutrition/lib/nutritionStorage.ts
+++ b/apps/web/src/modules/nutrition/lib/nutritionStorage.ts
@@ -1,11 +1,19 @@
 /**
  * Web I/O-адаптер для модуля Харчування: prefs, pantries, log.
  *
+ * Stage 8 PR #057n-tombstone (`docs/planning/storage-roadmap.md`): the
+ * `load*` / `persist*` helpers below no longer touch `localStorage`.
+ * The SQLite-WASM `nutrition_*` tables are the source of truth — reads
+ * pull from the in-process cache populated by
+ * `refreshNutritionSqliteState` (warmed at boot), and writes go through
+ * the dual-write pipeline (`triggerNutritionDualWrite`) which mirrors
+ * to SQLite and bumps the cache so subsequent reads see the change.
+ *
  * Pure-логіка (normalize/default/mutation-хелпери + типи + LS-ключі) живе
- * у `@sergeant/nutrition-domain` і спільна з `apps/mobile`. Тут лишаються
- * лише `load*`/`persist*` поверх `createModuleStorage` і реекспорти
- * старої поверхні цього модуля, щоб існуючі `../lib/nutritionStorage.js`
- * імпорти всередині `apps/web` не довелось переписувати.
+ * у `@sergeant/nutrition-domain` і спільна з `apps/mobile`. Реекспорти
+ * старої поверхні цього модуля лишаються тут, щоб існуючі
+ * `../lib/nutritionStorage.js` імпорти всередині `apps/web` не довелось
+ * переписувати.
  */
 import {
   NUTRITION_ACTIVE_PANTRY_KEY,
@@ -22,7 +30,6 @@ import {
   type Pantry,
 } from "@sergeant/nutrition-domain";
 
-import { nutritionStorage } from "./nutritionStorageInstance";
 import {
   isNutritionDualWriteRegistered,
   triggerNutritionDualWrite,
@@ -32,6 +39,7 @@ import type {
   NutritionMealSnapshot,
   NutritionPantrySnapshot,
 } from "./dualWrite/diff.js";
+import { getCachedNutritionSqliteState } from "./sqliteReader.js";
 
 export {
   NUTRITION_ACTIVE_PANTRY_KEY,
@@ -75,98 +83,111 @@ export type {
 } from "@sergeant/nutrition-domain";
 
 // ─────────────────────────────────────────────
-// I/O wrappers (createModuleStorage / localStorage)
+// Reads — backed by the SQLite warm cache (Stage 8 PR #057n-tombstone).
+//
+// Before the boot completes the cache returns its `EMPTY_CACHE`
+// defaults; the hooks pair these synchronous reads with an overlay
+// effect that re-renders once the cache warms (see `sqliteReadGate`).
 // ─────────────────────────────────────────────
 
 export function loadNutritionPrefs(
-  key: string = NUTRITION_PREFS_KEY,
+  _key: string = NUTRITION_PREFS_KEY,
 ): NutritionPrefs {
-  return normalizeNutritionPrefs(nutritionStorage.readJSON(key, null));
+  const cache = getCachedNutritionSqliteState();
+  return cache.prefs
+    ? normalizeNutritionPrefs(cache.prefs)
+    : defaultNutritionPrefs();
 }
 
 export function persistNutritionPrefs(
   prefs: NutritionPrefs | null | undefined,
-  key: string = NUTRITION_PREFS_KEY,
+  _key: string = NUTRITION_PREFS_KEY,
 ): boolean {
   const prev = peekNutritionDualWriteState();
-  const ok = nutritionStorage.writeJSON(key, prefs || defaultNutritionPrefs());
-  if (ok && prev !== null) {
-    triggerNutritionDualWrite(prev, peekNutritionDualWriteState() ?? prev);
-  }
-  return ok;
+  if (prev === null) return true;
+  const next: NutritionDualWriteState = {
+    ...prev,
+    prefs: {
+      prefsJson: JSON.stringify(prefs || defaultNutritionPrefs()),
+      activePantryId: prev.prefs?.activePantryId ?? null,
+    },
+  };
+  triggerNutritionDualWrite(prev, next);
+  return true;
 }
 
 export function loadActivePantryId(
-  activeKey: string = NUTRITION_ACTIVE_PANTRY_KEY,
+  _activeKey: string = NUTRITION_ACTIVE_PANTRY_KEY,
 ): string {
-  const v = nutritionStorage.readRaw(activeKey, null);
-  return v ? String(v) : "home";
+  const cache = getCachedNutritionSqliteState();
+  return cache.activePantryId ?? "home";
 }
 
 export function loadPantries(
-  key: string = NUTRITION_PANTRIES_KEY,
-  activeKey: string = NUTRITION_ACTIVE_PANTRY_KEY,
+  _key: string = NUTRITION_PANTRIES_KEY,
+  _activeKey: string = NUTRITION_ACTIVE_PANTRY_KEY,
 ): Pantry[] {
-  const parsed = nutritionStorage.readJSON(key, null);
-  const normalized = normalizePantries(parsed);
-  if (normalized.length > 0) return normalized;
+  const cache = getCachedNutritionSqliteState();
+  if (cache.pantries.length > 0) return cache.pantries;
 
-  // Legacy v0 pantry migration is handled by storageManager
-  // (nutrition_001_migrate_legacy_pantry). By the time this code runs after
-  // app boot, the v1 key already has data if any v0 data existed.
-  const fallback = makeDefaultPantry();
-  nutritionStorage.writeRaw(activeKey, fallback.id);
-  return [fallback];
+  // No SQLite-side pantries (fresh user, or boot not yet complete).
+  // The hook's first paint gets a single default `home` pantry — the
+  // first user mutation will dual-write the row to SQLite via
+  // `persistPantries` below.
+  return [makeDefaultPantry()];
 }
 
 export function persistPantries(
-  key: string = NUTRITION_PANTRIES_KEY,
-  activeKey: string = NUTRITION_ACTIVE_PANTRY_KEY,
+  _key: string = NUTRITION_PANTRIES_KEY,
+  _activeKey: string = NUTRITION_ACTIVE_PANTRY_KEY,
   pantries?: Pantry[] | null,
   activeId?: string | null,
 ): boolean {
   const prev = peekNutritionDualWriteState();
-  const a = nutritionStorage.writeJSON(
-    key,
-    Array.isArray(pantries) ? pantries : [],
-  );
-  const b = activeId
-    ? nutritionStorage.writeRaw(activeKey, String(activeId))
-    : true;
-  const ok = a && b;
-  if (ok && prev !== null) {
-    triggerNutritionDualWrite(prev, peekNutritionDualWriteState() ?? prev);
-  }
-  return ok;
+  if (prev === null) return true;
+  const nextPantries: Pantry[] = Array.isArray(pantries) ? pantries : [];
+  const nextActive: string | null = activeId ? String(activeId) : null;
+  const next: NutritionDualWriteState = {
+    ...prev,
+    pantries: extractPantrySnapshots(nextPantries),
+    prefs: {
+      prefsJson:
+        prev.prefs?.prefsJson ?? JSON.stringify(defaultNutritionPrefs()),
+      activePantryId: nextActive ?? prev.prefs?.activePantryId ?? null,
+    },
+  };
+  triggerNutritionDualWrite(prev, next);
+  return true;
 }
 
 export function loadNutritionLog(
-  key: string = NUTRITION_LOG_KEY,
+  _key: string = NUTRITION_LOG_KEY,
 ): NutritionLog {
-  const parsed = nutritionStorage.readJSON(key, null);
-  return normalizeNutritionLog(parsed);
+  const cache = getCachedNutritionSqliteState();
+  return normalizeNutritionLog(cache.log);
 }
 
 export function persistNutritionLog(
   log: NutritionLog | null | undefined,
-  key: string = NUTRITION_LOG_KEY,
+  _key: string = NUTRITION_LOG_KEY,
 ): boolean {
   const prev = peekNutritionDualWriteState();
-  const ok = nutritionStorage.writeJSON(key, log || {});
-  if (ok && prev !== null) {
-    triggerNutritionDualWrite(prev, peekNutritionDualWriteState() ?? prev);
-  }
-  return ok;
+  if (prev === null) return true;
+  const next: NutritionDualWriteState = {
+    ...prev,
+    meals: extractMealSnapshots(normalizeNutritionLog(log ?? {})),
+  };
+  triggerNutritionDualWrite(prev, next);
+  return true;
 }
 
 // ─────────────────────────────────────────────
-// Dual-write state extraction (Stage 4 PR #032)
+// Dual-write state extraction (Stage 4 PR #032; rewired by
+// PR #057n-tombstone to peek the SQLite warm cache instead of LS).
 //
-// Reads the parts of LS that map to `nutrition_*` SQLite tables and
-// returns a `NutritionDualWriteState`. Returns `null` when no dual-write
-// context is registered — the LS-write call sites use this as a fast-path
-// gate so the extraction cost (a couple of LS reads) is only paid when
-// the dual-write feature is actually on.
+// Returns `null` when no dual-write context is registered — the
+// write call sites use this as a fast-path gate so we never enqueue
+// SQLite ops pre-auth.
 //
 // Recipes are intentionally excluded on web: they live in IndexedDB
 // (`recipeBook.ts`) rather than LS, so they are not yet wired into the
@@ -177,23 +198,14 @@ export function persistNutritionLog(
 function peekNutritionDualWriteState(): NutritionDualWriteState | null {
   if (!isNutritionDualWriteRegistered()) return null;
   try {
-    const log = loadNutritionLog();
-    const pantries = nutritionStorage.readJSON(NUTRITION_PANTRIES_KEY, null);
-    const normalizedPantries = normalizePantries(pantries);
-    const activePantryRaw = nutritionStorage.readRaw(
-      NUTRITION_ACTIVE_PANTRY_KEY,
-      null,
-    );
-    const activePantryId = activePantryRaw ? String(activePantryRaw) : null;
-    const prefsParsed = nutritionStorage.readJSON(NUTRITION_PREFS_KEY, null);
-    const prefs = normalizeNutritionPrefs(prefsParsed);
-
+    const cache = getCachedNutritionSqliteState();
+    const prefs = cache.prefs ?? defaultNutritionPrefs();
     return {
-      meals: extractMealSnapshots(log),
-      pantries: extractPantrySnapshots(normalizedPantries),
+      meals: extractMealSnapshots(normalizeNutritionLog(cache.log)),
+      pantries: extractPantrySnapshots(normalizePantries(cache.pantries)),
       prefs: {
         prefsJson: JSON.stringify(prefs),
-        activePantryId,
+        activePantryId: cache.activePantryId ?? null,
       },
       recipes: [],
     };

--- a/apps/web/src/modules/nutrition/lib/residualImport.ts
+++ b/apps/web/src/modules/nutrition/lib/residualImport.ts
@@ -1,0 +1,225 @@
+/**
+ * Boot-time residual-import helper for the Nutrition LS keys.
+ *
+ * Stage 8 PR #057n-tombstone of `docs/planning/storage-roadmap.md`.
+ * Reads any leftover values from the now-deprecated LS keys
+ * (`nutrition_log_v1`, `nutrition_pantries_v1`,
+ * `nutrition_active_pantry_v1`, `nutrition_prefs_v1`), imports them
+ * into the local `nutrition_*` SQLite tables (idempotent + LWW-safe),
+ * and then deletes the LS entries. Subsequent boots no-op because the
+ * LS keys are gone.
+ *
+ * The import uses a deliberately stale `clientTs` (epoch zero) so the
+ * adapter's LWW guard always lets existing SQLite rows win — we never
+ * clobber newer SQLite data with a stale LS snapshot.
+ *
+ * Mobile parity lives at
+ * `apps/mobile/src/modules/nutrition/lib/residualImport.ts`.
+ */
+
+import type { SqliteMigrationClient } from "@sergeant/db-schema/migrate/sqlite";
+import {
+  NUTRITION_ACTIVE_PANTRY_KEY,
+  NUTRITION_LOG_KEY,
+  NUTRITION_PANTRIES_KEY,
+  NUTRITION_PREFS_KEY,
+  defaultNutritionPrefs,
+  normalizeNutritionLog,
+  normalizeNutritionPrefs,
+  normalizePantries,
+  type NutritionLog,
+  type NutritionPrefs,
+  type Pantry,
+} from "@sergeant/nutrition-domain";
+
+import { applyNutritionDualWriteOps } from "./dualWrite/adapter.js";
+import {
+  diffNutritionDualWriteOps,
+  type NutritionDualWriteState,
+  type NutritionMealSnapshot,
+  type NutritionPantrySnapshot,
+} from "./dualWrite/diff.js";
+import { nutritionStorage } from "./nutritionStorageInstance";
+
+const STALE_TIMESTAMP = "1970-01-01T00:00:00.000Z";
+
+const EMPTY_STATE: NutritionDualWriteState = {
+  meals: [],
+  pantries: [],
+  prefs: null,
+  recipes: [],
+};
+
+export interface ResidualImportResult {
+  /** `true` when at least one LS key had data that was imported. */
+  readonly imported: boolean;
+  /** `true` when LS keys were present and have been deleted. */
+  readonly cleaned: boolean;
+}
+
+/**
+ * Import any residual Nutrition LS data into SQLite, then delete the
+ * LS entries. Always returns successfully — failures fall back to a
+ * no-op so the boot path can keep going.
+ */
+export async function importNutritionResidualFromLs(
+  client: SqliteMigrationClient,
+  userId: string,
+): Promise<ResidualImportResult> {
+  const log = readLogFromLs();
+  const pantries = readPantriesFromLs();
+  const activePantryId = readActivePantryFromLs();
+  const prefs = readPrefsFromLs();
+
+  const hasAny =
+    log !== null ||
+    pantries !== null ||
+    activePantryId !== null ||
+    prefs !== null;
+  if (!hasAny) return { imported: false, cleaned: false };
+
+  // Build a NutritionDualWriteState from whatever was found in LS.
+  // Slots that are missing fall back to the empty / default value so
+  // the diff against `EMPTY_STATE` only emits ops for slots we have.
+  const next: NutritionDualWriteState = {
+    meals: log ? extractMealSnapshots(normalizeNutritionLog(log)) : [],
+    pantries: pantries
+      ? extractPantrySnapshots(normalizePantries(pantries))
+      : [],
+    prefs:
+      prefs !== null || activePantryId !== null
+        ? {
+            prefsJson: JSON.stringify(
+              prefs ? normalizeNutritionPrefs(prefs) : defaultNutritionPrefs(),
+            ),
+            activePantryId,
+          }
+        : null,
+    recipes: [],
+  };
+
+  const ops = diffNutritionDualWriteOps(EMPTY_STATE, next);
+
+  if (ops.length > 0) {
+    try {
+      await applyNutritionDualWriteOps(client, ops, {
+        userId,
+        clientTs: STALE_TIMESTAMP,
+      });
+    } catch (err) {
+      console.warn(
+        "[nutrition.residualImport] apply failed; LS keys retained",
+        err instanceof Error ? err.message : err,
+      );
+      return { imported: false, cleaned: false };
+    }
+  }
+
+  // Delete the LS keys after a successful import. Done unconditionally
+  // (i.e. even when ops.length === 0, e.g. LS held only an empty `{}`)
+  // so a half-cleared LS state can't keep retriggering the import on
+  // every boot.
+  nutritionStorage.removeItem(NUTRITION_LOG_KEY);
+  nutritionStorage.removeItem(NUTRITION_PANTRIES_KEY);
+  nutritionStorage.removeItem(NUTRITION_ACTIVE_PANTRY_KEY);
+  nutritionStorage.removeItem(NUTRITION_PREFS_KEY);
+
+  return { imported: ops.length > 0, cleaned: true };
+}
+
+// -----------------------------------------------------------------------
+// LS readers — defensive: any throw collapses to `null` so the import
+// proceeds with whatever else was readable.
+// -----------------------------------------------------------------------
+
+function readLogFromLs(): unknown | null {
+  try {
+    return nutritionStorage.readJSON<unknown>(NUTRITION_LOG_KEY, null);
+  } catch {
+    return null;
+  }
+}
+
+function readPantriesFromLs(): unknown | null {
+  try {
+    return nutritionStorage.readJSON<unknown>(NUTRITION_PANTRIES_KEY, null);
+  } catch {
+    return null;
+  }
+}
+
+function readActivePantryFromLs(): string | null {
+  try {
+    const raw = nutritionStorage.readRaw(NUTRITION_ACTIVE_PANTRY_KEY, null);
+    return raw === null ? null : String(raw);
+  } catch {
+    return null;
+  }
+}
+
+function readPrefsFromLs(): unknown | null {
+  try {
+    return nutritionStorage.readJSON<unknown>(NUTRITION_PREFS_KEY, null);
+  } catch {
+    return null;
+  }
+}
+
+// -----------------------------------------------------------------------
+// Snapshot extractors — copies of the helpers that previously lived in
+// `nutritionStorage.ts` (private). The LS-read path that owned them is
+// gone; the residual-import is the last consumer of the LS layout.
+// -----------------------------------------------------------------------
+
+function extractMealSnapshots(log: NutritionLog): NutritionMealSnapshot[] {
+  const out: NutritionMealSnapshot[] = [];
+  for (const [dateKey, day] of Object.entries(log)) {
+    const meals = Array.isArray(day?.meals) ? day.meals : [];
+    for (const m of meals) {
+      if (!m || typeof m !== "object" || !m.id) continue;
+      out.push({
+        id: String(m.id),
+        dateKey,
+        time: typeof m.time === "string" ? m.time : "",
+        mealType: typeof m.mealType === "string" ? m.mealType : "snack",
+        name: typeof m.name === "string" ? m.name : "",
+        label: typeof m.label === "string" ? m.label : "",
+        macros: m.macros ?? null,
+        source: typeof m.source === "string" ? m.source : "manual",
+        macroSource:
+          typeof m.macroSource === "string" ? m.macroSource : "manual",
+        amountG: typeof m.amount_g === "number" ? m.amount_g : null,
+        foodId: typeof m.foodId === "string" ? m.foodId : null,
+        isDemo: m.demo === true,
+      });
+    }
+  }
+  return out;
+}
+
+function extractPantrySnapshots(
+  pantries: readonly Pantry[],
+): NutritionPantrySnapshot[] {
+  return pantries.map((p) => ({
+    id: p.id,
+    name: p.name,
+    text: p.text,
+    items: (p.items ?? []).map((it, idx) => ({
+      id: `${p.id}::${idx}::${it.name ?? ""}`,
+      name: it.name,
+      qty: typeof it.qty === "number" ? it.qty : null,
+      unit: typeof it.unit === "string" ? it.unit : null,
+      notes: typeof it.notes === "string" ? it.notes : null,
+    })),
+  }));
+}
+
+// Internal exports for tests.
+export const __testing = {
+  STALE_TIMESTAMP,
+  extractMealSnapshots,
+  extractPantrySnapshots,
+};
+
+// Tell TS we use NutritionPrefs in the doc comment scope.
+export type { NutritionPrefs };

--- a/apps/web/src/modules/nutrition/lib/sqliteReadBoot.ts
+++ b/apps/web/src/modules/nutrition/lib/sqliteReadBoot.ts
@@ -7,7 +7,12 @@
  * available:
  *
  *  1. Runs the nutrition SQLite migrations so the tables exist.
- *  2. Performs the initial `refreshNutritionSqliteState()` so the cache
+ *  2. Stage 8 PR #057n-tombstone: imports any residual LS values
+ *     (`nutrition_log_v1`, `nutrition_pantries_v1`,
+ *     `nutrition_active_pantry_v1`, `nutrition_prefs_v1`) into the
+ *     SQLite tables and deletes the LS keys. Idempotent; subsequent
+ *     boots no-op once the LS keys are gone.
+ *  3. Performs the initial `refreshNutritionSqliteState()` so the cache
  *     is warm before the first overlay read.
  *
  * Stage 8 PR #057n dropped `feature.nutrition.sqlite_v2.read_sqlite` —
@@ -19,6 +24,7 @@
 import { recordReadFallback } from "../../../core/observability/dualWriteTelemetry.js";
 import { getSqliteDb } from "../../../core/db/sqlite.js";
 import { migrateNutrition } from "./clientMigrate.js";
+import { importNutritionResidualFromLs } from "./residualImport.js";
 import { refreshNutritionSqliteState } from "./sqliteReader.js";
 
 let booted = false;
@@ -40,6 +46,14 @@ export async function bootNutritionSqliteReadPath(
     const handle = await getSqliteDb();
     const client = handle.migrationClient();
     await migrateNutrition(client);
+
+    // Stage 8 PR #057n-tombstone: drain LS into SQLite before the
+    // first cache refresh so warm-up sees any leftover values that
+    // older builds wrote. Failures here are non-fatal — the residual
+    // helper logs and falls back to a no-op so the boot can keep
+    // going on a fresh-install / clean-LS device.
+    await importNutritionResidualFromLs(client, userId);
+
     await refreshNutritionSqliteState(client, userId);
 
     booted = true;

--- a/apps/web/src/modules/nutrition/lib/sqliteReader.ts
+++ b/apps/web/src/modules/nutrition/lib/sqliteReader.ts
@@ -311,3 +311,22 @@ export async function refreshNutritionSqliteState(
 export function clearNutritionSqliteCache(): void {
   cache = { ...EMPTY_CACHE };
 }
+
+/**
+ * Test helper: seed the cache directly without running migrations / SQLite
+ * queries. The provided fields override the empty defaults and the cache
+ * is marked as refreshed (`refreshedAt`) so consumers treat it as warm.
+ *
+ * Stage 8 PR #057n-tombstone — used by `nutritionStorage.test.ts` and the
+ * hook tests now that the load/persist surface reads from this cache
+ * instead of LS.
+ */
+export function __setNutritionSqliteCacheForTests(
+  partial: Partial<SqliteNutritionCache>,
+): void {
+  cache = {
+    ...EMPTY_CACHE,
+    refreshedAt: new Date().toISOString(),
+    ...partial,
+  };
+}

--- a/docs/planning/storage-roadmap.md
+++ b/docs/planning/storage-roadmap.md
@@ -1,6 +1,6 @@
 # Storage & Sync — Roadmap до production-ready
 
-> **Last validated:** 2026-05-08 by @Skords-01 (Stage 9 COMPLETE 7/7 — PRs #060–#066 landed; PR #066 moved `createMemoryKVStore` to `@sergeant/shared/test-utils` and kept the web SSR/private-mode memory fallback app-local. Stage 9 hotfix tail (boot-path resilience for `sync_op_outbox`) landed post-canary — див. § Stage 9 нижче. Stage 7 9/9 — COMPLETE. Stage 8 dual-write default-on landed для всіх 4 модулів: Routine [#2133](https://github.com/Skords-01/Sergeant/pull/2133), Fizruk [#2135](https://github.com/Skords-01/Sergeant/pull/2135), Nutrition + Finyk + Finyk Mono mirror [#2178](https://github.com/Skords-01/Sergeant/pull/2178); plus Stage 8 dual-write telemetry sink (`ff92dbb4`) і PR #058 mobile sync-engine writer-runtime boot path landed у [#2118](https://github.com/Skords-01/Sergeant/pull/2118) alongside CloudSync v1 client cleanup. Read-default-on slice [#2179](https://github.com/Skords-01/Sergeant/pull/2179) was rolled back via [#2181](https://github.com/Skords-01/Sergeant/pull/2181) (`2735fa75`) after a PWA habit-input regression — re-rollout gated on stability re-verify. **Read-default-on quartet re-rolled out** після rollback #2181: Routine [#2244](https://github.com/Skords-01/Sergeant/pull/2244) (PR #055r2), Fizruk [#2247](https://github.com/Skords-01/Sergeant/pull/2247) (PR #055f2), Nutrition [#2251](https://github.com/Skords-01/Sergeant/pull/2251) (PR #055n2), Finyk (`24616449`, PR #055k2). **Stage 8 §3 parity probe quartet COMPLETE** на всіх 4 dual-write модулях: Routine ([#2243](https://github.com/Skords-01/Sergeant/pull/2243), `4ea2c952`), Fizruk ([#2257](https://github.com/Skords-01/Sergeant/pull/2257), PR #055f3), Nutrition ([#2259](https://github.com/Skords-01/Sergeant/pull/2259), PR #055n3), Finyk ([#2260](https://github.com/Skords-01/Sergeant/pull/2260), PR #055k3) — `<m>.sqlite.dualwrite.parity` decision-gate metric тепер populated на всіх 4 модулях. **Stage 8 dual-write feature-flag drop quartet COMPLETE** з revised scope (drop flag-gating only, не LS-write — schema-gap для Routine, parity з Routine для решти): Routine `#056r` (`ff852475`), Fizruk `#056f` (`abc575f0`), Finyk `#056k` ([#2265](https://github.com/Skords-01/Sergeant/pull/2265), `535a9984`), Nutrition `#056n` ([#2266](https://github.com/Skords-01/Sergeant/pull/2266), `65fe17fe`). **Outstanding:** Stage 8 — 4 module rollout PR-ів left (`#057*` quartet — drop LS-readers + tombstone `STORAGE_KEYS.{ROUTINE,FIZRUK_*,NUTRITION_*,FINYK_*}`), 14d canary-gated; plus Stage 10 candidate (Routine SQLite schema extension) before Routine LS-write can be dropped. Stage 9 KV store swap is complete. #045 Redis — opt-in optional Stage-6 follow-up. **Next review:** 2026-08-05.
+> **Last validated:** 2026-05-08 by @Skords-01 (Stage 9 COMPLETE 7/7 — PRs #060–#066 landed; PR #066 moved `createMemoryKVStore` to `@sergeant/shared/test-utils` and kept the web SSR/private-mode memory fallback app-local. Stage 9 hotfix tail (boot-path resilience for `sync_op_outbox`) landed post-canary — див. § Stage 9 нижче. Stage 7 9/9 — COMPLETE. Stage 8 dual-write default-on landed для всіх 4 модулів: Routine [#2133](https://github.com/Skords-01/Sergeant/pull/2133), Fizruk [#2135](https://github.com/Skords-01/Sergeant/pull/2135), Nutrition + Finyk + Finyk Mono mirror [#2178](https://github.com/Skords-01/Sergeant/pull/2178); plus Stage 8 dual-write telemetry sink (`ff92dbb4`) і PR #058 mobile sync-engine writer-runtime boot path landed у [#2118](https://github.com/Skords-01/Sergeant/pull/2118) alongside CloudSync v1 client cleanup. Read-default-on slice [#2179](https://github.com/Skords-01/Sergeant/pull/2179) was rolled back via [#2181](https://github.com/Skords-01/Sergeant/pull/2181) (`2735fa75`) after a PWA habit-input regression — re-rollout gated on stability re-verify. **Read-default-on quartet re-rolled out** після rollback #2181: Routine [#2244](https://github.com/Skords-01/Sergeant/pull/2244) (PR #055r2), Fizruk [#2247](https://github.com/Skords-01/Sergeant/pull/2247) (PR #055f2), Nutrition [#2251](https://github.com/Skords-01/Sergeant/pull/2251) (PR #055n2), Finyk (`24616449`, PR #055k2). **Stage 8 §3 parity probe quartet COMPLETE** на всіх 4 dual-write модулях: Routine ([#2243](https://github.com/Skords-01/Sergeant/pull/2243), `4ea2c952`), Fizruk ([#2257](https://github.com/Skords-01/Sergeant/pull/2257), PR #055f3), Nutrition ([#2259](https://github.com/Skords-01/Sergeant/pull/2259), PR #055n3), Finyk ([#2260](https://github.com/Skords-01/Sergeant/pull/2260), PR #055k3) — `<m>.sqlite.dualwrite.parity` decision-gate metric тепер populated на всіх 4 модулях. **Stage 8 dual-write feature-flag drop quartet COMPLETE** з revised scope (drop flag-gating only, не LS-write — schema-gap для Routine, parity з Routine для решти): Routine `#056r` (`ff852475`), Fizruk `#056f` (`abc575f0`), Finyk `#056k` ([#2265](https://github.com/Skords-01/Sergeant/pull/2265), `535a9984`), Nutrition `#056n` ([#2266](https://github.com/Skords-01/Sergeant/pull/2266), `65fe17fe`). **Stage 8 read-flag drop quartet COMPLETE** (registry + hook + boot cleanup, sets the canary for #057\*-tombstone): Nutrition `#057n-flag` ([#2269](https://github.com/Skords-01/Sergeant/pull/2269)), Finyk `#057k-flag` ([#2270](https://github.com/Skords-01/Sergeant/pull/2270)), Fizruk `#057f-flag` ([#2271](https://github.com/Skords-01/Sergeant/pull/2271)), Routine `#057r-flag` ([#2273](https://github.com/Skords-01/Sergeant/pull/2273)). **Stage 8 #057\*-tombstone quartet IN PROGRESS:** Nutrition `#057n-tombstone` ✅ LANDED (full LS-write + LS-read drop, residual-import, `STORAGE_KEYS.NUTRITION_*` `@deprecated`). **Outstanding:** Stage 8 — 3 module tombstone PR-ів left (`#057f-tombstone` Fizruk, `#057k-tombstone` Finyk; `#057r-tombstone` Routine blocked by Stage 10 schema extension), 14d canary-gated. Stage 9 KV store swap is complete. #045 Redis — opt-in optional Stage-6 follow-up. **Next review:** 2026-08-05.
 > **Status:** Active
 >
 > **Stage status (one-line summary):**
@@ -3035,13 +3035,30 @@ via SqliteReader`).
 NUTRITION_*`. Зняти стару migration `storageManager #002`
   (legacy single pantry → multi pantry), бо residual-import
   bootstrap покриє цей переїзд.
-  - **PR #057n-flag** ✅ LANDED — drop the now-redundant
+  - **PR #057n-flag** ✅ LANDED ([#2269](https://github.com/Skords-01/Sergeant/pull/2269)) —
+    drop the now-redundant
     `feature.nutrition.sqlite_v2.read_sqlite` flag-check from
     web + mobile (registry entry, hooks, boot, reader gate).
     SQLite read-overlay тепер unconditional once boot completes;
     LS first-paint read залишається synchronous fallback. Pre-step
     для `#057n-tombstone` (LS-reader drop + `STORAGE_KEYS`
     tombstone + residual-import bootstrap).
+  - **PR #057n-tombstone** ✅ LANDED — full LS-write + LS-read
+    drop for Nutrition (web + mobile). `nutritionStorage.ts` /
+    `nutritionStore.ts` `load*` тепер хитают the SQLite warm
+    cache (`getCachedNutritionSqliteState`); `persist*` /
+    `save*` фірять диф через `triggerNutritionDualWrite` без
+    жодного `localStorage.setItem` / MMKV `safeWriteLS`. Boot
+    додає `importNutritionResidualFromMmkv` /
+    `importNutritionResidualFromLocalStorage` (idempotent
+    LS→SQLite migration з stale LWW timestamp і delete LS keys
+    after successful apply). Hooks втратили MMKV /
+    `storage` listeners — cache-tick-bump після dual-write
+    apply тепер єдиний "value changed" сигнал.
+    `STORAGE_KEYS.{NUTRITION_LOG, NUTRITION_PANTRIES,
+NUTRITION_ACTIVE_PANTRY, NUTRITION_PREFS}` помічені
+    `@deprecated` (entries kept так як є cross-module reads
+    у tombstoned reader paths під час residual-import).
 
 #### **Finyk (4 PR-и)** — структура ідентична
 

--- a/packages/shared/src/lib/storageKeys.ts
+++ b/packages/shared/src/lib/storageKeys.ts
@@ -92,11 +92,27 @@ export const STORAGE_KEYS = {
   FIZRUK_REST_SETTINGS: "fizruk_rest_settings_v1",
 
   // ─── Nutrition ────────────────────────────────────────────────────────
+  // Stage 8 PR #057n-tombstone: the keys below are tombstoned. The
+  // SQLite-WASM (web) / expo-sqlite (mobile) `nutrition_*` tables are
+  // the canonical source of truth. The boot-time residual-import helper
+  // (`apps/{web,mobile}/src/modules/nutrition/lib/residualImport.ts`)
+  // imports any leftover values written by older builds into SQLite
+  // and then deletes the LS / MMKV entries. Entries are kept here (not
+  // deleted) so legacy cross-module reads / fixtures still resolve to
+  // the same string literals. **Do NOT add new reads/writes against
+  // these keys.**
+  /** @deprecated Stage 8 PR #057n-tombstone — use SQLite `nutrition_meals`. */
   NUTRITION_LOG: "nutrition_log_v1",
+  /** @deprecated Stage 8 PR #057n-tombstone — use SQLite `nutrition_pantries` / `nutrition_pantry_items`. */
   NUTRITION_PANTRIES: "nutrition_pantries_v1",
+  /** @deprecated Stage 8 PR #057n-tombstone — use SQLite `nutrition_prefs.active_pantry_id`. */
   NUTRITION_ACTIVE_PANTRY: "nutrition_active_pantry_v1",
+  /** @deprecated Stage 8 PR #057n-tombstone — use SQLite `nutrition_prefs`. */
   NUTRITION_PREFS: "nutrition_prefs_v1",
-  /** Локальна книга збережених рецептів (mobile MMKV; web — IndexedDB). */
+  /**
+   * Локальна книга збережених рецептів (mobile MMKV; web — IndexedDB).
+   * @deprecated Stage 8 PR #057n-tombstone — use SQLite `nutrition_recipes`.
+   */
   NUTRITION_SAVED_RECIPES: "nutrition_recipe_book_v1",
 
   // ─── Weekly Digest ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Stage 8 PR #057n-tombstone (full scope): drops every `localStorage` / MMKV read **and** write for Nutrition (web + mobile) and tombstones the four `STORAGE_KEYS.NUTRITION_*` literals. SQLite (`nutrition_*` tables) is now the only source of truth for log, pantries, active pantry, and prefs. A boot-time residual-import helper migrates any leftover LS/MMKV values into SQLite (idempotent, stale LWW timestamp so existing SQLite rows always win) and then deletes the LS/MMKV entries.

Concretely:

- `apps/web/src/modules/nutrition/lib/nutritionStorage.ts` and `apps/mobile/src/modules/nutrition/lib/nutritionStore.ts` — `load*` reads `getCachedNutritionSqliteState()`; `persist*` / `save*` diff prev→next and fan out via `triggerNutritionDualWrite`. No `localStorage.setItem` / `safeWriteLS` left in either file (water + shopping helpers on mobile keep their MMKV path).
- New `residualImport.ts` (web + mobile) wired into `sqliteReadBoot.ts` before `refreshNutritionSqliteState`. After a successful import → SQLite rows it deletes the LS / MMKV keys.
- Hooks (`useNutritionLog`, `useNutritionPrefs`, `useNutritionPantries`) lose their `storage` / MMKV `addOnValueChangedListener` — cache-tick-bump after dual-write apply is the only "value changed" signal.
- `apps/web/src/core/App.tsx` (AppInner) hoists Nutrition dual-write + SQLite read boot to app-level so cross-module callers (settings, `nutritionBackup.ts`) hit a warm cache.
- `nutritionBackup.ts` (web): `apply*` no longer calls `safeWriteLS` — it goes through `persistPantries` / `persistNutritionPrefs` / `persistNutritionLog`.
- `STORAGE_KEYS.{NUTRITION_LOG, NUTRITION_PANTRIES, NUTRITION_ACTIVE_PANTRY, NUTRITION_PREFS, NUTRITION_SAVED_RECIPES}` annotated `@deprecated` with a header explaining the residual-import contract. Entries are kept (not removed) so legacy cross-module reads / residual-import keep resolving to the same string literals.
- `docs/planning/storage-roadmap.md` — header summary updated; `#057n-tombstone` row marked LANDED with the full description.

Tests rewritten to seed the SQLite cache via `__setNutritionSqliteCacheForTests` and assert dual-write dispatch instead of LS contents (`apps/web/src/modules/nutrition/lib/nutritionStorage.test.ts`, `…/domain/nutritionBackup.test.ts`, `apps/mobile/src/modules/nutrition/lib/__tests__/nutritionStore.test.ts`, hook tests).

This is the first of the `#057*-tombstone` quartet. Sister PRs `#057k-tombstone` (Finyk), `#057f-tombstone` (Fizruk) follow; `#057r-tombstone` (Routine) stays blocked on the Stage 10 schema extension.

## Governing Skill

- Primary skill: n/a (no skill activated for this work)
- Secondary skill: n/a

## Playbook

- Primary playbook: n/a
- Why this playbook: n/a
- If no playbook matched, why: Storage-roadmap migration steps live in `docs/planning/storage-roadmap.md` and follow the per-module Stage 8 pattern set by `#055*` / `#056*` / `#057*-flag`.

## Verification

```bash
pnpm --filter @sergeant/web typecheck     # passes
pnpm --filter @sergeant/mobile typecheck  # passes
pnpm --filter @sergeant/web lint          # passes
pnpm --filter @sergeant/mobile lint       # passes
pnpm --filter @sergeant/web test -- --run src/modules/nutrition
#  Test Files  22 passed (22)  /  Tests  208 passed (208)
pnpm --filter @sergeant/mobile test -- --testPathPattern='modules/nutrition'
#  Test Suites: 7 passed, 7 total  /  Tests: 46 passed, 46 total
pnpm exec prettier --check (all touched files)  # passes
```

Additional checks:

- [x] Local lint / typecheck / unit tests green (web + mobile)
- [ ] Local smoke / manual validation completed — **NOT performed**; recommend a follow-up smoke pass on a build with seeded LS data to confirm residual-import path before canary rollout
- [ ] E2E suite — relying on CI

## Docs and Governance

- [x] Updated `docs/planning/storage-roadmap.md` (header summary + per-module Nutrition section).
- [x] Checked whether `AGENTS.md` needed an update — no.
- [x] Checked whether a playbook or skill needed an update — no.
- [x] Checked whether governance / review docs needed an update — no.

Updated docs:

- `docs/planning/storage-roadmap.md`

## Risk and Rollout

- **User-visible risk: high.** This is the first PR that fully removes the LS / MMKV write safety net for Nutrition. If `triggerNutritionDualWrite` returns early (because `isNutritionDualWriteRegistered()` is `false`, e.g. boot order regression), user mutations are silently dropped. The mobile test has an explicit "no-op when dual-write context is not registered" case — please review whether the App-level hoisting in `apps/web/src/core/App.tsx` reliably runs before any Nutrition consumer mounts.
- **First-paint:** initial state is now `{}` until the SQLite cache warms (~50–100ms after boot). Residual-import runs before `refreshNutritionSqliteState` so the very first cold-cache paint after migrating from a legacy LS-only build still shows correct data.
- **Rollout:** standard 14d canary on the already-merged `#057n-flag` (PR #2269). Should land **before** `#057k-tombstone` / `#057f-tombstone` to validate the residual-import + dual-write-only pattern on the smallest module first.
- **Backout plan:** revert this PR. The `STORAGE_KEYS.NUTRITION_*` entries are tombstoned (not deleted), so the LS reader paths can be re-introduced quickly. However, any user data written **after** this PR lands lives only in SQLite — a revert won't rehydrate LS, and revert-then-rebuild relies on the SQLite tables already being canonical. Forward-fix preferred over revert.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian (mixed UA/EN as in the rest of `storage-roadmap.md`).
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes — please scrutinise

1. **Boot ordering in `apps/web/src/core/App.tsx`.** Nutrition dual-write + SQLite read boot are hoisted to AppInner so `nutritionBackup.ts` and Settings see a warm cache. Verify no Nutrition consumer renders before the boot runs (otherwise saves silently no-op or reads return empty until the cache tick).
2. **Residual-import correctness** in `apps/web/src/modules/nutrition/lib/residualImport.ts` and `apps/mobile/src/modules/nutrition/lib/residualImport.ts`. The helper deletes LS / MMKV keys **only after** SQLite apply succeeds — please confirm the success/failure boundary is right (partial apply must not delete LS keys). LWW uses an epoch-zero timestamp so any non-empty SQLite row always wins; verify that's the desired semantics for users with stale LS but pre-populated SQLite from `#055n2`/`#056n` canary.
3. **`nutritionBackup.ts` apply path** no longer swallows quota errors via `safeWriteLS`. The new `persist*` calls go through dual-write; the dual-write best-effort happy path is what populates SQLite, and `window.location.reload()` after restore lets residual-import fix anything left over. Confirm this is acceptable for the restore UX.
4. **`STORAGE_KEYS.NUTRITION_*` kept (not deleted).** Header explains why (cross-module reads + residual-import resolution). Worth a grep to confirm no consumer outside of the residual-import / tombstoned reader paths still uses these literals to write.
5. **Test coverage gap:** there's no automated coverage of the residual-import path itself (LS→SQLite migration, key deletion, idempotency, partial-failure rollback). Worth adding before the rest of the quartet lands.
6. **Mobile-only:** the water and shopping-list helpers in `nutritionStore.ts` still write to MMKV by design — they're outside the `nutrition_*` SQLite schema. Tombstone deprecation comments target only the four migrated keys; `WATER_LOG_KEY` / `SHOPPING_LIST_KEY` are intentionally not annotated.

Link to Devin session: https://app.devin.ai/sessions/2b119b4c50e5435ab155963e9099467a
Requested by: @Skords-01

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops all Nutrition `localStorage` and MMKV reads/writes on web and mobile. SQLite `nutrition_*` is now the single source of truth, with a boot-time residual import that migrates any leftovers and deletes old keys.

- **Refactors**
  - `load*` now read from `getCachedNutritionSqliteState`; `persist*`/`save*` diff prev→next and call `triggerNutritionDualWrite` (no LS/MMKV writes; water/shopping remain on MMKV).
  - Adds `residualImport.ts` (web + mobile) to migrate `NUTRITION_*` keys into SQLite with epoch-zero LWW, then delete the keys; runs before the first cache refresh.
  - Hooks (`useNutritionLog`, `useNutritionPrefs`, `useNutritionPantries`) drop LS/MMKV listeners and re-render on the SQLite cache tick.
  - Web shell hoists Nutrition boot: `useNutritionDualWriteBoot` + `useNutritionSqliteReadBoot` in `App.tsx` so cross-module callers hit a warm cache.
  - Dual-write apply now refreshes the SQLite cache and notifies the tick.
  - `nutritionBackup.ts` writes via `persistPantries`/`persistNutritionPrefs`/`persistNutritionLog` (no `safeWriteLS`).
  - Tombstones `STORAGE_KEYS.NUTRITION_*` with `@deprecated` notes; kept for residual-import and legacy references.
  - Tests seed the cache via `__setNutritionSqliteCacheForTests` and assert dual-write dispatch instead of LS/MMKV behavior.

<sup>Written for commit 1dc07c5c4111c5eddf09f1e5f364b1853e803ce6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved nutrition data storage architecture for enhanced reliability and performance
  * Automatic legacy nutrition data migration during app initialization
  * Optimized cache synchronization for nutrition preferences, meals, and pantry data

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Skords-01/Sergeant/pull/2274)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->