### PR TITLE
feat(mobile): mirror Stage 10 full-state Routine dual-write to SQLite (#070r-mobile-dualwrite)

### DIFF
--- a/apps/mobile/src/lib/observability/dualWriteTelemetry.ts
+++ b/apps/mobile/src/lib/observability/dualWriteTelemetry.ts
@@ -1,0 +1,153 @@
+/**
+ * Mobile mirror of `apps/web/src/core/observability/dualWriteTelemetry.ts`.
+ *
+ * Stage 8 of `docs/planning/storage-roadmap.md` defines three
+ * client-side decision-gate metrics:
+ *
+ *   - `<module>.sqlite.dualwrite.error_rate` ≤ 0.1 % over 14 d
+ *   - `<module>.sqlite.dualwrite.parity` (LS ↔ SQLite read equality)
+ *   - `<module>.sqlite.read.fallback`     = 0 in steady state
+ *
+ * The web sink also pushes sticky **Sentry tags** so Discover can
+ * facet on bucketed counts. Mobile observability (`./observability`)
+ * currently exposes only `addSentryBreadcrumb` — no `setTag` /
+ * `setContext`. To keep the orchestrator API symmetrical with web,
+ * this module exposes the same `record*` hooks but the tag-side is
+ * a no-op until a mobile-side `setSentryTag` lands. Breadcrumbs are
+ * still emitted on errors / mismatches / fallbacks so triage retains
+ * the same trail in mobile Sentry events.
+ *
+ * **Stage 10 mobile mirror** introduces `recordParityCheck` for
+ * Routine — see `../../modules/routine/lib/dualWrite/parity.ts`.
+ *
+ * @see apps/web/src/core/observability/dualWriteTelemetry.ts — single
+ *      source-of-truth for the bucket boundaries and gate thresholds.
+ */
+
+import { addSentryBreadcrumb } from "../observability";
+
+export type DualWriteModule = "routine" | "fizruk" | "nutrition" | "finyk";
+
+const MODULES: readonly DualWriteModule[] = [
+  "routine",
+  "fizruk",
+  "nutrition",
+  "finyk",
+];
+
+interface ModuleCounters {
+  applied: number;
+  skipped: number;
+  erroredOps: number;
+  sqliteUnavailable: number;
+  readFallback: number;
+  parityMatch: number;
+  parityMismatch: number;
+}
+
+function blankCounters(): ModuleCounters {
+  return {
+    applied: 0,
+    skipped: 0,
+    erroredOps: 0,
+    sqliteUnavailable: 0,
+    readFallback: 0,
+    parityMatch: 0,
+    parityMismatch: 0,
+  };
+}
+
+const counters: Record<DualWriteModule, ModuleCounters> = {
+  routine: blankCounters(),
+  fizruk: blankCounters(),
+  nutrition: blankCounters(),
+  finyk: blankCounters(),
+};
+
+export interface DualWriteOutcomeRecord {
+  status: "applied" | "skipped";
+  result?: { applied?: number; errored?: number; skipped?: number };
+  reason?: string;
+}
+
+export function recordDualWriteOutcome(
+  module: DualWriteModule,
+  outcome: DualWriteOutcomeRecord,
+): void {
+  const c = counters[module];
+  if (outcome.status === "applied") {
+    c.applied += 1;
+    const erroredThisBatch = outcome.result?.errored ?? 0;
+    if (erroredThisBatch > 0) {
+      c.erroredOps += erroredThisBatch;
+      addSentryBreadcrumb({
+        category: "storage",
+        level: "warning",
+        message: `dualwrite ${module} ops errored`,
+        data: {
+          module,
+          errored: erroredThisBatch,
+          applied: outcome.result?.applied ?? 0,
+        },
+      });
+    }
+  } else {
+    c.skipped += 1;
+    if (outcome.reason === "sqlite-unavailable") {
+      c.sqliteUnavailable += 1;
+      addSentryBreadcrumb({
+        category: "storage",
+        level: "warning",
+        message: `dualwrite ${module} fell back: sqlite-unavailable`,
+        data: { module, reason: outcome.reason },
+      });
+    }
+  }
+}
+
+export function recordReadFallback(
+  module: DualWriteModule,
+  reason: string,
+): void {
+  const c = counters[module];
+  c.readFallback += 1;
+  addSentryBreadcrumb({
+    category: "storage",
+    level: "warning",
+    message: `read.fallback ${module}: ${reason}`,
+    data: { module, reason },
+  });
+}
+
+export function recordParityCheck(
+  module: DualWriteModule,
+  result: "match" | "mismatch",
+  details?: Record<string, unknown>,
+): void {
+  const c = counters[module];
+  if (result === "match") {
+    c.parityMatch += 1;
+  } else {
+    c.parityMismatch += 1;
+    addSentryBreadcrumb({
+      category: "storage",
+      level: "warning",
+      message: `dualwrite parity mismatch: ${module}`,
+      data: { module, ...(details ?? {}) },
+    });
+  }
+}
+
+/** Test-only escape hatch — clears every module's counters. */
+export function __resetDualWriteTelemetryForTests(): void {
+  for (const m of MODULES) {
+    counters[m] = blankCounters();
+  }
+}
+
+/** Test-only read of the in-memory counters. */
+export function __peekDualWriteTelemetryForTests(
+  module: DualWriteModule,
+): Readonly<ModuleCounters> {
+  return { ...counters[module] };
+}

--- a/apps/mobile/src/modules/routine/lib/dualWrite/__tests__/adapter.test.ts
+++ b/apps/mobile/src/modules/routine/lib/dualWrite/__tests__/adapter.test.ts
@@ -261,4 +261,237 @@ describe("applyRoutineDualWriteOps (mobile, better-sqlite3)", () => {
       expect.objectContaining({ error: "boom" }),
     );
   });
+
+  // -----------------------------------------------------------------------
+  // Stage 10: full-state entity ops
+  // -----------------------------------------------------------------------
+
+  describe("Stage 10 ops", () => {
+    function listAll<R extends Record<string, unknown>>(table: string): R[] {
+      // The sync better-sqlite3 client returns `R[]` directly even though
+      // the `SqliteMigrationClient` interface widens to `R[] | Promise<R[]>`
+      // for the async expo-sqlite path.
+      return client.all<R>(
+        `SELECT * FROM ${table} ORDER BY rowid ASC`,
+        [],
+      ) as R[];
+    }
+
+    it("habit-upsert inserts a row in routine_habits", async () => {
+      const result = await applyRoutineDualWriteOps(
+        client,
+        [
+          {
+            kind: "habit-upsert",
+            habit: {
+              id: "h1",
+              name: "Drink water",
+              emoji: "💧",
+              archived: false,
+              paused: false,
+              tagIds: ["t1"],
+              weekdays: [1, 2, 3, 4, 5],
+              createdAt: T0,
+            },
+          },
+        ],
+        { userId: USER_ID, clientTs: T1, logger },
+      );
+      expect(result).toEqual({ applied: 1, errored: 0, skipped: 0 });
+      const rows = listAll<{
+        id: string;
+        name: string;
+        emoji: string;
+        tag_ids_json: string;
+        archived: number;
+        weekdays_json: string;
+        deleted_at: string | null;
+      }>("routine_habits");
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        id: "h1",
+        name: "Drink water",
+        emoji: "💧",
+        archived: 0,
+        deleted_at: null,
+      });
+      expect(JSON.parse(rows[0]!.tag_ids_json)).toEqual(["t1"]);
+      expect(JSON.parse(rows[0]!.weekdays_json)).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it("habit-upsert is LWW-guarded by updated_at", async () => {
+      await applyRoutineDualWriteOps(
+        client,
+        [
+          {
+            kind: "habit-upsert",
+            habit: { id: "h1", name: "New name", createdAt: T0 },
+          },
+        ],
+        { userId: USER_ID, clientTs: T2, logger },
+      );
+      // Stale write — must not overwrite the newer row.
+      await applyRoutineDualWriteOps(
+        client,
+        [
+          {
+            kind: "habit-upsert",
+            habit: { id: "h1", name: "Stale", createdAt: T0 },
+          },
+        ],
+        { userId: USER_ID, clientTs: T1, logger },
+      );
+      const rows = listAll<{ name: string; updated_at: string }>(
+        "routine_habits",
+      );
+      expect(rows[0]).toMatchObject({ name: "New name", updated_at: T2 });
+    });
+
+    it("habit-delete soft-deletes the row", async () => {
+      await applyRoutineDualWriteOps(
+        client,
+        [
+          {
+            kind: "habit-upsert",
+            habit: { id: "h1", name: "X", createdAt: T0 },
+          },
+        ],
+        { userId: USER_ID, clientTs: T1, logger },
+      );
+      await applyRoutineDualWriteOps(
+        client,
+        [{ kind: "habit-delete", habitId: "h1" }],
+        { userId: USER_ID, clientTs: T2, logger },
+      );
+      const rows = listAll<{ deleted_at: string | null }>("routine_habits");
+      expect(rows[0]).toMatchObject({ deleted_at: T2 });
+    });
+
+    it("tag-upsert + tag-delete round-trip", async () => {
+      await applyRoutineDualWriteOps(
+        client,
+        [
+          {
+            kind: "tag-upsert",
+            tag: { id: "t1", name: "morning", scope: "user" },
+          },
+        ],
+        { userId: USER_ID, clientTs: T1, logger },
+      );
+      let rows = listAll<{
+        name: string;
+        scope: string;
+        deleted_at: string | null;
+      }>("routine_tags");
+      expect(rows[0]).toMatchObject({ name: "morning", scope: "user" });
+
+      await applyRoutineDualWriteOps(
+        client,
+        [{ kind: "tag-delete", tagId: "t1" }],
+        { userId: USER_ID, clientTs: T2, logger },
+      );
+      rows = listAll<{
+        name: string;
+        scope: string;
+        deleted_at: string | null;
+      }>("routine_tags");
+      expect(rows[0]?.deleted_at).toBe(T2);
+    });
+
+    it("category-upsert writes to routine_categories", async () => {
+      await applyRoutineDualWriteOps(
+        client,
+        [
+          {
+            kind: "category-upsert",
+            category: { id: "c1", name: "Health", emoji: "🏥" },
+          },
+        ],
+        { userId: USER_ID, clientTs: T1, logger },
+      );
+      const rows = listAll<{ name: string; emoji: string }>(
+        "routine_categories",
+      );
+      expect(rows[0]).toMatchObject({ name: "Health", emoji: "🏥" });
+    });
+
+    it("prefs-set upserts a single row keyed by user_id", async () => {
+      await applyRoutineDualWriteOps(
+        client,
+        [{ kind: "prefs-set", prefs: { showFizrukInCalendar: true } }],
+        { userId: USER_ID, clientTs: T1, logger },
+      );
+      await applyRoutineDualWriteOps(
+        client,
+        [{ kind: "prefs-set", prefs: { showFizrukInCalendar: false } }],
+        { userId: USER_ID, clientTs: T2, logger },
+      );
+      const rows = listAll<{ data_json: string }>("routine_prefs");
+      expect(rows).toHaveLength(1);
+      expect(JSON.parse(rows[0]!.data_json)).toEqual({
+        showFizrukInCalendar: false,
+      });
+    });
+
+    it("pushup-upsert writes per (user, date_key)", async () => {
+      await applyRoutineDualWriteOps(
+        client,
+        [
+          { kind: "pushup-upsert", dateKey: "2026-05-01", reps: 30 },
+          { kind: "pushup-upsert", dateKey: "2026-05-02", reps: 40 },
+        ],
+        { userId: USER_ID, clientTs: T1, logger },
+      );
+      const rows = listAll<{ date_key: string; reps: number }>(
+        "routine_pushups",
+      );
+      expect(rows).toHaveLength(2);
+      const map = new Map(rows.map((r) => [r.date_key, r.reps]));
+      expect(map.get("2026-05-01")).toBe(30);
+      expect(map.get("2026-05-02")).toBe(40);
+    });
+
+    it("habit-order-set persists JSON array", async () => {
+      await applyRoutineDualWriteOps(
+        client,
+        [{ kind: "habit-order-set", orderedIds: ["h2", "h1", "h3"] }],
+        { userId: USER_ID, clientTs: T1, logger },
+      );
+      const rows = listAll<{ order_json: string }>("routine_habit_order");
+      expect(JSON.parse(rows[0]!.order_json)).toEqual(["h2", "h1", "h3"]);
+    });
+
+    it("completion-note upsert + delete cycle", async () => {
+      await applyRoutineDualWriteOps(
+        client,
+        [
+          {
+            kind: "completion-note-upsert",
+            noteKey: "h1__2026-05-01",
+            note: "did well",
+          },
+        ],
+        { userId: USER_ID, clientTs: T1, logger },
+      );
+      let rows = listAll<{ note: string; deleted_at: string | null }>(
+        "routine_completion_notes",
+      );
+      expect(rows[0]).toMatchObject({ note: "did well", deleted_at: null });
+
+      await applyRoutineDualWriteOps(
+        client,
+        [
+          {
+            kind: "completion-note-delete",
+            noteKey: "h1__2026-05-01",
+          },
+        ],
+        { userId: USER_ID, clientTs: T2, logger },
+      );
+      rows = listAll<{ note: string; deleted_at: string | null }>(
+        "routine_completion_notes",
+      );
+      expect(rows[0]?.deleted_at).toBe(T2);
+    });
+  });
 });

--- a/apps/mobile/src/modules/routine/lib/dualWrite/__tests__/diff.test.ts
+++ b/apps/mobile/src/modules/routine/lib/dualWrite/__tests__/diff.test.ts
@@ -3,6 +3,9 @@
  *
  * Pure-function diff has no platform-specific behaviour, so the
  * cases mirror the web spec exactly (jest assertion API).
+ *
+ * **Stage 10 mobile mirror** extends the diff coverage from the
+ * completion-only baseline to the full 7-table entity ops set.
  */
 import type { RoutineState } from "@sergeant/routine-domain";
 
@@ -65,7 +68,7 @@ describe("diffRoutineDualWriteOps", () => {
     ]);
   });
 
-  it("captures hard-delete as completion-removes for every dateKey", () => {
+  it("captures hard-delete as completion-removes for every dateKey + habit-delete", () => {
     const prev = makeState({
       habits: [
         { id: "h1", name: "Drink water" },
@@ -80,10 +83,12 @@ describe("diffRoutineDualWriteOps", () => {
     expect(diffRoutineDualWriteOps(prev, next)).toEqual([
       { kind: "completion-remove", habitId: "h1", dateKey: "2026-05-01" },
       { kind: "completion-remove", habitId: "h1", dateKey: "2026-05-02" },
+      // Stage 10: habit removed from the array → habit-delete
+      { kind: "habit-delete", habitId: "h1" },
     ]);
   });
 
-  it("emits habit-rename when same id has a different name", () => {
+  it("emits habit-rename + habit-upsert when same id has a different name", () => {
     const prev = makeState({
       habits: [{ id: "h1", name: "Drink water" }],
       completions: { h1: ["2026-05-01"] },
@@ -99,10 +104,26 @@ describe("diffRoutineDualWriteOps", () => {
         prevName: "Drink water",
         nextName: "Drink 2L of water",
       },
+      // Stage 10: name change also emits habit-upsert
+      {
+        kind: "habit-upsert",
+        habit: { id: "h1", name: "Drink 2L of water" },
+      },
     ]);
   });
 
-  it("orders ops deterministically: adds, removes, renames", () => {
+  it("emits habit-upsert (and no habit-rename) when the habit is brand new", () => {
+    const prev = makeState({ habits: [], completions: {} });
+    const next = makeState({
+      habits: [{ id: "h1", name: "Drink water" }],
+      completions: {},
+    });
+    expect(diffRoutineDualWriteOps(prev, next)).toEqual([
+      { kind: "habit-upsert", habit: { id: "h1", name: "Drink water" } },
+    ]);
+  });
+
+  it("orders ops deterministically: adds, removes, renames, then entity ops", () => {
     const prev = makeState({
       habits: [
         { id: "h2", name: "Stretch" },
@@ -140,6 +161,11 @@ describe("diffRoutineDualWriteOps", () => {
         prevName: "Stretch",
         nextName: "Stretch slowly",
       },
+      // Stage 10: name change also emits habit-upsert
+      {
+        kind: "habit-upsert",
+        habit: { id: "h2", name: "Stretch slowly" },
+      },
     ]);
   });
 
@@ -167,6 +193,180 @@ describe("diffRoutineDualWriteOps", () => {
         dateKey: "2026-05-01",
       },
     ]);
+  });
+
+  // -----------------------------------------------------------------------
+  // Stage 10: habit-upsert / habit-delete
+  // -----------------------------------------------------------------------
+
+  it("emits habit-upsert when a new habit appears", () => {
+    const prev = makeState({ habits: [] });
+    const next = makeState({
+      habits: [{ id: "h1", name: "Drink water", emoji: "💧" }],
+    });
+    const ops = diffRoutineDualWriteOps(prev, next);
+    expect(ops).toContainEqual({
+      kind: "habit-upsert",
+      habit: { id: "h1", name: "Drink water", emoji: "💧" },
+    });
+  });
+
+  it("emits habit-delete when a habit is removed", () => {
+    const prev = makeState({
+      habits: [{ id: "h1", name: "Drink water" }],
+    });
+    const next = makeState({ habits: [] });
+    const ops = diffRoutineDualWriteOps(prev, next);
+    expect(ops).toContainEqual({ kind: "habit-delete", habitId: "h1" });
+  });
+
+  it("emits habit-upsert when archived flag changes", () => {
+    const prev = makeState({
+      habits: [{ id: "h1", name: "Drink water", archived: false }],
+    });
+    const next = makeState({
+      habits: [{ id: "h1", name: "Drink water", archived: true }],
+    });
+    const ops = diffRoutineDualWriteOps(prev, next);
+    expect(ops).toContainEqual({
+      kind: "habit-upsert",
+      habit: { id: "h1", name: "Drink water", archived: true },
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Stage 10: tag-upsert / tag-delete
+  // -----------------------------------------------------------------------
+
+  it("emits tag-upsert when a new tag appears", () => {
+    const prev = makeState({ tags: [] });
+    const next = makeState({ tags: [{ id: "t1", name: "morning" }] });
+    const ops = diffRoutineDualWriteOps(prev, next);
+    expect(ops).toContainEqual({
+      kind: "tag-upsert",
+      tag: { id: "t1", name: "morning" },
+    });
+  });
+
+  it("emits tag-delete when a tag is removed", () => {
+    const prev = makeState({ tags: [{ id: "t1", name: "morning" }] });
+    const next = makeState({ tags: [] });
+    const ops = diffRoutineDualWriteOps(prev, next);
+    expect(ops).toContainEqual({ kind: "tag-delete", tagId: "t1" });
+  });
+
+  // -----------------------------------------------------------------------
+  // Stage 10: category-upsert / category-delete
+  // -----------------------------------------------------------------------
+
+  it("emits category-upsert when a new category appears", () => {
+    const prev = makeState({ categories: [] });
+    const next = makeState({
+      categories: [{ id: "c1", name: "Health", emoji: "🏥" }],
+    });
+    const ops = diffRoutineDualWriteOps(prev, next);
+    expect(ops).toContainEqual({
+      kind: "category-upsert",
+      category: { id: "c1", name: "Health", emoji: "🏥" },
+    });
+  });
+
+  it("emits category-delete when a category is removed", () => {
+    const prev = makeState({
+      categories: [{ id: "c1", name: "Health" }],
+    });
+    const next = makeState({ categories: [] });
+    const ops = diffRoutineDualWriteOps(prev, next);
+    expect(ops).toContainEqual({ kind: "category-delete", categoryId: "c1" });
+  });
+
+  // -----------------------------------------------------------------------
+  // Stage 10: prefs-set
+  // -----------------------------------------------------------------------
+
+  it("emits prefs-set when prefs object changes", () => {
+    const prev = makeState({ prefs: {} });
+    const next = makeState({ prefs: { showFizrukInCalendar: true } });
+    const ops = diffRoutineDualWriteOps(prev, next);
+    expect(ops).toContainEqual({
+      kind: "prefs-set",
+      prefs: { showFizrukInCalendar: true },
+    });
+  });
+
+  it("does NOT emit prefs-set when JSON is structurally equal", () => {
+    const prefs = { showFizrukInCalendar: true };
+    const prev = makeState({ prefs: { ...prefs } });
+    const next = makeState({ prefs: { ...prefs } });
+    const ops = diffRoutineDualWriteOps(prev, next);
+    expect(ops.filter((o) => o.kind === "prefs-set")).toHaveLength(0);
+  });
+
+  // -----------------------------------------------------------------------
+  // Stage 10: pushup-upsert
+  // -----------------------------------------------------------------------
+
+  it("emits pushup-upsert when a pushup entry changes", () => {
+    const prev = makeState({ pushupsByDate: {} });
+    const next = makeState({ pushupsByDate: { "2026-05-01": 30 } });
+    const ops = diffRoutineDualWriteOps(prev, next);
+    expect(ops).toContainEqual({
+      kind: "pushup-upsert",
+      dateKey: "2026-05-01",
+      reps: 30,
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Stage 10: habit-order-set
+  // -----------------------------------------------------------------------
+
+  it("emits habit-order-set when habitOrder changes", () => {
+    const prev = makeState({ habitOrder: ["h1", "h2"] });
+    const next = makeState({ habitOrder: ["h2", "h1"] });
+    const ops = diffRoutineDualWriteOps(prev, next);
+    expect(ops).toContainEqual({
+      kind: "habit-order-set",
+      orderedIds: ["h2", "h1"],
+    });
+  });
+
+  it("does NOT emit habit-order-set when order is structurally equal", () => {
+    const prev = makeState({ habitOrder: ["h1", "h2"] });
+    const next = makeState({ habitOrder: ["h1", "h2"] });
+    const ops = diffRoutineDualWriteOps(prev, next);
+    expect(ops.filter((o) => o.kind === "habit-order-set")).toHaveLength(0);
+  });
+
+  // -----------------------------------------------------------------------
+  // Stage 10: completion-note-upsert / completion-note-delete
+  // -----------------------------------------------------------------------
+
+  it("emits completion-note-upsert when a note is added", () => {
+    const prev = makeState({ completionNotes: {} });
+    const next = makeState({
+      completionNotes: { "h1__2026-05-01": "did well" },
+    });
+    const ops = diffRoutineDualWriteOps(prev, next);
+    expect(ops).toContainEqual({
+      kind: "completion-note-upsert",
+      noteKey: "h1__2026-05-01",
+      note: "did well",
+    });
+  });
+
+  it("emits completion-note-delete when a note is cleared", () => {
+    const prev = makeState({
+      completionNotes: { "h1__2026-05-01": "did well" },
+    });
+    const next = makeState({
+      completionNotes: { "h1__2026-05-01": "" },
+    });
+    const ops = diffRoutineDualWriteOps(prev, next);
+    expect(ops).toContainEqual({
+      kind: "completion-note-delete",
+      noteKey: "h1__2026-05-01",
+    });
   });
 });
 

--- a/apps/mobile/src/modules/routine/lib/dualWrite/__tests__/parity.test.ts
+++ b/apps/mobile/src/modules/routine/lib/dualWrite/__tests__/parity.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Parity probe tests — mirror of
+ * `apps/web/src/modules/routine/lib/dualWrite/__tests__/parity.test.ts`.
+ *
+ * Stage 10 mobile mirror: validates that `probeRoutineParity` returns
+ * `match` when MMKV-derived state and SQLite agree across all 7
+ * Stage 10 entity classes, and `mismatch` (with class-level details)
+ * when they disagree.
+ */
+import Database from "better-sqlite3";
+import type { SqliteMigrationClient } from "@sergeant/db-schema/migrate/sqlite";
+import type { RoutineState } from "@sergeant/routine-domain";
+
+import { migrateRoutine } from "../../clientMigrate";
+import { applyRoutineDualWriteOps } from "../adapter";
+import { probeRoutineParity } from "../parity";
+
+function syncClient(db: ReturnType<typeof Database>): SqliteMigrationClient {
+  return {
+    exec(sql) {
+      db.exec(sql);
+    },
+    run(sql, params) {
+      db.prepare(sql).run(...((params ?? []) as unknown[]));
+    },
+    all<R extends Record<string, unknown>>(
+      sql: string,
+      params?: readonly unknown[],
+    ): R[] {
+      const stmt = db.prepare(sql);
+      const result = params ? stmt.all(...(params as unknown[])) : stmt.all();
+      return result as R[];
+    },
+  };
+}
+
+function makeState(overrides: Partial<RoutineState> = {}): RoutineState {
+  return {
+    schemaVersion: 1,
+    prefs: {},
+    tags: [],
+    categories: [],
+    habits: [],
+    completions: {},
+    pushupsByDate: {},
+    habitOrder: [],
+    completionNotes: {},
+    ...overrides,
+  };
+}
+
+const USER_ID = "user-1";
+const T1 = "2026-05-01T10:00:00.000+00:00";
+
+describe("probeRoutineParity", () => {
+  let db: ReturnType<typeof Database>;
+  let client: SqliteMigrationClient;
+
+  beforeEach(async () => {
+    db = new Database(":memory:");
+    client = syncClient(db);
+    await migrateRoutine(client);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("reports match when both LS and SQLite are empty", async () => {
+    const state = makeState();
+    const outcome = await probeRoutineParity(client, USER_ID, state);
+    expect(outcome.result).toBe("match");
+  });
+
+  it("reports match after a full dual-write apply", async () => {
+    const state = makeState({
+      habits: [{ id: "h1", name: "Drink water", createdAt: T1 }],
+      tags: [{ id: "t1", name: "morning" }],
+      categories: [{ id: "c1", name: "Health" }],
+      completions: { h1: ["2026-05-01"] },
+      pushupsByDate: { "2026-05-01": 30 },
+      habitOrder: ["h1"],
+      completionNotes: { "h1__2026-05-01": "did well" },
+      prefs: { showFizrukInCalendar: true },
+    });
+    await applyRoutineDualWriteOps(
+      client,
+      [
+        {
+          kind: "habit-upsert",
+          habit: { id: "h1", name: "Drink water", createdAt: T1 },
+        },
+        { kind: "tag-upsert", tag: { id: "t1", name: "morning" } },
+        { kind: "category-upsert", category: { id: "c1", name: "Health" } },
+        {
+          kind: "completion-add",
+          habitId: "h1",
+          habitName: "Drink water",
+          dateKey: "2026-05-01",
+        },
+        { kind: "pushup-upsert", dateKey: "2026-05-01", reps: 30 },
+        { kind: "habit-order-set", orderedIds: ["h1"] },
+        {
+          kind: "completion-note-upsert",
+          noteKey: "h1__2026-05-01",
+          note: "did well",
+        },
+        { kind: "prefs-set", prefs: { showFizrukInCalendar: true } },
+      ],
+      { userId: USER_ID, clientTs: T1 },
+    );
+    const outcome = await probeRoutineParity(client, USER_ID, state);
+    expect(outcome.result).toBe("match");
+  });
+
+  it("reports mismatch when SQLite is missing a habit present in LS", async () => {
+    const state = makeState({
+      habits: [{ id: "h1", name: "Drink water", createdAt: T1 }],
+    });
+    const outcome = await probeRoutineParity(client, USER_ID, state);
+    expect(outcome.result).toBe("mismatch");
+    expect(outcome.details).toMatchObject({
+      habits: { ls: 1, sqlite: 0 },
+    });
+  });
+
+  it("reports mismatch when SQLite has a stale prefs blob", async () => {
+    await applyRoutineDualWriteOps(
+      client,
+      [{ kind: "prefs-set", prefs: { showFizrukInCalendar: true } }],
+      { userId: USER_ID, clientTs: T1 },
+    );
+    const state = makeState({ prefs: { showFizrukInCalendar: false } });
+    const outcome = await probeRoutineParity(client, USER_ID, state);
+    expect(outcome.result).toBe("mismatch");
+  });
+
+  it("reports mismatch when habit order differs", async () => {
+    await applyRoutineDualWriteOps(
+      client,
+      [{ kind: "habit-order-set", orderedIds: ["h1", "h2"] }],
+      { userId: USER_ID, clientTs: T1 },
+    );
+    const state = makeState({ habitOrder: ["h2", "h1"] });
+    const outcome = await probeRoutineParity(client, USER_ID, state);
+    expect(outcome.result).toBe("mismatch");
+  });
+
+  it("excludes empty notes from LS-side cardinality", async () => {
+    // SQLite has no notes; LS has only an empty-string note. The
+    // probe must treat the empty-string entry as absent (parity match).
+    const state = makeState({
+      completionNotes: { "h1__2026-05-01": "" },
+    });
+    const outcome = await probeRoutineParity(client, USER_ID, state);
+    expect(outcome.result).toBe("match");
+  });
+});

--- a/apps/mobile/src/modules/routine/lib/dualWrite/adapter.ts
+++ b/apps/mobile/src/modules/routine/lib/dualWrite/adapter.ts
@@ -10,6 +10,21 @@ import { buildCompletionRowId, type RoutineDualWriteOp } from "./diff";
  * web copy for the full design notes (best-effort, idempotency,
  * LWW guard, rename semantics).
  *
+ * **Stage 10 mobile mirror** extends the adapter from the
+ * single-table `routine_entries` mirror to all 7 new tables shipped
+ * in PR #070r-schema. Each op kind maps to exactly one table:
+ *
+ *   - `completion-add` / `completion-remove` → `routine_entries`
+ *   - `habit-rename` → `routine_entries` (denormalized name cascade)
+ *   - `habit-upsert` / `habit-delete` → `routine_habits`
+ *   - `tag-upsert` / `tag-delete` → `routine_tags`
+ *   - `category-upsert` / `category-delete` → `routine_categories`
+ *   - `prefs-set` → `routine_prefs`
+ *   - `pushup-upsert` → `routine_pushups`
+ *   - `habit-order-set` → `routine_habit_order`
+ *   - `completion-note-upsert` / `completion-note-delete` →
+ *     `routine_completion_notes`
+ *
  * Both copies use the same `SqliteMigrationClient` (`{exec, run, all}`)
  * shape so a single SQL surface serves both web (sqlite-wasm via
  * `migrationClient()` on the singleton) and mobile (expo-sqlite via
@@ -62,7 +77,7 @@ export async function applyRoutineDualWriteOps(
     } catch (err) {
       errored += 1;
       logger("warn", "dual-write op failed", {
-        op,
+        op: op.kind,
         error: err instanceof Error ? err.message : String(err),
       });
     }
@@ -80,6 +95,9 @@ async function applyOne(
 ): Promise<ApplyOutcome> {
   const { userId, clientTs } = options;
   switch (op.kind) {
+    // -----------------------------------------------------------------
+    // Legacy ops (routine_entries)
+    // -----------------------------------------------------------------
     case "completion-add": {
       const id = buildCompletionRowId(op.habitId, op.dateKey);
       await client.run(
@@ -121,6 +139,207 @@ async function applyOne(
       );
       return "applied";
     }
+
+    // -----------------------------------------------------------------
+    // Stage 10 ops (routine_habits)
+    // -----------------------------------------------------------------
+    case "habit-upsert": {
+      const h = op.habit;
+      await client.run(
+        `INSERT INTO routine_habits
+           (id, user_id, name, emoji, tag_ids_json, category_id,
+            archived, paused, recurrence, start_date, end_date,
+            time_of_day, reminder_times_json, weekdays_json,
+            created_at, updated_at, deleted_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+         ON CONFLICT(id) DO UPDATE SET
+           name = excluded.name,
+           emoji = excluded.emoji,
+           tag_ids_json = excluded.tag_ids_json,
+           category_id = excluded.category_id,
+           archived = excluded.archived,
+           paused = excluded.paused,
+           recurrence = excluded.recurrence,
+           start_date = excluded.start_date,
+           end_date = excluded.end_date,
+           time_of_day = excluded.time_of_day,
+           reminder_times_json = excluded.reminder_times_json,
+           weekdays_json = excluded.weekdays_json,
+           updated_at = excluded.updated_at,
+           deleted_at = NULL
+         WHERE excluded.updated_at > routine_habits.updated_at`,
+        [
+          h.id,
+          userId,
+          h.name,
+          h.emoji ?? "",
+          JSON.stringify(h.tagIds ?? []),
+          h.categoryId ?? null,
+          h.archived ? 1 : 0,
+          h.paused ? 1 : 0,
+          h.recurrence ?? "daily",
+          h.startDate ?? null,
+          h.endDate ?? null,
+          h.timeOfDay ?? "",
+          JSON.stringify(h.reminderTimes ?? []),
+          JSON.stringify(h.weekdays ?? [0, 1, 2, 3, 4, 5, 6]),
+          h.createdAt ?? clientTs,
+          clientTs,
+        ],
+      );
+      return "applied";
+    }
+    case "habit-delete": {
+      await client.run(
+        `UPDATE routine_habits
+            SET deleted_at = ?, updated_at = ?
+          WHERE id = ?
+            AND user_id = ?
+            AND updated_at < ?`,
+        [clientTs, clientTs, op.habitId, userId, clientTs],
+      );
+      return "applied";
+    }
+
+    // -----------------------------------------------------------------
+    // Stage 10 ops (routine_tags)
+    // -----------------------------------------------------------------
+    case "tag-upsert": {
+      const t = op.tag;
+      await client.run(
+        `INSERT INTO routine_tags
+           (id, user_id, name, scope, created_at, updated_at, deleted_at)
+         VALUES (?, ?, ?, ?, ?, ?, NULL)
+         ON CONFLICT(id) DO UPDATE SET
+           name = excluded.name,
+           scope = excluded.scope,
+           updated_at = excluded.updated_at,
+           deleted_at = NULL
+         WHERE excluded.updated_at > routine_tags.updated_at`,
+        [t.id, userId, t.name, t.scope ?? "", clientTs, clientTs],
+      );
+      return "applied";
+    }
+    case "tag-delete": {
+      await client.run(
+        `UPDATE routine_tags
+            SET deleted_at = ?, updated_at = ?
+          WHERE id = ?
+            AND user_id = ?
+            AND updated_at < ?`,
+        [clientTs, clientTs, op.tagId, userId, clientTs],
+      );
+      return "applied";
+    }
+
+    // -----------------------------------------------------------------
+    // Stage 10 ops (routine_categories)
+    // -----------------------------------------------------------------
+    case "category-upsert": {
+      const c = op.category;
+      await client.run(
+        `INSERT INTO routine_categories
+           (id, user_id, name, emoji, created_at, updated_at, deleted_at)
+         VALUES (?, ?, ?, ?, ?, ?, NULL)
+         ON CONFLICT(id) DO UPDATE SET
+           name = excluded.name,
+           emoji = excluded.emoji,
+           updated_at = excluded.updated_at,
+           deleted_at = NULL
+         WHERE excluded.updated_at > routine_categories.updated_at`,
+        [c.id, userId, c.name, c.emoji ?? "", clientTs, clientTs],
+      );
+      return "applied";
+    }
+    case "category-delete": {
+      await client.run(
+        `UPDATE routine_categories
+            SET deleted_at = ?, updated_at = ?
+          WHERE id = ?
+            AND user_id = ?
+            AND updated_at < ?`,
+        [clientTs, clientTs, op.categoryId, userId, clientTs],
+      );
+      return "applied";
+    }
+
+    // -----------------------------------------------------------------
+    // Stage 10 ops (routine_prefs — single row per user)
+    // -----------------------------------------------------------------
+    case "prefs-set": {
+      await client.run(
+        `INSERT INTO routine_prefs (user_id, data_json, updated_at)
+         VALUES (?, ?, ?)
+         ON CONFLICT(user_id) DO UPDATE SET
+           data_json = excluded.data_json,
+           updated_at = excluded.updated_at
+         WHERE excluded.updated_at > routine_prefs.updated_at`,
+        [userId, JSON.stringify(op.prefs), clientTs],
+      );
+      return "applied";
+    }
+
+    // -----------------------------------------------------------------
+    // Stage 10 ops (routine_pushups — one row per (user, date))
+    // -----------------------------------------------------------------
+    case "pushup-upsert": {
+      await client.run(
+        `INSERT INTO routine_pushups (user_id, date_key, reps, updated_at)
+         VALUES (?, ?, ?, ?)
+         ON CONFLICT(user_id, date_key) DO UPDATE SET
+           reps = excluded.reps,
+           updated_at = excluded.updated_at
+         WHERE excluded.updated_at > routine_pushups.updated_at`,
+        [userId, op.dateKey, op.reps, clientTs],
+      );
+      return "applied";
+    }
+
+    // -----------------------------------------------------------------
+    // Stage 10 ops (routine_habit_order — single row per user)
+    // -----------------------------------------------------------------
+    case "habit-order-set": {
+      await client.run(
+        `INSERT INTO routine_habit_order (user_id, order_json, updated_at)
+         VALUES (?, ?, ?)
+         ON CONFLICT(user_id) DO UPDATE SET
+           order_json = excluded.order_json,
+           updated_at = excluded.updated_at
+         WHERE excluded.updated_at > routine_habit_order.updated_at`,
+        [userId, JSON.stringify(op.orderedIds), clientTs],
+      );
+      return "applied";
+    }
+
+    // -----------------------------------------------------------------
+    // Stage 10 ops (routine_completion_notes)
+    // -----------------------------------------------------------------
+    case "completion-note-upsert": {
+      await client.run(
+        `INSERT INTO routine_completion_notes
+           (user_id, note_key, note, updated_at, deleted_at)
+         VALUES (?, ?, ?, ?, NULL)
+         ON CONFLICT(user_id, note_key) DO UPDATE SET
+           note = excluded.note,
+           updated_at = excluded.updated_at,
+           deleted_at = NULL
+         WHERE excluded.updated_at > routine_completion_notes.updated_at`,
+        [userId, op.noteKey, op.note, clientTs],
+      );
+      return "applied";
+    }
+    case "completion-note-delete": {
+      await client.run(
+        `UPDATE routine_completion_notes
+            SET deleted_at = ?, updated_at = ?
+          WHERE user_id = ?
+            AND note_key = ?
+            AND updated_at < ?`,
+        [clientTs, clientTs, userId, op.noteKey, clientTs],
+      );
+      return "applied";
+    }
+
     default: {
       const _exhaustive: never = op;
       void _exhaustive;

--- a/apps/mobile/src/modules/routine/lib/dualWrite/diff.ts
+++ b/apps/mobile/src/modules/routine/lib/dualWrite/diff.ts
@@ -1,17 +1,30 @@
-import type { RoutineState } from "@sergeant/routine-domain";
+import type {
+  Habit,
+  RoutinePrefs,
+  RoutineState,
+} from "@sergeant/routine-domain";
 
 /**
  * Pure-function diff between two `RoutineState` snapshots, producing
  * the list of operations the dual-write layer must mirror to local
- * SQLite (`routine_entries` table).
+ * SQLite.
  *
  * Stage 4 PR #024 of `docs/planning/storage-roadmap.md`. Mirrors
  * `apps/web/src/modules/routine/lib/dualWrite/diff.ts` byte-for-byte
  * — kept duplicated until Stage 5 promotes the dual-write helpers
  * into a workspace package alongside the SPIKE library.
  *
+ * **Stage 10 mobile mirror** extends the diff from completions-only
+ * (routine_entries) to all 7 new tables shipped in PR #070r-schema.
+ * The op kinds and ordering match the web implementation exactly so
+ * the SQLite mirror remains LWW-consistent across devices.
+ *
  * See the web copy for full mapping rules and design notes.
  */
+
+// -----------------------------------------------------------------------
+// Legacy op types (completion-add / completion-remove / habit-rename)
+// -----------------------------------------------------------------------
 
 export interface CompletionAddOp {
   readonly kind: "completion-add";
@@ -33,15 +46,110 @@ export interface HabitRenameOp {
   readonly nextName: string;
 }
 
+// -----------------------------------------------------------------------
+// Stage 10 op types
+// -----------------------------------------------------------------------
+
+export interface HabitUpsertOp {
+  readonly kind: "habit-upsert";
+  readonly habit: Habit;
+}
+
+export interface HabitDeleteOp {
+  readonly kind: "habit-delete";
+  readonly habitId: string;
+}
+
+export interface TagUpsertOp {
+  readonly kind: "tag-upsert";
+  readonly tag: {
+    readonly id: string;
+    readonly name: string;
+    readonly scope?: string;
+  };
+}
+
+export interface TagDeleteOp {
+  readonly kind: "tag-delete";
+  readonly tagId: string;
+}
+
+export interface CategoryUpsertOp {
+  readonly kind: "category-upsert";
+  readonly category: {
+    readonly id: string;
+    readonly name: string;
+    readonly emoji?: string;
+  };
+}
+
+export interface CategoryDeleteOp {
+  readonly kind: "category-delete";
+  readonly categoryId: string;
+}
+
+export interface PrefsSetOp {
+  readonly kind: "prefs-set";
+  readonly prefs: RoutinePrefs;
+}
+
+export interface PushupUpsertOp {
+  readonly kind: "pushup-upsert";
+  readonly dateKey: string;
+  readonly reps: number;
+}
+
+export interface HabitOrderSetOp {
+  readonly kind: "habit-order-set";
+  readonly orderedIds: readonly string[];
+}
+
+export interface CompletionNoteUpsertOp {
+  readonly kind: "completion-note-upsert";
+  readonly noteKey: string;
+  readonly note: string;
+}
+
+export interface CompletionNoteDeleteOp {
+  readonly kind: "completion-note-delete";
+  readonly noteKey: string;
+}
+
 export type RoutineDualWriteOp =
   | CompletionAddOp
   | CompletionRemoveOp
-  | HabitRenameOp;
+  | HabitRenameOp
+  | HabitUpsertOp
+  | HabitDeleteOp
+  | TagUpsertOp
+  | TagDeleteOp
+  | CategoryUpsertOp
+  | CategoryDeleteOp
+  | PrefsSetOp
+  | PushupUpsertOp
+  | HabitOrderSetOp
+  | CompletionNoteUpsertOp
+  | CompletionNoteDeleteOp;
 
 /**
  * Compute the dual-write operation list for the transition `prev → next`.
- * Returns an empty list when `prev === next` (the common case for
- * reducer no-ops).
+ *
+ * Identity short-cut: if the same reference is passed for both states
+ * (the common case when an MMKV-reducer returned `state` unchanged) the
+ * function returns an empty list immediately.
+ *
+ * Stable iteration order:
+ *
+ *   1. completion-add (habitId asc, dateKey asc)
+ *   2. completion-remove (habitId asc, dateKey asc)
+ *   3. habit-rename (habitId asc)
+ *   4. habit-upsert / habit-delete (habitId asc)
+ *   5. tag-upsert / tag-delete (tagId asc)
+ *   6. category-upsert / category-delete (categoryId asc)
+ *   7. prefs-set (at most one)
+ *   8. pushup-upsert (dateKey asc)
+ *   9. habit-order-set (at most one)
+ *  10. completion-note-upsert / completion-note-delete (noteKey asc)
  */
 export function diffRoutineDualWriteOps(
   prev: RoutineState,
@@ -49,18 +157,45 @@ export function diffRoutineDualWriteOps(
 ): RoutineDualWriteOp[] {
   if (prev === next) return [];
 
-  const adds: CompletionAddOp[] = [];
-  const removes: CompletionRemoveOp[] = [];
-  const renames: HabitRenameOp[] = [];
+  const ops: RoutineDualWriteOp[] = [];
 
-  const prevHabitNames = new Map<string, string>();
-  for (const h of prev.habits) prevHabitNames.set(h.id, h.name);
+  // --- Legacy: completion-add / completion-remove / habit-rename ---
+  diffCompletionOps(prev, next, ops);
+  diffHabitRenameOps(prev, next, ops);
+
+  // --- Stage 10: full-state entity ops ---
+  diffHabitEntityOps(prev, next, ops);
+  diffTagOps(prev, next, ops);
+  diffCategoryOps(prev, next, ops);
+  diffPrefsOps(prev, next, ops);
+  diffPushupOps(prev, next, ops);
+  diffHabitOrderOps(prev, next, ops);
+  diffCompletionNoteOps(prev, next, ops);
+
+  return ops;
+}
+
+/** Build the canonical id used as the SQLite primary key for completions. */
+export function buildCompletionRowId(habitId: string, dateKey: string): string {
+  return `${habitId}:${dateKey}`;
+}
+
+// -----------------------------------------------------------------------
+// Legacy diff helpers
+// -----------------------------------------------------------------------
+
+function diffCompletionOps(
+  prev: RoutineState,
+  next: RoutineState,
+  ops: RoutineDualWriteOp[],
+): void {
   const nextHabitNames = new Map<string, string>();
   for (const h of next.habits) nextHabitNames.set(h.id, h.name);
 
   const prevSet = buildCompletionSet(prev.completions);
   const nextSet = buildCompletionSet(next.completions);
 
+  const adds: CompletionAddOp[] = [];
   for (const key of nextSet) {
     if (prevSet.has(key)) continue;
     const split = splitCompletionKey(key);
@@ -74,7 +209,9 @@ export function diffRoutineDualWriteOps(
       dateKey: split.dateKey,
     });
   }
+  adds.sort(byHabitThenDate);
 
+  const removes: CompletionRemoveOp[] = [];
   for (const key of prevSet) {
     if (nextSet.has(key)) continue;
     const split = splitCompletionKey(key);
@@ -85,27 +222,238 @@ export function diffRoutineDualWriteOps(
       dateKey: split.dateKey,
     });
   }
+  removes.sort(byHabitThenDate);
 
-  for (const [habitId, nextName] of nextHabitNames) {
-    const prevName = prevHabitNames.get(habitId);
+  ops.push(...adds, ...removes);
+}
+
+function diffHabitRenameOps(
+  prev: RoutineState,
+  next: RoutineState,
+  ops: RoutineDualWriteOp[],
+): void {
+  const prevNames = new Map<string, string>();
+  for (const h of prev.habits) prevNames.set(h.id, h.name);
+  const nextNames = new Map<string, string>();
+  for (const h of next.habits) nextNames.set(h.id, h.name);
+
+  const renames: HabitRenameOp[] = [];
+  for (const [habitId, nextName] of nextNames) {
+    const prevName = prevNames.get(habitId);
     if (typeof prevName !== "string") continue;
     if (prevName === nextName) continue;
     renames.push({ kind: "habit-rename", habitId, prevName, nextName });
   }
-
-  adds.sort(byHabitThenDate);
-  removes.sort(byHabitThenDate);
   renames.sort((a, b) =>
     a.habitId < b.habitId ? -1 : a.habitId > b.habitId ? 1 : 0,
   );
-
-  return [...adds, ...removes, ...renames];
+  ops.push(...renames);
 }
 
-/** Build the canonical id used as the SQLite primary key for completions. */
-export function buildCompletionRowId(habitId: string, dateKey: string): string {
-  return `${habitId}:${dateKey}`;
+// -----------------------------------------------------------------------
+// Stage 10 diff helpers
+// -----------------------------------------------------------------------
+
+function diffHabitEntityOps(
+  prev: RoutineState,
+  next: RoutineState,
+  ops: RoutineDualWriteOp[],
+): void {
+  diffEntityArray(
+    prev.habits,
+    next.habits,
+    (h) => h.id,
+    habitChanged,
+    (h) => ops.push({ kind: "habit-upsert", habit: h }),
+    (id) => ops.push({ kind: "habit-delete", habitId: id }),
+  );
 }
+
+function diffTagOps(
+  prev: RoutineState,
+  next: RoutineState,
+  ops: RoutineDualWriteOp[],
+): void {
+  diffEntityArray(
+    prev.tags,
+    next.tags,
+    (t) => t.id,
+    tagChanged,
+    (t) => ops.push({ kind: "tag-upsert", tag: t }),
+    (id) => ops.push({ kind: "tag-delete", tagId: id }),
+  );
+}
+
+function diffCategoryOps(
+  prev: RoutineState,
+  next: RoutineState,
+  ops: RoutineDualWriteOp[],
+): void {
+  diffEntityArray(
+    prev.categories,
+    next.categories,
+    (c) => c.id,
+    categoryChanged,
+    (c) => ops.push({ kind: "category-upsert", category: c }),
+    (id) => ops.push({ kind: "category-delete", categoryId: id }),
+  );
+}
+
+function diffPrefsOps(
+  prev: RoutineState,
+  next: RoutineState,
+  ops: RoutineDualWriteOp[],
+): void {
+  if (prev.prefs === next.prefs) return;
+  if (JSON.stringify(prev.prefs) === JSON.stringify(next.prefs)) return;
+  ops.push({ kind: "prefs-set", prefs: next.prefs });
+}
+
+function diffPushupOps(
+  prev: RoutineState,
+  next: RoutineState,
+  ops: RoutineDualWriteOp[],
+): void {
+  if (prev.pushupsByDate === next.pushupsByDate) return;
+  const pushups: PushupUpsertOp[] = [];
+  const allKeys = new Set([
+    ...Object.keys(prev.pushupsByDate ?? {}),
+    ...Object.keys(next.pushupsByDate ?? {}),
+  ]);
+  for (const dateKey of allKeys) {
+    const prevVal = (prev.pushupsByDate ?? {})[dateKey] ?? 0;
+    const nextVal = (next.pushupsByDate ?? {})[dateKey] ?? 0;
+    if (prevVal !== nextVal) {
+      pushups.push({ kind: "pushup-upsert", dateKey, reps: nextVal });
+    }
+  }
+  pushups.sort((a, b) =>
+    a.dateKey < b.dateKey ? -1 : a.dateKey > b.dateKey ? 1 : 0,
+  );
+  ops.push(...pushups);
+}
+
+function diffHabitOrderOps(
+  prev: RoutineState,
+  next: RoutineState,
+  ops: RoutineDualWriteOp[],
+): void {
+  if (prev.habitOrder === next.habitOrder) return;
+  const prevOrder = prev.habitOrder ?? [];
+  const nextOrder = next.habitOrder ?? [];
+  if (
+    prevOrder.length === nextOrder.length &&
+    prevOrder.every((id, i) => id === nextOrder[i])
+  ) {
+    return;
+  }
+  ops.push({ kind: "habit-order-set", orderedIds: nextOrder });
+}
+
+function diffCompletionNoteOps(
+  prev: RoutineState,
+  next: RoutineState,
+  ops: RoutineDualWriteOp[],
+): void {
+  if (prev.completionNotes === next.completionNotes) return;
+  const prevNotes = prev.completionNotes ?? {};
+  const nextNotes = next.completionNotes ?? {};
+  const upserts: CompletionNoteUpsertOp[] = [];
+  const deletes: CompletionNoteDeleteOp[] = [];
+  const allKeys = new Set([
+    ...Object.keys(prevNotes),
+    ...Object.keys(nextNotes),
+  ]);
+  for (const noteKey of allKeys) {
+    const prevVal = prevNotes[noteKey] ?? "";
+    const nextVal = nextNotes[noteKey] ?? "";
+    if (prevVal === nextVal) continue;
+    if (nextVal.trim() === "") {
+      deletes.push({ kind: "completion-note-delete", noteKey });
+    } else {
+      upserts.push({ kind: "completion-note-upsert", noteKey, note: nextVal });
+    }
+  }
+  upserts.sort((a, b) =>
+    a.noteKey < b.noteKey ? -1 : a.noteKey > b.noteKey ? 1 : 0,
+  );
+  deletes.sort((a, b) =>
+    a.noteKey < b.noteKey ? -1 : a.noteKey > b.noteKey ? 1 : 0,
+  );
+  ops.push(...upserts, ...deletes);
+}
+
+// -----------------------------------------------------------------------
+// Generic entity-array diff (mirrors Fizruk's `diffArray`)
+// -----------------------------------------------------------------------
+
+function diffEntityArray<T extends { readonly id: string }>(
+  prev: readonly T[],
+  next: readonly T[],
+  getId: (item: T) => string,
+  hasChanged: (prev: T, next: T) => boolean,
+  onUpsert: (item: T) => void,
+  onDelete: (id: string) => void,
+): void {
+  const prevMap = new Map<string, T>();
+  for (const item of prev) prevMap.set(getId(item), item);
+  const nextMap = new Map<string, T>();
+  for (const item of next) nextMap.set(getId(item), item);
+
+  const sortedNextIds = [...nextMap.keys()].sort();
+  for (const id of sortedNextIds) {
+    const nextItem = nextMap.get(id)!;
+    const prevItem = prevMap.get(id);
+    if (!prevItem) {
+      onUpsert(nextItem);
+    } else if (prevItem !== nextItem && hasChanged(prevItem, nextItem)) {
+      onUpsert(nextItem);
+    }
+  }
+
+  const sortedPrevIds = [...prevMap.keys()].sort();
+  for (const id of sortedPrevIds) {
+    if (!nextMap.has(id)) {
+      onDelete(id);
+    }
+  }
+}
+
+function habitChanged(prev: Habit, next: Habit): boolean {
+  return (
+    prev.name !== next.name ||
+    prev.emoji !== next.emoji ||
+    prev.categoryId !== next.categoryId ||
+    prev.archived !== next.archived ||
+    prev.paused !== next.paused ||
+    prev.recurrence !== next.recurrence ||
+    prev.startDate !== next.startDate ||
+    prev.endDate !== next.endDate ||
+    prev.timeOfDay !== next.timeOfDay ||
+    prev.tagIds !== next.tagIds ||
+    prev.reminderTimes !== next.reminderTimes ||
+    prev.weekdays !== next.weekdays ||
+    prev.createdAt !== next.createdAt
+  );
+}
+
+function tagChanged(
+  prev: { id: string; name: string; scope?: string },
+  next: { id: string; name: string; scope?: string },
+): boolean {
+  return prev.name !== next.name || prev.scope !== next.scope;
+}
+
+function categoryChanged(
+  prev: { id: string; name: string; emoji?: string },
+  next: { id: string; name: string; emoji?: string },
+): boolean {
+  return prev.name !== next.name || prev.emoji !== next.emoji;
+}
+
+// -----------------------------------------------------------------------
+// Completion set helpers (unchanged from PR #024)
+// -----------------------------------------------------------------------
 
 const SEPARATOR = "\u0000";
 

--- a/apps/mobile/src/modules/routine/lib/dualWrite/index.ts
+++ b/apps/mobile/src/modules/routine/lib/dualWrite/index.ts
@@ -2,11 +2,17 @@ import type { RoutineState } from "@sergeant/routine-domain";
 import type { SqliteMigrationClient } from "@sergeant/db-schema/migrate/sqlite";
 
 import {
+  recordDualWriteOutcome,
+  recordParityCheck,
+  recordReadFallback,
+} from "../../../../lib/observability/dualWriteTelemetry";
+import {
   applyRoutineDualWriteOps,
   type ApplyDualWriteResult,
   type DualWriteLogger,
 } from "./adapter";
 import { diffRoutineDualWriteOps } from "./diff";
+import { probeRoutineParity } from "./parity";
 
 /**
  * Orchestrator for the routine dual-write layer (mobile mirror of
@@ -21,10 +27,14 @@ import { diffRoutineDualWriteOps } from "./diff";
  * Stage 8 PR #056r removed `isEnabled()` from the context — the
  * legacy `feature.routine.sqlite_v2.dual_write` flag was default-on
  * with no toggle path remaining. Registration is `userId`-gated only.
- * The MMKV write stays as the source-of-truth for non-completion
- * routine state (habits / tags / categories / prefs / pushups /
- * habitOrder / completionNotes) because the routine SQLite schema is
- * narrower (only `routine_entries` + `routine_streaks`).
+ *
+ * **Stage 10 mobile mirror** extends the orchestrator from the
+ * completion-only mirror (`routine_entries` only) to the full
+ * `RoutineState` (all 7 new tables shipped in PR #070r-schema). The
+ * MMKV write stays as the source-of-truth for the read path on
+ * mobile until the MMKV-write drop follow-up — but the SQLite mirror
+ * is now complete enough that a parity probe can validate
+ * convergence.
  *
  * Decoupling: see the web copy for the rationale (avoids cycles
  * between LS layer ↔ auth ↔ sqlite singleton, keeps tests independent).
@@ -56,7 +66,23 @@ export function isRoutineDualWriteRegistered(): boolean {
   return registeredContext !== null;
 }
 
+/**
+ * Run the dual-write pipeline for a `prev → next` MMKV-state transition.
+ *
+ * Every call records its terminal outcome through
+ * `recordDualWriteOutcome("routine", …)` so the Stage 8 decision-gate
+ * counters stay current on mobile Sentry breadcrumbs.
+ */
 export async function dualWriteRoutineState(
+  prev: RoutineState,
+  next: RoutineState,
+): Promise<DualWriteOutcome> {
+  const outcome = await runDualWriteRoutineState(prev, next);
+  recordDualWriteOutcome("routine", outcome);
+  return outcome;
+}
+
+async function runDualWriteRoutineState(
   prev: RoutineState,
   next: RoutineState,
 ): Promise<DualWriteOutcome> {
@@ -93,6 +119,25 @@ export async function dualWriteRoutineState(
     clientTs: ctx.getNow(),
     logger: ctx.logger,
   });
+
+  // Stage 8 parity probe — best-effort: never throws, never disturbs
+  // the dual-write outcome. A failed probe-read is tagged distinctly
+  // (`recordReadFallback`) so triage can tell `SELECT failing` apart
+  // from a real MMKV↔SQLite divergence (`recordParityCheck("…",
+  // "mismatch", …)`). Stage 10 mobile mirror extends the probe to
+  // all 7 entity classes — see `./parity.ts`.
+  try {
+    const parity = await probeRoutineParity(client, userId, next);
+    recordParityCheck("routine", parity.result, parity.details);
+  } catch (err) {
+    recordReadFallback(
+      "routine",
+      err instanceof Error
+        ? `parity-probe-failed: ${err.message}`
+        : "parity-probe-failed",
+    );
+  }
+
   return { status: "applied", result };
 }
 

--- a/apps/mobile/src/modules/routine/lib/dualWrite/parity.ts
+++ b/apps/mobile/src/modules/routine/lib/dualWrite/parity.ts
@@ -1,0 +1,344 @@
+import type { RoutineState } from "@sergeant/routine-domain";
+import type { SqliteMigrationClient } from "@sergeant/db-schema/migrate/sqlite";
+
+/**
+ * Parity probe for the Routine SQLite dual-write layer (mobile mirror
+ * of `apps/web/src/modules/routine/lib/dualWrite/parity.ts`).
+ *
+ * Stage 8 §3 of `docs/planning/storage-roadmap.md` defines a
+ * `<module>.sqlite.dualwrite.parity` decision-gate metric. Mobile —
+ * historically — only emitted dual-write ops for completions, so the
+ * mobile probe stayed completions-only. **Stage 10 mobile mirror**
+ * extends the probe to all 7 new Stage 10 tables so the LS
+ * (MMKV) ↔ SQLite invariant can be verified for the full
+ * `RoutineState`:
+ *
+ *   - `routine_habits` (id-set parity)
+ *   - `routine_tags` (id-set parity)
+ *   - `routine_categories` (id-set parity)
+ *   - `routine_prefs` (JSON blob parity)
+ *   - `routine_pushups` (date-key set parity)
+ *   - `routine_habit_order` (JSON array parity)
+ *   - `routine_completion_notes` (note-key set parity)
+ *
+ * The probe is best-effort: it must NEVER throw, and any read failure
+ * is surfaced as a `read.fallback` — distinct from a real parity
+ * mismatch — so triage can tell `SELECT failing` apart from `LS and
+ * SQLite genuinely disagree`. The orchestrator (`./index.ts`)
+ * implements that distinction.
+ */
+
+interface ParityProbeOutcome {
+  result: "match" | "mismatch";
+  details: Record<string, unknown>;
+}
+
+/**
+ * Read the active Routine state from SQLite for `userId` and compare
+ * it to the LS-derived `next`. All entity classes are compared by
+ * id-set cardinality; singleton tables (prefs, habit_order) are
+ * compared by JSON equality.
+ *
+ * The function may throw if any SQLite read fails. The caller is
+ * expected to catch and route that to `recordReadFallback` rather
+ * than `recordParityCheck("…", "mismatch", …)` — see `./index.ts`.
+ */
+export async function probeRoutineParity(
+  client: SqliteMigrationClient,
+  userId: string,
+  next: RoutineState,
+): Promise<ParityProbeOutcome> {
+  // --- Completions (routine_entries) ---
+  const completionsDiff = await probeCompletions(client, userId, next);
+
+  // --- Habits (routine_habits) ---
+  const habitsDiff = await probeIdSet(
+    client,
+    "routine_habits",
+    userId,
+    next.habits.map((h) => h.id),
+  );
+
+  // --- Tags (routine_tags) ---
+  const tagsDiff = await probeIdSet(
+    client,
+    "routine_tags",
+    userId,
+    next.tags.map((t) => t.id),
+  );
+
+  // --- Categories (routine_categories) ---
+  const categoriesDiff = await probeIdSet(
+    client,
+    "routine_categories",
+    userId,
+    next.categories.map((c) => c.id),
+  );
+
+  // --- Pushups (routine_pushups) ---
+  const pushupsDiff = await probePushups(client, userId, next);
+
+  // --- Completion notes (routine_completion_notes) ---
+  const notesDiff = await probeNotes(client, userId, next);
+
+  // --- Prefs (routine_prefs) — JSON blob equality ---
+  const prefsDiff = await probePrefs(client, userId, next);
+
+  // --- Habit order (routine_habit_order) — JSON array equality ---
+  const orderDiff = await probeHabitOrder(client, userId, next);
+
+  const allMatch =
+    completionsDiff.match &&
+    habitsDiff.match &&
+    tagsDiff.match &&
+    categoriesDiff.match &&
+    pushupsDiff.match &&
+    notesDiff.match &&
+    prefsDiff.match &&
+    orderDiff.match;
+
+  const details: Record<string, unknown> = {
+    completions: completionsDiff.details,
+    habits: habitsDiff.details,
+    tags: tagsDiff.details,
+    categories: categoriesDiff.details,
+    pushups: pushupsDiff.details,
+    notes: notesDiff.details,
+    prefs: prefsDiff.details,
+    order: orderDiff.details,
+  };
+
+  return { result: allMatch ? "match" : "mismatch", details };
+}
+
+// -----------------------------------------------------------------------
+// Completions (routine_entries)
+// -----------------------------------------------------------------------
+
+interface DiffResult {
+  match: boolean;
+  details: Record<string, unknown>;
+}
+
+async function probeCompletions(
+  client: SqliteMigrationClient,
+  userId: string,
+  next: RoutineState,
+): Promise<DiffResult> {
+  const rows = await client.all<{ id: string }>(
+    `SELECT id FROM routine_entries
+       WHERE user_id = ? AND deleted_at IS NULL`,
+    [userId],
+  );
+
+  const sqliteSet = new Set<string>();
+  for (const row of rows) {
+    const sep = row.id.indexOf(":");
+    if (sep <= 0 || sep === row.id.length - 1) continue;
+    const dateKey = row.id.slice(sep + 1);
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(dateKey)) continue;
+    sqliteSet.add(row.id);
+  }
+
+  const lsSet = buildExpectedCompletionSet(next.completions);
+  return compareIdSets(lsSet, sqliteSet);
+}
+
+// -----------------------------------------------------------------------
+// Generic id-set probe (habits, tags, categories)
+// -----------------------------------------------------------------------
+
+async function probeIdSet(
+  client: SqliteMigrationClient,
+  table: string,
+  userId: string,
+  lsIds: string[],
+): Promise<DiffResult> {
+  const rows = await client.all<{ id: string }>(
+    `SELECT id FROM ${table}
+       WHERE user_id = ? AND deleted_at IS NULL`,
+    [userId],
+  );
+  const sqliteSet = new Set<string>();
+  for (const row of rows) {
+    if (typeof row.id === "string" && row.id.length > 0) sqliteSet.add(row.id);
+  }
+  const lsSet = new Set(lsIds);
+  return compareIdSets(lsSet, sqliteSet);
+}
+
+// -----------------------------------------------------------------------
+// Pushups (routine_pushups) — compare by date_key set
+// -----------------------------------------------------------------------
+
+async function probePushups(
+  client: SqliteMigrationClient,
+  userId: string,
+  next: RoutineState,
+): Promise<DiffResult> {
+  const rows = await client.all<{ date_key: string; reps: number }>(
+    `SELECT date_key, reps FROM routine_pushups WHERE user_id = ?`,
+    [userId],
+  );
+  const sqliteMap = new Map<string, number>();
+  for (const row of rows) sqliteMap.set(row.date_key, row.reps);
+
+  const lsMap = next.pushupsByDate ?? {};
+  const allKeys = new Set([...Object.keys(lsMap), ...sqliteMap.keys()]);
+
+  let mismatch = false;
+  let lsOnly = 0;
+  let sqliteOnly = 0;
+  for (const key of allKeys) {
+    const lsVal = lsMap[key] ?? 0;
+    const sqliteVal = sqliteMap.get(key) ?? 0;
+    if (lsVal !== sqliteVal) {
+      mismatch = true;
+      if (sqliteVal === 0) lsOnly += 1;
+      else if (lsVal === 0) sqliteOnly += 1;
+    }
+  }
+
+  if (!mismatch) {
+    return {
+      match: true,
+      details: { ls: Object.keys(lsMap).length, sqlite: sqliteMap.size },
+    };
+  }
+  return {
+    match: false,
+    details: {
+      ls: Object.keys(lsMap).length,
+      sqlite: sqliteMap.size,
+      lsOnly,
+      sqliteOnly,
+    },
+  };
+}
+
+// -----------------------------------------------------------------------
+// Completion notes (routine_completion_notes) — compare by note_key set
+// -----------------------------------------------------------------------
+
+async function probeNotes(
+  client: SqliteMigrationClient,
+  userId: string,
+  next: RoutineState,
+): Promise<DiffResult> {
+  const rows = await client.all<{ note_key: string }>(
+    `SELECT note_key FROM routine_completion_notes
+       WHERE user_id = ? AND deleted_at IS NULL`,
+    [userId],
+  );
+  const sqliteSet = new Set<string>();
+  for (const row of rows) sqliteSet.add(row.note_key);
+
+  const lsNotes = next.completionNotes ?? {};
+  const lsSet = new Set<string>();
+  for (const [key, val] of Object.entries(lsNotes)) {
+    if (typeof val === "string" && val.trim() !== "") lsSet.add(key);
+  }
+
+  return compareIdSets(lsSet, sqliteSet);
+}
+
+// -----------------------------------------------------------------------
+// Prefs (routine_prefs) — JSON blob equality
+// -----------------------------------------------------------------------
+
+async function probePrefs(
+  client: SqliteMigrationClient,
+  userId: string,
+  next: RoutineState,
+): Promise<DiffResult> {
+  const rows = await client.all<{ data_json: string }>(
+    `SELECT data_json FROM routine_prefs WHERE user_id = ?`,
+    [userId],
+  );
+  const sqliteJson = rows.length > 0 ? rows[0]!.data_json : "{}";
+  const lsJson = JSON.stringify(next.prefs ?? {});
+  const match = sqliteJson === lsJson;
+  return {
+    match,
+    details: match
+      ? { equal: true }
+      : { lsLen: lsJson.length, sqliteLen: sqliteJson.length },
+  };
+}
+
+// -----------------------------------------------------------------------
+// Habit order (routine_habit_order) — JSON array equality
+// -----------------------------------------------------------------------
+
+async function probeHabitOrder(
+  client: SqliteMigrationClient,
+  userId: string,
+  next: RoutineState,
+): Promise<DiffResult> {
+  const rows = await client.all<{ order_json: string }>(
+    `SELECT order_json FROM routine_habit_order WHERE user_id = ?`,
+    [userId],
+  );
+  const sqliteJson = rows.length > 0 ? rows[0]!.order_json : "[]";
+  const lsJson = JSON.stringify(next.habitOrder ?? []);
+  const match = sqliteJson === lsJson;
+  return {
+    match,
+    details: match
+      ? { equal: true }
+      : { lsLen: lsJson.length, sqliteLen: sqliteJson.length },
+  };
+}
+
+// -----------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------
+
+function buildExpectedCompletionSet(
+  completions: Record<string, string[]> | undefined,
+): Set<string> {
+  const out = new Set<string>();
+  if (!completions || typeof completions !== "object") return out;
+  for (const [habitId, dateKeys] of Object.entries(completions)) {
+    if (!Array.isArray(dateKeys)) continue;
+    for (const dk of dateKeys) {
+      if (typeof dk !== "string" || dk.length === 0) continue;
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(dk)) continue;
+      out.add(`${habitId}:${dk}`);
+    }
+  }
+  return out;
+}
+
+function compareIdSets(lsSet: Set<string>, sqliteSet: Set<string>): DiffResult {
+  if (lsSet.size === sqliteSet.size) {
+    let allMatch = true;
+    for (const key of lsSet) {
+      if (!sqliteSet.has(key)) {
+        allMatch = false;
+        break;
+      }
+    }
+    if (allMatch) {
+      return {
+        match: true,
+        details: { ls: lsSet.size, sqlite: sqliteSet.size },
+      };
+    }
+  }
+
+  let lsOnly = 0;
+  let sqliteOnly = 0;
+  for (const key of lsSet) if (!sqliteSet.has(key)) lsOnly += 1;
+  for (const key of sqliteSet) if (!lsSet.has(key)) sqliteOnly += 1;
+
+  return {
+    match: false,
+    details: {
+      ls: lsSet.size,
+      sqlite: sqliteSet.size,
+      lsOnly,
+      sqliteOnly,
+    },
+  };
+}

--- a/apps/mobile/src/modules/routine/lib/sqliteReader.ts
+++ b/apps/mobile/src/modules/routine/lib/sqliteReader.ts
@@ -1,12 +1,41 @@
 /**
- * SQLite-backed read path for routine completions (mobile).
+ * SQLite-backed read path for routine state fields (mobile).
  *
- * Mirror of `apps/web/src/modules/routine/lib/sqliteReader.ts`.
- * See the web copy for the full design rationale (PR #025 of
+ * Mirror of `apps/web/src/modules/routine/lib/sqliteReader.ts`. See
+ * the web copy for the full design rationale (PR #025 of
  * `docs/planning/storage-roadmap.md`).
+ *
+ * **Stage 10 mobile mirror** extends the reader from completions-only
+ * (routine_entries) to all 7 new tables introduced in PR #070r-schema:
+ *
+ *   - `routine_habits` → `Habit[]`
+ *   - `routine_tags` → `Tag[]`
+ *   - `routine_categories` → `Category[]`
+ *   - `routine_prefs` → `RoutinePrefs`
+ *   - `routine_pushups` → `Record<string, number>`
+ *   - `routine_habit_order` → `string[]`
+ *   - `routine_completion_notes` → `Record<string, string>`
+ *
+ * The reader is synchronous-looking but wraps the lazy expo-sqlite
+ * client. Cache is populated by `refreshSqliteRoutineState()`, which
+ * is called once at boot (after migration) and after every dual-write
+ * cycle. MMKV remains the source-of-truth for the mobile read path
+ * until the Stage 10 mobile MMKV-write drop follow-up; this cache
+ * exists today so parity probes have a canonical SQLite snapshot to
+ * compare LS against.
  */
 
 import type { SqliteMigrationClient } from "@sergeant/db-schema/migrate/sqlite";
+import type {
+  Habit,
+  Tag,
+  Category,
+  RoutinePrefs,
+} from "@sergeant/routine-domain";
+
+// -----------------------------------------------------------------------
+// Legacy completions cache (unchanged API, still used by loadRoutineState)
+// -----------------------------------------------------------------------
 
 export interface SqliteCompletionsCache {
   completions: Record<string, string[]>;
@@ -56,4 +85,259 @@ export async function refreshSqliteCompletions(
 
 export function clearSqliteCompletionsCache(): void {
   cache = { ...EMPTY_CACHE };
+}
+
+// -----------------------------------------------------------------------
+// Stage 10: full-state SQLite read cache
+// -----------------------------------------------------------------------
+
+export interface SqliteRoutineStateCache {
+  habits: Habit[];
+  tags: Tag[];
+  categories: Category[];
+  prefs: RoutinePrefs;
+  pushupsByDate: Record<string, number>;
+  habitOrder: string[];
+  completionNotes: Record<string, string>;
+  refreshedAt: string | null;
+}
+
+const EMPTY_STATE_CACHE: SqliteRoutineStateCache = {
+  habits: [],
+  tags: [],
+  categories: [],
+  prefs: {},
+  pushupsByDate: {},
+  habitOrder: [],
+  completionNotes: {},
+  refreshedAt: null,
+};
+
+let stateCache: SqliteRoutineStateCache = { ...EMPTY_STATE_CACHE };
+
+/** Returns the current full-state cache (sync, zero-cost). */
+export function getCachedSqliteRoutineState(): SqliteRoutineStateCache {
+  return stateCache;
+}
+
+/**
+ * Refresh the full-state cache from all Stage 10 SQLite tables.
+ * Call after boot migration, after dual-write, and after sync pull.
+ */
+export async function refreshSqliteRoutineState(
+  client: SqliteMigrationClient,
+  userId: string,
+): Promise<SqliteRoutineStateCache> {
+  const [habits, tags, categories, prefs, pushups, order, notes] =
+    await Promise.all([
+      readHabits(client, userId),
+      readTags(client, userId),
+      readCategories(client, userId),
+      readPrefs(client, userId),
+      readPushups(client, userId),
+      readHabitOrder(client, userId),
+      readCompletionNotes(client, userId),
+    ]);
+
+  stateCache = {
+    habits,
+    tags,
+    categories,
+    prefs,
+    pushupsByDate: pushups,
+    habitOrder: order,
+    completionNotes: notes,
+    refreshedAt: new Date().toISOString(),
+  };
+  return stateCache;
+}
+
+/** Reset full-state cache — used by tests. */
+export function clearSqliteRoutineStateCache(): void {
+  stateCache = { ...EMPTY_STATE_CACHE };
+}
+
+/**
+ * Test helper: seed the full-state cache directly without running
+ * migrations / SQLite queries.
+ */
+export function __setRoutineSqliteStateCacheForTests(
+  partial: Partial<SqliteRoutineStateCache>,
+): void {
+  stateCache = {
+    ...EMPTY_STATE_CACHE,
+    refreshedAt: new Date().toISOString(),
+    ...partial,
+  };
+}
+
+/**
+ * Test helper: seed the legacy completions cache.
+ */
+export function __setRoutineSqliteCompletionsCacheForTests(
+  partial: Partial<SqliteCompletionsCache>,
+): void {
+  cache = {
+    ...EMPTY_CACHE,
+    refreshedAt: new Date().toISOString(),
+    ...partial,
+  };
+}
+
+// -----------------------------------------------------------------------
+// Per-table readers (Stage 10)
+// -----------------------------------------------------------------------
+
+interface HabitRow extends Record<string, unknown> {
+  id: string;
+  name: string;
+  emoji: string;
+  tag_ids_json: string;
+  category_id: string | null;
+  archived: number;
+  paused: number;
+  recurrence: string;
+  start_date: string | null;
+  end_date: string | null;
+  time_of_day: string;
+  reminder_times_json: string;
+  weekdays_json: string;
+  created_at: string;
+}
+
+async function readHabits(
+  client: SqliteMigrationClient,
+  userId: string,
+): Promise<Habit[]> {
+  const rows = await client.all<HabitRow>(
+    `SELECT id, name, emoji, tag_ids_json, category_id,
+            archived, paused, recurrence, start_date, end_date,
+            time_of_day, reminder_times_json, weekdays_json, created_at
+       FROM routine_habits
+      WHERE user_id = ? AND deleted_at IS NULL
+      ORDER BY id ASC`,
+    [userId],
+  );
+  return rows.map((r) => ({
+    id: r.id,
+    name: r.name,
+    emoji: r.emoji || undefined,
+    tagIds: safeJsonParse<string[]>(r.tag_ids_json, []),
+    categoryId: r.category_id ?? undefined,
+    archived: r.archived === 1,
+    paused: r.paused === 1,
+    recurrence: r.recurrence,
+    startDate: r.start_date ?? undefined,
+    endDate: r.end_date ?? undefined,
+    timeOfDay: r.time_of_day || undefined,
+    reminderTimes: safeJsonParse<string[]>(r.reminder_times_json, []),
+    weekdays: safeJsonParse<number[]>(r.weekdays_json, []),
+    createdAt: r.created_at,
+  }));
+}
+
+interface TagRow extends Record<string, unknown> {
+  id: string;
+  name: string;
+  scope: string;
+}
+
+async function readTags(
+  client: SqliteMigrationClient,
+  userId: string,
+): Promise<Tag[]> {
+  const rows = await client.all<TagRow>(
+    `SELECT id, name, scope FROM routine_tags
+      WHERE user_id = ? AND deleted_at IS NULL ORDER BY id ASC`,
+    [userId],
+  );
+  return rows.map((r) => ({
+    id: r.id,
+    name: r.name,
+    scope: r.scope || undefined,
+  }));
+}
+
+interface CategoryRow extends Record<string, unknown> {
+  id: string;
+  name: string;
+  emoji: string;
+}
+
+async function readCategories(
+  client: SqliteMigrationClient,
+  userId: string,
+): Promise<Category[]> {
+  const rows = await client.all<CategoryRow>(
+    `SELECT id, name, emoji FROM routine_categories
+      WHERE user_id = ? AND deleted_at IS NULL ORDER BY id ASC`,
+    [userId],
+  );
+  return rows.map((r) => ({
+    id: r.id,
+    name: r.name,
+    emoji: r.emoji || undefined,
+  }));
+}
+
+async function readPrefs(
+  client: SqliteMigrationClient,
+  userId: string,
+): Promise<RoutinePrefs> {
+  const rows = await client.all<
+    { data_json: string } & Record<string, unknown>
+  >(`SELECT data_json FROM routine_prefs WHERE user_id = ?`, [userId]);
+  if (rows.length === 0) return {};
+  return safeJsonParse<RoutinePrefs>(rows[0]!.data_json, {});
+}
+
+async function readPushups(
+  client: SqliteMigrationClient,
+  userId: string,
+): Promise<Record<string, number>> {
+  const rows = await client.all<
+    { date_key: string; reps: number } & Record<string, unknown>
+  >(`SELECT date_key, reps FROM routine_pushups WHERE user_id = ?`, [userId]);
+  const out: Record<string, number> = {};
+  for (const row of rows) out[row.date_key] = row.reps;
+  return out;
+}
+
+async function readHabitOrder(
+  client: SqliteMigrationClient,
+  userId: string,
+): Promise<string[]> {
+  const rows = await client.all<
+    { order_json: string } & Record<string, unknown>
+  >(`SELECT order_json FROM routine_habit_order WHERE user_id = ?`, [userId]);
+  if (rows.length === 0) return [];
+  return safeJsonParse<string[]>(rows[0]!.order_json, []);
+}
+
+async function readCompletionNotes(
+  client: SqliteMigrationClient,
+  userId: string,
+): Promise<Record<string, string>> {
+  const rows = await client.all<
+    { note_key: string; note: string } & Record<string, unknown>
+  >(
+    `SELECT note_key, note FROM routine_completion_notes
+      WHERE user_id = ? AND deleted_at IS NULL`,
+    [userId],
+  );
+  const out: Record<string, string> = {};
+  for (const row of rows) out[row.note_key] = row.note;
+  return out;
+}
+
+// -----------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------
+
+function safeJsonParse<T>(json: string, fallback: T): T {
+  try {
+    return JSON.parse(json) as T;
+  } catch {
+    return fallback;
+  }
 }


### PR DESCRIPTION
## Summary

Mobile follow-up to **Stage 10 (web)**, which landed in [#2279](https://github.com/Skords-01/Sergeant/pull/2279) (schema, 7 нових Routine SQLite/Pg таблиць + Drizzle + client `004_routine_full_state.sql` + server `050_routine_full_state.sql`) і [#2281](https://github.com/Skords-01/Sergeant/pull/2281) (web `dualWrite/diff.ts` + `parity.ts` + `sqliteReader.ts` + `adapter.ts` extended до full-state).

На mobile dual-write для Routine з часів SPIKE [#022](https://github.com/Skords-01/Sergeant/pull/2118) залишався **completion-only** — `apps/mobile/src/modules/routine/lib/dualWrite/diff.ts` емітив лише `completion-add` / `completion-remove` / `habit-rename`, а 7 нових Routine SQLite таблиць (`routine_habits`, `routine_tags`, `routine_categories`, `routine_prefs`, `routine_pushups`, `routine_habit_order`, `routine_completion_notes`) на mobile-клієнтах залишалися порожніми. Цей PR закриває цей gap — формалізований у `docs/planning/storage-roadmap.md` як рядок "10 — Routine SQLite full-state (mobile mirror)" (PR [#2285](https://github.com/Skords-01/Sergeant/pull/2285)).

Що змінено (тільки `apps/mobile/src/modules/routine/**` + один новий telemetry-файл):

- **`dualWrite/diff.ts`**: `RoutineDualWriteOp` розширено з 3 legacy variants до повного Stage 10 set — `habit/tag/category/prefs/pushup/habit-order/completion-note` upserts + deletes (точне дзеркало `apps/web/.../dualWrite/diff.ts` із [#2281](https://github.com/Skords-01/Sergeant/pull/2281)).
- **`dualWrite/adapter.ts`**: apply paths для всіх 14 op kinds. Кожен upsert LWW-guarded — incoming op перезаписує row тільки якщо `clientTs` строго новіший за `updated_at` (як у web adapter).
- **`sqliteReader.ts`**: warm cache тепер hydrate з усіх 7 нових таблиць замість тільки `routine_completions`.
- **`dualWrite/parity.ts`** (new): best-effort LS↔SQLite id-set / blob comparison для 7 entity classes, повертає `{ result: 'match' | 'mismatch', details }` — дає `<m>.sqlite.dualwrite.parity` decision-gate сигнал.
- **`apps/mobile/src/lib/observability/dualWriteTelemetry.ts`** (new): mobile-mirror `apps/web/src/core/observability/dualWriteTelemetry.ts`. Експорти: `recordDualWriteOutcome` / `recordReadFallback` / `recordParityCheck`. Breadcrumb-сторона працює через `addSentryBreadcrumb`; tag-сторона — no-op до моменту, коли mobile отримає `setSentryTag` (зберіг той самий surface, що й web — wiring буде однорядковим).
- **`dualWrite/index.ts`**: orchestrator тепер записує dual-write outcome і запускає parity-probe **після** того, як adapter застосував ops. Probe загорнутий у try/catch — read-failures ідуть у `recordReadFallback` (відрізняється від реальних LS↔SQLite divergences, які йдуть через `recordParityCheck(..., 'mismatch')`). Probe ніколи не зриває dual-write outcome.

**MMKV-write на mobile НЕ дропається** в цьому PR — це окремий follow-up (`#057r-tombstone-mobile`), щоб parity-probe спочатку запекся у проді.

## Governing Skill

- Primary skill: `.agents/skills/sergeant-mobile-expo/SKILL.md` — поверхня зміни — `apps/mobile/src/modules/routine/**` + `apps/mobile/src/lib/observability/`.
- Secondary skill (if truly needed): n/a — зміни обмежені mobile dual-write шаром, не торкають schema (Stage 10 schema вже landed у [#2279](https://github.com/Skords-01/Sergeant/pull/2279)) і не торкають web.

## Playbook

- Primary playbook: n/a
- Why this playbook: —
- If no playbook matched, why: для Stage 8/Stage 10 dual-write rollout-у виділеного playbook нема. Це восьмий схожий PR у серії і дзеркалить web-варіант [#2281](https://github.com/Skords-01/Sergeant/pull/2281) майже 1-в-1.

## Verification

```bash
pnpm --filter @sergeant/mobile lint
pnpm --filter @sergeant/mobile typecheck
pnpm --filter @sergeant/mobile exec jest --testPathPattern='(routine|observability/dualWrite)'
```

Локальний результат:

- `pnpm --filter @sergeant/mobile lint` — **0 errors / 0 warnings**.
- `pnpm --filter @sergeant/mobile typecheck` (`tsc -p tsconfig.json --noEmit`) — **0 errors**.
- Routine + observability suite: **14 suites / 104 tests — PASS**, з них:
  - `dualWrite/__tests__/diff.test.ts` — 8 → **23** cases (по одному на кожний Stage 10 op + edge cases).
  - `dualWrite/__tests__/adapter.test.ts` — 7 → **16** cases. Verified: habit upsert з LWW guard, habit delete, tag round-trip, category upsert, prefs set, pushup upsert, habit-order set, completion-note cycle.
  - `dualWrite/__tests__/parity.test.ts` (new) — **6** cases: empty match, full-apply match, missing-habit mismatch, stale-prefs mismatch, order mismatch, empty-notes exclusion.
  - `dualWrite/__tests__/integration.test.ts` — pre-existing 6 cases все ще PASS.

Pre-existing failure у `apps/mobile/src/core/settings/NotificationsSection.test.tsx` (Nutrition reminder prefs) — flake на main, відтворюється і без цих змін; не пов'язана з PR.

Additional checks:

- [x] Local smoke / manual validation completed.
- [x] Surface-specific checks completed.

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. — Stage 10 mobile mirror рядок у `docs/planning/storage-roadmap.md` уже формалізовано в окремому drift PR ([#2285](https://github.com/Skords-01/Sergeant/pull/2285), `21f003cd`); цей PR — code частина.
- [x] I checked whether `AGENTS.md` needed an update. — ні, hard rules не зачіпає.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a (drift вже у [#2285](https://github.com/Skords-01/Sergeant/pull/2285))

## Risk and Rollout

- **User-visible risk:** низький. Dual-write і parity-probe — best-effort фон, обгорнуті в try/catch. Mobile-користувач продовжує читати Routine з MMKV (read-path не змінюється). LWW guard + parity-probe + MMKV-source-of-truth → data-loss risk = 0.
- **Rollout / deploy order:** merge на main → next mobile build (Expo update channel). Без canary per early-stage dev policy.
- **Backout plan:** revert цього PR; mobile повертається до completion-only dual-write поведінки. Без schema-rollback потреб (схема Stage 10 web вже у проді з [#2279](https://github.com/Skords-01/Sergeant/pull/2279)).

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

- Точна сторона дзеркала web [#2281](https://github.com/Skords-01/Sergeant/pull/2281).
- Tag-сторона `dualWriteTelemetry.ts` — no-op до моменту коли mobile отримає `setSentryTag` (breadcrumbs працюють зараз).
- **Out of scope (наступні PR-и):** `#057r-tombstone-mobile` (drop MMKV-write для Routine); wiring `setSentryTag` infra PR.
- Немає нових SQL міграцій / змін у `packages/db-schema` / web / server / api-client.

---

- Devin session: https://app.devin.ai/sessions/d686ee6cadd04be2ae8378903d1fb3f0
- Requested by: dmytro.s.stakhov (@Skords-01)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mobile mirrors Stage 10 Routine dual-write: we now write the full Routine state to SQLite across 7 tables (not just completions). Adds a parity probe and telemetry; the mobile read path stays on MMKV for now.

- New Features
  - Expanded diff/adapter to 14 op kinds with LWW guards, covering `routine_habits`, `routine_tags`, `routine_categories`, `routine_prefs`, `routine_pushups`, `routine_habit_order`, `routine_completion_notes` (plus existing completions/rename).
  - Added parity probe that compares MMKV ↔ SQLite after apply; logs match/mismatch and treats read failures as fallbacks without failing the write.
  - Introduced telemetry hooks: `recordDualWriteOutcome`, `recordReadFallback`, `recordParityCheck` (Sentry breadcrumbs; tag wiring to follow).
  - Extended SQLite reader cache to hydrate from all 7 tables for parity and future use.
  - Orchestrator now records outcomes and runs the probe post-apply. MMKV writes remain; the drop will come in a follow-up.

<sup>Written for commit 5c1c05d42038537b6fa3bb2fa2d9313918c37c0e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

