### PR TITLE
feat(mobile): #073-tombstone — drop NUTRITION_SAVED_RECIPES MMKV write + extend residualImport

### DIFF
--- a/apps/mobile/app/(tabs)/nutrition/recipe/[id].tsx
+++ b/apps/mobile/app/(tabs)/nutrition/recipe/[id].tsx
@@ -1,6 +1,7 @@
 /**
  * Deep-link target for `sergeant://food/recipe/{id}`.
- * Показує збережений на пристрої рецепт (MMKV, ключ `NUTRITION_SAVED_RECIPES`).
+ * Показує збережений на пристрої рецепт із SQLite-таблиці `nutrition_recipes`
+ * (Stage 13 PR #073 of `docs/planning/storage-roadmap.md` — MMKV-write tombstoned).
  */
 import { useLocalSearchParams } from "expo-router";
 

--- a/apps/mobile/src/modules/nutrition/hooks/useSavedRecipeById.ts
+++ b/apps/mobile/src/modules/nutrition/hooks/useSavedRecipeById.ts
@@ -1,10 +1,7 @@
 import { useEffect, useState } from "react";
 
-import { STORAGE_KEYS } from "@sergeant/shared";
-
-import { _getMMKVInstance } from "@/lib/storage";
-
 import { getRecipeById, type SavedRecipe } from "../lib/recipeBookStore";
+import { useNutritionSqliteReadTick } from "../lib/sqliteReadGate";
 
 export function useSavedRecipeById(id: string | string[] | undefined): {
   recipe: SavedRecipe | undefined;
@@ -15,21 +12,14 @@ export function useSavedRecipeById(id: string | string[] | undefined): {
     recipeId ? getRecipeById(String(recipeId)) : undefined,
   );
 
+  // Stage 13 PR #073 of `docs/planning/storage-roadmap.md` — recipes
+  // live exclusively in the SQLite warm cache after the MMKV-write
+  // tombstone. The cache tick is the only re-render signal.
+  const sqliteCacheTick = useNutritionSqliteReadTick();
   useEffect(() => {
     const key = String(recipeId || "").trim();
-    if (!key) {
-      setRecipe(undefined);
-      return;
-    }
-    setRecipe(getRecipeById(key));
-    const mmkv = _getMMKVInstance();
-    const sub = mmkv.addOnValueChangedListener((changedKey) => {
-      if (changedKey === STORAGE_KEYS.NUTRITION_SAVED_RECIPES) {
-        setRecipe(getRecipeById(key));
-      }
-    });
-    return () => sub.remove();
-  }, [recipeId]);
+    setRecipe(key ? getRecipeById(key) : undefined);
+  }, [recipeId, sqliteCacheTick]);
 
   return { recipe, recipeId: String(recipeId) };
 }

--- a/apps/mobile/src/modules/nutrition/hooks/useSavedRecipesList.ts
+++ b/apps/mobile/src/modules/nutrition/hooks/useSavedRecipesList.ts
@@ -1,9 +1,5 @@
 import { useEffect, useState } from "react";
 
-import { STORAGE_KEYS } from "@sergeant/shared";
-
-import { _getMMKVInstance } from "@/lib/storage";
-
 import { loadSavedRecipes, type SavedRecipe } from "../lib/recipeBookStore";
 import { getCachedNutritionSqliteState } from "../lib/sqliteReader";
 import { useNutritionSqliteReadTick } from "../lib/sqliteReadGate";
@@ -13,25 +9,14 @@ export function useSavedRecipesList(): { recipes: SavedRecipe[] } {
     loadSavedRecipes(),
   );
 
-  useEffect(() => {
-    setRecipes(loadSavedRecipes());
-    const mmkv = _getMMKVInstance();
-    const sub = mmkv.addOnValueChangedListener((key) => {
-      if (key === STORAGE_KEYS.NUTRITION_SAVED_RECIPES) {
-        setRecipes(loadSavedRecipes());
-      }
-    });
-    return () => sub.remove();
-  }, []);
-
-  // Stage 4 PR #033 + Stage 8 PR #057n: overlay saved recipes from
-  // the local SQLite cache once it's warm. MMKV first-paint read
-  // above stays as a synchronous fallback.
+  // Stage 13 PR #073 of `docs/planning/storage-roadmap.md` — recipes
+  // live exclusively in the SQLite warm cache after the MMKV-write
+  // tombstone. The cache tick is the only re-render signal.
   const sqliteCacheTick = useNutritionSqliteReadTick();
   useEffect(() => {
     const cache = getCachedNutritionSqliteState();
     if (cache.refreshedAt === null) return;
-    setRecipes(cache.recipes);
+    setRecipes(loadSavedRecipes());
   }, [sqliteCacheTick]);
 
   return { recipes };

--- a/apps/mobile/src/modules/nutrition/lib/__tests__/recipeBookStore.test.ts
+++ b/apps/mobile/src/modules/nutrition/lib/__tests__/recipeBookStore.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Stage 13 PR #073 of `docs/planning/storage-roadmap.md` — recipes
+ * read from the SQLite warm cache and `saveRecipeBook` dual-writes
+ * via `triggerNutritionDualWrite` without MMKV.
+ */
 const mockSafeReadLS = jest.fn();
 const mockSafeWriteLS = jest.fn();
 jest.mock("@/lib/storage", () => ({
@@ -5,7 +10,14 @@ jest.mock("@/lib/storage", () => ({
   safeWriteLS: (...args: unknown[]) => mockSafeWriteLS(...args),
 }));
 
-import { STORAGE_KEYS } from "@sergeant/shared";
+const mockTriggerDualWrite = jest.fn();
+const mockIsRegistered = jest.fn();
+
+jest.mock("../dualWrite", () => ({
+  triggerNutritionDualWrite: (...args: unknown[]) =>
+    mockTriggerDualWrite(...args),
+  isNutritionDualWriteRegistered: () => mockIsRegistered(),
+}));
 
 import {
   getRecipeById,
@@ -13,13 +25,41 @@ import {
   loadSavedRecipes,
   normalizeSavedRecipe,
   removeSavedRecipe,
+  type SavedRecipe,
   upsertSavedRecipe,
 } from "../recipeBookStore";
+import {
+  __setNutritionSqliteCacheForTests,
+  clearNutritionSqliteCache,
+} from "../sqliteReader";
 
 beforeEach(() => {
   mockSafeReadLS.mockReset().mockReturnValue(null);
   mockSafeWriteLS.mockReset().mockReturnValue(true);
+  mockTriggerDualWrite.mockReset();
+  mockIsRegistered.mockReset().mockReturnValue(true);
+  clearNutritionSqliteCache();
 });
+
+function makeRecipe(partial: Partial<SavedRecipe>): SavedRecipe {
+  return {
+    id: partial.id ?? "r",
+    title: partial.title ?? "X",
+    timeMinutes: partial.timeMinutes ?? null,
+    servings: partial.servings ?? null,
+    ingredients: partial.ingredients ?? [],
+    steps: partial.steps ?? [],
+    tips: partial.tips ?? [],
+    macros: partial.macros ?? {
+      kcal: null,
+      protein_g: null,
+      fat_g: null,
+      carbs_g: null,
+    },
+    createdAt: partial.createdAt ?? 0,
+    updatedAt: partial.updatedAt ?? 0,
+  };
+}
 
 describe("recipeBookStore", () => {
   it("normalizeSavedRecipe maps partial objects", () => {
@@ -29,71 +69,98 @@ describe("recipeBookStore", () => {
     expect(r.ingredients).toEqual([]);
   });
 
-  it("loadSavedRecipes reads { recipes: [] } and legacy array", () => {
-    mockSafeReadLS.mockReturnValue({
-      recipes: [
-        { id: "r1", title: "A", updatedAt: 2 },
-        { id: "r2", title: "B", updatedAt: 5 },
-      ],
-    });
-    const a = loadSavedRecipes();
-    expect(a[0]?.id).toBe("r2");
-    expect(a[1]?.id).toBe("r1");
-
-    mockSafeReadLS.mockReturnValue([{ id: "x", title: "X", updatedAt: 1 }]);
-    const b = loadSavedRecipes();
-    expect(b[0]?.id).toBe("x");
+  it("loadSavedRecipes returns an empty list when the cache is cold", () => {
+    expect(loadSavedRecipes()).toEqual([]);
+    expect(mockSafeReadLS).not.toHaveBeenCalled();
   });
 
-  it("getRecipeById finds by id", () => {
-    mockSafeReadLS.mockReturnValue({
-      recipes: [{ id: "q", title: "Q", updatedAt: 1 }],
+  it("loadSavedRecipes reads from the SQLite warm cache, sorted by updatedAt desc", () => {
+    __setNutritionSqliteCacheForTests({
+      recipes: [
+        makeRecipe({ id: "r1", title: "A", updatedAt: 2 }),
+        makeRecipe({ id: "r2", title: "B", updatedAt: 5 }),
+      ],
+    });
+    const out = loadSavedRecipes();
+    expect(out[0]?.id).toBe("r2");
+    expect(out[1]?.id).toBe("r1");
+    expect(mockSafeReadLS).not.toHaveBeenCalled();
+  });
+
+  it("getRecipeById finds by id from the SQLite warm cache", () => {
+    __setNutritionSqliteCacheForTests({
+      recipes: [makeRecipe({ id: "q", title: "Q", updatedAt: 1 })],
     });
     expect(getRecipeById("q")?.title).toBe("Q");
     expect(getRecipeById("missing")).toBeUndefined();
   });
 
-  it("upsertSavedRecipe writes to MMKV under the saved-recipes key", () => {
-    mockSafeReadLS.mockReturnValue({ recipes: [] });
+  it("upsertSavedRecipe dispatches a dual-write op and never touches MMKV", () => {
     upsertSavedRecipe({ id: "n1", title: "New" });
-    expect(mockSafeWriteLS).toHaveBeenCalled();
-    const call = mockSafeWriteLS.mock.calls.find(
-      (c) => c[0] === STORAGE_KEYS.NUTRITION_SAVED_RECIPES,
-    );
-    expect(call).toBeTruthy();
+    expect(mockSafeWriteLS).not.toHaveBeenCalled();
+    expect(mockTriggerDualWrite).toHaveBeenCalledTimes(1);
+    const [, next] = mockTriggerDualWrite.mock.calls[0]!;
+    expect(next.recipes.map((r: { id: string }) => r.id)).toEqual(["n1"]);
   });
 
-  it("removeSavedRecipe drops one entry", () => {
-    mockSafeReadLS.mockReturnValue({
+  it("upsertSavedRecipe is a silent no-op when dual-write is not registered", () => {
+    mockIsRegistered.mockReturnValue(false);
+    upsertSavedRecipe({ id: "n1", title: "New" });
+    expect(mockTriggerDualWrite).not.toHaveBeenCalled();
+    expect(mockSafeWriteLS).not.toHaveBeenCalled();
+  });
+
+  it("removeSavedRecipe drops one entry via dual-write", () => {
+    __setNutritionSqliteCacheForTests({
       recipes: [
-        { id: "a", title: "A", updatedAt: 1 },
-        { id: "b", title: "B", updatedAt: 2 },
+        makeRecipe({ id: "a", title: "A", updatedAt: 1 }),
+        makeRecipe({ id: "b", title: "B", updatedAt: 2 }),
       ],
     });
     const ok = removeSavedRecipe("a");
     expect(ok).toBe(true);
-    const written = mockSafeWriteLS.mock.calls.find(
-      (c) => c[0] === STORAGE_KEYS.NUTRITION_SAVED_RECIPES,
-    )?.[1] as { recipes: { id: string }[] };
-    expect(written?.recipes?.map((r) => r.id)).toEqual(["b"]);
+    expect(mockSafeWriteLS).not.toHaveBeenCalled();
+    expect(mockTriggerDualWrite).toHaveBeenCalledTimes(1);
+    const [, next] = mockTriggerDualWrite.mock.calls[0]!;
+    expect(next.recipes.map((r: { id: string }) => r.id)).toEqual(["b"]);
   });
 
-  it("importRecipesFromJson accepts array and book shape", () => {
-    mockSafeReadLS.mockReturnValue({ recipes: [] });
-    const a = importRecipesFromJson(
-      JSON.stringify([{ id: "i1", title: "One" }]),
-    );
-    expect(a).toEqual({ ok: true, count: 1 });
+  it("removeSavedRecipe returns false when the id is unknown", () => {
+    __setNutritionSqliteCacheForTests({
+      recipes: [makeRecipe({ id: "a", title: "A" })],
+    });
+    expect(removeSavedRecipe("missing")).toBe(false);
+    expect(mockTriggerDualWrite).not.toHaveBeenCalled();
+  });
 
-    mockSafeReadLS.mockReturnValue({ recipes: [] });
+  it("importRecipesFromJson batches all entries into a single dual-write", () => {
+    const a = importRecipesFromJson(
+      JSON.stringify([
+        { id: "i1", title: "One" },
+        { id: "i2", title: "Two" },
+      ]),
+    );
+    expect(a).toEqual({ ok: true, count: 2 });
+    expect(mockSafeWriteLS).not.toHaveBeenCalled();
+    expect(mockTriggerDualWrite).toHaveBeenCalledTimes(1);
+    const [, next] = mockTriggerDualWrite.mock.calls[0]!;
+    const ids = next.recipes
+      .map((r: { id: string }) => r.id)
+      .sort((x: string, y: string) => x.localeCompare(y));
+    expect(ids).toEqual(["i1", "i2"]);
+  });
+
+  it("importRecipesFromJson accepts the { recipes: […] } book shape", () => {
     const b = importRecipesFromJson(
       JSON.stringify({ recipes: [{ id: "i2", title: "Two" }] }),
     );
     expect(b).toEqual({ ok: true, count: 1 });
+    expect(mockTriggerDualWrite).toHaveBeenCalledTimes(1);
   });
 
   it("importRecipesFromJson returns error for invalid input", () => {
     expect(importRecipesFromJson("not json")).toMatchObject({ ok: false });
     expect(importRecipesFromJson("[]")?.ok).toBe(false);
+    expect(mockTriggerDualWrite).not.toHaveBeenCalled();
   });
 });

--- a/apps/mobile/src/modules/nutrition/lib/recipeBookStore.ts
+++ b/apps/mobile/src/modules/nutrition/lib/recipeBookStore.ts
@@ -1,16 +1,25 @@
 /**
- * Локальна книга рецептів (MMKV), формат узгоджений з web `recipeBook.ts` (SavedRecipe + JSON blob).
+ * Локальна книга рецептів (mobile).
+ *
+ * Stage 13 PR #073 of `docs/planning/storage-roadmap.md` —
+ * `loadSavedRecipes` reads recipes з SQLite warm cache (`nutrition_recipes`),
+ * `saveRecipeBook` диспатчить через `triggerNutritionDualWrite` без
+ * MMKV-write. Boot-time `residualImport.ts` дренує старі MMKV-блоби
+ * `nutrition_recipe_book_v1` у SQLite і видаляє ключ.
+ *
+ * Mirror того ж pattern, що Stage 11 / PR #057n-tombstone-mobile
+ * розгорнув для water-log + shopping-list.
  */
+import { normalizeMacrosNullable, type NullableMacros } from "@sergeant/shared";
+
 import {
-  STORAGE_KEYS,
-  normalizeMacrosNullable,
-  type NullableMacros,
-} from "@sergeant/shared";
-
-import { safeReadLS, safeWriteLS } from "@/lib/storage";
-
-import { triggerNutritionDualWrite } from "./dualWrite";
+  isNutritionDualWriteRegistered,
+  triggerNutritionDualWrite,
+  type NutritionDualWriteState,
+} from "./dualWrite";
+import type { NutritionRecipeSnapshot } from "./dualWrite/diff";
 import { peekNutritionDualWriteState } from "./dualWriteState";
+import { getCachedNutritionSqliteState } from "./sqliteReader";
 
 export interface SavedRecipe {
   id: string;
@@ -72,24 +81,11 @@ export function normalizeSavedRecipe(raw: unknown): SavedRecipe {
   };
 }
 
-type RecipeBookV1 = { recipes: SavedRecipe[] };
-
-function asBook(raw: unknown): RecipeBookV1 {
-  if (Array.isArray(raw)) {
-    return { recipes: raw.map((x) => normalizeSavedRecipe(x)) };
-  }
-  const o =
-    raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
-  const arr = Array.isArray(o.recipes) ? o.recipes : [];
-  return { recipes: arr.map((x) => normalizeSavedRecipe(x)) };
-}
-
 export function loadSavedRecipes(): SavedRecipe[] {
-  const parsed = asBook(
-    safeReadLS<unknown>(STORAGE_KEYS.NUTRITION_SAVED_RECIPES, null),
+  const cache = getCachedNutritionSqliteState();
+  return [...cache.recipes].sort(
+    (a, b) => (b.updatedAt || 0) - (a.updatedAt || 0),
   );
-  const list = Array.isArray(parsed.recipes) ? parsed.recipes : [];
-  return [...list].sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0));
 }
 
 export function getRecipeById(id: string): SavedRecipe | undefined {
@@ -97,14 +93,26 @@ export function getRecipeById(id: string): SavedRecipe | undefined {
   return loadSavedRecipes().find((r) => r.id === id);
 }
 
+export function extractRecipeSnapshots(
+  recipes: readonly SavedRecipe[],
+): NutritionRecipeSnapshot[] {
+  return recipes.map((r) => ({
+    id: r.id,
+    title: r.title,
+    dataJson: JSON.stringify(r),
+  }));
+}
+
 export function saveRecipeBook(recipes: readonly SavedRecipe[]): boolean {
+  if (!isNutritionDualWriteRegistered()) return true;
   const prev = peekNutritionDualWriteState();
-  const book: RecipeBookV1 = { recipes: [...recipes] };
-  const ok = safeWriteLS(STORAGE_KEYS.NUTRITION_SAVED_RECIPES, book);
-  if (ok && prev !== null) {
-    triggerNutritionDualWrite(prev, peekNutritionDualWriteState() ?? prev);
-  }
-  return ok;
+  if (prev === null) return true;
+  const next: NutritionDualWriteState = {
+    ...prev,
+    recipes: extractRecipeSnapshots(recipes),
+  };
+  triggerNutritionDualWrite(prev, next);
+  return true;
 }
 
 /** Оновити або додати рецепт (для майбутнього збереження з UI / AI). */
@@ -127,7 +135,9 @@ export function removeSavedRecipe(id: string): boolean {
 
 /**
  * Імпорт з експорту web (JSON) / масиву / об'єкта { recipes: [...] }.
- * Кожен елемент нормалізується; існуючі id перезаписуються.
+ * Кожен елемент нормалізується; існуючі id перезаписуються. Усі updates
+ * батчаться в один `saveRecipeBook` щоб уникнути race-у з SQLite cache
+ * refresh-ом між послідовними викликами.
  */
 export function importRecipesFromJson(
   raw: string,
@@ -159,8 +169,13 @@ export function importRecipesFromJson(
     return { ok: false, error: "Порожній список" };
   }
 
+  const byId = new Map<string, SavedRecipe>(
+    loadSavedRecipes().map((r) => [r.id, r]),
+  );
   for (const item of list) {
-    upsertSavedRecipe(item);
+    const next = normalizeSavedRecipe(item);
+    byId.set(next.id, { ...next, updatedAt: Date.now() });
   }
+  saveRecipeBook([...byId.values()]);
   return { ok: true, count: list.length };
 }

--- a/apps/mobile/src/modules/nutrition/lib/residualImport.ts
+++ b/apps/mobile/src/modules/nutrition/lib/residualImport.ts
@@ -3,13 +3,17 @@
  *
  * Stage 8 PR #057n-tombstone of `docs/planning/storage-roadmap.md`
  * (mobile parity for `apps/web/src/modules/nutrition/lib/residualImport.ts`).
+ * Stage 13 PR #073 extended this drain to also cover the saved-recipes
+ * MMKV blob (`nutrition_recipe_book_v1`).
+ *
  * Reads any leftover values from the now-deprecated MMKV keys
  * (`nutrition_log_v1`, `nutrition_pantries_v1`,
  * `nutrition_active_pantry_v1`, `nutrition_prefs_v1`,
- * `nutrition_water_v1`, `nutrition_shopping_list_v1`), imports them
- * into the local `nutrition_*` SQLite tables (idempotent + LWW-safe),
- * and then deletes the MMKV entries. Subsequent boots no-op because
- * the MMKV keys are gone.
+ * `nutrition_water_v1`, `nutrition_shopping_list_v1`,
+ * `nutrition_recipe_book_v1`), imports them into the local
+ * `nutrition_*` SQLite tables (idempotent + LWW-safe), and then
+ * deletes the MMKV entries. Subsequent boots no-op because the MMKV
+ * keys are gone.
  *
  * The import uses a deliberately stale `clientTs` (epoch zero) so the
  * adapter's LWW guard always lets existing SQLite rows win — we never
@@ -34,6 +38,7 @@ import {
   type NutritionPrefs,
   type Pantry,
 } from "@sergeant/nutrition-domain";
+import { STORAGE_KEYS } from "@sergeant/shared";
 
 import { safeReadLS, safeReadStringLS, safeRemoveLS } from "@/lib/storage";
 
@@ -43,7 +48,9 @@ import {
   type NutritionDualWriteState,
   type NutritionMealSnapshot,
   type NutritionPantrySnapshot,
+  type NutritionRecipeSnapshot,
 } from "./dualWrite/diff";
+import { normalizeSavedRecipe, type SavedRecipe } from "./recipeBookStore";
 
 const STALE_TIMESTAMP = "1970-01-01T00:00:00.000Z";
 
@@ -78,6 +85,7 @@ export async function importNutritionResidualFromMmkv(
   const prefs = readPrefsFromMmkv();
   const waterLog = readWaterLogFromMmkv();
   const shoppingList = readShoppingListFromMmkv();
+  const recipes = readRecipesFromMmkv();
 
   const hasAny =
     log !== null ||
@@ -85,7 +93,8 @@ export async function importNutritionResidualFromMmkv(
     activePantryId !== null ||
     prefs !== null ||
     waterLog !== null ||
-    shoppingList !== null;
+    shoppingList !== null ||
+    recipes !== null;
   if (!hasAny) return { imported: false, cleaned: false };
 
   // Build a NutritionDualWriteState from whatever was found in MMKV.
@@ -108,7 +117,14 @@ export async function importNutritionResidualFromMmkv(
             activePantryId,
           }
         : null,
-    recipes: [],
+    // Stage 13 PR #073 — drain the saved-recipe blob. Each recipe is
+    // normalized against `SavedRecipe` and serialized into
+    // `nutrition_recipes.data_json`. The MMKV blob shape was
+    // `{ recipes: SavedRecipe[] }` (or a bare array on legacy builds);
+    // both layouts collapse via `extractRecipesFromMmkvBlob`.
+    recipes: recipes
+      ? extractRecipeSnapshots(extractRecipesFromMmkvBlob(recipes))
+      : [],
     // Stage 11 / PR #057n-tombstone-mobile — also drain the water-log
     // and shopping-list slices. Empty MMKV maps yield empty SQLite rows
     // (the diff emits no ops for `{} → {}`), so this is a free no-op
@@ -146,6 +162,7 @@ export async function importNutritionResidualFromMmkv(
   safeRemoveLS(NUTRITION_PREFS_KEY);
   safeRemoveLS(WATER_LOG_KEY);
   safeRemoveLS(SHOPPING_LIST_KEY);
+  safeRemoveLS(STORAGE_KEYS.NUTRITION_SAVED_RECIPES);
 
   return { imported: ops.length > 0, cleaned: true };
 }
@@ -204,6 +221,14 @@ function readShoppingListFromMmkv(): unknown | null {
   }
 }
 
+function readRecipesFromMmkv(): unknown | null {
+  try {
+    return safeReadLS<unknown>(STORAGE_KEYS.NUTRITION_SAVED_RECIPES, null);
+  } catch {
+    return null;
+  }
+}
+
 // -----------------------------------------------------------------------
 // Snapshot extractors — copies of the helpers that previously lived in
 // `dualWriteState.ts` (private). The MMKV-read path that owned them is
@@ -253,11 +278,40 @@ function extractPantrySnapshots(
   }));
 }
 
+function extractRecipesFromMmkvBlob(raw: unknown): SavedRecipe[] {
+  let list: unknown[] = [];
+  if (Array.isArray(raw)) {
+    list = raw;
+  } else if (
+    raw &&
+    typeof raw === "object" &&
+    "recipes" in raw &&
+    Array.isArray((raw as { recipes: unknown }).recipes)
+  ) {
+    list = (raw as { recipes: unknown[] }).recipes;
+  } else {
+    return [];
+  }
+  return list.map((item) => normalizeSavedRecipe(item));
+}
+
+function extractRecipeSnapshots(
+  recipes: readonly SavedRecipe[],
+): NutritionRecipeSnapshot[] {
+  return recipes.map((r) => ({
+    id: r.id,
+    title: r.title,
+    dataJson: JSON.stringify(r),
+  }));
+}
+
 // Internal exports for tests.
 export const __testing = {
   STALE_TIMESTAMP,
   extractMealSnapshots,
   extractPantrySnapshots,
+  extractRecipesFromMmkvBlob,
+  extractRecipeSnapshots,
 };
 
 // Tell TS we use NutritionPrefs in the doc comment scope.

--- a/packages/shared/src/lib/storageKeys.ts
+++ b/packages/shared/src/lib/storageKeys.ts
@@ -149,7 +149,11 @@ export const STORAGE_KEYS = {
   NUTRITION_PREFS: "nutrition_prefs_v1",
   /**
    * Локальна книга збережених рецептів (mobile MMKV; web — IndexedDB).
-   * @deprecated Stage 8 PR #057n-tombstone — use SQLite `nutrition_recipes`.
+   * Mobile MMKV-write path tombstoned by Stage 13 PR #073; reads now
+   * come from the SQLite warm cache. Web copy lives in the
+   * `nutrition_recipes` IndexedDB store inside `sergeant-db` and uses
+   * its own dual-write/residual-import path.
+   * @deprecated Stage 13 PR #073 — use SQLite `nutrition_recipes`.
    */
   NUTRITION_SAVED_RECIPES: "nutrition_recipe_book_v1",
 


### PR DESCRIPTION
## Summary

Stage 13 PR #073 of `docs/planning/storage-roadmap.md` (lines 3910-3932) — закриває останній pending Group B mobile tombstone для nutrition saved-recipes. Mirrors Stage 11 / PR #057n-tombstone-mobile pattern, що закрив water-log + shopping-list.

- `apps/mobile/src/modules/nutrition/lib/recipeBookStore.ts` — `loadSavedRecipes` / `getRecipeById` читають з SQLite warm cache (`getCachedNutritionSqliteState().recipes`); `saveRecipeBook` диспатчить через `triggerNutritionDualWrite` без `safeWriteLS`. `importRecipesFromJson` тепер батчить весь imported set в один dual-write щоб уникнути race-у проти async cache refresh-у.
- `apps/mobile/src/modules/nutrition/lib/residualImport.ts` — додано drain MMKV `nutrition_recipe_book_v1` на boot із тим самим epoch-zero `clientTs` LWW guard-ом, що інші слоти; ключ видаляється після успішного apply (idempotent).
- `apps/mobile/src/modules/nutrition/hooks/useSavedRecipesList.ts` + `useSavedRecipeById.ts` — drop MMKV `addOnValueChangedListener` (немає більше MMKV write-ів для цього слоту); `useNutritionSqliteReadTick` залишається єдиним re-render signal-ом, як і інші nutrition hooks після #057n.
- `apps/mobile/src/modules/nutrition/lib/__tests__/recipeBookStore.test.ts` — переписано: seed SQLite warm cache через `__setNutritionSqliteCacheForTests`, asserting save paths не торкаються MMKV (mirror nutritionStore.test.ts shape з #057n).
- `packages/shared/src/lib/storageKeys.ts` — `NUTRITION_SAVED_RECIPES` `@deprecated` tag перетягнуто на Stage 13 PR #073 з пояснення що mobile MMKV-write tombstoned (web copy лишається в IndexedDB store `nutrition_recipes` зі своїм окремим dual-write/residual-import path-ом).

## Governing Skill

- Primary skill: `.agents/skills/sergeant-start-here/SKILL.md` (no specialist skill — direct mirror of an existing tombstone pattern).

## Playbook

- Primary playbook: n/a — direct execution of the documented Stage 13 PR #073 spec in `docs/planning/storage-roadmap.md` lines 3910-3932.
- If no playbook matched, why: this is a 1:1 mirror of the already-landed Stage 11 PR #057n-tombstone-mobile (water-log + shopping-list) for the recipes slot — the recipe lives in the existing tombstone playbook surface that previous PRs followed.

## Verification

```bash
pnpm --filter @sergeant/mobile lint        # 0 errors
pnpm --filter @sergeant/mobile typecheck   # 0 errors
pnpm --filter @sergeant/mobile test -- --testPathPattern="(recipeBookStore|nutritionStore)"
# Test Suites: 2 passed, 2 total
# Tests:       34 passed, 34 total (12 recipeBookStore + 22 nutritionStore)
```

Full mobile test suite — 1 pre-existing failure in `src/core/settings/NotificationsSection.test.tsx` (asserts NUTRITION_PREFS MMKV write that was already tombstoned by Stage 8 PR #057n — confirmed via `git stash` baseline check, not caused by this PR).

Additional checks:

- [x] Local smoke / manual validation completed (typecheck + lint + targeted nutrition tests)
- [x] Surface-specific checks completed (mobile-only diff; no web/server impact)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- `packages/shared/src/lib/storageKeys.ts` — `NUTRITION_SAVED_RECIPES` JSDoc annotation rotated forward to Stage 13 PR #073.
- `apps/mobile/app/(tabs)/nutrition/recipe/[id].tsx` — file-level doc comment updated to reflect the SQLite source.

`docs/planning/storage-roadmap.md` Stage 13 status (`5/9 → 6/9` after this lands) буде оновлено в окремому doc-only commit після Stage 13 quartet (`#073` + `#077` + `#078`) повністю проб'ється.

## Risk and Rollout

- User-visible risk: **none expected**. Cold-boot users with MMKV-only recipes — `residualImport` drains the blob into SQLite із stale epoch-zero `clientTs`, тому SQLite-сторінка ніколи не клобирить newer SQLite row-и. Save paths без registered dual-write context (pre-auth) — silent no-op (legacy MMKV-write also dropped, so first paint stays on the in-memory hook state).
- Rollout / deploy order: standalone — no ordering dependency on other Stage 13 PRs.
- Backout plan: `git revert` цього коміту повертає MMKV write/read paths без data-loss (SQLite continues to be source-of-truth; MMKV would just resume being a stale cache).

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

- Note the cycle-via-deferred-imports between `recipeBookStore.ts` (imports `peekNutritionDualWriteState` from `./dualWriteState`) and `dualWriteState.ts` (imports `loadSavedRecipes` from `./recipeBookStore`) — this cycle pre-existed the PR and resolves at runtime via JS live bindings; nothing executes at module-load time.
- `importRecipesFromJson` batch behavior changed: previously each item triggered an individual MMKV write + dual-write peek-trigger pair; now all items collapse into a single `saveRecipeBook` call, which is the only correct shape after the MMKV-write drop (otherwise the second `loadSavedRecipes()` call would see a stale cache between async dual-writes).
- The eslint-plugin-sergeant-design "tracked-keys" list (`packages/eslint-plugin-sergeant-design/index.js` `TRACKED_STORAGE_KEY_VALUES`) does NOT include `nutrition_recipe_book_v1` — nutrition was retired from `SYNC_MODULES` back in PR #034, so the AC bullet "tracked-keys list shrinks by 1" was already satisfied by upstream work; the eslint.config.js `^NUTRITION_(?:LOG|PANTRIES|ACTIVE_PANTRY|PREFS|SAVED_RECIPES)$` selector remains because the underlying `apps/mobile/src/modules/nutrition/**` ignore-block already covers all canonical module callsites.

Link to Devin session: https://app.devin.ai/sessions/a485ad63f69b47c68de458794f2b0506
Requested by: @Skords-01

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops writing saved recipes to MMKV and reads them from the SQLite warm cache. On boot, migrates any leftover `NUTRITION_SAVED_RECIPES` data into `nutrition_recipes` and deletes the old key.

- **Refactors**
  - Read recipes from the SQLite warm cache; remove MMKV listeners in `useSavedRecipesList` and `useSavedRecipeById` and use `useNutritionSqliteReadTick` for re-renders.
  - Drop MMKV writes in `saveRecipeBook`; dispatch dual-write via `triggerNutritionDualWrite` (guarded by `isNutritionDualWriteRegistered`); add recipe snapshot extraction.
  - Batch `importRecipesFromJson` into a single save to avoid cache refresh races; overwrite by id.
  - Update tests to seed the SQLite cache and assert no MMKV writes; refresh docs/comments and deprecate notes in `@sergeant/shared`.

- **Migration**
  - Boot-time residual import drains `nutrition_recipe_book_v1` from MMKV into SQLite using an epoch-zero LWW guard, then removes the key. No manual steps required.

<sup>Written for commit dd83360c15e190abd65dca763b1256734638c103. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

