### PR TITLE
fix(openclaw): use the  package (not @sinclair/typebox)

### DIFF
--- a/Dockerfile.openclaw-gateway
+++ b/Dockerfile.openclaw-gateway
@@ -81,7 +81,7 @@ RUN cat > ./packages/openclaw-plugin/package.json <<EOF
   "openclaw": { "extensions": ["./dist/index.js"] },
   "dependencies": {
     "openclaw": "${OPENCLAW_VERSION}",
-    "@sinclair/typebox": "^0.34.0",
+    "typebox": "^1.1.37",
     "zod": "^4.3.6"
   }
 }

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -16,7 +16,11 @@
  */
 
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
-import { Type, type TSchema } from "@sinclair/typebox";
+// openclaw 5.7 bundles `typebox@1.1.x` (the new package by sinclairzx81,
+// successor to @sinclair/typebox). Schemas built with @sinclair/typebox use
+// different internal Symbol keys, so openclaw silently rejects them. Import
+// from the same package openclaw uses.
+import { Type, type TSchema } from "typebox";
 import { OpenClawHttpClient } from "./http-client.js";
 import { parsePluginConfig } from "./config.js";
 
@@ -468,6 +472,16 @@ export default definePluginEntry({
     "Sergeant agent gateway plugin (Stage 2 — 25 read-tools, no hooks yet)",
 
   register(api) {
+    const logger =
+      (api as { logger?: { info: (m: string, f?: unknown) => void; warn: (m: string, f?: unknown) => void } })
+        .logger ??
+      ({
+        info: (m: string, f?: unknown) =>
+          console.log(`[sergeant] ${m}`, f ?? ""),
+        warn: (m: string, f?: unknown) =>
+          console.warn(`[sergeant] ${m}`, f ?? ""),
+      } as { info: (m: string, f?: unknown) => void; warn: (m: string, f?: unknown) => void });
+
     const candidate =
       (api as { pluginConfig?: unknown }).pluginConfig ??
       (api as { config?: unknown }).config ??
@@ -481,39 +495,55 @@ export default definePluginEntry({
     });
 
     const tools = makeTools(config.founderUserId);
+    let ok = 0;
+    let failed = 0;
+    const failures: Array<{ name: string; error: string }> = [];
 
     for (const tool of tools) {
       const buildBody = tool.formatBody ?? ((p: Record<string, unknown>) => p);
-      api.registerTool({
-        name: tool.name,
-        description: tool.description,
-        parameters: tool.params,
-        async execute(_id, params) {
-          try {
-            const body = buildBody(params);
-            const response = await http.post<unknown>(tool.endpoint, body);
-            return {
-              content: [
-                {
-                  type: "text",
-                  text:
-                    typeof response === "string"
-                      ? response
-                      : JSON.stringify(response, null, 2),
-                },
-              ],
-            };
-          } catch (err) {
-            const msg = err instanceof Error ? err.message : String(err);
-            return {
-              content: [
-                { type: "text", text: `(${tool.name} failed: ${msg})` },
-              ],
-            };
-          }
-        },
-      });
+      try {
+        api.registerTool({
+          name: tool.name,
+          description: tool.description,
+          parameters: tool.params,
+          async execute(_id, params) {
+            try {
+              const body = buildBody(params as Record<string, unknown>);
+              const response = await http.post<unknown>(tool.endpoint, body);
+              const text =
+                typeof response === "string"
+                  ? response
+                  : JSON.stringify(response, null, 2);
+              return {
+                content: [{ type: "text", text }],
+                details: response,
+              };
+            } catch (err) {
+              const msg = err instanceof Error ? err.message : String(err);
+              return {
+                content: [
+                  { type: "text", text: `(${tool.name} failed: ${msg})` },
+                ],
+              };
+            }
+          },
+        });
+        ok++;
+      } catch (err) {
+        failed++;
+        failures.push({
+          name: tool.name,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
     }
+
+    logger.info("sergeant.tools.registered", {
+      total: tools.length,
+      ok,
+      failed,
+      failures: failures.length > 0 ? failures : undefined,
+    });
   },
 });
 

--- a/packages/openclaw-plugin/src/types/openclaw-ambient.d.ts
+++ b/packages/openclaw-plugin/src/types/openclaw-ambient.d.ts
@@ -82,7 +82,7 @@ declare module "openclaw/plugin-sdk/plugin-entry" {
   export default definePluginEntry;
 }
 
-declare module "@sinclair/typebox" {
+declare module "typebox" {
   // Minimal surface — covers what src/index.ts uses. The runtime values come
   // from the actual @sinclair/typebox install in the runtime stage.
   export interface TSchema {


### PR DESCRIPTION
## TL;DR

**Found root cause** for "agent doesn't see my tools" via `npm pack openclaw@2026.5.7` source inspection. openclaw bundles **`typebox` (v1.1.x)** — the new package by sinclairzx81, **not** `@sinclair/typebox`. Same-looking API, different internal Symbol keys. Our schemas built with `@sinclair/typebox` were silently rejected by openclaw's registry.

## Evidence

Looked inside the actual npm tarball:

```bash
$ npm pack openclaw@2026.5.7
$ grep -r "import.*typebox" dist/extensions/skill-workshop/index.js
import { Type } from "typebox";    # ← !!
```

The bundled `skill-workshop` plugin imports from `typebox`. Its tools DO show up in agent palettes. Ours, built from `@sinclair/typebox`, don't — because openclaw's runtime treats them as foreign objects without TypeBox's expected Symbol-keyed metadata (Kind, Modifier).

Confirmed identity in npm: both packages are published by user `sinclair` (Haydn Paterson), same GitHub repo. `typebox` is the successor; `@sinclair/typebox` is the older/scoped publication.

## Why our deploys looked healthy

- Gateway log: `2 plugins: sergeant, telegram` ✓ (plugin loaded)
- `tools.allow` validation matched all 25 names ✓ (against manifest's `contracts.tools`)
- No error logs ✓ (registry silently dropped tools without throwing)
- But agent system prompt only included coding-profile tools — no plugin tools

## Three coordinated changes

1. `src/index.ts` — `import { Type } from "typebox"`
2. `src/types/openclaw-ambient.d.ts` — `declare module "typebox"`
3. `Dockerfile.openclaw-gateway` runtime package.json synthesis — install `typebox@^1.1.37` instead of `@sinclair/typebox`

## Defensive instrumentation added

- `try/catch` around each `api.registerTool` call
- `details` field on tool results (matches openclaw's native `textResult`/`jsonResult` shape)
- `logger.info("sergeant.tools.registered", { total, ok, failed, failures })` — next deploy log will prove every tool registered

## Verification after merge

Look for in runtime logs:
```
[plugins] sergeant.tools.registered { total: 25, ok: 25, failed: 0 }
```
And in Telegram, the agent should list `recall_memory`, `query_app_db`, `read_github`, etc. when asked about its tools — and successfully call them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing plugin tools by switching to `typebox` (not `@sinclair/typebox`) to match openclaw’s runtime so schemas register correctly. Adds simple logging and error handling around tool registration, and returns `details` from tool executions for easier debugging.

- **Bug Fixes**
  - Import `Type`/`TSchema` from `typebox` and update ambient types to stop schema rejection.
  - Wrap each `api.registerTool` in try/catch and log `sergeant.tools.registered { total, ok, failed }`.
  - Include `details` alongside text content in tool results.

- **Dependencies**
  - Replace `@sinclair/typebox` with `typebox@^1.1.37` in the gateway runtime.

<sup>Written for commit 4229ed28a74a928c85b6ef4540a04cc949ded9ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

