### PR TITLE
feat(web): rename pantry via tap on active name instead of button

### DIFF
--- a/apps/web/src/modules/nutrition/components/PantryManagerSheet.test.tsx
+++ b/apps/web/src/modules/nutrition/components/PantryManagerSheet.test.tsx
@@ -9,7 +9,7 @@
 //
 // UX-roast 2026-05 §3.4 — додаємо `idle`-режим форми. У цьому стані
 // інпут «Назва складу» взагалі не показано, доки користувач явно не
-// натиснув «+ Новий склад» / «Перейменувати активний». Перевіряємо:
+// натиснув «+ Новий склад» або не тапнув по назві активного складу. Перевіряємо:
 //   • в `idle` форма прихована;
 //   • у режимі `create` поряд зі «Створити» стоїть «Скасувати», а не
 //     «Видалити»;
@@ -113,9 +113,25 @@ describe("PantryManagerSheet (PR-37 / §3.2 + 2026-05 §3.4)", () => {
     expect(screen.queryByRole("button", { name: "Скасувати" })).toBeNull();
     // The action triggers (still visible) confirm the sheet is interactive.
     expect(screen.getByRole("button", { name: "+ Новий склад" })).toBeTruthy();
-    expect(
-      screen.getByRole("button", { name: "Перейменувати активний" }),
-    ).toBeTruthy();
+  });
+
+  it("triggers onBeginRename when tapping the active pantry row", () => {
+    const onBeginRename = vi.fn();
+    render(
+      <PantryManagerSheet
+        {...makeProps({
+          pantries: [
+            { id: "home", name: "Дім", items: [], text: "" },
+            { id: "work", name: "Робота", items: [], text: "" },
+          ],
+          activePantryId: "home",
+        })}
+        onBeginRename={onBeginRename}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Дім/ }));
+    expect(onBeginRename).toHaveBeenCalledTimes(1);
   });
 
   it("invokes setPantryForm with idle when Cancel is clicked", () => {

--- a/apps/web/src/modules/nutrition/components/PantryManagerSheet.tsx
+++ b/apps/web/src/modules/nutrition/components/PantryManagerSheet.tsx
@@ -131,7 +131,13 @@ export function PantryManagerSheet({
             <button
               key={p.id}
               type="button"
-              onClick={() => setActivePantryId(p.id)}
+              onClick={() => {
+                if (active) {
+                  onBeginRename();
+                } else {
+                  setActivePantryId(p.id);
+                }
+              }}
               className={cn(
                 "w-full text-left px-4 py-3 border-b border-line last:border-0 hover:bg-panelHi transition-colors",
                 active && "bg-nutrition/10",
@@ -139,7 +145,13 @@ export function PantryManagerSheet({
               aria-pressed={active}
             >
               <div className="flex items-center justify-between gap-3">
-                <div className="text-style-label text-text truncate">
+                <div
+                  className={cn(
+                    "text-style-label text-text truncate",
+                    active &&
+                      "underline decoration-nutrition/30 underline-offset-2",
+                  )}
+                >
                   {p.name || "Склад"}
                 </div>
                 {active ? (
@@ -153,30 +165,17 @@ export function PantryManagerSheet({
         })}
       </div>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 mb-4">
+      <div className="mb-4">
         <Button
           type="button"
           aria-pressed={pantryForm.mode === "create"}
           className={cn(
-            "h-12 min-h-[44px] bg-nutrition-strong text-white hover:bg-nutrition-hover",
+            "w-full h-12 min-h-[44px] bg-nutrition-strong text-white hover:bg-nutrition-hover",
             pantryForm.mode === "create" && "ring-2 ring-nutrition/60",
           )}
           onClick={onBeginCreate}
         >
           + Новий склад
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          aria-pressed={pantryForm.mode === "rename"}
-          className={cn(
-            "h-12 min-h-[44px]",
-            pantryForm.mode === "rename" &&
-              "border border-nutrition text-text bg-panelHi",
-          )}
-          onClick={onBeginRename}
-        >
-          Перейменувати активний
         </Button>
       </div>
 


### PR DESCRIPTION
## Summary

Перейменування складу тепер відбувається через клік/тап по рядку активного складу, а не через окрему кнопку «Перейменувати активний». Кнопку прибрано, `+ Новий склад` займає всю ширину. Активна назва підкреслена (`underline decoration-nutrition/30`) як візуальний хінт інтерактивності.

- Tap active pantry row → enters rename mode (`onBeginRename`)
- Tap inactive pantry row → selects it (unchanged behavior)
- Removed «Перейменувати активний» button
- Updated tests: added `triggers onBeginRename when tapping the active pantry row`

## Governing Skill

- Primary skill: `sergeant-web-ui`
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a
- Why this playbook: n/a
- If no playbook matched, why: Simple UX polish — no playbook covers pantry manager sheet refactors specifically.

## Verification

```bash
pnpm --filter @sergeant/web test -- --run src/modules/nutrition/components/PantryManagerSheet.test.tsx
# 7 passed (7)

pnpm --filter @sergeant/web typecheck
# ✓ no errors

npx eslint apps/web/src/modules/nutrition/components/PantryManagerSheet.tsx apps/web/src/modules/nutrition/components/PantryManagerSheet.test.tsx
# ✓ clean
```

Additional checks:

- [ ] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a

## Risk and Rollout

- User-visible risk: Low — rename affordance moves from a button to the pantry row; all existing functionality preserved.
- Rollout / deploy order: Standard Vercel preview → merge to main.
- Backout plan: Revert the single commit.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

No migrations, env changes, or auth changes. Pure UI refactor in `PantryManagerSheet`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rename a pantry by tapping the active pantry row. This replaces the «Перейменувати активний» button for a cleaner, more direct interaction.

- **Refactors**
  - Tapping the active row triggers rename; tapping an inactive row still selects it.
  - «+ Новий склад» is now full-width.
  - Active pantry name is underlined to hint interactivity.
  - Tests updated to assert `onBeginRename` when tapping the active row.

<sup>Written for commit 31fd4009af3a203ba0cf78aa08b7c213c42b9089. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Active pantry row now enters rename mode when tapped; inactive pantries can be selected independently with a single tap.
  * Streamlined pantry management by consolidating actions and removing the separate rename button.

* **Style**
  * Active pantry label styling enhanced with underline decoration.

* **Tests**
  * Enhanced test coverage for updated pantry interaction behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Skords-01/Sergeant/pull/2529)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->