### PR TITLE
chore(root): drop HubDashboard from max-lines allowlist (0013)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1095,10 +1095,7 @@ export default [
   // ships. The allowlist is intentionally explicit (not a glob) so each
   // file shows up in `git blame` / `git log` against this rule.
   {
-    files: [
-      "apps/web/src/core/lib/hubChatContext.ts",
-      "apps/web/src/core/hub/HubDashboard.tsx",
-    ],
+    files: ["apps/web/src/core/lib/hubChatContext.ts"],
     rules: {
       "max-lines": "off",
     },


### PR DESCRIPTION
## Summary

`apps/web/src/core/hub/HubDashboard.tsx` була декомпонована **837 → 115 LOC** у комміті [`61e0093f`](https://github.com/Skords-01/Sergeant/commit/61e0093f) (`refactor(web): decompose HubDashboard 837→115 LOC (T1)`), але запис у `overrides` allowlist для `max-lines` у `eslint.config.js` тоді не прибрали. Цей PR прибирає його — Sprint 2 пункт `decomp-r2-hubdashboard` з [`0013-module-decomposition-round-2`](https://github.com/Skords-01/Sergeant/blob/main/docs/initiatives/0013-module-decomposition-round-2.md).

Після цього PR в allowlist залишається **1 запис** (`apps/web/src/core/lib/hubChatContext.ts`) — критерій DONE #1 ініціативи 0013 (`≤2 файли в allowlist`) уже задоволений.

## Governing Skill

- Primary skill: `sergeant-web-ui` (Hard Rule #18 — `max-lines: [error, 600]` allowlist drain)
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a
- Why this playbook: тривіальна allowlist-cleanup зміна на 3 рядки в `eslint.config.js`; per-file decomp PR шаблон з 0013 виконано окремим коммітом раніше.
- If no playbook matched, why: чистий cleanup-PR після пост-фактум фіксу (decomp шипнули, але allowlist drop забули).

## Verification

```bash
$ pnpm --filter @sergeant/web lint
> @sergeant/web@0.1.0 lint /home/ubuntu/repos/Sergeant/apps/web
> eslint .
# (no output, exit 0)

$ pnpm --filter @sergeant/web typecheck
> tsc -p tsconfig.json --noEmit && tsc -p tsconfig.sw.json --noEmit
# (no output, exit 0)

$ pnpm --filter @sergeant/web test -- --run HubDashboard
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

`pnpm --filter @sergeant/db-schema build` потрібен як pre-step (відомий setup-крок з 0013 Outcome нотатки) — у CI це робить турборепо-граф автоматично через `dependsOn`.

Additional checks:

- [x] Local smoke / manual validation completed (`pnpm --filter @sergeant/web lint/typecheck/test` зелені)
- [x] Surface-specific checks completed (`max-lines` гард тепер активний для `HubDashboard.tsx`)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. — тільки `eslint.config.js`, нічого не змінює user-facing поведінки; status-update ініціативи 0013 поїде у наступному PR `decomp-r2-hubchatcontext` разом з drop entire override block.
- [x] I checked whether `AGENTS.md` needed an update. — Hard Rule #18 текст не змінюється.
- [x] I checked whether a playbook or skill needed an update. — ні, цей PR суто механічний.
- [x] I checked whether governance docs or review docs needed an update. — ні.

Updated docs:

- n/a

## Risk and Rollout

- User-visible risk: жодного — лише посилення лінт-гарду на вже-декомпонований файл.
- Rollout / deploy order: merge у `main`, deploy через звичайний Vercel preview → production pipeline.
- Backout plan: revert цього коміту (одна позиція в `files` array).

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian. (нічого з docs не змінювалось у цьому PR-і)
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

- `apps/web/src/core/hub/HubDashboard.tsx` зараз 115 LOC raw — на півпорядку менше за поріг `max-lines: 600` (skipBlankLines + skipComments). Drop allowlist-у безпечний.
- Залишковий запис в overrides блоку — `apps/web/src/core/lib/hubChatContext.ts` (681 LOC); його decomp + повний knife-off allowlist-у заплановані як `decomp-r2-hubchatcontext` (наступний PR з цієї сесії).
- Pre-existing baseline: `pnpm lint` на `main` падає через `apps/server/src/modules/billing/getUserPlan.test.ts:5:60` (`@typescript-eslint/no-explicit-any`) — не зачіпається цим PR-ом.
