### PR TITLE
feat(db-schema): #070n-schema — extend Nutrition schema to water_log + shopping_list (Stage 11)

### DIFF
--- a/apps/server/src/migrations/051_nutrition_full_state.down.sql
+++ b/apps/server/src/migrations/051_nutrition_full_state.down.sql
@@ -1,0 +1,10 @@
+-- Rollback for migration 051_nutrition_full_state.sql
+-- (Stage 11 / PR #070n-schema in `docs/planning/storage-roadmap.md`).
+--
+-- Local-only rollback — production never runs `down.sql` (rule #4 in
+-- AGENTS.md). Each statement is `IF EXISTS`-guarded so the file stays
+-- idempotent (rule #4 re-application invariant — the
+-- `rollback-sanity` round-trip harness asserts this).
+
+DROP TABLE IF EXISTS nutrition_shopping_list;
+DROP TABLE IF EXISTS nutrition_water_log;

--- a/apps/server/src/migrations/051_nutrition_full_state.sql
+++ b/apps/server/src/migrations/051_nutrition_full_state.sql
@@ -1,0 +1,29 @@
+-- Stage 11 / PR #070n-schema — extend Nutrition Postgres schema to full
+-- LS-state coverage: water_log, shopping_list.
+--
+-- Mirrors the SQLite client-side migration
+-- `002_nutrition_full_state.sql` in
+-- `packages/db-schema/src/sqlite/migrations/index.ts`.
+--
+-- All tables are additive — safe to re-run on an existing database.
+-- FK to "user"(id) with ON DELETE CASCADE keeps referential integrity
+-- (client-side SQLite omits FK because there is no auth schema there).
+--
+-- Why these two tables specifically:
+--   - water_log та shopping_list — це ті дві LS-only сутності, які
+--     Stage 4 (PR #031) лишив поза dual-write. Web `#057n-tombstone`
+--     (PR #2274) їх теж не зачепив. Stage 11 закриває цей schema gap.
+
+CREATE TABLE IF NOT EXISTS nutrition_water_log (
+  user_id     TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  date_key    TEXT NOT NULL,
+  volume_ml   INTEGER NOT NULL DEFAULT 0,
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, date_key)
+);
+
+CREATE TABLE IF NOT EXISTS nutrition_shopping_list (
+  user_id     TEXT PRIMARY KEY REFERENCES "user"(id) ON DELETE CASCADE,
+  data        JSONB NOT NULL DEFAULT '{"categories":[]}'::jsonb,
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/apps/server/src/migrations/__tests__/051-nutrition-full-state.test.ts
+++ b/apps/server/src/migrations/__tests__/051-nutrition-full-state.test.ts
@@ -1,0 +1,408 @@
+// Migration 051 — focused round-trip for the Nutrition full-state tables
+// (Stage 11 / PR #070n-schema of `docs/planning/storage-roadmap.md`).
+//
+// Mirrors `050-routine-full-state.test.ts`: same Docker / pgvector
+// testcontainer harness, same soft-skip behaviour, same assertions
+// shape — the only thing that changes is the table list and the
+// per-table column checks.
+//
+// Asserts that:
+//   1. applying every forward migration leaves both new nutrition
+//      tables present with the columns documented in
+//      `apps/server/src/migrations/051_nutrition_full_state.sql`,
+//   2. running `051_nutrition_full_state.down.sql` drops them,
+//   3. the down migration is idempotent (rule #4 invariant),
+//   4. down → re-up restores the schema fingerprint byte-for-byte.
+
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+import { fileURLToPath } from "url";
+import pg from "pg";
+import { GenericContainer, Wait } from "testcontainers";
+import type { StartedTestContainer } from "testcontainers";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MIGRATIONS_DIR = path.resolve(__dirname, "..");
+
+const TIMEOUT_MS = 180_000;
+
+// Stage 11 / PR #070n-schema introduces 2 new tables (extending the
+// 035_nutrition_tables.sql baseline of meals / pantries / pantry_items
+// / prefs / recipes). The test scopes itself to the new tables only.
+const NUTRITION_FULL_STATE_TABLES = [
+  "nutrition_shopping_list",
+  "nutrition_water_log",
+] as const;
+
+let container: StartedTestContainer | undefined;
+let pool: pg.Pool | undefined;
+let dockerAvailable = false;
+let skipReason: string | null = null;
+
+beforeAll(async () => {
+  try {
+    container = await new GenericContainer("pgvector/pgvector:pg16")
+      .withEnvironment({
+        POSTGRES_USER: "hub",
+        POSTGRES_PASSWORD: "hub",
+        POSTGRES_DB: "hub_test",
+      })
+      .withExposedPorts(5432)
+      .withWaitStrategy(
+        Wait.forLogMessage(/database system is ready to accept connections/, 2),
+      )
+      .start();
+
+    const host = container.getHost();
+    const port = container.getMappedPort(5432);
+    pool = new pg.Pool({
+      connectionString: `postgresql://hub:hub@${host}:${port}/hub_test`,
+      max: 4,
+    });
+    dockerAvailable = true;
+  } catch (e) {
+    skipReason = e instanceof Error ? e.message : String(e);
+    console.warn(
+      `[051-nutrition-full-state] Skipping: Testcontainers unavailable — ${skipReason}`,
+    );
+  }
+}, TIMEOUT_MS);
+
+afterAll(async () => {
+  if (pool) {
+    await pool.end().catch(() => {
+      /* noop */
+    });
+  }
+  if (container) {
+    await container.stop().catch(() => {
+      /* noop */
+    });
+  }
+}, TIMEOUT_MS);
+
+async function readMigrationFiles(): Promise<string[]> {
+  const files = await fs.readdir(MIGRATIONS_DIR);
+  return files
+    .filter((f) => /^\d{3}_.+\.sql$/.test(f) && !f.endsWith(".down.sql"))
+    .sort();
+}
+
+async function execSqlFile(p: pg.Pool, file: string): Promise<void> {
+  const sql = (
+    await fs.readFile(path.join(MIGRATIONS_DIR, file), "utf8")
+  ).trim();
+  if (!sql) return;
+  await p.query(sql);
+}
+
+async function resetSchema(p: pg.Pool): Promise<void> {
+  await p.query(`DROP SCHEMA public CASCADE; CREATE SCHEMA public;`);
+  await p.query(`GRANT ALL ON SCHEMA public TO public;`);
+}
+
+async function listFullStateTables(p: pg.Pool): Promise<string[]> {
+  const r = await p.query<{ tablename: string }>(
+    `SELECT tablename FROM pg_tables
+     WHERE schemaname = 'public'
+       AND tablename = ANY($1::text[])
+     ORDER BY tablename`,
+    [[...NUTRITION_FULL_STATE_TABLES]],
+  );
+  return r.rows.map((row) => row.tablename);
+}
+
+async function listColumns(
+  p: pg.Pool,
+  table: string,
+): Promise<{ name: string; type: string; nullable: string }[]> {
+  const r = await p.query<{
+    column_name: string;
+    data_type: string;
+    is_nullable: string;
+  }>(
+    `SELECT column_name, data_type, is_nullable
+     FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = $1
+     ORDER BY ordinal_position`,
+    [table],
+  );
+  return r.rows.map((row) => ({
+    name: row.column_name,
+    type: row.data_type,
+    nullable: row.is_nullable,
+  }));
+}
+
+describe("051_nutrition_full_state migration", () => {
+  it(
+    "creates both new nutrition tables after forward migration",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+
+      const tables = await listFullStateTables(pool);
+      expect(tables).toEqual([...NUTRITION_FULL_STATE_TABLES]);
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "nutrition_water_log is keyed on (user_id, date_key)",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+
+      const cols = await listColumns(pool, "nutrition_water_log");
+      expect(cols.map((c) => c.name)).toEqual([
+        "user_id",
+        "date_key",
+        "volume_ml",
+        "updated_at",
+      ]);
+
+      const byName = Object.fromEntries(cols.map((c) => [c.name, c]));
+      expect(byName["user_id"]!.type).toBe("text");
+      expect(byName["user_id"]!.nullable).toBe("NO");
+      expect(byName["date_key"]!.type).toBe("text");
+      expect(byName["date_key"]!.nullable).toBe("NO");
+      expect(byName["volume_ml"]!.type).toBe("integer");
+      expect(byName["volume_ml"]!.nullable).toBe("NO");
+      expect(byName["updated_at"]!.type).toBe("timestamp with time zone");
+
+      const pkCheck = await pool.query<{ column_name: string }>(
+        `SELECT a.attname AS column_name
+         FROM   pg_index i
+         JOIN   pg_attribute a ON a.attrelid = i.indrelid
+                              AND a.attnum   = ANY(i.indkey)
+         WHERE  i.indrelid = 'public.nutrition_water_log'::regclass
+           AND  i.indisprimary
+         ORDER BY a.attnum`,
+      );
+      expect(pkCheck.rows.map((r) => r.column_name)).toEqual([
+        "user_id",
+        "date_key",
+      ]);
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "nutrition_shopping_list is a per-user singleton with jsonb data",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+
+      const cols = await listColumns(pool, "nutrition_shopping_list");
+      expect(cols.map((c) => c.name)).toEqual([
+        "user_id",
+        "data",
+        "updated_at",
+      ]);
+
+      const byName = Object.fromEntries(cols.map((c) => [c.name, c]));
+      expect(byName["user_id"]!.type).toBe("text");
+      expect(byName["user_id"]!.nullable).toBe("NO");
+      expect(byName["data"]!.type).toBe("jsonb");
+      expect(byName["data"]!.nullable).toBe("NO");
+      expect(byName["updated_at"]!.type).toBe("timestamp with time zone");
+
+      const pkCheck = await pool.query<{ column_name: string }>(
+        `SELECT a.attname AS column_name
+         FROM   pg_index i
+         JOIN   pg_attribute a ON a.attrelid = i.indrelid
+                              AND a.attnum   = ANY(i.indkey)
+         WHERE  i.indrelid = 'public.nutrition_shopping_list'::regclass
+           AND  i.indisprimary`,
+      );
+      expect(pkCheck.rows.map((r) => r.column_name)).toEqual(["user_id"]);
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "round-trips a row through nutrition_water_log",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+
+      // Seed a user so the FK to "user"(id) is satisfied.
+      await pool.query(
+        `INSERT INTO "user" (id, email, name, "emailVerified", "createdAt", "updatedAt")
+         VALUES ('u1', 'u1@example.com', 'U1', false, now(), now())`,
+      );
+
+      await pool.query(
+        `INSERT INTO nutrition_water_log (user_id, date_key, volume_ml)
+         VALUES ($1, $2, $3)`,
+        ["u1", "2026-05-09", 750],
+      );
+
+      const r = await pool.query<{
+        user_id: string;
+        date_key: string;
+        volume_ml: number;
+      }>(
+        `SELECT user_id, date_key, volume_ml FROM nutrition_water_log WHERE user_id = $1`,
+        ["u1"],
+      );
+      expect(r.rows).toEqual([
+        { user_id: "u1", date_key: "2026-05-09", volume_ml: 750 },
+      ]);
+
+      // Composite-PK upsert (`ON CONFLICT (user_id, date_key)`) is the
+      // shape dual-write will use.
+      await pool.query(
+        `INSERT INTO nutrition_water_log (user_id, date_key, volume_ml)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (user_id, date_key)
+         DO UPDATE SET volume_ml = EXCLUDED.volume_ml, updated_at = now()`,
+        ["u1", "2026-05-09", 1500],
+      );
+      const r2 = await pool.query<{ volume_ml: number }>(
+        `SELECT volume_ml FROM nutrition_water_log WHERE user_id = $1 AND date_key = $2`,
+        ["u1", "2026-05-09"],
+      );
+      expect(r2.rows[0]!.volume_ml).toBe(1500);
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "round-trips a JSONB document through nutrition_shopping_list",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+
+      await pool.query(
+        `INSERT INTO "user" (id, email, name, "emailVerified", "createdAt", "updatedAt")
+         VALUES ('u1', 'u1@example.com', 'U1', false, now(), now())`,
+      );
+
+      const doc = {
+        categories: [
+          {
+            name: "Овочі",
+            items: [
+              {
+                id: "si_1",
+                name: "помідори",
+                quantity: "1 кг",
+                note: "",
+                checked: false,
+              },
+            ],
+          },
+        ],
+      };
+
+      await pool.query(
+        `INSERT INTO nutrition_shopping_list (user_id, data) VALUES ($1, $2::jsonb)`,
+        ["u1", JSON.stringify(doc)],
+      );
+
+      const r = await pool.query<{ data: typeof doc }>(
+        `SELECT data FROM nutrition_shopping_list WHERE user_id = $1`,
+        ["u1"],
+      );
+      expect(r.rows[0]!.data).toEqual(doc);
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "051_nutrition_full_state.down.sql drops both tables",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+      expect((await listFullStateTables(pool)).length).toBe(
+        NUTRITION_FULL_STATE_TABLES.length,
+      );
+
+      await execSqlFile(pool, "051_nutrition_full_state.down.sql");
+      expect(await listFullStateTables(pool)).toEqual([]);
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "051_nutrition_full_state.down.sql is idempotent",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+
+      await execSqlFile(pool, "051_nutrition_full_state.down.sql");
+      // Second run must not raise — `IF EXISTS` keeps it idempotent
+      // per AGENTS rule #4.
+      await execSqlFile(pool, "051_nutrition_full_state.down.sql");
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "down then re-up restores the same schema fingerprint",
+    async (ctx) => {
+      if (!dockerAvailable || !pool) {
+        ctx.skip();
+        return;
+      }
+      const ups = await readMigrationFiles();
+      await resetSchema(pool);
+      for (const f of ups) await execSqlFile(pool, f);
+
+      const before = {
+        tables: await listFullStateTables(pool),
+        waterLog: await listColumns(pool, "nutrition_water_log"),
+        shoppingList: await listColumns(pool, "nutrition_shopping_list"),
+      };
+
+      await execSqlFile(pool, "051_nutrition_full_state.down.sql");
+      await execSqlFile(pool, "051_nutrition_full_state.sql");
+
+      const after = {
+        tables: await listFullStateTables(pool),
+        waterLog: await listColumns(pool, "nutrition_water_log"),
+        shoppingList: await listColumns(pool, "nutrition_shopping_list"),
+      };
+
+      expect(after).toEqual(before);
+    },
+    TIMEOUT_MS,
+  );
+});

--- a/docs/planning/storage-roadmap.md
+++ b/docs/planning/storage-roadmap.md
@@ -3038,9 +3038,11 @@ Split into 2 PRs:
 
 **Scope (4 PRs, mirror of Stage 10 pattern):**
 
-- **PR #070n-schema** 📋 PROPOSED — 2 нові SQLite/Pg таблиці
+- **PR #070n-schema** 🚧 IN PROGRESS — 2 нові SQLite/Pg таблиці
   (`nutrition_water_log`, `nutrition_shopping_list`) + Drizzle schemas
-  (SQLite + Pg) + sequential client migration `005_nutrition_full_state.sql`
+  (SQLite + Pg) + sequential client migration
+  `002_nutrition_full_state.sql` (per-module ledger numbering — Nutrition
+  starts at `001_nutrition_tables.sql`, не глобальне `005_*`).
   - server migration `051_nutrition_full_state.sql` (+ companion
     `051_nutrition_full_state.down.sql` + 051 round-trip testcontainer
     harness modelled on 050).

--- a/packages/db-schema/src/__tests__/pg-nutrition-snapshot.test.ts
+++ b/packages/db-schema/src/__tests__/pg-nutrition-snapshot.test.ts
@@ -6,6 +6,8 @@ import {
   nutritionPantryItems,
   nutritionPrefs,
   nutritionRecipes,
+  nutritionShoppingList,
+  nutritionWaterLog,
 } from "../pg/nutrition.js";
 
 /**
@@ -261,5 +263,73 @@ describe("pg/nutritionRecipes schema snapshot", () => {
   it("declares the soft-delete partial index", () => {
     const indexNames = config.indexes.map((i) => i.config.name);
     expect(indexNames).toContain("nutrition_recipes_user_active_idx");
+  });
+});
+
+describe("pg/nutritionWaterLog schema snapshot", () => {
+  const config = getTableConfig(nutritionWaterLog);
+
+  it("has the canonical table name", () => {
+    expect(config.name).toBe("nutrition_water_log");
+  });
+
+  it("declares all expected columns", () => {
+    const columnNames = config.columns.map((c) => c.name);
+    expect(columnNames).toEqual([
+      "user_id",
+      "date_key",
+      "volume_ml",
+      "updated_at",
+    ]);
+  });
+
+  it("declares column types matching migration 051", () => {
+    const columnMap = Object.fromEntries(
+      config.columns.map((c) => [c.name, c]),
+    );
+    expect(columnMap["user_id"]!.columnType).toBe("PgText");
+    expect(columnMap["user_id"]!.notNull).toBe(true);
+    expect(columnMap["date_key"]!.columnType).toBe("PgText");
+    expect(columnMap["date_key"]!.notNull).toBe(true);
+    expect(columnMap["volume_ml"]!.columnType).toBe("PgInteger");
+    expect(columnMap["volume_ml"]!.notNull).toBe(true);
+    expect(columnMap["volume_ml"]!.hasDefault).toBe(true);
+    expect(columnMap["updated_at"]!.columnType).toBe("PgTimestamp");
+    expect(columnMap["updated_at"]!.notNull).toBe(true);
+    expect(columnMap["updated_at"]!.hasDefault).toBe(true);
+  });
+
+  it("is keyed on (user_id, date_key)", () => {
+    expect(config.primaryKeys).toHaveLength(1);
+    const pk = config.primaryKeys[0]!;
+    expect(pk.columns.map((c) => c.name)).toEqual(["user_id", "date_key"]);
+  });
+});
+
+describe("pg/nutritionShoppingList schema snapshot", () => {
+  const config = getTableConfig(nutritionShoppingList);
+
+  it("has the canonical table name", () => {
+    expect(config.name).toBe("nutrition_shopping_list");
+  });
+
+  it("declares all expected columns", () => {
+    const columnNames = config.columns.map((c) => c.name);
+    expect(columnNames).toEqual(["user_id", "data", "updated_at"]);
+  });
+
+  it("declares column types matching migration 051", () => {
+    const columnMap = Object.fromEntries(
+      config.columns.map((c) => [c.name, c]),
+    );
+    expect(columnMap["user_id"]!.columnType).toBe("PgText");
+    expect(columnMap["user_id"]!.primary).toBe(true);
+    expect(columnMap["user_id"]!.notNull).toBe(true);
+    expect(columnMap["data"]!.columnType).toBe("PgJsonb");
+    expect(columnMap["data"]!.notNull).toBe(true);
+    expect(columnMap["data"]!.hasDefault).toBe(true);
+    expect(columnMap["updated_at"]!.columnType).toBe("PgTimestamp");
+    expect(columnMap["updated_at"]!.notNull).toBe(true);
+    expect(columnMap["updated_at"]!.hasDefault).toBe(true);
   });
 });

--- a/packages/db-schema/src/__tests__/sqlite-nutrition-snapshot.test.ts
+++ b/packages/db-schema/src/__tests__/sqlite-nutrition-snapshot.test.ts
@@ -6,6 +6,8 @@ import {
   nutritionPantryItems,
   nutritionPrefs,
   nutritionRecipes,
+  nutritionShoppingList,
+  nutritionWaterLog,
 } from "../sqlite/nutrition.js";
 import {
   NUTRITION_CLIENT_MIGRATIONS,
@@ -311,9 +313,76 @@ describe("sqlite/nutritionRecipes schema snapshot", () => {
   });
 });
 
+describe("sqlite/nutritionWaterLog schema snapshot", () => {
+  const config = getTableConfig(nutritionWaterLog);
+
+  it("has the canonical table name", () => {
+    expect(config.name).toBe("nutrition_water_log");
+  });
+
+  it("declares all expected columns", () => {
+    const columnNames = config.columns.map((c) => c.name);
+    expect(columnNames).toEqual([
+      "user_id",
+      "date_key",
+      "volume_ml",
+      "updated_at",
+    ]);
+  });
+
+  it("declares column types matching the inline migration", () => {
+    const columnMap = Object.fromEntries(
+      config.columns.map((c) => [c.name, c]),
+    );
+    expect(columnMap["user_id"]!.dataType).toBe("string");
+    expect(columnMap["user_id"]!.notNull).toBe(true);
+    expect(columnMap["date_key"]!.dataType).toBe("string");
+    expect(columnMap["date_key"]!.notNull).toBe(true);
+    expect(columnMap["volume_ml"]!.dataType).toBe("number");
+    expect(columnMap["volume_ml"]!.notNull).toBe(true);
+    expect(columnMap["volume_ml"]!.hasDefault).toBe(true);
+    expect(columnMap["updated_at"]!.dataType).toBe("string");
+    expect(columnMap["updated_at"]!.notNull).toBe(true);
+    expect(columnMap["updated_at"]!.hasDefault).toBe(true);
+  });
+
+  it("is keyed on (user_id, date_key)", () => {
+    expect(config.primaryKeys).toHaveLength(1);
+    const pk = config.primaryKeys[0]!;
+    expect(pk.columns.map((c) => c.name)).toEqual(["user_id", "date_key"]);
+  });
+});
+
+describe("sqlite/nutritionShoppingList schema snapshot", () => {
+  const config = getTableConfig(nutritionShoppingList);
+
+  it("has the canonical table name", () => {
+    expect(config.name).toBe("nutrition_shopping_list");
+  });
+
+  it("declares all expected columns", () => {
+    const columnNames = config.columns.map((c) => c.name);
+    expect(columnNames).toEqual(["user_id", "data_json", "updated_at"]);
+  });
+
+  it("declares column types matching the inline migration", () => {
+    const columnMap = Object.fromEntries(
+      config.columns.map((c) => [c.name, c]),
+    );
+    expect(columnMap["user_id"]!.dataType).toBe("string");
+    expect(columnMap["user_id"]!.primary).toBe(true);
+    expect(columnMap["user_id"]!.notNull).toBe(true);
+    expect(columnMap["data_json"]!.dataType).toBe("string");
+    expect(columnMap["data_json"]!.notNull).toBe(true);
+    expect(columnMap["data_json"]!.hasDefault).toBe(true);
+    expect(columnMap["updated_at"]!.dataType).toBe("string");
+    expect(columnMap["updated_at"]!.notNull).toBe(true);
+    expect(columnMap["updated_at"]!.hasDefault).toBe(true);
+  });
+});
+
 describe("sqlite/nutrition migrations exports", () => {
-  it("exports a single 001_nutrition_tables.sql migration", () => {
-    expect(NUTRITION_CLIENT_MIGRATIONS).toHaveLength(1);
+  it("ships the 001_nutrition_tables.sql baseline", () => {
     expect(NUTRITION_CLIENT_MIGRATIONS[0]!.name).toBe(
       "001_nutrition_tables.sql",
     );
@@ -331,6 +400,23 @@ describe("sqlite/nutrition migrations exports", () => {
     );
     expect(NUTRITION_CLIENT_MIGRATIONS[0]!.sql).toMatch(
       /CREATE TABLE IF NOT EXISTS nutrition_recipes/,
+    );
+  });
+
+  it("ships the Stage 11 002_nutrition_full_state.sql delta", () => {
+    // Append-only — `001_*` first, then `002_*` for the Stage 11 delta.
+    expect(NUTRITION_CLIENT_MIGRATIONS).toHaveLength(2);
+    expect(NUTRITION_CLIENT_MIGRATIONS[1]!.name).toBe(
+      "002_nutrition_full_state.sql",
+    );
+    expect(NUTRITION_CLIENT_MIGRATIONS[1]!.sql).toMatch(
+      /CREATE TABLE IF NOT EXISTS nutrition_water_log/,
+    );
+    expect(NUTRITION_CLIENT_MIGRATIONS[1]!.sql).toMatch(
+      /CREATE TABLE IF NOT EXISTS nutrition_shopping_list/,
+    );
+    expect(NUTRITION_CLIENT_MIGRATIONS[1]!.sql).toMatch(
+      /PRIMARY KEY \(user_id, date_key\)/,
     );
   });
 

--- a/packages/db-schema/src/pg/index.ts
+++ b/packages/db-schema/src/pg/index.ts
@@ -28,6 +28,8 @@ export {
   nutritionPantryItems,
   nutritionPrefs,
   nutritionRecipes,
+  nutritionWaterLog,
+  nutritionShoppingList,
 } from "./nutrition.js";
 export {
   finykHiddenAccounts,

--- a/packages/db-schema/src/pg/nutrition.ts
+++ b/packages/db-schema/src/pg/nutrition.ts
@@ -4,6 +4,7 @@ import {
   integer,
   jsonb,
   pgTable,
+  primaryKey,
   real,
   text,
   timestamp,
@@ -182,3 +183,49 @@ export const nutritionRecipes = pgTable(
       .where(sql`${table.deletedAt} IS NULL`),
   ],
 );
+
+// ---------------------------------------------------------------------
+// Stage 11 — extend Nutrition schema to full LS coverage
+// (water_log, shopping_list).
+// Mirrors migration 051_nutrition_full_state.sql.
+// ---------------------------------------------------------------------
+
+/**
+ * Postgres schema for `nutrition_water_log` table.
+ *
+ * Один рядок на (user, date) — мілілітри води за день. Дзеркалить
+ * `routine_pushups` за формою (per-(user, date) лічильник). Day key —
+ * `YYYY-MM-DD` у локальному часовому поясі користувача (як уже працює
+ * `WaterLog` blob у `packages/nutrition-domain/src/waterLog.ts`).
+ *
+ * Soft-delete не потрібен — обнулення дня = `volume_ml = 0` або просто
+ * відсутність рядка для цієї дати.
+ */
+export const nutritionWaterLog = pgTable(
+  "nutrition_water_log",
+  {
+    userId: text("user_id").notNull(),
+    dateKey: text("date_key").notNull(),
+    volumeMl: integer("volume_ml").notNull().default(0),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [primaryKey({ columns: [table.userId, table.dateKey] })],
+);
+
+/**
+ * Postgres schema for `nutrition_shopping_list` table.
+ *
+ * Один рядок на користувача — JSON blob категорій + items
+ * (`ShoppingList` shape із `packages/nutrition-domain/src/shoppingList.ts`).
+ * Цілий документ читається разом коли користувач відкриває список —
+ * per-item normalisation тут не потрібна.
+ */
+export const nutritionShoppingList = pgTable("nutrition_shopping_list", {
+  userId: text("user_id").primaryKey(),
+  data: jsonb().notNull().default({ categories: [] }),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});

--- a/packages/db-schema/src/sqlite/index.ts
+++ b/packages/db-schema/src/sqlite/index.ts
@@ -88,6 +88,8 @@ export {
   nutritionPantryItems,
   nutritionPrefs,
   nutritionRecipes,
+  nutritionWaterLog,
+  nutritionShoppingList,
 } from "./nutrition.js";
 export {
   finykHiddenAccounts,

--- a/packages/db-schema/src/sqlite/migrations/index.ts
+++ b/packages/db-schema/src/sqlite/migrations/index.ts
@@ -623,6 +623,35 @@ CREATE INDEX IF NOT EXISTS nutrition_recipes_user_active_idx_lite
 `;
 
 /**
+ * Stage 11 / PR #070n-schema — extend Nutrition SQLite schema to full
+ * LS-state coverage (water_log, shopping_list).
+ *
+ * Mirrors the Postgres migration `051_nutrition_full_state.sql`.
+ * Append-only — `001_nutrition_tables.sql` shipped first; this file
+ * is `002_*` so already-migrated client DBs only apply the delta.
+ *
+ * Why these two tables specifically:
+ *   - water_log та shopping_list — це ті дві LS-only сутності, які
+ *     Stage 4 (PR #031) лишив поза dual-write. Web `#057n-tombstone`
+ *     (PR #2274) їх теж не зачепив. Stage 11 закриває цей schema gap.
+ */
+const NUTRITION_002_FULL_STATE_SQL = `
+CREATE TABLE IF NOT EXISTS nutrition_water_log (
+  user_id     TEXT NOT NULL,
+  date_key    TEXT NOT NULL,
+  volume_ml   INTEGER NOT NULL DEFAULT 0,
+  updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (user_id, date_key)
+);
+
+CREATE TABLE IF NOT EXISTS nutrition_shopping_list (
+  user_id     TEXT PRIMARY KEY,
+  data_json   TEXT NOT NULL DEFAULT '{"categories":[]}',
+  updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+`;
+
+/**
  * Ordered list of bundled client migrations for the Nutrition module on
  * SQLite. Pass this directly to `runMigrations` from
  * `@sergeant/db-schema/migrate`.
@@ -632,9 +661,16 @@ CREATE INDEX IF NOT EXISTS nutrition_recipes_user_active_idx_lite
  * migrations are independent — each module can be migrated, rolled
  * out, and rolled back without affecting the others. Same rationale
  * as fizruk's split from routine in PR #027.
+ *
+ * `002_nutrition_full_state.sql` extends the schema to full LS-state
+ * coverage (Stage 11 / PR #070n-schema).
  */
 export const NUTRITION_CLIENT_MIGRATIONS: readonly MigrationFile[] = [
   { name: "001_nutrition_tables.sql", sql: NUTRITION_001_SQL },
+  {
+    name: "002_nutrition_full_state.sql",
+    sql: NUTRITION_002_FULL_STATE_SQL,
+  },
 ] as const;
 
 /**

--- a/packages/db-schema/src/sqlite/nutrition.ts
+++ b/packages/db-schema/src/sqlite/nutrition.ts
@@ -1,6 +1,7 @@
 import {
   index,
   integer,
+  primaryKey,
   real,
   sqliteTable,
   text,
@@ -176,3 +177,51 @@ export const nutritionRecipes = sqliteTable(
       .where(sql`${table.deletedAt} IS NULL`),
   ],
 );
+
+// ---------------------------------------------------------------------
+// Stage 11 — extend Nutrition schema to full LS coverage
+// (water_log, shopping_list).
+// Mirrors migration 002_nutrition_full_state.sql in
+// `packages/db-schema/src/sqlite/migrations/index.ts`.
+// ---------------------------------------------------------------------
+
+/**
+ * SQLite schema for the `nutrition_water_log` table.
+ *
+ * Один рядок на (user, date) — мілілітри води за день. Дзеркалить
+ * `routine_pushups` за формою. Day key — `YYYY-MM-DD` у локальному
+ * часовому поясі користувача (як уже працює `WaterLog` blob у
+ * `packages/nutrition-domain/src/waterLog.ts`).
+ *
+ * Soft-delete не потрібен — обнулення дня = `volume_ml = 0` або
+ * відсутність рядка.
+ */
+export const nutritionWaterLog = sqliteTable(
+  "nutrition_water_log",
+  {
+    userId: text("user_id").notNull(),
+    dateKey: text("date_key").notNull(),
+    volumeMl: integer("volume_ml").notNull().default(0),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
+  (table) => [primaryKey({ columns: [table.userId, table.dateKey] })],
+);
+
+/**
+ * SQLite schema for the `nutrition_shopping_list` table.
+ *
+ * Один рядок на користувача — JSON blob категорій + items
+ * (`ShoppingList` shape із `packages/nutrition-domain/src/shoppingList.ts`).
+ * JSONB → TEXT (JSON-encoded). Цілий документ читається разом коли
+ * користувач відкриває список — per-item normalisation тут не
+ * потрібна.
+ */
+export const nutritionShoppingList = sqliteTable("nutrition_shopping_list", {
+  userId: text("user_id").primaryKey(),
+  dataJson: text("data_json").notNull().default('{"categories":[]}'),
+  updatedAt: text("updated_at")
+    .notNull()
+    .default(sql`(datetime('now'))`),
+});


### PR DESCRIPTION
## Summary

Stage 11 / PR `#070n-schema` of `docs/planning/storage-roadmap.md` — open the
Nutrition SQLite ↔ Pg schema gap that web `#057n-tombstone` (#2274) left
behind. Adds two new entity classes:

- `nutrition_water_log` — per-(user, date) water consumption (мл за день),
  composite PK `(user_id, date_key)`. Mirrors the shape of `routine_pushups`.
- `nutrition_shopping_list` — per-user singleton JSONB blob (`{categories:[…]}`)
  matching `ShoppingList` shape from `packages/nutrition-domain/src/shoppingList.ts`.

Mirror of Stage 10 pattern (Routine):

- Drizzle Postgres schema: `packages/db-schema/src/pg/nutrition.ts` + index
  re-exports.
- Drizzle SQLite schema: `packages/db-schema/src/sqlite/nutrition.ts` + index
  re-exports (TEXT for TIMESTAMPTZ, TEXT for JSONB, composite PK via
  `primaryKey({ columns: [...] })`).
- Server migration `apps/server/src/migrations/051_nutrition_full_state.sql`
  + companion `.down.sql`. FK to `"user"(id) ON DELETE CASCADE`. Each
  statement `IF EXISTS`-guarded so down stays idempotent (rule #4).
- Client bundled migration: appended `002_nutrition_full_state.sql` to
  `NUTRITION_CLIENT_MIGRATIONS` (per-module ledger numbering — Nutrition
  ledger starts at `001_nutrition_tables.sql`, не глобальне `005_*`).
- Round-trip testcontainer harness
  `apps/server/src/migrations/__tests__/051-nutrition-full-state.test.ts`
  (8 tests: forward, columns, composite-PK shape, JSONB row round-trip,
  composite-PK upsert, down drops, down idempotent, down→up restores
  fingerprint). Soft-skips when Docker is unavailable (same pattern as
  `050-routine-full-state.test.ts`).
- Snapshot lockdown: `pg-nutrition-snapshot.test.ts` +
  `sqlite-nutrition-snapshot.test.ts` extended with new describes.

Roadmap entry for `#070n-schema` flipped from 📋 PROPOSED to 🚧 IN PROGRESS.

## Governing Skill

- Primary skill: `.agents/skills/sergeant-db-schema/SKILL.md` (Drizzle +
  migrations).
- Secondary skill (if truly needed): n/a.

## Playbook

- Primary playbook: n/a — pattern fully captured by Stage 10 reference
  (`050_routine_full_state.sql` + `050-routine-full-state.test.ts`); цей PR є
  механічним повтором того ж паттерну на меншому surface.
- Why this playbook: see above.
- If no playbook matched, why: see above.

## Verification

```bash
pnpm --filter @sergeant/db-schema build         # tsc -p tsconfig.build.json — OK
pnpm --filter @sergeant/db-schema typecheck     # tsc --noEmit — OK
pnpm --filter @sergeant/db-schema test          # 437 tests pass (incl. new pg+sqlite snapshots)
pnpm --filter @sergeant/server typecheck        # tsc --noEmit — OK
pnpm --filter @sergeant/server test src/migrations/__tests__/051-nutrition-full-state.test.ts
                                                # 8/8 pass against pgvector/pgvector:pg16 testcontainer
pnpm lint                                       # turbo run lint + всі repo-level lints — OK
```

Additional checks:

- [x] Local smoke / manual validation completed (testcontainer round-trip).
- [x] Surface-specific checks completed (snapshot tests assert column order,
      types, defaults, primary keys, indexes; rollback-sanity test
      autodiscovers the new migration).

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- `docs/planning/storage-roadmap.md` — Stage 11 `#070n-schema` flipped
  PROPOSED → IN PROGRESS, fixed migration filename hint
  (`002_nutrition_full_state.sql` per-module ledger).

## Risk and Rollout

- **User-visible risk:** none. Schema is additive — new tables, no changes
  to existing rows, no consumer code reads from them yet (dual-write
  in `#070n-dualwrite`).
- **Rollout / deploy order:**
  1. Merge this PR → CI runs `pnpm db:migrate` against staging on next
     deploy → tables exist (web + mobile clients pick up
     `002_nutrition_full_state.sql` on next migration run via
     `runMigrations` from `@sergeant/db-schema/migrate`).
  2. `#070n-dualwrite` (web) — emit ops, mirror writes on every LS-set.
  3. `#070n-mobile-dualwrite` — same on mobile.
  4. `#057n-extended-tombstone` — drop LS/MMKV writes + residualImport.
- **Backout plan:** revert + `psql -f 051_nutrition_full_state.down.sql`
  (idempotent IF EXISTS). No production has yet read from these tables, so
  rollback is loss-free.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

- **Migration:** new `apps/server/src/migrations/051_nutrition_full_state.sql`
  + companion `.down.sql`. Sequential after `050_routine_full_state.sql`. No
  destructive ops on existing tables.
- **Schema PK shape:** `nutrition_water_log` uses composite PK
  `(user_id, date_key)`, intentionally mirroring `routine_pushups`. Same
  upsert shape (`ON CONFLICT (user_id, date_key)`) is what dual-write will
  use in `#070n-dualwrite`.
- **Per-module migration numbering:** Nutrition ledger uses
  `__nutrition_migrations` so the `002_*` filename here doesn't conflict
  with routine's `004_routine_full_state.sql` (separate ledger,
  intentionally split in PR #027). The same rationale applied to fizruk's
  `__fizruk_migrations`.
- **Why no soft-delete on these tables:** water log = per-day counter,
  shopping list = per-user singleton — both have natural "delete by
  setting to empty" semantics, no archival need. Mirror of how
  `routine_pushups` and `routine_habit_order` are shaped in Stage 10.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `nutrition_water_log` and `nutrition_shopping_list` to the Nutrition schema (SQLite + Postgres) for full local-state coverage and to enable dual-write next. Advances #070n-schema (Stage 11); all changes are additive.

- **New Features**
  - `nutrition_water_log`: per-(user, date) water ml counter; composite PK `(user_id, date_key)`.
  - `nutrition_shopping_list`: per-user singleton document; JSONB in Pg, JSON TEXT in SQLite.

- **Migration**
  - Server: `051_nutrition_full_state.sql` (+ `.down.sql`), FK to `"user"(id)` with ON DELETE CASCADE.
  - Client: `002_nutrition_full_state.sql` appended to `NUTRITION_CLIENT_MIGRATIONS` in `@sergeant/db-schema` (separate `__nutrition_migrations` ledger).
  - Drizzle schemas for Pg/SQLite with updated exports; snapshot tests and a pg testcontainer round-trip validate forward/down and idempotence.

<sup>Written for commit 893cc45a64399f094472db1a5872cabe6fdf6883. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added water intake tracking to the Nutrition module, allowing daily volume logging per user.
  * Added shopping list functionality to Nutrition for organizing and storing meal planning data.

* **Tests**
  * Added comprehensive test coverage for new Nutrition features, including schema validation and data integrity checks.

* **Documentation**
  * Updated Nutrition roadmap to reflect Stage 11 feature progress.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Skords-01/Sergeant/pull/2290)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->