### PR TITLE
fix(openclaw-plugin): use ambient TS declarations instead of npm-inst…

### DIFF
--- a/Dockerfile.openclaw-gateway
+++ b/Dockerfile.openclaw-gateway
@@ -37,19 +37,11 @@ COPY packages/shared ./packages/shared
 COPY packages/openclaw-plugin ./packages/openclaw-plugin
 
 # Stage 1 rewrite: index.ts imports from `openclaw/plugin-sdk/plugin-entry` and
-# `@sinclair/typebox`. These are NOT in the workspace's pnpm-lock.yaml (would
-# require a `pnpm install` cycle to add). We can't `npm install` directly into
-# the plugin dir because its package.json has `"@sergeant/shared": "workspace:*"`
-# which npm refuses (EUNSUPPORTEDPROTOCOL). Workaround: install the type deps
-# into a side dir, then layer them into the plugin's pnpm-managed node_modules.
-RUN mkdir -p /tmp/openclaw-types && \
-    cd /tmp/openclaw-types && \
-    printf '{"name":"openclaw-types","version":"0.0.0","private":true}' > package.json && \
-    npm install --no-audit --no-fund --loglevel=error \
-      openclaw@2026.5.7 \
-      @sinclair/typebox@^0.34.0 && \
-    mkdir -p /build/packages/openclaw-plugin/node_modules && \
-    cp -R /tmp/openclaw-types/node_modules/. /build/packages/openclaw-plugin/node_modules/
+# `@sinclair/typebox`. These aren't in pnpm-lock.yaml. Rather than fighting with
+# npm-in-pnpm-workspace install issues at build time, the plugin ships an
+# ambient .d.ts (src/types/openclaw-ambient.d.ts) that satisfies tsc. The
+# packages are installed at runtime via the synthesised slim package.json in
+# the runtime stage below.
 
 RUN pnpm --filter @sergeant/openclaw-plugin build
 

--- a/packages/openclaw-plugin/src/types/openclaw-ambient.d.ts
+++ b/packages/openclaw-plugin/src/types/openclaw-ambient.d.ts
@@ -1,0 +1,102 @@
+/**
+ * Ambient TypeScript declarations for openclaw 5.7 plugin SDK and TypeBox.
+ *
+ * Why: the workspace's pnpm-lock.yaml doesn't include `openclaw` or
+ * `@sinclair/typebox`, and regenerating the lockfile in Docker is brittle
+ * (npm chokes on pnpm's `workspace:*` protocol). For build-time type
+ * checking we only need the *shape* of these modules — the actual JS lands
+ * at runtime via the synthesised slim package.json in the Docker runtime
+ * stage. These declarations describe just enough of each API surface to
+ * compile src/index.ts without errors.
+ *
+ * When openclaw publishes proper types we can `pnpm add` it (locking deps)
+ * and delete this file. Until then, this is the pragmatic boundary.
+ */
+
+declare module "openclaw/plugin-sdk/plugin-entry" {
+  /**
+   * Real openclaw 5.7 plugin entry contract — see docs.openclaw.ai/plugin-sdk.
+   * The host calls `register(api)` once during plugin load with a runtime
+   * API surface that exposes `registerTool`, `on` (for hooks), `config`,
+   * etc. We type `api` permissively here because openclaw evolves the
+   * surface across patch versions and we don't want compile-time coupling.
+   */
+  export interface OpenClawPluginApi {
+    registerTool: (tool: PluginTool, opts?: { optional?: boolean }) => void;
+    on?: (
+      eventName: string,
+      handler: (event: unknown) => unknown,
+      opts?: { priority?: number; timeoutMs?: number },
+    ) => void;
+    registerHook?: (
+      eventName: string | string[],
+      handler: (event: unknown) => unknown,
+      opts?: { priority?: number; timeoutMs?: number },
+    ) => void;
+    /** Parsed plugin config (openclaw injects it before `register` runs). */
+    config?: unknown;
+    pluginConfig?: unknown;
+    logger?: {
+      debug: (msg: string, fields?: Record<string, unknown>) => void;
+      info: (msg: string, fields?: Record<string, unknown>) => void;
+      warn: (msg: string, fields?: Record<string, unknown>) => void;
+      error: (msg: string, fields?: Record<string, unknown>) => void;
+    };
+  }
+
+  export interface PluginTool {
+    name: string;
+    description: string;
+    /** TypeBox schema (or JSON Schema literal). */
+    parameters: unknown;
+    execute: (
+      invocationId: string,
+      params: Record<string, unknown>,
+    ) => Promise<{
+      content: Array<{ type: "text"; text: string }>;
+    }>;
+  }
+
+  export interface PluginDefinition {
+    id: string;
+    name: string;
+    description: string;
+    /** Called once at plugin load time with the runtime API surface. */
+    register: (api: OpenClawPluginApi) => void | Promise<void>;
+    /** Optional fields openclaw 5.7 also honours but we don't use yet. */
+    kind?: string;
+    configSchema?: unknown;
+    reload?: boolean;
+  }
+
+  /** Plugin entry helper — passthrough at runtime; gives us type safety. */
+  export function definePluginEntry(def: PluginDefinition): PluginDefinition;
+  export default definePluginEntry;
+}
+
+declare module "@sinclair/typebox" {
+  // Minimal surface — covers what src/index.ts uses. The runtime values come
+  // from the actual @sinclair/typebox install in the runtime stage.
+  export interface TSchema {
+    [key: string]: unknown;
+  }
+
+  interface TypeBuilder {
+    Object: (
+      props: Record<string, TSchema>,
+      opts?: Record<string, unknown>,
+    ) => TSchema;
+    String: (opts?: Record<string, unknown>) => TSchema;
+    Number: (opts?: Record<string, unknown>) => TSchema;
+    Boolean: (opts?: Record<string, unknown>) => TSchema;
+    Array: (items: TSchema, opts?: Record<string, unknown>) => TSchema;
+    Record: (key: TSchema, value: TSchema) => TSchema;
+    Optional: (schema: TSchema) => TSchema;
+    Unknown: () => TSchema;
+    Any: () => TSchema;
+    Literal: (value: string | number | boolean) => TSchema;
+    Union: (schemas: TSchema[]) => TSchema;
+  }
+
+  export const Type: TypeBuilder;
+}


### PR DESCRIPTION
…all hack

Previous fix tried to npm-install openclaw + typebox into a side dir and cp them into the plugin's pnpm-managed node_modules. That fails because pnpm's node_modules has symlinks to .pnpm/ that cp -R can't merge with real dirs from the npm install.

Cleaner approach: ship an ambient src/types/openclaw-ambient.d.ts that declares the module shapes tsc needs to compile (the actual JS lands at runtime from the synthesised slim package.json). Zero Docker-side package-manager gymnastics; one .d.ts file describes the surface.

When openclaw types are added to the workspace lockfile via a proper pnpm install cycle, this ambient .d.ts can be removed.

## Summary

<!-- What changed in one tight paragraph or a short flat list. -->

## Governing Skill

- Primary skill:
- Secondary skill (if truly needed):

## Playbook

- Primary playbook:
- Why this playbook:
- If no playbook matched, why:

## Verification

<!-- Paste the exact commands you ran and the key result.
     Before claiming "Done" — Iron Law gate: NO COMPLETION CLAIMS WITHOUT
     FRESH VERIFICATION EVIDENCE. See `sergeant-review-and-merge` SKILL.md
     § "Verification gate" (.agents/skills/sergeant-review-and-merge/SKILL.md). -->

```bash
pnpm lint
pnpm typecheck
```

Additional checks:

- [ ] Local smoke / manual validation completed
- [ ] Surface-specific checks completed

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [ ] I checked whether `AGENTS.md` needed an update.
- [ ] I checked whether a playbook or skill needed an update.
- [ ] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a

## Risk and Rollout

- User-visible risk:
- Rollout / deploy order:
- Backout plan:

## Hard Rule #15

- [ ] I read `AGENTS.md` before coding.
- [ ] Internal docs I touched are in Ukrainian.
- [ ] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

<!-- Per `docs/governance/audit-freeze-2026-05-05.md`. New files under
docs/audits/, docs/initiatives/, docs/playbooks/, docs/adr/ trigger a
non-blocking CI warning. If this PR adds such a file, add `[skip-freeze]`
or `[freeze-exception]` to the PR title and explain below. Otherwise leave
this section as-is or remove. -->

- [ ] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

<!-- Flag migrations, env changes, HubChat tools, auth, or anything else that deserves extra reviewer attention. -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the plugin to ambient TypeScript declarations for `openclaw/plugin-sdk/plugin-entry` and `@sinclair/typebox`, removing the brittle Docker npm-in-pnpm workaround. Typechecks now pass without touching the workspace lockfile; runtime still installs the actual JS.

- **Refactors**
  - Added `packages/openclaw-plugin/src/types/openclaw-ambient.d.ts` with minimal SDK and `Type` shapes.
  - Removed Dockerfile step that `npm install`ed deps into a side dir and copied into pnpm `node_modules`.
  - Note: when these deps are added via `pnpm`, this ambient file can be deleted.

<sup>Written for commit 0813ee45ca9a43549ba2847b8a884f3fa5eb14fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

