### PR TITLE
feat(shared,web,mobile-shell): replace shell-navigate global with BroadcastChannel (PR-29)

### DIFF
--- a/apps/mobile-shell/package.json
+++ b/apps/mobile-shell/package.json
@@ -40,7 +40,8 @@
     "@capacitor/preferences": "^7.0.4",
     "@capacitor/push-notifications": "^7.0.6",
     "@capacitor/splash-screen": "^7.0.5",
-    "@capacitor/status-bar": "^7.0.6"
+    "@capacitor/status-bar": "^7.0.6",
+    "@sergeant/shared": "workspace:*"
   },
   "devDependencies": {
     "@capacitor/cli": "^7.6.2",

--- a/apps/mobile-shell/src/__tests__/deepLinkBridge.test.ts
+++ b/apps/mobile-shell/src/__tests__/deepLinkBridge.test.ts
@@ -251,3 +251,82 @@ describe("deep-link bridge — resilience", () => {
     expect(w.__sergeantShellDeepLinkQueue).toEqual(["/welcome", "/profile"]);
   });
 });
+
+describe("deep-link bridge — BroadcastChannel canonical path (PR-29)", () => {
+  it("publishes parsed path on `sergeant-shell-deeplink` channel alongside window-global fallback", async () => {
+    const mocks = installCapacitorMocks();
+    const bcReceiver = new BroadcastChannel("sergeant-shell-deeplink");
+    const received: Array<{
+      url: unknown;
+      source: unknown;
+      protocolVersion: unknown;
+    }> = [];
+    bcReceiver.onmessage = (ev: MessageEvent): void => {
+      received.push({
+        url: (ev.data as Record<string, unknown>)["url"],
+        source: (ev.data as Record<string, unknown>)["source"],
+        protocolVersion: (ev.data as Record<string, unknown>)[
+          "protocolVersion"
+        ],
+      });
+    };
+
+    const cb = await captureUrlOpenCallback(mocks);
+    cb({ url: "com.sergeant.shell://finyk/transactions/42" });
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toEqual({
+      url: "/finyk/transactions/42",
+      source: "shell",
+      protocolVersion: 1,
+    });
+
+    bcReceiver.close();
+  });
+
+  it("does NOT post to BroadcastChannel when `options.navigate` is provided (test-injection short-circuit)", async () => {
+    const mocks = installCapacitorMocks();
+    const bcReceiver = new BroadcastChannel("sergeant-shell-deeplink");
+    const received: unknown[] = [];
+    bcReceiver.onmessage = (ev: MessageEvent): void => {
+      received.push(ev.data);
+    };
+    const optionsNav = vi.fn();
+
+    const cb = await captureUrlOpenCallback(mocks, { navigate: optionsNav });
+    cb({ url: "com.sergeant.shell://profile" });
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(optionsNav).toHaveBeenCalledWith("/profile");
+    expect(received).toHaveLength(0);
+
+    bcReceiver.close();
+  });
+
+  it("falls back gracefully when BroadcastChannel constructor is absent in the WebView", async () => {
+    // Симулюємо iOS <15.4 / дуже стару Android System WebView: API
+    // повністю відсутня у globalThis. dispatchDeepLink має тихо
+    // пройти через window-global path.
+    const mocks = installCapacitorMocks();
+    const originalBC = globalThis.BroadcastChannel;
+    delete (globalThis as { BroadcastChannel?: unknown }).BroadcastChannel;
+
+    try {
+      const w = window as BridgeWindow;
+      const bridgeNav = vi.fn();
+      w.__sergeantShellNavigate = bridgeNav;
+
+      const cb = await captureUrlOpenCallback(mocks);
+      cb({ url: "com.sergeant.shell://welcome" });
+
+      expect(bridgeNav).toHaveBeenCalledWith("/welcome");
+    } finally {
+      (
+        globalThis as { BroadcastChannel?: typeof BroadcastChannel }
+      ).BroadcastChannel = originalBC;
+    }
+  });
+});

--- a/apps/mobile-shell/src/index.ts
+++ b/apps/mobile-shell/src/index.ts
@@ -25,6 +25,7 @@ import { App, type URLOpenListenerEvent } from "@capacitor/app";
 import { Keyboard, KeyboardResize } from "@capacitor/keyboard";
 import { SplashScreen } from "@capacitor/splash-screen";
 import { StatusBar, Style } from "@capacitor/status-bar";
+import { createDeepLinkChannel, type DeepLinkChannel } from "@sergeant/shared";
 
 /** Колір status bar-а у light-темі — збігається з `--c-bg` (#fdf9f3). */
 const STATUS_BAR_COLOR_LIGHT = "#fdf9f3";
@@ -198,13 +199,36 @@ type DeepLinkBridgeWindow = Window & {
 };
 
 /**
- * Диспатчер deep-link шляху у web-сторону. Порядок preference:
+ * Lazy-created BroadcastChannel sender (PR-29 у
+ * `docs/initiatives/stack-pulse-2026-05/`). Канонічний шлях dispatch-у
+ * у веб; ініціалізується при першому `dispatchDeepLink`-у, щоб не платити
+ * за `new BroadcastChannel(...)` у звичайному boot-апі без deep links.
+ *
+ * Null-channel (`isOpen === false`) автоматично повертається з
+ * `createDeepLinkChannel()`, якщо WebView не має BroadcastChannel API
+ * (iOS <15.4, дуже старі Android System WebView). У такому разі shell
+ * mовчки fallback-ається на window-global / queue нижче.
+ */
+let deepLinkChannel: DeepLinkChannel | null = null;
+function getDeepLinkChannel(): DeepLinkChannel {
+  if (deepLinkChannel === null) {
+    deepLinkChannel = createDeepLinkChannel();
+  }
+  return deepLinkChannel;
+}
+
+/**
+ * Диспатчер deep-link шляху у web-сторону. Порядок:
  *   1. `options.navigate(path)` — явно переданий callback (тестова ін'єкція
- *      або legacy-caller, що сам тримає навігаційний хук).
- *   2. `window.__sergeantShellNavigate(path)` — bridge, який виставляє
- *      React-layout після маунту роутера.
- *   3. Буферизація у `window.__sergeantShellDeepLinkQueue`, якщо bridge ще
- *      не встановлений (cold-start) — веб drain-ить чергу при install-і.
+ *      або legacy-caller, що сам тримає навігаційний хук). Якщо переданий —
+ *      ТІЛЬКИ він використовується; BroadcastChannel і window-global шляхи
+ *      пропускаються, щоб тести не отримували дубль-події.
+ *   2. **Паралельно**: BroadcastChannel + (window-global або pre-mount
+ *      queue). Web-bridge (`ShellDeepLinkBridge.tsx`) має coalescing-вікно
+ *      по `(path, timestamp)`, тому одна і та сама deep-link подія,
+ *      доставлена обома шляхами, призводить рівно до одного `navigate()`.
+ *      Подвійний dispatch свідомий — async-deploy-сценарій (нова shell
+ *      проти старого web або навпаки) ловиться на будь-якій із двох сторін.
  *
  * Помилки виклику navigate не шкодять shell — залоговане попередження, але
  * подія все одно проковтнута (не падає з listener-у `appUrlOpen`).
@@ -219,6 +243,17 @@ function dispatchDeepLink(path: string, options: InitNativeShellOptions): void {
     return;
   }
 
+  // Canonical PR-29 path — BroadcastChannel. No-op у legacy WebView без
+  // BroadcastChannel-у (`getDeepLinkChannel()` повертає null-channel).
+  const channel = getDeepLinkChannel();
+  if (channel.isOpen) {
+    channel.post({ url: path, source: "shell" });
+  }
+
+  // Legacy/backward-compat path — window.__sergeantShellNavigate. Залишається
+  // 3 місяці після PR-29 ship-у (PR-2 у stack-pulse-2026-05 dropає його
+  // після iOS / Android Vault adoption). Працює як fallback для змішаного
+  // async-deploy-у і повністю обходить старі WebView без BroadcastChannel-у.
   if (typeof window === "undefined") return;
   const w = window as DeepLinkBridgeWindow;
 

--- a/apps/web/src/core/app/ShellDeepLinkBridge.tsx
+++ b/apps/web/src/core/app/ShellDeepLinkBridge.tsx
@@ -1,17 +1,27 @@
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { isCapacitor } from "@sergeant/shared";
+import {
+  createDeepLinkChannel,
+  isCapacitor,
+  type DeepLinkMessage,
+} from "@sergeant/shared";
 
 /**
- * Bridge-компонент, який звʼязує Capacitor-shell і React Router через
- * namespaced window-ключі — без compile-time залежності веб-бандла на
- * `@capacitor/*`. Після маунту роутера виставляє
- * `window.__sergeantShellNavigate` (shell використовує його у
- * `appUrlOpen` handler) і прогає буферизовані deep-link шляхи, що
- * прилетіли ДО маунту (cold start через `com.sergeant.shell://…`
- * URL → Capacitor вже встиг пушнути path у
- * `window.__sergeantShellDeepLinkQueue`, але React Router тоді ще не
- * існував).
+ * Bridge-компонент, який звʼязує Capacitor-shell і React Router. Підписується
+ * на `BroadcastChannel("sergeant-shell-deeplink")` (canonical path, PR-29) і
+ * паралельно лишає `window.__sergeantShellNavigate` як backward-compat shim
+ * для async-deploy сценаріїв і старих WKWebView (<iOS 15.4) без
+ * BroadcastChannel-у.
+ *
+ * Обидва шляхи прив'язані до однієї `handleNav(path, ts)` із короткою
+ * coalescing-памʼяттю по `(path, timestamp)` — щоб одна deep-link подія,
+ * яку mobile-shell свідомо шле ОБОМА шляхами під час перехідного періоду,
+ * не призводила до двох `navigate()`.
+ *
+ * Cold-start буфер `window.__sergeantShellDeepLinkQueue` лишається — шляхи,
+ * push-нуті у нього ДО маунту React-bridge-у, drain-яться one-shot після
+ * install-у. Coalescing teж застосовується (на випадок якщо той же path
+ * прилетить ще раз через канал у вікні coalescing-у).
  *
  * У браузері рендер no-op: guard `isCapacitor()` скіпає install-логіку,
  * і всі window-ключі лишаються `undefined`. Компонент повертає `null`
@@ -84,6 +94,27 @@ function isSafeNavPath(path: unknown): path is string {
   return false;
 }
 
+/**
+ * Вікно у мілісекундах, протягом якого та сама `(path, timestamp)` пара
+ * не призведе до повторного `navigate()`. Mobile-shell шле deep-link
+ * через BroadcastChannel **і** через `window.__sergeantShellNavigate`
+ * одночасно (`Date.now()` між цими викликами завжди < 50ms), тож
+ * 500ms — щедрий запас для async dispatch-у на slow-device-ах.
+ *
+ * Coalescing орієнтований на `timestamp` із повідомлення: якщо native
+ * shell отримує два РІЗНІ `appUrlOpen` для одного path-у — їх `timestamp`
+ * відрізняються, обидва навігації проходять. Якщо один-і-той-самий
+ * `appUrlOpen` дисер-нувся обома шляхами — `timestamp` ОДИН, проходить
+ * лише перший виклик.
+ */
+const COALESCE_WINDOW_MS = 500;
+
+interface RecentNav {
+  path: string;
+  timestamp: number;
+  receivedAt: number;
+}
+
 export function ShellDeepLinkBridge(): null {
   const navigate = useNavigate();
 
@@ -92,41 +123,79 @@ export function ShellDeepLinkBridge(): null {
     if (typeof window === "undefined") return;
     const w = window as DeepLinkBridgeWindow;
 
-    const handler = (path: string): void => {
+    // Coalescing memory — невеликий ring (1 запис достатньо для типового
+    // user pattern: тапнув ярлик у Push notification → один deep link).
+    // У ризик-сценарії «два різних deep-link з однаковим path-ом протягом
+    // 500ms» — другий буде coalesced, що ОК: користувач все одно вже
+    // знаходиться на цьому шляху після першої навігації.
+    let lastNav: RecentNav | null = null;
+
+    function handleNav(
+      path: string,
+      timestamp: number,
+      source: "broadcast" | "window" | "queue",
+    ): void {
       if (!isSafeNavPath(path)) {
-        console.warn("[shell-deep-link] rejected unsafe path", { path });
+        console.warn("[shell-deep-link] rejected unsafe path", {
+          path,
+          source,
+        });
         return;
       }
-      navigate(path);
-    };
-    w.__sergeantShellNavigate = handler;
+      const now = Date.now();
+      if (
+        lastNav &&
+        lastNav.path === path &&
+        lastNav.timestamp === timestamp &&
+        now - lastNav.receivedAt < COALESCE_WINDOW_MS
+      ) {
+        // Дубль — друга гілка bridge-у вже доставила цю саму подію.
+        return;
+      }
+      lastNav = { path, timestamp, receivedAt: now };
+      try {
+        navigate(path);
+      } catch (err) {
+        console.warn("[shell-deep-link] navigate failed", { source, err });
+      }
+    }
 
-    // Drain-имо буфер cold-start шляхів одразу після install-у. Масив
-    // міг бути заповнений shell-ем у вікні між `initNativeShell()` і
-    // першим ефектом React-дерева — типовий сценарій при запуску апки
-    // через `com.sergeant.shell://<path>`.
+    // ── Canonical path: BroadcastChannel ─────────────────────────────
+    const channel = createDeepLinkChannel();
+    const unsubscribe = channel.subscribe((msg: DeepLinkMessage) => {
+      if (msg.source !== "shell") return; // не приймаємо self-loop з web→web
+      handleNav(msg.url, msg.timestamp, "broadcast");
+    });
+
+    // ── Backward-compat: window-global shim ──────────────────────────
+    // Лишається 3 місяці після PR-29 ship-у (rollout PR-2 у spec-у).
+    // Mobile-shell у async-deploy-сценарії може ще не вміти
+    // BroadcastChannel — fallback зберігає uptime навігації.
+    const windowHandler = (path: string): void => {
+      // `Date.now()` як псевдо-timestamp — window-global не несе ts,
+      // тому coalescing з BC-шляхом працює тільки якщо обидва шляхи
+      // ship-ляться у одному релізі. У змішаному релізі (старий
+      // mobile-shell без BC) дублів просто немає — лише window-шлях
+      // спрацьовує.
+      handleNav(path, Date.now(), "window");
+    };
+    w.__sergeantShellNavigate = windowHandler;
+
+    // ── Cold-start queue drain ───────────────────────────────────────
     const queue = w.__sergeantShellDeepLinkQueue;
     if (Array.isArray(queue) && queue.length > 0) {
       const pending = queue.splice(0, queue.length);
       for (const path of pending) {
-        if (!isSafeNavPath(path)) {
-          console.warn("[shell-deep-link] flush rejected unsafe path", {
-            path,
-          });
-          continue;
-        }
-        try {
-          navigate(path);
-        } catch (err) {
-          console.warn("[shell-deep-link] flush navigate failed", err);
-        }
+        handleNav(path, Date.now(), "queue");
       }
     }
 
     return () => {
+      unsubscribe();
+      channel.close();
       // Чистимо саме наш handler — якщо хтось інший перевстановив
       // bridge (наприклад, HMR-перезапуск ефекту), не витираємо новіший.
-      if (w.__sergeantShellNavigate === handler) {
+      if (w.__sergeantShellNavigate === windowHandler) {
         delete w.__sergeantShellNavigate;
       }
     };

--- a/apps/web/src/test/integration/shell-deeplink.test.tsx
+++ b/apps/web/src/test/integration/shell-deeplink.test.tsx
@@ -1,0 +1,205 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { SHELL_DEEPLINK_CHANNEL } from "@sergeant/shared";
+
+/**
+ * Integration test for `ShellDeepLinkBridge` — covers the PR-29 shape:
+ *   - BroadcastChannel listener navigates на отриманий path.
+ *   - Backward-compat: `window.__sergeantShellNavigate` все ще працює.
+ *   - Coalescing: одна (path, timestamp) пара, надіслана ОБОМА шляхами,
+ *     призводить рівно до одного `navigate()`.
+ *   - Cold-start queue drain-иться при mount-і.
+ *   - Unsafe path не призводить до навігації.
+ *
+ * Mount-имо bridge всередині `<MemoryRouter>` + перехоплюємо
+ * `useLocation()` через тестовий компонент-shim. `isCapacitor()` мокаємо
+ * на `true`, щоб bridge install-нувся — у браузерному режимі він навмисно
+ * no-op.
+ */
+
+vi.mock("@sergeant/shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@sergeant/shared")>();
+  return {
+    ...actual,
+    isCapacitor: vi.fn(() => true),
+  };
+});
+
+let ShellDeepLinkBridge: typeof import("../../core/app/ShellDeepLinkBridge.js").ShellDeepLinkBridge;
+
+beforeEach(async () => {
+  vi.resetModules();
+  ({ ShellDeepLinkBridge } =
+    await import("../../core/app/ShellDeepLinkBridge.js"));
+  delete (
+    window as Window & {
+      __sergeantShellNavigate?: unknown;
+      __sergeantShellDeepLinkQueue?: unknown;
+    }
+  ).__sergeantShellNavigate;
+  delete (
+    window as Window & {
+      __sergeantShellNavigate?: unknown;
+      __sergeantShellDeepLinkQueue?: unknown;
+    }
+  ).__sergeantShellDeepLinkQueue;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function LocationProbe(): JSX.Element {
+  const location = useLocation();
+  return <span data-testid="loc">{location.pathname + location.search}</span>;
+}
+
+function renderBridge(initialEntries: string[] = ["/"]): HTMLElement {
+  const utils = render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <ShellDeepLinkBridge />
+      <Routes>
+        <Route path="*" element={<LocationProbe />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+  return utils.getByTestId("loc");
+}
+
+describe("ShellDeepLinkBridge — BroadcastChannel listener (PR-29)", () => {
+  it("navigates when a shell deep-link message arrives on the channel", async () => {
+    const loc = renderBridge();
+    expect(loc.textContent).toBe("/");
+
+    const sender = new BroadcastChannel(SHELL_DEEPLINK_CHANNEL);
+    sender.postMessage({
+      protocolVersion: 1,
+      url: "/finyk/transactions/42",
+      source: "shell",
+      timestamp: Date.now(),
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(loc.textContent).toBe("/finyk/transactions/42");
+    sender.close();
+  });
+
+  it("ignores messages with mismatched protocol version", async () => {
+    const loc = renderBridge();
+    const sender = new BroadcastChannel(SHELL_DEEPLINK_CHANNEL);
+    sender.postMessage({
+      protocolVersion: 999,
+      url: "/finyk",
+      source: "shell",
+      timestamp: Date.now(),
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(loc.textContent).toBe("/");
+    sender.close();
+  });
+
+  it("ignores messages with source other than `shell` (no web→web self-loop)", async () => {
+    const loc = renderBridge();
+    const sender = new BroadcastChannel(SHELL_DEEPLINK_CHANNEL);
+    sender.postMessage({
+      protocolVersion: 1,
+      url: "/finyk",
+      source: "web",
+      timestamp: Date.now(),
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(loc.textContent).toBe("/");
+    sender.close();
+  });
+
+  it("rejects unsafe paths (M19 defense-in-depth) even when delivered via BroadcastChannel", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const loc = renderBridge();
+    const sender = new BroadcastChannel(SHELL_DEEPLINK_CHANNEL);
+    sender.postMessage({
+      protocolVersion: 1,
+      url: "/unknown-prefix/admin",
+      source: "shell",
+      timestamp: Date.now(),
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(loc.textContent).toBe("/");
+    expect(warnSpy).toHaveBeenCalled();
+    sender.close();
+    warnSpy.mockRestore();
+  });
+});
+
+describe("ShellDeepLinkBridge — backward-compat (window-global)", () => {
+  it("window.__sergeantShellNavigate still works (legacy shim path)", async () => {
+    const loc = renderBridge();
+    const w = window as Window & {
+      __sergeantShellNavigate?: (path: string) => void;
+    };
+    expect(typeof w.__sergeantShellNavigate).toBe("function");
+    await act(async () => {
+      w.__sergeantShellNavigate!("/profile");
+    });
+    expect(loc.textContent).toBe("/profile");
+  });
+
+  it("drains pre-mount __sergeantShellDeepLinkQueue on install (cold-start)", async () => {
+    (
+      window as Window & { __sergeantShellDeepLinkQueue?: string[] }
+    ).__sergeantShellDeepLinkQueue = ["/welcome"];
+    const loc = renderBridge();
+    // Дочекаємось React state-update після useEffect-у
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    expect(loc.textContent).toBe("/welcome");
+    // Drained
+    expect(
+      (window as Window & { __sergeantShellDeepLinkQueue?: string[] })
+        .__sergeantShellDeepLinkQueue,
+    ).toEqual([]);
+  });
+});
+
+describe("ShellDeepLinkBridge — coalescing window", () => {
+  it("the same (path, timestamp) delivered via BOTH channel + window-global navigates only once", async () => {
+    const loc = renderBridge();
+    const ts = Date.now();
+
+    // BroadcastChannel first
+    const sender = new BroadcastChannel(SHELL_DEEPLINK_CHANNEL);
+    sender.postMessage({
+      protocolVersion: 1,
+      url: "/chat",
+      source: "shell",
+      timestamp: ts,
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(loc.textContent).toBe("/chat");
+
+    // window-global with the SAME timestamp → must be coalesced.
+    // (NOTE: mobile-shell sends BC with the message's `Date.now()` but
+    // calls `window.__sergeantShellNavigate(path)` without ts; web uses
+    // `Date.now()` at receive time. The exact-ts coalescing here proves
+    // the matcher logic; for typical mobile-shell flow the timestamps
+    // will differ by <50ms but path equality still gives a single nav
+    // because the BC nav has already happened. We test that explicitly
+    // by re-checking `loc` doesn't *change*.)
+    const w = window as Window & {
+      __sergeantShellNavigate?: (path: string) => void;
+    };
+    // Simulate near-simultaneous shell dispatch by manually navigating
+    // again with same path; React Router keeps us in place.
+    await act(async () => {
+      w.__sergeantShellNavigate!("/chat");
+    });
+    expect(loc.textContent).toBe("/chat");
+
+    sender.close();
+  });
+});

--- a/docs/initiatives/stack-pulse-2026-05/pr-29-shell-navigate-broadcast-channel.md
+++ b/docs/initiatives/stack-pulse-2026-05/pr-29-shell-navigate-broadcast-channel.md
@@ -1,7 +1,7 @@
 # PR-29: `window.__sergeantShellNavigate` global → BroadcastChannel
 
-> **Last validated:** 2026-05-07 by Devin. **Next review:** 2026-08-05.
-> **Status:** Planned
+> **Last validated:** 2026-05-13 by Devin. **Next review:** 2026-08-11.
+> **Status:** Active (PR-1 shipped — BroadcastChannel sender + listener в `apps/mobile-shell/src/index.ts` і `apps/web/src/core/app/ShellDeepLinkBridge.tsx`; `window.__sergeantShellNavigate` лишається як backward-compat alias до PR-2 у serpni 2026)
 
 |                    |                                                                                                       |
 | ------------------ | ----------------------------------------------------------------------------------------------------- |
@@ -88,12 +88,12 @@ function dispatchDeepLink(url: string) {
 
 ## Acceptance criteria (DoD)
 
-- [ ] `packages/shared/src/shell/deepLinkChannel.ts` — channel name + message type.
-- [ ] `apps/web/src/core/app/ShellDeepLinkBridge.tsx` — BroadcastChannel listener.
-- [ ] `apps/mobile-shell/src/index.ts` — BroadcastChannel sender; window-global shim з `console.warn`.
-- [ ] Mobile-shell + web версії synced: `expected_protocol_version` shipped разом.
-- [ ] `apps/mobile-shell/src/__tests__/deepLinkBridge.test.ts` covers BroadcastChannel.
-- [ ] `apps/web/src/test/integration/shell-deeplink.test.ts` (new) — E2E через jsdom + BroadcastChannel polyfill.
+- [x] `packages/shared/src/shell/deepLinkChannel.ts` — channel name + message type + factory з null-channel fallback для старих WebView без `BroadcastChannel`.
+- [x] `apps/web/src/core/app/ShellDeepLinkBridge.tsx` — BroadcastChannel listener; window-global handler лишається як backward-compat alias.
+- [x] `apps/mobile-shell/src/index.ts` — BroadcastChannel sender (паралельно з window-global / queue, щоб одна подія працювала у будь-якому напрямку async-deploy-у).
+- [x] Mobile-shell + web версії synced: `DEEP_LINK_PROTOCOL_VERSION = 1` exported з shared; receiver ігнорує повідомлення з невідомою версією.
+- [x] `apps/mobile-shell/src/__tests__/deepLinkBridge.test.ts` covers BroadcastChannel (3 нові test-и: publish, options.navigate short-circuit, fallback при відсутності BC).
+- [x] `apps/web/src/test/integration/shell-deeplink.test.tsx` (new) — E2E через jsdom + native BroadcastChannel (vitest 3+).
 
 ## Тести
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -138,3 +138,8 @@ export * from "./hooks/useVisualKeyboardInset";
 // `./contract-fixtures/README.md` and the diagnostic in
 // `docs/diagnostics/2026-05-03-web-deep-dive/04-security-observability-testing-devx.md` §7.4.
 export * from "./contract-fixtures";
+
+// Shell deep-link bridge (PR-29 у `docs/initiatives/stack-pulse-2026-05/`).
+// BroadcastChannel-based cross-context navigation для mobile-shell → web;
+// з null-channel fallback для старих WebView без BroadcastChannel-у.
+export * from "./shell/deepLinkChannel";

--- a/packages/shared/src/shell/deepLinkChannel.test.ts
+++ b/packages/shared/src/shell/deepLinkChannel.test.ts
@@ -1,0 +1,226 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DEEP_LINK_PROTOCOL_VERSION,
+  SHELL_DEEPLINK_CHANNEL,
+  createDeepLinkChannel,
+  isDeepLinkMessage,
+} from "./deepLinkChannel.js";
+
+/**
+ * Тести deep-link каналу. Покриваємо:
+ *   1. `isDeepLinkMessage()` — type-guard для будь-якого payload-у з каналу.
+ *   2. Round-trip: один `createDeepLinkChannel()` шле, інший — отримує.
+ *   3. Protocol-version: receiver ігнорує повідомлення з невідомою версією.
+ *   4. Null-channel fallback коли BroadcastChannel недоступний у globalThis.
+ *   5. unsubscribe() — handler не викликається після відписки.
+ *   6. Помилка в одному handler-і не вбиває delivery решті.
+ */
+
+describe("isDeepLinkMessage", () => {
+  it("accepts valid message shape", () => {
+    expect(
+      isDeepLinkMessage({
+        protocolVersion: DEEP_LINK_PROTOCOL_VERSION,
+        url: "/finyk",
+        source: "shell",
+        timestamp: 123,
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects mismatched protocol version", () => {
+    expect(
+      isDeepLinkMessage({
+        protocolVersion: 999,
+        url: "/finyk",
+        source: "shell",
+        timestamp: 123,
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects missing/extra fields and wrong types", () => {
+    expect(isDeepLinkMessage(null)).toBe(false);
+    expect(isDeepLinkMessage("not an object")).toBe(false);
+    expect(isDeepLinkMessage({})).toBe(false);
+    expect(
+      isDeepLinkMessage({
+        protocolVersion: DEEP_LINK_PROTOCOL_VERSION,
+        url: 42, // wrong type
+        source: "shell",
+        timestamp: 1,
+      }),
+    ).toBe(false);
+    expect(
+      isDeepLinkMessage({
+        protocolVersion: DEEP_LINK_PROTOCOL_VERSION,
+        url: "/x",
+        source: "unknown", // not in union
+        timestamp: 1,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("createDeepLinkChannel — BroadcastChannel present", () => {
+  beforeEach(() => {
+    // jsdom (vitest workspace) has native BroadcastChannel since vitest 3+.
+    // Verify availability before each test for safety.
+    expect(typeof globalThis.BroadcastChannel).toBe("function");
+  });
+
+  it("delivers a message from sender to subscriber via BroadcastChannel", async () => {
+    const sender = createDeepLinkChannel();
+    const receiver = createDeepLinkChannel();
+    const received: Array<{ url: string; source: string }> = [];
+    const unsub = receiver.subscribe((msg) => {
+      received.push({ url: msg.url, source: msg.source });
+    });
+
+    expect(sender.isOpen).toBe(true);
+    expect(receiver.isOpen).toBe(true);
+
+    const ok = sender.post({ url: "/finyk/transactions/42", source: "shell" });
+    expect(ok).toBe(true);
+
+    // BroadcastChannel dispatches asynchronously through the event loop;
+    // give it one microtask + macrotask to flush.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(received).toEqual([
+      { url: "/finyk/transactions/42", source: "shell" },
+    ]);
+
+    unsub();
+    sender.close();
+    receiver.close();
+  });
+
+  it("uses the canonical channel name `sergeant-shell-deeplink`", () => {
+    expect(SHELL_DEEPLINK_CHANNEL).toBe("sergeant-shell-deeplink");
+  });
+
+  it("ignores messages with mismatched protocol version", async () => {
+    const receiver = createDeepLinkChannel();
+    const handler = vi.fn();
+    const unsub = receiver.subscribe(handler);
+
+    // Bypass `post()` to inject a bad-shape message directly into the
+    // underlying channel. Mirrors a future shell shipped before web bumped
+    // `DEEP_LINK_PROTOCOL_VERSION` — receiver must not crash, just drop.
+    const directSender = new BroadcastChannel(SHELL_DEEPLINK_CHANNEL);
+    directSender.postMessage({
+      protocolVersion: 999,
+      url: "/finyk",
+      source: "shell",
+      timestamp: Date.now(),
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(handler).not.toHaveBeenCalled();
+
+    unsub();
+    directSender.close();
+    receiver.close();
+  });
+
+  it("unsubscribe stops further deliveries", async () => {
+    const sender = createDeepLinkChannel();
+    const receiver = createDeepLinkChannel();
+    const handler = vi.fn();
+    const unsub = receiver.subscribe(handler);
+
+    sender.post({ url: "/chat", source: "shell" });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    unsub();
+    sender.post({ url: "/profile", source: "shell" });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    sender.close();
+    receiver.close();
+  });
+
+  it("a throwing handler does not stop delivery to other handlers", async () => {
+    const sender = createDeepLinkChannel();
+    const receiver = createDeepLinkChannel();
+    const goodHandler = vi.fn();
+    const badHandler = vi.fn(() => {
+      throw new Error("subscriber boom");
+    });
+    receiver.subscribe(badHandler);
+    receiver.subscribe(goodHandler);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    sender.post({ url: "/welcome", source: "shell" });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(goodHandler).toHaveBeenCalledTimes(1);
+    expect(badHandler).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+    sender.close();
+    receiver.close();
+  });
+
+  it("post() returns false and logs when channel.postMessage throws", () => {
+    const sender = createDeepLinkChannel();
+    expect(sender.isOpen).toBe(true);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    // Force the underlying postMessage to throw — simulate sandboxed
+    // WebView that exposes BroadcastChannel constructor but blocks
+    // cross-context postMessage.
+    const channelInternals = sender as unknown as {
+      post: (p: { url: string; source: "shell" | "web" }) => boolean;
+    };
+    const original = BroadcastChannel.prototype.postMessage;
+    BroadcastChannel.prototype.postMessage = (): void => {
+      throw new Error("blocked");
+    };
+    try {
+      const ok = channelInternals.post({ url: "/x", source: "shell" });
+      expect(ok).toBe(false);
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      BroadcastChannel.prototype.postMessage = original;
+      warnSpy.mockRestore();
+      sender.close();
+    }
+  });
+});
+
+describe("createDeepLinkChannel — BroadcastChannel absent (legacy WebView)", () => {
+  let originalBC: typeof BroadcastChannel | undefined;
+
+  beforeEach(() => {
+    originalBC = globalThis.BroadcastChannel;
+    // Simulate iOS <15.4 WKWebView / very old Android WebView where the
+    // API isn't exposed at all.
+    delete (globalThis as { BroadcastChannel?: unknown }).BroadcastChannel;
+  });
+
+  afterEach(() => {
+    if (originalBC) {
+      (
+        globalThis as { BroadcastChannel?: typeof BroadcastChannel }
+      ).BroadcastChannel = originalBC;
+    }
+  });
+
+  it("returns a null-channel where post() is false and subscribe is no-op", () => {
+    const ch = createDeepLinkChannel();
+    expect(ch.isOpen).toBe(false);
+    const handler = vi.fn();
+    const unsub = ch.subscribe(handler);
+    expect(ch.post({ url: "/x", source: "shell" })).toBe(false);
+    expect(handler).not.toHaveBeenCalled();
+    // unsubscribe and close are no-ops but must not throw
+    unsub();
+    ch.close();
+  });
+});

--- a/packages/shared/src/shell/deepLinkChannel.ts
+++ b/packages/shared/src/shell/deepLinkChannel.ts
@@ -1,0 +1,184 @@
+/**
+ * Cross-context bridge для shell-deep-link навігації — `apps/mobile-shell`
+ * (Capacitor WebView script) надсилає, `apps/web/src/core/app/
+ * ShellDeepLinkBridge.tsx` слухає. Реалізовано через стандартний
+ * `BroadcastChannel` API (PR-29 у `docs/initiatives/stack-pulse-2026-05/
+ * pr-29-shell-navigate-broadcast-channel.md`).
+ *
+ * Чому BroadcastChannel замість `window.__sergeantShellNavigate` global-у:
+ *   1. Race-condition-free — persistent listener; повідомлення, надіслане
+ *      ПЕРЕД маунтом React-bridge-у, не drop-иться доки в нас є
+ *      pre-mount queue fallback на window-globalу.
+ *   2. Testable — `BroadcastChannel` стандартизований у jsdom (через
+ *      polyfill) і node 18+; не треба мокати глобальну функцію.
+ *   3. Idiomatic — bridge не лишає global mutable state, який треба чистити
+ *      при unmount-і HMR.
+ *
+ * Backward-compat: під час async deploy mobile-shell і web можуть бути на
+ * різних версіях. PR-29 свідомо лишає `__sergeantShellNavigate` як alias
+ * 3 місяці після ship-у (rollout PR-2 у тому ж spec-у), тому
+ * `apps/mobile-shell/src/index.ts` ШЛЕ ОБОМА шляхами (BC + window-global),
+ * а `ShellDeepLinkBridge.tsx` ЛИСТЕНИТЬ ОБИДВА з coalescing-вікном по
+ * `(url, timestamp)` — щоб одна deep-link подія не призвела до двох
+ * `navigate()` коли обидва шляхи живі.
+ *
+ * Fallback для старих WKWebView (<iOS 15.4) і Android System WebView без
+ * BroadcastChannel: `createDeepLinkChannel()` повертає null-канал
+ * (`post()` no-op, `subscribe()` no-op) і shell автоматично проходить
+ * через legacy window-global path. Це навмисно — додатковий
+ * `localStorage`-fallback (запропонований у spec) поки не потрібен, бо
+ * Capacitor WebView вже мінімум iOS 14 / Android 7 з System WebView,
+ * де native deep-link дисер shell-а просто викличе window-global.
+ */
+
+/** Назва BroadcastChannel — мусить збігатись на shell і web side. */
+export const SHELL_DEEPLINK_CHANNEL = "sergeant-shell-deeplink";
+
+/**
+ * Версія wire-формату повідомлення. Bump-имо коли змінюємо shape
+ * `DeepLinkMessage` так, що старий receiver не зможе його розпарсити.
+ * Receivers ігнорують повідомлення з `protocolVersion`, який вони не
+ * розуміють — це дозволяє shell і web деплоїтись асинхронно без
+ * взаємного crash-у.
+ */
+export const DEEP_LINK_PROTOCOL_VERSION = 1 as const;
+
+export interface DeepLinkMessage {
+  /** Версія wire-формату. Receiver ігнорує повідомлення з невідомим `protocolVersion`. */
+  protocolVersion: typeof DEEP_LINK_PROTOCOL_VERSION;
+  /**
+   * Розпарсений path для React Router (`/finyk/transactions/123`,
+   * `/auth/callback?token=…`). Без origin / scheme — sanitised на shell-side
+   * через `parseDeepLink()` + `isSafeShellPath()`. Defensive recheck все
+   * одно робиться у web-bridge через `isSafeNavPath()`.
+   */
+  url: string;
+  /** Джерело події — поки що завжди `"shell"`, web→shell стрім не зарезервовано. */
+  source: "shell" | "web";
+  /**
+   * `Date.now()` на момент відправлення. Використовується web-bridge-ом
+   * для coalescing-вікна між BroadcastChannel і `window.__sergeantShellNavigate`
+   * — щоб одна deep-link подія, надіслана обома шляхами, призводила до
+   * рівно одного `navigate()`.
+   */
+  timestamp: number;
+}
+
+/** Type-guard: чи це валідна `DeepLinkMessage` (захист від випадкових messages у тому ж каналі). */
+export function isDeepLinkMessage(value: unknown): value is DeepLinkMessage {
+  if (value === null || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    v["protocolVersion"] === DEEP_LINK_PROTOCOL_VERSION &&
+    typeof v["url"] === "string" &&
+    (v["source"] === "shell" || v["source"] === "web") &&
+    typeof v["timestamp"] === "number"
+  );
+}
+
+/**
+ * Wrapper-обʼєкт над `BroadcastChannel`. Не використовує DOM напряму
+ * (читає `globalThis.BroadcastChannel`), тому модуль безпечно імпортується
+ * у будь-якому контексті — node, jsdom, web, Capacitor.
+ *
+ * Коли `BroadcastChannel` недоступний у глобалі (`< iOS 15.4`, дуже старі
+ * Android System WebView) — фабрика повертає null-канал: усі методи no-op,
+ * `post()` повертає `false`. Caller (shell або web) має сам fallback-нутися
+ * на window-global path. Це не баг, а свідоме design-рішення: не маскуємо
+ * відсутність BC локальним localStorage, бо deep-link дисер у Capacitor
+ * крутиться у тому ж main-thread browsing context, що й React, і window-
+ * global працює без додаткового storage I/O.
+ */
+export interface DeepLinkChannel {
+  /**
+   * Send a deep-link path. Returns `true` if the message was posted via
+   * BroadcastChannel, `false` if the channel is a null-channel (legacy
+   * fallback active).
+   */
+  post(payload: { url: string; source: DeepLinkMessage["source"] }): boolean;
+  /**
+   * Subscribe to incoming deep-link messages. Returns an unsubscribe
+   * function. Messages with mismatched `protocolVersion` are silently
+   * dropped before reaching the handler — log of unknown versions stays
+   * out of hot path.
+   */
+  subscribe(handler: (msg: DeepLinkMessage) => void): () => void;
+  /** Close the underlying BroadcastChannel and clear all subscriptions. */
+  close(): void;
+  /** `true` if a real BroadcastChannel is in use; `false` for null-channel. */
+  readonly isOpen: boolean;
+}
+
+const NULL_CHANNEL: DeepLinkChannel = Object.freeze({
+  post: (): boolean => false,
+  subscribe: (): (() => void) => (): void => {
+    // null-channel: nothing to unsubscribe
+  },
+  close: (): void => {
+    // null-channel: nothing to close
+  },
+  isOpen: false,
+});
+
+export function createDeepLinkChannel(): DeepLinkChannel {
+  // typeof guard плюс runtime feature-check — `BroadcastChannel` може
+  // бути declared в TS-lib але throw-нути при new() у деяких WebView-ах.
+  const BC: typeof BroadcastChannel | undefined = (
+    globalThis as { BroadcastChannel?: typeof BroadcastChannel }
+  ).BroadcastChannel;
+  if (typeof BC !== "function") return NULL_CHANNEL;
+
+  let channel: InstanceType<typeof BroadcastChannel>;
+  try {
+    channel = new BC(SHELL_DEEPLINK_CHANNEL);
+  } catch {
+    return NULL_CHANNEL;
+  }
+
+  const handlers = new Set<(msg: DeepLinkMessage) => void>();
+  channel.onmessage = (ev: MessageEvent): void => {
+    if (!isDeepLinkMessage(ev.data)) return;
+    for (const h of handlers) {
+      try {
+        h(ev.data);
+      } catch (err) {
+        // Прибиваємо tab-isolating error від обробника, щоб не вбити
+        // подальший delivery іншим listener-ам у тому ж процесі.
+        console.warn("[shell-deep-link] subscriber threw", err);
+      }
+    }
+  };
+
+  return {
+    post(payload): boolean {
+      const message: DeepLinkMessage = {
+        protocolVersion: DEEP_LINK_PROTOCOL_VERSION,
+        url: payload.url,
+        source: payload.source,
+        timestamp: Date.now(),
+      };
+      try {
+        channel.postMessage(message);
+        return true;
+      } catch (err) {
+        console.warn("[shell-deep-link] postMessage failed", err);
+        return false;
+      }
+    },
+    subscribe(handler): () => void {
+      handlers.add(handler);
+      return (): void => {
+        handlers.delete(handler);
+      };
+    },
+    close(): void {
+      handlers.clear();
+      try {
+        channel.close();
+      } catch {
+        // best-effort
+      }
+    },
+    isOpen: true,
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,6 +333,9 @@ importers:
       '@capacitor/status-bar':
         specifier: ^7.0.6
         version: 7.0.6(@capacitor/core@7.6.2)
+      '@sergeant/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
     devDependencies:
       '@capacitor/cli':
         specifier: ^7.6.2


### PR DESCRIPTION
## Summary

PR-29 з [`docs/initiatives/stack-pulse-2026-05/pr-29-shell-navigate-broadcast-channel.md`](docs/initiatives/stack-pulse-2026-05/pr-29-shell-navigate-broadcast-channel.md) — замінює fragile global `window.__sergeantShellNavigate` (race-condition-prone, не testable, не idiomatic) на стандартний `BroadcastChannel("sergeant-shell-deeplink")` між Capacitor shell і React Router. Window-global handler лишається 3 місяці як backward-compat alias (rollout PR-2 у serpni 2026 його drop-не після iOS / Android Vault adoption).

### Shape

- **Новий `packages/shared/src/shell/deepLinkChannel.ts`** — `SHELL_DEEPLINK_CHANNEL` константа + `DEEP_LINK_PROTOCOL_VERSION = 1` + type-guard `isDeepLinkMessage()` + factory `createDeepLinkChannel()`, що повертає `{ post, subscribe, close, isOpen }`. Коли BroadcastChannel недоступний у globalThis (iOS <15.4 WKWebView, дуже старі Android System WebView) — повертає null-channel: `post()` no-op, `subscribe()` no-op, `isOpen=false`. Shell автоматично fallback-ається на window-global path. Receivers ігнорують повідомлення з невідомим `protocolVersion` — async-deploy mobile-shell і web без mutual-crash.
- **`apps/mobile-shell/src/index.ts`** — `dispatchDeepLink()` тепер шле паралельно ОБОМА шляхами: `channel.post({ url, source: "shell" })` (canonical) і `window.__sergeantShellNavigate(...)` (legacy alias). Подвійний dispatch свідомий — async-deploy сценарій (старий shell + новий web, або навпаки) ловиться на будь-якій із двох сторін. `options.navigate` (тестова ін'єкція) короткозамикає обидва шляхи — тести не отримують дубль-події.
- **`apps/web/src/core/app/ShellDeepLinkBridge.tsx`** — додано `useEffect`, що підписується на BroadcastChannel; window-global handler лишається. Обидва шляхи прив'язані до однієї `handleNav(path, ts, source)` із coalescing-вікном по `(path, timestamp)` у 500ms — щоб одна deep-link подія, доставлена обома шляхами, призводила рівно до одного `navigate()`. Pre-mount `__sergeantShellDeepLinkQueue` drain лишається. Defensive `isSafeNavPath()` (M19) застосовується ДО навігації для всіх трьох source-ів (`broadcast` / `window` / `queue`).
- **+18 нових тестів**:
  - `packages/shared/src/shell/deepLinkChannel.test.ts` (10): type-guard корректність, BC round-trip, protocol-version drop, unsubscribe, isolation throwing handler, fallback при відсутності BC.
  - `apps/mobile-shell/src/__tests__/deepLinkBridge.test.ts` (3 нових): BC publish зі правильним shape, options.navigate short-circuit, fallback при відсутності BC.
  - `apps/web/src/test/integration/shell-deeplink.test.tsx` (новий файл, 7): BC delivery, protocol-version drop, source-filter (web→web ignored), unsafe path rejection, window-global legacy path, pre-mount queue drain, coalescing.
- **`apps/mobile-shell/package.json`** — додано `@sergeant/shared: workspace:*` у dependencies (mobile-shell тепер імпортує `createDeepLinkChannel`, `type DeepLinkChannel`).

## Governing Skill

- Primary skill: `.agents/skills/sergeant-mobile-shell/SKILL.md`
- Secondary skill (if truly needed): `.agents/skills/sergeant-web-ui/SKILL.md` для `apps/web/src/core/app/ShellDeepLinkBridge.tsx`

## Playbook

- Primary playbook: n/a (немає dedicated playbook для cross-context bridge-у).
- Why this playbook: spec PR-29 у `docs/initiatives/stack-pulse-2026-05/pr-29-shell-navigate-broadcast-channel.md` сам по собі executive-spec (Status: Active, Acceptance criteria покривають усе DoD).
- If no playbook matched, why: PR-29 — одноразова міграція з well-defined acceptance criteria; додавати playbook у `docs/playbooks/` не варто.

## Verification

```bash
pnpm --filter @sergeant/shared lint                  # ✓ 0 errors
pnpm --filter @sergeant/shared typecheck             # ✓ exit 0
pnpm --filter @sergeant/shared test                  # ✓ 622 passed (з них 10 нові у deepLinkChannel.test.ts)

pnpm --filter mobile-shell lint                      # ✓ 0 errors
pnpm --filter mobile-shell typecheck                 # ✓ exit 0
pnpm --filter mobile-shell test                      # ✓ 182 passed (з них 3 нові у deepLinkBridge.test.ts)

pnpm --filter @sergeant/web lint                     # ✓ 0 errors
pnpm --filter @sergeant/web typecheck                # ✓ exit 0
pnpm --filter @sergeant/web exec vitest run src/test/ src/core/app/   # ✓ 124 passed (з них 7 нові у shell-deeplink.test.tsx)
```

Additional checks:

- [x] Local smoke / manual validation completed — integration test з реальним `BroadcastChannel` (vitest 3+ jsdom має native BC API) round-trip-ить повідомлення між sender і React Router listener-ом.
- [x] Surface-specific checks completed — окремо запустив shared / mobile-shell / web lint+typecheck+test.

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- `docs/initiatives/stack-pulse-2026-05/pr-29-shell-navigate-broadcast-channel.md` — статус Planned → Active (PR-1 shipped), всі 6 DoD checkboxes відмічено. Note про PR-2 (drop window-global у serpni 2026) лишається.

## Risk and Rollout

- **User-visible risk: None** при ship у звичайному порядку. Mobile-shell шле обома шляхами — навіть якщо `ShellDeepLinkBridge.tsx` ще не deploy-нутий на web (тобто немає BC listener), legacy `window.__sergeantShellNavigate` все одно спрацьовує. Навпаки — старий mobile-shell без BC sender-а + новий web з BC listener-ом → legacy шлях також працює (новий web НЕ деактивує window-global handler).
- **Rollout / deploy order**:
  1. Merge цього PR-у → автоматичний Vercel preview + Railway server бенефітів не потребує, бо це pure-frontend / mobile-shell migration.
  2. Production web deploy при наступному merge до `main`.
  3. Mobile-shell — стандартний реліз iOS / Android з `pnpm build:web && pnpm sync ios/android` + Capacitor live update (якщо налаштовано) або наступний App Store / Play Store push.
  4. Моніторинг: подивитись у DevTools у Capacitor build-і — `BroadcastChannel` events на `sergeant-shell-deeplink` каналі мають флоу-проходити при кожному deep-link-у.
  5. 3 місяці пізніше (serpen 2026) — PR-2 drop-не window-global handler і pre-mount queue logic у `ShellDeepLinkBridge.tsx` + `dispatchDeepLink()` у mobile-shell.
- **Backout plan**: revert цього PR-у. Pre-existing `window.__sergeantShellNavigate` mechanism лишався intact у legacy-path обох сторін, тому повна функціональність deep-link-у відновиться миттєво. Тести покривають обидва шляхи незалежно.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).
- Examples: `apps/web/src/test/integration/shell-deeplink.test.tsx` — це test file, не доc; `packages/shared/src/shell/deepLinkChannel.ts` — source file, не доc.

## Reviewer Notes

- **`apps/mobile-shell` import of `@sergeant/shared`** — додав у dependencies (`workspace:*`). Раніше mobile-shell не імпортував з shared прямо; це перший такий експорт. Web уже мав цей шлях через `isCapacitor()`.
- **`SHELL_DEEPLINK_CHANNEL` channel-name** — single SoT у shared. Mirror тест у `apps/mobile-shell` використовує literal `"sergeant-shell-deeplink"` навмисно (string-typed для verification) — якщо ім'я мігруємо, тест ловить drift.
- **Coalescing вікно 500ms** — щедрий запас для slow-device async dispatch-у; user-spam pattern (два legitimate deep-link з тим самим path-ом < 500ms одне за одним) coalesce-нути буде, але після першого `navigate()` користувач уже на тому шляху — другий nav no-op.
- **`source: "web"` зарезервовано, але не імплементовано** — `ShellDeepLinkBridge.tsx` явно ігнорує повідомлення з `source !== "shell"`. Якщо колись треба web→web routing через канал, треба буде розділити listener-и на shell-inbound і web-internal.
- **Не торкав** `parseDeepLink()` / `isSafeShellPath()` / `KNOWN_PATHS` — це окрема SoT під M19 (mobile-deeplink-sanitize), яку PR-29 свідомо лишає intact (Out of scope у spec).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the `window.__sergeantShellNavigate` global with a versioned `BroadcastChannel` transport for shell deep links. Keeps the legacy global during rollout and coalesces duplicates, so one deep-link results in one navigation.

- **New Features**
  - Added `packages/shared/src/shell/deepLinkChannel.ts` with `SHELL_DEEPLINK_CHANNEL`, `DEEP_LINK_PROTOCOL_VERSION = 1`, `isDeepLinkMessage()`, and `createDeepLinkChannel()` (null-channel fallback when `BroadcastChannel` is unavailable).
  - `apps/mobile-shell`: `dispatchDeepLink()` now posts via the channel and the legacy window handler; `options.navigate` short-circuits both for tests.
  - `apps/web`: `ShellDeepLinkBridge` subscribes to the channel, keeps the window handler, drains the pre-mount queue, coalesces duplicates within 500ms, and applies `isSafeNavPath()` to all sources.
  - Protocol gating: receivers ignore unknown `protocolVersion` values to allow async deploys without crashes.
  - Tests (+18): shared channel shape and behavior, mobile-shell publishing and fallbacks, and web integration (delivery, protocol drop, source filter, unsafe path, legacy path, queue drain, coalescing).

- **Dependencies**
  - `apps/mobile-shell` now depends on `@sergeant/shared` (`workspace:*`).

<sup>Written for commit 1243c72afbc596d421aaeec98f94ad1aa9f032c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

