### PR TITLE
fix(openclaw-gateway): downgrade openclaw runtime 2026.5.7 → 2026.5.6

### DIFF
--- a/Dockerfile.openclaw-gateway
+++ b/Dockerfile.openclaw-gateway
@@ -43,7 +43,13 @@ FROM --platform=linux/amd64 node:24-alpine
 WORKDIR /app
 
 # OpenClaw runtime — pinned stable (Locked #2). Bump via Renovate PR.
-RUN npm install -g openclaw@2026.5.7
+# Downgraded 2026.5.7 → 2026.5.6: v5.7 introduced a config-validation pass
+# that strips `plugins.entries.<custom-id>.config` for non-bundled plugins
+# (races with patch-sergeant-config.mjs), causing the sergeant plugin's
+# register() to crash with `"undefined" is not valid JSON`. v5.6 does not
+# have that pass; combined with the env-var fallback in parsePluginConfig
+# the plugin loads cleanly on every restart.
+RUN npm install -g openclaw@2026.5.6
 
 # Copy compiled plugin output + plugin manifest (entry → ./dist/index.js).
 COPY --from=plugin-builder /build/packages/openclaw-plugin/dist ./packages/openclaw-plugin/dist


### PR DESCRIPTION
## Summary

Downgrade pinned OpenClaw runtime from `2026.5.7` to `2026.5.6`.

## Why

v2026.5.7 introduced a config-validation pass at gateway boot that strips `plugins.entries.<custom-id>.config` for non-bundled plugins. The strip fires *after* `patch-sergeant-config.mjs` runs (visible in logs as `Config overwrite ... changedPaths=1` between the patch and `register()`), so the sergeant plugin's `register()` receives the literal string `"undefined"` and crashes in `JSON.parse`.

This leaves the Telegram bot working as a generic OpenClaw assistant but **without sergeant agents/tools** (Сергій, Артем, Олексій, 24 read + 5 write tools).

## What changes

- `Dockerfile.openclaw-gateway`: `openclaw@2026.5.7` → `openclaw@2026.5.6`

## Test plan

- [ ] Railway auto-deploys after merge.
- [ ] Container logs show `Installed plugin: sergeant` *without* `failed during register`.
- [ ] `/cofounder`, `/eng`, `/devops` agent shortcuts respond in Telegram DM.

## Note

Combined with #2428's env-fallback in `parsePluginConfig`, the plugin will load cleanly even if the strip behavior returns in a future runtime.

🤖 Generated with Claude Sonnet 4.6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Downgrade the gateway runtime from `openclaw@2026.5.7` to `openclaw@2026.5.6`. This restores the sergeant plugin config and brings back Telegram agent shortcuts.

- **Bug Fixes**
  - v2026.5.7 added a boot-time validation that removed `plugins.entries.<custom-id>.config` for non-bundled plugins, causing `register()` to receive "undefined" and crash.
  - Pin `openclaw@2026.5.6` in `Dockerfile.openclaw-gateway` to bypass the strip; the plugin now installs and registers cleanly.

<sup>Written for commit c30f87259fa1925cd0c89825701ed367a4e26170. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

