### PR TITLE
fix(openclaw): expose plugin tools via tools.allow with explicit tool names

### DIFF
--- a/ops/openclaw/openclaw.example.json
+++ b/ops/openclaw/openclaw.example.json
@@ -21,7 +21,20 @@
   "session": { "dmScope": "per-channel-peer" },
   "tools": {
     "profile": "coding",
-    "allow": ["sergeant"]
+    "allow": [
+      "group:fs",
+      "group:runtime",
+      "group:web",
+      "group:sessions",
+      "group:memory",
+      "cron",
+      "image",
+      "image_generate",
+      "video_generate",
+      "recall_memory",
+      "query_app_db",
+      "read_github"
+    ]
   },
 
   "plugins": {


### PR DESCRIPTION
## Problem

After Stage 1 merge (#2438), gateway logs confirmed plugin loaded:
```
[gateway] http server listening (2 plugins: sergeant, telegram; ...)
```

But the agent couldn't call our tools. Telegram returned 500-style errors and runtime logs showed:

```
[agent/embedded] [tools] No callable tools remain after resolving explicit tool allowlist (tools.allow: sergeant); no registered tools matched.
Embedded agent failed before reply: No callable tools remain after resolving explicit tool allowlist...
```

## Root cause

Previous commit set `tools.allow: ["sergeant"]` assuming plugin id expands to the plugin's tool set. Per `docs.openclaw.ai/gateway/config-tools`:
- `tools.allow` **refines** profile (filters within it), accepts tool names, group references, `*` wildcards
- The literal "sergeant" matched no registered tool → allowlist resolved to empty set, even coding-profile tools dropped

## Fix

Enumerate coding-profile groups explicitly + add our 3 plugin tool names:

```json
"tools": {
  "profile": "coding",
  "allow": [
    "group:fs", "group:runtime", "group:web", "group:sessions", "group:memory",
    "cron", "image", "image_generate", "video_generate",
    "recall_memory", "query_app_db", "read_github"
  ]
}
```

## Verification after deploy

- Telegram agent stops returning "Something went wrong" on plugin tool calls
- Runtime log no longer shows "No callable tools remain"
- Agent introspection shows `recall_memory`, `query_app_db`, `read_github` in its tool list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose plugin tools by switching `tools.allow` from a plugin id to explicit tool names and coding-profile groups. Restores coding tools and enables `recall_memory`, `query_app_db`, and `read_github` to be callable.

- **Bug Fixes**
  - Updated `ops/openclaw/openclaw.example.json`: replaced `["sergeant"]` with `group:fs`, `group:runtime`, `group:web`, `group:sessions`, `group:memory`, plus `cron`, `image`, `image_generate`, `video_generate`, `recall_memory`, `query_app_db`, `read_github`.
  - Fixes “No callable tools remain” and stops Telegram 500s; agent now lists the plugin tools.

<sup>Written for commit 74a64381a7000b2f39eed0139fa392da7efd4bff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

