### PR TITLE
feat(mobile): #070f2-mobile-dualwrite — extend Fizruk dual-write for 3 more hooks

### DIFF
--- a/apps/mobile/src/modules/fizruk/hooks/usePlanTemplate.ts
+++ b/apps/mobile/src/modules/fizruk/hooks/usePlanTemplate.ts
@@ -19,6 +19,12 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { STORAGE_KEYS } from "@sergeant/shared";
 
 import { _getMMKVInstance, safeReadLS, safeWriteLS } from "@/lib/storage";
+import { triggerFizrukDualWrite } from "../lib/dualWrite";
+import {
+  EMPTY_FIZRUK_DUAL_WRITE_STATE,
+  extractPlanTemplateSnapshot,
+  peekFizrukDualWriteState,
+} from "../lib/fizrukDualWriteState";
 
 const STORAGE_KEY = STORAGE_KEYS.FIZRUK_PLAN_TEMPLATE;
 
@@ -86,6 +92,13 @@ export function usePlanTemplate(): UsePlanTemplateResult {
       // cross-source listener still fires consistently.
       safeWriteLS(STORAGE_KEY, next);
       setPlan(next);
+      // Stage 12.5 / PR #070f2-mobile-dualwrite — mirror to SQLite.
+      const baseState =
+        peekFizrukDualWriteState() ?? EMPTY_FIZRUK_DUAL_WRITE_STATE;
+      triggerFizrukDualWrite(
+        { ...baseState, planTemplate: extractPlanTemplateSnapshot(prev) },
+        { ...baseState, planTemplate: extractPlanTemplateSnapshot(next) },
+      );
       return true;
     },
     [],

--- a/apps/mobile/src/modules/fizruk/hooks/usePrograms.ts
+++ b/apps/mobile/src/modules/fizruk/hooks/usePrograms.ts
@@ -16,7 +16,7 @@
  * shim around those selectors + MMKV.
  */
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import {
   PROGRAM_CATALOGUE,
@@ -31,6 +31,12 @@ import {
 import { STORAGE_KEYS } from "@sergeant/shared";
 
 import { _getMMKVInstance, safeReadLS, safeWriteLS } from "@/lib/storage";
+import { triggerFizrukDualWrite } from "../lib/dualWrite";
+import {
+  EMPTY_FIZRUK_DUAL_WRITE_STATE,
+  extractProgramsSnapshot,
+  peekFizrukDualWriteState,
+} from "../lib/fizrukDualWriteState";
 
 const STORAGE_KEY = STORAGE_KEYS.FIZRUK_ACTIVE_PROGRAM;
 
@@ -74,6 +80,10 @@ export function usePrograms(
   const [state, setState] = useState<ActiveProgramState>(() =>
     normalizeActiveProgramState(safeReadLS<unknown>(STORAGE_KEY, null)),
   );
+  // Mirror the latest persisted state in a ref so the imperative
+  // setters can build the dual-write `prev → next` pair without
+  // depending on a stale closure of `state`.
+  const stateRef = useRef<ActiveProgramState>(state);
 
   // React to out-of-band writes to the same MMKV slot so the page
   // re-renders if anything else in the app touches this key.
@@ -81,16 +91,30 @@ export function usePrograms(
     const mmkv = _getMMKVInstance();
     const sub = mmkv.addOnValueChangedListener((changedKey) => {
       if (changedKey !== STORAGE_KEY) return;
-      setState(
-        normalizeActiveProgramState(safeReadLS<unknown>(STORAGE_KEY, null)),
+      const fresh = normalizeActiveProgramState(
+        safeReadLS<unknown>(STORAGE_KEY, null),
       );
+      stateRef.current = fresh;
+      setState(fresh);
     });
     return () => sub.remove();
   }, []);
 
   const persist = useCallback((next: ActiveProgramState) => {
+    const prev = stateRef.current;
+    if (prev.activeProgramId === next.activeProgramId) return;
+    stateRef.current = next;
     setState(next);
     safeWriteLS(STORAGE_KEY, next);
+    // Stage 12.5 / PR #070f2-mobile-dualwrite — mirror to SQLite.
+    // The cache-backed state seeds the dual-write input so the diff
+    // sees the full Fizruk shape; only the `programs` slot moves.
+    const baseState =
+      peekFizrukDualWriteState() ?? EMPTY_FIZRUK_DUAL_WRITE_STATE;
+    triggerFizrukDualWrite(
+      { ...baseState, programs: extractProgramsSnapshot(prev) },
+      { ...baseState, programs: extractProgramsSnapshot(next) },
+    );
   }, []);
 
   const activateProgram = useCallback(

--- a/apps/mobile/src/modules/fizruk/hooks/useWellbeing.ts
+++ b/apps/mobile/src/modules/fizruk/hooks/useWellbeing.ts
@@ -18,6 +18,12 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { STORAGE_KEYS } from "@sergeant/shared";
 
 import { _getMMKVInstance, safeReadLS, safeWriteLS } from "@/lib/storage";
+import { triggerFizrukDualWrite } from "../lib/dualWrite";
+import {
+  EMPTY_FIZRUK_DUAL_WRITE_STATE,
+  extractWellbeingSnapshots,
+  peekFizrukDualWriteState,
+} from "../lib/fizrukDualWriteState";
 
 const STORAGE_KEY = STORAGE_KEYS.FIZRUK_WELLBEING;
 
@@ -93,6 +99,13 @@ export function useWellbeing(): UseWellbeingResult {
       stateRef.current = next;
       safeWriteLS(STORAGE_KEY, next);
       setEntries(next);
+      // Stage 12.5 / PR #070f2-mobile-dualwrite — mirror to SQLite.
+      const baseState =
+        peekFizrukDualWriteState() ?? EMPTY_FIZRUK_DUAL_WRITE_STATE;
+      triggerFizrukDualWrite(
+        { ...baseState, wellbeing: extractWellbeingSnapshots(prev) },
+        { ...baseState, wellbeing: extractWellbeingSnapshots(next) },
+      );
     },
     [],
   );

--- a/apps/mobile/src/modules/fizruk/lib/dualWrite/__tests__/adapter.test.ts
+++ b/apps/mobile/src/modules/fizruk/lib/dualWrite/__tests__/adapter.test.ts
@@ -358,3 +358,358 @@ describe("applyFizrukDualWriteOps — Stage 12 ops (mobile, better-sqlite3)", ()
     expect(rows[0]!.name).toBe("Newer");
   });
 });
+
+describe("applyFizrukDualWriteOps — Stage 12.5 ops (mobile, better-sqlite3)", () => {
+  let db: ReturnType<typeof Database>;
+  let client: SqliteMigrationClient;
+
+  beforeEach(async () => {
+    db = new Database(":memory:");
+    client = syncClient(db);
+    await migrateFizruk(client);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  // --- Programs ---------------------------------------------------------
+
+  it("upserts a programs singleton row with the active id", async () => {
+    const ops: FizrukDualWriteOp[] = [
+      {
+        kind: "programs-set",
+        programs: { activeProgramId: "prog-1" },
+      },
+    ];
+    const result = await applyFizrukDualWriteOps(client, ops, {
+      userId: UID,
+      clientTs: TS1,
+      logger: silentLogger,
+    });
+    expect(result.applied).toBe(1);
+
+    const rows = client.all<Record<string, unknown>>(
+      "SELECT * FROM fizruk_programs WHERE user_id = ?",
+      [UID],
+    ) as unknown as Record<string, unknown>[];
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.active_program_id).toBe("prog-1");
+    expect(rows[0]!.updated_at).toBe(TS1);
+  });
+
+  it("upserts a programs row with null active id (cleared slot)", async () => {
+    await applyFizrukDualWriteOps(
+      client,
+      [{ kind: "programs-set", programs: { activeProgramId: "prog-1" } }],
+      { userId: UID, clientTs: TS1, logger: silentLogger },
+    );
+    await applyFizrukDualWriteOps(
+      client,
+      [{ kind: "programs-set", programs: { activeProgramId: null } }],
+      { userId: UID, clientTs: TS2, logger: silentLogger },
+    );
+    const rows = client.all<Record<string, unknown>>(
+      "SELECT active_program_id, updated_at FROM fizruk_programs WHERE user_id = ?",
+      [UID],
+    ) as unknown as Record<string, unknown>[];
+    expect(rows[0]!.active_program_id).toBeNull();
+    expect(rows[0]!.updated_at).toBe(TS2);
+  });
+
+  it("LWW guard: stale programs-set is a no-op", async () => {
+    await applyFizrukDualWriteOps(
+      client,
+      [{ kind: "programs-set", programs: { activeProgramId: "newer" } }],
+      { userId: UID, clientTs: TS2, logger: silentLogger },
+    );
+    await applyFizrukDualWriteOps(
+      client,
+      [{ kind: "programs-set", programs: { activeProgramId: "stale" } }],
+      { userId: UID, clientTs: TS1, logger: silentLogger },
+    );
+    const rows = client.all<Record<string, unknown>>(
+      "SELECT active_program_id FROM fizruk_programs WHERE user_id = ?",
+      [UID],
+    ) as unknown as Record<string, unknown>[];
+    expect(rows[0]!.active_program_id).toBe("newer");
+  });
+
+  // --- Plan template ----------------------------------------------------
+
+  it("upserts a plan-template singleton row with a non-null blob", async () => {
+    const ops: FizrukDualWriteOp[] = [
+      {
+        kind: "plan-template-set",
+        planTemplate: { dataJson: '{"id":"t1","name":"Push"}' },
+      },
+    ];
+    const result = await applyFizrukDualWriteOps(client, ops, {
+      userId: UID,
+      clientTs: TS1,
+      logger: silentLogger,
+    });
+    expect(result.applied).toBe(1);
+
+    const rows = client.all<Record<string, unknown>>(
+      "SELECT data_json, updated_at FROM fizruk_plan_templates WHERE user_id = ?",
+      [UID],
+    ) as unknown as Record<string, unknown>[];
+    expect(rows[0]!.data_json).toBe('{"id":"t1","name":"Push"}');
+    expect(rows[0]!.updated_at).toBe(TS1);
+  });
+
+  it("upserts a plan-template row with the JSON literal 'null' (cleared slot)", async () => {
+    await applyFizrukDualWriteOps(
+      client,
+      [
+        {
+          kind: "plan-template-set",
+          planTemplate: { dataJson: '{"id":"t1"}' },
+        },
+      ],
+      { userId: UID, clientTs: TS1, logger: silentLogger },
+    );
+    await applyFizrukDualWriteOps(
+      client,
+      [{ kind: "plan-template-set", planTemplate: { dataJson: "null" } }],
+      { userId: UID, clientTs: TS2, logger: silentLogger },
+    );
+    const rows = client.all<Record<string, unknown>>(
+      "SELECT data_json, updated_at FROM fizruk_plan_templates WHERE user_id = ?",
+      [UID],
+    ) as unknown as Record<string, unknown>[];
+    expect(rows[0]!.data_json).toBe("null");
+    expect(rows[0]!.updated_at).toBe(TS2);
+  });
+
+  it("LWW guard: stale plan-template-set is a no-op", async () => {
+    await applyFizrukDualWriteOps(
+      client,
+      [
+        {
+          kind: "plan-template-set",
+          planTemplate: { dataJson: '{"k":"newer"}' },
+        },
+      ],
+      { userId: UID, clientTs: TS2, logger: silentLogger },
+    );
+    await applyFizrukDualWriteOps(
+      client,
+      [
+        {
+          kind: "plan-template-set",
+          planTemplate: { dataJson: '{"k":"stale"}' },
+        },
+      ],
+      { userId: UID, clientTs: TS1, logger: silentLogger },
+    );
+    const rows = client.all<Record<string, unknown>>(
+      "SELECT data_json FROM fizruk_plan_templates WHERE user_id = ?",
+      [UID],
+    ) as unknown as Record<string, unknown>[];
+    expect(rows[0]!.data_json).toBe('{"k":"newer"}');
+  });
+
+  // --- Wellbeing --------------------------------------------------------
+
+  it("upserts a wellbeing entry keyed by (user_id, date_key)", async () => {
+    const ops: FizrukDualWriteOp[] = [
+      {
+        kind: "wellbeing-upsert",
+        entry: {
+          dateKey: "2026-05-01",
+          mood: 4,
+          energy: 3,
+          sleepQuality: 4,
+          sleepHours: 7.5,
+          notes: "good day",
+          updatedAt: TS1,
+        },
+      },
+    ];
+    const result = await applyFizrukDualWriteOps(client, ops, {
+      userId: UID,
+      clientTs: TS1,
+      logger: silentLogger,
+    });
+    expect(result.applied).toBe(1);
+
+    const rows = client.all<Record<string, unknown>>(
+      "SELECT * FROM fizruk_wellbeing WHERE user_id = ? AND date_key = ?",
+      [UID, "2026-05-01"],
+    ) as unknown as Record<string, unknown>[];
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.mood).toBe(4);
+    expect(rows[0]!.energy).toBe(3);
+    expect(rows[0]!.sleep_quality).toBe(4);
+    expect(rows[0]!.sleep_hours).toBe(7.5);
+    expect(rows[0]!.notes).toBe("good day");
+    expect(rows[0]!.deleted_at).toBeNull();
+  });
+
+  it("upserts a wellbeing entry with all optional fields null", async () => {
+    const ops: FizrukDualWriteOp[] = [
+      {
+        kind: "wellbeing-upsert",
+        entry: {
+          dateKey: "2026-05-02",
+          mood: null,
+          energy: null,
+          sleepQuality: null,
+          sleepHours: null,
+          notes: "",
+          updatedAt: TS1,
+        },
+      },
+    ];
+    await applyFizrukDualWriteOps(client, ops, {
+      userId: UID,
+      clientTs: TS1,
+      logger: silentLogger,
+    });
+    const rows = client.all<Record<string, unknown>>(
+      "SELECT mood, energy, sleep_quality, sleep_hours, notes FROM fizruk_wellbeing WHERE user_id = ? AND date_key = ?",
+      [UID, "2026-05-02"],
+    ) as unknown as Record<string, unknown>[];
+    expect(rows[0]!.mood).toBeNull();
+    expect(rows[0]!.energy).toBeNull();
+    expect(rows[0]!.sleep_quality).toBeNull();
+    expect(rows[0]!.sleep_hours).toBeNull();
+    expect(rows[0]!.notes).toBe("");
+  });
+
+  it("soft-deletes a wellbeing entry by date_key", async () => {
+    await applyFizrukDualWriteOps(
+      client,
+      [
+        {
+          kind: "wellbeing-upsert",
+          entry: {
+            dateKey: "2026-05-01",
+            mood: 5,
+            energy: 5,
+            sleepQuality: 5,
+            sleepHours: 8,
+            notes: "best day",
+            updatedAt: TS1,
+          },
+        },
+      ],
+      { userId: UID, clientTs: TS1, logger: silentLogger },
+    );
+    const result = await applyFizrukDualWriteOps(
+      client,
+      [{ kind: "wellbeing-delete", dateKey: "2026-05-01" }],
+      { userId: UID, clientTs: TS2, logger: silentLogger },
+    );
+    expect(result.applied).toBe(1);
+
+    const after = client.all<Record<string, unknown>>(
+      "SELECT deleted_at FROM fizruk_wellbeing WHERE user_id = ? AND date_key = ?",
+      [UID, "2026-05-01"],
+    ) as unknown as Record<string, unknown>[];
+    expect(after[0]!.deleted_at).toBe(TS2);
+  });
+
+  it("LWW guard: stale wellbeing upsert does not overwrite newer row", async () => {
+    await applyFizrukDualWriteOps(
+      client,
+      [
+        {
+          kind: "wellbeing-upsert",
+          entry: {
+            dateKey: "2026-05-01",
+            mood: 5,
+            energy: 5,
+            sleepQuality: 5,
+            sleepHours: 8,
+            notes: "newer",
+            updatedAt: TS2,
+          },
+        },
+      ],
+      { userId: UID, clientTs: TS2, logger: silentLogger },
+    );
+    await applyFizrukDualWriteOps(
+      client,
+      [
+        {
+          kind: "wellbeing-upsert",
+          entry: {
+            dateKey: "2026-05-01",
+            mood: 1,
+            energy: 1,
+            sleepQuality: 1,
+            sleepHours: 4,
+            notes: "stale",
+            updatedAt: TS1,
+          },
+        },
+      ],
+      { userId: UID, clientTs: TS1, logger: silentLogger },
+    );
+
+    const rows = client.all<Record<string, unknown>>(
+      "SELECT notes, mood FROM fizruk_wellbeing WHERE user_id = ? AND date_key = ?",
+      [UID, "2026-05-01"],
+    ) as unknown as Record<string, unknown>[];
+    expect(rows[0]!.notes).toBe("newer");
+    expect(rows[0]!.mood).toBe(5);
+  });
+
+  it("upsert after delete clears deleted_at", async () => {
+    await applyFizrukDualWriteOps(
+      client,
+      [
+        {
+          kind: "wellbeing-upsert",
+          entry: {
+            dateKey: "2026-05-01",
+            mood: 4,
+            energy: 4,
+            sleepQuality: 4,
+            sleepHours: 8,
+            notes: "first",
+            updatedAt: TS1,
+          },
+        },
+      ],
+      { userId: UID, clientTs: TS1, logger: silentLogger },
+    );
+    await applyFizrukDualWriteOps(
+      client,
+      [{ kind: "wellbeing-delete", dateKey: "2026-05-01" }],
+      { userId: UID, clientTs: TS2, logger: silentLogger },
+    );
+    // Re-upsert with newer timestamp must clear deleted_at.
+    await applyFizrukDualWriteOps(
+      client,
+      [
+        {
+          kind: "wellbeing-upsert",
+          entry: {
+            dateKey: "2026-05-01",
+            mood: 5,
+            energy: 5,
+            sleepQuality: 5,
+            sleepHours: 9,
+            notes: "rehydrated",
+            updatedAt: "2026-05-01T12:00:00.000Z",
+          },
+        },
+      ],
+      {
+        userId: UID,
+        clientTs: "2026-05-01T12:00:00.000Z",
+        logger: silentLogger,
+      },
+    );
+    const rows = client.all<Record<string, unknown>>(
+      "SELECT notes, deleted_at FROM fizruk_wellbeing WHERE user_id = ? AND date_key = ?",
+      [UID, "2026-05-01"],
+    ) as unknown as Record<string, unknown>[];
+    expect(rows[0]!.notes).toBe("rehydrated");
+    expect(rows[0]!.deleted_at).toBeNull();
+  });
+});

--- a/apps/mobile/src/modules/fizruk/lib/dualWrite/__tests__/diff.test.ts
+++ b/apps/mobile/src/modules/fizruk/lib/dualWrite/__tests__/diff.test.ts
@@ -7,6 +7,10 @@
  * **Stage 12 / PR #070f-mobile-dualwrite** — extends the diff
  * coverage from the original three classes (workouts, custom
  * exercises, measurements) to the full six classes shipped on web.
+ *
+ * **Stage 12.5 / PR #070f2-mobile-dualwrite** — covers the three
+ * remaining mobile-only entity classes (programs, plan-template,
+ * wellbeing) added by the same PR.
  */
 import {
   diffFizrukDualWriteOps,
@@ -15,6 +19,9 @@ import {
   type FizrukDualWriteState,
   type FizrukMeasurementSnapshot,
   type FizrukMonthlyPlanSnapshot,
+  type FizrukPlanTemplateSnapshot,
+  type FizrukProgramsSnapshot,
+  type FizrukWellbeingSnapshot,
   type FizrukWorkoutSnapshot,
   type FizrukWorkoutTemplateSnapshot,
 } from "../diff";
@@ -26,6 +33,9 @@ const EMPTY: FizrukDualWriteState = {
   dailyLog: [],
   monthlyPlan: null,
   workoutTemplates: [],
+  programs: null,
+  planTemplate: null,
+  wellbeing: [],
 };
 
 function makeWorkout(
@@ -76,6 +86,21 @@ function makeTemplate(
     exerciseIds: ["bench-press"],
     groups: [],
     updatedAt: "2026-05-01T10:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeWellbeing(
+  overrides: Partial<FizrukWellbeingSnapshot> = {},
+): FizrukWellbeingSnapshot {
+  return {
+    dateKey: "2026-05-01",
+    mood: 4,
+    energy: 3,
+    sleepQuality: 4,
+    sleepHours: 7.5,
+    notes: "",
+    updatedAt: "2026-05-01T07:00:00Z",
     ...overrides,
   };
 }
@@ -302,6 +327,193 @@ describe("diffFizrukDualWriteOps (mobile)", () => {
         "daily-log-upsert",
         "measurement-upsert",
         "monthly-plan-set",
+        "workout-template-upsert",
+        "workout-upsert",
+      ].sort(),
+    );
+  });
+
+  // --- Programs (Stage 12.5) ---
+
+  it("emits programs-set when active id changes from null to non-null", () => {
+    const programs: FizrukProgramsSnapshot = { activeProgramId: "prog-1" };
+    const next: FizrukDualWriteState = { ...EMPTY, programs };
+    const ops = diffFizrukDualWriteOps(EMPTY, next);
+    expect(ops).toHaveLength(1);
+    expect(ops[0]).toEqual({ kind: "programs-set", programs });
+  });
+
+  it("emits programs-set when active id changes", () => {
+    const a: FizrukProgramsSnapshot = { activeProgramId: "prog-1" };
+    const b: FizrukProgramsSnapshot = { activeProgramId: "prog-2" };
+    const prev: FizrukDualWriteState = { ...EMPTY, programs: a };
+    const next: FizrukDualWriteState = { ...EMPTY, programs: b };
+    const ops = diffFizrukDualWriteOps(prev, next);
+    expect(ops).toHaveLength(1);
+    expect(ops[0]).toEqual({ kind: "programs-set", programs: b });
+  });
+
+  it("emits programs-set when clearing the active program (id → null)", () => {
+    const a: FizrukProgramsSnapshot = { activeProgramId: "prog-1" };
+    const b: FizrukProgramsSnapshot = { activeProgramId: null };
+    const prev: FizrukDualWriteState = { ...EMPTY, programs: a };
+    const next: FizrukDualWriteState = { ...EMPTY, programs: b };
+    const ops = diffFizrukDualWriteOps(prev, next);
+    expect(ops).toHaveLength(1);
+    expect(ops[0]).toEqual({ kind: "programs-set", programs: b });
+  });
+
+  it("skips programs when active id unchanged across reference change", () => {
+    const a: FizrukProgramsSnapshot = { activeProgramId: "prog-1" };
+    const b: FizrukProgramsSnapshot = { activeProgramId: "prog-1" };
+    const prev: FizrukDualWriteState = { ...EMPTY, programs: a };
+    const next: FizrukDualWriteState = { ...EMPTY, programs: b };
+    expect(diffFizrukDualWriteOps(prev, next)).toEqual([]);
+  });
+
+  it("does not emit a programs op when next.programs is null (cold cache)", () => {
+    const a: FizrukProgramsSnapshot = { activeProgramId: "prog-1" };
+    const prev: FizrukDualWriteState = { ...EMPTY, programs: a };
+    expect(diffFizrukDualWriteOps(prev, EMPTY)).toEqual([]);
+  });
+
+  // --- Plan template (Stage 12.5) ---
+
+  it("emits plan-template-set when blob changes from null to present", () => {
+    const planTemplate: FizrukPlanTemplateSnapshot = {
+      dataJson: '{"id":"t1"}',
+    };
+    const next: FizrukDualWriteState = { ...EMPTY, planTemplate };
+    const ops = diffFizrukDualWriteOps(EMPTY, next);
+    expect(ops).toHaveLength(1);
+    expect(ops[0]).toEqual({ kind: "plan-template-set", planTemplate });
+  });
+
+  it("skips plan-template when JSON unchanged across reference change", () => {
+    const a: FizrukPlanTemplateSnapshot = { dataJson: '{"id":"t1"}' };
+    const b: FizrukPlanTemplateSnapshot = { dataJson: '{"id":"t1"}' };
+    const prev: FizrukDualWriteState = { ...EMPTY, planTemplate: a };
+    const next: FizrukDualWriteState = { ...EMPTY, planTemplate: b };
+    expect(diffFizrukDualWriteOps(prev, next)).toEqual([]);
+  });
+
+  it("emits plan-template-set when JSON differs", () => {
+    const a: FizrukPlanTemplateSnapshot = { dataJson: '{"id":"t1"}' };
+    const b: FizrukPlanTemplateSnapshot = { dataJson: '{"id":"t2"}' };
+    const prev: FizrukDualWriteState = { ...EMPTY, planTemplate: a };
+    const next: FizrukDualWriteState = { ...EMPTY, planTemplate: b };
+    const ops = diffFizrukDualWriteOps(prev, next);
+    expect(ops).toHaveLength(1);
+    expect(ops[0]).toEqual({ kind: "plan-template-set", planTemplate: b });
+  });
+
+  it("emits plan-template-set when slot is cleared to JSON literal 'null'", () => {
+    const a: FizrukPlanTemplateSnapshot = { dataJson: '{"id":"t1"}' };
+    const b: FizrukPlanTemplateSnapshot = { dataJson: "null" };
+    const prev: FizrukDualWriteState = { ...EMPTY, planTemplate: a };
+    const next: FizrukDualWriteState = { ...EMPTY, planTemplate: b };
+    const ops = diffFizrukDualWriteOps(prev, next);
+    expect(ops).toHaveLength(1);
+    expect(ops[0]).toEqual({ kind: "plan-template-set", planTemplate: b });
+  });
+
+  it("does not emit a plan-template op when next is null (cold cache)", () => {
+    const a: FizrukPlanTemplateSnapshot = { dataJson: '{"id":"t1"}' };
+    const prev: FizrukDualWriteState = { ...EMPTY, planTemplate: a };
+    expect(diffFizrukDualWriteOps(prev, EMPTY)).toEqual([]);
+  });
+
+  // --- Wellbeing (Stage 12.5) ---
+
+  it("detects wellbeing add", () => {
+    const e = makeWellbeing();
+    const next: FizrukDualWriteState = { ...EMPTY, wellbeing: [e] };
+    const ops = diffFizrukDualWriteOps(EMPTY, next);
+    expect(ops).toHaveLength(1);
+    expect(ops[0]).toEqual({ kind: "wellbeing-upsert", entry: e });
+  });
+
+  it("detects wellbeing delete (keyed by dateKey)", () => {
+    const e = makeWellbeing();
+    const prev: FizrukDualWriteState = { ...EMPTY, wellbeing: [e] };
+    const ops = diffFizrukDualWriteOps(prev, EMPTY);
+    expect(ops).toHaveLength(1);
+    expect(ops[0]).toEqual({
+      kind: "wellbeing-delete",
+      dateKey: "2026-05-01",
+    });
+  });
+
+  it("detects wellbeing update (mood changed)", () => {
+    const e1 = makeWellbeing({ mood: 3 });
+    const e2 = makeWellbeing({ mood: 5, updatedAt: "2026-05-01T08:00:00Z" });
+    const prev: FizrukDualWriteState = { ...EMPTY, wellbeing: [e1] };
+    const next: FizrukDualWriteState = { ...EMPTY, wellbeing: [e2] };
+    const ops = diffFizrukDualWriteOps(prev, next);
+    expect(ops).toHaveLength(1);
+    expect(ops[0]).toEqual({ kind: "wellbeing-upsert", entry: e2 });
+  });
+
+  it("skips wellbeing when fields equal across reference change", () => {
+    const e1 = makeWellbeing();
+    const e2 = makeWellbeing();
+    const prev: FizrukDualWriteState = { ...EMPTY, wellbeing: [e1] };
+    const next: FizrukDualWriteState = { ...EMPTY, wellbeing: [e2] };
+    expect(diffFizrukDualWriteOps(prev, next)).toEqual([]);
+  });
+
+  it("emits an upsert + a delete when one entry is replaced and another removed", () => {
+    const e1 = makeWellbeing({ dateKey: "2026-05-01" });
+    const e2 = makeWellbeing({ dateKey: "2026-05-02", mood: 5 });
+    const prev: FizrukDualWriteState = { ...EMPTY, wellbeing: [e1, e2] };
+    const replaced = makeWellbeing({
+      dateKey: "2026-05-01",
+      mood: 1,
+      updatedAt: "2026-05-01T09:00:00Z",
+    });
+    const next: FizrukDualWriteState = { ...EMPTY, wellbeing: [replaced] };
+    const ops = diffFizrukDualWriteOps(prev, next);
+    expect(ops).toHaveLength(2);
+    const kinds = ops.map((o) => o.kind).sort();
+    expect(kinds).toEqual(["wellbeing-delete", "wellbeing-upsert"]);
+  });
+
+  // --- Mixed (all nine entity classes) ---
+
+  it("handles changes across all nine entity classes in one diff", () => {
+    const w = makeWorkout();
+    const ex = makeExercise();
+    const m = makeMeasurement();
+    const d = makeDailyLog();
+    const monthly: FizrukMonthlyPlanSnapshot = { dataJson: '{"x":1}' };
+    const t = makeTemplate();
+    const programs: FizrukProgramsSnapshot = { activeProgramId: "prog-1" };
+    const planTemplate: FizrukPlanTemplateSnapshot = {
+      dataJson: '{"id":"t1"}',
+    };
+    const wb = makeWellbeing();
+
+    const ops = diffFizrukDualWriteOps(EMPTY, {
+      workouts: [w],
+      customExercises: [ex],
+      measurements: [m],
+      dailyLog: [d],
+      monthlyPlan: monthly,
+      workoutTemplates: [t],
+      programs,
+      planTemplate,
+      wellbeing: [wb],
+    });
+    const kinds = ops.map((o) => o.kind).sort();
+    expect(kinds).toEqual(
+      [
+        "custom-exercise-upsert",
+        "daily-log-upsert",
+        "measurement-upsert",
+        "monthly-plan-set",
+        "plan-template-set",
+        "programs-set",
+        "wellbeing-upsert",
         "workout-template-upsert",
         "workout-upsert",
       ].sort(),

--- a/apps/mobile/src/modules/fizruk/lib/dualWrite/__tests__/integration.test.ts
+++ b/apps/mobile/src/modules/fizruk/lib/dualWrite/__tests__/integration.test.ts
@@ -51,6 +51,9 @@ const EMPTY: FizrukDualWriteState = {
   dailyLog: [],
   monthlyPlan: null,
   workoutTemplates: [],
+  programs: null,
+  planTemplate: null,
+  wellbeing: [],
 };
 
 describe("dualWriteFizrukState orchestrator (mobile, Stage 12)", () => {
@@ -202,5 +205,38 @@ describe("dualWriteFizrukState orchestrator (mobile, Stage 12)", () => {
 
     const telemetry = __peekDualWriteTelemetryForTests("fizruk");
     expect(telemetry.parityMismatch).toBeGreaterThanOrEqual(1);
+  });
+
+  // --- Stage 12.5 -----------------------------------------------------
+
+  it("applies Stage 12.5 ops end-to-end and ticks parity match", async () => {
+    registerFizrukDualWriteContext(makeContext());
+    const next: FizrukDualWriteState = {
+      ...EMPTY,
+      programs: { activeProgramId: "prog-1" },
+      planTemplate: { dataJson: '{"id":"t1"}' },
+      wellbeing: [
+        {
+          dateKey: "2026-05-01",
+          mood: 4,
+          energy: 4,
+          sleepQuality: 4,
+          sleepHours: 7.5,
+          notes: "",
+          updatedAt: TS1,
+        },
+      ],
+    };
+    const outcome = await dualWriteFizrukState(EMPTY, next);
+    expect(outcome.status).toBe("applied");
+    if (outcome.status === "applied") {
+      expect(outcome.result.applied).toBe(3);
+      expect(outcome.result.errored).toBe(0);
+    }
+
+    const telemetry = __peekDualWriteTelemetryForTests("fizruk");
+    expect(telemetry.applied).toBe(1);
+    expect(telemetry.parityMatch).toBe(1);
+    expect(telemetry.parityMismatch).toBe(0);
   });
 });

--- a/apps/mobile/src/modules/fizruk/lib/dualWrite/__tests__/parity.test.ts
+++ b/apps/mobile/src/modules/fizruk/lib/dualWrite/__tests__/parity.test.ts
@@ -43,6 +43,9 @@ const EMPTY: FizrukDualWriteState = {
   dailyLog: [],
   monthlyPlan: null,
   workoutTemplates: [],
+  programs: null,
+  planTemplate: null,
+  wellbeing: [],
 };
 
 describe("probeFizrukParity (mobile)", () => {
@@ -206,5 +209,166 @@ describe("probeFizrukParity (mobile)", () => {
     const outcome = await probeFizrukParity(client, UID, state);
     const json = JSON.stringify(outcome);
     expect(json).not.toContain("secret-id-leak");
+  });
+
+  // --- Stage 12.5 — programs / plan-template / wellbeing -------------
+
+  it("reports match after a full Stage 12.5 dual-write apply", async () => {
+    const state: FizrukDualWriteState = {
+      ...EMPTY,
+      programs: { activeProgramId: "prog-1" },
+      planTemplate: { dataJson: '{"id":"t1"}' },
+      wellbeing: [
+        {
+          dateKey: "2026-05-01",
+          mood: 4,
+          energy: 4,
+          sleepQuality: 4,
+          sleepHours: 7.5,
+          notes: "",
+          updatedAt: TS1,
+        },
+      ],
+    };
+
+    await applyFizrukDualWriteOps(
+      client,
+      [
+        { kind: "programs-set", programs: state.programs! },
+        { kind: "plan-template-set", planTemplate: state.planTemplate! },
+        { kind: "wellbeing-upsert", entry: state.wellbeing![0]! },
+      ],
+      { userId: UID, clientTs: TS1 },
+    );
+
+    const outcome = await probeFizrukParity(client, UID, state);
+    expect(outcome.result).toBe("match");
+  });
+
+  it("reports mismatch when programs row is missing in SQLite but set in LS", async () => {
+    const state: FizrukDualWriteState = {
+      ...EMPTY,
+      programs: { activeProgramId: "prog-1" },
+    };
+    const outcome = await probeFizrukParity(client, UID, state);
+    expect(outcome.result).toBe("mismatch");
+    expect(outcome.details).toMatchObject({
+      programs: { ls: true, sqlite: false },
+    });
+  });
+
+  it("reports mismatch when programs active id differs", async () => {
+    await applyFizrukDualWriteOps(
+      client,
+      [{ kind: "programs-set", programs: { activeProgramId: "prog-A" } }],
+      { userId: UID, clientTs: TS1 },
+    );
+    const state: FizrukDualWriteState = {
+      ...EMPTY,
+      programs: { activeProgramId: "prog-B" },
+    };
+    const outcome = await probeFizrukParity(client, UID, state);
+    expect(outcome.result).toBe("mismatch");
+  });
+
+  it("does not include programs id values in mismatch details", async () => {
+    await applyFizrukDualWriteOps(
+      client,
+      [
+        {
+          kind: "programs-set",
+          programs: { activeProgramId: "sqlite-secret" },
+        },
+      ],
+      { userId: UID, clientTs: TS1 },
+    );
+    const state: FizrukDualWriteState = {
+      ...EMPTY,
+      programs: { activeProgramId: "ls-secret" },
+    };
+    const outcome = await probeFizrukParity(client, UID, state);
+    const json = JSON.stringify(outcome);
+    expect(json).not.toContain("sqlite-secret");
+    expect(json).not.toContain("ls-secret");
+  });
+
+  it("reports mismatch when SQLite has a stale plan-template blob", async () => {
+    await applyFizrukDualWriteOps(
+      client,
+      [
+        {
+          kind: "plan-template-set",
+          planTemplate: { dataJson: '{"v":"sqlite"}' },
+        },
+      ],
+      { userId: UID, clientTs: TS1 },
+    );
+    const state: FizrukDualWriteState = {
+      ...EMPTY,
+      planTemplate: { dataJson: '{"v":"ls"}' },
+    };
+    const outcome = await probeFizrukParity(client, UID, state);
+    expect(outcome.result).toBe("mismatch");
+  });
+
+  it("does not include plan-template blob bodies in mismatch details", async () => {
+    await applyFizrukDualWriteOps(
+      client,
+      [
+        {
+          kind: "plan-template-set",
+          planTemplate: { dataJson: '{"sqlite":"secret-blob-1"}' },
+        },
+      ],
+      { userId: UID, clientTs: TS1 },
+    );
+    const state: FizrukDualWriteState = {
+      ...EMPTY,
+      planTemplate: { dataJson: '{"ls":"secret-blob-2"}' },
+    };
+    const outcome = await probeFizrukParity(client, UID, state);
+    const json = JSON.stringify(outcome);
+    expect(json).not.toContain("secret-blob-1");
+    expect(json).not.toContain("secret-blob-2");
+  });
+
+  it("reports mismatch when wellbeing date_key sets diverge", async () => {
+    await applyFizrukDualWriteOps(
+      client,
+      [
+        {
+          kind: "wellbeing-upsert",
+          entry: {
+            dateKey: "2026-05-01",
+            mood: 4,
+            energy: 4,
+            sleepQuality: 4,
+            sleepHours: 8,
+            notes: "",
+            updatedAt: TS1,
+          },
+        },
+      ],
+      { userId: UID, clientTs: TS1 },
+    );
+    const state: FizrukDualWriteState = {
+      ...EMPTY,
+      wellbeing: [
+        {
+          dateKey: "2026-05-02",
+          mood: 4,
+          energy: 4,
+          sleepQuality: 4,
+          sleepHours: 8,
+          notes: "",
+          updatedAt: TS1,
+        },
+      ],
+    };
+    const outcome = await probeFizrukParity(client, UID, state);
+    expect(outcome.result).toBe("mismatch");
+    expect(outcome.details).toMatchObject({
+      wellbeing: { ls: 1, sqlite: 1, lsOnly: 1, sqliteOnly: 1 },
+    });
   });
 });

--- a/apps/mobile/src/modules/fizruk/lib/dualWrite/adapter.ts
+++ b/apps/mobile/src/modules/fizruk/lib/dualWrite/adapter.ts
@@ -7,6 +7,9 @@ import type {
   FizrukItemSnapshot,
   FizrukMeasurementSnapshot,
   FizrukMonthlyPlanSnapshot,
+  FizrukPlanTemplateSnapshot,
+  FizrukProgramsSnapshot,
+  FizrukWellbeingSnapshot,
   FizrukWorkoutSnapshot,
   FizrukWorkoutTemplateSnapshot,
 } from "./diff";
@@ -136,6 +139,23 @@ async function applyOne(
 
     case "workout-template-delete":
       await softDeleteWorkoutTemplate(client, op.templateId, userId, clientTs);
+      return "applied";
+
+    // Stage 12.5 / PR #070f2-mobile-dualwrite ops --------------------
+    case "programs-set":
+      await setPrograms(client, op.programs, userId, clientTs);
+      return "applied";
+
+    case "plan-template-set":
+      await setPlanTemplate(client, op.planTemplate, userId, clientTs);
+      return "applied";
+
+    case "wellbeing-upsert":
+      await upsertWellbeing(client, op.entry, userId, clientTs);
+      return "applied";
+
+    case "wellbeing-delete":
+      await softDeleteWellbeing(client, op.dateKey, userId, clientTs);
       return "applied";
 
     default: {
@@ -595,6 +615,100 @@ async function softDeleteWorkoutTemplate(
         SET deleted_at = ?, updated_at = ?
       WHERE id = ? AND user_id = ? AND updated_at < ?`,
     [clientTs, clientTs, templateId, userId, clientTs],
+  );
+}
+
+// -----------------------------------------------------------------------
+// Stage 12.5 / PR #070f2-mobile-dualwrite — programs singleton row
+// -----------------------------------------------------------------------
+
+async function setPrograms(
+  client: SqliteMigrationClient,
+  programs: FizrukProgramsSnapshot,
+  userId: string,
+  clientTs: string,
+): Promise<void> {
+  await client.run(
+    `INSERT INTO fizruk_programs (user_id, active_program_id, updated_at)
+     VALUES (?, ?, ?)
+     ON CONFLICT(user_id) DO UPDATE SET
+       active_program_id = excluded.active_program_id,
+       updated_at        = excluded.updated_at
+     WHERE excluded.updated_at > fizruk_programs.updated_at`,
+    [userId, programs.activeProgramId ?? null, clientTs],
+  );
+}
+
+// -----------------------------------------------------------------------
+// Stage 12.5 / PR #070f2-mobile-dualwrite — plan-template singleton row
+// -----------------------------------------------------------------------
+
+async function setPlanTemplate(
+  client: SqliteMigrationClient,
+  planTemplate: FizrukPlanTemplateSnapshot,
+  userId: string,
+  clientTs: string,
+): Promise<void> {
+  await client.run(
+    `INSERT INTO fizruk_plan_templates (user_id, data_json, updated_at)
+     VALUES (?, ?, ?)
+     ON CONFLICT(user_id) DO UPDATE SET
+       data_json  = excluded.data_json,
+       updated_at = excluded.updated_at
+     WHERE excluded.updated_at > fizruk_plan_templates.updated_at`,
+    [userId, planTemplate.dataJson ?? "null", clientTs],
+  );
+}
+
+// -----------------------------------------------------------------------
+// Stage 12.5 / PR #070f2-mobile-dualwrite — wellbeing per-(user,date) row
+// -----------------------------------------------------------------------
+
+async function upsertWellbeing(
+  client: SqliteMigrationClient,
+  e: FizrukWellbeingSnapshot,
+  userId: string,
+  clientTs: string,
+): Promise<void> {
+  await client.run(
+    `INSERT INTO fizruk_wellbeing
+       (user_id, date_key, mood, energy, sleep_quality, sleep_hours,
+        notes, created_at, updated_at, deleted_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+     ON CONFLICT(user_id, date_key) DO UPDATE SET
+       mood          = excluded.mood,
+       energy        = excluded.energy,
+       sleep_quality = excluded.sleep_quality,
+       sleep_hours   = excluded.sleep_hours,
+       notes         = excluded.notes,
+       updated_at    = excluded.updated_at,
+       deleted_at    = NULL
+     WHERE excluded.updated_at > fizruk_wellbeing.updated_at`,
+    [
+      userId,
+      e.dateKey,
+      toIntOrNull(e.mood),
+      toIntOrNull(e.energy),
+      toIntOrNull(e.sleepQuality),
+      toRealOrNull(e.sleepHours),
+      e.notes ?? "",
+      clientTs,
+      clientTs,
+    ],
+  );
+}
+
+async function softDeleteWellbeing(
+  client: SqliteMigrationClient,
+  dateKey: string,
+  userId: string,
+  clientTs: string,
+): Promise<void> {
+  await client.run(
+    `UPDATE fizruk_wellbeing
+        SET deleted_at = ?, updated_at = ?
+      WHERE user_id = ? AND date_key = ? AND updated_at < ?`,
+    [clientTs, clientTs, userId, dateKey, clientTs],
   );
 }
 

--- a/apps/mobile/src/modules/fizruk/lib/dualWrite/diff.ts
+++ b/apps/mobile/src/modules/fizruk/lib/dualWrite/diff.ts
@@ -19,9 +19,21 @@
  *   - `workout-template-upsert` / `workout-template-delete` —
  *     top-level `fizruk_workout_templates` rows (per-template).
  *
+ * **Stage 12.5 / PR #070f2-mobile-dualwrite** — extends the mobile
+ * snapshot + op set to the three remaining mobile-only Fizruk hook
+ * surfaces (`usePrograms`, `usePlanTemplate`, `useWellbeing`):
+ *
+ *   - `programs-set` — singleton `fizruk_programs` row holding the
+ *     active-program id (or `null` when no program is active).
+ *   - `plan-template-set` — singleton `fizruk_plan_templates` blob
+ *     (free-form JSON document, mirrors the monthly-plan shape).
+ *   - `wellbeing-upsert` / `wellbeing-delete` — composite-PK
+ *     `fizruk_wellbeing` rows keyed by `(user_id, date_key)`.
+ *
  * The diff order is stable: workouts → custom exercises →
- * measurements → daily-log → monthly-plan → workout-templates.
- * See the web copy for the full mapping rules and design notes.
+ * measurements → daily-log → monthly-plan → workout-templates →
+ * programs → plan-template → wellbeing. See the web copy for the
+ * full mapping rules and design notes.
  */
 
 // -----------------------------------------------------------------------
@@ -84,6 +96,27 @@ export interface WorkoutTemplateDeleteOp {
   readonly templateId: string;
 }
 
+// Stage 12.5 / PR #070f2-mobile-dualwrite -------------------------------
+export interface ProgramsSetOp {
+  readonly kind: "programs-set";
+  readonly programs: FizrukProgramsSnapshot;
+}
+
+export interface PlanTemplateSetOp {
+  readonly kind: "plan-template-set";
+  readonly planTemplate: FizrukPlanTemplateSnapshot;
+}
+
+export interface WellbeingUpsertOp {
+  readonly kind: "wellbeing-upsert";
+  readonly entry: FizrukWellbeingSnapshot;
+}
+
+export interface WellbeingDeleteOp {
+  readonly kind: "wellbeing-delete";
+  readonly dateKey: string;
+}
+
 export type FizrukDualWriteOp =
   | WorkoutUpsertOp
   | WorkoutDeleteOp
@@ -95,7 +128,11 @@ export type FizrukDualWriteOp =
   | DailyLogDeleteOp
   | MonthlyPlanSetOp
   | WorkoutTemplateUpsertOp
-  | WorkoutTemplateDeleteOp;
+  | WorkoutTemplateDeleteOp
+  | ProgramsSetOp
+  | PlanTemplateSetOp
+  | WellbeingUpsertOp
+  | WellbeingDeleteOp;
 
 // -----------------------------------------------------------------------
 // Snapshot shapes
@@ -192,6 +229,44 @@ export interface FizrukWorkoutTemplateSnapshot {
   readonly lastUsedAt?: string | null;
 }
 
+/**
+ * Stage 12.5 / PR #070f2-mobile-dualwrite — programs singleton.
+ * Mirrors the SQLite `fizruk_programs` row: just the active-program
+ * id (or `null` when no program is active). The diff treats the
+ * singleton as set-or-no-op (no delete op).
+ */
+export interface FizrukProgramsSnapshot {
+  readonly activeProgramId: string | null;
+}
+
+/**
+ * Stage 12.5 / PR #070f2-mobile-dualwrite — plan-template singleton.
+ * The whole document (or `null` when the slot is empty) is
+ * serialised to a JSON string so the diff can compare two payloads
+ * by byte-equality. The adapter writes `dataJson` straight into
+ * `fizruk_plan_templates.data_json` (default `'null'` for the
+ * empty slot — keeping the row present for LWW timestamping).
+ */
+export interface FizrukPlanTemplateSnapshot {
+  readonly dataJson: string;
+}
+
+/**
+ * Stage 12.5 / PR #070f2-mobile-dualwrite — wellbeing entry.
+ * Keyed by `dateKey` (`YYYY-MM-DD`); the SQLite primary key is the
+ * composite `(user_id, date_key)`. Mood / energy / sleepQuality are
+ * 1–5 integers; sleepHours is REAL (form supports half-hour ticks).
+ */
+export interface FizrukWellbeingSnapshot {
+  readonly dateKey: string;
+  readonly mood: number | null;
+  readonly energy: number | null;
+  readonly sleepQuality: number | null;
+  readonly sleepHours: number | null;
+  readonly notes: string;
+  readonly updatedAt: string;
+}
+
 // -----------------------------------------------------------------------
 // State shape
 // -----------------------------------------------------------------------
@@ -209,6 +284,14 @@ export interface FizrukDualWriteState {
   readonly monthlyPlan?: FizrukMonthlyPlanSnapshot | null;
   /** Stage 12 / PR #070f-mobile-dualwrite. */
   readonly workoutTemplates?: readonly FizrukWorkoutTemplateSnapshot[];
+  /** Stage 12.5 / PR #070f2-mobile-dualwrite. `null` ≡ "no programs
+   * row exists for the user yet" (cold cache). */
+  readonly programs?: FizrukProgramsSnapshot | null;
+  /** Stage 12.5 / PR #070f2-mobile-dualwrite. `null` ≡ cold cache;
+   * a present-but-empty document is encoded with `dataJson === 'null'`. */
+  readonly planTemplate?: FizrukPlanTemplateSnapshot | null;
+  /** Stage 12.5 / PR #070f2-mobile-dualwrite. */
+  readonly wellbeing?: readonly FizrukWellbeingSnapshot[];
 }
 
 // -----------------------------------------------------------------------
@@ -274,6 +357,26 @@ export function diffFizrukDualWriteOps(
     (id) => ops.push({ kind: "workout-template-delete", templateId: id }),
   );
 
+  // --- Programs (Stage 12.5) ---
+  diffProgramsOps(prev, next, ops);
+
+  // --- Plan template (Stage 12.5) ---
+  diffPlanTemplateOps(prev, next, ops);
+
+  // --- Wellbeing (Stage 12.5) — composite-PK array ---
+  diffArray(
+    (prev.wellbeing ?? []).map(toWellbeingDiffItem),
+    (next.wellbeing ?? []).map(toWellbeingDiffItem),
+    (e) => e.id,
+    wellbeingChanged,
+    (e) =>
+      ops.push({
+        kind: "wellbeing-upsert",
+        entry: e.snapshot,
+      }),
+    (id) => ops.push({ kind: "wellbeing-delete", dateKey: id }),
+  );
+
   return ops;
 }
 
@@ -298,6 +401,46 @@ function diffMonthlyPlanOps(
   }
   if (prevPlan && prevPlan.dataJson === nextPlan.dataJson) return;
   ops.push({ kind: "monthly-plan-set", monthlyPlan: nextPlan });
+}
+
+// -----------------------------------------------------------------------
+// Stage 12.5 — programs / plan-template singleton diffs
+// -----------------------------------------------------------------------
+
+function diffProgramsOps(
+  prev: FizrukDualWriteState,
+  next: FizrukDualWriteState,
+  ops: FizrukDualWriteOp[],
+): void {
+  const prevPrograms = prev.programs ?? null;
+  const nextPrograms = next.programs ?? null;
+  // `null` on `next` is treated as cold cache (no-op). A registered
+  // hook that explicitly clears the active program emits a snapshot
+  // with `activeProgramId === null` rather than `programs === null`.
+  if (nextPrograms === null) return;
+  if (
+    prevPrograms &&
+    prevPrograms.activeProgramId === nextPrograms.activeProgramId
+  ) {
+    return;
+  }
+  ops.push({ kind: "programs-set", programs: nextPrograms });
+}
+
+function diffPlanTemplateOps(
+  prev: FizrukDualWriteState,
+  next: FizrukDualWriteState,
+  ops: FizrukDualWriteOp[],
+): void {
+  const prevPlan = prev.planTemplate ?? null;
+  const nextPlan = next.planTemplate ?? null;
+  // `null` on `next` ≡ cold cache; the hook emits an explicit
+  // `dataJson === 'null'` payload when clearing the slot, and that
+  // round-trips through `fizruk_plan_templates.data_json` (default
+  // `'null'`) without triggering a delete op.
+  if (nextPlan === null) return;
+  if (prevPlan && prevPlan.dataJson === nextPlan.dataJson) return;
+  ops.push({ kind: "plan-template-set", planTemplate: nextPlan });
 }
 
 // -----------------------------------------------------------------------
@@ -389,5 +532,39 @@ function workoutTemplateChanged(
     prev.groups !== next.groups ||
     prev.updatedAt !== next.updatedAt ||
     (prev.lastUsedAt ?? null) !== (next.lastUsedAt ?? null)
+  );
+}
+
+// -----------------------------------------------------------------------
+// Stage 12.5 — wellbeing diff helpers
+// -----------------------------------------------------------------------
+
+/** Diff key wrapper so `diffArray` can key wellbeing rows by
+ * `dateKey` while still carrying the full snapshot through to the
+ * upsert op. */
+interface WellbeingDiffItem {
+  readonly id: string;
+  readonly snapshot: FizrukWellbeingSnapshot;
+}
+
+function toWellbeingDiffItem(
+  snapshot: FizrukWellbeingSnapshot,
+): WellbeingDiffItem {
+  return { id: snapshot.dateKey, snapshot };
+}
+
+function wellbeingChanged(
+  prev: WellbeingDiffItem,
+  next: WellbeingDiffItem,
+): boolean {
+  const a = prev.snapshot;
+  const b = next.snapshot;
+  return (
+    a.mood !== b.mood ||
+    a.energy !== b.energy ||
+    a.sleepQuality !== b.sleepQuality ||
+    a.sleepHours !== b.sleepHours ||
+    a.notes !== b.notes ||
+    a.updatedAt !== b.updatedAt
   );
 }

--- a/apps/mobile/src/modules/fizruk/lib/dualWrite/parity.ts
+++ b/apps/mobile/src/modules/fizruk/lib/dualWrite/parity.ts
@@ -27,6 +27,17 @@ import type { FizrukDualWriteState } from "./diff";
  *   6. **Workout templates** — top-level rows in
  *      `fizruk_workout_templates`.
  *
+ * **Stage 12.5 / PR #070f2-mobile-dualwrite** — adds three more
+ * mobile-only entity classes:
+ *
+ *   7. **Programs** — singleton `fizruk_programs` row compared by
+ *      `active_program_id` equality (or both-absent).
+ *   8. **Plan template** — singleton `fizruk_plan_templates` blob
+ *      compared by JSON-string equality.
+ *   9. **Wellbeing** — composite-PK `fizruk_wellbeing` rows keyed
+ *      by `(user_id, date_key)`; the probe compares the active
+ *      `date_key` set rather than synthetic ids.
+ *
  * The probe is best-effort: it must NEVER throw, and any read failure
  * is surfaced as a `read.fallback` — distinct from a real parity
  * mismatch — so triage can tell `SELECT failing` apart from `LS and
@@ -76,12 +87,19 @@ export async function probeFizrukParity(
     "fizruk_workout_templates",
     userId,
   );
+  // Stage 12.5 — wellbeing composite-PK active date_key set.
+  const sqliteWellbeingDates = await readActiveWellbeingDateKeys(
+    client,
+    userId,
+  );
 
   const lsWorkouts = buildIdSet(next.workouts);
   const lsCustomExercises = buildIdSet(next.customExercises);
   const lsMeasurements = buildIdSet(next.measurements);
   const lsDailyLog = buildIdSet(next.dailyLog ?? []);
   const lsWorkoutTemplates = buildIdSet(next.workoutTemplates ?? []);
+  // Wellbeing key is `dateKey`, not `id`; build a dedicated set.
+  const lsWellbeingDates = buildWellbeingDateSet(next.wellbeing ?? []);
 
   const workoutsDiff = compareSets(lsWorkouts, sqliteWorkouts);
   const customExercisesDiff = compareSets(
@@ -94,8 +112,12 @@ export async function probeFizrukParity(
     lsWorkoutTemplates,
     sqliteWorkoutTemplates,
   );
+  const wellbeingDiff = compareSets(lsWellbeingDates, sqliteWellbeingDates);
   // Stage 12 — monthly-plan singleton compared by JSON-blob equality.
   const monthlyPlanDiff = await probeMonthlyPlan(client, userId, next);
+  // Stage 12.5 — programs / plan-template singletons.
+  const programsDiff = await probePrograms(client, userId, next);
+  const planTemplateDiff = await probePlanTemplate(client, userId, next);
 
   const allMatch =
     workoutsDiff.match &&
@@ -103,7 +125,10 @@ export async function probeFizrukParity(
     measurementsDiff.match &&
     dailyLogDiff.match &&
     workoutTemplatesDiff.match &&
-    monthlyPlanDiff.match;
+    monthlyPlanDiff.match &&
+    programsDiff.match &&
+    planTemplateDiff.match &&
+    wellbeingDiff.match;
 
   if (allMatch) {
     return {
@@ -124,6 +149,12 @@ export async function probeFizrukParity(
           sqlite: sqliteWorkoutTemplates.size,
         },
         monthlyPlan: monthlyPlanDiff.details,
+        programs: programsDiff.details,
+        planTemplate: planTemplateDiff.details,
+        wellbeing: {
+          ls: lsWellbeingDates.size,
+          sqlite: sqliteWellbeingDates.size,
+        },
       },
     };
   }
@@ -167,6 +198,14 @@ export async function probeFizrukParity(
         sqliteOnly: workoutTemplatesDiff.sqliteOnly,
       },
       monthlyPlan: monthlyPlanDiff.details,
+      programs: programsDiff.details,
+      planTemplate: planTemplateDiff.details,
+      wellbeing: {
+        ls: lsWellbeingDates.size,
+        sqlite: sqliteWellbeingDates.size,
+        lsOnly: wellbeingDiff.lsOnly,
+        sqliteOnly: wellbeingDiff.sqliteOnly,
+      },
     },
   };
 }
@@ -200,6 +239,125 @@ async function readActiveIds(
 interface MonthlyPlanDiffResult {
   match: boolean;
   details: Record<string, unknown>;
+}
+
+// -----------------------------------------------------------------------
+// Stage 12.5 — wellbeing date_key probe + helpers
+// -----------------------------------------------------------------------
+
+async function readActiveWellbeingDateKeys(
+  client: SqliteMigrationClient,
+  userId: string,
+): Promise<Set<string>> {
+  const rows = await client.all<{ date_key: string }>(
+    `SELECT date_key FROM fizruk_wellbeing
+       WHERE user_id = ? AND deleted_at IS NULL`,
+    [userId],
+  );
+  const out = new Set<string>();
+  for (const row of rows) {
+    if (typeof row.date_key === "string" && row.date_key.length > 0) {
+      out.add(row.date_key);
+    }
+  }
+  return out;
+}
+
+function buildWellbeingDateSet(
+  entries: readonly { dateKey: string }[],
+): Set<string> {
+  const out = new Set<string>();
+  if (!Array.isArray(entries)) return out;
+  for (const e of entries) {
+    if (
+      e &&
+      typeof e === "object" &&
+      typeof e.dateKey === "string" &&
+      e.dateKey.length > 0
+    ) {
+      out.add(e.dateKey);
+    }
+  }
+  return out;
+}
+
+// -----------------------------------------------------------------------
+// Stage 12.5 — programs singleton probe (active id equality)
+// -----------------------------------------------------------------------
+
+interface SingletonDiffResult {
+  match: boolean;
+  details: Record<string, unknown>;
+}
+
+async function probePrograms(
+  client: SqliteMigrationClient,
+  userId: string,
+  next: FizrukDualWriteState,
+): Promise<SingletonDiffResult> {
+  const rows = await client.all<{ active_program_id: string | null }>(
+    `SELECT active_program_id FROM fizruk_programs WHERE user_id = ?`,
+    [userId],
+  );
+  const sqliteHas = rows.length > 0;
+  const lsHas = next.programs !== null && next.programs !== undefined;
+
+  if (!lsHas && !sqliteHas) {
+    return { match: true, details: { ls: false, sqlite: false } };
+  }
+  if (lsHas !== sqliteHas) {
+    return { match: false, details: { ls: lsHas, sqlite: sqliteHas } };
+  }
+  const sqliteId =
+    typeof rows[0]?.active_program_id === "string"
+      ? rows[0].active_program_id
+      : null;
+  const lsId = next.programs?.activeProgramId ?? null;
+  const equal = sqliteId === lsId;
+  return {
+    match: equal,
+    details: equal
+      ? { ls: true, sqlite: true, equal: true }
+      : { ls: true, sqlite: true, equalId: false },
+  };
+}
+
+// -----------------------------------------------------------------------
+// Stage 12.5 — plan-template singleton probe (JSON-blob equality)
+// -----------------------------------------------------------------------
+
+async function probePlanTemplate(
+  client: SqliteMigrationClient,
+  userId: string,
+  next: FizrukDualWriteState,
+): Promise<SingletonDiffResult> {
+  const rows = await client.all<{ data_json: string }>(
+    `SELECT data_json FROM fizruk_plan_templates WHERE user_id = ?`,
+    [userId],
+  );
+  const sqliteHas = rows.length > 0;
+  const lsHas = next.planTemplate !== null && next.planTemplate !== undefined;
+
+  if (!lsHas && !sqliteHas) {
+    return { match: true, details: { ls: false, sqlite: false } };
+  }
+  if (lsHas !== sqliteHas) {
+    return { match: false, details: { ls: lsHas, sqlite: sqliteHas } };
+  }
+  const sqliteJson = rows[0]?.data_json ?? "null";
+  const lsJson = next.planTemplate?.dataJson ?? "null";
+  const equal = sqliteJson === lsJson;
+  return {
+    match: equal,
+    details: equal
+      ? { ls: true, sqlite: true, equal: true }
+      : {
+          ls: true,
+          sqlite: true,
+          lsLen: lsJson.length,
+          sqliteLen: sqliteJson.length,
+        },
+  };
 }
 
 async function probeMonthlyPlan(

--- a/apps/mobile/src/modules/fizruk/lib/fizrukDualWriteState.ts
+++ b/apps/mobile/src/modules/fizruk/lib/fizrukDualWriteState.ts
@@ -67,7 +67,10 @@ import {
   type FizrukItemSnapshot,
   type FizrukMeasurementSnapshot,
   type FizrukMonthlyPlanSnapshot,
+  type FizrukPlanTemplateSnapshot,
+  type FizrukProgramsSnapshot,
   type FizrukSetSnapshot,
+  type FizrukWellbeingSnapshot,
   type FizrukWorkoutSnapshot,
   type FizrukWorkoutTemplateSnapshot,
 } from "./dualWrite/diff";
@@ -110,6 +113,37 @@ export interface FizrukWorkoutTemplateLike {
   lastUsedAt?: string | null;
 }
 
+/**
+ * Stage 12.5 / PR #070f2-mobile-dualwrite — hook-side shapes for the
+ * three remaining mobile-only Fizruk hooks. Kept loose so the
+ * extractor module stays hook-free.
+ */
+export interface FizrukProgramsLike {
+  /** Domain `ActiveProgramState.activeProgramId`. */
+  activeProgramId?: string | null;
+}
+
+/** Mirror of `usePlanTemplate` `PlanTemplate` (allow extra fields). */
+export interface FizrukPlanTemplateLike {
+  id?: string | null;
+  name?: string | null;
+  weekday?: Record<string, string | null>;
+  notes?: string | null;
+  updatedAt?: string | null;
+  [extra: string]: unknown;
+}
+
+export interface FizrukWellbeingEntryLike {
+  /** `YYYY-MM-DD` — primary key. Required (filtered out otherwise). */
+  date?: string | null;
+  mood?: number | null;
+  energy?: number | null;
+  sleepQuality?: number | null;
+  sleepHours?: number | null;
+  notes?: string | null;
+  updatedAt?: string | null;
+}
+
 export const EMPTY_FIZRUK_DUAL_WRITE_STATE: FizrukDualWriteState = {
   workouts: [],
   customExercises: [],
@@ -117,6 +151,9 @@ export const EMPTY_FIZRUK_DUAL_WRITE_STATE: FizrukDualWriteState = {
   dailyLog: [],
   monthlyPlan: null,
   workoutTemplates: [],
+  programs: null,
+  planTemplate: null,
+  wellbeing: [],
 };
 
 /**
@@ -137,6 +174,11 @@ export function peekFizrukDualWriteState(): FizrukDualWriteState | null {
       workoutTemplates: extractWorkoutTemplateSnapshots(
         cache.workoutTemplates ?? [],
       ),
+      programs: extractProgramsSnapshotFromCache(cache.programs ?? null),
+      planTemplate: extractPlanTemplateSnapshotFromCache(
+        cache.planTemplate ?? null,
+      ),
+      wellbeing: extractWellbeingSnapshots(cache.wellbeing ?? []),
     };
   } catch {
     return null;
@@ -296,6 +338,102 @@ function numericOrNull(v: unknown): number | null {
   if (v === null || v === undefined) return null;
   const n = Number(v);
   return Number.isFinite(n) ? n : null;
+}
+
+function integerOrNull(v: unknown): number | null {
+  const n = numericOrNull(v);
+  return n === null ? null : Math.round(n);
+}
+
+// -----------------------------------------------------------------------
+// Stage 12.5 / PR #070f2-mobile-dualwrite — extractors
+// -----------------------------------------------------------------------
+
+/**
+ * Extract a programs snapshot from a hook-shape `ActiveProgramState`
+ * (or any structurally compatible payload). Returns `null` only for
+ * cold cache (`state == null`); a present-but-empty active slot is
+ * encoded as `{ activeProgramId: null }`.
+ */
+export function extractProgramsSnapshot(
+  state: FizrukProgramsLike | null | undefined,
+): FizrukProgramsSnapshot | null {
+  if (state === null || state === undefined) return null;
+  if (typeof state !== "object") return null;
+  const id = state.activeProgramId;
+  return {
+    activeProgramId: typeof id === "string" && id.length > 0 ? id : null,
+  };
+}
+
+/**
+ * Extract a programs snapshot from the cached SQLite row. Mirrors
+ * `extractProgramsSnapshot` but accepts the cache shape directly so
+ * the cache peek path skips redundant transformations.
+ */
+function extractProgramsSnapshotFromCache(
+  cached: { activeProgramId: string | null } | null,
+): FizrukProgramsSnapshot | null {
+  if (cached === null) return null;
+  return { activeProgramId: cached.activeProgramId };
+}
+
+/**
+ * Extract a plan-template snapshot. Mirrors the monthly-plan extractor:
+ * the whole document is serialised to a stable JSON string. The empty
+ * slot (`null`) is encoded as the JSON literal `'null'` so the SQLite
+ * row stays present (and the LWW timestamp valid).
+ */
+export function extractPlanTemplateSnapshot(
+  state: FizrukPlanTemplateLike | null | undefined,
+): FizrukPlanTemplateSnapshot {
+  if (state === null || state === undefined) {
+    return { dataJson: "null" };
+  }
+  if (typeof state !== "object") return { dataJson: "null" };
+  // Trust the hook to keep the document plain-object-serialisable.
+  // `JSON.stringify` of a non-cyclic plain object never throws; if
+  // it does (custom toJSON), fall back to `null` so the row stays
+  // valid.
+  try {
+    return { dataJson: JSON.stringify(state) };
+  } catch {
+    return { dataJson: "null" };
+  }
+}
+
+function extractPlanTemplateSnapshotFromCache(
+  cached: { dataJson: string } | null,
+): FizrukPlanTemplateSnapshot | null {
+  if (cached === null) return null;
+  return { dataJson: cached.dataJson };
+}
+
+/**
+ * Extract wellbeing snapshots. Filters out entries with no `date`
+ * key (the SQLite primary key is `(user_id, date_key)` so the row
+ * is meaningless without a date).
+ */
+export function extractWellbeingSnapshots(
+  entries: readonly FizrukWellbeingEntryLike[],
+): FizrukWellbeingSnapshot[] {
+  const out: FizrukWellbeingSnapshot[] = [];
+  if (!Array.isArray(entries)) return out;
+  for (const e of entries) {
+    if (!e || typeof e !== "object") continue;
+    const date = typeof e.date === "string" ? e.date : null;
+    if (!date) continue;
+    out.push({
+      dateKey: date,
+      mood: integerOrNull(e.mood ?? null),
+      energy: integerOrNull(e.energy ?? null),
+      sleepQuality: integerOrNull(e.sleepQuality ?? null),
+      sleepHours: numericOrNull(e.sleepHours ?? null),
+      notes: typeof e.notes === "string" ? e.notes : "",
+      updatedAt: typeof e.updatedAt === "string" ? e.updatedAt : "",
+    });
+  }
+  return out;
 }
 
 // -----------------------------------------------------------------------

--- a/apps/mobile/src/modules/fizruk/lib/sqliteReader.ts
+++ b/apps/mobile/src/modules/fizruk/lib/sqliteReader.ts
@@ -13,6 +13,12 @@
  * The cache is consumed by `peekFizrukDualWriteState()` so each
  * dual-write trigger sees the SQLite-backed `prev` state for all
  * six classes.
+ *
+ * **Stage 12.5 / PR #070f2-mobile-dualwrite** — extends the cache to
+ * cover the three remaining mobile-only entity classes
+ * (`fizruk_programs`, `fizruk_plan_templates`, `fizruk_wellbeing`).
+ * The shape mirrors the hook payloads so a later read cutover can
+ * drive the hooks straight from the cache.
  */
 
 import type { SqliteMigrationClient } from "@sergeant/db-schema/migrate/sqlite";
@@ -72,6 +78,37 @@ export interface CachedWorkoutTemplate {
   lastUsedAt: string | null;
 }
 
+/**
+ * Stage 12.5 / PR #070f2-mobile-dualwrite — cached programs row.
+ * Only the active-program id needs to round-trip; the catalogue is
+ * shipped with the bundle.
+ */
+export interface CachedProgramsState {
+  activeProgramId: string | null;
+}
+
+/**
+ * Stage 12.5 / PR #070f2-mobile-dualwrite — cached plan-template
+ * singleton. The hook persists either a free-form object or `null`,
+ * so we keep the JSON blob verbatim and let the consumer parse it.
+ */
+export interface CachedPlanTemplateState {
+  /** Verbatim JSON blob from `fizruk_plan_templates.data_json`
+   * (default `'null'` for the empty slot). */
+  dataJson: string;
+}
+
+/** Stage 12.5 / PR #070f2-mobile-dualwrite — cached wellbeing entry. */
+export interface CachedWellbeingEntry {
+  date: string;
+  mood: number | null;
+  energy: number | null;
+  sleepQuality: number | null;
+  sleepHours: number | null;
+  notes: string;
+  updatedAt: string;
+}
+
 export interface SqliteFizrukCache {
   workouts: Workout[];
   customExercises: RawExerciseDef[];
@@ -82,6 +119,12 @@ export interface SqliteFizrukCache {
   monthlyPlan: CachedMonthlyPlanState | null;
   /** Stage 12 / PR #070f-mobile-dualwrite. */
   workoutTemplates: CachedWorkoutTemplate[];
+  /** Stage 12.5 / PR #070f2-mobile-dualwrite. `null` ≡ "no row yet". */
+  programs: CachedProgramsState | null;
+  /** Stage 12.5 / PR #070f2-mobile-dualwrite. `null` ≡ "no row yet". */
+  planTemplate: CachedPlanTemplateState | null;
+  /** Stage 12.5 / PR #070f2-mobile-dualwrite. */
+  wellbeing: CachedWellbeingEntry[];
   refreshedAt: string | null;
 }
 
@@ -92,6 +135,9 @@ const EMPTY_CACHE: SqliteFizrukCache = {
   dailyLog: [],
   monthlyPlan: null,
   workoutTemplates: [],
+  programs: null,
+  planTemplate: null,
+  wellbeing: [],
   refreshedAt: null,
 };
 
@@ -181,6 +227,28 @@ interface WorkoutTemplateRow {
   exercise_ids_json: string | null;
   groups_json: string | null;
   last_used_at: string | null;
+  updated_at: string | null;
+  [key: string]: unknown;
+}
+
+// Stage 12.5 / PR #070f2-mobile-dualwrite — row shapes for the new tables.
+interface ProgramsRow {
+  active_program_id: string | null;
+  [key: string]: unknown;
+}
+
+interface PlanTemplateRow {
+  data_json: string | null;
+  [key: string]: unknown;
+}
+
+interface WellbeingRow {
+  date_key: string;
+  mood: number | null;
+  energy: number | null;
+  sleep_quality: number | null;
+  sleep_hours: number | null;
+  notes: string | null;
   updated_at: string | null;
   [key: string]: unknown;
 }
@@ -286,6 +354,40 @@ function rowToWorkoutTemplate(row: WorkoutTemplateRow): CachedWorkoutTemplate {
   };
 }
 
+// Stage 12.5 / PR #070f2-mobile-dualwrite — row mappers ------------------
+
+function rowToPrograms(
+  row: ProgramsRow | undefined,
+): CachedProgramsState | null {
+  if (!row) return null;
+  return {
+    activeProgramId:
+      typeof row.active_program_id === "string" &&
+      row.active_program_id.length > 0
+        ? row.active_program_id
+        : null,
+  };
+}
+
+function rowToPlanTemplate(
+  row: PlanTemplateRow | undefined,
+): CachedPlanTemplateState | null {
+  if (!row) return null;
+  return { dataJson: row.data_json ?? "null" };
+}
+
+function rowToWellbeing(row: WellbeingRow): CachedWellbeingEntry {
+  return {
+    date: String(row.date_key),
+    mood: row.mood ?? null,
+    energy: row.energy ?? null,
+    sleepQuality: row.sleep_quality ?? null,
+    sleepHours: row.sleep_hours ?? null,
+    notes: row.notes ?? "",
+    updatedAt: row.updated_at ?? "",
+  };
+}
+
 function rowToMonthlyPlan(
   row: MonthlyPlanRow | undefined,
 ): CachedMonthlyPlanState | null {
@@ -332,6 +434,9 @@ export async function refreshFizrukSqliteState(
     dailyLogRows,
     monthlyPlanRows,
     workoutTemplateRows,
+    programsRows,
+    planTemplateRows,
+    wellbeingRows,
   ] = await Promise.all([
     client.all<WorkoutRow>(
       `SELECT id, started_at, ended_at, note, groups_json,
@@ -390,6 +495,22 @@ export async function refreshFizrukSqliteState(
           ORDER BY updated_at DESC, id ASC`,
       [userId],
     ),
+    // Stage 12.5 / PR #070f2-mobile-dualwrite ------------------------
+    client.all<ProgramsRow>(
+      `SELECT active_program_id FROM fizruk_programs WHERE user_id = ?`,
+      [userId],
+    ),
+    client.all<PlanTemplateRow>(
+      `SELECT data_json FROM fizruk_plan_templates WHERE user_id = ?`,
+      [userId],
+    ),
+    client.all<WellbeingRow>(
+      `SELECT date_key, mood, energy, sleep_quality, sleep_hours, notes, updated_at
+           FROM fizruk_wellbeing
+          WHERE user_id = ? AND deleted_at IS NULL
+          ORDER BY date_key DESC`,
+      [userId],
+    ),
   ]);
 
   const setsByItem = new Map<string, WorkoutItem["sets"]>();
@@ -418,6 +539,9 @@ export async function refreshFizrukSqliteState(
   const dailyLog = dailyLogRows.map(rowToDailyLog);
   const monthlyPlan = rowToMonthlyPlan(monthlyPlanRows[0]);
   const workoutTemplates = workoutTemplateRows.map(rowToWorkoutTemplate);
+  const programs = rowToPrograms(programsRows[0]);
+  const planTemplate = rowToPlanTemplate(planTemplateRows[0]);
+  const wellbeing = wellbeingRows.map(rowToWellbeing);
 
   cache = {
     workouts,
@@ -426,6 +550,9 @@ export async function refreshFizrukSqliteState(
     dailyLog,
     monthlyPlan,
     workoutTemplates,
+    programs,
+    planTemplate,
+    wellbeing,
     refreshedAt: new Date().toISOString(),
   };
   return cache;

--- a/docs/planning/storage-roadmap.md
+++ b/docs/planning/storage-roadmap.md
@@ -3177,6 +3177,35 @@ mobile dualwrite → tombstone). Stage 11 — повторюваний applicati
   `useWellbeing`, `useActiveFizrukWorkout`) ще не виведені з MMKV
   (потребують окремого `#070f-mobile-dualwrite` extension).
 
+**Stage 12.5 — extend mobile dual-write до залишкових hooks (3+1):**
+
+- **PR #070f2-mobile-dualwrite** 🚧 IN-FLIGHT — розширити
+  `apps/mobile/src/modules/fizruk/lib/dualWrite/{diff,adapter,parity}.ts`
+  - `sqliteReader.ts` + `fizrukDualWriteState.ts` extractors на 3
+    залишкові entity classes з виділеними SQLite таблицями:
+    `programs` (singleton, `fizruk_programs`), `plan-template`
+    (singleton JSON-blob, `fizruk_plan_templates`), `wellbeing`
+    (composite-PK array per `(user_id, date_key)`, `fizruk_wellbeing`).
+    Wire `triggerFizrukDualWrite` у `usePrograms` / `usePlanTemplate` /
+    `useWellbeing` (зберігаємо `safeWriteLS` для майбутнього
+    `#057f2-tombstone` PR). 4 нові ops (`programs-set`,
+    `plan-template-set`, `wellbeing-upsert`, `wellbeing-delete`) +
+    LWW guard на upsert (composite-PK для wellbeing).
+    Schemas вже існують з `#070f-schema` (Stage 12) — нових міграцій
+    не потрібно. Tests: extend `diff.test.ts` (+18 cases),
+    `adapter.test.ts` (+11), `parity.test.ts` (+6), `integration.test.ts`
+    (+1) — всі mobile fizruk suites зелені (192/192).
+- **PR #057f2-tombstone-mobile-stage12-5** 📋 PROPOSED — drop MMKV
+  writes у 3 hooks shipped у `#070f2`. Cache-overlay reads через
+  `getCachedFizrukSqliteState()`; `residualImport.ts` extended з
+  6 → 9 entity classes (`FIZRUK_PROGRAMS` / `FIZRUK_PLAN_TEMPLATE` /
+  `FIZRUK_WELLBEING`). `STORAGE_KEYS.FIZRUK_PROGRAMS` /
+  `STORAGE_KEYS.FIZRUK_WELLBEING` помічені `@deprecated`.
+- **PR #070f3-active-workout-dualwrite** 📋 PROPOSED — окремий
+  follow-up для `useActiveFizrukWorkout` (single string id у
+  Stage 9 `kv_store`, інший pipeline ніж 9 виділених таблиць).
+  Smaller PR (kv_store-shape adapter + extractor).
+
 **Done criteria.**
 
 - ~5–6 нових Fizruk таблиць populated в production (web + mobile).


### PR DESCRIPTION
## Summary

Stage 12.5 / PR #070f2-mobile-dualwrite — extend the mobile Fizruk
dual-write pipeline to cover the three remaining mobile-only entity
classes that have a dedicated SQLite table:

- **`programs`** (singleton, `fizruk_programs`)
- **`plan-template`** (singleton JSON blob, `fizruk_plan_templates`)
- **`wellbeing`** (composite-PK array per `(user_id, date_key)`, `fizruk_wellbeing`)

Schemas were shipped in `#070f-schema` (Stage 12) — no new migrations
are required. The fourth remaining hook, `useActiveFizrukWorkout`,
rides on the Stage 9 `kv_store` and is deferred to a follow-up PR
`#070f3-active-workout-dualwrite` (different pipeline).

This PR keeps `safeWriteLS` calls in place — MMKV writes are dropped
in the next PR, `#057f2-tombstone-mobile-stage12-5`.

**Changes:**

- `diff.ts` — 4 new ops (`programs-set`, `plan-template-set`,
  `wellbeing-upsert`, `wellbeing-delete`) + matching snapshot types.
  Singleton diffing for programs / plan-template; composite-PK
  diffing for wellbeing.
- `adapter.ts` — `ON CONFLICT(user_id) DO UPDATE` for the two
  singletons, `ON CONFLICT(user_id, date_key) DO UPDATE` for
  wellbeing, all guarded by the LWW (`updated_at`) check shared
  with Stage 12.
- `parity.ts` — `probePrograms` (id equality), `probePlanTemplate`
  (`dataJson` equality), wellbeing `date_key` set probe; mismatch
  details never include user-data values.
- `sqliteReader.ts` — warm-cache rows for the three new tables wired
  into `refreshFizrukSqliteCache()`.
- `fizrukDualWriteState.ts` — `extractProgramsSnapshot`,
  `extractPlanTemplateSnapshot`, `extractWellbeingSnapshots` (+ peek
  variants); `EMPTY_FIZRUK_DUAL_WRITE_STATE` extended to nine slots.
- `usePrograms` / `usePlanTemplate` / `useWellbeing` — trigger
  `triggerFizrukDualWrite` after each MMKV write.

## Governing Skill

- Primary skill: `fizruk-storage-migration` (Stage 12 mirror)
- Secondary skill: n/a

## Playbook

- Primary playbook: `docs/playbooks/storage-roadmap-stages.md` (Stage 12 dual-write extension)
- Why this playbook: this is a direct mirror of the Stage 12 dual-write extension pattern, just covering the remaining three mobile-only entity classes that share the same dedicated-table layout.
- If no playbook matched, why: n/a

## Verification

```bash
pnpm --filter @sergeant/mobile typecheck      # clean
pnpm --filter @sergeant/mobile lint           # clean
pnpm --filter @sergeant/mobile jest --testPathPattern fizruk
# Test Suites: 25 passed, Tests: 192 passed (was 157, +35 new)

pnpm typecheck                                # 16 packages, all green
pnpm format:check                             # all matched files use Prettier
pnpm lint                                     # turbo + scripts, all green
```

Additional checks:

- [x] Local smoke / manual validation completed (jest fizruk suite, 192/192 green)
- [x] Surface-specific checks completed (mobile typecheck, lint, format)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- `docs/planning/storage-roadmap.md` — Stage 12.5 pop-out note for
  `#070f2-mobile-dualwrite` (this PR), `#057f2-tombstone-mobile-stage12-5`
  (follow-up MMKV drop), and `#070f3-active-workout-dualwrite`
  (separate kv_store-pipeline follow-up).

## Risk and Rollout

- **User-visible risk:** very low — dual-write is fire-and-forget, all
  reads still come from MMKV, parity probe runs on every apply but
  failures only tick a metric (no user-visible behaviour change).
- **Rollout / deploy order:** mobile-only change. Lands behind the
  existing Stage 12 mobile pipeline; no flag flip required.
- **Backout plan:** revert the merge commit. The three new SQLite
  tables stay (they were shipped in `#070f-schema`); the dual-write
  trigger calls are localized to `usePrograms` / `usePlanTemplate` /
  `useWellbeing` and to the dual-write infra files.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

- The `wellbeing` adapter uses a composite-PK `ON CONFLICT(user_id, date_key)`
  upsert — first time we use composite-PK in Fizruk dual-write. The
  `parity.ts` probe also relies on a `date_key` set rather than an id
  set; double-check the `lsOnly` / `sqliteOnly` accounting in
  `probeWellbeing()` matches `probeDailyLog()` semantics.
- Hook-side wiring uses the same `useRef` pattern shipped in Stage 12
  (mirrors `useDailyLog`). `peekFizrukDualWriteState()` falls back to
  `EMPTY_FIZRUK_DUAL_WRITE_STATE` so the orchestrator is happy on cold
  cache.
- After this lands, `#057f2-tombstone-mobile-stage12-5` drops the
  `safeWriteLS` calls and extends `residualImport.ts` (6 → 9 entity
  classes); `#070f3-active-workout-dualwrite` covers the last
  remaining hook via the `kv_store` pipeline.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the mobile Fizruk dual-write to cover the last three mobile-only entities: programs, plan-template, and wellbeing. MMKV writes are mirrored to SQLite with LWW upserts and parity checks; no schema migrations; reads stay on MMKV for now.

- **New Features**
  - Added diff ops: `programs-set`, `plan-template-set`, `wellbeing-upsert`, `wellbeing-delete` (singleton/composite-PK aware).
  - Adapter: `ON CONFLICT(user_id)` upserts for programs/plan-template; `ON CONFLICT(user_id, date_key)` for wellbeing; all LWW-guarded; soft delete + rehydrate for wellbeing.
  - Parity: probes for programs (active id), plan-template (JSON equality), wellbeing (active `date_key` set); mismatch details avoid user data.
  - Cache/state: extended SQLite warm-cache and snapshot extractors; dual-write state now covers nine slots; `usePrograms`, `usePlanTemplate`, and `useWellbeing` trigger dual-write after each MMKV write.
  - Tests: expanded unit/integration coverage for diff, adapter, parity; all passing.

<sup>Written for commit 31817bab58a4c79c8e639722604ab62be6a3c608. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for programs, workout plans, and wellness data synchronization across storage systems.

* **Chores**
  * Enhanced data reliability and consistency mechanisms for the mobile app's fitness tracking storage.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Skords-01/Sergeant/pull/2313)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->