### PR TITLE
fix(openclaw-plugin): fix hook names for real openclaw 5.7 API

### DIFF
--- a/packages/openclaw-plugin/src/index.test.ts
+++ b/packages/openclaw-plugin/src/index.test.ts
@@ -101,20 +101,20 @@ describe("createOpenClawPlugin", () => {
     ]);
   });
 
-  it("registers llm_input + agent_turn_start + agent_turn_end + tool_call_post hooks (Variant B default)", () => {
+  it("registers llm_input + agent_turn_prepare + agent_end + after_tool_call hooks (Variant B default)", () => {
     const api = makeStubApi();
     createOpenClawPlugin(api, CONFIG);
 
     const hookNames = Array.from(api.registeredHooks.keys()).sort();
-    // Variant B (default) додає tool_call_pre + tool_call_post.
+    // Variant B (default) додає before_tool_call + after_tool_call.
     expect(hookNames).toContain("llm_input");
-    expect(hookNames).toContain("agent_turn_start");
-    expect(hookNames).toContain("agent_turn_end");
-    expect(hookNames).toContain("tool_call_pre");
-    expect(hookNames).toContain("tool_call_post");
+    expect(hookNames).toContain("agent_turn_prepare");
+    expect(hookNames).toContain("agent_end");
+    expect(hookNames).toContain("before_tool_call");
+    expect(hookNames).toContain("after_tool_call");
   });
 
-  it("uses Variant A → no tool_call_pre, native requiresConfirmation on write tool", () => {
+  it("uses Variant A → no before_tool_call, native requiresConfirmation on write tool", () => {
     const api = makeStubApi();
     const config = JSON.stringify({
       serverInternalUrl: "http://localhost:3000",
@@ -125,8 +125,8 @@ describe("createOpenClawPlugin", () => {
     createOpenClawPlugin(api, config);
 
     const hookNames = Array.from(api.registeredHooks.keys());
-    expect(hookNames).not.toContain("tool_call_pre");
-    expect(hookNames).toContain("tool_call_post");
+    expect(hookNames).not.toContain("before_tool_call");
+    expect(hookNames).toContain("after_tool_call");
 
     const writeTool = api.registeredTools.find(
       (t) => t.name === "create_github_issue",
@@ -134,7 +134,7 @@ describe("createOpenClawPlugin", () => {
     expect(writeTool?.requiresConfirmation).toBe(true);
   });
 
-  it("uses Variant C → native requiresConfirmation, no tool_call_pre, but tool_call_post audit", () => {
+  it("uses Variant C → native requiresConfirmation, no before_tool_call, but after_tool_call audit", () => {
     const api = makeStubApi();
     const config = JSON.stringify({
       serverInternalUrl: "http://localhost:3000",
@@ -149,7 +149,7 @@ describe("createOpenClawPlugin", () => {
     );
     expect(writeTool?.requiresConfirmation).toBe(true);
 
-    expect(Array.from(api.registeredHooks.keys())).toContain("tool_call_post");
+    expect(Array.from(api.registeredHooks.keys())).toContain("after_tool_call");
   });
 
   it("dispose clears in-memory correlator state", () => {

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -176,7 +176,7 @@ export function createOpenClawPlugin(
   api.registerHook("llm_input", routingHook);
 
   api.registerHook(
-    "agent_turn_start",
+    "agent_turn_prepare",
     createAgentTurnStartHook({
       http,
       founderUserId: config.founderUserId,
@@ -186,7 +186,7 @@ export function createOpenClawPlugin(
   );
 
   api.registerHook(
-    "agent_turn_end",
+    "agent_end",
     createAgentTurnEndHook({
       http,
       founderUserId: config.founderUserId,
@@ -299,45 +299,45 @@ export function createOpenClawPlugin(
   });
   api.registerTool(writeParts.tool);
   if (writeParts.toolCallPreHook) {
-    api.registerHook("tool_call_pre", writeParts.toolCallPreHook);
+    api.registerHook("before_tool_call", writeParts.toolCallPreHook);
   }
-  api.registerHook("tool_call_post", writeParts.toolCallPostHook);
+  api.registerHook("after_tool_call", writeParts.toolCallPostHook);
 
   // commit_to_strategy_doc (PR-D)
   const strategyDocParts = createCommitToStrategyDocTool(writeOpts);
   api.registerTool(strategyDocParts.tool);
   if (strategyDocParts.toolCallPreHook) {
-    api.registerHook("tool_call_pre", strategyDocParts.toolCallPreHook);
+    api.registerHook("before_tool_call", strategyDocParts.toolCallPreHook);
   }
-  api.registerHook("tool_call_post", strategyDocParts.toolCallPostHook);
+  api.registerHook("after_tool_call", strategyDocParts.toolCallPostHook);
 
   // post_to_topic (PR-D)
   const postToTopicParts = createPostToTopicTool(writeOpts);
   api.registerTool(postToTopicParts.tool);
   if (postToTopicParts.toolCallPreHook) {
-    api.registerHook("tool_call_pre", postToTopicParts.toolCallPreHook);
+    api.registerHook("before_tool_call", postToTopicParts.toolCallPreHook);
   }
-  api.registerHook("tool_call_post", postToTopicParts.toolCallPostHook);
+  api.registerHook("after_tool_call", postToTopicParts.toolCallPostHook);
 
   // pause_workflow (PR-D)
   const pauseWorkflowParts = createPauseWorkflowTool(writeOpts);
   api.registerTool(pauseWorkflowParts.tool);
   if (pauseWorkflowParts.toolCallPreHook) {
-    api.registerHook("tool_call_pre", pauseWorkflowParts.toolCallPreHook);
+    api.registerHook("before_tool_call", pauseWorkflowParts.toolCallPreHook);
   }
-  api.registerHook("tool_call_post", pauseWorkflowParts.toolCallPostHook);
+  api.registerHook("after_tool_call", pauseWorkflowParts.toolCallPostHook);
 
   // mute_alert (PR-D)
   const muteAlertParts = createMuteAlertTool(writeOpts);
   api.registerTool(muteAlertParts.tool);
   if (muteAlertParts.toolCallPreHook) {
-    api.registerHook("tool_call_pre", muteAlertParts.toolCallPreHook);
+    api.registerHook("before_tool_call", muteAlertParts.toolCallPreHook);
   }
-  api.registerHook("tool_call_post", muteAlertParts.toolCallPostHook);
+  api.registerHook("after_tool_call", muteAlertParts.toolCallPostHook);
 
   // ─── n8n Tier C audit gate (PR-D Phase 4) ────────────────────────────
   api.registerHook(
-    "tool_call_post",
+    "after_tool_call",
     createN8nTierCPostHook({
       founderUserId: config.founderUserId,
       auditSink,

--- a/packages/openclaw-plugin/src/sdk-types.ts
+++ b/packages/openclaw-plugin/src/sdk-types.ts
@@ -93,12 +93,18 @@ export interface ToolDefinition<TParams = unknown> {
 // ─────────────────────────────────────────────────────────────────────────
 
 export type HookName =
+  // Internal aliases (used by tests + write-tool files)
   | "agent_turn_start"
   | "agent_turn_end"
-  | "llm_input"
-  | "llm_output"
   | "tool_call_pre"
-  | "tool_call_post";
+  | "tool_call_post"
+  // Real openclaw 5.7 hook names (used when calling api.registerHook)
+  | "agent_turn_prepare"  // real name for agent_turn_start
+  | "agent_end"           // real name for agent_turn_end
+  | "before_tool_call"    // real name for tool_call_pre
+  | "after_tool_call"     // real name for tool_call_post
+  | "llm_input"
+  | "llm_output";
 
 export interface HookContextBase {
   invocationId: string;
@@ -151,17 +157,18 @@ export interface ToolCallPostContext extends HookContextBase {
 }
 
 /** Discriminated context type by hook name. */
-export type HookContext<H extends HookName> = H extends "agent_turn_start"
-  ? AgentTurnStartContext
-  : H extends "agent_turn_end"
-    ? AgentTurnEndContext
-    : H extends "llm_input"
-      ? LlmInputContext
-      : H extends "tool_call_pre"
-        ? ToolCallPreContext
-        : H extends "tool_call_post"
-          ? ToolCallPostContext
-          : HookContextBase;
+export type HookContext<H extends HookName> =
+  H extends "agent_turn_start" | "agent_turn_prepare"
+    ? AgentTurnStartContext
+    : H extends "agent_turn_end" | "agent_end"
+      ? AgentTurnEndContext
+      : H extends "llm_input"
+        ? LlmInputContext
+        : H extends "tool_call_pre" | "before_tool_call"
+          ? ToolCallPreContext
+          : H extends "tool_call_post" | "after_tool_call"
+            ? ToolCallPostContext
+            : HookContextBase;
 
 /**
  * Hook handler return shape. Hooks can:


### PR DESCRIPTION
## Summary

- Real openclaw 5.7 runtime uses different hook names than the local stubs guessed
- `"agent_turn_start"` → `"agent_turn_prepare"` (real 5.7 name)
- `"agent_turn_end"` → `"agent_end"` (real 5.7 name)
- `"tool_call_pre"` → `"before_tool_call"` (real 5.7 name)
- `"tool_call_post"` → `"after_tool_call"` (real 5.7 name)
- `"llm_input"` — unchanged (already correct)

## Root cause

`sdk-types.ts` was a guess-stub written before the real SDK existed. Runtime throws `Error: hook registration missing name` when receiving an unknown hook name. The first valid call (`"llm_input"`) passes; `"agent_turn_start"` (line 178) crashes immediately.

## Changes

- `sdk-types.ts`: added real 5.7 names to `HookName` union + `HookContext` discriminator (internal aliases kept for backward compat)
- `index.ts`: all 11 `api.registerHook()` calls use real names now
- `index.test.ts`: updated expectations to match real names

## Expected result after deploy

Runtime log should show:
```
[gateway] http server listening (2 plugins: telegram, sergeant; ...)
```
instead of `Error: hook registration missing name`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches `openclaw-plugin` to the real OpenClaw 5.7 hook names to prevent “hook registration missing name” and allow the runtime to start correctly. Backwards compatibility is kept via aliases; no migration needed.

- **Bug Fixes**
  - Updated `sdk-types.ts` to include real hook names and map `HookContext` discriminators; kept old aliases for compatibility.
  - Replaced all `api.registerHook()` calls with `agent_turn_prepare`, `agent_end`, `before_tool_call`, and `after_tool_call` (`llm_input` unchanged).
  - Adjusted `index.test.ts` expectations to the new names.

<sup>Written for commit e5a1a7b038d14f6b2b9371847e284581ea301a88. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

