### PR TITLE
fix(openclaw-plugin): bracket-notation env access for TS strict mode

### DIFF
--- a/packages/openclaw-plugin/src/config.ts
+++ b/packages/openclaw-plugin/src/config.ts
@@ -133,19 +133,19 @@ export function parsePluginConfig(
 function buildConfigFromEnv(): Record<string, unknown> {
   const env = process.env;
   const cfg: Record<string, unknown> = {
-    serverInternalUrl: env.SERVER_INTERNAL_URL,
-    internalApiKey: env.INTERNAL_API_KEY,
-    founderUserId: env.OPENCLAW_FOUNDER_USER_ID,
+    serverInternalUrl: env["SERVER_INTERNAL_URL"],
+    internalApiKey: env["INTERNAL_API_KEY"],
+    founderUserId: env["OPENCLAW_FOUNDER_USER_ID"],
     approvalVariant: "B",
     cheapRouterSystemPromptPath: "/root/.openclaw/cheap-router.system.md",
   };
-  if (env.OPENCLAW_MAX_PER_CALL_USD) {
-    cfg.maxPerCallUsd = env.OPENCLAW_MAX_PER_CALL_USD;
+  if (env["OPENCLAW_MAX_PER_CALL_USD"]) {
+    cfg["maxPerCallUsd"] = env["OPENCLAW_MAX_PER_CALL_USD"];
   }
-  if (env.OPENCLAW_COUNCIL_USD_BUDGET) {
-    cfg.councilUsdBudget = env.OPENCLAW_COUNCIL_USD_BUDGET;
+  if (env["OPENCLAW_COUNCIL_USD_BUDGET"]) {
+    cfg["councilUsdBudget"] = env["OPENCLAW_COUNCIL_USD_BUDGET"];
   }
-  if (env.N8N_API_URL) cfg.n8nApiUrl = env.N8N_API_URL;
-  if (env.N8N_API_KEY) cfg.n8nApiKey = env.N8N_API_KEY;
+  if (env["N8N_API_URL"]) cfg["n8nApiUrl"] = env["N8N_API_URL"];
+  if (env["N8N_API_KEY"]) cfg["n8nApiKey"] = env["N8N_API_KEY"];
   return cfg;
 }


### PR DESCRIPTION
## Summary

Follow-up to #2428 — Docker build (`pnpm --filter @sergeant/openclaw-plugin build`) failed in #2429 deploy with TS4111 errors:

```
src/config.ts(136,28): error TS4111: Property 'SERVER_INTERNAL_URL' comes from an index signature, so it must be accessed with ['SERVER_INTERNAL_URL'].
...
```

`tsc -p tsconfig.build.json` uses `noPropertyAccessFromIndexSignature: true`, so `process.env.X` is rejected. Switch to bracket notation throughout `buildConfigFromEnv`.

## Why this is urgent

Without this fix the openclaw-gateway service is stuck on a failed deploy — the merged downgrade (#2429) cannot build, so Railway is still serving the v2026.5.7 image with broken sergeant plugin.

🤖 Generated with Claude Sonnet 4.6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `process.env.X` with `process.env["X"]` in `buildConfigFromEnv` to comply with `noPropertyAccessFromIndexSignature` and resolve TS4111. Fixes `tsc` errors in the Docker build, unblocking `@sergeant/openclaw-plugin` and the gateway deploy.

<sup>Written for commit 6d51689cb86a6eba36fb1eab506d3bdb4cd21756. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

