### PR TITLE
docs(agents): fix PR 5 number in roadmap (#2377 → #2378)

### DIFF
--- a/docs/agents/skills-evolution-roadmap.md
+++ b/docs/agents/skills-evolution-roadmap.md
@@ -184,7 +184,7 @@ PR проходить у roadmap, якщо він задовольняє всі 
 
 ---
 
-### PR 5 — Security body-scan як гейт у `pnpm lint:skills` (≈1 день, M) ✅ (merged: #2377, 2026-05-10)
+### PR 5 — Security body-scan як гейт у `pnpm lint:skills` (≈1 день, M) ✅ (merged: #2378, 2026-05-10)
 
 **Проблема.** `pnpm lint:skills` зараз перевіряє shape (frontmatter, links) + integrity (SHA-256 ↔ skills-lock.json). Не перевіряє body на injection-патерни. `agentskill.sh` запровадив сервер-side static analysis на 12 категорій загроз після широковідомого OpenClaw-інциденту; це доцільно мати як local CI-gate теж.
 
@@ -350,7 +350,7 @@ PR проходить у roadmap, якщо він задовольняє всі 
 | 2   | Verification gate in review skill | S      | **Highest**    | none                | ✅ #2373 |
 | 3   | Postgres references               | M      | High           | (no hard dep)       |          |
 | 4   | E2E testing skill                 | M      | Medium         | (no hard dep)       |          |
-| 5   | Security body-scan in lint:skills | M      | High           | none                | ✅ #2377 |
+| 5   | Security body-scan in lint:skills | M      | High           | none                | ✅ #2378 |
 | 6   | References folder convention      | S      | Medium         | depends on PR 3 / 4 |          |
 | 7   | Skill evals (substring)           | L      | Medium-High    | depends on PR 1     |          |
 | 8   | Real-LLM eval runner              | L      | Medium         | depends on PR 7     |          |


### PR DESCRIPTION
## Summary

Fix incorrect PR number for PR 5 (Security body-scan) in `skills-evolution-roadmap.md`. The actual merged PR was #2378, not #2377. Two occurrences updated: header line and priority matrix table.

## Governing Skill

- Primary skill: `sergeant-start-here`

## Playbook

- Primary playbook: n/a
- If no playbook matched, why: Trivial doc fix

## Verification

```bash
grep '2378' docs/agents/skills-evolution-roadmap.md
# line 187 and line 353 both show #2378
```

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- `docs/agents/skills-evolution-roadmap.md` — PR number fix

## Risk and Rollout

- User-visible risk: None
- Rollout / deploy order: Merge
- Backout plan: Revert commit

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

Cosmetic fix only — corrects the merged PR number reference.

Link to Devin session: https://app.devin.ai/sessions/db84e64f06cf4534a6de170d96d19ea6
Requested by: @Skords-01

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Correct the PR number for PR 5 (Security body-scan gate in `pnpm lint:skills`) in the skills evolution roadmap: use #2378 instead of #2377.
Updated the PR 5 header and the priority matrix row to point to the correct merged PR.

<sup>Written for commit 21536d1a08aacdcd6a27d98edbd7d5d839171fb0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

