### PR TITLE
feat(migrations): close out Stage 10 / PR #070r-schema (down.sql + round-trip test + sqlite/index re-export)

### DIFF
--- a/apps/server/src/migrations/050_routine_full_state.down.sql
+++ b/apps/server/src/migrations/050_routine_full_state.down.sql
@@ -1,0 +1,21 @@
+-- Rollback for migration 050_routine_full_state.sql
+-- (Stage 10 / PR #070r-schema in `docs/planning/storage-roadmap.md`).
+--
+-- Local-only rollback — production never runs `down.sql` (rule #4 in
+-- AGENTS.md). Order: indexes first, then tables. Each statement is
+-- `IF EXISTS`-guarded so the file stays idempotent (rule #4
+-- re-application invariant — the `rollback-sanity` round-trip
+-- harness asserts this).
+
+DROP INDEX IF EXISTS routine_habits_user_active_idx;
+DROP INDEX IF EXISTS routine_tags_user_active_idx;
+DROP INDEX IF EXISTS routine_categories_user_active_idx;
+DROP INDEX IF EXISTS routine_completion_notes_user_active_idx;
+
+DROP TABLE IF EXISTS routine_completion_notes;
+DROP TABLE IF EXISTS routine_habit_order;
+DROP TABLE IF EXISTS routine_pushups;
+DROP TABLE IF EXISTS routine_prefs;
+DROP TABLE IF EXISTS routine_categories;
+DROP TABLE IF EXISTS routine_tags;
+DROP TABLE IF EXISTS routine_habits;

--- a/apps/server/src/migrations/__tests__/050-routine-full-state.test.ts
+++ b/apps/server/src/migrations/__tests__/050-routine-full-state.test.ts
@@ -1,0 +1,429 @@
+// Migration 050 — focused round-trip for the Routine full-state tables
+// (Stage 10 / PR #070r-schema of `docs/planning/storage-roadmap.md`).
+//
+// Mirrors `035-nutrition-tables.test.ts` and `039-finyk-tables.test.ts`:
+// same Docker / pgvector testcontainer harness, same soft-skip
+// behaviour, same assertions shape — the only thing that changes is
+// the table list and the per-table column checks. Keeping the
+// harness identical means a regression in the migration-runner shows
+// up the same way for all three modules in CI logs.
+//
+// Asserts that:
+//   1. applying every forward migration leaves all 7 new routine tables
+//      present with the columns / indexes documented in
+//      `apps/server/src/migrations/050_routine_full_state.sql`,
+//   2. running `050_routine_full_state.down.sql` drops them all (and
+//      removes the explicit indexes),
+//   3. the down migration is idempotent (rule #4 invariant),
+//   4. down → re-up restores the schema fingerprint byte-for-byte.
+
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+import { fileURLToPath } from "url";
+import pg from "pg";
+import { GenericContainer, Wait } from "testcontainers";
+import type { StartedTestContainer } from "testcontainers";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MIGRATIONS_DIR = path.resolve(__dirname, "..");
+
+const TIMEOUT_MS = 180_000;
+
+// Stage 10 / PR #070r-schema introduces 7 new tables (extending the
+// 026_routine_tables.sql baseline of `routine_entries` /
+// `routine_streaks`). The test scopes itself to the new tables only —
+// the baseline pair stays out of this list and out of the
+// down.sql so we don't accidentally drop production tables that
+// migration 026 owns.
+const ROUTINE_FULL_STATE_TABLES = [
+  "routine_categories",
+  "routine_completion_notes",
+  "routine_habit_order",
+  "routine_habits",
+  "routine_prefs",
+  "routine_pushups",
+  "routine_tags",
+] as const;
+
+const ROUTINE_FULL_STATE_INDEXES = [
+  "routine_categories_user_active_idx",
+  "routine_completion_notes_user_active_idx",
+  "routine_habits_user_active_idx",
+  "routine_tags_user_active_idx",
+] as const;
+
+let container: StartedTestContainer | undefined;
+let pool: pg.Pool | undefined;
+let dockerAvailable = false;
+let skipReason: string | null = null;
+
+beforeAll(async () => {
+  try {
+    container = await new GenericContainer("pgvector/pgvector:pg16")
+      .withEnvironment({
+        POSTGRES_USER: "hub",
+        POSTGRES_PASSWORD: "hub",
+        POSTGRES_DB: "hub_test",
+      })
+      .withExposedPorts(5432)
+      .withWaitStrategy(
+        Wait.forLogMessage(/database system is ready to accept connections/, 2),
+      )
+      .start();
+
+    const host = container.getHost();
+    const port = container.getMappedPort(5432);
+    pool = new pg.Pool({
+      connectionString: `postgresql://hub:hub@${host}:${port}/hub_test`,
+      max: 4,
+    });
+    dockerAvailable = true;
+  } catch (e) {
+    skipReason = e instanceof Error ? e.message : String(e);
+    console.warn(
+      `[050-routine-full-state] Skipping: Testcontainers unavailable — ${skipReason}`,
+    );
+  }
+}, TIMEOUT_MS);
+
+afterAll(async () => {
+  if (pool) {
+    await pool.end().catch(() => {
+      /* noop */
+    });
+  }
+  if (container) {
+    await container.stop().catch(() => {
+      /* noop */
+    });
+  }
+}, TIMEOUT_MS);
+
+async function readMigrationFiles(): Promise<string[]> {
+  const files = await fs.readdir(MIGRATIONS_DIR);
+  return files
+    .filter((f) => /^\d{3}_.+\.sql$/.test(f) && !f.endsWith(".down.sql"))
+    .sort();
+}
+
+async function execSqlFile(p: pg.Pool, file: string): Promise<void> {
+  const sql = (
+    await fs.readFile(path.join(MIGRATIONS_DIR, file), "utf8")
+  ).trim();
+  if (!sql) return;
+  await p.query(sql);
+}
+
+async function resetSchema(p: pg.Pool): Promise<void> {
+  await p.query(`DROP SCHEMA public CASCADE; CREATE SCHEMA public;`);
+  await p.query(`GRANT ALL ON SCHEMA public TO public;`);
+}
+
+async function listFullStateTables(p: pg.Pool): Promise<string[]> {
+  const r = await p.query<{ tablename: string }>(
+    `SELECT tablename FROM pg_tables
+     WHERE schemaname = 'public'
+       AND tablename = ANY($1::text[])
+     ORDER BY tablename`,
+    [[...ROUTINE_FULL_STATE_TABLES]],
+  );
+  return r.rows.map((row) => row.tablename);
+}
+
+async function listFullStateIndexes(p: pg.Pool): Promise<string[]> {
+  const r = await p.query<{ indexname: string }>(
+    `SELECT indexname FROM pg_indexes
+     WHERE schemaname = 'public'
+       AND indexname = ANY($1::text[])
+     ORDER BY indexname`,
+    [[...ROUTINE_FULL_STATE_INDEXES]],
+  );
+  return r.rows.map((row) => row.indexname);
+}
+
+async function listColumns(
+  p: pg.Pool,
+  table: string,
+): Promise<{ name: string; type: string; nullable: string }[]> {
+  const r = await p.query<{
+    column_name: string;
+    data_type: string;
+    is_nullable: string;
+  }>(
+    `SELECT column_name, data_type, is_nullable
+     FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = $1
+     ORDER BY ordinal_position`,
+    [table],
+  );
+  return r.rows.map((row) => ({
+    name: row.column_name,
+    type: row.data_type,
+    nullable: row.is_nullable,
+  }));
+}
+
+describe("050_routine_full_state migration", () => {
+  it(
+    "creates all 7 new routine tables and their explicit indexes after forward migration",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+
+      const tables = await listFullStateTables(pool);
+      expect(tables).toEqual([...ROUTINE_FULL_STATE_TABLES]);
+
+      const indexes = await listFullStateIndexes(pool);
+      expect(indexes).toEqual([...ROUTINE_FULL_STATE_INDEXES]);
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "routine_habits has the documented column shape with jsonb arrays",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+
+      const cols = await listColumns(pool, "routine_habits");
+      expect(cols.map((c) => c.name)).toEqual([
+        "id",
+        "user_id",
+        "name",
+        "emoji",
+        "tag_ids",
+        "category_id",
+        "archived",
+        "paused",
+        "recurrence",
+        "start_date",
+        "end_date",
+        "time_of_day",
+        "reminder_times",
+        "weekdays",
+        "created_at",
+        "updated_at",
+        "deleted_at",
+      ]);
+
+      const byName = Object.fromEntries(cols.map((c) => [c.name, c]));
+      expect(byName["id"]!.type).toBe("uuid");
+      expect(byName["id"]!.nullable).toBe("NO");
+      expect(byName["user_id"]!.type).toBe("text");
+      expect(byName["user_id"]!.nullable).toBe("NO");
+      expect(byName["tag_ids"]!.type).toBe("jsonb");
+      expect(byName["tag_ids"]!.nullable).toBe("NO");
+      expect(byName["reminder_times"]!.type).toBe("jsonb");
+      expect(byName["weekdays"]!.type).toBe("jsonb");
+      expect(byName["archived"]!.type).toBe("boolean");
+      expect(byName["paused"]!.type).toBe("boolean");
+      expect(byName["created_at"]!.type).toBe("timestamp with time zone");
+      expect(byName["deleted_at"]!.nullable).toBe("YES");
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "routine_pushups is keyed on (user_id, date_key)",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+
+      const cols = await listColumns(pool, "routine_pushups");
+      expect(cols.map((c) => c.name)).toEqual([
+        "user_id",
+        "date_key",
+        "reps",
+        "updated_at",
+      ]);
+
+      const pkCheck = await pool.query<{ column_name: string }>(
+        `SELECT a.attname AS column_name
+         FROM   pg_index i
+         JOIN   pg_attribute a ON a.attrelid = i.indrelid
+                              AND a.attnum   = ANY(i.indkey)
+         WHERE  i.indrelid = 'public.routine_pushups'::regclass
+           AND  i.indisprimary
+         ORDER BY a.attnum`,
+      );
+      expect(pkCheck.rows.map((r) => r.column_name)).toEqual([
+        "user_id",
+        "date_key",
+      ]);
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "routine_completion_notes is keyed on (user_id, note_key) with soft-delete",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+
+      const cols = await listColumns(pool, "routine_completion_notes");
+      expect(cols.map((c) => c.name)).toEqual([
+        "user_id",
+        "note_key",
+        "note",
+        "updated_at",
+        "deleted_at",
+      ]);
+
+      const pkCheck = await pool.query<{ column_name: string }>(
+        `SELECT a.attname AS column_name
+         FROM   pg_index i
+         JOIN   pg_attribute a ON a.attrelid = i.indrelid
+                              AND a.attnum   = ANY(i.indkey)
+         WHERE  i.indrelid = 'public.routine_completion_notes'::regclass
+           AND  i.indisprimary
+         ORDER BY a.attnum`,
+      );
+      expect(pkCheck.rows.map((r) => r.column_name)).toEqual([
+        "user_id",
+        "note_key",
+      ]);
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "routine_prefs / routine_habit_order are per-user singletons",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+
+      const prefsCols = await listColumns(pool, "routine_prefs");
+      expect(prefsCols.map((c) => c.name)).toEqual([
+        "user_id",
+        "data",
+        "updated_at",
+      ]);
+      const prefsByName = Object.fromEntries(prefsCols.map((c) => [c.name, c]));
+      expect(prefsByName["data"]!.type).toBe("jsonb");
+
+      const orderCols = await listColumns(pool, "routine_habit_order");
+      expect(orderCols.map((c) => c.name)).toEqual([
+        "user_id",
+        "order",
+        "updated_at",
+      ]);
+      const orderByName = Object.fromEntries(orderCols.map((c) => [c.name, c]));
+      expect(orderByName["order"]!.type).toBe("jsonb");
+
+      for (const table of ["routine_prefs", "routine_habit_order"] as const) {
+        const pkCheck = await pool.query<{ column_name: string }>(
+          `SELECT a.attname AS column_name
+           FROM   pg_index i
+           JOIN   pg_attribute a ON a.attrelid = i.indrelid
+                                AND a.attnum   = ANY(i.indkey)
+           WHERE  i.indrelid = $1::regclass
+             AND  i.indisprimary`,
+          [`public.${table}`],
+        );
+        expect(pkCheck.rows.map((r) => r.column_name)).toEqual(["user_id"]);
+      }
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "050_routine_full_state.down.sql drops every full-state table",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+      expect((await listFullStateTables(pool)).length).toBe(
+        ROUTINE_FULL_STATE_TABLES.length,
+      );
+
+      await execSqlFile(pool, "050_routine_full_state.down.sql");
+      expect(await listFullStateTables(pool)).toEqual([]);
+      expect(await listFullStateIndexes(pool)).toEqual([]);
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "050_routine_full_state.down.sql is idempotent",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+
+      await execSqlFile(pool, "050_routine_full_state.down.sql");
+      // Second run must not raise — `IF EXISTS` keeps it idempotent
+      // per AGENTS rule #4.
+      await execSqlFile(pool, "050_routine_full_state.down.sql");
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "down then re-up restores the same schema fingerprint",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+
+      const before = {
+        tables: await listFullStateTables(pool),
+        indexes: await listFullStateIndexes(pool),
+        habits: await listColumns(pool, "routine_habits"),
+        prefs: await listColumns(pool, "routine_prefs"),
+        completionNotes: await listColumns(pool, "routine_completion_notes"),
+      };
+
+      await execSqlFile(pool, "050_routine_full_state.down.sql");
+      await execSqlFile(pool, "050_routine_full_state.sql");
+
+      const after = {
+        tables: await listFullStateTables(pool),
+        indexes: await listFullStateIndexes(pool),
+        habits: await listColumns(pool, "routine_habits"),
+        prefs: await listColumns(pool, "routine_prefs"),
+        completionNotes: await listColumns(pool, "routine_completion_notes"),
+      };
+
+      expect(after).toEqual(before);
+    },
+    TIMEOUT_MS,
+  );
+});

--- a/packages/db-schema/src/sqlite/index.ts
+++ b/packages/db-schema/src/sqlite/index.ts
@@ -5,6 +5,13 @@ export { kvStore } from "./kvStore.js";
 export {
   routineEntries,
   routineStreaks,
+  routineHabits,
+  routineTags,
+  routineCategories,
+  routinePrefs,
+  routinePushups,
+  routineHabitOrder,
+  routineCompletionNotes,
   syncOpOutbox,
   syncOpCursor,
   SYNC_OP_OUTBOX_OPS,


### PR DESCRIPTION
## Summary

Closes the remaining gaps for **Stage 10 / PR #070r-schema** (`docs/planning/storage-roadmap.md`). The 7 new Routine SQLite/Pg tables (`routine_habits`, `routine_tags`, `routine_categories`, `routine_prefs`, `routine_pushups`, `routine_habit_order`, `routine_completion_notes`), Drizzle schemas (SQLite + Pg), client migration `004_routine_full_state.sql`, server migration `050_routine_full_state.sql`, and snapshot tests had already landed. Three pieces were missing:

- **`packages/db-schema/src/sqlite/index.ts`** — re-export the 7 new SQLite tables from the dialect entrypoint. Pg/index.ts already lists all 7; the SQLite side was the only outlier vs. the per-module pattern established by Fizruk / Nutrition / Finyk.
- **`apps/server/src/migrations/050_routine_full_state.down.sql`** — local-only rollback for the new tables (production never runs `.down.sql` per AGENTS rule #4 / `pre-merge-migration-checklist.md`). Drops the 4 explicit indexes and 7 tables, all `IF EXISTS`-guarded so re-application is idempotent — same shape as `035_nutrition_tables.down.sql` / `039_finyk_tables.down.sql`.
- **`apps/server/src/migrations/__tests__/050-routine-full-state.test.ts`** — focused round-trip testcontainer harness modelled on the existing `035-nutrition-tables.test.ts` / `039-finyk-tables.test.ts`. Verifies (i) all 7 tables and 4 explicit indexes after forward migration, (ii) `routine_habits` column shape with `jsonb` tag_ids/reminder_times/weekdays, (iii) composite PKs on `routine_pushups (user_id, date_key)` and `routine_completion_notes (user_id, note_key)`, (iv) singleton PKs on `routine_prefs` / `routine_habit_order`, (v) down.sql drops everything, (vi) down.sql is idempotent, (vii) down → re-up restores the schema fingerprint byte-for-byte.

The `rollback-sanity.test.ts` catch-all (audit PR-5.B) already covered 050 generically once the down.sql lands; the focused 050 test adds the same per-module diagnostic clarity that 035/039 give for nutrition/finyk.

This PR is **schema-only** (no read/write paths use the new tables yet). Routine LS-write removal (`#057r-tombstone`) and the dual-write extension (PR #070r-dualwrite, currently PROPOSED in the roadmap) remain follow-ups.

## Governing Skill

- Primary skill: `sergeant-data-and-migrations`
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: [`docs/playbooks/pre-merge-migration-checklist.md`](docs/playbooks/pre-merge-migration-checklist.md)
- Why this playbook: PR adds files in `apps/server/src/migrations/` (new `*.down.sql` + test for the existing `050_*.sql` forward migration). Checklist is satisfied additively — see Verification.
- If no playbook matched, why: n/a

## Verification

```bash
pnpm --filter @sergeant/db-schema test          # 23 files / 422 tests pass
pnpm --filter @sergeant/db-schema typecheck     # clean
pnpm --filter @sergeant/db-schema lint          # clean
pnpm --filter @sergeant/db-schema build         # required before server typecheck
pnpm --filter @sergeant/server typecheck        # clean
pnpm --filter @sergeant/server lint             # 0 errors, 4 pre-existing warnings
pnpm lint:migrations                            # Migration lint passed
pnpm --filter @sergeant/server exec vitest run \
  src/migrations/__tests__/050-routine-full-state.test.ts
  # 8/8 tests pass against pgvector/pgvector:pg16 testcontainer
pnpm --filter @sergeant/server exec vitest run \
  src/migrations/__tests__/rollback-sanity.test.ts
  # 4/4 tests pass — full round-trip across all migrations including new 050
pnpm --filter @sergeant/db-schema exec vitest run \
  src/__tests__/sqlite-routine-snapshot.test.ts \
  src/__tests__/pg-routine-snapshot.test.ts
  # 72/72 tests pass — Stage 10 snapshots cover the new exports
```

Pre-merge migration checklist (per `docs/playbooks/pre-merge-migration-checklist.md`):

- [x] **A. Numbering**: `050_*.sql` already sequential and merged. `050_*.down.sql` companion lands here. No new forward migration in this PR.
- [x] **B. DROP-safety**: down.sql drops only the 7 tables introduced by 050 (not the routine_entries / routine_streaks baseline from 026). Production never runs down.sql.
- [x] **C. bigint-coercion**: n/a — no new columns are `BIGINT` / `BIGSERIAL` / `numeric`. JSONB / TEXT / TIMESTAMPTZ / BOOLEAN only.
- [x] **D. API contract sync**: n/a — no server endpoints read or write these tables yet (pure schema).
- [x] **E. Idempotency & defaults**: down.sql uses `IF EXISTS` on every DROP; idempotency asserted by the new round-trip test (re-running down.sql does not raise).
- [x] **F. Performance & locks**: n/a — pure CREATE/DROP, no ALTER / UPDATE / LOCK.
- [x] **G. RLS**: same baseline as 026/035/039 — no RLS-policy on routine_* tables yet, will land alongside the API endpoints in PR #070r-dualwrite.
- [x] **H. Local verification**: 8/8 tests pass against pgvector testcontainer, see Verification.
- [x] **I. CI verification**: `pnpm lint:migrations` green; rollback-sanity already covers 050 once down.sql lands.
- [x] **J. Rollout-readiness**: 050 is additive `CREATE TABLE IF NOT EXISTS` — Railway pre-deploy already applies it cleanly.

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a — `docs/planning/storage-roadmap.md` Stage 10 / PR #070r-schema status will flip from IN PROGRESS to LANDED in a follow-up commit once this PR merges (per the existing pattern where the roadmap is updated post-merge with the actual PR number).

## Risk and Rollout

- **User-visible risk**: zero — pure schema-only addition with no read/write paths attached. Tables sit empty until PR #070r-dualwrite (PROPOSED) wires up the dual-write diff/apply paths.
- **Rollout / deploy order**: this PR ships only a `.down.sql` + test for the existing forward migration. Railway pre-deploy already runs `050_routine_full_state.sql`; nothing in this PR touches that flow.
- **Backout plan**: `git revert` is sufficient — the new test is opt-in (soft-skips without Docker) and the down.sql is local-only.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

- The new server test takes ~22s on a cold pgvector pull, ~6s when the image is cached. It uses the same soft-skip pattern as 035/039 so non-Docker dev setups stay green.
- The SQLite re-export brings the slice in parity with PG. No consumer relied on the missing exports yet (otherwise it would have been a typecheck error long ago), so this is a no-op for current callers but unblocks PR #070r-dualwrite which will import these symbols.
- The roadmap update (Stage 10 / PR #070r-schema → LANDED with this PR's number) is intentionally deferred to a follow-up so this PR stays scoped and the doc gets the merged PR number.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finalizes Stage 10 / PR #070r-schema by adding a local rollback, a round‑trip migration test, and aligning SQLite exports. Schema-only; no runtime reads/writes changed.

- **Migration**
  - Added 050_routine_full_state.down.sql to drop the 7 routine_* tables and 4 indexes with IF EXISTS; production never runs downs.
  - Added a focused testcontainer round-trip test (forward → down → re-up) that checks table/index presence, key shapes, idempotency, and schema fingerprint on pg16.

- **Refactors**
  - Re-exported the 7 new SQLite routine tables from packages/db-schema/src/sqlite/index.ts to match PG and unblock `@sergeant/db-schema/sqlite` consumers.

<sup>Written for commit 05cb80eab10dc97f08fc57f270026577c60b7e92. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

