### PR TITLE
fix(openclaw-plugin): fix TS build error — PluginApi[services][messaging] type

### DIFF
--- a/ops/openclaw/openclaw.example.json
+++ b/ops/openclaw/openclaw.example.json
@@ -23,6 +23,7 @@
 
   "plugins": {
     "bundledDiscovery": "compat",
+    "allow": ["sergeant"],
     "entries": {
       "anthropic": { "enabled": true },
       "telegram": { "enabled": true },

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -33,7 +33,6 @@ import {
   createAgentTurnEndHook,
 } from "./audit.js";
 import { createRoutingHook, type RoutingHookOptions } from "./routing-hook.js";
-import type { ToolResult } from "./sdk-types.js";
 import { createRecallMemoryTool } from "./tools/recall-memory.js";
 import { createReadStrategyDocsTool } from "./tools/read-strategy-docs.js";
 import { createQueryAppDbTool } from "./tools/query-app-db.js";
@@ -69,7 +68,14 @@ import {
   type WriteToolFactoryOptions,
 } from "./write-tools/write-tool-factory.js";
 import { createN8nTierCPostHook } from "./write-tools/n8n-tier-c-gate.js";
-import { definePluginEntry, type Plugin, type PluginApi } from "./sdk-types.js";
+import {
+  definePluginEntry,
+  type MessagingService,
+  type Plugin,
+  type PluginApi,
+  type RuntimeService,
+  type ToolResult,
+} from "./sdk-types.js";
 
 export interface CreatePluginOptions {
   /** Optional fetch override for tests / OpenTelemetry instrumentation. */
@@ -97,7 +103,25 @@ export function createOpenClawPlugin(
   });
 
   const correlator = new InvocationCorrelator();
-  const log = api.services.runtime.log;
+  // Prefer real openclaw 5.7 api.logger; fall back to legacy services.runtime.log
+  // (test stubs) or console if neither is present.
+  const log: RuntimeService["log"] =
+    api.services?.runtime?.log ??
+    ((level, msg, fields?) => {
+      const fn =
+        api.logger?.[level as keyof NonNullable<PluginApi["logger"]>];
+      if (typeof fn === "function") fn(msg, fields ?? undefined);
+      else
+        (
+          console[
+            level === "error"
+              ? "error"
+              : level === "warn"
+                ? "warn"
+                : "debug"
+          ] as (...args: unknown[]) => void
+        )(`[sergeant] ${msg}`, fields ?? "");
+    });
 
   // ─── Tool registry (for shortcut router dispatching) ─────────────────
   const toolRegistry = new Map<
@@ -231,11 +255,23 @@ export function createOpenClawPlugin(
   // Shared options for all Variant B write-tools: audit sink, messaging,
   // approval timeout.
   const auditSink = createHttpAuditSink(http, 0);
+  // Real openclaw 5.7 runtime does not inject api.services.messaging — fall
+  // back to a stub that logs the unavailability so write-tool approval flows
+  // degrade gracefully instead of crashing the plugin at register time.
+  const messaging: MessagingService = api.services?.messaging ?? {
+    send: async (text) => {
+      log("warn", "[messaging unavailable] " + text);
+      return { messageId: "unavailable" };
+    },
+    waitForCallback: async () => {
+      throw new Error("openclaw runtime did not inject messaging service");
+    },
+  };
   const writeOpts: WriteToolFactoryOptions = {
     http,
     founderUserId: config.founderUserId,
     variant: config.approvalVariant,
-    messaging: api.services.messaging,
+    messaging,
     approvalCallbackTimeoutMs: config.approvalCallbackTimeoutMs,
     auditSink,
     log,
@@ -246,7 +282,7 @@ export function createOpenClawPlugin(
     http,
     founderUserId: config.founderUserId,
     variant: config.approvalVariant,
-    messaging: api.services.messaging,
+    messaging,
     approvalCallbackTimeoutMs: config.approvalCallbackTimeoutMs,
     recordAudit: async (record) => {
       await auditSink({

--- a/packages/openclaw-plugin/src/sdk-types.ts
+++ b/packages/openclaw-plugin/src/sdk-types.ts
@@ -231,11 +231,22 @@ export interface RuntimeService {
 }
 
 export interface PluginApi {
-  registerTool: <TParams>(tool: ToolDefinition<TParams>) => void;
+  registerTool: <TParams>(tool: ToolDefinition<TParams>, opts?: { optional?: boolean }) => void;
   registerHook: <H extends HookName>(name: H, handler: HookHandler<H>) => void;
-  services: {
-    messaging: MessagingService;
-    runtime: RuntimeService;
+  // Real openclaw 5.7 injected API (api.logger / api.pluginConfig).
+  // Not present in v5.6 stubs or test mocks that only supply services.*.
+  logger?: {
+    debug: (msg: string, fields?: Record<string, unknown>) => void;
+    info: (msg: string, fields?: Record<string, unknown>) => void;
+    warn: (msg: string, fields?: Record<string, unknown>) => void;
+    error: (msg: string, fields?: Record<string, unknown>) => void;
+  };
+  /** Parsed plugin config from openclaw.json plugins.entries.<id>.config (5.7+). */
+  pluginConfig?: unknown;
+  // Legacy stub surface used by tests and v5.6. Not injected by real 5.7 runtime.
+  services?: {
+    messaging?: MessagingService;
+    runtime?: RuntimeService;
   };
 }
 

--- a/packages/openclaw-plugin/src/write-tools/create-github-issue.test.ts
+++ b/packages/openclaw-plugin/src/write-tools/create-github-issue.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import { createCreateGithubIssueTool } from "./create-github-issue.js";
 import { OpenClawHttpClient } from "./../http-client.js";
 import type {
-  PluginApi,
+  MessagingService,
   ToolCallPreContext,
   ToolCallPostContext,
 } from "./../sdk-types.js";
@@ -27,7 +27,7 @@ function makeHttp(
 
 function makeMessaging(
   callbackData: string,
-): PluginApi["services"]["messaging"] {
+): MessagingService {
   const sentMessageId = "msg_001";
   return {
     send: vi.fn().mockResolvedValue({ messageId: sentMessageId }),
@@ -214,7 +214,7 @@ describe("create_github_issue — Variant B (custom hook + own UX)", () => {
     const http = makeHttp(() => ({
       body: { url: "https://gh/x", number: 1, title: "t" },
     }));
-    const messaging: PluginApi["services"]["messaging"] = {
+    const messaging: MessagingService = {
       send: vi.fn().mockResolvedValue({ messageId: "msg" }),
       waitForCallback: vi.fn().mockRejectedValue(new Error("timeout")),
     };

--- a/packages/openclaw-plugin/src/write-tools/create-github-issue.ts
+++ b/packages/openclaw-plugin/src/write-tools/create-github-issue.ts
@@ -42,7 +42,7 @@ import { OpenClawHttpError } from "./../http-client.js";
 import type {
   ToolDefinition,
   HookHandler,
-  PluginApi,
+  MessagingService,
   ToolResult,
 } from "./../sdk-types.js";
 import {
@@ -80,7 +80,7 @@ export interface CreateGithubIssueOptions {
   founderUserId: string;
   variant: ApprovalVariant;
   /** Injected SDK services — for messaging (Variant B). */
-  messaging?: PluginApi["services"]["messaging"];
+  messaging?: MessagingService;
   /** Callback wait timeout (Variant B). */
   approvalCallbackTimeoutMs: number;
   /** Optional injected clock for tests (latency tracking). */

--- a/packages/openclaw-plugin/src/write-tools/write-tool-factory.ts
+++ b/packages/openclaw-plugin/src/write-tools/write-tool-factory.ts
@@ -19,7 +19,7 @@ import { OpenClawHttpError } from "../http-client.js";
 import type {
   ToolDefinition,
   HookHandler,
-  PluginApi,
+  MessagingService,
   ToolResult,
 } from "../sdk-types.js";
 import {
@@ -95,7 +95,7 @@ export interface WriteToolFactoryOptions {
   http: OpenClawHttpClient;
   founderUserId: string;
   variant: ApprovalVariant;
-  messaging?: PluginApi["services"]["messaging"];
+  messaging?: MessagingService;
   approvalCallbackTimeoutMs: number;
   auditSink?: WriteAuditSink;
   now?: () => number;


### PR DESCRIPTION
## Summary

- The previous PR (#2433) made `PluginApi.services` optional, but `write-tool-factory.ts` and `create-github-issue.ts` still referenced `PluginApi["services"]["messaging"]` as a type, which TypeScript rejects when `services` is optional
- Build failure: `error TS2339: Property 'messaging' does not exist on type '{ messaging?: MessagingService; runtime?: RuntimeService; } | undefined'`
- Fix: Replace `PluginApi["services"]["messaging"]` with direct `MessagingService` import in all three affected files

## Root cause

Railway build log showed:
```
src/write-tools/create-github-issue.ts(83,37): error TS2339: Property 'messaging' does not exist on type ...
src/write-tools/write-tool-factory.ts(98,37): error TS2339: Property 'messaging' does not exist on type ...
```

## Test plan

- [ ] Railway Docker build completes (pnpm build passes tsc)
- [ ] Gateway container starts and sergeant plugin loads without `TypeError: Cannot read properties of undefined`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TypeScript build errors and aligns the plugin with the real OpenClaw 5.7 API. Adds a logger fallback and a safe messaging stub so registration no longer crashes when `services` are missing.

- **Bug Fixes**
  - Replaced `PluginApi["services"]["messaging"]` with `MessagingService` in write tools to resolve TS errors.
  - Updated `PluginApi` types: `services` is optional; added `logger` and `pluginConfig` for 5.7 compatibility.
  - Added a log adapter that prefers `api.services?.runtime.log`, then `api.logger`, then `console`.
  - Introduced a defensive `messaging` stub when unavailable; write tools use this to degrade gracefully.
  - Updated `openclaw.example.json` with `plugins.allow: ["sergeant"]` to satisfy 5.7 gateway expectations.

<sup>Written for commit 8c86021bea9dcd60425028c7df92ecf4a04daf9c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

