### PR TITLE
fix(docker): install openclaw type deps via side dir (npm chokes on w…

### DIFF
--- a/Dockerfile.openclaw-gateway
+++ b/Dockerfile.openclaw-gateway
@@ -38,12 +38,18 @@ COPY packages/openclaw-plugin ./packages/openclaw-plugin
 
 # Stage 1 rewrite: index.ts imports from `openclaw/plugin-sdk/plugin-entry` and
 # `@sinclair/typebox`. These are NOT in the workspace's pnpm-lock.yaml (would
-# require a `pnpm install` cycle to add). Install them locally via npm so tsc
-# can resolve types; they're also pulled at runtime in the slim package.json.
-RUN cd ./packages/openclaw-plugin && \
-    npm install --no-save --no-audit --no-fund --loglevel=error \
+# require a `pnpm install` cycle to add). We can't `npm install` directly into
+# the plugin dir because its package.json has `"@sergeant/shared": "workspace:*"`
+# which npm refuses (EUNSUPPORTEDPROTOCOL). Workaround: install the type deps
+# into a side dir, then layer them into the plugin's pnpm-managed node_modules.
+RUN mkdir -p /tmp/openclaw-types && \
+    cd /tmp/openclaw-types && \
+    printf '{"name":"openclaw-types","version":"0.0.0","private":true}' > package.json && \
+    npm install --no-audit --no-fund --loglevel=error \
       openclaw@2026.5.7 \
-      @sinclair/typebox@^0.34.0
+      @sinclair/typebox@^0.34.0 && \
+    mkdir -p /build/packages/openclaw-plugin/node_modules && \
+    cp -R /tmp/openclaw-types/node_modules/. /build/packages/openclaw-plugin/node_modules/
 
 RUN pnpm --filter @sergeant/openclaw-plugin build
 


### PR DESCRIPTION
…orkspace:*)

The plugin-builder stage tried to npm install openclaw and @sinclair/typebox directly into ./packages/openclaw-plugin, but npm bails with EUNSUPPORTEDPROTOCOL because the workspace package.json carries "@sergeant/shared": "workspace:*" (a pnpm-only protocol).

Workaround: install into /tmp/openclaw-types (clean package.json with no workspace deps), then layer the resulting node_modules into the plugin directory so tsc can resolve the types.

## Summary

<!-- What changed in one tight paragraph or a short flat list. -->

## Governing Skill

- Primary skill:
- Secondary skill (if truly needed):

## Playbook

- Primary playbook:
- Why this playbook:
- If no playbook matched, why:

## Verification

<!-- Paste the exact commands you ran and the key result.
     Before claiming "Done" — Iron Law gate: NO COMPLETION CLAIMS WITHOUT
     FRESH VERIFICATION EVIDENCE. See `sergeant-review-and-merge` SKILL.md
     § "Verification gate" (.agents/skills/sergeant-review-and-merge/SKILL.md). -->

```bash
pnpm lint
pnpm typecheck
```

Additional checks:

- [ ] Local smoke / manual validation completed
- [ ] Surface-specific checks completed

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [ ] I checked whether `AGENTS.md` needed an update.
- [ ] I checked whether a playbook or skill needed an update.
- [ ] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a

## Risk and Rollout

- User-visible risk:
- Rollout / deploy order:
- Backout plan:

## Hard Rule #15

- [ ] I read `AGENTS.md` before coding.
- [ ] Internal docs I touched are in Ukrainian.
- [ ] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

<!-- Per `docs/governance/audit-freeze-2026-05-05.md`. New files under
docs/audits/, docs/initiatives/, docs/playbooks/, docs/adr/ trigger a
non-blocking CI warning. If this PR adds such a file, add `[skip-freeze]`
or `[freeze-exception]` to the PR title and explain below. Otherwise leave
this section as-is or remove. -->

- [ ] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

<!-- Flag migrations, env changes, HubChat tools, auth, or anything else that deserves extra reviewer attention. -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the plugin-builder Docker stage by installing `openclaw` and `@sinclair/typebox` into a temp dir and copying the resulting `node_modules` into `packages/openclaw-plugin`. This avoids `npm` EUNSUPPORTEDPROTOCOL errors from `@sergeant/shared` using `workspace:*` and lets `tsc` resolve types without a full `pnpm install`.

<sup>Written for commit e324f726c2c0656fec87ed1de799bf79e76ab2e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

