### PR TITLE
fix(openclaw-plugin): env-var fallback when config block is stripped

### DIFF
--- a/packages/openclaw-plugin/src/config.ts
+++ b/packages/openclaw-plugin/src/config.ts
@@ -96,8 +96,27 @@ export type PluginConfig = z.infer<typeof PluginConfigSchema>;
 /**
  * Parses `configJson` (рядок з openclaw.json) у валідовану `PluginConfig`.
  * Кидає ZodError при misconfig — caller (entry point) ловить + log-ує.
+ *
+ * Robustness: OpenClaw runtime іноді передає літеральний рядок `"undefined"`,
+ * `"null"` або порожній рядок, коли config block у `plugins.entries.sergeant`
+ * стрипається валідацією gateway (race з patch-as-code; див. ops/openclaw/
+ * patch-sergeant-config.mjs). У такому випадку — fallback на env vars,
+ * які Railway вже надає (`SERVER_INTERNAL_URL`, `INTERNAL_API_KEY`,
+ * `OPENCLAW_FOUNDER_USER_ID`, ...).
  */
-export function parsePluginConfig(configJson: string): PluginConfig {
+export function parsePluginConfig(
+  configJson: string | null | undefined,
+): PluginConfig {
+  const isMissing =
+    configJson == null ||
+    configJson === "" ||
+    configJson === "undefined" ||
+    configJson === "null";
+
+  if (isMissing) {
+    return PluginConfigSchema.parse(buildConfigFromEnv());
+  }
+
   let parsed: unknown;
   try {
     parsed = JSON.parse(configJson);
@@ -109,4 +128,24 @@ export function parsePluginConfig(configJson: string): PluginConfig {
     );
   }
   return PluginConfigSchema.parse(parsed);
+}
+
+function buildConfigFromEnv(): Record<string, unknown> {
+  const env = process.env;
+  const cfg: Record<string, unknown> = {
+    serverInternalUrl: env.SERVER_INTERNAL_URL,
+    internalApiKey: env.INTERNAL_API_KEY,
+    founderUserId: env.OPENCLAW_FOUNDER_USER_ID,
+    approvalVariant: "B",
+    cheapRouterSystemPromptPath: "/root/.openclaw/cheap-router.system.md",
+  };
+  if (env.OPENCLAW_MAX_PER_CALL_USD) {
+    cfg.maxPerCallUsd = env.OPENCLAW_MAX_PER_CALL_USD;
+  }
+  if (env.OPENCLAW_COUNCIL_USD_BUDGET) {
+    cfg.councilUsdBudget = env.OPENCLAW_COUNCIL_USD_BUDGET;
+  }
+  if (env.N8N_API_URL) cfg.n8nApiUrl = env.N8N_API_URL;
+  if (env.N8N_API_KEY) cfg.n8nApiKey = env.N8N_API_KEY;
+  return cfg;
 }


### PR DESCRIPTION
## Summary

When OpenClaw gateway boots, its config-validation pass strips `plugins.entries.sergeant.config` immediately after `patch-sergeant-config.mjs` re-injects it (visible as `Config overwrite ... changedPaths=1` between the patch and `register()`). The plugin then receives the literal string `"undefined"` and crashes in `JSON.parse`.

This PR makes `parsePluginConfig` tolerant: when it sees `undefined"/"null"/empty, it builds config from `process.env` using the same Railway vars the JSON normally references via `${VAR}` interpolation.

## Why this fixes it

The fixes in #2425 (configSchema, plugins install ordering, patch-as-code) reduced but did not eliminate the race — gateway still wins the validation pass and clears the config block before `register()` runs. A code-level fallback is the only fix that does not depend on runtime patch ordering.

## Test plan

- [ ] Merge to main → Railway auto-deploys → logs show `[plugins] sergeant` registered without error.
- [ ] `@kOPENCLAW_GATEWAY_BOT` responds in Telegram DM with sergeant agents (24 read tools + 5 write tools available).

🤖 Generated with Claude Sonnet 4.6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `openclaw-plugin` from crashing when the gateway strips `plugins.entries.sergeant.config` by falling back to env-based config. If the config is missing or `"undefined"`/`"null"`, the plugin now builds a valid config and registers reliably.

- Bug Fixes
  - `parsePluginConfig` accepts null/empty/`"undefined"`/`"null"` and builds config from env.
  - Reads required vars: SERVER_INTERNAL_URL, INTERNAL_API_KEY, OPENCLAW_FOUNDER_USER_ID; optional: OPENCLAW_MAX_PER_CALL_USD, OPENCLAW_COUNCIL_USD_BUDGET, N8N_API_URL, N8N_API_KEY.

<sup>Written for commit ead7501cab428e6bb1f5244ecb75d37baf5fe9a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Configuration parsing is now more robust, gracefully handling missing or invalid inputs with automatic fallback to environment variables and sensible defaults.
* Enhanced flexibility for optional configuration fields that are automatically populated when corresponding environment variables are present.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Skords-01/Sergeant/pull/2428)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->