### PR TITLE
feat(shared): #078 — retire feature.finyk.sqlite_v2.mono_mirror flag + mark Stage 13 COMPLETE

### DIFF
--- a/apps/mobile/src/core/lib/featureFlags.test.ts
+++ b/apps/mobile/src/core/lib/featureFlags.test.ts
@@ -33,13 +33,12 @@ describe("mobile featureFlags", () => {
     expect(flag).toBeUndefined();
   });
 
-  it("keeps Finyk Mono mirror default-on for Stage 8 PR #055k1", () => {
+  it("Stage 13 PR #078 drop: feature.finyk.sqlite_v2.mono_mirror більше не існує у реєстрі", () => {
     const flag = EXPERIMENTAL_FLAGS.find(
       (item) => item.id === "feature.finyk.sqlite_v2.mono_mirror",
     );
 
-    expect(flag).toBeDefined();
-    expect(flag?.defaultValue).toBe(true);
+    expect(flag).toBeUndefined();
   });
 
   it("Stage 8 PR #057r drop: feature.routine.sqlite_v2.read_sqlite більше не існує у реєстрі", () => {

--- a/apps/mobile/src/core/lib/featureFlags.ts
+++ b/apps/mobile/src/core/lib/featureFlags.ts
@@ -54,13 +54,9 @@ export const EXPERIMENTAL_FLAGS: readonly FlagDefinition[] = [
       "Глобальний пошук і дії через клавіатуру. Ранній preview — може не працювати у деяких PWA-кейсах.",
     defaultValue: false,
   },
-  {
-    id: "feature.finyk.sqlite_v2.mono_mirror",
-    label: "Finyk — Mono cache mirror",
-    description:
-      "Mono транзакції / акаунти / balance-snapshots мирорять у локальну SQLite (`finyk_mono_transactions`, `finyk_mono_accounts`, `finyk_mono_account_snapshots`) на кожен Mono fetch. Reads у `transactionsStore.realTx` оверлеять з SQLite до прильоту наступного MMKV-снапшота. MMKV-write (`finyk_tx_cache`, `finyk_info_cache`, `finyk_tx_cache_last_good`) залишається як safety net. Stage 8 PR #055k1 storage-roadmap — default-on rollout. Default: on.",
-    defaultValue: true,
-  },
+  // Stage 13 PR #078: `feature.finyk.sqlite_v2.mono_mirror` retired.
+  // Previously defaultValue: true. Mono mirror now triggers
+  // unconditionally — see monoMirrorBoot.ts / monoMirrorGate.ts.
 ] as const;
 
 const DEFAULTS: FlagValues = Object.freeze(

--- a/apps/mobile/src/modules/finyk/hooks/useFinykMonoMirrorBoot.ts
+++ b/apps/mobile/src/modules/finyk/hooks/useFinykMonoMirrorBoot.ts
@@ -2,11 +2,9 @@
  * React hook that boots the SQLite Mono cache mirror on mobile.
  *
  * PR #038 of `docs/planning/storage-roadmap.md` (mobile parity for
- * web PR #038). When the `feature.finyk.sqlite_v2.mono_mirror` flag
- * is on, this hook runs `bootFinykMonoMirror()` once after mount so
- * `transactionsStore` can overlay reads from the local
- * `finyk_mono_*` tables instead of relying on the MMKV-only Mono
- * cache for cold-start renders.
+ * web PR #038). Stage 13 PR #078 retired the flag — the mirror now
+ * boots unconditionally after mount so `transactionsStore` can overlay
+ * reads from the local `finyk_mono_*` tables.
  *
  * Fire-and-forget — boot failures fall back to MMKV silently
  * (console warning only).

--- a/apps/mobile/src/modules/finyk/lib/monoMirrorBoot.ts
+++ b/apps/mobile/src/modules/finyk/lib/monoMirrorBoot.ts
@@ -3,43 +3,22 @@
  *
  * Mirrors `apps/mobile/src/modules/finyk/lib/sqliteReadBoot.ts`. Called
  * once from `useFinykMonoMirrorBoot` after the auth `me` cache is
- * available. Evaluates `feature.finyk.sqlite_v2.mono_mirror` and, when
- * enabled, runs the finyk migrations + initial cache refresh so the
- * `transactionsStore` overlay can paint cached rows on cold start.
+ * available.
  *
- * Boot is **outside React** so we cannot use `useFlag()` here — we
- * read the persisted flag map directly from MMKV (`@hub_flags_v1`),
- * the same key `useFlag` reads from.
+ * Stage 13 PR #078: the `feature.finyk.sqlite_v2.mono_mirror` flag has
+ * been retired — the mirror now boots unconditionally.
  *
  * Fail-soft: any thrown error is caught, logged via `console.warn`
  * and surfaces as `false` so consumers keep reading from MMKV.
  */
 
-import { safeReadLS } from "@/lib/storage";
 import { getSqliteMigrationClient } from "@/core/db/sqlite";
-import {
-  EXPERIMENTAL_FLAGS,
-  FLAGS_KEY,
-  type FlagValues,
-} from "@/core/lib/featureFlags";
 
 import { migrateFinyk } from "./clientMigrate";
 import { refreshFinykMonoMirrorState } from "./monoMirrorReader";
 
-const FLAG_ID = "feature.finyk.sqlite_v2.mono_mirror";
-
-function readFlagFromStorage(): boolean {
-  const stored = safeReadLS<FlagValues>(FLAGS_KEY, null);
-  if (stored && typeof stored === "object") {
-    const v = stored[FLAG_ID];
-    if (typeof v === "boolean") return v;
-  }
-  const def = EXPERIMENTAL_FLAGS.find((f) => f.id === FLAG_ID);
-  return def ? def.defaultValue : false;
-}
-
 /**
- * Initialise the Mono mirror cache if the flag is on.
+ * Initialise the Mono mirror cache.
  *
  * @param userId - The authenticated user's id. When falsy the boot is
  *   skipped (pre-auth window).
@@ -49,9 +28,6 @@ export async function bootFinykMonoMirror(
   userId: string | null | undefined,
 ): Promise<boolean> {
   if (!userId) return false;
-
-  const enabled = readFlagFromStorage();
-  if (!enabled) return false;
 
   try {
     const client = await getSqliteMigrationClient();

--- a/apps/mobile/src/modules/finyk/lib/monoMirrorGate.ts
+++ b/apps/mobile/src/modules/finyk/lib/monoMirrorGate.ts
@@ -3,17 +3,16 @@
  *
  * Mirrors `apps/web/src/modules/finyk/lib/monoMirrorGate.ts`. The
  * mobile Finyk module exposes Mono transactions through
- * `transactionsStore.ts` (MMKV-backed) — when the
- * `feature.finyk.sqlite_v2.mono_mirror` flag is on we overlay the
- * stored slice from the SQLite cache. The pub-sub here lets that
- * overlay re-render after every refresh.
+ * `transactionsStore.ts` (MMKV-backed) — the SQLite cache overlay
+ * fires unconditionally. The pub-sub here lets that overlay re-render
+ * after every refresh.
+ *
+ * Stage 13 PR #078: the `feature.finyk.sqlite_v2.mono_mirror` flag
+ * has been retired. `useFinykMonoMirrorFlag()` now returns `true`
+ * unconditionally.
  */
 
 import { useSyncExternalStore } from "react";
-
-import { useFlag } from "@/core/lib/featureFlags";
-
-const MIRROR_FLAG_ID = "feature.finyk.sqlite_v2.mono_mirror";
 
 let cacheTick = 0;
 const listeners = new Set<() => void>();
@@ -34,13 +33,13 @@ export function useFinykMonoMirrorTick(): number {
   return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }
 
-/** Flag-gated read-overlay enable. */
+/** Formerly flag-gated; now unconditionally `true` (Stage 13 PR #078). */
 export function useFinykMonoMirrorFlag(): boolean {
-  return useFlag(MIRROR_FLAG_ID);
+  return true;
 }
 
 export interface FinykMonoMirrorGate {
-  /** Current value of `feature.finyk.sqlite_v2.mono_mirror`. */
+  /** Always `true` since Stage 13 PR #078 retired the flag. */
   readonly enabled: boolean;
   /**
    * Tick counter that bumps after every successful mirror refresh —

--- a/apps/mobile/src/modules/finyk/lib/monoMirrorReader.ts
+++ b/apps/mobile/src/modules/finyk/lib/monoMirrorReader.ts
@@ -3,8 +3,8 @@
  *
  * Mirrors `apps/web/src/modules/finyk/lib/monoMirrorReader.ts` — same
  * cache shape, same refresh helper. Mobile consumers
- * (`transactionsStore.ts`) overlay their state from this cache when
- * the `feature.finyk.sqlite_v2.mono_mirror` flag is on.
+ * (`transactionsStore.ts`) overlay their state from this cache
+ * unconditionally (Stage 13 PR #078 retired the flag).
  */
 
 import type { SqliteMigrationClient } from "@sergeant/db-schema/migrate/sqlite";

--- a/apps/web/src/core/lib/featureFlags.test.ts
+++ b/apps/web/src/core/lib/featureFlags.test.ts
@@ -98,12 +98,13 @@ describe("featureFlags", () => {
     expect(setFlag("feature.finyk.sqlite_v2.dual_write", true)).toBe(false);
   });
 
-  it("Finyk Mono mirror увімкнений за замовчуванням для Stage 8 PR #055k1", async () => {
-    const { getFlag, setFlag } = await loadFresh();
-    expect(getFlag("feature.finyk.sqlite_v2.mono_mirror")).toBe(true);
-
-    expect(setFlag("feature.finyk.sqlite_v2.mono_mirror", false)).toBe(true);
+  it("Stage 13 PR #078 drop: feature.finyk.sqlite_v2.mono_mirror більше не існує у реєстрі", async () => {
+    const { getFlag, setFlag, FLAG_REGISTRY } = await loadFresh();
+    expect(
+      FLAG_REGISTRY.find((f) => f.id === "feature.finyk.sqlite_v2.mono_mirror"),
+    ).toBeUndefined();
     expect(getFlag("feature.finyk.sqlite_v2.mono_mirror")).toBe(false);
+    expect(setFlag("feature.finyk.sqlite_v2.mono_mirror", true)).toBe(false);
   });
 
   it("Stage 8 PR #057n drop: feature.nutrition.sqlite_v2.read_sqlite більше не існує у реєстрі", async () => {

--- a/apps/web/src/core/lib/featureFlags.ts
+++ b/apps/web/src/core/lib/featureFlags.ts
@@ -59,14 +59,9 @@ export const FLAG_REGISTRY: readonly FlagDefinition[] = [
     defaultValue: false,
     experimental: true,
   },
-  {
-    id: "feature.finyk.sqlite_v2.mono_mirror",
-    label: "Finyk — Mono cache mirror",
-    description:
-      "Mono транзакції / акаунти / balance-snapshots мирорять у локальну SQLite (`finyk_mono_transactions`, `finyk_mono_accounts`, `finyk_mono_account_snapshots`) на кожен fetch. Reads у `useMonobankWebhook` оверлеять з SQLite до прильоту мережі. LS-write (`finyk_tx_cache`, `finyk_info_cache`, `finyk_tx_cache_last_good`) залишається як safety net. Stage 8 PR #055k1 storage-roadmap — default-on rollout. Default: on.",
-    defaultValue: true,
-    experimental: true,
-  },
+  // Stage 13 PR #078: `feature.finyk.sqlite_v2.mono_mirror` retired.
+  // Previously defaultValue: true, experimental: true. Mono mirror now
+  // triggers unconditionally — see monoMirrorBoot.ts / monoMirrorGate.ts.
 ] as const;
 
 export type FlagId = (typeof FLAG_REGISTRY)[number]["id"];

--- a/apps/web/src/modules/finyk/hooks/useFinykMonoMirrorBoot.ts
+++ b/apps/web/src/modules/finyk/hooks/useFinykMonoMirrorBoot.ts
@@ -1,14 +1,13 @@
 /**
  * React hook that boots the SQLite Mono cache mirror.
  *
- * PR #038 of `docs/planning/storage-roadmap.md`. When the
- * `feature.finyk.sqlite_v2.mono_mirror` flag is on, this hook runs
- * `bootFinykMonoMirror()` once after mount so `useMonobankWebhook`
- * can overlay reads from the local `finyk_mono_*` tables instead of
- * blocking on the API fetch for cold-start renders.
+ * PR #038 of `docs/planning/storage-roadmap.md`. Stage 13 PR #078
+ * retired the `feature.finyk.sqlite_v2.mono_mirror` flag — the mirror
+ * now boots unconditionally after mount so `useMonobankWebhook` can
+ * overlay reads from the local `finyk_mono_*` tables.
  *
  * Fire-and-forget — boot failures fall back to LS silently (console
- * warning only). Render-time gating is the consumer's responsibility.
+ * warning only).
  */
 
 import { useEffect, useRef } from "react";

--- a/apps/web/src/modules/finyk/lib/monoMirrorBoot.ts
+++ b/apps/web/src/modules/finyk/lib/monoMirrorBoot.ts
@@ -3,28 +3,27 @@
  *
  * Mirrors `sqliteReadBoot.ts` (PR #037). Called once from
  * `useFinykMonoMirrorBoot()` after the auth `me` query and the
- * sqlite-wasm singleton are available. Evaluates
- * `feature.finyk.sqlite_v2.mono_mirror` and, when enabled:
+ * sqlite-wasm singleton are available.
+ *
+ * Stage 13 PR #078: the `feature.finyk.sqlite_v2.mono_mirror` flag
+ * has been retired — the mirror now boots unconditionally.
  *
  *  1. Runs the finyk SQLite migrations (002 ships the mono mirror
  *     tables — see `packages/db-schema/src/sqlite/migrations`).
  *  2. Performs the initial `refreshFinykMonoMirrorState()` so the
  *     cache is warm before the first overlay read.
  *
- * Idempotent — calling it twice with the same flag value is a no-op.
+ * Idempotent — calling it twice is a no-op.
  */
 
-import { getFlag } from "../../../core/lib/featureFlags.js";
 import { getSqliteDb } from "../../../core/db/sqlite.js";
 import { migrateFinyk } from "./clientMigrate.js";
 import { refreshFinykMonoMirrorState } from "./monoMirrorReader.js";
 
-const FLAG_ID = "feature.finyk.sqlite_v2.mono_mirror";
-
 let booted = false;
 
 /**
- * Initialise the Mono mirror cache if the flag is on.
+ * Initialise the Mono mirror cache.
  *
  * @param userId - The authenticated user's id (from the `me` query).
  *   When `null` the boot is skipped (pre-auth window).
@@ -34,9 +33,7 @@ export async function bootFinykMonoMirror(
   userId: string | null,
 ): Promise<boolean> {
   if (booted) return false;
-
-  const enabled = getFlag(FLAG_ID);
-  if (!enabled || !userId) return false;
+  if (!userId) return false;
 
   try {
     const handle = await getSqliteDb();

--- a/apps/web/src/modules/finyk/lib/monoMirrorGate.ts
+++ b/apps/web/src/modules/finyk/lib/monoMirrorGate.ts
@@ -3,14 +3,14 @@
  *
  * Mirrors `sqliteReadGate.ts` (PR #037) — a tiny in-process pub-sub
  * so consumers (currently `useMonobankWebhook`) re-render after the
- * mirror cache is refreshed. The flag is the user-facing
- * `feature.finyk.sqlite_v2.mono_mirror` toggle.
+ * mirror cache is refreshed.
+ *
+ * Stage 13 PR #078: the `feature.finyk.sqlite_v2.mono_mirror` flag
+ * has been retired. `useFinykMonoMirrorFlag()` now returns `true`
+ * unconditionally so all consumers always run the mirror path.
  */
 
 import { useSyncExternalStore } from "react";
-import { useFlag } from "../../../core/lib/featureFlags";
-
-const MIRROR_FLAG_ID = "feature.finyk.sqlite_v2.mono_mirror";
 
 let cacheTick = 0;
 const listeners = new Set<() => void>();
@@ -34,13 +34,13 @@ export function useFinykMonoMirrorTick(): number {
   return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }
 
-/** Flag-gated read-overlay enable. */
+/** Formerly flag-gated; now unconditionally `true` (Stage 13 PR #078). */
 export function useFinykMonoMirrorFlag(): boolean {
-  return useFlag(MIRROR_FLAG_ID);
+  return true;
 }
 
 export interface FinykMonoMirrorGate {
-  /** Current value of `feature.finyk.sqlite_v2.mono_mirror`. */
+  /** Always `true` since Stage 13 PR #078 retired the flag. */
   readonly enabled: boolean;
   /**
    * Tick counter that bumps after every successful mirror refresh —

--- a/docs/planning/storage-roadmap.md
+++ b/docs/planning/storage-roadmap.md
@@ -3790,29 +3790,31 @@ strengthen the same swap rather than extending it. Tracked у audit
 
 ### Stage 13 — Audit findings & post-migration cleanup
 
-> **Status:** 🔄 IN PROGRESS (6/9 LANDED, 3 PROPOSED) — last updated 2026-05-10.
+> **Status:** ✅ COMPLETE (9/9 LANDED) — last updated 2026-05-10.
 >
-> **Landed (6/9):** PR #071 ✅ ([#2322](https://github.com/Skords-01/Sergeant/pull/2322)
+> **Landed (9/9):** PR #071 ✅ ([#2322](https://github.com/Skords-01/Sergeant/pull/2322)
 > — mobile `hubBackup` delegates to module-level apply, 4 new module-level
 > backup helpers + integration test); PR #072 ✅ ([#2320](https://github.com/Skords-01/Sergeant/pull/2320)
-> — weekly-digest SQLite `finyk_prefs.monthly_plan_json` reader); PR #074
-> ✅ ([#2325](https://github.com/Skords-01/Sergeant/pull/2325) — finyk
-> `showBalance` slot bundle із SQLite-overlay `finyk_prefs.show_balance` +
-> LS first-paint fallback; closes audit finding A4); PR #075
-> ✅ ([#2321](https://github.com/Skords-01/Sergeant/pull/2321) — finyk
-> LS-only slots `excluded_stat_txs` + `dismissed_recurring` migrated to
-> SQLite cross-device sync); PR #076 ✅ ([#2319](https://github.com/Skords-01/Sergeant/pull/2319)
-> — dropped dead `syncedKV.ts` + `SYNC_EVENT/SYNC_STATUS_EVENT` + lying
-> OpenAPI registrations); PR #079 ✅ ([#2324](https://github.com/Skords-01/Sergeant/pull/2324)
-> — doc drift refresh: Initiative 0003 Phase 2 PR placeholder resolved +
-> Phase 6 bullets carry explicit commit/PR refs; ADR-0047 amendment +
-> Phase 7 exit-criteria already in-tree from audit-prep commit
-> `37bcba1c`).
->
-> **Still proposed (3/9):** PR #073 (mobile `NUTRITION_SAVED_RECIPES`
-> tombstone), PR #077 (drop dead sync-metadata STORAGE_KEYS +
-> `dirtyCount/queuedCount` from `useSyncStatus`), PR #078 (retire
-> `feature.finyk.sqlite_v2.mono_mirror` flag).
+> — weekly-digest SQLite `finyk_prefs.monthly_plan_json` reader); PR #073
+> ✅ ([#2366](https://github.com/Skords-01/Sergeant/pull/2366) — mobile
+> `NUTRITION_SAVED_RECIPES` MMKV-write tombstone + residualImport drain);
+> PR #074 ✅ ([#2325](https://github.com/Skords-01/Sergeant/pull/2325)
+> — finyk `showBalance` slot bundle із SQLite-overlay
+> `finyk_prefs.show_balance` + LS first-paint fallback; closes audit
+> finding A4); PR #075 ✅ ([#2321](https://github.com/Skords-01/Sergeant/pull/2321)
+> — finyk LS-only slots `excluded_stat_txs` + `dismissed_recurring`
+> migrated to SQLite cross-device sync); PR #076
+> ✅ ([#2319](https://github.com/Skords-01/Sergeant/pull/2319) — dropped
+> dead `syncedKV.ts` + `SYNC_EVENT/SYNC_STATUS_EVENT` + lying OpenAPI
+> registrations); PR #077 ✅ ([#2367](https://github.com/Skords-01/Sergeant/pull/2367)
+> — drop 11 dead `STORAGE_KEYS.{SYNC,MOBILE_SYNC}_*` entries + web
+> `dirtyCount`/`queuedCount` from `useSyncStatus`); PR #078 ✅ (retire
+> `feature.finyk.sqlite_v2.mono_mirror` flag — last sqlite_v2 flag;
+> mono mirror boots unconditionally); PR #079
+> ✅ ([#2324](https://github.com/Skords-01/Sergeant/pull/2324) — doc drift
+> refresh: Initiative 0003 Phase 2 PR placeholder resolved + Phase 6
+> bullets carry explicit commit/PR refs; ADR-0047 amendment + Phase 7
+> exit-criteria already in-tree from audit-prep commit `37bcba1c`).
 >
 > Post-Stage-12.5 audit (read-only review всіх `safeWriteLS`/`safeReadLS`
 > callsites + `STORAGE_KEYS` references + sync-engine exports + OpenAPI
@@ -3910,7 +3912,7 @@ strengthen the same swap rather than extending it. Tracked у audit
 
 **Group B — Partial tombstones (MEDIUM).**
 
-#### **PR #073 — `chore(mobile,nutrition): drop NUTRITION_SAVED_RECIPES MMKV write + extend residualImport`** 📋 PROPOSED — MEDIUM
+#### **PR #073 — `chore(mobile,nutrition): drop NUTRITION_SAVED_RECIPES MMKV write + extend residualImport`** ✅ LANDED ([#2366](https://github.com/Skords-01/Sergeant/pull/2366), 2026-05-10) — MEDIUM
 
 - **Symptom.** `apps/mobile/src/modules/nutrition/lib/recipeBookStore.ts:88-107`
   усе ще робить `safeReadLS(NUTRITION_SAVED_RECIPES)` для read-path і
@@ -4008,7 +4010,7 @@ strengthen the same swap rather than extending it. Tracked у audit
   consumers.
 - **Dep.** None.
 
-#### **PR #077 — `chore(shared): drop dead sync-metadata STORAGE_KEYS + web useSyncStatus dirtyCount/queuedCount`** 📋 PROPOSED — MEDIUM (~50 LOC)
+#### **PR #077 — `chore(shared): drop dead sync-metadata STORAGE_KEYS + web useSyncStatus dirtyCount/queuedCount`** ✅ LANDED ([#2367](https://github.com/Skords-01/Sergeant/pull/2367), 2026-05-10) — MEDIUM (~50 LOC)
 
 - **B3 — Web `useSyncStatus.dirtyCount` / `queuedCount` perpetually 0.**
   `apps/web/src/core/cloudSync/hook/useSyncStatus.ts:33-34` returns
@@ -4034,7 +4036,7 @@ strengthen the same swap rather than extending it. Tracked у audit
   проти dropped names.
 - **Dep.** None — все це stale-references.
 
-#### **PR #078 — `chore(finyk): retire feature.finyk.sqlite_v2.mono_mirror flag`** 📋 PROPOSED — LOW (mirror #057k-flag pattern)
+#### **PR #078 — `chore(finyk): retire feature.finyk.sqlite_v2.mono_mirror flag`** ✅ LANDED (2026-05-10) — LOW (mirror #057k-flag pattern)
 
 - **Symptom.** Останній sqlite_v2 flag still gated. `defaultValue:
 true, experimental: true` у `featureFlags.ts:62-69`. Усі інші
@@ -4122,25 +4124,26 @@ true, experimental: true` у `featureFlags.ts:62-69`. Усі інші
 7. **Тиждень 7+:** PR #078 (mono_mirror flag retire) — після burn-in
    window.
 
-**Done criteria для Stage 13.**
+**Done criteria для Stage 13.** All met as of 2026-05-10.
 
-- 0 production reads/writes для `STORAGE_KEYS.{SYNC,MOBILE_SYNC}_*`
-  (10 dropped entries).
-- 0 production imports `createSyncedKVStore` /
-  `SYNC_EVENT` / `SYNC_STATUS_EVENT`.
-- OpenAPI generated spec не показує v1 sync endpoints як живі.
-- Mobile hubBackup round-trip post-tombstone — passes integration
-  test.
-- Weekly-digest на web + mobile reads `finyk_prefs.monthly_plan_json`
-  (SQLite) для `monthlyBudget`.
-- Initiative 0003 Phase 6 → Done з посиланнями.
-- ADR-0047 містить exit-criteria для sunset routes (8-week clean
-  signal або 2026-08-04 — whichever first).
-- (Optional) `feature.finyk.sqlite_v2.mono_mirror` retired (last
-  sqlite_v2 flag).
+- ✅ 0 production reads/writes для `STORAGE_KEYS.{SYNC,MOBILE_SYNC}_*`
+  (11 dropped entries — PR #077).
+- ✅ 0 production imports `createSyncedKVStore` /
+  `SYNC_EVENT` / `SYNC_STATUS_EVENT` (PR #076).
+- ✅ OpenAPI generated spec не показує v1 sync endpoints як живі
+  (PR #076).
+- ✅ Mobile hubBackup round-trip post-tombstone — passes integration
+  test (PR #071).
+- ✅ Weekly-digest на web + mobile reads `finyk_prefs.monthly_plan_json`
+  (SQLite) для `monthlyBudget` (PR #072).
+- ✅ Initiative 0003 Phase 6 → Done з посиланнями (PR #079).
+- ✅ ADR-0047 містить exit-criteria для sunset routes (8-week clean
+  signal або 2026-08-04 — whichever first) (PR #079).
+- ✅ `feature.finyk.sqlite_v2.mono_mirror` retired (last sqlite_v2
+  flag) — PR #078.
 
-**Calendar (early-stage dev, без canary):** ~3 тижні coding на 0.5
-FTE (≈8 PR-ів, переважно small) + 4 тижні burn-in для PR #078.
+**Calendar (actual):** 9 PRs landed across 2026-05-10 — early-stage
+dev cadence, burn-in window for PR #078 waived per user decision.
 
 ---
 


### PR DESCRIPTION
## Summary

Stage 13 PR #078 of `docs/planning/storage-roadmap.md` — retires the last remaining `sqlite_v2` feature flag (`feature.finyk.sqlite_v2.mono_mirror`) and marks Stage 13 as 9/9 COMPLETE.

**Flag retirement (mirrors PR #057k-flag pattern):**
- Drop registry entry from web `FLAG_REGISTRY` + mobile `EXPERIMENTAL_FLAGS`
- `monoMirrorBoot.ts` (web + mobile): remove flag check — boot runs unconditionally when userId available
- `monoMirrorGate.ts` (web + mobile): `useFinykMonoMirrorFlag()` returns `true` unconditionally — all consumers (`useMonobankWebhook`, `transactionsStore`) always run the mirror path
- LS-write safety net intentionally kept (Stage 12.6 scope)
- Test updates: web + mobile `featureFlags.test.ts` assert flag absent from registry

**Roadmap update:**
- Status block: `🔄 IN PROGRESS (6/9)` → `✅ COMPLETE (9/9 LANDED)`
- Added PR #073 ([#2366](https://github.com/Skords-01/Sergeant/pull/2366)), PR #077 ([#2367](https://github.com/Skords-01/Sergeant/pull/2367)), PR #078 to landed list
- Done criteria: all 8 items checked with per-PR cross-references
- Calendar: updated to actual delivery date (2026-05-10)

Files changed:
- `apps/web/src/core/lib/featureFlags.ts` — flag entry removed
- `apps/web/src/core/lib/featureFlags.test.ts` — assert flag absent
- `apps/web/src/modules/finyk/lib/monoMirrorBoot.ts` — flag check removed
- `apps/web/src/modules/finyk/lib/monoMirrorGate.ts` — always returns `true`
- `apps/web/src/modules/finyk/hooks/useFinykMonoMirrorBoot.ts` — doc updated
- `apps/mobile/src/core/lib/featureFlags.ts` — flag entry removed
- `apps/mobile/src/core/lib/featureFlags.test.ts` — assert flag absent
- `apps/mobile/src/modules/finyk/lib/monoMirrorBoot.ts` — flag check removed
- `apps/mobile/src/modules/finyk/lib/monoMirrorGate.ts` — always returns `true`
- `apps/mobile/src/modules/finyk/lib/monoMirrorReader.ts` — doc updated
- `apps/mobile/src/modules/finyk/hooks/useFinykMonoMirrorBoot.ts` — doc updated
- `docs/planning/storage-roadmap.md` — Stage 13 marked COMPLETE

## Governing Skill

- Primary skill: n/a — direct execution of documented Stage 13 spec.

## Playbook

- Primary playbook: n/a
- Why this playbook: n/a
- If no playbook matched, why: spec lives directly in `docs/planning/storage-roadmap.md` Stage 13 § PR #078.

## Verification

```bash
pnpm --filter @sergeant/web typecheck      # 0 errors
pnpm --filter @sergeant/mobile typecheck   # 0 errors
pnpm --filter @sergeant/web lint           # 0 errors
pnpm --filter @sergeant/mobile lint        # 0 errors

# Mobile featureFlags tests — all 9 pass
cd apps/mobile && pnpm exec jest --passWithNoTests --testPathPattern="featureFlags"

# Web featureFlags.test.ts — 15/15 fail pre-existing (sqlite-wasm env;
# verified via git stash — same failure on clean main). Not caused by
# this PR.
```

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed (grep confirms 0 remaining `getFlag(\"feature.finyk.sqlite_v2.mono_mirror\")` / `readFlagFromStorage()` calls)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- `docs/planning/storage-roadmap.md` — Stage 13 status → COMPLETE, done criteria all checked, calendar updated.

## Risk and Rollout

- User-visible risk: **none**. Flag was `defaultValue: true` — 100% of users already had mono mirror on. This PR removes the ability to toggle it off (which nobody does in early-stage dev with no users).
- Rollout / deploy order: standalone, no ordering constraints.
- Backout plan: `git revert` — re-adds the flag entry and the gating.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

- `web featureFlags.test.ts` has a pre-existing env failure (sqlite-wasm import in `storage.ts:45` when running in jsdom). Verified on clean main via `git stash` — all 15 tests fail identically without this PR's changes. Not a regression.
- LS-write safety net (`finyk_tx_cache`, `finyk_info_cache`, `finyk_tx_cache_last_good`) intentionally NOT dropped in this PR — that's Stage 12.6 scope or a separate future PR.
- `transactionsStore.ts` and `useMonobankWebhook.ts` still call `useFinykMonoMirrorGate()` — the gate now always returns `enabled: true`, so the mirror path is unconditional. A follow-up cleanup could inline the tick subscription and remove the `enabled` guard entirely, but that's cosmetic.

Link to Devin session: https://app.devin.ai/sessions/a485ad63f69b47c68de458794f2b0506
Requested by: @Skords-01

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retires the `feature.finyk.sqlite_v2.mono_mirror` flag and makes the Mono mirror always on across web and mobile. No user-visible change; the flag was already default-on. Stage 13 is now complete.

- **Refactors**
  - Removed the flag from web `FLAG_REGISTRY` and mobile `EXPERIMENTAL_FLAGS`.
  - Made boot unconditional when `userId` is available; `useFinykMonoMirrorFlag()` now always returns `true`, so consumers always follow the mirror path.
  - Updated tests to assert the flag is absent.
  - Kept the LS safety net in place for now.
  - Updated `docs/planning/storage-roadmap.md` to mark Stage 13 complete.

<sup>Written for commit 91d52a9456580f5c53793ca20ea336d100fc2ace. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

