### PR TITLE
docs(agents): add subproject AGENTS.md and agents.md-spec discoverability boost

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,22 @@
 
 Repo policy lives here in `AGENTS.md`. Platform-specific wrappers such as `CLAUDE.md` and `DEVIN.md` only add runtime/tool notes and must not become parallel sources of truth.
 
+## Quick commands
+
+> **One-liner pre-PR check:** `pnpm check` (= `pnpm format:check && pnpm lint && pnpm typecheck && pnpm test && pnpm build`). Same matrix runs in CI — full breakdown in [`§ Verification before PR`](#verification-before-pr).
+
+```bash
+pnpm install --frozen-lockfile        # exact deps from lockfile (Hard Rule — see CONTRIBUTING.md)
+pnpm dev:db                           # docker postgres + run migrations
+pnpm dev:server                       # backend  → http://localhost:3000
+pnpm dev:web                          # frontend → http://localhost:5173
+
+pnpm format:check && pnpm lint && pnpm typecheck && pnpm test   # = pnpm check
+pnpm --filter @sergeant/web test      # focus a single workspace
+```
+
+Surface-scoped quick references (commands, gotchas, specialist skill pointer) live in sub-tree AGENTS.md files: [`apps/web/AGENTS.md`](./apps/web/AGENTS.md), [`apps/server/AGENTS.md`](./apps/server/AGENTS.md), [`apps/mobile/AGENTS.md`](./apps/mobile/AGENTS.md).
+
 ## Repo overview
 
 - **pnpm 9** + **Turborepo** monorepo, **Node 20**, **TypeScript 6**.
@@ -115,6 +131,19 @@ If you legitimately need to raise a limit (e.g. a major new dependency), bump th
 - Use path aliases (`@shared/*`, `@finyk/*`, etc.) instead of relative `../../../`.
 - Dependency bumps — separate PRs (don't mix with features).
 - When deleting a file — first `grep` its imports across the entire monorepo.
+
+## Commit and PR conventions
+
+Conventional Commits with **explicit scope** (Hard Rule #5). Scope enum: `web`, `server`, `mobile`, `mobile-shell`, `console`, `shared`, `api-client`, `finyk-domain`, `fizruk-domain`, `nutrition-domain`, `routine-domain`, `insights`, `design-tokens`, `config`, `db-schema`, `eslint-plugins`, `migrations`, `agents`, `deps`, `docs`, `ci`, `root` — canonical list in [`commitlint.config.js`](./commitlint.config.js). The `commit-msg` Husky hook + commitlint CI gate block invalid scopes.
+
+Example commit subjects (= squash-merge PR titles):
+
+- `feat(web): add HubChat reset action`
+- `fix(server): coerce bigint balance to number in /sync`
+- `chore(deps): bump react-router-dom 7.1.0 → 7.2.0`
+- `docs(agents): add subproject AGENTS.md for apps/*`
+
+PR body follows [`.github/PULL_REQUEST_TEMPLATE.md`](./.github/PULL_REQUEST_TEMPLATE.md): Summary → Governing Skill → Playbook → Verification → Docs and Governance → Risk and Rollout → Hard Rule #15 acknowledgement. Do **not** force-push to `main`/`master` (Hard Rule #6) and do **not** skip Husky pre-commit hooks (Hard Rule #7).
 
 ## Verification before PR
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 > **Гроші, тіло, звички, їжа — в одному додатку. Local-first. Приватно.**
 > Sergeant — це особистий hub для дисциплінованої щоденки: один додаток замість п'яти, з AI-коучем, що бачить весь твій день.
 
+> **AI coding agent or tool?** Read [`AGENTS.md`](./AGENTS.md) — repo policy, hard rules, and the agent operating system (skills, playbooks). Sub-tree quick references: [`apps/web/AGENTS.md`](./apps/web/AGENTS.md), [`apps/server/AGENTS.md`](./apps/server/AGENTS.md), [`apps/mobile/AGENTS.md`](./apps/mobile/AGENTS.md).
+
 <!-- Hero asset slot: replace this comment with `<img src="docs/assets/sergeant-hero.png" alt="Sergeant dashboard preview" width="1280" />` after PR-02b lands the asset (see docs/assets/README.md). -->
 
 <p align="center"><em>(Hero screenshot pending — see <a href="./docs/assets/README.md">docs/assets/</a> capture instructions; PR-02b adds the actual file.)</em></p>

--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -1,0 +1,45 @@
+# Agents in apps/mobile
+
+> **Last validated:** 2026-05-10 by @Skords-01 / Devin. **Next review:** 2026-08-08.
+> **Status:** Active
+
+> **Single source of truth → root [`AGENTS.md`](../../AGENTS.md).** Sub-tree quick reference для агентів, що працюють в `apps/mobile/` (Expo + React Native). Сусідній `apps/mobile-shell/` (Capacitor wrapper) ділить ту саму specialist skill, але має окрему build pipeline (web bundle через `apps/web`).
+
+## Specialist skill
+
+[`.agents/skills/sergeant-mobile-expo/SKILL.md`](../../.agents/skills/sergeant-mobile-expo/SKILL.md) — `apps/mobile`, `apps/mobile-shell`, Expo Router boundaries, NativeWind, MMKV, no DOM leakage.
+
+## Stack snapshot
+
+Expo 52 + React Native 0.76 + Expo Router (file-based) + NativeWind. Storage: MMKV (не localStorage). Тести: Jest. E2E: Detox (iOS sim). Статус — **internal dev-client**: готово до `eas build --profile development`, ще не для store. Mobile strategy ADR — [`0052-mobile-strategy-capacitor-primary`](../../docs/adr/0052-mobile-strategy-capacitor-primary.md).
+
+## Quick commands
+
+```bash
+pnpm --filter @sergeant/mobile start            # Expo dev server
+pnpm --filter @sergeant/mobile ios              # iOS sim
+pnpm --filter @sergeant/mobile android          # Android emu
+pnpm --filter @sergeant/mobile web              # Expo web (debug)
+pnpm --filter @sergeant/mobile typecheck
+pnpm --filter @sergeant/mobile test             # Jest (--passWithNoTests OK)
+pnpm --filter @sergeant/mobile test:coverage
+pnpm --filter @sergeant/mobile e2e:test:ios     # Detox iOS sim
+pnpm --filter @sergeant/mobile check-build-config  # before EAS build
+```
+
+## Surface-specific gotchas
+
+- **No DOM leakage:** mobile-код не імпортує `window`/`document`/DOM-only API. Перевіряй імпорти зі shared-пакетів і не тягни напряму з `apps/web`. ESLint ловить найочевидніше — але краще перевіряти у feature-cycle.
+- **Storage:** MMKV, не localStorage. Спільні утиліти зі shared-пакетів повинні бути storage-agnostic (приймати storage adapter), інакше web/mobile почнуть розходитись.
+- **Routing:** Expo Router file-based (`app/` directory). Не плутати з `react-router-dom` з web.
+- **NativeWind:** Tailwind-like, але **не** Tailwind — частина класів не підтримується. Tailwind preset з `@sergeant/design-tokens` — джерело правди для токенів; перевіряй сумісність із NativeWind перед використанням.
+- **Build config:** `pnpm --filter @sergeant/mobile check-build-config` валідує `app.config.ts` + `eas.json` перед EAS build — запускай локально перед PR, що чіпає mobile config.
+- **Domain invariants** (Kyiv time, kopiykas as `number`, Better Auth opaque user IDs) — однакові з web/server, див. корінь.
+
+## Deeper docs
+
+- App README: [`apps/mobile/README.md`](./README.md)
+- Mobile strategy ADR: [`docs/adr/0052-mobile-strategy-capacitor-primary.md`](../../docs/adr/0052-mobile-strategy-capacitor-primary.md)
+- Capacitor / deep links / RN migration: [`docs/mobile/`](../../docs/mobile/)
+- Routing catalog: [`docs/agents/agent-skills-catalog.md`](../../docs/agents/agent-skills-catalog.md)
+- Domain invariants: [`docs/architecture/domain-invariants.md`](../../docs/architecture/domain-invariants.md)

--- a/apps/server/AGENTS.md
+++ b/apps/server/AGENTS.md
@@ -1,0 +1,50 @@
+# Agents in apps/server
+
+> **Last validated:** 2026-05-10 by @Skords-01 / Devin. **Next review:** 2026-08-08.
+> **Status:** Active
+
+> **Single source of truth → root [`AGENTS.md`](../../AGENTS.md).** Цей файл — sub-tree quick reference для агентів, що працюють у `apps/server/`. Не дублюй repo policy: hard rules і CI matrix живуть у корені.
+
+## Specialist skill
+
+[`.agents/skills/sergeant-server-api/SKILL.md`](../../.agents/skills/sergeant-server-api/SKILL.md) — `apps/server`, `packages/api-client`, bigint coercion, contract triplet, Kyiv time rules. Для SQL/міграцій додатково підвантаж [`sergeant-data-and-migrations`](../../.agents/skills/sergeant-data-and-migrations/SKILL.md).
+
+## Stack snapshot
+
+Node 20 + Express + PostgreSQL 16 (`pg`) + Better Auth (cookie + bearer) + Anthropic Claude (tool-use, streaming). Деплой: Railway via [`Dockerfile.api`](../../Dockerfile.api). Тести: Vitest unit + Testcontainers (real Postgres) інтеграційні.
+
+## Quick commands
+
+```bash
+pnpm dev:server                                       # http://localhost:3000
+pnpm db:up                                            # docker postgres
+pnpm db:migrate                                       # apply SQL migrations
+pnpm --filter @sergeant/server build
+pnpm --filter @sergeant/server test                   # Vitest unit
+pnpm --filter @sergeant/server test:integration       # Testcontainers
+pnpm --filter @sergeant/server test:coverage
+pnpm --filter @sergeant/server typecheck
+pnpm api:generate-openapi                             # regenerate OpenAPI on contract change
+pnpm api:check-openapi                                # freshness gate (CI-blocking)
+```
+
+## Surface-specific gotchas
+
+- **DB types (Hard Rule #1):** `pg` returns `bigint` as **string**. Coerce to `number` in serializers — never leak strings to API consumers or RQ caches.
+- **API contract triplet (Hard Rule #3):** server response shape ↔ `@sergeant/api-client` types ↔ test must move together. Run `pnpm api:generate-openapi` + `pnpm api:generate-openapi-types` when shapes change; CI gates: `pnpm api:check-openapi` + `pnpm api:check-openapi-types`.
+- **Migrations (Hard Rule #4):** sequential numbering, no gaps. Two-phase for `DROP` (deploy a writer that ignores the column → ship migration → remove the writer). Generator: `pnpm gen` → `migration`. Lint gate: `pnpm lint:migrations`.
+- **Domain invariants:** Europe/Kyiv timezone; minor units (kopiykas) as `number` for money; user IDs are Better Auth opaque strings (not UUID). Full anti-pattern list: [`docs/architecture/domain-invariants.md`](../../docs/architecture/domain-invariants.md).
+- **Logging (Hard Rule #21):** Pino redaction policy enforced — never log raw secrets, headers, PII, or request bodies that contain them. Use `apps/server/src/obs/logger.ts` redact paths.
+- **Auth secrets (Hard Rule #20):** no OpenClaw PATs in production; rotate via [`docs/playbooks/rotate-secrets.md`](../../docs/playbooks/rotate-secrets.md).
+
+## Health & deploy
+
+`/health` p95 < 100 ms (informal SLO). Pre-deploy: `pnpm db:migrate` (requires `MIGRATE_DATABASE_URL` = public DB URL). Anthropic `/api/chat` p95 first token < 1.5 s.
+
+## Deeper docs
+
+- App README: [`apps/server/README.md`](./README.md)
+- Domain invariants: [`docs/architecture/domain-invariants.md`](../../docs/architecture/domain-invariants.md)
+- Routing catalog: [`docs/agents/agent-skills-catalog.md`](../../docs/agents/agent-skills-catalog.md)
+- Better Auth wiring: [`.agents/skills/better-auth-best-practices/SKILL.md`](../../.agents/skills/better-auth-best-practices/SKILL.md)
+- HubChat tool/executor coordination: [`.agents/skills/sergeant-hubchat/SKILL.md`](../../.agents/skills/sergeant-hubchat/SKILL.md)

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -1,0 +1,47 @@
+# Agents in apps/web
+
+> **Last validated:** 2026-05-10 by @Skords-01 / Devin. **Next review:** 2026-08-08.
+> **Status:** Active
+
+> **Single source of truth → root [`AGENTS.md`](../../AGENTS.md).** Цей файл — sub-tree quick reference для агентів, що працюють лише в `apps/web/`. Не дублюй repo policy: hard rules, ownership map, performance budgets і CI matrix живуть у корені.
+
+## Specialist skill
+
+[`.agents/skills/sergeant-web-ui/SKILL.md`](../../.agents/skills/sergeant-web-ui/SKILL.md) — apps/web, PWA, Tailwind, a11y, opacity scale, `-strong` fills, storage wrappers, query keys.
+
+## Stack snapshot
+
+React 18 + Vite 6 + Tailwind 3 + TanStack React Query + Better Auth (cookie sessions) + Service Worker (`src/sw.ts`). Deploy: Vercel preview per PR + production on merge to `main`. Tests: Vitest + MSW + React Testing Library; a11y/E2E: Playwright + axe.
+
+## Quick commands
+
+```bash
+pnpm dev:web                                   # http://localhost:5173 (proxies /api → :3000)
+pnpm --filter @sergeant/web build              # production build
+pnpm --filter @sergeant/web build:capacitor    # build for Capacitor shell
+pnpm --filter @sergeant/web test               # Vitest
+pnpm --filter @sergeant/web test:a11y          # Playwright + axe
+pnpm --filter @sergeant/web test:coverage      # Vitest with coverage
+pnpm --filter @sergeant/web typecheck
+pnpm --filter @sergeant/web size               # size-limit (CI gate)
+```
+
+## Surface-specific gotchas
+
+- **RQ keys (Hard Rule #2):** only via `apps/web/src/shared/lib/api/queryKeys.ts` factories (`finykKeys`, `nutritionKeys`, `hubKeys`, `coachKeys`, `digestKeys`, `pushKeys`). No inline `queryKey: [...]`.
+- **Tailwind colour-opacity (Hard Rule #8):** opacity steps must be on the registered scale; saturated brand fills behind `text-white` need the `-strong` companion (Rule #9). No arbitrary hex in `className` (Rule #11). Use `focus-visible:` not `focus:` (Rule #14).
+- **Module accents (Rule #12):** module-accent containment — no foreign accents inside a module subtree.
+- **Module size (Hard Rule #18):** `max-lines: 600` for web TS/TSX. Active initiative — split before crossing.
+- **Storage:** wrapper from `@shared/storage`; allowlist enforced by `pnpm lint:localstorage-allowlist`.
+- **Touch targets:** `Button` auto-applies `min-h-[44px] min-w-[44px]` for `xs`/`sm`/`iconOnly`; opt out with `data-compact` only for intentionally small cells (heatmaps).
+
+## Bundle budget
+
+CI gate via `size-limit`. Canonical numbers: root [`AGENTS.md § Performance budgets`](../../AGENTS.md#performance-budgets) and `apps/web/package.json` → `"size-limit"` (`../server/dist/assets/*` after Vite output is copied for unified-mode serving).
+
+## Deeper docs
+
+- App README: [`apps/web/README.md`](./README.md)
+- Routing catalog: [`docs/agents/agent-skills-catalog.md`](../../docs/agents/agent-skills-catalog.md)
+- Module ownership: [`docs/architecture/module-ownership.md`](../../docs/architecture/module-ownership.md)
+- Domain invariants (Kyiv time, kopiykas as `number`): [`docs/architecture/domain-invariants.md`](../../docs/architecture/domain-invariants.md)


### PR DESCRIPTION
## Summary

Increase compatibility with the [agents.md](https://agents.md) ecosystem (Cursor, Copilot Coding Agent, UiPath Autopilot, Codex, Devin, ...) by making the existing Sergeant agent contract more discoverable to tools that scan only the top of `README.md` or look for the *closest* `AGENTS.md` to the file they are editing. No repo policy is added or moved — root `AGENTS.md` remains the single source of truth, and the new sub-tree files explicitly delegate back to it.

Concretely:

- New sub-tree quick references following the agents.md spec, each linking the matching specialist skill from `docs/agents/agent-skills-catalog.md` and listing surface-specific quick commands and gotchas:
  - <code>apps/web/AGENTS.md</code> → `sergeant-web-ui` (RQ keys factory, opacity scale, `-strong` companion, `focus-visible:`, module-size 600, touch-target rules).
  - <code>apps/server/AGENTS.md</code> → `sergeant-server-api` (+ `sergeant-data-and-migrations` pointer): bigint coercion, OpenAPI freshness gates, two-phase migrations, Pino redaction, Kyiv time / kopiykas / Better Auth opaque IDs.
  - <code>apps/mobile/AGENTS.md</code> → `sergeant-mobile-expo`: no DOM leakage, MMKV (not localStorage), Expo Router, NativeWind caveats, EAS build-config check.
- Root `AGENTS.md` gains:
  - A top-level **Quick commands** section right after the agent operating system (install, db:up, dev:server, dev:web, `pnpm check`, single-workspace test) with a pointer to the three sub-tree files.
  - A **Commit and PR conventions** section before "Verification before PR" — full Conventional Commits scope enum mirrored from `commitlint.config.js` plus four sample subjects (`feat(web): ...`, `fix(server): ...`, `chore(deps): ...`, `docs(agents): ...`) and a pointer to `.github/PULL_REQUEST_TEMPLATE.md`.
- `README.md` gets a single "AI coding agent or tool? → AGENTS.md" line near the top so agents that scan only the first ~20 lines of README still find the contract, with hop-links to the three sub-tree files.

Hard rules, ownership map, performance budgets, and CI matrix are NOT duplicated — sub-tree files reference the root, and the existing `pnpm lint:hard-rules-registry` 3-way sync is untouched.

## Governing Skill

- Primary skill: `sergeant-feature-delivery` (small docs slice, no behavior change).
- Secondary skill (if truly needed): n/a — this PR is governance/docs, not code.

## Playbook

- Primary playbook: n/a — no playbook covers "add subproject AGENTS.md to align with the agents.md spec". Closest neighbor is `docs/playbooks/README.md` (execution recipes overview), but this is a one-off doc addition rather than a recurring recipe.
- Why this playbook: n/a.
- If no playbook matched, why: pure-docs delta with no code/behavior/contract change. Discoverability and language gates already enforce shape.

## Verification

```bash
pnpm format:check                       # → exit 0 (no Prettier diff)
pnpm lint:discoverability               # → ✅ Discoverability OK — 19 route(s) reachable within budget.
pnpm docs:check-freshness-coverage      # → All tracked markdown files have a freshness header.
pnpm docs:check-links                   # → ✅ All markdown links resolve. (14 pre-existing external 404/abort, non-fatal, not in this PR)
pnpm lint:playbook-language             # → OK Playbook + SKILL language: 60 file(s) checked, 0 violation(s).
pnpm lint:skills                        # → OK 12 skills pass shape contract; 12 skills match SHA-256 in skills-lock.json.
pnpm lint:hard-rules-registry           # → ✅ Hard Rules registry OK — 21 rule(s) in sync with AGENTS.md and CONTRIBUTING.md.
pnpm docs:check-playbook-index          # → ✅ docs/playbooks/INDEX.md is up to date (48 playbooks).
```

Additional checks:

- [x] Local smoke / manual validation completed (read every new/changed link target relatively from its file location).
- [x] Surface-specific checks completed (sub-tree files reference real specialist skills from the catalog).

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update. → **Yes, this PR is the update.**
- [x] I checked whether a playbook or skill needed an update. → No skill/playbook content changes; sub-tree AGENTS.md files reference existing specialist skills by path.
- [x] I checked whether governance docs or review docs needed an update. → No — hard rules registry, scope enum, and review checklist are unchanged; this PR only adds discoverability surfaces.

Updated docs:

- `AGENTS.md` (added Quick commands + Commit and PR conventions)
- `README.md` (added AI agent/tool pointer line)
- `apps/web/AGENTS.md` (new)
- `apps/server/AGENTS.md` (new)
- `apps/mobile/AGENTS.md` (new)

## Risk and Rollout

- User-visible risk: **none** — pure-docs change. No code path, no migration, no env var, no contract.
- Rollout / deploy order: merge to `main`; no deploy step needed (Vercel/Railway pipelines do not depend on these files).
- Backout plan: revert the merge commit. The root `AGENTS.md` content that already shipped is unchanged in semantics — only two new sections appended in safe positions.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian. (Sub-tree AGENTS.md bodies are mixed UA/EN matching root `AGENTS.md` style: code/headers in EN, prose in UA.)
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

- Conscious choices the reviewer might want to flip:
  1. **Quick commands placement** — placed right after "Agent operating system" and before "Repo overview" so the first ~30 lines of `AGENTS.md` give an agent both routing (skills) and runnable commands. If you'd rather keep "Repo overview" first, the section moves cleanly.
  2. **Sub-tree AGENTS.md scope** — only `apps/web`, `apps/server`, `apps/mobile`. Skipped `apps/mobile-shell` (Capacitor wrapper — small, and `apps/mobile/AGENTS.md` mentions it explicitly) and `tools/console` (low traffic). Easy to add in a follow-up if you want.
  3. **No CODEOWNERS entries added** — sub-tree AGENTS.md files inherit `apps/web/**` etc. ownership from the existing CODEOWNERS rules, so `pnpm lint:codeowners` is unaffected. If you want explicit owners for these specific files, happy to add.
  4. **No discoverability route added** — `scripts/check-discoverability.mjs` does not currently model "agent-in-sub-tree" as a role. The new sub-tree files are reachable from the root in 1 hop and from `README.md` in 1 hop, so existing routes are fine. If you want a `sub-tree-agent` role with `entrypoints: ["AGENTS.md", "README.md"]` and targets pointing at the three sub-tree files, that is a one-line addition to the `ROUTES` array.

Link to Devin session: https://app.devin.ai/sessions/e5f4fad4257641c598ccf517f0daea10
Requested by: @Skords-01

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve agents.md discoverability by adding subproject `AGENTS.md` files for `apps/web`, `apps/server`, and `apps/mobile`, plus quick commands and commit conventions in the root `AGENTS.md`. Adds a top-level pointer in `README.md`. No code changes.

- New Features
  - Added `apps/web/AGENTS.md`, `apps/server/AGENTS.md`, `apps/mobile/AGENTS.md` quick refs that link to their specialist skills and list surface-specific commands and gotchas.
  - Root `AGENTS.md`: added Quick commands and a Commit and PR conventions section (scope enum mirrors `commitlint.config.js`, with sample subjects).
  - `README.md`: added an early pointer to `AGENTS.md` and the three sub-tree files.
  - Root `AGENTS.md` remains the single source of truth; no policy duplication; CI and hard rules unchanged.

<sup>Written for commit 4c69034bde4048523624c29380f61b014de2d914. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

