### PR TITLE
fix(openclaw-plugin): api.logger + defensive messaging for openclaw 5.7

### DIFF
--- a/ops/openclaw/openclaw.example.json
+++ b/ops/openclaw/openclaw.example.json
@@ -23,6 +23,7 @@
 
   "plugins": {
     "bundledDiscovery": "compat",
+    "allow": ["sergeant"],
     "entries": {
       "anthropic": { "enabled": true },
       "telegram": { "enabled": true },

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -33,7 +33,6 @@ import {
   createAgentTurnEndHook,
 } from "./audit.js";
 import { createRoutingHook, type RoutingHookOptions } from "./routing-hook.js";
-import type { ToolResult } from "./sdk-types.js";
 import { createRecallMemoryTool } from "./tools/recall-memory.js";
 import { createReadStrategyDocsTool } from "./tools/read-strategy-docs.js";
 import { createQueryAppDbTool } from "./tools/query-app-db.js";
@@ -69,7 +68,14 @@ import {
   type WriteToolFactoryOptions,
 } from "./write-tools/write-tool-factory.js";
 import { createN8nTierCPostHook } from "./write-tools/n8n-tier-c-gate.js";
-import { definePluginEntry, type Plugin, type PluginApi } from "./sdk-types.js";
+import {
+  definePluginEntry,
+  type MessagingService,
+  type Plugin,
+  type PluginApi,
+  type RuntimeService,
+  type ToolResult,
+} from "./sdk-types.js";
 
 export interface CreatePluginOptions {
   /** Optional fetch override for tests / OpenTelemetry instrumentation. */
@@ -97,7 +103,25 @@ export function createOpenClawPlugin(
   });
 
   const correlator = new InvocationCorrelator();
-  const log = api.services.runtime.log;
+  // Prefer real openclaw 5.7 api.logger; fall back to legacy services.runtime.log
+  // (test stubs) or console if neither is present.
+  const log: RuntimeService["log"] =
+    api.services?.runtime?.log ??
+    ((level, msg, fields?) => {
+      const fn =
+        api.logger?.[level as keyof NonNullable<PluginApi["logger"]>];
+      if (typeof fn === "function") fn(msg, fields ?? undefined);
+      else
+        (
+          console[
+            level === "error"
+              ? "error"
+              : level === "warn"
+                ? "warn"
+                : "debug"
+          ] as (...args: unknown[]) => void
+        )(`[sergeant] ${msg}`, fields ?? "");
+    });
 
   // ─── Tool registry (for shortcut router dispatching) ─────────────────
   const toolRegistry = new Map<
@@ -231,11 +255,23 @@ export function createOpenClawPlugin(
   // Shared options for all Variant B write-tools: audit sink, messaging,
   // approval timeout.
   const auditSink = createHttpAuditSink(http, 0);
+  // Real openclaw 5.7 runtime does not inject api.services.messaging — fall
+  // back to a stub that logs the unavailability so write-tool approval flows
+  // degrade gracefully instead of crashing the plugin at register time.
+  const messaging: MessagingService = api.services?.messaging ?? {
+    send: async (text) => {
+      log("warn", "[messaging unavailable] " + text);
+      return { messageId: "unavailable" };
+    },
+    waitForCallback: async () => {
+      throw new Error("openclaw runtime did not inject messaging service");
+    },
+  };
   const writeOpts: WriteToolFactoryOptions = {
     http,
     founderUserId: config.founderUserId,
     variant: config.approvalVariant,
-    messaging: api.services.messaging,
+    messaging,
     approvalCallbackTimeoutMs: config.approvalCallbackTimeoutMs,
     auditSink,
     log,
@@ -246,7 +282,7 @@ export function createOpenClawPlugin(
     http,
     founderUserId: config.founderUserId,
     variant: config.approvalVariant,
-    messaging: api.services.messaging,
+    messaging,
     approvalCallbackTimeoutMs: config.approvalCallbackTimeoutMs,
     recordAudit: async (record) => {
       await auditSink({

--- a/packages/openclaw-plugin/src/sdk-types.ts
+++ b/packages/openclaw-plugin/src/sdk-types.ts
@@ -231,11 +231,22 @@ export interface RuntimeService {
 }
 
 export interface PluginApi {
-  registerTool: <TParams>(tool: ToolDefinition<TParams>) => void;
+  registerTool: <TParams>(tool: ToolDefinition<TParams>, opts?: { optional?: boolean }) => void;
   registerHook: <H extends HookName>(name: H, handler: HookHandler<H>) => void;
-  services: {
-    messaging: MessagingService;
-    runtime: RuntimeService;
+  // Real openclaw 5.7 injected API (api.logger / api.pluginConfig).
+  // Not present in v5.6 stubs or test mocks that only supply services.*.
+  logger?: {
+    debug: (msg: string, fields?: Record<string, unknown>) => void;
+    info: (msg: string, fields?: Record<string, unknown>) => void;
+    warn: (msg: string, fields?: Record<string, unknown>) => void;
+    error: (msg: string, fields?: Record<string, unknown>) => void;
+  };
+  /** Parsed plugin config from openclaw.json plugins.entries.<id>.config (5.7+). */
+  pluginConfig?: unknown;
+  // Legacy stub surface used by tests and v5.6. Not injected by real 5.7 runtime.
+  services?: {
+    messaging?: MessagingService;
+    runtime?: RuntimeService;
   };
 }
 


### PR DESCRIPTION
## Summary

- **Root cause**: plugin crashed at register time with `TypeError: Cannot read properties of undefined (reading 'runtime')` because `sdk-types.ts` was a local stub that expected `api.services.runtime` and `api.services.messaging` — neither of which exist in the real openclaw 5.7 runtime
- **Real API**: openclaw 5.7 injects `api.logger.{debug,info,warn,error}` for logging; no `services.*` is present
- Added `plugins.allow: ["sergeant"]` to silence the persistent `plugins.allow is empty` warning

## Changes

- `sdk-types.ts` — mark `services` as optional; add `logger?` field to `PluginApi` matching real 5.7 API (test stubs still provide `services.*`, unchanged)
- `index.ts` — tri-level log adapter: `api.services?.runtime?.log` → `api.logger` → `console`; defensive `messaging` const with graceful fallback stub so write-tool approval flows don't crash register()
- `openclaw.example.json` — add `plugins.allow: ["sergeant"]`

## Test plan

- [ ] Railway deploys successfully and plugin registers without `TypeError: Cannot read properties of undefined (reading 'runtime')`
- [ ] Logs show `Installed plugin: sergeant` without subsequent register crash
- [ ] `openclaw plugins list` shows sergeant as active
- [ ] Telegram bot responds to DM

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents register-time crash in `openclaw-plugin` on Openclaw 5.7 by adapting to the 5.7 API: use `api.logger` when present and add a defensive messaging fallback. Also silences the “plugins.allow is empty” warning in the example config.

- **Bug Fixes**
  - Updated `PluginApi` types: `services` now optional; added `logger` and `pluginConfig`; `registerTool` supports `{ optional?: boolean }`.
  - Logging order: `api.services?.runtime?.log` → `api.logger` → `console`.
  - Added a safe `messaging` stub when `api.services.messaging` is missing; used by write-tool flows.
  - Example config: added `plugins.allow: ["sergeant"]`.

<sup>Written for commit 880411eaabe20fb9615b823435c2f0a6d5bfd6d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

