### PR TITLE
fix(openclaw-gateway): revert to openclaw@2026.5.7

### DIFF
--- a/Dockerfile.openclaw-gateway
+++ b/Dockerfile.openclaw-gateway
@@ -43,13 +43,13 @@ FROM --platform=linux/amd64 node:24-alpine
 WORKDIR /app
 
 # OpenClaw runtime — pinned stable (Locked #2). Bump via Renovate PR.
-# Downgraded 2026.5.7 → 2026.5.6: v5.7 introduced a config-validation pass
-# that strips `plugins.entries.<custom-id>.config` for non-bundled plugins
-# (races with patch-sergeant-config.mjs), causing the sergeant plugin's
-# register() to crash with `"undefined" is not valid JSON`. v5.6 does not
-# have that pass; combined with the env-var fallback in parsePluginConfig
-# the plugin loads cleanly on every restart.
-RUN npm install -g openclaw@2026.5.6
+# Reverted to 2026.5.7 (was briefly 2026.5.6). v5.6's PluginApi does not
+# expose `api.services.runtime`, so the sergeant plugin crashes with
+# `TypeError: Cannot read properties of undefined (reading 'runtime')` at
+# register time. v5.7 ships the runtime services API the plugin relies on;
+# the config-block strip bug is now handled at the plugin level by the
+# env-var fallback in parsePluginConfig (see #2428).
+RUN npm install -g openclaw@2026.5.7
 
 # Copy compiled plugin output + plugin manifest (entry → ./dist/index.js).
 COPY --from=plugin-builder /build/packages/openclaw-plugin/dist ./packages/openclaw-plugin/dist


### PR DESCRIPTION
## Summary

Revert #2429 — go back to `openclaw@2026.5.7`.

## Why

The 5.6 downgrade exposed a worse problem: v5.6's `PluginApi` does not expose `services.runtime`, so the sergeant plugin crashes at register time:

```
[plugins] sergeant failed during register:
  TypeError: Cannot read properties of undefined (reading 'runtime')
```

The plugin reads `api.services.runtime.log` (`src/index.ts:100`). That API only exists in 5.7.

## Why this is now safe on 5.7

The original 5.7 problem (`"undefined" is not valid JSON` because gateway strips `plugins.entries.sergeant.config` on boot) is **already defended** at the plugin level by the env-var fallback in #2428: when `parsePluginConfig` receives `"undefined"`, it builds the config from `process.env` instead, and `register()` proceeds normally.

## Test plan

- [ ] Railway auto-deploys.
- [ ] Logs show `Installed plugin: sergeant` *without* either `is not valid JSON` or `reading 'runtime'`.
- [ ] `/commands` in Telegram lists a `sergeant` section with `/metrics`, `/status`, `/runway`, `/sentry`, `/cofounder`, `/eng`, etc.

🤖 Generated with Claude Sonnet 4.6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the gateway to `openclaw@2026.5.7` to restore `api.services.runtime` needed by the sergeant plugin and stop the register-time crash.

- **Bug Fixes**
  - `openclaw@2026.5.6` lacked `services.runtime`, causing `TypeError: reading 'runtime'` during plugin register.
  - The 5.7 config-strip issue is now covered by the plugin’s env-var fallback from #2428, so boot proceeds normally.

<sup>Written for commit 2c66f8404b49a633dd2bbf278edd29dedb21c227. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

