### PR TITLE
fix(openclaw-plugin): add required `label` field to every tool

### DIFF
--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -69,10 +69,25 @@ function resolvePluginConfig(candidate: unknown): Record<string, unknown> {
  */
 interface ToolSpec {
   name: string;
+  /**
+   * Optional UI display label. If omitted, auto-derived from `name` at
+   * registration time. openclaw's AgentTool interface (pi-agent-core)
+   * requires `label` — tools without it are silently dropped from the
+   * agent palette.
+   */
+  label?: string;
   description: string;
   params: TSchema;
   endpoint: string;
   formatBody?: (params: Record<string, unknown>) => unknown;
+}
+
+/** Convert snake_case tool name → "Snake Case" Title for fallback `label`. */
+function toLabel(name: string): string {
+  return name
+    .split("_")
+    .map((w) => (w.length === 0 ? w : w[0]!.toUpperCase() + w.slice(1)))
+    .join(" ");
 }
 
 function makeTools(founderUserId: string): ToolSpec[] {
@@ -504,6 +519,7 @@ export default definePluginEntry({
       try {
         api.registerTool({
           name: tool.name,
+          label: tool.label ?? toLabel(tool.name),
           description: tool.description,
           parameters: tool.params,
           async execute(_id, params) {

--- a/packages/openclaw-plugin/src/types/openclaw-ambient.d.ts
+++ b/packages/openclaw-plugin/src/types/openclaw-ambient.d.ts
@@ -46,14 +46,21 @@ declare module "openclaw/plugin-sdk/plugin-entry" {
 
   export interface PluginTool {
     name: string;
+    /**
+     * UI display label — required by openclaw's AgentTool interface
+     * (pi-agent-core). Tools without `label` are silently dropped.
+     */
+    label: string;
     description: string;
-    /** TypeBox schema (or JSON Schema literal). */
+    /** TypeBox schema from the `typebox` package (not `@sinclair/typebox`). */
     parameters: unknown;
     execute: (
       invocationId: string,
       params: Record<string, unknown>,
     ) => Promise<{
       content: Array<{ type: "text"; text: string }>;
+      /** Structured payload — pi-agent-core's AgentToolResult requires this. */
+      details?: unknown;
     }>;
   }
 


### PR DESCRIPTION
ROOT CAUSE round 2: Even after fixing the typebox-vs-@sinclair/typebox package mismatch, the deploy logged sergeant.tools.registered for all 25 tools but the agent still saw only the coding-profile defaults.

Inspected the upstream type chain:
  openclaw 5.7  registerTool: (tool: AnyAgentTool | factory) => void
  pi-agent-core AgentTool<T> extends Tool<T> { label: string, execute }
                Tool<T>      { name, description, parameters }

`label` is a required field that openclaw inherits from pi-agent-core's AgentTool. JavaScript runtime doesn't enforce it (no schema check at boundary), but openclaw's tool palette projection silently drops tools that lack `label` — which matches the symptom (registration succeeds, agent never sees the tool).

Three changes:

  1. src/index.ts — ToolSpec.label is optional; registration loop auto-derives from `name` via `toLabel(snake_case) → "Snake Case"` so we don't have to spell out 25 labels manually
  2. registerTool call now passes `label: tool.label ?? toLabel(tool.name)`
  3. ambient .d.ts PluginTool gains required `label` + optional `details` on the execute return type (also required by AgentToolResult)

Verified against the actual AgentTool / Tool / AgentToolResult interfaces in @mariozechner/pi-agent-core@0.73.1 and @mariozechner/pi-ai@0.73.1, both downloaded via `npm pack` for inspection.

## Summary

<!-- What changed in one tight paragraph or a short flat list. -->

## Governing Skill

- Primary skill:
- Secondary skill (if truly needed):

## Playbook

- Primary playbook:
- Why this playbook:
- If no playbook matched, why:

## Verification

<!-- Paste the exact commands you ran and the key result.
     Before claiming "Done" — Iron Law gate: NO COMPLETION CLAIMS WITHOUT
     FRESH VERIFICATION EVIDENCE. See `sergeant-review-and-merge` SKILL.md
     § "Verification gate" (.agents/skills/sergeant-review-and-merge/SKILL.md). -->

```bash
pnpm lint
pnpm typecheck
```

Additional checks:

- [ ] Local smoke / manual validation completed
- [ ] Surface-specific checks completed

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [ ] I checked whether `AGENTS.md` needed an update.
- [ ] I checked whether a playbook or skill needed an update.
- [ ] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a

## Risk and Rollout

- User-visible risk:
- Rollout / deploy order:
- Backout plan:

## Hard Rule #15

- [ ] I read `AGENTS.md` before coding.
- [ ] Internal docs I touched are in Ukrainian.
- [ ] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

<!-- Per `docs/governance/audit-freeze-2026-05-05.md`. New files under
docs/audits/, docs/initiatives/, docs/playbooks/, docs/adr/ trigger a
non-blocking CI warning. If this PR adds such a file, add `[skip-freeze]`
or `[freeze-exception]` to the PR title and explain below. Otherwise leave
this section as-is or remove. -->

- [ ] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

<!-- Flag migrations, env changes, HubChat tools, auth, or anything else that deserves extra reviewer attention. -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure every `openclaw` plugin tool has a required `label` so all tools show up in the agent palette. Labels are auto-derived from snake_case `name` values; ambient types now match `pi-agent-core`.

- **Bug Fixes**
  - Pass `label: tool.label ?? toLabel(tool.name)` during registration and add `toLabel(name)` helper.
  - Update ambient `PluginTool` type to require `label` and allow optional `details` in the execute result.

<sup>Written for commit f5e8dd95545ea1a4679906f03a0e657193c11f2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

