### PR TITLE
fix(openclaw): wipe stale workspace skills for Stage 1 MVP

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "node --import tsx src/index.js",
+    "dev": "node --env-file=.env --import tsx src/index.js",
     "build": "node build.mjs",
     "start": "node dist-server/index.js",
     "start:replit": "SERVER_MODE=replit node --import tsx src/index.js",

--- a/apps/server/src/modules/mono/connection.ts
+++ b/apps/server/src/modules/mono/connection.ts
@@ -15,6 +15,7 @@ import {
   webhookSecretHash,
 } from "./crypto.js";
 import type { EncryptedToken } from "./crypto.js";
+import { scheduleHistoryBackfill } from "./historyFetch.js";
 
 /**
  * POST /api/mono/connect  — register Monobank webhook + persist connection.
@@ -251,6 +252,14 @@ export async function connectHandler(
     fingerprint,
     accountsCount: accounts.length,
   });
+
+  // Fire-and-forget: fetch last 30 days of transactions for each account.
+  // Runs after the response is sent so the connect call is never delayed.
+  scheduleHistoryBackfill(
+    userId,
+    accounts.map((a) => a.id),
+    encKey,
+  );
 
   // Validate response against the SSOT (Hard Rule #3) so any drift between
   // server emit and `MonoConnectResponse` z.infer in the api-client throws

--- a/apps/server/src/modules/mono/historyFetch.ts
+++ b/apps/server/src/modules/mono/historyFetch.ts
@@ -1,0 +1,289 @@
+/**
+ * Monobank statement backfill — fetches the last 30 days of transactions for
+ * all accounts immediately after a user connects their token.
+ *
+ * Called fire-and-forget from `connectHandler` so it never delays the HTTP
+ * response. Errors are logged but not re-thrown — a failed backfill is
+ * non-fatal; future webhooks will fill the gap going forward.
+ *
+ * Rate limit: Monobank allows 1 statement request per 60 s per token.
+ * With multiple accounts we sleep 62 s between each to stay within the limit.
+ */
+
+import { z } from "zod";
+import { pool } from "../../db.js";
+import { logger } from "../../obs/logger.js";
+import { enqueueMemoryIngest } from "../ai-memory/ingestQueue.js";
+import { categorizeMcc } from "./mccCategories.js";
+import { decryptToken } from "./crypto.js";
+
+const MONO_API_TIMEOUT_MS = 15_000;
+/** Monobank personal statement rate limit: 1 req / 60 s per token. */
+const BETWEEN_ACCOUNTS_DELAY_MS = 62_000;
+const HISTORY_DAYS = 30;
+
+const CURRENCY_SYMBOL: Record<number, string> = {
+  980: "₴",
+  840: "$",
+  978: "€",
+  826: "£",
+  985: "zł",
+};
+
+const BackfillItemSchema = z.object({
+  id: z.string().min(1).max(64),
+  time: z.number().int().nonnegative().finite(),
+  description: z.string().max(500).optional().default(""),
+  mcc: z.number().int().nonnegative().max(99_999).default(0),
+  originalMcc: z.number().int().nonnegative().max(99_999).optional(),
+  hold: z.boolean().optional(),
+  amount: z.number().int().finite(),
+  operationAmount: z.number().int().finite(),
+  currencyCode: z.number().int().nonnegative().max(9_999),
+  commissionRate: z.number().int().finite().optional(),
+  cashbackAmount: z.number().int().finite().optional(),
+  balance: z.number().int().finite().optional(),
+  comment: z.string().max(500).optional(),
+  receiptId: z.string().max(64).optional(),
+  invoiceId: z.string().max(64).optional(),
+  counterEdrpou: z.string().max(32).optional(),
+  counterIban: z.string().max(64).optional(),
+  counterName: z.string().max(200).optional(),
+});
+type BackfillItem = z.infer<typeof BackfillItemSchema>;
+
+function buildMemoryContent(
+  item: BackfillItem,
+  categorySlug: string | null,
+): string {
+  const isExpense = item.amount < 0;
+  const verb = isExpense ? "Витрата" : "Надходження";
+  const symbol = CURRENCY_SYMBOL[item.currencyCode] ?? "";
+  const major = Math.abs(item.amount / 100);
+  const sign = isExpense ? "−" : "+";
+  const formatted = major.toLocaleString("uk-UA", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+  const amountStr = symbol ? `${sign}${formatted} ${symbol}` : `${sign}${formatted}`;
+  const description = (item.description || "Без опису").trim().slice(0, 200);
+  const dateIso = new Date(item.time * 1000).toISOString().slice(0, 10);
+  const categoryPart = categorySlug ? ` · ${categorySlug}` : "";
+  return `${verb} ${amountStr} ${description}${categoryPart} · ${dateIso}`;
+}
+
+async function upsertTransactions(
+  userId: string,
+  monoAccountId: string,
+  items: BackfillItem[],
+): Promise<number> {
+  if (items.length === 0) return 0;
+  let inserted = 0;
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    for (const item of items) {
+      const categorySlug = categorizeMcc(item.mcc);
+      const result = await client.query<{ inserted: boolean }>(
+        `INSERT INTO mono_transaction
+           (user_id, mono_account_id, mono_tx_id, time, amount, operation_amount,
+            currency_code, mcc, original_mcc, hold, description, comment,
+            cashback_amount, commission_rate, balance, receipt_id, invoice_id,
+            counter_edrpou, counter_iban, counter_name, raw, source, category_slug)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,'backfill',$22)
+         ON CONFLICT (user_id, mono_tx_id) DO NOTHING
+         RETURNING (xmax = 0) AS inserted`,
+        [
+          userId,
+          monoAccountId,
+          item.id,
+          new Date(item.time * 1000).toISOString(),
+          item.amount,
+          item.operationAmount,
+          item.currencyCode,
+          item.mcc ?? null,
+          item.originalMcc ?? null,
+          item.hold ?? null,
+          item.description ?? null,
+          item.comment ?? null,
+          item.cashbackAmount ?? null,
+          item.commissionRate ?? null,
+          item.balance ?? null,
+          item.receiptId ?? null,
+          item.invoiceId ?? null,
+          item.counterEdrpou ?? null,
+          item.counterIban ?? null,
+          item.counterName ?? null,
+          JSON.stringify(item),
+          categorySlug,
+        ],
+      );
+      if (result.rows[0]?.inserted) {
+        inserted++;
+        void enqueueMemoryIngest({
+          userId,
+          source: "finyk",
+          sourceRef: item.id,
+          content: buildMemoryContent(item, categorySlug),
+          metadata: {
+            monoAccountId,
+            amount: item.amount,
+            currencyCode: item.currencyCode,
+            mcc: item.mcc ?? null,
+            categorySlug,
+            time: new Date(item.time * 1000).toISOString(),
+          },
+        });
+      }
+    }
+    await client.query("COMMIT");
+  } catch (err) {
+    await client.query("ROLLBACK").catch(() => {});
+    throw err;
+  } finally {
+    client.release();
+  }
+  return inserted;
+}
+
+async function fetchAccountStatement(
+  token: string,
+  monoAccountId: string,
+  fromTs: number,
+  toTs: number,
+): Promise<BackfillItem[]> {
+  const url = `https://api.monobank.ua/personal/statement/${monoAccountId}/${fromTs}/${toTs}`;
+  const res = await fetch(url, {
+    headers: { "X-Token": token },
+    signal: AbortSignal.timeout(MONO_API_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Monobank statement ${res.status}: ${body.slice(0, 200)}`);
+  }
+  const raw: unknown = await res.json();
+  if (!Array.isArray(raw)) return [];
+  return raw.flatMap((item) => {
+    const parsed = BackfillItemSchema.safeParse(item);
+    return parsed.success ? [parsed.data] : [];
+  });
+}
+
+interface BackfillAccount {
+  id: string;
+}
+
+interface BackfillConnectionRow {
+  token_ciphertext: Buffer;
+  token_iv: Buffer;
+  token_tag: Buffer;
+}
+
+export async function runMonoHistoryBackfill(
+  userId: string,
+  accounts: BackfillAccount[],
+  encryptedToken: BackfillConnectionRow,
+  encKey: string,
+): Promise<void> {
+  const token = decryptToken(
+    {
+      ciphertext: encryptedToken.token_ciphertext,
+      iv: encryptedToken.token_iv,
+      tag: encryptedToken.token_tag,
+    },
+    encKey,
+  );
+
+  const toTs = Math.floor(Date.now() / 1000);
+  const fromTs = toTs - HISTORY_DAYS * 24 * 60 * 60;
+
+  let totalInserted = 0;
+
+  for (let i = 0; i < accounts.length; i++) {
+    const account = accounts[i]!;
+    if (i > 0) {
+      // Respect Monobank rate limit between accounts
+      await new Promise((resolve) =>
+        setTimeout(resolve, BETWEEN_ACCOUNTS_DELAY_MS),
+      );
+    }
+    try {
+      const items = await fetchAccountStatement(
+        token,
+        account.id,
+        fromTs,
+        toTs,
+      );
+      const inserted = await upsertTransactions(userId, account.id, items);
+      totalInserted += inserted;
+      logger.info({
+        msg: "mono_backfill_account_done",
+        userId,
+        monoAccountId: account.id,
+        fetched: items.length,
+        inserted,
+      });
+    } catch (err) {
+      logger.warn({
+        msg: "mono_backfill_account_error",
+        userId,
+        monoAccountId: account.id,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  await pool
+    .query(
+      `UPDATE mono_connection SET last_backfill_at = NOW(), updated_at = NOW() WHERE user_id = $1`,
+      [userId],
+    )
+    .catch((err: unknown) => {
+      logger.warn({ msg: "mono_backfill_update_at_error", err });
+    });
+
+  logger.info({
+    msg: "mono_backfill_complete",
+    userId,
+    accounts: accounts.length,
+    totalInserted,
+  });
+}
+
+/**
+ * Schedule a history backfill after connect. Reads the encrypted token back
+ * from DB so the plaintext is never kept in a long-lived closure.
+ */
+export function scheduleHistoryBackfill(
+  userId: string,
+  accountIds: string[],
+  encKey: string,
+): void {
+  if (accountIds.length === 0) return;
+
+  setImmediate(() => {
+    pool
+      .query<BackfillConnectionRow>(
+        `SELECT token_ciphertext, token_iv, token_tag
+         FROM mono_connection WHERE user_id = $1`,
+        [userId],
+      )
+      .then((result) => {
+        const row = result.rows[0];
+        if (!row) return;
+        return runMonoHistoryBackfill(
+          userId,
+          accountIds.map((id) => ({ id })),
+          row,
+          encKey,
+        );
+      })
+      .catch((err: unknown) => {
+        logger.warn({
+          msg: "mono_backfill_schedule_error",
+          userId,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      });
+  });
+}

--- a/ops/openclaw/docker-entrypoint.sh
+++ b/ops/openclaw/docker-entrypoint.sh
@@ -11,11 +11,20 @@ mkdir -p ~/.openclaw/workspace/skills
 # Lay down main config (overwrites on each restart).
 cp /app/ops/openclaw/openclaw.example.json ~/.openclaw/openclaw.json
 
-# Sync supplementary assets (skills, shortcuts, cheap-router prompt, n8n allowlist).
-# These are consumed by @sergeant/openclaw-plugin at runtime via paths under ~/.openclaw.
-cp -r /app/ops/openclaw/skills/. ~/.openclaw/workspace/skills/
-cp /app/ops/openclaw/cheap-router.system.md ~/.openclaw/cheap-router.system.md
-cp /app/ops/openclaw/n8n-allowlist.json ~/.openclaw/n8n-allowlist.json
+# Stage 1 MVP: the workspace skills/ + cheap-router prompt + n8n-allowlist
+# were authored for the pre-rewrite plugin and reference 24+ tools that the
+# MVP plugin doesn't register yet (recall_memory, query_app_db, read_github
+# only). Leaving them in place poisons the agent's persona — it reads the
+# SKILL.md docs, believes it's "Sergeant CTO with full tool-set", then can't
+# find the tools it expects and surfaces confusing "I don't have X" answers.
+#
+# Wipe the volume-persisted copies on every start. Re-introduce these assets
+# stage by stage as we migrate tools in Stages 2-4.
+rm -rf ~/.openclaw/workspace/skills/* \
+       ~/.openclaw/cheap-router.system.md \
+       ~/.openclaw/n8n-allowlist.json
+# Re-create empty skills dir to keep the path valid for openclaw.
+mkdir -p ~/.openclaw/workspace/skills
 
 # Plugin bootstrap: @sergeant/openclaw-plugin lives in packages/openclaw-plugin and
 # is loaded into the Gateway as an OpenClaw plugin. Install state lives on the


### PR DESCRIPTION
## Problem

After PR #2445 deployed, runtime logs confirmed:
- Plugin loads cleanly (`2 plugins: sergeant, telegram`)
- `tools.allow` matched our 3 plugin tools (no "unknown entries" for them)
- No `No callable tools remain` errors

But the Telegram agent **still claims** "у мене нема recall_memory". The user spotted why: the `~/.openclaw/workspace/skills/` directory we copy from `ops/openclaw/skills/` contains 15 persona SKILL.md files (`sergeant-eng`, `sergeant-growth`, `morning-digest`, etc.) — each lists 5-10 tools by name that the Stage 1 MVP plugin doesn't register.

The agent reads these as persona/system context, believes itself to be "Sergeant with full tool-set", and surfaces hallucinated "I don't have X" answers when its prompt-shaped expectation collides with the actual 3-tool registry.

## Fix

Stop copying `skills/`, `cheap-router.system.md`, `n8n-allowlist.json` from the Docker image to the persistent volume on every container start. Wipe any volume-persisted copies on startup. These re-enter stage-by-stage as Stages 2-4 migrate their underlying tools.

## Verification after deploy

- Bot in Telegram becomes a generic openclaw agent (no Sergeant persona, no morning council references)
- When asked "use recall_memory", it actually attempts the tool call
- Persona/skill features return progressively as we migrate tools in PR-B, PR-C, PR-D

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes stale OpenClaw workspace personas on startup to match the Stage 1 tool set, and adds a background 30-day Monobank history backfill after connect that feeds transaction memories.

- **Bug Fixes**
  - Delete `~/.openclaw/workspace/skills`, `cheap-router.system.md`, and `n8n-allowlist.json` on container start; recreate empty `skills/`.
  - Prevents persona/tool mismatch so the bot stops referencing unavailable tools in Stage 1.

- **New Features**
  - After Monobank connect, fetch last 30 days of statements per account in the background.
  - Respect 1 req/min rate limit; upsert transactions and enqueue memory ingest for each new item.
  - Load `.env` in `apps/server` dev via `--env-file=.env`.

<sup>Written for commit 13394dc796fb7dda706a2b33777ebe9475f7c94f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

