### PR TITLE
fix(web): paywall on ai-memory, chat timeout, module suggestions, finyk retry

### DIFF
--- a/apps/server/src/routes/ai-memory.ts
+++ b/apps/server/src/routes/ai-memory.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import type { Pool } from "pg";
 
 import {
   asyncHandler,
@@ -6,6 +7,7 @@ import {
   requireSession,
   setModule,
 } from "../http/index.js";
+import { requirePlan } from "../modules/billing/requirePlan.js";
 import { ingestMemoryHandler } from "../modules/ai-memory/ingestRoute.js";
 import { recallMemoryHandler } from "../modules/ai-memory/recallRoute.js";
 
@@ -24,7 +26,7 @@ import { recallMemoryHandler } from "../modules/ai-memory/recallRoute.js";
  * але тут все одно ставимо stop, щоб один зломаний клієнт не зміг через
  * Redis затопити worker-pool.
  */
-export function createAiMemoryRouter(): Router {
+export function createAiMemoryRouter({ pool }: { pool: Pool }): Router {
   const r = Router();
   r.use("/api/ai-memory", setModule("ai-memory"));
   r.use(
@@ -38,11 +40,13 @@ export function createAiMemoryRouter(): Router {
   r.post(
     "/api/ai-memory/ingest",
     requireSession(),
+    requirePlan(pool, "pro"),
     asyncHandler(ingestMemoryHandler),
   );
   r.post(
     "/api/ai-memory/recall",
     requireSession(),
+    requirePlan(pool, "pro"),
     asyncHandler(recallMemoryHandler),
   );
   return r;

--- a/apps/server/src/routes/index.ts
+++ b/apps/server/src/routes/index.ts
@@ -55,5 +55,5 @@ export function registerRoutes(app: Express, { pool }: { pool: Pool }): void {
   app.use(createPushRouter());
   app.use(createTranscribeRouter());
   app.use(createWaitlistRouter());
-  app.use(createAiMemoryRouter());
+  app.use(createAiMemoryRouter({ pool }));
 }

--- a/apps/web/src/core/hub/chat/ChatEmpty.tsx
+++ b/apps/web/src/core/hub/chat/ChatEmpty.tsx
@@ -1,5 +1,8 @@
+import { useMemo } from "react";
 import { Icon } from "@shared/components/ui/Icon";
 import { messages } from "@shared/i18n/uk";
+import { getActiveModules } from "@sergeant/shared";
+import { localStorageStore } from "../dashboard/dashboardStore";
 
 export interface ChatEmptyProps {
   /**
@@ -66,6 +69,11 @@ const SUGGESTIONS: readonly Suggestion[] = [
  * §A12 з docs/audits/2026-05-06-ux-roast-pr-plan.md.
  */
 export function ChatEmpty({ onPickSuggestion }: ChatEmptyProps) {
+  const visibleSuggestions = useMemo(() => {
+    const active = new Set(getActiveModules(localStorageStore));
+    return SUGGESTIONS.filter((s) => active.size === 0 || active.has(s.id));
+  }, []);
+
   return (
     <div
       data-testid="chat-empty"
@@ -80,7 +88,7 @@ export function ChatEmpty({ onPickSuggestion }: ChatEmptyProps) {
         {messages.hub.chatEmptyDescription}
       </p>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 w-full max-w-md">
-        {SUGGESTIONS.map((s) => (
+        {visibleSuggestions.map((s) => (
           <button
             key={s.id}
             type="button"

--- a/apps/web/src/core/hub/chat/useChatSend.ts
+++ b/apps/web/src/core/hub/chat/useChatSend.ts
@@ -221,6 +221,15 @@ export function useChatSend({
       abortRef.current = ac;
       const signal = ac.signal;
 
+      // Auto-abort after 90 s — prevents the UI from hanging forever if
+      // the Anthropic stream stalls mid-response or the server drops the
+      // SSE connection silently.
+      let timedOut = false;
+      const timeoutId = setTimeout(() => {
+        timedOut = true;
+        ac.abort();
+      }, 90_000);
+
       try {
         const context = contextRef.current.text || buildContextMeasured();
         if (!contextRef.current.text) {
@@ -399,16 +408,22 @@ export function useChatSend({
           if (shouldSpeak) maybeSpeak(reply);
         }
       } catch (e) {
-        // Explicit cancel (cancel button or chat close) shouldn't
-        // surface as an error — drop a quiet marker.
-        if (isApiError(e) && e.kind === "aborted") {
-          setMessages((m) => [...m, makeAssistantMsg("⏹ Запит скасовано.")]);
-        } else if ((e as { name?: string } | null)?.name === "AbortError") {
+        const isAbort =
+          (isApiError(e) && e.kind === "aborted") ||
+          (e as { name?: string } | null)?.name === "AbortError";
+        if (isAbort && timedOut) {
+          setMessages((m) => [
+            ...m,
+            makeAssistantMsg("⏱ Час очікування вичерпано. Спробуй ще раз."),
+          ]);
+        } else if (isAbort) {
+          // Explicit cancel (cancel button or chat close).
           setMessages((m) => [...m, makeAssistantMsg("⏹ Запит скасовано.")]);
         } else {
           setMessages((m) => [...m, makeAssistantMsg(friendlyChatError(e))]);
         }
       } finally {
+        clearTimeout(timeoutId);
         if (abortRef.current === ac) abortRef.current = null;
         setLoading(false);
       }

--- a/apps/web/src/modules/finyk/pages/Analytics.tsx
+++ b/apps/web/src/modules/finyk/pages/Analytics.tsx
@@ -201,6 +201,7 @@ export function Analytics({ mono, storage }: AnalyticsProps) {
     {},
   );
   const [loading, setLoading] = useState(false);
+  const [fetchError, setFetchError] = useState<string | null>(null);
   const fetchingRef = useRef(new Set<string>());
 
   const monthKey = `${year}-${String(month).padStart(2, "0")}`;
@@ -217,6 +218,7 @@ export function Analytics({ mono, storage }: AnalyticsProps) {
       if (monthCache[key]) return;
       fetchingRef.current.add(key);
       setLoading(true);
+      setFetchError(null);
       mono
         .fetchMonth(y, m1 - 1)
         .then((txs) => {
@@ -227,6 +229,7 @@ export function Analytics({ mono, storage }: AnalyticsProps) {
           // disconnected fetch should remain refetchable on the next
           // navigation. Leaving the key absent keeps `comparison`/UI in
           // a "no data yet" state instead of a misleading "0 ₴" state.
+          setFetchError("Не вдалось завантажити транзакції");
         })
         .finally(() => {
           fetchingRef.current.delete(key);
@@ -238,6 +241,15 @@ export function Analytics({ mono, storage }: AnalyticsProps) {
     },
     [mono, monthCache],
   );
+
+  const retryCurrentMonth = useCallback(() => {
+    setMonthCache((prev) => {
+      const next = { ...prev };
+      delete next[monthKey];
+      return next;
+    });
+    setFetchError(null);
+  }, [monthKey]);
 
   useEffect(() => {
     if (!isCurrentMonth) ensureMonth(year, month, monthKey);
@@ -305,6 +317,19 @@ export function Analytics({ mono, storage }: AnalyticsProps) {
     <div className="flex-1 overflow-y-auto">
       <div className="max-w-4xl mx-auto px-4 pt-4 page-tabbar-pad space-y-4">
         <MonthNav year={year} month={month} onChange={handleMonthChange} />
+
+        {fetchError && (
+          <div className="flex items-center justify-between gap-3 px-4 py-3 rounded-xl bg-danger/10 border border-danger/20 text-sm text-danger">
+            <span>{fetchError}</span>
+            <button
+              type="button"
+              onClick={retryCurrentMonth}
+              className="shrink-0 font-medium underline underline-offset-2 hover:no-underline"
+            >
+              Повторити
+            </button>
+          </div>
+        )}
 
         {/* Summary */}
         <Section title="Підсумок місяця">


### PR DESCRIPTION
## Summary

- **AI Memory paywall**: `/api/ai-memory/ingest` and `/api/ai-memory/recall` now require Pro plan via `requirePlan` middleware — was open to all authenticated users before
- **Chat 90s timeout**: `useChatSend` auto-aborts in-flight requests after 90 seconds; shows distinct message for timeout vs explicit cancel (`⏱` vs `⏹`)
- **Module-aware ChatEmpty**: suggestion chips in the empty chat state now filter to active modules only (falls back to all suggestions when no modules are active)
- **Analytics retry**: `Analytics.tsx` shows an error banner with a "Повторити" button when fetching a historical month fails — previously failed silently with 0 ₴

## Test plan

- [ ] Connect a Monobank token → navigate to Analytics → historical months load
- [ ] Navigate to Analytics for a past month → simulate offline → confirm error banner appears with retry button
- [ ] Open `/chat` with only Finyk module active → confirm only Finyk suggestion chip appears
- [ ] Send a chat message and wait 90s (or mock) → confirm timeout message shown
- [ ] Free plan user calls `POST /api/ai-memory/ingest` → confirm 402 response
- [ ] Pro plan (or `STRIPE_ENABLED=false`) → confirm ingest/recall work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces Pro-only access for AI Memory APIs and improves chat and analytics UX with better timeouts, suggestions, and retry handling.

- New Features
  - AI Memory paywall: `POST /api/ai-memory/ingest` and `POST /api/ai-memory/recall` now require the Pro plan via `requirePlan(pool, "pro")`.
  - Chat timeout: auto-aborts in-flight requests after 90s and shows distinct messages for timeout (⏱) vs manual cancel (⏹).
  - Module-aware suggestions: the empty chat state now shows suggestion chips only for active modules (falls back to all when none are active). Uses `@sergeant/shared` module state.
  - Analytics retry: when a historical month fetch fails, show an error banner with a “Повторити” button instead of silently showing 0 ₴.

<sup>Written for commit 966acd5e0e8a112832ea6d46929b7d8224cf2428. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI memory features now require a pro plan to access.
  * Chat suggestion chips now filter based on active modules for a more focused experience.
  * Analytics now displays error messages when data fetches fail, with retry functionality.

* **Improvements**
  * Chat requests now timeout after 90 seconds with appropriate user feedback.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Skords-01/Sergeant/pull/2451)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->