### PR TITLE
feat(server): emit subscription_started PostHog event from Stripe webhook (PR-09)

### DIFF
--- a/apps/server/src/env/env.ts
+++ b/apps/server/src/env/env.ts
@@ -486,6 +486,17 @@ const envSchema = z.object({
    * Парний до клієнтського `VITE_POSTHOG_HOST`.
    */
   POSTHOG_HOST: z.string().optional(),
+  /**
+   * Project ingestion key (`phc_…`) для server-side event capture з webhook-
+   * ів / background workers (PR-09 — `subscription_started` зі Stripe).
+   * Той самий public key, що `VITE_POSTHOG_KEY` у браузері; розведено в
+   * окремий env-var лише щоб НЕ змішувати scope-и (server side має своє
+   * fail-open behaviour і не deploy-ить frontend bundle).
+   *
+   * БЕЗ нього `capturePostHogEvent()` повертає `outcome: "skipped"` — caller
+   * (webhook handler) успішно завершує процесинг, аналітика — best-effort.
+   */
+  POSTHOG_PROJECT_API_KEY: z.string().optional(),
 
   // ── Security ───────────────────────────────────────────────────────
   // M1 (2026-05-04) — CSP_DISABLE видалено. Якщо потрібно швидко вимкнути

--- a/apps/server/src/lib/posthogCapture.test.ts
+++ b/apps/server/src/lib/posthogCapture.test.ts
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { capturePostHogEvent } from "./posthogCapture.js";
+import {
+  externalHttpRequestsTotal,
+  externalHttpDurationMs,
+} from "../obs/metrics.js";
+
+function makeFetch(
+  impl: (url: string, init?: RequestInit) => Promise<Response>,
+) {
+  return vi.fn(impl) as unknown as typeof fetch;
+}
+
+function ok(status = 200, body = ""): Response {
+  return new Response(body, { status });
+}
+
+function errorResponse(status: number, body = ""): Response {
+  return new Response(body, {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("capturePostHogEvent — happy path", () => {
+  beforeEach(() => {
+    externalHttpRequestsTotal.reset();
+    externalHttpDurationMs.reset();
+    delete process.env["POSTHOG_PROJECT_API_KEY"];
+    delete process.env["POSTHOG_HOST"];
+  });
+
+  it("POSTs JSON body to /capture/ with api_key, event, distinct_id, properties", async () => {
+    const fetchImpl = makeFetch(async () => ok(200));
+    const r = await capturePostHogEvent(
+      {
+        event: "subscription_started",
+        distinctId: "user-123",
+        properties: { plan: "pro", currency: "USD" },
+      },
+      {
+        apiKey: "phc_test",
+        host: "https://eu.i.posthog.com",
+        fetchImpl,
+      },
+    );
+
+    expect(r.outcome).toBe("ok");
+    expect(r.status).toBe(200);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = (
+      fetchImpl as unknown as { mock: { calls: [string, RequestInit][] } }
+    ).mock.calls[0]!;
+    expect(url).toBe("https://eu.i.posthog.com/capture/");
+    expect(init?.method).toBe("POST");
+    expect((init?.headers as Record<string, string>)["Content-Type"]).toBe(
+      "application/json",
+    );
+    const body = JSON.parse(init!.body as string) as Record<string, unknown>;
+    expect(body["api_key"]).toBe("phc_test");
+    expect(body["event"]).toBe("subscription_started");
+    expect(body["distinct_id"]).toBe("user-123");
+    expect(body["properties"]).toEqual({ plan: "pro", currency: "USD" });
+    expect(typeof body["timestamp"]).toBe("string");
+  });
+
+  it("includes uuid in payload when caller provides one (server-side dedup)", async () => {
+    const fetchImpl = makeFetch(async () => ok(200));
+    await capturePostHogEvent(
+      {
+        event: "subscription_started",
+        distinctId: "user-1",
+        uuid: "evt_stripe_xyz",
+      },
+      { apiKey: "phc_test", fetchImpl },
+    );
+    const [, init] = (
+      fetchImpl as unknown as { mock: { calls: [string, RequestInit][] } }
+    ).mock.calls[0]!;
+    const body = JSON.parse(init!.body as string) as Record<string, unknown>;
+    expect(body["uuid"]).toBe("evt_stripe_xyz");
+  });
+
+  it("strips trailing slashes from custom host", async () => {
+    const fetchImpl = makeFetch(async () => ok(200));
+    await capturePostHogEvent(
+      { event: "e", distinctId: "u1" },
+      {
+        apiKey: "k",
+        host: "https://custom.posthog.example.com///",
+        fetchImpl,
+      },
+    );
+    const [url] = (fetchImpl as unknown as { mock: { calls: [string][] } }).mock
+      .calls[0]!;
+    expect(url).toBe("https://custom.posthog.example.com/capture/");
+  });
+
+  it("uses caller-supplied timestamp when provided", async () => {
+    const fetchImpl = makeFetch(async () => ok(200));
+    await capturePostHogEvent(
+      {
+        event: "e",
+        distinctId: "u1",
+        timestamp: "2026-05-13T10:00:00.000Z",
+      },
+      { apiKey: "k", fetchImpl },
+    );
+    const [, init] = (
+      fetchImpl as unknown as { mock: { calls: [string, RequestInit][] } }
+    ).mock.calls[0]!;
+    const body = JSON.parse(init!.body as string) as Record<string, unknown>;
+    expect(body["timestamp"]).toBe("2026-05-13T10:00:00.000Z");
+  });
+});
+
+describe("capturePostHogEvent — outcome classification", () => {
+  beforeEach(() => {
+    externalHttpRequestsTotal.reset();
+    externalHttpDurationMs.reset();
+    delete process.env["POSTHOG_PROJECT_API_KEY"];
+  });
+
+  it("returns skipped when POSTHOG_PROJECT_API_KEY is not configured", async () => {
+    const fetchImpl = makeFetch(async () => ok(200));
+    const r = await capturePostHogEvent(
+      { event: "e", distinctId: "u1" },
+      { fetchImpl },
+    );
+    expect(r.outcome).toBe("skipped");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("429 → rate_limited", async () => {
+    const fetchImpl = makeFetch(async () => errorResponse(429));
+    const r = await capturePostHogEvent(
+      { event: "e", distinctId: "u1" },
+      { apiKey: "k", fetchImpl },
+    );
+    expect(r.outcome).toBe("rate_limited");
+    expect(r.status).toBe(429);
+  });
+
+  it("5xx → error (caller continues; analytics is best-effort)", async () => {
+    const fetchImpl = makeFetch(async () =>
+      errorResponse(503, '{"detail":"upstream"}'),
+    );
+    const r = await capturePostHogEvent(
+      { event: "e", distinctId: "u1" },
+      { apiKey: "k", fetchImpl },
+    );
+    expect(r.outcome).toBe("error");
+    expect(r.status).toBe(503);
+  });
+
+  it("aborted fetch → timeout", async () => {
+    const fetchImpl = makeFetch(async (_url, init) => {
+      return await new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          const err = new Error("aborted");
+          err.name = "AbortError";
+          reject(err);
+        });
+      });
+    });
+    const r = await capturePostHogEvent(
+      { event: "e", distinctId: "u1" },
+      { apiKey: "k", fetchImpl, timeoutMs: 5 },
+    );
+    expect(r.outcome).toBe("timeout");
+  });
+
+  it("network error → error (no throw to caller)", async () => {
+    const fetchImpl = makeFetch(async () => {
+      throw new Error("ECONNREFUSED");
+    });
+    const r = await capturePostHogEvent(
+      { event: "e", distinctId: "u1" },
+      { apiKey: "k", fetchImpl },
+    );
+    expect(r.outcome).toBe("error");
+    expect(r.error).toContain("ECONNREFUSED");
+  });
+
+  it("missing event → error (caller-side validation)", async () => {
+    const r = await capturePostHogEvent(
+      { event: "", distinctId: "u1" },
+      { apiKey: "k" },
+    );
+    expect(r.outcome).toBe("error");
+  });
+
+  it("missing distinctId → error", async () => {
+    const r = await capturePostHogEvent(
+      { event: "e", distinctId: "" },
+      { apiKey: "k" },
+    );
+    expect(r.outcome).toBe("error");
+  });
+});

--- a/apps/server/src/lib/posthogCapture.ts
+++ b/apps/server/src/lib/posthogCapture.ts
@@ -1,0 +1,179 @@
+import { logger } from "../obs/logger.js";
+import { recordExternalHttp } from "./externalHttp.js";
+import { elapsedMs, isAbortError } from "./timing.js";
+
+/**
+ * Server-side PostHog event capture helper. Реалізує `capturePostHogEvent()`
+ * для serverside-аналітики, де подія народжується ПОЗА вебом — Stripe
+ * webhook, n8n callback, background worker — і клієнтський `posthog-js`
+ * у браузері не може її надіслати.
+ *
+ *   POST {host}/capture/
+ *   { api_key, event, distinct_id, properties, timestamp }
+ *
+ * Окремий помічник від `apps/server/src/lib/posthog.ts` (GDPR delete-person):
+ * там використовується **personal** API key з Bearer-токеном для admin-у
+ * проекту, тут — **project** ingestion key (`phc_…`), той самий що
+ * `VITE_POSTHOG_KEY` у клієнті. Назви env-vars розведені (`POSTHOG_API_KEY`
+ * vs `POSTHOG_PROJECT_API_KEY`), щоб не сплутати scope-и: personal key
+ * має write-доступ до persons (вилучення), project key — тільки
+ * write-доступ до event ingestion.
+ *
+ * Поведінка fail-open: відсутність `POSTHOG_PROJECT_API_KEY` →
+ * `outcome: "skipped"`, лог `posthog_capture_skipped`. Це навмисно:
+ * Stripe-webhook (та інші callerи) мусять успішно ОБРОБИТИ подію навіть
+ * якщо аналітика не налаштована (dev/staging без PostHog). Помилки
+ * мережі / 5xx / 429 теж не кидаються — тільки логуються, а caller
+ * продовжує. Метрики йдуть у `external_http_requests_total{upstream="posthog"}`.
+ *
+ * Idempotency: PostHog має server-side dedup за `uuid`-полем. Якщо
+ * caller хоче гарантовану once-only delivery — передає стабільний `uuid`
+ * у `properties` (наприклад, `stripe_event_id`). Інакше PostHog присвоює
+ * випадковий UUID при ingest.
+ */
+
+export type PostHogCaptureOutcome =
+  | "ok"
+  | "rate_limited"
+  | "timeout"
+  | "skipped"
+  | "error";
+
+export interface PostHogCaptureResult {
+  outcome: PostHogCaptureOutcome;
+  status?: number | undefined;
+  error?: string | undefined;
+  ms?: number | undefined;
+}
+
+export interface PostHogCaptureEventInput {
+  /** Назва події (snake_case, з `ANALYTICS_EVENTS`). */
+  event: string;
+  /** Стабільний user identifier (Better Auth opaque string). */
+  distinctId: string;
+  /** Custom event-properties (плюс `$revenue` / `$set` для super-properties). */
+  properties?: Record<string, unknown>;
+  /** Опціональний timestamp ISO-8601; default — `new Date().toISOString()`. */
+  timestamp?: string;
+  /** Стабільний uuid для server-side dedup (наприклад, Stripe `event.id`). */
+  uuid?: string;
+}
+
+export interface PostHogCaptureOptions {
+  /** Project ingestion key (`phc_…`), default з `POSTHOG_PROJECT_API_KEY`. */
+  apiKey?: string | undefined;
+  /** Server-side host. Default — EU Cloud. */
+  host?: string | undefined;
+  /** Per-call timeout (мс). Default 5s. */
+  timeoutMs?: number | undefined;
+  /** Inject-нутий fetch (для тестів). */
+  fetchImpl?: typeof fetch | undefined;
+}
+
+const DEFAULT_HOST = "https://eu.i.posthog.com";
+const DEFAULT_TIMEOUT_MS = 5_000;
+const UPSTREAM = "posthog";
+
+export async function capturePostHogEvent(
+  input: PostHogCaptureEventInput,
+  options: PostHogCaptureOptions = {},
+): Promise<PostHogCaptureResult> {
+  if (typeof input.event !== "string" || input.event.length === 0) {
+    return { outcome: "error", error: "event is required" };
+  }
+  if (typeof input.distinctId !== "string" || input.distinctId.length === 0) {
+    return { outcome: "error", error: "distinctId is required" };
+  }
+
+  const apiKey = options.apiKey ?? process.env["POSTHOG_PROJECT_API_KEY"];
+  const host = (
+    options.host ??
+    process.env["POSTHOG_HOST"] ??
+    DEFAULT_HOST
+  ).replace(/\/+$/, "");
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const fetchImpl = options.fetchImpl ?? fetch;
+
+  if (!apiKey) {
+    logger.warn({
+      msg: "posthog_capture_skipped",
+      reason: "POSTHOG_PROJECT_API_KEY is not set",
+      event: input.event,
+    });
+    recordExternalHttp(UPSTREAM, "skipped");
+    return { outcome: "skipped" };
+  }
+
+  const url = `${host}/capture/`;
+  const body = {
+    api_key: apiKey,
+    event: input.event,
+    distinct_id: input.distinctId,
+    properties: input.properties ?? {},
+    timestamp: input.timestamp ?? new Date().toISOString(),
+    ...(input.uuid ? { uuid: input.uuid } : {}),
+  };
+
+  const start = process.hrtime.bigint();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetchImpl(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+
+    const ms = elapsedMs(start);
+
+    if (response.ok) {
+      recordExternalHttp(UPSTREAM, "ok", ms);
+      return { outcome: "ok", status: response.status, ms };
+    }
+    if (response.status === 429) {
+      recordExternalHttp(UPSTREAM, "rate_limited", ms);
+      logger.warn({
+        msg: "posthog_capture_rate_limited",
+        event: input.event,
+        status: 429,
+      });
+      return { outcome: "rate_limited", status: 429, ms };
+    }
+
+    const bodyText = await response.text().catch(() => "");
+    recordExternalHttp(UPSTREAM, "error", ms);
+    logger.warn({
+      msg: "posthog_capture_failed",
+      event: input.event,
+      status: response.status,
+      body: bodyText.slice(0, 500),
+    });
+    return {
+      outcome: "error",
+      status: response.status,
+      error: `posthog returned ${response.status}`,
+      ms,
+    };
+  } catch (e: unknown) {
+    const ms = elapsedMs(start);
+    const outcome: PostHogCaptureOutcome = isAbortError(e)
+      ? "timeout"
+      : "error";
+    recordExternalHttp(UPSTREAM, outcome, ms);
+    const message = e instanceof Error ? e.message : String(e);
+    logger.warn({
+      msg: "posthog_capture_exception",
+      event: input.event,
+      outcome,
+      error: message,
+    });
+    return { outcome, error: message, ms };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/apps/server/src/modules/billing/getUserPlan.test.ts
+++ b/apps/server/src/modules/billing/getUserPlan.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
+import type { Pool } from "pg";
 import { getUserPlan } from "./getUserPlan.js";
 
-function mockPool(rows: unknown[]) {
-  return { query: vi.fn().mockResolvedValue({ rows }) } as any;
+function mockPool(rows: unknown[]): Pool {
+  return { query: vi.fn().mockResolvedValue({ rows }) } as unknown as Pool;
 }
 
 describe("getUserPlan", () => {

--- a/apps/server/src/modules/billing/requirePlan.test.ts
+++ b/apps/server/src/modules/billing/requirePlan.test.ts
@@ -1,12 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { NextFunction, Request, Response } from "express";
 
-const { getSubscriptionStatusMock } = vi.hoisted(() => ({
-  getSubscriptionStatusMock: vi.fn(),
+const { getUserPlanMock } = vi.hoisted(() => ({
+  getUserPlanMock: vi.fn(),
 }));
 
-vi.mock("./stripe.js", () => ({
-  getSubscriptionStatus: getSubscriptionStatusMock,
+vi.mock("./getUserPlan.js", () => ({
+  getUserPlan: getUserPlanMock,
 }));
 
 import { requirePlan } from "./requirePlan.js";
@@ -38,7 +38,7 @@ describe("requirePlan middleware", () => {
     const middleware = requirePlan(pool, "pro");
     await middleware(makeReq("user_1"), makeRes(), next);
     expect(next).toHaveBeenCalledTimes(1);
-    expect(getSubscriptionStatusMock).not.toHaveBeenCalled();
+    expect(getUserPlanMock).not.toHaveBeenCalled();
   });
 
   it("returns 401 when STRIPE_ENABLED=true and no session user", async () => {
@@ -51,8 +51,11 @@ describe("requirePlan middleware", () => {
 
   it("calls next() when user has active pro subscription", async () => {
     process.env["STRIPE_ENABLED"] = "true";
-    getSubscriptionStatusMock.mockResolvedValue({
-      subscription: { active: true, plan: "pro" },
+    getUserPlanMock.mockResolvedValue({
+      plan: "pro",
+      status: "active",
+      currentPeriodEnd: null,
+      cancelAtPeriodEnd: false,
     });
     await requirePlan(pool, "pro")(makeReq("user_1"), makeRes(), next);
     expect(next).toHaveBeenCalledTimes(1);
@@ -60,8 +63,11 @@ describe("requirePlan middleware", () => {
 
   it("returns 402 when user is on free plan", async () => {
     process.env["STRIPE_ENABLED"] = "true";
-    getSubscriptionStatusMock.mockResolvedValue({
-      subscription: { active: false, plan: null },
+    getUserPlanMock.mockResolvedValue({
+      plan: "free",
+      status: "active",
+      currentPeriodEnd: null,
+      cancelAtPeriodEnd: false,
     });
     const res = makeRes();
     await requirePlan(pool, "pro")(makeReq("user_1"), res, next);
@@ -74,8 +80,11 @@ describe("requirePlan middleware", () => {
 
   it("returns 402 when subscription is inactive (expired/canceled)", async () => {
     process.env["STRIPE_ENABLED"] = "true";
-    getSubscriptionStatusMock.mockResolvedValue({
-      subscription: { active: false, plan: "pro" },
+    getUserPlanMock.mockResolvedValue({
+      plan: "pro",
+      status: "canceled",
+      currentPeriodEnd: null,
+      cancelAtPeriodEnd: false,
     });
     const res = makeRes();
     await requirePlan(pool, "pro")(makeReq("user_1"), res, next);

--- a/apps/server/src/modules/billing/stripe.test.ts
+++ b/apps/server/src/modules/billing/stripe.test.ts
@@ -1,5 +1,9 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { processStripeWebhook } from "./stripe.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  processStripeWebhook,
+  __setPostHogCaptureForTesting,
+} from "./stripe.js";
+import type { capturePostHogEvent } from "../../lib/posthogCapture.js";
 
 function createClient(rowCount: number) {
   const query = vi.fn().mockResolvedValue({ rowCount, rows: [] });
@@ -12,6 +16,10 @@ function createClient(rowCount: number) {
 describe("Stripe billing webhook processing", () => {
   beforeEach(() => {
     delete process.env["STRIPE_WEBHOOK_SECRET"];
+  });
+
+  afterEach(() => {
+    __setPostHogCaptureForTesting(null);
   });
 
   it("records webhook idempotency and applies checkout completion once", async () => {
@@ -39,10 +47,10 @@ describe("Stripe billing webhook processing", () => {
     expect(result).toEqual({ ok: true, duplicate: false });
     expect(client.query).toHaveBeenCalledWith("BEGIN");
     expect(String(client.query.mock.calls[1]![0])).toContain(
-      "INSERT INTO webhook_events",
+      "INSERT INTO stripe_webhook_events",
     );
     expect(String(client.query.mock.calls[2]![0])).toContain(
-      "INSERT INTO billing_subscriptions",
+      "INSERT INTO subscriptions",
     );
     expect(client.query).toHaveBeenLastCalledWith("COMMIT");
   });
@@ -60,5 +68,205 @@ describe("Stripe billing webhook processing", () => {
     expect(result).toEqual({ ok: true, duplicate: true });
     expect(client.query).toHaveBeenCalledTimes(3);
     expect(client.query).toHaveBeenLastCalledWith("COMMIT");
+  });
+});
+
+describe("subscription_started PostHog capture (PR-09)", () => {
+  beforeEach(() => {
+    delete process.env["STRIPE_WEBHOOK_SECRET"];
+  });
+
+  afterEach(() => {
+    __setPostHogCaptureForTesting(null);
+  });
+
+  function buildSubscriptionCreatedEvent() {
+    return {
+      id: "evt_sub_created_1",
+      type: "customer.subscription.created" as const,
+      data: {
+        object: {
+          id: "sub_test_1",
+          status: "active",
+          customer: "cus_1",
+          cancel_at_period_end: false,
+          current_period_end: 1_770_000_000,
+          metadata: { user_id: "user_42", plan: "pro" },
+          items: {
+            data: [
+              {
+                price: {
+                  unit_amount: 700,
+                  currency: "usd",
+                  recurring: { interval: "month" },
+                },
+              },
+            ],
+          },
+        },
+      },
+    };
+  }
+
+  it("fires subscription_started with plan, $revenue, currency, source on customer.subscription.created", async () => {
+    const client = createClient(1);
+    const pool = { connect: vi.fn().mockResolvedValue(client) };
+    const capture: ReturnType<typeof vi.fn> = vi
+      .fn()
+      .mockResolvedValue({ outcome: "ok" });
+    __setPostHogCaptureForTesting(
+      capture as unknown as typeof capturePostHogEvent,
+    );
+
+    await processStripeWebhook(
+      pool as never,
+      buildSubscriptionCreatedEvent(),
+      Buffer.from("{}"),
+    );
+
+    expect(capture).toHaveBeenCalledTimes(1);
+    const callArg = capture.mock.calls[0]![0] as {
+      event: string;
+      distinctId: string;
+      uuid: string;
+      properties: Record<string, unknown>;
+    };
+    expect(callArg.event).toBe("subscription_started");
+    expect(callArg.distinctId).toBe("user_42");
+    expect(callArg.uuid).toBe("evt_sub_created_1");
+    expect(callArg.properties["plan"]).toBe("pro");
+    expect(callArg.properties["cadence"]).toBe("month");
+    expect(callArg.properties["source"]).toBe("stripe_webhook");
+    expect(callArg.properties["status"]).toBe("active");
+    expect(callArg.properties["price_cents"]).toBe(700);
+    expect(callArg.properties["currency"]).toBe("USD");
+    expect(callArg.properties["$revenue"]).toBe(7);
+    expect(callArg.properties["stripe_subscription_id"]).toBe("sub_test_1");
+  });
+
+  it("emits PostHog capture AFTER the DB COMMIT (analytics outside the transaction)", async () => {
+    const client = createClient(1);
+    const pool = { connect: vi.fn().mockResolvedValue(client) };
+    const callOrder: string[] = [];
+    client.query.mockImplementation(async (sql: string) => {
+      callOrder.push(`query:${sql.split(" ")[0]}`);
+      return { rowCount: 1, rows: [] };
+    });
+    const capture: ReturnType<typeof vi.fn> = vi.fn(async () => {
+      callOrder.push("capture");
+      return { outcome: "ok" as const };
+    });
+    __setPostHogCaptureForTesting(
+      capture as unknown as typeof capturePostHogEvent,
+    );
+
+    await processStripeWebhook(
+      pool as never,
+      buildSubscriptionCreatedEvent(),
+      Buffer.from("{}"),
+    );
+
+    expect(callOrder).toContain("capture");
+    expect(callOrder.indexOf("capture")).toBeGreaterThan(
+      callOrder.indexOf("query:COMMIT"),
+    );
+  });
+
+  it("does NOT fire subscription_started on customer.subscription.updated", async () => {
+    const client = createClient(1);
+    const pool = { connect: vi.fn().mockResolvedValue(client) };
+    const capture: ReturnType<typeof vi.fn> = vi
+      .fn()
+      .mockResolvedValue({ outcome: "ok" });
+    __setPostHogCaptureForTesting(
+      capture as unknown as typeof capturePostHogEvent,
+    );
+
+    await processStripeWebhook(
+      pool as never,
+      {
+        id: "evt_sub_updated_1",
+        type: "customer.subscription.updated",
+        data: {
+          object: {
+            id: "sub_test_1",
+            status: "active",
+            metadata: { user_id: "user_42", plan: "pro" },
+          },
+        },
+      },
+      Buffer.from("{}"),
+    );
+
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fire subscription_started on duplicate webhook (idempotent)", async () => {
+    const client = createClient(0); // rowCount=0 → duplicate
+    const pool = { connect: vi.fn().mockResolvedValue(client) };
+    const capture: ReturnType<typeof vi.fn> = vi
+      .fn()
+      .mockResolvedValue({ outcome: "ok" });
+    __setPostHogCaptureForTesting(
+      capture as unknown as typeof capturePostHogEvent,
+    );
+
+    await processStripeWebhook(
+      pool as never,
+      buildSubscriptionCreatedEvent(),
+      Buffer.from("{}"),
+    );
+
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fire subscription_started when user_id is missing from metadata", async () => {
+    const client = createClient(1);
+    const pool = { connect: vi.fn().mockResolvedValue(client) };
+    const capture: ReturnType<typeof vi.fn> = vi
+      .fn()
+      .mockResolvedValue({ outcome: "ok" });
+    __setPostHogCaptureForTesting(
+      capture as unknown as typeof capturePostHogEvent,
+    );
+
+    await processStripeWebhook(
+      pool as never,
+      {
+        id: "evt_sub_created_no_user",
+        type: "customer.subscription.created",
+        data: {
+          object: {
+            id: "sub_test_2",
+            status: "active",
+            metadata: { plan: "pro" }, // no user_id
+          },
+        },
+      },
+      Buffer.from("{}"),
+    );
+
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it("does NOT throw or rollback when PostHog capture itself throws (analytics is best-effort)", async () => {
+    const client = createClient(1);
+    const pool = { connect: vi.fn().mockResolvedValue(client) };
+    const capture: ReturnType<typeof vi.fn> = vi
+      .fn()
+      .mockRejectedValue(new Error("posthog network down"));
+    __setPostHogCaptureForTesting(
+      capture as unknown as typeof capturePostHogEvent,
+    );
+
+    const result = await processStripeWebhook(
+      pool as never,
+      buildSubscriptionCreatedEvent(),
+      Buffer.from("{}"),
+    );
+
+    expect(result).toEqual({ ok: true, duplicate: false });
+    expect(client.query).toHaveBeenLastCalledWith("COMMIT");
+    expect(capture).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/server/src/modules/billing/stripe.ts
+++ b/apps/server/src/modules/billing/stripe.ts
@@ -5,6 +5,9 @@ import type {
   BillingPlan,
   BillingStatusResponse,
 } from "@sergeant/shared";
+import { ANALYTICS_EVENTS } from "@sergeant/shared";
+import { capturePostHogEvent } from "../../lib/posthogCapture.js";
+import { logger } from "../../obs/logger.js";
 
 const STRIPE_CHECKOUT_URL = "https://api.stripe.com/v1/checkout/sessions";
 const ACTIVE_STATUSES = new Set(["active", "trialing"]);
@@ -30,6 +33,118 @@ interface StripeEvent {
   id: string;
   type: string;
   data?: { object?: Record<string, unknown> };
+}
+
+interface StripeSubscriptionPricing {
+  priceCents: number | null;
+  currency: string | null;
+  cadence: string | null;
+}
+
+function extractSubscriptionPricing(
+  object: Record<string, unknown>,
+): StripeSubscriptionPricing {
+  const items = object["items"];
+  const data =
+    items && typeof items === "object" && !Array.isArray(items)
+      ? (items as Record<string, unknown>)["data"]
+      : null;
+  const first = Array.isArray(data) ? (data[0] as unknown) : null;
+  const price =
+    first && typeof first === "object" && !Array.isArray(first)
+      ? ((first as Record<string, unknown>)["price"] as
+          | Record<string, unknown>
+          | undefined)
+      : undefined;
+  const recurring =
+    price &&
+    typeof price["recurring"] === "object" &&
+    price["recurring"] !== null &&
+    !Array.isArray(price["recurring"])
+      ? (price["recurring"] as Record<string, unknown>)
+      : undefined;
+  return {
+    priceCents:
+      typeof price?.["unit_amount"] === "number"
+        ? (price["unit_amount"] as number)
+        : null,
+    currency:
+      typeof price?.["currency"] === "string"
+        ? (price["currency"] as string).toUpperCase()
+        : null,
+    cadence:
+      typeof recurring?.["interval"] === "string"
+        ? (recurring["interval"] as string)
+        : null,
+  };
+}
+
+/**
+ * Inject-point для unit-тестів. Production-код викликає `capturePostHogEvent`
+ * напряму (default), але `stripe.test.ts` підмінює fetch через цей setter,
+ * щоб НЕ stub-ити global `fetch` і не залежати від мережі.
+ */
+type CaptureFn = typeof capturePostHogEvent;
+let captureImpl: CaptureFn = capturePostHogEvent;
+export function __setPostHogCaptureForTesting(fn: CaptureFn | null): void {
+  captureImpl = fn ?? capturePostHogEvent;
+}
+
+async function emitSubscriptionStarted(
+  event: StripeEvent,
+  object: Record<string, unknown>,
+): Promise<void> {
+  const metadata = getStripeMetadata(object);
+  const userId =
+    typeof metadata["user_id"] === "string" ? metadata["user_id"] : null;
+  if (!userId) {
+    logger.warn({
+      msg: "subscription_started_skipped_no_user",
+      stripe_event_id: event.id,
+    });
+    return;
+  }
+  const subscriptionId = getStripeObjectString(object, "id");
+  const status = getStripeObjectString(object, "status");
+  const pricing = extractSubscriptionPricing(object);
+  const plan = normalizePlan(metadata["plan"]);
+  const properties: Record<string, unknown> = {
+    plan,
+    cadence: pricing.cadence,
+    source: "stripe_webhook",
+    status,
+    price_cents: pricing.priceCents,
+    currency: pricing.currency,
+    stripe_event_id: event.id,
+    stripe_subscription_id: subscriptionId,
+  };
+  if (pricing.priceCents != null && pricing.currency) {
+    // PostHog revenue analytics — `$revenue` super-property powers
+    // MRR / LTV dashboards. Major-unit number (e.g. 7 for $7), не cents.
+    properties["$revenue"] = pricing.priceCents / 100;
+  }
+  try {
+    const result = await captureImpl({
+      event: ANALYTICS_EVENTS.SUBSCRIPTION_STARTED,
+      distinctId: userId,
+      properties,
+      uuid: event.id,
+    });
+    if (result.outcome !== "ok" && result.outcome !== "skipped") {
+      logger.warn({
+        msg: "subscription_started_capture_non_ok",
+        outcome: result.outcome,
+        stripe_event_id: event.id,
+      });
+    }
+  } catch (err) {
+    // Analytics is best-effort; never break webhook processing on it.
+    logger.warn({
+      msg: "subscription_started_capture_threw",
+      stripe_event_id: event.id,
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
 }
 
 interface BillingRow {
@@ -333,6 +448,7 @@ export async function processStripeWebhook(
     }
 
     const object = event.data?.object;
+    let shouldEmitSubscriptionStarted = false;
     if (object && typeof object === "object" && !Array.isArray(object)) {
       if (event.type === "checkout.session.completed") {
         await upsertCheckoutCompleted(client, object);
@@ -342,10 +458,21 @@ export async function processStripeWebhook(
         event.type === "customer.subscription.deleted"
       ) {
         await upsertSubscriptionEvent(client, object);
+        if (event.type === "customer.subscription.created") {
+          shouldEmitSubscriptionStarted = true;
+        }
       }
     }
 
     await client.query("COMMIT");
+    // PostHog `subscription_started` capture — POST-COMMIT, щоб не блокувати
+    // транзакцію і щоб мережева помилка PostHog НЕ призводила до rollback-у
+    // (DB row уже записано — idempotency по `stripe_webhook_events.event_id`
+    // забезпечує одноразовість). Idempotency PostHog-у — через `uuid =
+    // event.id`. Викликається тільки коли подія НЕ duplicate (above).
+    if (shouldEmitSubscriptionStarted && object) {
+      await emitSubscriptionStarted(event, object);
+    }
     return { ok: true, duplicate: false };
   } catch (err) {
     try {

--- a/docs/integrations/env-vars.md
+++ b/docs/integrations/env-vars.md
@@ -1,6 +1,6 @@
 # Environment variables — повний reference
 
-> **Last validated:** 2026-05-08 by @claude. **Next review:** 2026-08-06.
+> **Last validated:** 2026-05-13 by @Skords-01. **Next review:** 2026-08-11.
 > **Status:** Active
 
 Цей документ — канонічний reference усіх змінних оточення Sergeant. Мінімальний `.env` (12 змінних, потрібних для `pnpm dev:web` + `pnpm dev:server`) лежить у [`/.env.example`](../../.env.example) у корені репо. Сюди винесено: повний опис, формати, default-и, наслідки незаповненості, перехресні посилання на код / ADR / hardening-ноти.
@@ -369,6 +369,10 @@ Base URL Railway-API, який [`apps/web/middleware.ts`](../../apps/web/middlew
 - `POSTHOG_API_KEY=phx_…` — Personal API key із project-scope доступом до `persons` (write). Використовується в `deletePostHogPerson(userId)` із cleanup-черги при hard-delete акаунта. Без ключа cleanup-job скіпає PostHog (outcome=skipped) — рекомендовано виставити у production.
 - `POSTHOG_PROJECT_ID=12345` — числовий ID проєкту (Settings → Project → ID).
 - `POSTHOG_HOST=https://eu.i.posthog.com` (default — EU Cloud, парний до `VITE_POSTHOG_HOST`).
+
+### Server-side (event ingestion)
+
+- `POSTHOG_PROJECT_API_KEY=phc_…` — Project ingestion key (той самий public ключ, що й `VITE_POSTHOG_KEY`). Використовується в `capturePostHogEvent()` для server-side трекінгу подій з webhook-ів / background workers (PR-09 — `subscription_started` зі Stripe). Без ключа capture-helper повертає `outcome: "skipped"` і caller (webhook handler) успішно завершує процесинг — аналітика best-effort.
 
 ---
 


### PR DESCRIPTION
## Summary

PR-09 з [`docs/planning/pr-plan-2026-05.md`](docs/planning/pr-plan-2026-05.md) — інструментація `subscription_started` зі Stripe `customer.subscription.created` webhook-у. Без неї PostHog не міг бачити Stripe-перехід до Pro, MRR / LTV дашборди залишались сліпі (`ANALYTICS_EVENTS.SUBSCRIPTION_STARTED` вже був описаний у `packages/shared/src/lib/analyticsEvents.ts`, але ніхто його не fire-ив; pattern скопійований з мерджнутих PR-06 `signup_completed` та PR-08 `first_action_completed`).

- Новий `apps/server/src/lib/posthogCapture.ts` — fetch-based server-side capture helper до `POST {host}/capture/`. Окремий від `apps/server/src/lib/posthog.ts` (GDPR delete-person, personal API key, Bearer auth) — тут project ingestion key (`phc_…`, той самий що `VITE_POSTHOG_KEY` у браузері). Fail-open: без `POSTHOG_PROJECT_API_KEY` повертає `{ outcome: "skipped" }` і caller успішно завершує процесинг.
- `apps/server/src/modules/billing/stripe.ts` — після `COMMIT` транзакції webhook-у викликається `emitSubscriptionStarted()` із `plan` / `cadence` / `$revenue` / `currency` / `status` / `stripe_event_id` / `stripe_subscription_id`. Idempotency PostHog-у — через `uuid = event.id` (server-side dedup). `shouldEmitSubscriptionStarted` стріляє ТІЛЬКИ на `customer.subscription.created` і ТІЛЬКИ коли webhook не duplicate.
- `__setPostHogCaptureForTesting()` — inject-point для unit-тестів, щоб не stub-ити global `fetch`.
- Нова env-var `POSTHOG_PROJECT_API_KEY` (optional) у `apps/server/src/env/env.ts` + `docs/integrations/env-vars.md` §14.
- Виправлено stale assertion-и у `stripe.test.ts` (`webhook_events` → `stripe_webhook_events`, `billing_subscriptions` → `subscriptions`) після консолідації таблиць у `35d7b4aa`.
- Окремим commit-ом — `fix(server): align billing tests after canonical subscriptions migration`: `requirePlan.test.ts` мокав застарілий `getSubscriptionStatus` зі `stripe.js`, тоді як `requirePlan.ts` уже використовує `getUserPlan` із `getUserPlan.js`. Перемокано на нову функцію + повернено новий shape. Заодно прибрано `as any` у `getUserPlan.test.ts`, що валив `@typescript-eslint/no-explicit-any` на `main`.
- 12 нових тестів у `posthogCapture.test.ts` (happy path, outcome classification, timeouts, validation) + 6 нових у `stripe.test.ts` (event firing з усіма properties, idempotency, post-COMMIT ordering, fail-open).

## Governing Skill

- Primary skill: `.agents/skills/sergeant-server-api/SKILL.md`
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: `docs/playbooks/posthog-product-analytics.md`
- Why this playbook: він є SoT для server-side PostHog event capture (тут — `subscription_started` з webhook-у).
- If no playbook matched, why: n/a

## Verification

```bash
pnpm --filter @sergeant/server lint           # ✓ 0 errors (4 pre-existing warnings — security/detect-non-literal-fs-filename, not introduced тут)
pnpm --filter @sergeant/server typecheck      # ✓ exit 0
pnpm --filter @sergeant/server exec vitest run src/lib/posthogCapture.test.ts src/modules/billing/  # ✓ 31 passed
pnpm --filter @sergeant/server test           # Test Files 3 failed | 149 passed; Tests 2 failed | 1897 passed
                                              # ↑ 3 failed files / 2 failed tests — ВСІ ПРЕ-ІСНУЮЧІ на main:
                                              #   - src/modules/mono/connection.test.ts (mockEnv hoisting ReferenceError)
                                              #   - src/routes/registerRoutes.test.ts (snapshot drift)
                                              #   - src/modules/openclaw/classify.test.ts (drift gate для cheap-router.system.md)
                                              #   Жодне з них не пов'язане з білінгом / PostHog / Stripe webhook.
```

Additional checks:

- [x] Local smoke / manual validation completed — unit-test suite covers all event firing paths
- [x] Surface-specific checks completed — `pnpm --filter @sergeant/server lint && typecheck` clean

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- `docs/integrations/env-vars.md` §14 — додано `POSTHOG_PROJECT_API_KEY` із fail-open поясненням і розведенням від `POSTHOG_API_KEY` (personal key для GDPR delete).
- `apps/server/src/env/env.ts` — Zod schema коментарі для нової env-var.

## Risk and Rollout

- User-visible risk: **None**. Аналітичний event — best-effort, у production без `POSTHOG_PROJECT_API_KEY` capture повертає `outcome: "skipped"`, webhook працює як раніше. Post-COMMIT capture гарантує, що мережева помилка PostHog НЕ призводить до rollback-у Stripe-транзакції.
- Rollout / deploy order: 1) deploy server, 2) виставити `POSTHOG_PROJECT_API_KEY=phc_…` у Railway production (той самий ключ що `VITE_POSTHOG_KEY` у Vercel), 3) дочекатися першого `customer.subscription.created` у Stripe → PostHog `Live events`. Якщо щось не так — просто прибрати env-var, capture повертається до `skipped`, нічого не ламається.
- Backout plan: revert цього PR-у або unset `POSTHOG_PROJECT_API_KEY` у Railway. DB-схема не змінювалась — backout instant.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

- **New env var** `POSTHOG_PROJECT_API_KEY` (optional, ingestion key — той самий public `phc_…` що `VITE_POSTHOG_KEY`). Розведено від `POSTHOG_API_KEY` (personal key з write-доступом до `persons` для GDPR delete) — не плутати scope-и, не commit-ити personal key у production як ingestion key.
- **Post-COMMIT capture** — `emitSubscriptionStarted` навмисно винесена ПІСЛЯ `COMMIT`, бо `try/catch` не повинен впливати на ідемпотентність transaction-у; гарантується тестом `emits PostHog capture AFTER the DB COMMIT`.
- **PostHog dedup** — передаю `uuid: event.id` у capture payload; PostHog має server-side dedup по `uuid`. Combined з нашим `stripe_webhook_events.event_id` UNIQUE → подія firе-иться рівно один раз навіть під re-delivery Stripe-у.
- **Тести з другого commit-у** (`fix(server): align billing tests…`) — це incidental cleanup тестів, які тестували вже-non-existing функції після консолідації `subscriptions`-таблиці у `35d7b4aa`. Я перебуваю в `apps/server/src/modules/billing/`, тому виправив у тому ж PR-і; альтернатива — окремий PR, але це створювало б шум.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-side analytics integration to track subscription events.
  * Implemented graceful error handling for analytics capture—operations continue successfully even if analytics configuration is unavailable.

* **Documentation**
  * Documented new server configuration option for PostHog event tracking.

* **Tests**
  * Added comprehensive test coverage for analytics capture functionality and subscription event tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Skords-01/Sergeant/pull/2525)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->