### PR TITLE
Rewrite/openclaw plugin stage1

### DIFF
--- a/docs/planning/sprint-roadmap-q2q3-2026.md
+++ b/docs/planning/sprint-roadmap-q2q3-2026.md
@@ -1,0 +1,436 @@
+# Sergeant — Спринтовий роадмап Q2–Q3 2026
+
+> **Last validated:** 2026-05-11 by @Skords-01. **Next review:** 2026-07-01.
+> **Status:** Active
+
+> Єдиний спринтовий трекер платформи Sergeant: продуктові фічі + технічний борг.
+> Джерела: [`docs/audits/2026-04-28-implementation-roadmap.md`](../audits/2026-04-28-implementation-roadmap.md),
+> [`docs/launch/tech/openclaw-roadmap.md`](../launch/tech/openclaw-roadmap.md),
+> [`docs/launch/tech/telegram-improvements-roadmap.md`](../launch/tech/telegram-improvements-roadmap.md).
+
+---
+
+## Зміст
+
+1. [Поточний стан](#1-поточний-стан)
+2. [Спринт 5 — OpenClaw проактивність](#2-спринт-5-2026-05-12--2026-05-23)
+3. [Спринт 6 — Weekly rituals + Alert accountability](#3-спринт-6-2026-05-26--2026-06-06)
+4. [Спринт 7 — Webhook hardening + DX](#4-спринт-7-2026-06-09--2026-06-20)
+5. [Спринт 8 — Performance + Strategic mode](#5-спринт-8-2026-06-23--2026-07-04)
+6. [Backlog](#6-backlog-later--q3-2026)
+
+---
+
+## 1. Поточний стан
+
+### 1.1. Тех-борг (відкриті задачі)
+
+Повний контекст і деталі реалізації — у [`2026-04-28-implementation-roadmap.md`](../audits/2026-04-28-implementation-roadmap.md).
+
+| ID | Задача | Деталь | Статус |
+|----|--------|--------|--------|
+| T1 | HubDashboard decomposition | `HubDashboard.tsx` 743 LOC → ~100 LOC | ⏳ В процесі |
+| T2 | Capacitor boundary tests | 0 тестів → 10+ у `apps/mobile-shell` | ❌ Не почато |
+| T3 | Великі файли (батч 3) | `Workouts.tsx` 744, `LogCard.tsx` 736, `NutritionApp.tsx` 728 | ⏳ Частково |
+| T4 | Bundle size | 615 KB (brotli) → 550 KB | ⏳ Потребує перевірки |
+| T5 | Lighthouse CI | LCP < 2.0s у CI | ❌ Не почато |
+| T6 | Backend dedup | `pantry → prompt-builders.ts` | ⏳ Потребує перевірки |
+| T7 | Mobile flaky tests | CI pass rate верифікація | ~Закрито (потребує 20-run check) |
+
+### 1.2. Продуктові задачі (відкриті)
+
+Повний контекст — у [`openclaw-roadmap.md`](../launch/tech/openclaw-roadmap.md) та [`telegram-improvements-roadmap.md`](../launch/tech/telegram-improvements-roadmap.md).
+
+| ID | Задача | Джерело | Wave | Effort |
+|----|--------|---------|------|--------|
+| O1 | Phase 2.A: Ранкова повістка 08:30 Kyiv | openclaw §Phase 2 | W2 | M |
+| O2 | C.2: Sentry breadcrumbs у tool-calls | tg-improvements §4.3 | W2 | XS |
+| O3 | Phase 2.B: Friday weekly + monthly OKR | openclaw §Phase 2 | W3 | M |
+| O4 | B.1: Alert dedup / occurrence-counter (10-min window) | tg-improvements §4.2 | W3 | M |
+| O5 | W3 PR-3: `/alerts pending` slash-команда | tg-improvements §3.2 | W3 | S |
+| O6 | W4.1: bootstrap setWebhook poll-and-retry hardening | tg-improvements §3.5.1 | W4 | XS |
+| O7 | A.6+A.7: `/help` discovery + persona quick-row | tg-improvements §4.1 | W4 | S |
+| O8 | Phase 3: `/plan`, `/analyze`, `/okr` | openclaw §Phase 3 | Later | L |
+| O9 | Alert-bot: 17 workflow ACK-wirings (W3 follow-up від W3 PR-2) | tg-improvements §3.2 | W3+ | M |
+
+### 1.3. Вже зроблено (довідка)
+
+| Компонент | Що закрито |
+|-----------|------------|
+| TypeScript strict | ✅ 13/13 пакетів = 100% (Спринти 1–3) |
+| localStorage migration | ✅ ~90% (ESLint `no-raw-local-storage: error`, allowlist ~10 файлів) |
+| Sentry | ✅ web + mobile + server |
+| Prompt cache | ✅ `cache_control: ephemeral` у `chat.ts` |
+| OpenTelemetry | ✅ distributed tracing у `apps/server/src/obs/` |
+| OpenClaw Phase 1+1.5+2.5+4 | ✅ shipped (ADR-0031/32/33/36/37) |
+| Alert ACK-button foundation | ✅ `tg_alert_acks` table + WF-04/103/104 (ADR-0038) |
+| `/audit since=` + CSV | ✅ [#1462](https://github.com/Skords-01/Sergeant/pull/1462) |
+| WF-15 Bad request fix | ✅ [#1469](https://github.com/Skords-01/Sergeant/pull/1469) |
+| Webhook delivery для OpenClaw | ✅ [#1514](https://github.com/Skords-01/Sergeant/pull/1514), live 2026-05-03 |
+| dev-stack top-15 | ✅ 15/15 закрито |
+| i18n Phase 1+2+3 | ✅ sync/zod migrated, `no-cyrillic-jsx-literal` ESLint rule (#1942) |
+| CloudSync engine | ✅ lifecycle, push loop, scheduler, DLQ (#1929–#1941) |
+| Agent OS hardening | ✅ Initiative 0009 (#1949) |
+
+---
+
+## 2. Спринт 5 (2026-05-12 – 2026-05-23)
+
+**Тема: OpenClaw проактивність**
+
+**Мета:** OpenClaw перестає бути 100% reactive — Phase 2.A в production.
+Паралельно: CI health verification і Sentry coverage у tool-calls.
+
+### Задачі
+
+#### O1: Ранкова повістка 08:30 Kyiv (Phase 2.A) `Продукт` `M`
+
+**Що:** cron (Railway scheduler або n8n WF-101) → `POST /api/internal/openclaw/ritual/morning` → DM ≤8 рядків з:
+- Stripe MRR delta (24h)
+- PostHog signups (24h)
+- Sentry new issues (24h)
+- GitHub PR queue (open count)
+- Open ops-alerts count
+- 1 пропозиція дня (з cofounder-memory recall)
+
+**Acceptance:**
+- [ ] DM до founder щодня 08:30 Kyiv (будні)
+- [ ] Idempotency — skip якщо сьогодні вже надсилав
+- [ ] Failover — якщо ritual не вдався → пост у `⚙️ Контрол-план` через alert-bot
+- [ ] LLM cost ~$0.10 на ritual (в межах `OPENCLAW_DAILY_USD_BUDGET=$5`)
+
+**Пов'язане:** [openclaw-roadmap §Phase 2](../launch/tech/openclaw-roadmap.md), [ADR-0039](../adr/0039-openclaw-proactive-cron-rituals.md) (draft)
+
+---
+
+#### O2: Sentry breadcrumbs у tool-calls `Tech` `XS`
+
+**Що:** після кожного tool-call у OpenClaw agent-loop — додавати Sentry breadcrumb з `tool_name`, `latency_ms`, `status`.
+
+**Файл:** `tools/console/src/agents/openclaw.ts` — у `runAgentTurn` helper.
+
+**Acceptance:**
+- [ ] Sentry event для помилки у tool-call містить breadcrumb з `tool_name` tag
+- [ ] Немає performance overhead > 1ms на tool-call
+
+---
+
+#### O5: `/alerts pending` slash-команда `Продукт` `S`
+
+**Що:** нова slash-команда у `@OpenClaw_sergeant_bot` DM що показує unacked alerts з `tg_alert_acks`.
+
+**Файл:** `tools/console/src/openclaw/handler.ts`
+
+**Acceptance:**
+- [ ] `/alerts pending` → список unacked P0/P1 alert-ів з часом з моменту публікації
+- [ ] Якщо немає unacked → "Всі алерти прочитані ✅"
+- [ ] Audit row у `openclaw_invocations` для кожного виклику
+
+---
+
+#### T7: CI verification mobile flaky tests `Tech` `S`
+
+**Що:** верифікувати що `isReduceMotionEnabled` mock pattern виправлено у CI.
+
+**Файли:**
+- `apps/mobile/src/core/dashboard/WeeklyDigestFooter.test.tsx`
+- `apps/mobile/src/core/settings/HubSettingsPage.test.tsx`
+
+**Acceptance:**
+- [ ] CI mobile job — 100% pass rate за останні 20 run-ів
+- [ ] Якщо flaky — застосувати pattern з `OnboardingWizard` fix (commit `53853e00`)
+
+---
+
+## 3. Спринт 6 (2026-05-26 – 2026-06-06)
+
+**Тема: Weekly rituals + Alert accountability**
+
+**Мета:** Закрити Telegram Wave 3 повністю. OpenClaw Phase 2.B в production.
+Продовжити розбивку великих компонентів — HubDashboard.
+
+### Задачі
+
+#### O3: Friday weekly review + monthly OKR (Phase 2.B) `Продукт` `M`
+
+**Що:**
+- **Friday 18:00 Kyiv:** тиждень в цифрах vs. попередній + closed PRs + 2-3 priorities на наступний тиждень.
+- **1-го числа місяця 09:00 Kyiv:** OKR progress з `docs/strategy/` + risks/blockers + recalibration suggestion.
+- Broadcast у `📊 Дайджести` topic (per [ADR-0031 §6 resolved decision](../launch/tech/openclaw-roadmap.md)).
+
+**Acceptance:**
+- [ ] П'ятниця 18:00 — DM weekly review
+- [ ] 1-го числа 09:00 — DM monthly OKR review
+- [ ] Broadcast у `📊 Дайджести` при weekly і monthly review
+
+**Пов'язане:** [openclaw-roadmap §Phase 2](../launch/tech/openclaw-roadmap.md), ADR-0039
+
+---
+
+#### O4: Alert dedup / occurrence-counter (10-min window) `Продукт` `M`
+
+**Що:** перш ніж слати новий alert з того самого `workflow_id`, перевірити чи не було повідомлення за останні 10 хвилин. Якщо було — edit існуючого повідомлення: додати occurrence-counter `(×3)` замість нового.
+
+**Схема:**
+```sql
+-- нова колонка у tg_alert_acks або окрема таблиця dedup
+ALTER TABLE tg_alert_acks ADD COLUMN IF NOT EXISTS occurrence_count INT NOT NULL DEFAULT 1;
+ALTER TABLE tg_alert_acks ADD COLUMN IF NOT EXISTS last_occurrence_at TIMESTAMPTZ;
+```
+
+**Acceptance:**
+- [ ] Не більше 1 нового повідомлення / 10 хв по одному workflow
+- [ ] Occurrence counter видно у message-і (`⚠️ WF-15 failed (×4)`)
+- [ ] Dedup не блокує escalation (P0 unacked 15min → ескалація незалежно від dedup-у)
+
+---
+
+#### O9: 17 workflow ACK-wirings `Продукт` `M`
+
+**Що:** дотягнути pattern із WF-04 (reference wiring з W3 PR-2 [#1480](https://github.com/Skords-01/Sergeant/pull/1480)) до решти broadcast workflows. Кожен WF що шле P0/P1 alert має:
+1. Формувати payload через `POST /api/internal/alerts/post`
+2. Отримувати inline-keyboard `[ ✅ Прочитав | 🔄 Розбираю | 🔕 Замутити 30хв ]`
+
+**Пріоритет wirings:**
+1. WF-03 (Sentry P0), WF-18 (Railway crash), WF-22 (DB alerts) — критичні
+2. WF-01/02/05..14/16/17/19..21 — решта
+
+**Acceptance:**
+- [ ] Всі P0/P1 workflows мають 3-кнопковий row при нових alert-ах
+- [ ] WF-103 (escalation cron) коректно знаходить unacked-и від всіх wired workflows
+- [ ] `ops/n8n-workflows/` JSON оновлені у git (`"active": false` → staging → prod toggle)
+
+---
+
+#### T1: HubDashboard decomposition `Tech` `M`
+
+**Scope:** `apps/web/src/core/hub/HubDashboard.tsx` (743 LOC → ~100 LOC)
+
+**Запропонована структура:**
+```
+apps/web/src/core/hub/
+├── HubDashboard.tsx          # Container (~100 LOC)
+├── HubHeader.tsx             # Navigation + greeting (~80 LOC)
+├── TodayFocusCard.tsx        # Recommendation engine widget (~150 LOC)
+├── ModuleQuickActions.tsx    # 4 module shortcuts (~120 LOC)
+├── WeeklyProgressChart.tsx   # Cross-module chart (~180 LOC)
+├── RecentActivityFeed.tsx    # Activity timeline (~150 LOC)
+├── useHubAggregation.ts      # Data aggregation hook (~100 LOC)
+└── hub.types.ts              # TypeScript types (~40 LOC)
+```
+
+**Acceptance:**
+- [ ] `HubDashboard.tsx` < 150 LOC
+- [ ] Всі існуючі тести проходять
+- [ ] Жодних circular dependencies (перевірити `pnpm lint`)
+
+---
+
+## 4. Спринт 7 (2026-06-09 – 2026-06-20)
+
+**Тема: Webhook hardening + великі файли**
+
+**Мета:** W4 hardening items + залишки tech debt (великі компоненти + Capacitor).
+
+### Задачі
+
+#### O6: bootstrap setWebhook poll-and-retry hardening `Tech` `XS`
+
+**Scope:** `tools/console/src/openclaw/bootstrap.ts::registerOpenClawWebhook`
+
+**Що:** після `bot.api.setWebhook(...)` — `getWebhookInfo`, перевірити `url === expected`, при mismatch → retry з backoff (max 3 спроби: 1s / 2s / 4s).
+
+**Acceptance:**
+- [ ] Unit test: mismatch on first attempt → recovery on second
+- [ ] Sentry breadcrumb `[openclaw] webhook recovered after race` при retry-успіху
+- [ ] Smoke: long-poll → webhook → long-poll → webhook redeploy без ручного curl-у
+
+**Пов'язане:** [ADR-0041 §5](../adr/0041-openclaw-telegram-webhook.md), [tg-improvements §3.5.1](../launch/tech/telegram-improvements-roadmap.md)
+
+---
+
+#### O7: `/help` discovery + persona quick-row `Продукт` `S`
+
+**Scope:** `tools/console/src/openclaw/handler.ts`
+
+**Що:**
+- **`/help`** — inline-keyboard або форматований текст з усіма доступними командами та персонами.
+- **Persona quick-row** — у boot-message (ранкова повістка) — одна кнопка-рядок для переходу до персони (`/ops`, `/growth`, `/eng`, `/finance`).
+
+**Acceptance:**
+- [ ] `/help` → повний список команд (`/ops`, `/growth`, `/eng`, `/finance`, `/cofounder`, `/council`, `/status`, `/metrics`, `/digest`, `/logs`, `/review`, `/audit`, `/alerts`, `/help`)
+- [ ] Persona quick-row видно у ранковому повідомленні
+
+---
+
+#### T2: Capacitor boundary tests `Tech` `M`
+
+**Scope:** `apps/mobile-shell/tests/boundary.test.ts` (новий файл)
+
+**Що:**
+```typescript
+describe("Capacitor Boundary Tests", () => {
+  describe("Web Compatibility", () => {
+    it("web bundle loads without errors");
+    it("no unsupported APIs are called");
+    it("service worker registration works");
+  });
+  describe("Native Bridge", () => {
+    it("Filesystem plugin accessible");
+    it("Storage plugin accessible");
+    it("Network plugin accessible");
+  });
+  describe("Deep Links", () => {
+    it("handles sergeant:// scheme");
+    it("handles universal links");
+  });
+});
+```
+
+**Acceptance:**
+- [ ] 10+ boundary tests, CI зелений
+- [ ] `pnpm --filter @sergeant/mobile-shell test` проходить
+
+---
+
+#### T3: Великі файли — батч 3 `Tech` `M`
+
+**Файли:**
+| Файл | LOC зараз | Ціль |
+|------|-----------|------|
+| `modules/fizruk/pages/Workouts.tsx` | 744 | < 250 |
+| `modules/fizruk/components/LogCard.tsx` | 736 | < 250 |
+| `modules/nutrition/NutritionApp.tsx` | 728 | < 250 |
+
+**Acceptance:**
+- [ ] Кожен файл < 250 LOC
+- [ ] `pnpm typecheck` без нових помилок
+- [ ] Всі існуючі тести проходять
+
+---
+
+## 5. Спринт 8 (2026-06-23 – 2026-07-04)
+
+**Тема: Performance + Strategic mode**
+
+**Мета:** Bundle size і Core Web Vitals, backend cleanup, початок Phase 3 OpenClaw.
+
+### Задачі
+
+#### T4: Bundle size 615 KB → 550 KB `Tech` `M`
+
+**Стратегії (за savings):**
+
+| Стратегія | Потенційна економія |
+|-----------|---------------------|
+| Lazy load Recharts | ~30 KB |
+| Tree-shake date-fns | ~15 KB |
+| Split code by route | ~20 KB |
+| Remove unused icons | ~10 KB |
+
+**Команда:** `pnpm --filter @sergeant/web build && pnpm size-limit`
+
+**Acceptance:**
+- [ ] `pnpm size-limit` проходить (ліміт 550 KB brotli)
+- [ ] Жодних регресій LCP > 2.5s у Lighthouse
+
+---
+
+#### T5: Lighthouse CI `Tech` `S`
+
+**Що:**
+```yaml
+# .github/workflows/lighthouse.yml
+name: Lighthouse CI
+on: [pull_request]
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: treosh/lighthouse-ci-action@v12
+        with:
+          configPath: "./lighthouserc.json"
+          uploadArtifacts: true
+```
+
+**Acceptance:**
+- [ ] LCP < 2.0s у CI
+- [ ] PR блокується якщо LCP > 2.5s (warn) або > 3.0s (error)
+
+---
+
+#### T6: Backend dedup `pantry → prompt-builders.ts` `Tech` `S`
+
+**Scope:** `apps/server/src/`
+
+**Що:** верифікувати і довершити consolidation `pantry → lib/prompt-builders.ts`. FNV-1a hashing — перевірити `lib/backupKey.ts` на повноту.
+
+**Acceptance:**
+- [ ] 0 дублікатів шаблону `pantry → prompt` у `apps/server/src/`
+- [ ] `pnpm --filter @sergeant/server typecheck` без нових помилок
+
+---
+
+#### O8-start: Phase 3 `/plan` mode (початок) `Продукт` `L (partial)`
+
+**Scope:** `tools/console/src/openclaw/handler.ts` + `apps/server/src/modules/openclaw/`
+
+**Що (Phase 3 перший crescent):**
+- `docs/strategy/` — нова директорія з YAML-frontmatter (`objective`, `kr[]`, `current_state`, `last_review_at`).
+- `/plan <topic>` — структурований 4-step session:
+  1. Goal — уточнення цілі
+  2. Context — підтягнути дані з tools + memory
+  3. Options — 2–3 варіанти з trade-offs
+  4. Decision → `record_decision` + suggest-PR до `docs/strategy/<slug>.md`
+
+**Acceptance:**
+- [ ] `/plan churn-reduction` → 4-step session → PR з `docs/strategy/churn-reduction.md`
+- [ ] ADR-0040 задрафтовано і approve-нуто перед реалізацією
+
+**Пов'язане:** [openclaw-roadmap §Phase 3](../launch/tech/openclaw-roadmap.md)
+
+---
+
+## 6. Backlog (Later / Q3 2026+)
+
+### OpenClaw / Telegram
+
+| ID | Задача | Effort | ADR |
+|----|--------|--------|-----|
+| A.2 | Phase 3: `/analyze` + `/okr` modes | L | 0040 |
+| A.3 | "Approve all" batch button для write-tools | M | — |
+| A.4 | Diff-preview для `commit_to_strategy_doc` | M | — |
+| A.5 | Voice notes input (Whisper transcription) | M | — |
+| A.8 | `/forget {topic}` — memory-write з approval | M | — |
+| A.10 | Edit message → re-run loop | S | — |
+| A.11 | Reply threading (`reply_to_message_id`) | M | — |
+| A.12 | Nightly self-summary 02:00 Kyiv | S | — |
+| B.2 | `/silence WF-15 30m` topic command | M | — |
+| B.4 | Daily P0/P1/P2 pinned message у `⚙️ Контрол-план` | M | — |
+| C.1 | Multi-instance failover / Postgres advisory leader | L | 0042 |
+| C.3 | Bot token rotation policy | M | 0043 |
+
+### Технічний борг
+
+| ID | Задача | Effort |
+|----|--------|--------|
+| T8 | i18n Phase 4+ (після Phase 1-3 shipped) | L |
+| T9 | localStorage allowlist → 0 (cloudSync internals review) | S |
+| T10 | `Overview.tsx` (494 LOC → < 250) | M |
+| T11 | DB-persistence pending approvals (Phase 5 multi-operator) | L |
+
+---
+
+## Метрики по спринтах
+
+| Спринт | Продуктові задачі | Tech задачі | Загальний effort |
+|--------|-------------------|-------------|-----------------|
+| Спринт 5 | O1, O2, O5 | T7 | ~5–6 днів |
+| Спринт 6 | O3, O4, O9 | T1 | ~8–10 днів |
+| Спринт 7 | O6, O7 | T2, T3 | ~7–9 днів |
+| Спринт 8 | O8-start | T4, T5, T6 | ~8–10 днів |
+
+---
+
+**Документ оновлено 2026-05-11. Активний спринт — Спринт 5. Наступний review — 2026-07-01.**

--- a/ops/openclaw/openclaw.example.json
+++ b/ops/openclaw/openclaw.example.json
@@ -19,7 +19,10 @@
   },
 
   "session": { "dmScope": "per-channel-peer" },
-  "tools": { "profile": "coding" },
+  "tools": {
+    "profile": "coding",
+    "allow": ["sergeant"]
+  },
 
   "plugins": {
     "bundledDiscovery": "compat",


### PR DESCRIPTION
## Summary

<!-- What changed in one tight paragraph or a short flat list. -->

## Governing Skill

- Primary skill:
- Secondary skill (if truly needed):

## Playbook

- Primary playbook:
- Why this playbook:
- If no playbook matched, why:

## Verification

<!-- Paste the exact commands you ran and the key result.
     Before claiming "Done" — Iron Law gate: NO COMPLETION CLAIMS WITHOUT
     FRESH VERIFICATION EVIDENCE. See `sergeant-review-and-merge` SKILL.md
     § "Verification gate" (.agents/skills/sergeant-review-and-merge/SKILL.md). -->

```bash
pnpm lint
pnpm typecheck
```

Additional checks:

- [ ] Local smoke / manual validation completed
- [ ] Surface-specific checks completed

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [ ] I checked whether `AGENTS.md` needed an update.
- [ ] I checked whether a playbook or skill needed an update.
- [ ] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a

## Risk and Rollout

- User-visible risk:
- Rollout / deploy order:
- Backout plan:

## Hard Rule #15

- [ ] I read `AGENTS.md` before coding.
- [ ] Internal docs I touched are in Ukrainian.
- [ ] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

<!-- Per `docs/governance/audit-freeze-2026-05-05.md`. New files under
docs/audits/, docs/initiatives/, docs/playbooks/, docs/adr/ trigger a
non-blocking CI warning. If this PR adds such a file, add `[skip-freeze]`
or `[freeze-exception]` to the PR title and explain below. Otherwise leave
this section as-is or remove. -->

- [ ] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

<!-- Flag migrations, env changes, HubChat tools, auth, or anything else that deserves extra reviewer attention. -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable the `sergeant` OpenClaw plugin tools in Stage 1 by allowing them in the agent config, so the agent sees more than the default `coding` profile. Also added the Q2–Q3 2026 sprint roadmap as the single planning tracker.

- **Bug Fixes**
  - Updated `ops/openclaw/openclaw.example.json` to include `tools.allow: ["sergeant"]`, restoring plugin tools (e.g., `recall_memory`, `query_app_db`, `read_github`) in the agent’s palette.

- **Migration**
  - Add `"allow": ["sergeant"]` under `tools` in your OpenClaw config (keep `"profile": "coding"`).
  - Restart the OpenClaw runtime/bot.
  - Verify: gateway logs list `sergeant`, and the agent lists the plugin tools.

<sup>Written for commit aaf7879f8458903dcf43c1b9fde7bd3a0d7c7df0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added sprint roadmap document for Q2–Q3 2026, outlining upcoming work, technical debt initiatives, and performance metrics.

* **Chores**
  * Updated example configuration file to reflect current tool configuration standards.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Skords-01/Sergeant/pull/2443)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->