### PR TITLE
test(api-client): cover http client boundaries

### DIFF
--- a/packages/api-client/src/httpClient.test.ts
+++ b/packages/api-client/src/httpClient.test.ts
@@ -339,3 +339,105 @@ describe("httpClient — AbortSignal", () => {
     vi.useRealTimers();
   });
 });
+
+describe("httpClient — boundary behavior", () => {
+  it("503 Retry-After HTTP-date прокидається як retryAfterMs", async () => {
+    const now = Date.parse("2026-05-13T00:00:00.000Z");
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    mockFetchOnce(
+      new Response(JSON.stringify({ error: "maintenance" }), {
+        status: 503,
+        headers: {
+          "content-type": "application/json",
+          "retry-after": new Date(now + 125_000).toUTCString(),
+        },
+      }),
+    );
+
+    const err = await http.get("/api/x").catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(503);
+    expect((err as ApiError).retryAfterMs).toBe(125_000);
+  });
+
+  it("offline network-помилка має user-facing offline message та isOffline=true", async () => {
+    vi.spyOn(navigator, "onLine", "get").mockReturnValue(false);
+    mockFetchOnce(new TypeError("fetch failed"));
+
+    const err = await http.get("/api/x").catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).kind).toBe("network");
+    expect((err as ApiError).message).toBe(
+      "Немає підключення до інтернету. Спробуй пізніше.",
+    );
+    expect((err as ApiError).isOffline).toBe(true);
+  });
+
+  it("401 не ретраїться автоматично, але наступний запит бере оновлений token", async () => {
+    const getToken = vi
+      .fn<() => string>()
+      .mockReturnValueOnce("expired")
+      .mockReturnValueOnce("fresh");
+    const client = createHttpClient({ getToken });
+    const fn = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({ error: "unauthorized" }, { status: 401 }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ ok: true }));
+    globalThis.fetch = fn as unknown as typeof fetch;
+
+    const err = await client.get("/api/me").catch((e: unknown) => e);
+    const second = await client.get<{ ok: true }>("/api/me");
+
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(401);
+    expect((err as ApiError).isAuth).toBe(true);
+    expect(second).toEqual({ ok: true });
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(
+      ((fn.mock.calls[0]?.[1] as RequestInit).headers as Headers).get(
+        "Authorization",
+      ),
+    ).toBe("Bearer expired");
+    expect(
+      ((fn.mock.calls[1]?.[1] as RequestInit).headers as Headers).get(
+        "Authorization",
+      ),
+    ).toBe("Bearer fresh");
+  });
+
+  it("timeoutMs скасовує fetch через AbortSignal і чистить таймер після raw response", async () => {
+    vi.useFakeTimers();
+    const clearSpy = vi.spyOn(globalThis, "clearTimeout");
+    const client = createHttpClient({
+      fetchImpl: vi.fn(
+        async (_url: string | URL | Request, init?: RequestInit) => {
+          expect(init?.signal).toBeInstanceOf(AbortSignal);
+          expect(init?.signal?.aborted).toBe(false);
+          return jsonResponse({ ok: true });
+        },
+      ) as unknown as typeof fetch,
+    });
+
+    await expect(
+      client.raw("/api/stream", { timeoutMs: 1_000 }),
+    ).resolves.toBeInstanceOf(Response);
+
+    expect(clearSpy).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
+  it("5xx без Retry-After залишається HTTP-помилкою без client-side backoff", async () => {
+    mockFetchOnce(jsonResponse({ error: "boom" }, { status: 502 }));
+
+    const err = await http.get("/api/x").catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).kind).toBe("http");
+    expect((err as ApiError).status).toBe(502);
+    expect((err as ApiError).retryAfterMs).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds PR-T33 coverage from `docs/testing/2026-05-05-tests-pr-plan.md` for `packages/api-client` HTTP boundary behavior.
- Covers 503 `Retry-After` HTTP-date parsing, offline network messaging, 401 auth boundary/token refresh across calls, timeout cleanup for raw responses, and 5xx without client-side backoff.
- Keeps the change test-only; no runtime client contract changes.

## Governing Skill

- Primary skill: `sergeant-server-api`
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a
- Why this playbook: Test-only package coverage; no endpoint or response-shape change.
- If no playbook matched, why: Existing api-client Vitest patterns were sufficient.

## Verification

```bash
pnpm --filter @sergeant/api-client test -- src/httpClient.test.ts
pnpm --dir packages/api-client exec vitest run --coverage src/httpClient.test.ts --coverage.include=src/httpClient.ts --coverage.include=src/ApiError.ts --coverage.thresholds.lines=70 --coverage.thresholds.branches=70 --coverage.thresholds.functions=70 --coverage.thresholds.statements=70
pnpm exec eslint packages/api-client/src/httpClient.test.ts
pnpm --filter @sergeant/api-client typecheck
pnpm --filter @sergeant/api-client test
pnpm --filter @sergeant/api-client test:coverage
pnpm --filter @sergeant/api-client build
```

Additional checks:

- [ ] Local smoke / manual validation completed
- [x] Surface-specific checks completed

Coverage result for `httpClient.ts` + `ApiError.ts`: 90.27% statements / 86.8% branches / 83.87% functions / 93.08% lines.

Note: `@sergeant/api-client` has no `build` script, so pnpm reported `None of the selected packages has a "build" script`.

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a

## Risk and Rollout

- User-visible risk: Low; test-only coverage addition.
- Rollout / deploy order: Normal CI merge.
- Backout plan: Revert this PR.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

PR-T33 from `docs/testing/2026-05-05-tests-pr-plan.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add boundary tests for `@sergeant/api-client` HTTP client to lock down error handling, auth, and timeout behavior; test-only with no runtime changes. Tests cover: parsing 503 Retry-After HTTP-date into retryAfterMs; offline network message with isOffline=true; 401 not auto-retried and next request uses fresh token; `timeoutMs` aborts fetch and clears timer on raw responses; 5xx without client-side backoff.

<sup>Written for commit b1ea8259398219c3c0bfe8a7afe0dd99303a7916. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for HTTP client edge cases, including retry-after header parsing, offline detection, token refresh on 401 errors, timeout handling with abort signals, and server error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Skords-01/Sergeant/pull/2513)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->