### PR TITLE
fix(openclaw-plugin): pin @mistralai/mistralai@2.2.1 + --ignore-scripts in gateway Dockerfile

### DIFF
--- a/Dockerfile.openclaw-gateway
+++ b/Dockerfile.openclaw-gateway
@@ -60,7 +60,13 @@ ARG OPENCLAW_VERSION=2026.5.7
 # register time. v5.7 ships the runtime services API the plugin relies on;
 # the config-block strip bug is now handled at the plugin level by the
 # env-var fallback in parsePluginConfig (see #2428).
-RUN npm install -g openclaw@${OPENCLAW_VERSION}
+#
+# `--ignore-scripts`: prevents postinstall scripts from running for any of
+# openclaw's transitive deps. Defence-in-depth against the
+# `@mistralai/mistralai@2.2.2-2.2.4` supply-chain incident (see the slim
+# plugin install block below for the full rationale). openclaw and its
+# legitimate deps do not require postinstall hooks at install time.
+RUN npm install -g --ignore-scripts openclaw@${OPENCLAW_VERSION}
 
 # Copy compiled plugin output + plugin manifest (entry → ./dist/index.js).
 COPY --from=plugin-builder /build/packages/openclaw-plugin/dist ./packages/openclaw-plugin/dist
@@ -71,6 +77,16 @@ COPY --from=plugin-builder /build/packages/openclaw-plugin/openclaw.plugin.json 
 # package.json carries `@sergeant/shared` + devDependencies that don't resolve at
 # runtime; openclaw's manifest-dependency scanner walks them and bails on missing
 # symlinks. Keep `openclaw.extensions` and `type: module` aligned with the source.
+#
+# `overrides` pins `@mistralai/mistralai@2.2.1` (last known-good release, 2026-04-21).
+# Versions 2.2.2 / 2.2.3 / 2.2.4 were published in rapid succession on
+# 2026-05-11 (within 8 minutes) carrying a `preinstall: node setup.mjs` that
+# downloads `bun` and tries to execute an obfuscated `router_init.js` /
+# `tanstack_runner.js` — matches the npm "tanstack" malware pattern
+# disclosed 2026-05-04 (gbhackers.com). Even when the script crashes (the
+# `tanstack_runner.js` file is missing from the tarball), it breaks `npm
+# install` and blocks Railway deploys of the gateway. Pin until upstream
+# Mistral confirms a clean release or `openclaw` drops the transitive dep.
 RUN cat > ./packages/openclaw-plugin/package.json <<EOF
 {
   "name": "@sergeant/openclaw-plugin",
@@ -83,11 +99,21 @@ RUN cat > ./packages/openclaw-plugin/package.json <<EOF
     "openclaw": "${OPENCLAW_VERSION}",
     "typebox": "^1.1.37",
     "zod": "^4.3.6"
+  },
+  "overrides": {
+    "@mistralai/mistralai": "2.2.1"
   }
 }
 EOF
 
-RUN cd ./packages/openclaw-plugin && npm install --omit=dev --no-audit --no-fund --loglevel=error
+# `--ignore-scripts`: defence-in-depth alongside the `@mistralai/mistralai`
+# pin above. The slim runtime tree (`openclaw` + `typebox` + `zod` + their
+# transitive deps) ships no native bindings and needs no postinstall hooks,
+# so executing arbitrary scripts from transitive deps at image-build time
+# is pure attack surface. If upstream ever ships a dep that legitimately
+# needs `postinstall`, the runtime image will fail-fast at start (missing
+# binding) rather than silently exfiltrating credentials.
+RUN cd ./packages/openclaw-plugin && npm install --omit=dev --ignore-scripts --no-audit --no-fund --loglevel=error
 
 # Copy ops config-as-code (openclaw.example.json, skills/, cheap-router.system.md, n8n-allowlist.json).
 COPY ops/openclaw ./ops/openclaw


### PR DESCRIPTION
## Summary

Розблоковує Railway-деплой `sergeant-openclaw-gateway`, який падає на `npm install` через свіжо-отруєну транзитивну залежність `@mistralai/mistralai`.

Транзитивний npm-пакет `@mistralai/mistralai` (тягнеться через `openclaw@2026.5.7`) сьогодні `2026-05-11` отримав 3 rapid-fire релізи: `2.2.2` о `22:45 UTC`, `2.2.3` о `22:49 UTC`, `2.2.4` о `22:53 UTC` (між ними ~8 хвилин). У `package.json` усіх трьох з'явився `"preinstall": "node setup.mjs"`, який:

1. Завантажує `bun` з GitHub-релізу до `/tmp/bun-dl-XXX/bun`
2. Намагається виконати з цим бунем `tanstack_runner.js` всередині пакета
3. Файл `tanstack_runner.js` відсутній у тарболі, але `router_init.js` (2.3 МБ обфускованого коду single-letter vars + hex hashes) — є

Патерн збігається з `tanstack` malware-кампанією, [розкритою gbhackers.com 2026-05-04](https://gbhackers.com/tanstack-package-abuses-postinstall/). Тут exfiltration не виконується (бо core-файл відсутній), але `npm install` валиться з exit-1 і блокує всі деплої гейтвея.

**Що це значить для нас:**

- Деплой `sergeant-openclaw-gateway` (Railway, проєкт `humorous-eagerness`):
  - `7551b7cb` о `22:32:13 UTC` — SUCCESS (білд до публікації `2.2.2`)
  - `22f4152b` о `22:50:20 UTC` — **FAILED** на `npm install @mistralai/mistralai`
- Як побічний ефект, у production досі стара версія плагіна без label-field фіксу з #2453, через що openclaw 5.7 SDK тихо викидає всі 25 read-tools з agent palette, і бот у Telegram «не має команд».

## Зміни

`Dockerfile.openclaw-gateway`:

1. **Пін `@mistralai/mistralai@2.2.1`** через `overrides` у синтезованому slim runtime `package.json`. `2.2.1` — останній відомий чистий реліз від `2026-04-21`. Pin тримаємо доки upstream Mistral не підтвердить clean release або `openclaw` не прибере транзитивну залежність.
2. **`--ignore-scripts`** додано до обох npm-install-ів в runtime-стейджі (global `openclaw` і slim plugin tree). Defence-in-depth: runtime-дерево (`openclaw` + `typebox` + `zod` + транзитивні) не містить native-bindings, тому postinstall-хуки не потрібні; запуск довільних postinstall-скриптів на image-build time — pure attack surface.

Документація всередині `Dockerfile.openclaw-gateway` оновлена з повним обґрунтуванням обох рішень.

## Governing Skill

- Primary skill: `.agents/skills/sergeant-devops/SKILL.md` (Dockerfile + Railway runtime)
- Secondary skill: n/a

## Playbook

- Primary playbook: n/a
- Why this playbook: інцидент-реакція на свіжу supply-chain атаку; готового playbook під цей конкретний сценарій (отруєний транзитивний npm-пакет) у репо немає.
- If no playbook matched, why: див. вище. Якщо такі інциденти повторюватимуться, варто додати окремий playbook у `docs/playbooks/` — наразі додаю розгорнутий коментар у Dockerfile, цього достатньо для відкату.

## Verification

Локальний lint (Dockerfile-only change, не зачіпає JS/TS):

```bash
# n/a — single Dockerfile change, no JS/TS/markdown lint surfaces touched.
```

Семантична перевірка пінy:

```bash
cd /tmp/mistral-check && tar -xzf mistralai-mistralai-2.2.1.tgz
cat package/package.json | python3 -c "import json,sys; d=json.load(sys.stdin); print('scripts:', d.get('scripts',{}))"
# → scripts: {} (порожньо — no preinstall, no postinstall, чисто)
```

vs. `2.2.4`:

```bash
cd /tmp/mistral-check && tar -xzf mistralai-mistralai-2.2.4.tgz
cat package/package.json | python3 -c "import json,sys; d=json.load(sys.stdin); print('scripts:', d.get('scripts',{}))"
# → scripts: {'preinstall': 'node setup.mjs'}
```

Real-build верифікація — Railway redeploy після мерджа цього PR (Dockerfile-зміни не build-cached на нашому контролі).

Additional checks:

- [x] Local smoke / manual validation completed (npm pack + setup.mjs inspect)
- [x] Surface-specific checks completed (Dockerfile change reviewed manually)

## Docs and Governance

- [x] Я оновив docs (Dockerfile inline-документація розгорнута).
- [x] Перевірив, чи `AGENTS.md` потребує update — ні, це інцидентна реакція без зміни repo-policy.
- [x] Перевірив, чи playbook/skill потребує update — створення нового playbook залишаю follow-up'ом (див. вище).
- [x] Перевірив governance/review docs — без змін.

Updated docs:

- `Dockerfile.openclaw-gateway` inline-документація (обґрунтування `overrides` + `--ignore-scripts`).

## Risk and Rollout

- **User-visible risk:** мінімальний. Pin фіксує `@mistralai/mistralai` на остання-stable. `--ignore-scripts` пропускає **тільки** install-time hooks; runtime-поведінка openclaw і плагіна не змінюється. Якщо у майбутньому openclaw почне залежати від чогось із native-bindings — runtime fail-fast при старті (краще, ніж тихий exfil).
- **Rollout / deploy order:** merge → Railway watcher автоматично запускає новий deploy `sergeant-openclaw-gateway`.
- **Backout plan:** revert цього коміту → повертаємось до `npm install` без pin/ignore-scripts. Це знову зробить деплой залежним від доступності чистих версій `@mistralai/mistralai` на npm; якщо отруєні версії ще online — деплой знову впаде.

## Hard Rule #15

- [x] Прочитав `AGENTS.md` перед роботою.
- [x] Внутрішня документація українською (commit message + цей PR-body + inline Dockerfile-коментарі).
- [x] Не використовував `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] Цей PR не додає нових файлів у `docs/audits/`, `docs/initiatives/`, `docs/playbooks/`, `docs/adr/`.

## Reviewer Notes

- **Послідовна робота:** після мерджа цього PR і успішного Railway-деплою — окремий **PR B** відновить мінімальний `system.md` / persona-skill (зараз `docker-entrypoint.sh` стирає `~/.openclaw/workspace/skills/*` на кожному старті, тому модель Claude не знає про доступні tools). Без B бот може мати tools у palette (завдяки `label`-фіксу з #2453, який нарешті задеплоїться), але без контексту їх не покличе.
- **Follow-up можливості:**
  1. Запропонувати upstream `openclaw` запіннити `@mistralai/mistralai` у власному `package.json`.
  2. Повідомити npm-security та Mistral про підозрілий `setup.mjs` у версіях `2.2.2-2.2.4`.
  3. Розглянути додавання hardening-картки у `docs/security/hardening/` за прикладом існуючих L*-файлів.
- **Pre-existing CI failures на main** (`pnpm test:coverage` / E2E timeout :3000) до цього PR відношення не мають.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks Railway deploys of `sergeant-openclaw-gateway` by pinning `@mistralai/mistralai@2.2.1` and disabling install scripts in the gateway Dockerfile. Prevents failures from the `preinstall` script introduced in `2.2.2–2.2.4`.

- **Bug Fixes**
  - Pin `@mistralai/mistralai` to `2.2.1` via `overrides` in the slim runtime `package.json` to bypass the poisoned `2.2.2–2.2.4` that break `npm install`.
  - Add `--ignore-scripts` to both `npm install -g openclaw` and the slim plugin install to block postinstall hooks and ensure builds succeed.

<sup>Written for commit 4173be1d29362d201c4027becaff3a1c6b10bbe5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

