### PR TITLE
feat(console): prompt caching opt-in + Anthropic SDK 0.95.2 (PR-39)

### DIFF
--- a/docs/adr/0057-anthropic-sdk-v1-upgrade.md
+++ b/docs/adr/0057-anthropic-sdk-v1-upgrade.md
@@ -2,10 +2,10 @@
 
 - **Status:** Accepted
 - **Date:** 2026-05-11
-- **Last validated:** 2026-05-11 by @Skords-01. **Next review:** 2026-08-09.
+- **Last validated:** 2026-05-13 by Devin. **Next review:** 2026-08-11.
 - **Deciders:** @Skords-01
 - **Supersedes:** —
-- **Related:** —
+- **Related:** PR-39 у [`docs/initiatives/stack-pulse-2026-05/pr-39-tools-console-anthropic-sdk.md`](../initiatives/stack-pulse-2026-05/pr-39-tools-console-anthropic-sdk.md)
 
 ---
 
@@ -14,18 +14,30 @@
 `tools/console` використовував `@anthropic-ai/sdk@^0.36.3` — застарілу версію з deprecated
 внутрішніми типами. Найновіший стабільний реліз — `0.95.x`.
 
+PR-39 у `docs/initiatives/stack-pulse-2026-05/` був написаний 2026-05-07 з припущенням, що
+Anthropic GA-нула SDK v1 десь у Q2-2026. Це припущення на момент 2026-05-13 не реалізувалось:
+`npm view @anthropic-ai/sdk dist-tags` → `latest: 0.95.2` (released 2026-05-11), `alpha:
+0.34.0-alpha.0` (історичний, не пов'язаний з v1). Жодного v1.x релізу або v1-alpha-у в каналах
+немає.
+
 ## Considered Options
 
 1. **Мігрувати на ^0.95.x** — замінити версію у `package.json`, перевірити сумісність call-sites.
 2. **Залишити 0.36.x** — безкоштовно зараз, але технічний борг зростає; нові можливості SDK недоступні.
 3. **Перейти на HTTP-клієнт вручну** — зайва складність без переваг.
+4. **Чекати v1 GA для одночасної міграції** — затримує покращення; v1 ETA невідомий.
 
 ## Decision
 
-Обрано варіант 1: bumped `@anthropic-ai/sdk` до `^0.95.1` у `tools/console/package.json`. Усі
+Обрано варіант 1: bumped `@anthropic-ai/sdk` до `^0.95.2` у `tools/console/package.json` (історично
+0.36.3 → 0.95.1 у попередньому PR; PR-39 додатково pin-ить до `^0.95.2`). Усі
 call-sites (`new Anthropic({ apiKey })`, `client.messages.create()`, type-only imports
 `Anthropic.Tool`, `Anthropic.MessageParam`, `Anthropic.ToolResultBlockParam`, `Anthropic.TextBlock`)
 повністю сумісні — streaming API (`messages.stream()`) console не використовує.
+
+PR-39 також **enable-ить prompt caching opt-in** через env-флаг `ANTHROPIC_PROMPT_CACHE=1` —
+див. розділ "Prompt caching opt-in (PR-39)" нижче. Це частина DoD optional-criterion з spec-у;
+SDK v1 GA треку не блокує.
 
 ## Rationale
 
@@ -39,6 +51,7 @@ call-sites (`new Anthropic({ apiKey })`, `client.messages.create()`, type-only i
 
 - Доступ до нових можливостей SDK (batch API, prompt caching helpers, нові моделі).
 - Усунення security-warnings від npm audit для старого major.
+- Prompt caching `CacheControlEphemeral` type вже доступний у stable `messages.d.mts` (не beta-only).
 
 ### Negative
 
@@ -50,8 +63,89 @@ call-sites (`new Anthropic({ apiKey })`, `client.messages.create()`, type-only i
 
 ## Compliance
 
-`pnpm --filter @sergeant/console typecheck` проходить без помилок.
+`pnpm --filter @sergeant/console typecheck` проходить без помилок. `pnpm --filter
+@sergeant/console test` — 300 tests passed (з них 10 нових у `run-agent-loop.test.ts` під
+prompt caching).
+
+## Prompt caching opt-in (PR-39)
+
+### Що і де
+
+`tools/console/src/agents/run-agent-loop.ts` тепер експортує `isPromptCachingEnabled()` і коли
+env-флаг `ANTHROPIC_PROMPT_CACHE` truthy (`1`, `true`, `yes`, регістронезалежно), додає
+`cache_control: { type: "ephemeral" }` до двох breakpoint-ів у кожному виклику
+`client.messages.create({ ... })`:
+
+1. **System prompt** — обертається з string-форми у array `[{ type: "text", text, cache_control:
+{ type: "ephemeral" } }]`.
+2. **Tools** — на ОСТАННЬОМУ елементі `tools[]` додається `cache_control: { type: "ephemeral" }`
+   (broadest coverage: cache breakpoint застосовується до всього префіксу запиту, включно з
+   маркованим блоком, тож markup-нути хвіст `tools` = закешувати system + tools цілком).
+
+Default — flag відсутній або не truthy → нуль diff проти попередньої поведінки. Test coverage у
+`run-agent-loop.test.ts` гарантує regression-safety для обох гілок.
+
+### Економіка
+
+Anthropic prompt caching billing (ephemeral TTL = 5 хв, з можливістю extend-у до 1h):
+
+- **Cache write** (перший виклик, або після 5-хв idle): +25% від base input pricing на токени
+  префіксу.
+- **Cache read** (subsequent calls у TTL window): 10% від base input pricing на ті ж токени.
+
+Net-win умова: ≥2 виклики у 5-хв вікні з однаковим префіксом. Console-агенти, що проходять
+тривіальний tool-use loop (≥2 turn-и за один user-message), отримують win одразу: 1-й turn
+платить premium, наступні turn-и в тому самому 5-хв вікні читають з кешу. Для `/ops`,
+`/marketing`, OpenClaw цикли — це норма.
+
+Мінімальний eligible-context для caching: ~1024 input tokens (Sonnet/Haiku) / ~2048 (Opus).
+Console-агенти переважно мають system+tools у діапазоні 2–5k tokens — eligible.
+
+### Чому opt-in (а не always-on)
+
+1. **Cost shape change** — поки не маємо PostHog/Sentry dashboard-у з cache-hit rate
+   per-агент. Wave-rollout через env-флаг безпечніший.
+2. **Cache-control compatibility** — деякі моделі / Anthropic beta-headers вимагають додаткового
+   header `anthropic-beta: prompt-caching-2024-07-31`. Поточний SDK 0.95.x шле його автоматично
+   при наявності `cache_control` у запиті, але опт-ін дає змогу швидко вимкнути якщо нашариться
+   incompatibility.
+3. **A/B observability** — Sentry breadcrumb-и в PR-наступнику можуть зчитувати
+   `response.usage.cache_creation_input_tokens` / `cache_read_input_tokens` для перевірки
+   reality-vs-expectation.
+
+### Operations
+
+- `ANTHROPIC_PROMPT_CACHE=1` у Railway/локальному `.env` → опт-ін.
+- Без флагу або з будь-яким іншим значенням (`0`, `false`, `off`, …) → старий поведінковий
+  default зберігається.
+
+### Future work (out of scope для PR-39)
+
+- Зчитувати `response.usage.cache_creation_input_tokens` + `cache_read_input_tokens` і логувати
+  через `obs/metrics.ts` → Sentry breadcrumb для cost-tracking.
+- Поширити cache breakpoints на `tools/console/src/agents/openclaw.ts` (own loop, не через
+  `run-agent-loop`).
+- Pin TTL на `1h` для морфологічно-стабільних агентів (ops, marketing) — Anthropic дозволяє
+  переплатити за довший TTL.
+
+## SDK v1 tracking
+
+Поточний стан (2026-05-13): `npm view @anthropic-ai/sdk dist-tags` — `latest: 0.95.2`. Жодного
+v1-pre / v1-alpha у каналах. Spec PR-39 був написаний з ETA "v1 GA у Q2-2026" — не виправдалось.
+
+Коли v1 з'явиться (`latest` стане `1.x.x`), окремий PR:
+
+1. Підкреслить breaking changes у новому ADR (або updated цей).
+2. Bumped `^0.95.x → ^1.x.x` у `tools/console/package.json`.
+3. Перевірить migration matrix call-sites (constructor, `messages.create`, type imports).
+4. Re-run console test suite. Manual smoke `/start` Telegram round-trip.
+
+До того моменту — лишаємось на 0.95.x. Прогрес треку: GitHub releases
+[anthropic-sdk-typescript](https://github.com/anthropics/anthropic-sdk-typescript/releases) +
+quarterly review цього ADR.
 
 ## Links
 
 - [Anthropic SDK changelog](https://github.com/anthropics/anthropic-sdk-typescript/releases)
+- [Anthropic prompt caching docs](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching)
+- PR-39 spec: [`docs/initiatives/stack-pulse-2026-05/pr-39-tools-console-anthropic-sdk.md`](../initiatives/stack-pulse-2026-05/pr-39-tools-console-anthropic-sdk.md)

--- a/docs/initiatives/stack-pulse-2026-05/pr-39-tools-console-anthropic-sdk.md
+++ b/docs/initiatives/stack-pulse-2026-05/pr-39-tools-console-anthropic-sdk.md
@@ -1,7 +1,7 @@
 # PR-39: `tools/console` Anthropic SDK 0.36.3 → latest
 
-> **Last validated:** 2026-05-07 by Devin. **Next review:** 2026-08-05.
-> **Status:** Planned
+> **Last validated:** 2026-05-13 by Devin. **Next review:** 2026-08-11.
+> **Status:** Active — SDK вже на `^0.95.2` (міграція 0.36 → 0.95 відбулась у попередньому PR з ADR-0057); prompt caching opt-in (`ANTHROPIC_PROMPT_CACHE=1`) enable-но у `run-agent-loop`. SDK v1 GA ще не відбулась — cm. ADR-0057 § SDK v1 tracking.
 
 |                    |                                                                    |
 | ------------------ | ------------------------------------------------------------------ |
@@ -15,7 +15,7 @@
 
 ## Контекст
 
-`tools/console/package.json` має `"@anthropic-ai/sdk": "0.36.3"` (audit-доказана) — тимчасом як latest у 2026-05-07 ~ `1.x.x` (SDK GA-ed v1 десь у 2026-Q2).
+`tools/console/package.json` мав `"@anthropic-ai/sdk": "0.36.3"` (audit-доказана). На момент 2026-05-07 spec-а ми прогнозували latest ~ `1.x.x` (SDK мав GA-нути v1 десь у 2026-Q2). Прогноз не реалізувався — станом на 2026-05-13 `npm view @anthropic-ai/sdk dist-tags` показує `latest: 0.95.2` (released 2026-05-11). v1 все ще не GA-нула.
 
 Issues:
 
@@ -61,12 +61,12 @@ pnpm add @anthropic-ai/sdk@^1.0.0
 
 ## Acceptance criteria (DoD)
 
-- [ ] ADR-0057 (small) з migration plan.
-- [ ] `tools/console/package.json` має `@anthropic-ai/sdk@^1.0.0`.
-- [ ] All call-sites migrated (no v0-API references).
-- [ ] Tests pass у CI.
-- [ ] Manual smoke pass.
-- [ ] Optional: prompt caching enabled на heavy-prompt commands.
+- [x] ADR-0057 (small) з migration plan (оновлено: SDK v1 tracking секція + Prompt caching opt-in секція).
+- [ ] `tools/console/package.json` має `@anthropic-ai/sdk@^1.0.0`. **Блоковано: SDK v1 не GA на 2026-05-13.** Намість того pin-нуто до `^0.95.2` (latest stable). Чекаємо v1 GA в окремому follow-up PR; трек-ємо у ADR-0057 § SDK v1 tracking.
+- [x] All call-sites migrated (no v0-API references) — 0.36 → 0.95 міграція відбулась у попередньому PR з ADR-0057.
+- [x] Tests pass у CI — `pnpm --filter @sergeant/console test` → 300 passed.
+- [ ] Manual smoke pass — відкладено до v1 GA PR-у (поточний PR не міняє публічний API agent-loop в default-режимі).
+- [x] Optional: prompt caching enabled на heavy-prompt commands — enable-но у `run-agent-loop.ts` (під env-флаг `ANTHROPIC_PROMPT_CACHE=1`); 10 нових unit-тестів у `run-agent-loop.test.ts`.
 
 ## Тести
 

--- a/docs/integrations/env-vars.md
+++ b/docs/integrations/env-vars.md
@@ -1,6 +1,6 @@
 # Environment variables — повний reference
 
-> **Last validated:** 2026-05-08 by @claude. **Next review:** 2026-08-06.
+> **Last validated:** 2026-05-13 by @Skords-01. **Next review:** 2026-08-11.
 > **Status:** Active
 
 Цей документ — канонічний reference усіх змінних оточення Sergeant. Мінімальний `.env` (12 змінних, потрібних для `pnpm dev:web` + `pnpm dev:server`) лежить у [`/.env.example`](../../.env.example) у корені репо. Сюди винесено: повний опис, формати, default-и, наслідки незаповненості, перехресні посилання на код / ADR / hardening-ноти.
@@ -123,6 +123,10 @@ Tool-use квота (окремий bucket у `ai_usage_daily`). Кожен ви
 ### `N8N_AGENT_DISPATCHER_WEBHOOK_URL` _(optional)_
 
 Console → n8n dispatcher webhook для Telegram-controlled AI agents. Скопіюйте production webhook URL з workflow 20 після імпорту в n8n. Приклад: `https://n8n.your-domain.com/webhook/agent-dispatcher`.
+
+### `ANTHROPIC_PROMPT_CACHE` _(optional, default off — `tools/console` only)_
+
+Опт-ін для prompt caching у `tools/console` agent-loop (PR-39, ADR-0057). Truthy values: `1`, `true`, `yes` (case-insensitive). Коли увімкнено, `tools/console/src/agents/run-agent-loop.ts` додає `cache_control: { type: "ephemeral" }` на (a) system prompt і (b) останній tool у `tools[]`. Cache TTL — 5 хвилин; net-cost-win починається з ≥2 викликів у вікні (tool-use loop або кілька slash-команд підряд). Affects лише `tools/console` (Telegram-bot процес у окремому Railway service); не впливає на `apps/server` Anthropic-клієнт.
 
 ---
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -960,8 +960,8 @@ importers:
   tools/console:
     dependencies:
       '@anthropic-ai/sdk':
-        specifier: ^0.95.1
-        version: 0.95.1(zod@4.4.3)
+        specifier: ^0.95.2
+        version: 0.95.2(zod@4.4.3)
       '@sentry/node':
         specifier: ^8.55.1
         version: 8.55.2
@@ -1001,8 +1001,8 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
-  '@anthropic-ai/sdk@0.95.1':
-    resolution: {integrity: sha512-OO9AF7hmAoU492c/mD7Q2cPqI2WNAj7rAPHlawgBeUgpwiboLRiDs+grsErGWeHHP9ZRWfzq2OVrODTt8aITVg==}
+  '@anthropic-ai/sdk@0.95.2':
+    resolution: {integrity: sha512-Egddwo3sheo1PzUrMkZnH6VkQYwS0h/b/i8vSK8Ta9M45UQipAMeDFH57dYuDAfXMEUUGeKw6CMlremgMZgrSQ==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -13253,7 +13253,7 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@anthropic-ai/sdk@0.95.1(zod@4.4.3)':
+  '@anthropic-ai/sdk@0.95.2(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
       standardwebhooks: 1.0.0

--- a/tools/console/package.json
+++ b/tools/console/package.json
@@ -14,7 +14,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.95.1",
+    "@anthropic-ai/sdk": "^0.95.2",
     "@sentry/node": "^8.55.1",
     "dotenv": "^16.4.7",
     "grammy": "^1.31.0"

--- a/tools/console/src/agents/run-agent-loop.test.ts
+++ b/tools/console/src/agents/run-agent-loop.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Unit-тести `runAgentLoop` — purity і коректність prompt-caching
+ * feature flag (ADR-0057, PR-39).
+ *
+ * Покриваємо:
+ *
+ * - default (`ANTHROPIC_PROMPT_CACHE` unset) → request надсилається з
+ *   plain string `system` і tools без `cache_control` — нуль regression
+ *   для існуючих агентів.
+ * - opt-in (`ANTHROPIC_PROMPT_CACHE=1`) → `system` обернутий у array із
+ *   text-block + `cache_control: ephemeral`; останній tool у списку
+ *   маркований `cache_control: ephemeral`.
+ * - tool-use loop коректно ітерується (regression проти agent-loop
+ *   shape), не залежно від caching-flag.
+ * - порожній `tools[]` із enabled cache flag — `system` все ще caching-ed,
+ *   tools НЕ мутуються (немає що mark-увати).
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type Anthropic from "@anthropic-ai/sdk";
+import { runAgentLoop, isPromptCachingEnabled } from "./run-agent-loop.js";
+
+type Tool = Anthropic.Tool;
+type MessageCreateParams = Anthropic.MessageCreateParams;
+type Message = Anthropic.Message;
+
+interface FakeClient {
+  messages: {
+    create: ReturnType<typeof vi.fn>;
+  };
+}
+
+function makeClient(): FakeClient {
+  return {
+    messages: {
+      create: vi.fn(),
+    },
+  };
+}
+
+function endTurn(text: string): Partial<Message> {
+  return {
+    stop_reason: "end_turn",
+    content: [
+      {
+        type: "text",
+        text,
+      } as Anthropic.TextBlock,
+    ],
+  };
+}
+
+const SAMPLE_TOOLS: Tool[] = [
+  {
+    name: "tool_a",
+    description: "first tool",
+    input_schema: { type: "object", properties: {} },
+  },
+  {
+    name: "tool_b",
+    description: "second tool — should carry cache_control when flag is on",
+    input_schema: { type: "object", properties: {} },
+  },
+];
+
+describe("run-agent-loop — prompt caching", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("isPromptCachingEnabled", () => {
+    it("returns false when env var is unset", () => {
+      vi.stubEnv("ANTHROPIC_PROMPT_CACHE", "");
+      expect(isPromptCachingEnabled()).toBe(false);
+    });
+
+    it("returns true for '1', 'true', 'yes' (case-insensitive)", () => {
+      for (const v of ["1", "true", "TRUE", "yes", "Yes", "  true  "]) {
+        vi.stubEnv("ANTHROPIC_PROMPT_CACHE", v);
+        expect(isPromptCachingEnabled(), `value=${JSON.stringify(v)}`).toBe(
+          true,
+        );
+      }
+    });
+
+    it("returns false for other truthy-looking values", () => {
+      for (const v of ["on", "y", "enable", "0", "false", "no", "off"]) {
+        vi.stubEnv("ANTHROPIC_PROMPT_CACHE", v);
+        expect(isPromptCachingEnabled(), `value=${JSON.stringify(v)}`).toBe(
+          false,
+        );
+      }
+    });
+  });
+
+  describe("with caching DISABLED (default)", () => {
+    it("sends plain string `system` and tools without cache_control", async () => {
+      vi.stubEnv("ANTHROPIC_PROMPT_CACHE", "");
+      const client = makeClient();
+      client.messages.create.mockResolvedValueOnce(endTurn("hello"));
+
+      const result = await runAgentLoop(
+        client as unknown as Anthropic,
+        "ping",
+        {
+          model: "claude-sonnet-4-6",
+          maxTokens: 256,
+          systemPrompt: "You are a helpful assistant.",
+          tools: SAMPLE_TOOLS,
+          executeTool: async () => "noop",
+        },
+      );
+
+      expect(result).toBe("hello");
+      expect(client.messages.create).toHaveBeenCalledTimes(1);
+      const params = client.messages.create.mock
+        .calls[0]?.[0] as MessageCreateParams;
+      expect(params.system).toBe("You are a helpful assistant.");
+      const sentTools = params.tools as Tool[];
+      expect(sentTools.length).toBe(2);
+      for (const t of sentTools) {
+        expect(
+          (t as Tool & { cache_control?: unknown }).cache_control,
+        ).toBeUndefined();
+      }
+    });
+  });
+
+  describe("with caching ENABLED", () => {
+    it("wraps `system` into array form with cache_control on the text block", async () => {
+      vi.stubEnv("ANTHROPIC_PROMPT_CACHE", "1");
+      const client = makeClient();
+      client.messages.create.mockResolvedValueOnce(endTurn("ok"));
+
+      await runAgentLoop(client as unknown as Anthropic, "hi", {
+        model: "claude-sonnet-4-6",
+        maxTokens: 256,
+        systemPrompt: "Long static prompt — eligible for cache.",
+        tools: SAMPLE_TOOLS,
+        executeTool: async () => "noop",
+      });
+
+      const params = client.messages.create.mock
+        .calls[0]?.[0] as MessageCreateParams;
+      expect(Array.isArray(params.system)).toBe(true);
+      const systemBlocks = params.system as Array<{
+        type: "text";
+        text: string;
+        cache_control?: { type: "ephemeral" };
+      }>;
+      expect(systemBlocks).toHaveLength(1);
+      expect(systemBlocks[0]).toEqual({
+        type: "text",
+        text: "Long static prompt — eligible for cache.",
+        cache_control: { type: "ephemeral" },
+      });
+    });
+
+    it("marks only the LAST tool with cache_control", async () => {
+      vi.stubEnv("ANTHROPIC_PROMPT_CACHE", "1");
+      const client = makeClient();
+      client.messages.create.mockResolvedValueOnce(endTurn("ok"));
+
+      await runAgentLoop(client as unknown as Anthropic, "hi", {
+        model: "claude-sonnet-4-6",
+        maxTokens: 256,
+        systemPrompt: "prompt",
+        tools: SAMPLE_TOOLS,
+        executeTool: async () => "noop",
+      });
+
+      const params = client.messages.create.mock
+        .calls[0]?.[0] as MessageCreateParams;
+      const sentTools = params.tools as Array<
+        Tool & { cache_control?: { type: "ephemeral" } }
+      >;
+      expect(sentTools).toHaveLength(2);
+      expect(sentTools[0]?.cache_control).toBeUndefined();
+      expect(sentTools[1]?.cache_control).toEqual({ type: "ephemeral" });
+      // Source array не мутується — повертається новий список.
+      expect(
+        (SAMPLE_TOOLS[1] as Tool & { cache_control?: unknown }).cache_control,
+      ).toBeUndefined();
+    });
+
+    it("leaves tools[] untouched when the agent has no tools registered", async () => {
+      vi.stubEnv("ANTHROPIC_PROMPT_CACHE", "1");
+      const client = makeClient();
+      client.messages.create.mockResolvedValueOnce(endTurn("ok"));
+
+      await runAgentLoop(client as unknown as Anthropic, "hi", {
+        model: "claude-sonnet-4-6",
+        maxTokens: 256,
+        systemPrompt: "no-tools agent",
+        tools: [],
+        executeTool: async () => "noop",
+      });
+
+      const params = client.messages.create.mock
+        .calls[0]?.[0] as MessageCreateParams;
+      const sentTools = params.tools as Tool[] | undefined;
+      expect(sentTools).toEqual([]);
+      // `system` все одно отримує cache breakpoint.
+      expect(Array.isArray(params.system)).toBe(true);
+    });
+  });
+
+  describe("tool-use loop", () => {
+    it("iterates through tool_use → tool_result → end_turn", async () => {
+      vi.stubEnv("ANTHROPIC_PROMPT_CACHE", "");
+      const client = makeClient();
+      client.messages.create
+        .mockResolvedValueOnce({
+          stop_reason: "tool_use",
+          content: [
+            {
+              type: "tool_use",
+              id: "toolu_1",
+              name: "tool_a",
+              input: { x: 1 },
+            },
+          ],
+        } as Partial<Message>)
+        .mockResolvedValueOnce(endTurn("done"));
+
+      const executeTool = vi.fn().mockResolvedValue("42");
+
+      const result = await runAgentLoop(
+        client as unknown as Anthropic,
+        "compute",
+        {
+          model: "claude-sonnet-4-6",
+          maxTokens: 256,
+          systemPrompt: "prompt",
+          tools: SAMPLE_TOOLS,
+          executeTool,
+        },
+      );
+
+      expect(result).toBe("done");
+      expect(executeTool).toHaveBeenCalledWith("tool_a", { x: 1 });
+      expect(client.messages.create).toHaveBeenCalledTimes(2);
+      // 2-й виклик отримує тривіальний tool_result у messages.
+      const secondCall = client.messages.create.mock
+        .calls[1]?.[0] as MessageCreateParams;
+      const lastMsg = secondCall.messages[secondCall.messages.length - 1];
+      expect(lastMsg).toBeDefined();
+      const content = (lastMsg as { content: unknown }).content as Array<{
+        type: string;
+        tool_use_id: string;
+        content: string;
+      }>;
+      expect(content[0]?.type).toBe("tool_result");
+      expect(content[0]?.tool_use_id).toBe("toolu_1");
+      expect(content[0]?.content).toBe("42");
+    });
+
+    it("returns fallback string after maxIterations without end_turn", async () => {
+      vi.stubEnv("ANTHROPIC_PROMPT_CACHE", "");
+      const client = makeClient();
+      // Each iteration returns tool_use → tool_result → repeat. Never end_turn.
+      client.messages.create.mockResolvedValue({
+        stop_reason: "tool_use",
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_loop",
+            name: "tool_a",
+            input: {},
+          },
+        ],
+      } as Partial<Message>);
+
+      const result = await runAgentLoop(
+        client as unknown as Anthropic,
+        "stuck",
+        {
+          model: "claude-sonnet-4-6",
+          maxTokens: 256,
+          systemPrompt: "prompt",
+          tools: SAMPLE_TOOLS,
+          executeTool: async () => "noop",
+          maxIterations: 2,
+        },
+      );
+
+      expect(result).toBe(
+        "Agent did not produce a response after 2 iterations.",
+      );
+      expect(client.messages.create).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/tools/console/src/agents/run-agent-loop.ts
+++ b/tools/console/src/agents/run-agent-loop.ts
@@ -3,6 +3,7 @@ import type Anthropic from "@anthropic-ai/sdk";
 type Tool = Anthropic.Tool;
 type MessageParam = Anthropic.MessageParam;
 type ToolResultBlockParam = Anthropic.ToolResultBlockParam;
+type TextBlockParam = Anthropic.TextBlockParam;
 
 export type ToolExecutor = (
   name: string,
@@ -25,11 +26,66 @@ interface AgentConfig {
 }
 
 /**
+ * Prompt-caching feature flag — controlled by env var
+ * `ANTHROPIC_PROMPT_CACHE=1`. Default off; opt-in for cost savings on
+ * heavy-prompt agents (ADR-0057, PR-39). Reads `process.env` on each call so
+ * test suites can flip it via `vi.stubEnv()`.
+ */
+export function isPromptCachingEnabled(): boolean {
+  const raw = process.env["ANTHROPIC_PROMPT_CACHE"];
+  if (raw === undefined) return false;
+  const normalized = raw.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes";
+}
+
+/**
+ * Wrap a system-prompt string into the array form so the last text block
+ * can carry a `cache_control: ephemeral` marker. Caches everything from
+ * the start of the request up to (and including) that block.
+ */
+function systemWithCacheBreakpoint(
+  systemPrompt: string,
+): string | Array<TextBlockParam> {
+  if (!isPromptCachingEnabled()) return systemPrompt;
+  return [
+    {
+      type: "text",
+      text: systemPrompt,
+      cache_control: { type: "ephemeral" },
+    },
+  ];
+}
+
+/**
+ * Stamp `cache_control: ephemeral` on the LAST tool definition. Anthropic's
+ * cache breakpoint applies to everything from the start of the request up
+ * to and including the marked block; marking the tail of `tools` (which
+ * follows `system` in wire order) gives the broadest cache coverage.
+ */
+function toolsWithCacheBreakpoint(tools: Tool[]): Tool[] {
+  if (!isPromptCachingEnabled()) return tools;
+  if (tools.length === 0) return tools;
+  return tools.map((tool, index) => {
+    if (index !== tools.length - 1) return tool;
+    return {
+      ...tool,
+      cache_control: { type: "ephemeral" },
+    } satisfies Tool;
+  });
+}
+
+/**
  * Shared agent loop: sends user message through Anthropic's tool-use cycle.
  *
  * Each console agent (ops, marketing, etc.) defines its own system prompt,
  * tools, and tool executor — this function handles the repetitive message
  * loop logic so agents stay DRY.
+ *
+ * Prompt caching (ADR-0057): when env var `ANTHROPIC_PROMPT_CACHE` is
+ * truthy (`1` / `true` / `yes`), the static system prompt + tools prefix
+ * is marked with `cache_control: ephemeral`. First call within the 5-min
+ * TTL pays a ~25% premium on prefix tokens; subsequent calls pay 10% on
+ * cache reads. Net win for any agent with ≥2 turns or ≥2 calls in 5min.
  */
 export async function runAgentLoop(
   client: Anthropic,
@@ -38,13 +94,15 @@ export async function runAgentLoop(
 ): Promise<string> {
   const maxIter = config.maxIterations ?? 5;
   const messages: MessageParam[] = [{ role: "user", content: userMessage }];
+  const system = systemWithCacheBreakpoint(config.systemPrompt);
+  const tools = toolsWithCacheBreakpoint(config.tools);
 
   for (let i = 0; i < maxIter; i++) {
     const response = await client.messages.create({
       model: config.model,
       max_tokens: config.maxTokens,
-      system: config.systemPrompt,
-      tools: config.tools,
+      system,
+      tools,
       messages,
     });
 


### PR DESCRIPTION
## Summary

PR-39 з [`docs/initiatives/stack-pulse-2026-05/pr-39-tools-console-anthropic-sdk.md`](docs/initiatives/stack-pulse-2026-05/pr-39-tools-console-anthropic-sdk.md) — закриває optional DoD-item _"prompt caching enabled на heavy-prompt commands"_ і pin-ить `@anthropic-ai/sdk` до latest stable (`^0.95.2`). Початковий target spec-у — bump до `^1.0.0` — **не виконано через зовнішню реальність**: на 2026-05-13 `npm view @anthropic-ai/sdk dist-tags` показує `latest: 0.95.2`; v1 ще не GA. Track-ємо у [`ADR-0057 § SDK v1 tracking`](docs/adr/0057-anthropic-sdk-v1-upgrade.md) — окремий follow-up PR піднімe до `^1.x.x` коли Anthropic зарелізить v1.

### Shape

- **`tools/console/package.json`** — `"@anthropic-ai/sdk": "^0.95.1" → "^0.95.2"`. Patch bump у тій же 0.95.x line; жодних API змін.
- **`tools/console/src/agents/run-agent-loop.ts`** — додано:
  - `export function isPromptCachingEnabled()` — читає `process.env.ANTHROPIC_PROMPT_CACHE`, truthy для `1` / `true` / `yes` (case-insensitive + whitespace-tolerant). Default — false.
  - `systemWithCacheBreakpoint(systemPrompt)` — коли flag on, обертає string у array-form `[{ type: "text", text, cache_control: { type: "ephemeral" } }]`.
  - `toolsWithCacheBreakpoint(tools)` — коли flag on і `tools.length > 0`, stamp-ить `cache_control: { type: "ephemeral" }` на ОСТАННЬОМУ tool. Не мутує input array (functional immutable update).
  - `runAgentLoop()` будує `system` + `tools` через ці helper-и один раз ДО циклу (idempotent across iterations), потім використовує у кожному `client.messages.create({ ... })`.
- **`tools/console/src/agents/run-agent-loop.test.ts`** (new, 10 tests):
  - `isPromptCachingEnabled`: unset → false; truthy matrix `["1", "true", "TRUE", "yes", "Yes", "  true  "]`; falsy-looking `["on", "y", "enable", "0", "false", "no", "off"]` (важливо — лише суворі truthy values: уникнення accidental enable).
  - Default OFF: regression test — request надсилається з plain string `system` і tools без `cache_control` field. Нуль behavioral diff для існуючих агентів.
  - Opt-in ON: `system` стає array-form з cache-control breakpoint; останній tool отримує cache_control; перший tool лишається чистим. Source `tools[]` НЕ мутується.
  - Zero-tools edge case: `system` все ще caching-ed, `tools[]` лишається порожнім.
  - Tool-use loop regression: ітерує через `tool_use → tool_result → end_turn` коректно (mock на 2 виклики client.messages.create).
  - Max-iterations fallback: коли модель ніколи не повертає `end_turn`, повертає fallback-message після `maxIterations`.
- **`docs/adr/0057-anthropic-sdk-v1-upgrade.md`** — додано дві секції:
  - "Prompt caching opt-in (PR-39)" — що і де, економіка (cache-write +25%, cache-read 10% від base input pricing; net-win за ≥2 викликів у 5-хв вікні), чому opt-in (рискі: cost shape change, beta-header compat, A/B observability), operations, future work.
  - "SDK v1 tracking" — стан 2026-05-13, що зробимо коли v1 з'явиться.
- **`docs/initiatives/stack-pulse-2026-05/pr-39-tools-console-anthropic-sdk.md`** — статус Planned → Active; DoD checkboxes оновлено (4/6 done; v1 bump блокований reality, manual smoke перенесено до v1 GA PR-у).
- **`docs/integrations/env-vars.md` §3** — нова doc-stanza `ANTHROPIC_PROMPT_CACHE`. Affects лише `tools/console` (Telegram-bot процес у окремому Railway service); НЕ впливає на `apps/server` Anthropic-клієнт.

## Governing Skill

- Primary skill: `.agents/skills/sergeant-server-api/SKILL.md` — найближче за стилем (Node/TS-сервісний код + Anthropic SDK + audit-логування), хоча `tools/console` не входить у `apps/server`. Немає dedicated `sergeant-console` skill-у.
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a.
- Why this playbook: PR-39 — точкова міграція з вузьким blast-radius (`tools/console` тільки). Spec PR-39 + ADR-0057 самі по собі executive playbook.
- If no playbook matched, why: створювати dedicated playbook для одноразової SDK-migration не варто; ADR-0057 captures permanent reference.

## Verification

```bash
pnpm install --frozen-lockfile=false --filter @sergeant/console   # ✓ resolves to @anthropic-ai/sdk@0.95.2
pnpm --filter @sergeant/console lint                              # ✓ 0 errors
pnpm --filter @sergeant/console typecheck                         # ✓ exit 0
pnpm --filter @sergeant/console test                              # ✓ 300 passed (з них 10 нових у run-agent-loop.test.ts)
```

Additional checks:

- [x] Local smoke / manual validation completed — agent-loop default-mode (env-флаг OFF) гарантовано regression-free завдяки snapshot-style тестам.
- [x] Surface-specific checks completed — `tools/console` lint + typecheck + test зелені.

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- `docs/adr/0057-anthropic-sdk-v1-upgrade.md` — додано "Prompt caching opt-in (PR-39)" і "SDK v1 tracking" секції.
- `docs/initiatives/stack-pulse-2026-05/pr-39-tools-console-anthropic-sdk.md` — статус Planned → Active; DoD checkboxes; пояснення розбіжності між spec-target-ом ("v1 GA у Q2-2026") і фактичним станом ринку.
- `docs/integrations/env-vars.md` §3 — нова `ANTHROPIC_PROMPT_CACHE` doc-stanza.

## Risk and Rollout

- **User-visible risk: None at default.** Env-флаг OFF за замовчуванням — нуль diff проти попередньої поведінки. У 300 unit-тестах опт-ін гілка протестована окремо від default.
- **Rollout / deploy order**:
  1. Merge цього PR-у → Railway редеплоїть `tools/console` без флагу. Жоден агент НЕ отримує prompt caching автоматично.
  2. Operator (Skords-01) додає `ANTHROPIC_PROMPT_CACHE=1` у Railway env vars `tools/console` service-у коли готовий моніторити cache-stats.
  3. Перші 24 години після ввімкнення: спостерігати Anthropic billing dashboard для cache_creation_input_tokens / cache_read_input_tokens delta. Якщо cache-hit rate < 30% або з'являється `prompt_caching_2024-07-31` beta header rejection — вимкнути флаг (set до `0`).
  4. Якщо стабільно > 30% cache-hit → залишити on, оптимально розглянути always-on у follow-up PR.
- **Backout plan**: revert цього PR-у (повертає `^0.95.1` і прибирає `cache_control` гілки). Або просто `unset ANTHROPIC_PROMPT_CACHE` у Railway — runtime поведінка повертається до pre-PR-39.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below). PR-39 оновлює існуючі ADR-0057 + spec-doc; не створює нових.

## Reviewer Notes

- **Чому не bump до v1**: `npm view @anthropic-ai/sdk dist-tags` → `latest: 0.95.2`, `alpha: 0.34.0-alpha.0`. Жодного v1.x / v1-alpha / v1-beta релізу станом на 2026-05-13. Оригінальний spec PR-39 (написаний 2026-05-07) припускав GA у Q2-2026 — припущення не справдилось. Замість блокування PR-у на v1, реалізував opt-in prompt caching (Optional DoD item) як меaningful deliverable; v1 bump окремий follow-up.
- **Чому opt-in, а не always-on**: див. ADR-0057 § "Чому opt-in". Коротко: ризик cost-shape-change без observability, можлива incompatibility з beta-header для деяких моделей, A/B-trackability через env-flag.
- **Чому marking last tool, а не first**: cache_control breakpoint застосовується до всього префіксу запиту, включно з маркованим блоком. Marking хвоста `tools[]` (який у wire-order йде ПІСЛЯ system) дає broadest coverage — кешуються і system + всі tools. Anthropic-документація прямо рекомендує цей pattern.
- **Чому не торкнув `tools/console/src/agents/openclaw.ts`**: openclaw має власну agent-loop logic (не через `run-agent-loop`); цей PR навмисно обмежений до spared agent-loop (ops, marketing, etc.). Розширення на openclaw — окремий PR з власною ADR-references.
- **Зворотна сумісність `process.env.ANTHROPIC_PROMPT_CACHE`**: helper `isPromptCachingEnabled()` reads env на кожен виклик `runAgentLoop` (не cached на module-load). Це навмисно — тести можуть flip-нути env через `vi.stubEnv()` без module-reset, а operations можуть змінити cache-mode без bot restart.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in prompt caching to the `tools/console` agent loop and pins `@anthropic-ai/sdk` to `^0.95.2`. Default behavior is unchanged; enable caching via `ANTHROPIC_PROMPT_CACHE` to reduce cost on multi‑turn calls. v1 upgrade will follow when GA.

- **New Features**
  - `ANTHROPIC_PROMPT_CACHE` flag (`1`/`true`/`yes`) enables prompt caching.
  - When enabled: wraps `system` as a text block with `cache_control: { type: "ephemeral" }` and marks the last tool with the same cache control; inputs are not mutated.
  - Added 10 unit tests covering flag parsing, default-off behavior, opt-in path, zero-tools, tool-use loop, and max-iterations fallback.

- **Migration**
  - No action needed by default.
  - To enable: set `ANTHROPIC_PROMPT_CACHE=1` for the `tools/console` service. Scope is limited to `tools/console`; other clients are unaffected.

<sup>Written for commit d3da95334545776f10146cf2ed1fbe83cd03f07c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

