### PR TITLE
[codex] Fix local date drift in Fizruk progress

### DIFF
--- a/apps/web/src/modules/fizruk/hooks/usePushupActivity.test.tsx
+++ b/apps/web/src/modules/fizruk/hooks/usePushupActivity.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  __setRoutineSqliteStateCacheForTests,
+  clearSqliteCompletionsCache,
+  clearSqliteRoutineStateCache,
+} from "../../routine/lib/sqliteReader";
+import { usePushupActivity } from "./usePushupActivity";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(2026, 0, 5, 0, 30));
+  clearSqliteCompletionsCache();
+  clearSqliteRoutineStateCache();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  clearSqliteCompletionsCache();
+  clearSqliteRoutineStateCache();
+});
+
+describe("usePushupActivity", () => {
+  it("aggregates stats with local day keys from Routine history", () => {
+    __setRoutineSqliteStateCacheForTests({
+      pushupsByDate: {
+        "2025-12-06": 2,
+        "2025-12-29": 5,
+        "2026-01-05": 9,
+      },
+    });
+
+    const { result } = renderHook(() => usePushupActivity(31));
+
+    expect(result.current.stats).toEqual({
+      todayCount: 9,
+      week: 14,
+      month: 16,
+    });
+    expect(result.current.hasData).toBe(true);
+  });
+});

--- a/apps/web/src/modules/fizruk/hooks/usePushupActivity.ts
+++ b/apps/web/src/modules/fizruk/hooks/usePushupActivity.ts
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { addDays, dateKeyFromDate } from "@sergeant/routine-domain";
 import { ROUTINE_EVENT } from "../../routine/lib/routineStorage";
 import { buildPushupHistoryFromRoutine } from "../../routine/lib/routinePushupsRead";
 
@@ -31,13 +32,10 @@ export function usePushupActivity(days = 30) {
   }, [syncKey, days]);
 
   const stats = useMemo(() => {
-    const today = new Date().toISOString().slice(0, 10);
-    const weekAgo = new Date(Date.now() - 7 * 86400000)
-      .toISOString()
-      .slice(0, 10);
-    const monthAgo = new Date(Date.now() - 30 * 86400000)
-      .toISOString()
-      .slice(0, 10);
+    const now = new Date();
+    const today = dateKeyFromDate(now);
+    const weekAgo = dateKeyFromDate(addDays(now, -7));
+    const monthAgo = dateKeyFromDate(addDays(now, -30));
     const todayCount = history.find((d) => d.date === today)?.total ?? 0;
     const week = history
       .filter((d) => d.date >= weekAgo)

--- a/apps/web/src/modules/fizruk/lib/exerciseProgress.test.ts
+++ b/apps/web/src/modules/fizruk/lib/exerciseProgress.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import type { WorkoutItem } from "@sergeant/fizruk-domain";
+import { dateKeyFromDate } from "@sergeant/fizruk-domain/domain/plan/calendar";
+
+import {
+  buildStrengthProgressData,
+  startOfLocalIsoWeek,
+} from "./exerciseProgress";
+
+function strengthItem(
+  sets: Array<{ weightKg: number; reps: number }>,
+): WorkoutItem {
+  return {
+    id: "item-1",
+    exerciseId: "bench",
+    nameUk: "Bench",
+    primaryGroup: "chest",
+    musclesPrimary: ["chest"],
+    musclesSecondary: [],
+    type: "strength",
+    sets,
+  };
+}
+
+describe("exercise progress aggregation", () => {
+  it("buckets early-Monday local workouts into the same local ISO week", () => {
+    const monday = new Date(2026, 0, 5, 0, 30);
+    const wednesday = new Date(2026, 0, 7, 18, 0);
+
+    expect(dateKeyFromDate(startOfLocalIsoWeek(monday))).toBe("2026-01-05");
+
+    const progress = buildStrengthProgressData([
+      {
+        workout: { startedAt: monday.toISOString() },
+        item: strengthItem([{ weightKg: 100, reps: 5 }]),
+      },
+      {
+        workout: { startedAt: wednesday.toISOString() },
+        item: strengthItem([{ weightKg: 80, reps: 10 }]),
+      },
+    ]);
+
+    expect(progress.rmPoints).toHaveLength(1);
+    expect(progress.rmPoints[0]!.value).toBe(117);
+    expect(progress.volPoints).toEqual([
+      { dateLabel: progress.rmPoints[0]!.dateLabel, value: 1300 },
+    ]);
+  });
+});

--- a/apps/web/src/modules/fizruk/lib/exerciseProgress.ts
+++ b/apps/web/src/modules/fizruk/lib/exerciseProgress.ts
@@ -1,0 +1,77 @@
+import {
+  epley1rm,
+  type Workout,
+  type WorkoutItem,
+  type WorkoutSet,
+} from "@sergeant/fizruk-domain";
+import { dateKeyFromDate } from "@sergeant/fizruk-domain/domain/plan/calendar";
+
+export interface ExerciseProgressPoint {
+  value: number;
+  dateLabel: string;
+}
+
+interface ExerciseHistoryEntry {
+  workout: Pick<Workout, "startedAt">;
+  item: WorkoutItem;
+}
+
+interface WeekBucket {
+  maxRm: number;
+  vol: number;
+  date: Date;
+}
+
+export function buildStrengthProgressData(history: ExerciseHistoryEntry[]): {
+  rmPoints: ExerciseProgressPoint[];
+  volPoints: ExerciseProgressPoint[];
+} {
+  const byWeek = new Map<string, WeekBucket>();
+  for (const { workout, item } of history) {
+    if (item?.type !== "strength" || !workout?.startedAt) continue;
+    const weekStart = startOfLocalIsoWeek(new Date(workout.startedAt));
+    const key = dateKeyFromDate(weekStart);
+    const sets: WorkoutSet[] = item.sets ?? [];
+    let maxRm = 0;
+    let vol = 0;
+    for (const s of sets) {
+      const rm = epley1rm(s.weightKg, s.reps);
+      if (rm > maxRm) maxRm = rm;
+      vol += (Number(s.weightKg) || 0) * (Number(s.reps) || 0);
+    }
+    const existing = byWeek.get(key) ?? { maxRm: 0, vol: 0, date: weekStart };
+    byWeek.set(key, {
+      maxRm: Math.max(existing.maxRm, maxRm),
+      vol: existing.vol + vol,
+      date: existing.date,
+    });
+  }
+
+  const sorted = [...byWeek.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .slice(-12);
+
+  const rmPoints = sorted.map(([, v]) => ({
+    value: Math.round(v.maxRm),
+    dateLabel: formatProgressDate(v.date),
+  }));
+  const volPoints = sorted.map(([, v]) => ({
+    value: Math.round(v.vol),
+    dateLabel: formatProgressDate(v.date),
+  }));
+  return { rmPoints, volPoints };
+}
+
+export function startOfLocalIsoWeek(d: Date): Date {
+  const weekStart = new Date(d);
+  weekStart.setDate(d.getDate() - ((d.getDay() + 6) % 7));
+  weekStart.setHours(0, 0, 0, 0);
+  return weekStart;
+}
+
+function formatProgressDate(d: Date): string {
+  return d.toLocaleDateString("uk-UA", {
+    day: "numeric",
+    month: "short",
+  });
+}

--- a/apps/web/src/modules/fizruk/pages/Exercise.tsx
+++ b/apps/web/src/modules/fizruk/pages/Exercise.tsx
@@ -16,6 +16,7 @@ import {
   ExerciseProgressChart,
   type ProgressPoint,
 } from "../components/ExerciseProgressChart";
+import { buildStrengthProgressData } from "../lib/exerciseProgress";
 import { fmt } from "../lib/numberFmt";
 
 interface HistoryEntry {
@@ -97,54 +98,7 @@ export function Exercise({ exerciseId }: { exerciseId: string }) {
   }, [ex, musclesUk]);
 
   const progressData = useMemo(() => {
-    interface WeekBucket {
-      maxRm: number;
-      vol: number;
-      date: Date;
-    }
-    const byWeek = new Map<string, WeekBucket>();
-    for (const { workout, item } of history) {
-      if (item?.type !== "strength" || !workout?.startedAt) continue;
-      const d = new Date(workout.startedAt);
-      const weekStart = new Date(d);
-      weekStart.setDate(d.getDate() - ((d.getDay() + 6) % 7));
-      weekStart.setHours(0, 0, 0, 0);
-      const key = weekStart.toISOString().slice(0, 10);
-      const sets: WorkoutSet[] = item.sets ?? [];
-      let maxRm = 0;
-      let vol = 0;
-      for (const s of sets) {
-        const rm = epley1rm(s.weightKg, s.reps);
-        if (rm > maxRm) maxRm = rm;
-        vol += (Number(s.weightKg) || 0) * (Number(s.reps) || 0);
-      }
-      const existing = byWeek.get(key) ?? { maxRm: 0, vol: 0, date: weekStart };
-      byWeek.set(key, {
-        maxRm: Math.max(existing.maxRm, maxRm),
-        vol: existing.vol + vol,
-        date: existing.date,
-      });
-    }
-
-    const sorted = [...byWeek.entries()]
-      .sort(([a], [b]) => a.localeCompare(b))
-      .slice(-12);
-
-    const rmPoints = sorted.map(([, v]) => ({
-      value: Math.round(v.maxRm),
-      dateLabel: v.date.toLocaleDateString("uk-UA", {
-        day: "numeric",
-        month: "short",
-      }),
-    }));
-    const volPoints = sorted.map(([, v]) => ({
-      value: Math.round(v.vol),
-      dateLabel: v.date.toLocaleDateString("uk-UA", {
-        day: "numeric",
-        month: "short",
-      }),
-    }));
-    return { rmPoints, volPoints };
+    return buildStrengthProgressData(history);
   }, [history]);
 
   const cardioData = useMemo(() => {

--- a/apps/web/src/modules/routine/lib/routinePushupsRead.test.ts
+++ b/apps/web/src/modules/routine/lib/routinePushupsRead.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { buildPushupHistoryFromRoutine } from "./routinePushupsRead";
+import {
+  __setRoutineSqliteStateCacheForTests,
+  clearSqliteCompletionsCache,
+  clearSqliteRoutineStateCache,
+} from "./sqliteReader";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(2026, 0, 5, 0, 30));
+  clearSqliteCompletionsCache();
+  clearSqliteRoutineStateCache();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  clearSqliteCompletionsCache();
+  clearSqliteRoutineStateCache();
+});
+
+describe("buildPushupHistoryFromRoutine", () => {
+  it("reads local date keys exactly and fills missing days with zeroes", () => {
+    __setRoutineSqliteStateCacheForTests({
+      pushupsByDate: {
+        "2026-01-03": 12,
+        "2026-01-05": 7,
+      },
+    });
+
+    expect(buildPushupHistoryFromRoutine(3)).toEqual([
+      { date: "2026-01-03", total: 12 },
+      { date: "2026-01-04", total: 0 },
+      { date: "2026-01-05", total: 7 },
+    ]);
+  });
+});

--- a/apps/web/src/modules/routine/lib/routinePushupsRead.ts
+++ b/apps/web/src/modules/routine/lib/routinePushupsRead.ts
@@ -1,3 +1,4 @@
+import { addDays, dateKeyFromDate } from "@sergeant/routine-domain";
 import { loadRoutineState } from "./routineStorage";
 
 /** Для сторінки Прогрес Фізрука — історія відтискань з даних Рутини */
@@ -10,9 +11,7 @@ export function buildPushupHistoryFromRoutine(days = 30) {
   const result: Array<{ date: string; total: number }> = [];
   const now = new Date();
   for (let i = days - 1; i >= 0; i--) {
-    const d = new Date(now);
-    d.setDate(d.getDate() - i);
-    const str = d.toISOString().slice(0, 10);
+    const str = dateKeyFromDate(addDays(now, -i));
     result.push({ date: str, total: data[str] ?? 0 });
   }
   return result;


### PR DESCRIPTION
## Summary
- replace UTC date-key usage in Routine pushup history with local Routine date-key helpers
- compute Fizruk pushup stats against the same local `YYYY-MM-DD` keys
- extract strength progress weekly aggregation and key weeks by local ISO-week start

## Root cause / impact
Routine stored pushups by local day keys, while Fizruk rebuilt and compared history with UTC `toISOString().slice(0, 10)` keys. Around local midnight, especially in Kyiv/non-UTC time zones, pushups could disappear from today/week/month progress. Exercise weekly buckets had the same UTC serialization drift for local Monday week starts.

## Validation
- `pnpm --filter @sergeant/web test -- src/modules/routine/lib/routinePushupsRead.test.ts src/modules/fizruk/hooks/usePushupActivity.test.tsx src/modules/fizruk/lib/exerciseProgress.test.ts`
- `pnpm --filter @sergeant/web typecheck`
- `pnpm --filter @sergeant/fizruk-domain typecheck`
- `pnpm exec prettier --check apps/web/src/modules/routine/lib/routinePushupsRead.ts apps/web/src/modules/routine/lib/routinePushupsRead.test.ts apps/web/src/modules/fizruk/hooks/usePushupActivity.ts apps/web/src/modules/fizruk/hooks/usePushupActivity.test.tsx apps/web/src/modules/fizruk/pages/Exercise.tsx apps/web/src/modules/fizruk/lib/exerciseProgress.ts apps/web/src/modules/fizruk/lib/exerciseProgress.test.ts`

Note: the broader `pnpm --filter @sergeant/web test -- src/modules/routine src/modules/fizruk` still hits pre-existing `@sergeant/db-schema/...` resolver failures in unrelated suites.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes local date drift in Fizruk progress by using local day keys and local ISO week buckets, so pushups no longer disappear around midnight. Unifies Routine and Fizruk date handling and adds tests.

- Bug Fixes
  - Use `dateKeyFromDate`/`addDays` from `@sergeant/routine-domain` for pushup stats and history ranges.
  - Compute weekly buckets from local ISO week start (Monday) and key by local `YYYY-MM-DD`.
  - Align `usePushupActivity` with Routine’s local keys for today/week/month totals.

- Refactors
  - Extract strength progress aggregation to `apps/web/src/modules/fizruk/lib/exerciseProgress.ts` (`buildStrengthProgressData`, `startOfLocalIsoWeek`) and update `Exercise.tsx`.
  - Add focused tests for pushup activity, routine history gap fill, and weekly progress bucketing.

<sup>Written for commit 5014a417765b1be719261b71dee42f428bdecbcf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

