### PR TITLE
refactor(web): decompose Workouts.tsx and LogCard.tsx — T3 batch 3

### DIFF
--- a/apps/web/src/modules/fizruk/hooks/useWorkoutsOrchestrator.ts
+++ b/apps/web/src/modules/fizruk/hooks/useWorkoutsOrchestrator.ts
@@ -1,0 +1,424 @@
+import { useCallback, useMemo, useState } from "react";
+import { safeReadStringLS } from "@shared/lib/storage/storage";
+import { requestCloudPull } from "@shared/lib/modules/cloudPullRequest";
+import type { DataStateQueryLike } from "@shared/components/ui/DataState";
+import { useToast } from "@shared/hooks/useToast";
+import { showUndoToast } from "@shared/lib/ui/undoToast";
+import { useExerciseCatalog } from "./useExerciseCatalog";
+import { useFizrukRestSound } from "./useFizrukRestSound";
+import type { RestTimerState } from "./useFizrukRestSound";
+import { useRecovery } from "./useRecovery";
+import {
+  useWorkoutTemplates,
+  type WorkoutTemplate,
+} from "./useWorkoutTemplates";
+import { useWorkouts } from "./useWorkouts";
+import {
+  useActiveWorkoutIdPersistence,
+  useLiveWorkoutTick,
+  useRestTimerCountdown,
+  useStaleActiveWorkoutCleanup,
+  useWorkoutsViewFromSession,
+} from "./useWorkoutsLifecycle";
+import { recoveryConflictsForExercise } from "@sergeant/fizruk-domain";
+import type { RawExerciseDef } from "@sergeant/fizruk-domain/data";
+import type { Workout, WorkoutGroup } from "@sergeant/fizruk-domain";
+import {
+  ACTIVE_WORKOUT_KEY,
+  summarizeWorkoutForFinish,
+} from "@sergeant/fizruk-domain";
+import type { FinishFlashState, WorkoutsView } from "../pages/Workouts.types";
+import {
+  buildGroupedExercises,
+  collectLastByExerciseId,
+  formatActiveDuration,
+  todayLocalDateString,
+} from "../pages/Workouts.helpers";
+import type { AddExerciseForm } from "../components/workouts/AddExerciseSheet";
+
+export function useWorkoutsOrchestrator() {
+  const toast = useToast();
+  const {
+    exercises,
+    search,
+    primaryGroupsUk,
+    equipmentUk,
+    musclesUk,
+    musclesByPrimaryGroup,
+    addExercise,
+    removeExercise,
+  } = useExerciseCatalog();
+  const rec = useRecovery();
+  const {
+    workouts,
+    loaded: workoutsLoaded,
+    createWorkout,
+    createWorkoutWithTimes,
+    updateWorkout,
+    deleteWorkout,
+    restoreWorkout,
+    endWorkout,
+    addItem,
+    updateItem,
+    removeItem,
+  } = useWorkouts();
+
+  const removeItemWithUndo = useCallback(
+    (workoutId: string, itemId: string) => {
+      const w = workouts.find((x) => x.id === workoutId);
+      if (!w) {
+        removeItem(workoutId, itemId);
+        return;
+      }
+      const snapshot = {
+        items: w.items || [],
+        groups: w.groups || [],
+      };
+      removeItem(workoutId, itemId);
+      showUndoToast(toast, {
+        msg: "Вправу видалено з тренування",
+        onUndo: () =>
+          updateWorkout(workoutId, {
+            items: snapshot.items,
+            groups: snapshot.groups,
+          }),
+      });
+    },
+    [workouts, removeItem, updateWorkout, toast],
+  );
+
+  const templateApi = useWorkoutTemplates();
+  const [q, setQ] = useState("");
+  const [equipmentFilter, setEquipmentFilter] = useState<string[]>([]);
+  const [selected, setSelected] = useState<RawExerciseDef | null>(null);
+  const [open, setOpen] = useState<Record<string, boolean>>(() => ({}));
+  const [addOpen, setAddOpen] = useState(false);
+  const [view, setView] = useState<WorkoutsView>("home");
+  const mode = view === "templates" || view === "home" ? "catalog" : view;
+  const [restTimer, setRestTimer] = useState<RestTimerState | null>(null);
+  const [activeWorkoutId, setActiveWorkoutId] = useState(() =>
+    safeReadStringLS(ACTIVE_WORKOUT_KEY),
+  );
+  const [finishFlash, setFinishFlash] = useState<FinishFlashState | null>(null);
+  const [deleteExerciseConfirm, setDeleteExerciseConfirm] = useState(false);
+  const [riskyTemplateConfirm, setRiskyTemplateConfirm] =
+    useState<WorkoutTemplate | null>(null);
+  const [now, setNow] = useState(Date.now());
+  const [retroOpen, setRetroOpen] = useState(false);
+  const [quickStartOpen, setQuickStartOpen] = useState(false);
+  const [retroDate, setRetroDate] = useState(() => todayLocalDateString());
+  const [retroTime, setRetroTime] = useState("18:00");
+  const [form, setForm] = useState<AddExerciseForm>(() => ({
+    nameUk: "",
+    primaryGroup: "chest",
+    musclesPrimary: [],
+    musclesSecondary: [],
+    equipment: ["bodyweight"],
+    description: "",
+  }));
+
+  const list = useMemo(() => search(q), [search, q]);
+  const activeWorkout: Workout | null =
+    workouts.find((w) => w.id === activeWorkoutId) || null;
+
+  const activeDuration = useMemo(
+    () =>
+      formatActiveDuration(
+        activeWorkout?.startedAt,
+        activeWorkout?.endedAt,
+        now,
+      ),
+    [activeWorkout?.startedAt, activeWorkout?.endedAt, now],
+  );
+
+  useActiveWorkoutIdPersistence(activeWorkoutId);
+  useStaleActiveWorkoutCleanup(
+    workoutsLoaded,
+    workouts,
+    activeWorkoutId,
+    setActiveWorkoutId,
+  );
+  useWorkoutsViewFromSession(setView);
+
+  const { markCompletedNaturally } = useFizrukRestSound(restTimer);
+  useRestTimerCountdown(restTimer, setRestTimer, markCompletedNaturally);
+  useLiveWorkoutTick(activeWorkout, setNow);
+
+  const addExerciseToActive = useCallback(
+    (ex: RawExerciseDef) => {
+      if (!activeWorkoutId) return;
+      const isCardio = ex.primaryGroup === "cardio";
+      addItem(activeWorkoutId, {
+        exerciseId: ex.id,
+        nameUk: ex?.name?.uk || ex?.name?.en,
+        primaryGroup: ex.primaryGroup,
+        musclesPrimary: ex?.muscles?.primary || [],
+        musclesSecondary: ex?.muscles?.secondary || [],
+        type: isCardio ? "distance" : "strength",
+        sets: isCardio ? undefined : [{ weightKg: 0, reps: 0 }],
+        durationSec: isCardio ? 0 : 0,
+        distanceM: isCardio ? 0 : 0,
+      });
+    },
+    [activeWorkoutId, addItem],
+  );
+
+  const handleExerciseInListClick = useCallback(
+    (ex: RawExerciseDef) => {
+      if (mode !== "log") {
+        setSelected(ex);
+        return;
+      }
+      if (!activeWorkoutId) {
+        toast.warning(
+          "Спочатку натисни «+ Нове» у блоці нижче, щоб з'явилось активне тренування.",
+        );
+        return;
+      }
+      if (activeWorkout?.endedAt) {
+        toast.warning(
+          "Це тренування вже завершено. Обери чернетку в «Останні тренування» або створи нове.",
+        );
+        return;
+      }
+      addExerciseToActive(ex);
+    },
+    [mode, activeWorkoutId, activeWorkout?.endedAt, addExerciseToActive, toast],
+  );
+
+  const executeTemplateStart = useCallback(
+    (tpl: WorkoutTemplate) => {
+      const picks: RawExerciseDef[] = (tpl?.exerciseIds || [])
+        .map((id: string) => exercises.find((e) => e.id === id))
+        .filter((e): e is RawExerciseDef => Boolean(e));
+      const w = createWorkout();
+      const exIdToItemId: Record<string, string> = {};
+      for (const ex of picks) {
+        const isCardio = ex.primaryGroup === "cardio";
+        const itemId = addItem(w.id, {
+          exerciseId: ex.id,
+          nameUk: ex?.name?.uk || ex?.name?.en,
+          primaryGroup: ex.primaryGroup,
+          musclesPrimary: ex?.muscles?.primary || [],
+          musclesSecondary: ex?.muscles?.secondary || [],
+          type: isCardio ? "distance" : "strength",
+          sets: isCardio ? undefined : [{ weightKg: 0, reps: 0 }],
+          durationSec: 0,
+          distanceM: isCardio ? 0 : 0,
+        });
+        exIdToItemId[ex.id] = itemId;
+      }
+      if ((tpl?.groups || []).length > 0) {
+        interface TemplateGroup {
+          id: string;
+          exerciseIds?: string[];
+          itemIds?: string[];
+          type?: "circuit" | "superset";
+          restSec?: number;
+        }
+        const workoutGroups: WorkoutGroup[] = (
+          (tpl.groups || []) as TemplateGroup[]
+        )
+          .map((g) => ({
+            id: g.id,
+            type: g.type,
+            restSec: g.restSec,
+            itemIds: (g.exerciseIds || [])
+              .map((exId: string) => exIdToItemId[exId])
+              .filter((id): id is string => Boolean(id)),
+          }))
+          .filter((g) => g.itemIds.length >= 2);
+        if (workoutGroups.length > 0) {
+          updateWorkout(w.id, { groups: workoutGroups });
+        }
+      }
+      if (tpl?.id) templateApi.markTemplateUsed(tpl.id);
+      setActiveWorkoutId(w.id);
+      setView("log");
+    },
+    [exercises, createWorkout, addItem, updateWorkout, templateApi],
+  );
+
+  const startWorkoutFromTemplate = useCallback(
+    (tpl: WorkoutTemplate) => {
+      const picks: RawExerciseDef[] = (tpl?.exerciseIds || [])
+        .map((id: string) => exercises.find((e) => e.id === id))
+        .filter((e): e is RawExerciseDef => Boolean(e));
+      if (!picks.length) {
+        toast.warning(
+          "У шаблоні немає вправ з каталогу. Відредагуй шаблон і додай вправи.",
+        );
+        return;
+      }
+      const risky = picks.some(
+        (ex) => recoveryConflictsForExercise(ex, rec.by).hasWarning,
+      );
+      if (risky) {
+        setRiskyTemplateConfirm(tpl);
+        return;
+      }
+      executeTemplateStart(tpl);
+    },
+    [exercises, rec.by, executeTemplateStart, toast],
+  );
+
+  const submitRetroWorkout = useCallback(() => {
+    const [y, mo, d] = retroDate.split("-").map(Number);
+    const [hh, mm] = (retroTime || "12:00").split(":").map(Number);
+    const startedAt = new Date(y!, mo! - 1, d, hh, mm, 0, 0).toISOString();
+    const w = createWorkoutWithTimes({ startedAt });
+    setActiveWorkoutId(w.id);
+    setRetroOpen(false);
+  }, [retroDate, retroTime, createWorkoutWithTimes]);
+
+  const lastByExerciseId = useMemo(
+    () => collectLastByExerciseId(workouts, activeWorkoutId),
+    [workouts, activeWorkoutId],
+  );
+
+  const grouped = useMemo(
+    () => buildGroupedExercises(list, equipmentFilter, primaryGroupsUk),
+    [list, equipmentFilter, primaryGroupsUk],
+  );
+
+  const finishedCount = useMemo(
+    () => (workouts || []).filter((w) => w.endedAt).length,
+    [workouts],
+  );
+
+  const recentWorkouts = useMemo(
+    () =>
+      [...(workouts || [])]
+        .sort(
+          (a, b) =>
+            new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
+        )
+        .slice(0, 3),
+    [workouts],
+  );
+
+  const handlePullRefresh = useCallback(() => requestCloudPull(2500), []);
+
+  const journalQuery: DataStateQueryLike<readonly Workout[]> = {
+    data: workoutsLoaded ? workouts : undefined,
+    isLoading: !workoutsLoaded,
+  };
+
+  const handleQuickStartConfirm = useCallback(
+    (picks: RawExerciseDef[]) => {
+      const w = createWorkout();
+      for (const ex of picks) {
+        const isCardio = ex.primaryGroup === "cardio";
+        addItem(w.id, {
+          exerciseId: ex.id,
+          nameUk: ex?.name?.uk || ex?.name?.en,
+          primaryGroup: ex.primaryGroup,
+          musclesPrimary: ex?.muscles?.primary || [],
+          musclesSecondary: ex?.muscles?.secondary || [],
+          type: isCardio ? "distance" : "strength",
+          sets: isCardio ? undefined : [{ weightKg: 0, reps: 0 }],
+          durationSec: isCardio ? 0 : 0,
+          distanceM: isCardio ? 0 : 0,
+        });
+      }
+      setActiveWorkoutId(w.id);
+      setQuickStartOpen(false);
+      setView("log");
+    },
+    [createWorkout, addItem],
+  );
+
+  const handleDeleteExerciseConfirm = useCallback(() => {
+    if (selected) {
+      const snapshot = selected;
+      if (removeExercise(snapshot.id)) {
+        setSelected(null);
+        showUndoToast(toast, {
+          msg: `Вправу «${snapshot?.name?.uk || "без назви"}» видалено`,
+          onUndo: () => addExercise(snapshot),
+        });
+      }
+    }
+    setDeleteExerciseConfirm(false);
+  }, [selected, removeExercise, addExercise, toast]);
+
+  const handleRiskyTemplateConfirm = useCallback(() => {
+    const tpl = riskyTemplateConfirm;
+    setRiskyTemplateConfirm(null);
+    if (!tpl) return;
+    executeTemplateStart(tpl);
+  }, [riskyTemplateConfirm, executeTemplateStart]);
+
+  return {
+    toast,
+    exercises,
+    search,
+    primaryGroupsUk,
+    equipmentUk,
+    musclesUk,
+    musclesByPrimaryGroup,
+    addExercise,
+    rec,
+    workouts,
+    workoutsLoaded,
+    createWorkout,
+    updateWorkout,
+    deleteWorkout,
+    restoreWorkout,
+    endWorkout,
+    updateItem,
+    removeItemWithUndo,
+    templateApi,
+    q,
+    setQ,
+    equipmentFilter,
+    setEquipmentFilter,
+    selected,
+    setSelected,
+    open,
+    setOpen,
+    addOpen,
+    setAddOpen,
+    view,
+    setView,
+    mode,
+    restTimer,
+    setRestTimer,
+    activeWorkoutId,
+    setActiveWorkoutId,
+    finishFlash,
+    setFinishFlash,
+    deleteExerciseConfirm,
+    setDeleteExerciseConfirm,
+    riskyTemplateConfirm,
+    setRiskyTemplateConfirm,
+    now,
+    retroOpen,
+    setRetroOpen,
+    quickStartOpen,
+    setQuickStartOpen,
+    retroDate,
+    setRetroDate,
+    retroTime,
+    setRetroTime,
+    form,
+    setForm,
+    activeWorkout,
+    activeDuration,
+    addExerciseToActive,
+    handleExerciseInListClick,
+    startWorkoutFromTemplate,
+    submitRetroWorkout,
+    lastByExerciseId,
+    grouped,
+    finishedCount,
+    recentWorkouts,
+    handlePullRefresh,
+    journalQuery,
+    handleQuickStartConfirm,
+    handleDeleteExerciseConfirm,
+    handleRiskyTemplateConfirm,
+    summarizeWorkoutForFinish,
+    recoveryConflictsForExercise,
+  };
+}

--- a/apps/web/src/modules/fizruk/pages/Workouts.tsx
+++ b/apps/web/src/modules/fizruk/pages/Workouts.tsx
@@ -1,21 +1,10 @@
-import { useCallback, useMemo, useState } from "react";
-import { safeReadStringLS } from "@shared/lib/storage/storage";
-import { requestCloudPull } from "@shared/lib/modules/cloudPullRequest";
 import { PullToRefresh } from "@shared/components/ui/PullToRefresh";
 import { Skeleton } from "@shared/components/ui/Skeleton";
-import {
-  DataState,
-  type DataStateQueryLike,
-} from "@shared/components/ui/DataState";
-import { useToast } from "@shared/hooks/useToast";
-import { showUndoToast } from "@shared/lib/ui/undoToast";
+import { DataState } from "@shared/components/ui/DataState";
 import { WorkoutTemplatesSection } from "../components/WorkoutTemplatesSection";
 import { RestTimerOverlay } from "../components/workouts/RestTimerOverlay";
 import { WorkoutFinishSheets } from "../components/workouts/WorkoutFinishSheets";
-import {
-  AddExerciseSheet,
-  type AddExerciseForm,
-} from "../components/workouts/AddExerciseSheet";
+import { AddExerciseSheet } from "../components/workouts/AddExerciseSheet";
 import { ExerciseDetailSheet } from "../components/workouts/ExerciseDetailSheet";
 import { WorkoutJournalSection } from "../components/workouts/WorkoutJournalSection";
 import { WorkoutCatalogSection } from "../components/workouts/WorkoutCatalogSection";
@@ -23,36 +12,7 @@ import { QuickStartSheet } from "../components/workouts/QuickStartSheet";
 import { WorkoutsHome } from "../components/workouts/WorkoutsHome";
 import { WorkoutsHeader } from "../components/workouts/WorkoutsHeader";
 import { WorkoutsConfirmDialogs } from "../components/workouts/WorkoutsConfirmDialogs";
-import { useExerciseCatalog } from "../hooks/useExerciseCatalog";
-import { useFizrukRestSound } from "../hooks/useFizrukRestSound";
-import type { RestTimerState } from "../hooks/useFizrukRestSound";
-import { useRecovery } from "../hooks/useRecovery";
-import {
-  useWorkoutTemplates,
-  type WorkoutTemplate,
-} from "../hooks/useWorkoutTemplates";
-import { useWorkouts } from "../hooks/useWorkouts";
-import {
-  useActiveWorkoutIdPersistence,
-  useLiveWorkoutTick,
-  useRestTimerCountdown,
-  useStaleActiveWorkoutCleanup,
-  useWorkoutsViewFromSession,
-} from "../hooks/useWorkoutsLifecycle";
-import { recoveryConflictsForExercise } from "@sergeant/fizruk-domain";
-import type { RawExerciseDef } from "@sergeant/fizruk-domain/data";
-import type { Workout, WorkoutGroup } from "@sergeant/fizruk-domain";
-import {
-  ACTIVE_WORKOUT_KEY,
-  summarizeWorkoutForFinish,
-} from "@sergeant/fizruk-domain";
-import type { FinishFlashState, WorkoutsView } from "./Workouts.types";
-import {
-  buildGroupedExercises,
-  collectLastByExerciseId,
-  formatActiveDuration,
-  todayLocalDateString,
-} from "./Workouts.helpers";
+import { useWorkoutsOrchestrator } from "../hooks/useWorkoutsOrchestrator";
 
 interface WorkoutsProps {
   /**
@@ -78,297 +38,7 @@ export function Workouts({
   onOpenRoutine,
   onOpenPrograms,
 }: WorkoutsProps = {}) {
-  const toast = useToast();
-  const {
-    exercises,
-    search,
-    primaryGroupsUk,
-    equipmentUk,
-    musclesUk,
-    musclesByPrimaryGroup,
-    addExercise,
-    removeExercise,
-  } = useExerciseCatalog();
-  const rec = useRecovery();
-  const {
-    workouts,
-    loaded: workoutsLoaded,
-    createWorkout,
-    createWorkoutWithTimes,
-    updateWorkout,
-    deleteWorkout,
-    restoreWorkout,
-    endWorkout,
-    addItem,
-    updateItem,
-    removeItem,
-  } = useWorkouts();
-  const removeItemWithUndo = useCallback(
-    (workoutId: string, itemId: string) => {
-      const w = workouts.find((x) => x.id === workoutId);
-      if (!w) {
-        removeItem(workoutId, itemId);
-        return;
-      }
-      const snapshot = {
-        items: w.items || [],
-        groups: w.groups || [],
-      };
-      removeItem(workoutId, itemId);
-      showUndoToast(toast, {
-        msg: "Вправу видалено з тренування",
-        onUndo: () =>
-          updateWorkout(workoutId, {
-            items: snapshot.items,
-            groups: snapshot.groups,
-          }),
-      });
-    },
-    [workouts, removeItem, updateWorkout, toast],
-  );
-  const templateApi = useWorkoutTemplates();
-  const [q, setQ] = useState("");
-  const [equipmentFilter, setEquipmentFilter] = useState<string[]>([]);
-  const [selected, setSelected] = useState<RawExerciseDef | null>(null);
-  const [open, setOpen] = useState<Record<string, boolean>>(() => ({}));
-  const [addOpen, setAddOpen] = useState(false);
-  // `view` drives the page chrome:
-  //   "home"      — new landing layout with active/start hero, recent 3
-  //                 journal rows and quick-link tiles. Replaces the old
-  //                 default that dropped users straight into the catalog.
-  //   "log"       — active-workout panel + exercise catalog below (this is
-  //                 where you actually run a session and add exercises).
-  //   "catalog"   — browse-only catalog (no active-workout wiring).
-  //   "templates" — workout templates list.
-  const [view, setView] = useState<WorkoutsView>("home");
-  // `mode` is still exposed to legacy subcomponents that branch on
-  // "catalog" vs "log" (exercise-in-list click handler, `ExerciseDetailSheet`,
-  // `WorkoutCatalogSection`). Kept in sync with `view` for those subviews.
-  const mode = view === "templates" || view === "home" ? "catalog" : view;
-  const [restTimer, setRestTimer] = useState<RestTimerState | null>(null);
-  const [activeWorkoutId, setActiveWorkoutId] = useState(() =>
-    safeReadStringLS(ACTIVE_WORKOUT_KEY),
-  );
-  const [finishFlash, setFinishFlash] = useState<FinishFlashState | null>(null);
-  const [deleteExerciseConfirm, setDeleteExerciseConfirm] = useState(false);
-  const [riskyTemplateConfirm, setRiskyTemplateConfirm] =
-    useState<WorkoutTemplate | null>(null); // stores template when risky
-  const [now, setNow] = useState(Date.now());
-  const [retroOpen, setRetroOpen] = useState(false);
-  const [quickStartOpen, setQuickStartOpen] = useState(false);
-  const [retroDate, setRetroDate] = useState(() => todayLocalDateString());
-  const [retroTime, setRetroTime] = useState("18:00");
-  const [form, setForm] = useState<AddExerciseForm>(() => ({
-    nameUk: "",
-    primaryGroup: "chest",
-    musclesPrimary: [],
-    musclesSecondary: [],
-    equipment: ["bodyweight"],
-    description: "",
-  }));
-  const list = useMemo(() => search(q), [search, q]);
-  const activeWorkout: Workout | null =
-    workouts.find((w) => w.id === activeWorkoutId) || null;
-
-  const activeDuration = useMemo(
-    () =>
-      formatActiveDuration(
-        activeWorkout?.startedAt,
-        activeWorkout?.endedAt,
-        now,
-      ),
-    [activeWorkout?.startedAt, activeWorkout?.endedAt, now],
-  );
-
-  useActiveWorkoutIdPersistence(activeWorkoutId);
-  useStaleActiveWorkoutCleanup(
-    workoutsLoaded,
-    workouts,
-    activeWorkoutId,
-    setActiveWorkoutId,
-  );
-  useWorkoutsViewFromSession(setView);
-
-  const { markCompletedNaturally } = useFizrukRestSound(restTimer);
-  useRestTimerCountdown(restTimer, setRestTimer, markCompletedNaturally);
-  useLiveWorkoutTick(activeWorkout, setNow);
-
-  const addExerciseToActive = useCallback(
-    (ex: RawExerciseDef) => {
-      if (!activeWorkoutId) return;
-      const isCardio = ex.primaryGroup === "cardio";
-      addItem(activeWorkoutId, {
-        exerciseId: ex.id,
-        nameUk: ex?.name?.uk || ex?.name?.en,
-        primaryGroup: ex.primaryGroup,
-        musclesPrimary: ex?.muscles?.primary || [],
-        musclesSecondary: ex?.muscles?.secondary || [],
-        type: isCardio ? "distance" : "strength",
-        sets: isCardio ? undefined : [{ weightKg: 0, reps: 0 }],
-        durationSec: isCardio ? 0 : 0,
-        distanceM: isCardio ? 0 : 0,
-      });
-    },
-    [activeWorkoutId, addItem],
-  );
-
-  const handleExerciseInListClick = useCallback(
-    (ex: RawExerciseDef) => {
-      if (mode !== "log") {
-        setSelected(ex);
-        return;
-      }
-      if (!activeWorkoutId) {
-        toast.warning(
-          "Спочатку натисни «+ Нове» у блоці нижче, щоб з’явилось активне тренування.",
-        );
-        return;
-      }
-      if (activeWorkout?.endedAt) {
-        toast.warning(
-          "Це тренування вже завершено. Обери чернетку в «Останні тренування» або створи нове.",
-        );
-        return;
-      }
-      addExerciseToActive(ex);
-    },
-    [mode, activeWorkoutId, activeWorkout?.endedAt, addExerciseToActive, toast],
-  );
-
-  const executeTemplateStart = useCallback(
-    (tpl: WorkoutTemplate) => {
-      const picks: RawExerciseDef[] = (tpl?.exerciseIds || [])
-        .map((id: string) => exercises.find((e) => e.id === id))
-        .filter((e): e is RawExerciseDef => Boolean(e));
-      const w = createWorkout();
-      const exIdToItemId: Record<string, string> = {};
-      for (const ex of picks) {
-        const isCardio = ex.primaryGroup === "cardio";
-        const itemId = addItem(w.id, {
-          exerciseId: ex.id,
-          nameUk: ex?.name?.uk || ex?.name?.en,
-          primaryGroup: ex.primaryGroup,
-          musclesPrimary: ex?.muscles?.primary || [],
-          musclesSecondary: ex?.muscles?.secondary || [],
-          type: isCardio ? "distance" : "strength",
-          sets: isCardio ? undefined : [{ weightKg: 0, reps: 0 }],
-          durationSec: 0,
-          distanceM: isCardio ? 0 : 0,
-        });
-        exIdToItemId[ex.id] = itemId;
-      }
-      if ((tpl?.groups || []).length > 0) {
-        // Templates persist `groups` as `unknown[]` (see useWorkoutTemplates),
-        // so narrow each group to the template-shape we read here before
-        // building the workout-side `groups` payload. The mapped shape
-        // matches the canonical `WorkoutGroup` (`id`, `itemIds` + the
-        // optional `type`/`restSec` carried over from the template).
-        interface TemplateGroup {
-          id: string;
-          exerciseIds?: string[];
-          itemIds?: string[];
-          type?: "circuit" | "superset";
-          restSec?: number;
-        }
-        const workoutGroups: WorkoutGroup[] = (
-          (tpl.groups || []) as TemplateGroup[]
-        )
-          .map((g) => ({
-            id: g.id,
-            type: g.type,
-            restSec: g.restSec,
-            itemIds: (g.exerciseIds || [])
-              .map((exId: string) => exIdToItemId[exId])
-              .filter((id): id is string => Boolean(id)),
-          }))
-          .filter((g) => g.itemIds.length >= 2);
-        if (workoutGroups.length > 0) {
-          updateWorkout(w.id, { groups: workoutGroups });
-        }
-      }
-      if (tpl?.id) templateApi.markTemplateUsed(tpl.id);
-      setActiveWorkoutId(w.id);
-      setView("log");
-    },
-    [exercises, createWorkout, addItem, updateWorkout, templateApi],
-  );
-
-  const startWorkoutFromTemplate = useCallback(
-    (tpl: WorkoutTemplate) => {
-      const picks: RawExerciseDef[] = (tpl?.exerciseIds || [])
-        .map((id: string) => exercises.find((e) => e.id === id))
-        .filter((e): e is RawExerciseDef => Boolean(e));
-      if (!picks.length) {
-        toast.warning(
-          "У шаблоні немає вправ з каталогу. Відредагуй шаблон і додай вправи.",
-        );
-        return;
-      }
-      const risky = picks.some(
-        (ex) => recoveryConflictsForExercise(ex, rec.by).hasWarning,
-      );
-      if (risky) {
-        setRiskyTemplateConfirm(tpl);
-        return;
-      }
-      executeTemplateStart(tpl);
-    },
-    [exercises, rec.by, executeTemplateStart, toast],
-  );
-
-  const submitRetroWorkout = useCallback(() => {
-    const [y, mo, d] = retroDate.split("-").map(Number);
-    const [hh, mm] = (retroTime || "12:00").split(":").map(Number);
-    const startedAt = new Date(y!, mo! - 1, d, hh, mm, 0, 0).toISOString();
-    const w = createWorkoutWithTimes({ startedAt });
-    setActiveWorkoutId(w.id);
-    setRetroOpen(false);
-  }, [retroDate, retroTime, createWorkoutWithTimes]);
-
-  const lastByExerciseId = useMemo(
-    () => collectLastByExerciseId(workouts, activeWorkoutId),
-    [workouts, activeWorkoutId],
-  );
-
-  const grouped = useMemo(
-    () => buildGroupedExercises(list, equipmentFilter, primaryGroupsUk),
-    [list, equipmentFilter, primaryGroupsUk],
-  );
-
-  const finishedCount = useMemo(
-    () => (workouts || []).filter((w) => w.endedAt).length,
-    [workouts],
-  );
-
-  const recentWorkouts = useMemo(
-    () =>
-      [...(workouts || [])]
-        .sort(
-          (a, b) =>
-            new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
-        )
-        .slice(0, 3),
-    [workouts],
-  );
-
-  // Workouts are local-first (MMKV-web), so PTR's job is to ask the
-  // App-level cloud-sync engine for a fresh pull. The local list will
-  // re-render automatically once the engine writes new state.
-  const handlePullRefresh = useCallback(() => requestCloudPull(2500), []);
-
-  // DataState contract for the workout journal:
-  //   - `useWorkouts` flips `loaded` from false → true after the first
-  //     hydration tick. While `loaded === false` we feed `data: undefined`
-  //     so DataState renders the skeleton slot; from the second tick on
-  //     `data` is the real list (possibly empty), which lets the journal
-  //     render its own "порожньо" empty-state without flashing it during
-  //     mount.
-  //   - `isLoading` mirrors the inverted `loaded` flag so a future
-  //     stale-revalidate (cloud pull → re-merge) keeps the list visible.
-  const journalQuery: DataStateQueryLike<readonly Workout[]> = {
-    data: workoutsLoaded ? workouts : undefined,
-    isLoading: !workoutsLoaded,
-  };
+  const o = useWorkoutsOrchestrator();
 
   const workoutsLoadingSkeleton = (
     <div
@@ -384,208 +54,159 @@ export function Workouts({
   );
 
   return (
-    <PullToRefresh onRefresh={handlePullRefresh} variant="fizruk">
+    <PullToRefresh onRefresh={o.handlePullRefresh} variant="fizruk">
       <div className="max-w-4xl mx-auto px-4 pt-4 page-tabbar-pad">
         <WorkoutsHeader
-          view={view}
-          activeWorkout={activeWorkout}
-          finishedCount={finishedCount}
-          onBack={() => setView("home")}
-          onAddCatalog={() => setAddOpen(true)}
+          view={o.view}
+          activeWorkout={o.activeWorkout}
+          finishedCount={o.finishedCount}
+          onBack={() => o.setView("home")}
+          onAddCatalog={() => o.setAddOpen(true)}
         />
 
-        {view === "home" ? (
+        {o.view === "home" ? (
           <WorkoutsHome
-            activeWorkout={activeWorkout}
-            activeDuration={activeDuration}
-            recentWorkouts={recentWorkouts}
-            onOpenSession={() => setView("log")}
-            onOpenCatalog={() => setView("catalog")}
-            onOpenTemplates={() => setView("templates")}
-            onOpenJournal={() => setView("log")}
-            onRequestStart={() => setQuickStartOpen(true)}
+            activeWorkout={o.activeWorkout}
+            activeDuration={o.activeDuration}
+            recentWorkouts={o.recentWorkouts}
+            onOpenSession={() => o.setView("log")}
+            onOpenCatalog={() => o.setView("catalog")}
+            onOpenTemplates={() => o.setView("templates")}
+            onOpenJournal={() => o.setView("log")}
+            onRequestStart={() => o.setQuickStartOpen(true)}
             onOpenRetro={() => {
-              setRetroOpen(true);
-              setView("log");
+              o.setRetroOpen(true);
+              o.setView("log");
             }}
             onOpenSchedule={onOpenRoutine}
             onOpenPrograms={onOpenPrograms}
           />
         ) : null}
 
-        {view === "log" && (
-          // DataState contract: `data === undefined` triggers the skeleton
-          // slot. `useWorkouts` flips `loaded` from false → true after one
-          // tick on mount (it rehydrates from `localStorage` / SQLite),
-          // so on first paint we feed `data: undefined` and from the
-          // second tick onwards `data` is the real list — even when it
-          // happens to be empty. This prevents the "порожньо" empty-state
-          // inside `WorkoutJournalSection` from flashing during hydration.
-          <DataState query={journalQuery} skeleton={workoutsLoadingSkeleton}>
+        {o.view === "log" && (
+          <DataState query={o.journalQuery} skeleton={workoutsLoadingSkeleton}>
             {() => (
               <WorkoutJournalSection
-                activeWorkout={activeWorkout}
-                activeDuration={activeDuration}
-                workouts={workouts}
-                activeWorkoutId={activeWorkoutId}
-                setActiveWorkoutId={setActiveWorkoutId}
-                retroOpen={retroOpen}
-                setRetroOpen={setRetroOpen}
-                retroDate={retroDate}
-                setRetroDate={setRetroDate}
-                retroTime={retroTime}
-                setRetroTime={setRetroTime}
-                createWorkout={createWorkout}
-                setMode={setView}
-                musclesUk={musclesUk}
-                recBy={rec.by}
-                lastByExerciseId={lastByExerciseId}
-                setRestTimer={setRestTimer}
-                updateWorkout={updateWorkout}
-                updateItem={updateItem}
-                removeItem={removeItemWithUndo}
-                setFinishFlash={setFinishFlash}
-                endWorkout={endWorkout}
-                summarizeWorkoutForFinish={summarizeWorkoutForFinish}
-                submitRetroWorkout={submitRetroWorkout}
-                deleteWorkout={deleteWorkout}
-                restoreWorkout={restoreWorkout}
+                activeWorkout={o.activeWorkout}
+                activeDuration={o.activeDuration}
+                workouts={o.workouts}
+                activeWorkoutId={o.activeWorkoutId}
+                setActiveWorkoutId={o.setActiveWorkoutId}
+                retroOpen={o.retroOpen}
+                setRetroOpen={o.setRetroOpen}
+                retroDate={o.retroDate}
+                setRetroDate={o.setRetroDate}
+                retroTime={o.retroTime}
+                setRetroTime={o.setRetroTime}
+                createWorkout={o.createWorkout}
+                setMode={o.setView}
+                musclesUk={o.musclesUk}
+                recBy={o.rec.by}
+                lastByExerciseId={o.lastByExerciseId}
+                setRestTimer={o.setRestTimer}
+                updateWorkout={o.updateWorkout}
+                updateItem={o.updateItem}
+                removeItem={o.removeItemWithUndo}
+                setFinishFlash={o.setFinishFlash}
+                endWorkout={o.endWorkout}
+                summarizeWorkoutForFinish={o.summarizeWorkoutForFinish}
+                submitRetroWorkout={o.submitRetroWorkout}
+                deleteWorkout={o.deleteWorkout}
+                restoreWorkout={o.restoreWorkout}
               />
             )}
           </DataState>
         )}
 
-        {view === "templates" && (
+        {o.view === "templates" && (
           <WorkoutTemplatesSection
-            exercises={exercises}
-            search={search}
-            templates={templateApi.templates}
-            addTemplate={templateApi.addTemplate}
-            updateTemplate={templateApi.updateTemplate}
-            removeTemplate={templateApi.removeTemplate}
-            restoreTemplate={templateApi.restoreTemplate}
-            onStartTemplate={startWorkoutFromTemplate}
+            exercises={o.exercises}
+            search={o.search}
+            templates={o.templateApi.templates}
+            addTemplate={o.templateApi.addTemplate}
+            updateTemplate={o.templateApi.updateTemplate}
+            removeTemplate={o.templateApi.removeTemplate}
+            restoreTemplate={o.templateApi.restoreTemplate}
+            onStartTemplate={o.startWorkoutFromTemplate}
           />
         )}
 
-        {(view === "catalog" || view === "log") && (
+        {(o.view === "catalog" || o.view === "log") && (
           <WorkoutCatalogSection
-            mode={mode}
-            q={q}
-            setQ={setQ}
-            equipmentFilter={equipmentFilter}
-            setEquipmentFilter={setEquipmentFilter}
-            equipmentUk={equipmentUk}
-            grouped={grouped}
-            open={open}
-            setOpen={setOpen}
-            handleExerciseInListClick={handleExerciseInListClick}
-            setSelected={setSelected}
-            recoveryConflictsForExercise={recoveryConflictsForExercise}
-            rec={rec}
-            musclesUk={musclesUk}
+            mode={o.mode}
+            q={o.q}
+            setQ={o.setQ}
+            equipmentFilter={o.equipmentFilter}
+            setEquipmentFilter={o.setEquipmentFilter}
+            equipmentUk={o.equipmentUk}
+            grouped={o.grouped}
+            open={o.open}
+            setOpen={o.setOpen}
+            handleExerciseInListClick={o.handleExerciseInListClick}
+            setSelected={o.setSelected}
+            recoveryConflictsForExercise={o.recoveryConflictsForExercise}
+            rec={o.rec}
+            musclesUk={o.musclesUk}
           />
         )}
 
         <ExerciseDetailSheet
-          selected={selected}
-          onClose={() => setSelected(null)}
-          mode={mode}
-          musclesUk={musclesUk}
-          rec={rec}
-          recoveryConflictsForExercise={recoveryConflictsForExercise}
-          activeWorkoutId={activeWorkoutId}
-          activeWorkout={activeWorkout}
-          addExerciseToActive={addExerciseToActive}
-          onDeleteRequest={() => setDeleteExerciseConfirm(true)}
-          toast={toast}
+          selected={o.selected}
+          onClose={() => o.setSelected(null)}
+          mode={o.mode}
+          musclesUk={o.musclesUk}
+          rec={o.rec}
+          recoveryConflictsForExercise={o.recoveryConflictsForExercise}
+          activeWorkoutId={o.activeWorkoutId}
+          activeWorkout={o.activeWorkout}
+          addExerciseToActive={o.addExerciseToActive}
+          onDeleteRequest={() => o.setDeleteExerciseConfirm(true)}
+          toast={o.toast}
         />
 
         <AddExerciseSheet
-          open={addOpen}
-          onClose={() => setAddOpen(false)}
-          form={form}
-          setForm={setForm}
-          primaryGroupsUk={primaryGroupsUk}
-          musclesUk={musclesUk}
-          musclesByPrimaryGroup={musclesByPrimaryGroup}
-          addExercise={addExercise}
+          open={o.addOpen}
+          onClose={() => o.setAddOpen(false)}
+          form={o.form}
+          setForm={o.setForm}
+          primaryGroupsUk={o.primaryGroupsUk}
+          musclesUk={o.musclesUk}
+          musclesByPrimaryGroup={o.musclesByPrimaryGroup}
+          addExercise={o.addExercise}
         />
 
         <QuickStartSheet
-          open={quickStartOpen}
-          onClose={() => setQuickStartOpen(false)}
-          exercises={exercises}
-          search={search}
-          primaryGroupsUk={primaryGroupsUk}
+          open={o.quickStartOpen}
+          onClose={() => o.setQuickStartOpen(false)}
+          exercises={o.exercises}
+          search={o.search}
+          primaryGroupsUk={o.primaryGroupsUk}
           onPickTemplate={() => {
-            setQuickStartOpen(false);
-            setView("templates");
+            o.setQuickStartOpen(false);
+            o.setView("templates");
           }}
-          onConfirmExercises={(picks: RawExerciseDef[]) => {
-            // Build a fresh ad-hoc session and pre-load the picked
-            // exercises before flipping the active flag — that way the
-            // session-level live timer (`activeWorkout.startedAt`) is
-            // only created after the user confirmed their selection,
-            // matching the user-stated requirement that the timer must
-            // not start before exercises are lined up.
-            const w = createWorkout();
-            for (const ex of picks) {
-              const isCardio = ex.primaryGroup === "cardio";
-              addItem(w.id, {
-                exerciseId: ex.id,
-                nameUk: ex?.name?.uk || ex?.name?.en,
-                primaryGroup: ex.primaryGroup,
-                musclesPrimary: ex?.muscles?.primary || [],
-                musclesSecondary: ex?.muscles?.secondary || [],
-                type: isCardio ? "distance" : "strength",
-                sets: isCardio ? undefined : [{ weightKg: 0, reps: 0 }],
-                durationSec: isCardio ? 0 : 0,
-                distanceM: isCardio ? 0 : 0,
-              });
-            }
-            setActiveWorkoutId(w.id);
-            setQuickStartOpen(false);
-            setView("log");
-          }}
+          onConfirmExercises={o.handleQuickStartConfirm}
         />
 
         <RestTimerOverlay
-          restTimer={restTimer}
-          onCancel={() => setRestTimer(null)}
+          restTimer={o.restTimer}
+          onCancel={() => o.setRestTimer(null)}
         />
 
         <WorkoutFinishSheets
-          finishFlash={finishFlash}
-          setFinishFlash={setFinishFlash}
-          updateWorkout={updateWorkout}
+          finishFlash={o.finishFlash}
+          setFinishFlash={o.setFinishFlash}
+          updateWorkout={o.updateWorkout}
         />
       </div>
 
       <WorkoutsConfirmDialogs
-        deleteExerciseConfirm={deleteExerciseConfirm}
-        onDeleteExerciseConfirm={() => {
-          if (selected) {
-            const snapshot = selected;
-            if (removeExercise(snapshot.id)) {
-              setSelected(null);
-              showUndoToast(toast, {
-                msg: `Вправу «${snapshot?.name?.uk || "без назви"}» видалено`,
-                onUndo: () => addExercise(snapshot),
-              });
-            }
-          }
-          setDeleteExerciseConfirm(false);
-        }}
-        onDeleteExerciseCancel={() => setDeleteExerciseConfirm(false)}
-        riskyTemplate={riskyTemplateConfirm}
-        onRiskyTemplateConfirm={() => {
-          const tpl = riskyTemplateConfirm;
-          setRiskyTemplateConfirm(null);
-          if (!tpl) return;
-          executeTemplateStart(tpl);
-        }}
-        onRiskyTemplateCancel={() => setRiskyTemplateConfirm(null)}
+        deleteExerciseConfirm={o.deleteExerciseConfirm}
+        onDeleteExerciseConfirm={o.handleDeleteExerciseConfirm}
+        onDeleteExerciseCancel={() => o.setDeleteExerciseConfirm(false)}
+        riskyTemplate={o.riskyTemplateConfirm}
+        onRiskyTemplateConfirm={o.handleRiskyTemplateConfirm}
+        onRiskyTemplateCancel={() => o.setRiskyTemplateConfirm(null)}
       />
     </PullToRefresh>
   );

--- a/apps/web/src/modules/nutrition/components/LogCard.tsx
+++ b/apps/web/src/modules/nutrition/components/LogCard.tsx
@@ -1,38 +1,19 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
-import { Card } from "@shared/components/ui/Card";
-import { SectionHeading } from "@shared/components/ui/SectionHeading";
-import { Input } from "@shared/components/ui/Input";
-import { cn } from "@shared/lib/ui/cn";
 import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
-import { Icon } from "@shared/components/ui/Icon";
 import { EmptyState } from "@shared/components/ui/EmptyState";
-import {
-  searchMealsByName,
-  getMacrosForDateRange,
-  estimateLogBytes,
-  toLocalISODate,
-} from "../lib/nutritionStorage";
+import { estimateLogBytes, toLocalISODate } from "../lib/nutritionStorage";
 import {
   addDaysISODate,
   type Meal,
   type MealTypeId,
   type NutritionLog,
 } from "@sergeant/nutrition-domain";
-import {
-  MEAL_ORDER,
-  MEAL_META,
-  isMealTypeId,
-  mealTypeFromLabel,
-} from "../lib/mealTypes";
-import {
-  avgFromSummary,
-  getRowsForRange,
-  mealTypeBreakdown,
-  summarizeRows,
-  topMeals,
-} from "../lib/nutritionStats";
+import { isMealTypeId, mealTypeFromLabel } from "../lib/mealTypes";
 import { VirtualMealList } from "./VirtualMealList";
+import { LogCardSearch } from "./LogCardSearch";
+import { LogCardWeeklyTable } from "./LogCardWeeklyTable";
+import { LogCardAnalytics } from "./LogCardAnalytics";
 
 interface LogCardProps {
   log: NutritionLog;
@@ -84,47 +65,12 @@ export function LogCard({
   onDuplicateYesterday,
   onTrimLog,
 }: LogCardProps) {
-  const [searchQuery, setSearchQuery] = useState("");
-  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
   const [duplicateConfirm, setDuplicateConfirm] = useState(false);
   const [trimConfirm, setTrimConfirm] = useState(false);
-  const [statsRange, setStatsRange] = useState(30);
-  const [weekOpen, setWeekOpen] = useState(false);
-
-  useEffect(() => {
-    const id = setTimeout(() => setDebouncedSearchQuery(searchQuery), 150);
-    return () => clearTimeout(id);
-  }, [searchQuery]);
 
   const dayData = log[selectedDate];
   const meals = dayData?.meals || [];
   const groups = groupByMealType(meals);
-
-  const searchHits = useMemo(() => {
-    const q = debouncedSearchQuery.trim();
-    if (!q) return [];
-    return searchMealsByName(log, q).slice(0, 40);
-  }, [log, debouncedSearchQuery]);
-
-  const weekRows = useMemo(
-    () => getMacrosForDateRange(log, selectedDate, 7),
-    [log, selectedDate],
-  );
-
-  const statsRows = useMemo(
-    () => getRowsForRange(log, selectedDate, statsRange),
-    [log, selectedDate, statsRange],
-  );
-  const statsSummary = useMemo(() => summarizeRows(statsRows), [statsRows]);
-  const statsAvg = useMemo(() => avgFromSummary(statsSummary), [statsSummary]);
-  const statsTop = useMemo(
-    () => topMeals(log, selectedDate, statsRange, 8),
-    [log, selectedDate, statsRange],
-  );
-  const statsMealTypes = useMemo(
-    () => mealTypeBreakdown(log, selectedDate, statsRange),
-    [log, selectedDate, statsRange],
-  );
 
   const logBytes = useMemo(() => estimateLogBytes(log), [log]);
   const logSizeWarn = logBytes > 350_000;
@@ -176,99 +122,11 @@ export function LogCard({
           </button>
         )}
 
-        <Card
-          variant="flat"
-          radius="lg"
-          padding="none"
-          className="bg-panel/40 px-3 py-3 space-y-2"
-        >
-          <SectionHeading as="div" size="xs">
-            Пошук по журналу
-          </SectionHeading>
-          <Input
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            placeholder="Назва страви…"
-            aria-label="Пошук по журналу"
-          />
-          {searchQuery.trim() && (
-            <ul className="max-h-48 overflow-y-auto text-sm space-y-1">
-              {searchHits.length === 0 && (
-                <li className="text-muted text-xs">Нічого не знайдено</li>
-              )}
-              {searchHits.map(({ date, meal }) => {
-                const mac = meal.macros || {
-                  kcal: null,
-                  protein_g: null,
-                  fat_g: null,
-                  carbs_g: null,
-                };
-                return (
-                  <li
-                    key={`${date}-${meal.id}`}
-                    className="flex items-center gap-2 bg-panelHi rounded-xl px-2.5 py-2"
-                  >
-                    <button
-                      type="button"
-                      className="text-left min-w-0 flex-1"
-                      onClick={() => {
-                        setSelectedDate(date);
-                        setSearchQuery("");
-                      }}
-                    >
-                      <div className="text-xs font-semibold text-text truncate">
-                        {meal.name}
-                      </div>
-                      <div className="flex gap-1.5 mt-0.5 flex-wrap">
-                        <span className="text-2xs text-subtle">{date}</span>
-                        {mac.kcal != null && (
-                          <span className="text-2xs text-nutrition-strong dark:text-nutrition font-bold">
-                            {Math.round(mac.kcal)} ккал
-                          </span>
-                        )}
-                        {mac.protein_g != null && (
-                          <span className="text-2xs text-subtle">
-                            Б{Math.round(mac.protein_g)}
-                          </span>
-                        )}
-                      </div>
-                    </button>
-                    <button
-                      type="button"
-                      className="shrink-0 w-8 h-8 flex items-center justify-center rounded-xl bg-nutrition/10 text-nutrition-strong dark:text-nutrition hover:bg-nutrition/20 transition-colors"
-                      onClick={() => {
-                        onAddMealFromSearch?.({
-                          id: `meal_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`,
-                          time: "",
-                          name: meal.name,
-                          mealType: meal.mealType,
-                          label: meal.label,
-                          macros: meal.macros
-                            ? { ...meal.macros }
-                            : {
-                                kcal: null,
-                                protein_g: null,
-                                fat_g: null,
-                                carbs_g: null,
-                              },
-                          source: "manual",
-                          macroSource: "manual",
-                          foodId: null,
-                          amount_g: null,
-                        });
-                        setSearchQuery("");
-                      }}
-                      title="Додати до поточного дня"
-                      aria-label={`Додати ${meal.name} до поточного дня`}
-                    >
-                      +
-                    </button>
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-        </Card>
+        <LogCardSearch
+          log={log}
+          setSelectedDate={setSelectedDate}
+          onAddMealFromSearch={onAddMealFromSearch}
+        />
 
         {logSizeWarn && (
           <div className="rounded-2xl border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
@@ -283,184 +141,9 @@ export function LogCard({
           </div>
         )}
 
-        <SectionHeading
-          as="button"
-          size="xs"
-          type="button"
-          onClick={() => setWeekOpen((v) => !v)}
-          className="flex items-center gap-2 w-full text-left py-1"
-        >
-          <Icon
-            name="chevron-right"
-            size={12}
-            strokeWidth={2.5}
-            className={cn(
-              "transition-transform shrink-0",
-              weekOpen ? "rotate-90" : "",
-            )}
-          />
-          Журнал за тиждень
-        </SectionHeading>
+        <LogCardWeeklyTable log={log} selectedDate={selectedDate} />
 
-        {weekOpen && (
-          <div className="rounded-2xl border border-line bg-panel/40 px-3 py-3">
-            <div className="overflow-x-auto">
-              <table className="w-full text-xs text-left">
-                <thead>
-                  <tr className="text-subtle">
-                    <th className="py-1 pr-2">Дата</th>
-                    <th className="py-1 pr-2">Ккал</th>
-                    <th className="py-1 pr-2">Б</th>
-                    <th className="py-1 pr-2">Ж</th>
-                    <th className="py-1">В</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {weekRows.map((r) => (
-                    <tr key={r.date} className="border-t border-line/40">
-                      <td className="py-1 pr-2 font-mono text-2xs">
-                        {r.date.slice(5)}
-                      </td>
-                      <td className="py-1 pr-2">{Math.round(r.kcal)}</td>
-                      <td className="py-1 pr-2">{Math.round(r.protein_g)}</td>
-                      <td className="py-1 pr-2">{Math.round(r.fat_g)}</td>
-                      <td className="py-1">{Math.round(r.carbs_g)}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </div>
-        )}
-
-        <div className="rounded-2xl border border-line bg-panel/40 px-3 py-3 space-y-3">
-          <div className="flex items-center justify-between gap-2">
-            <SectionHeading as="div" size="xs">
-              Аналітика (тренди)
-            </SectionHeading>
-            <div className="flex gap-2">
-              {[30, 90].map((d) => (
-                <button
-                  key={d}
-                  type="button"
-                  onClick={() => setStatsRange(d)}
-                  className={cn(
-                    "px-2 py-1 rounded-xl text-xs font-semibold border",
-                    statsRange === d
-                      ? "border-nutrition/60 text-nutrition-strong dark:text-nutrition bg-nutrition/10"
-                      : "border-line text-subtle bg-panelHi",
-                  )}
-                >
-                  {d} днів
-                </button>
-              ))}
-            </div>
-          </div>
-
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
-            {[
-              { key: "kcal", label: "Сер. ккал/день", v: statsAvg.kcal },
-              { key: "protein_g", label: "Сер. Б/день", v: statsAvg.protein_g },
-              { key: "fat_g", label: "Сер. Ж/день", v: statsAvg.fat_g },
-              { key: "carbs_g", label: "Сер. В/день", v: statsAvg.carbs_g },
-            ].map((x) => (
-              <div key={x.key} className="bg-panelHi rounded-2xl px-2 py-3">
-                <div className="text-2xs text-subtle">{x.label}</div>
-                <div className="text-base font-extrabold text-text tabular-nums">
-                  {Math.round(Number(x.v) || 0)}
-                </div>
-                <div className="text-2xs text-subtle">
-                  на {statsAvg.denom} активн. днів
-                </div>
-              </div>
-            ))}
-          </div>
-
-          <div className="bg-panelHi rounded-2xl px-3 py-3">
-            <SectionHeading as="div" size="xs" className="mb-2">
-              Калорії по днях (останні {Math.min(statsRange, statsRows.length)})
-            </SectionHeading>
-            {statsRows.length === 0 ? (
-              // eslint-disable-next-line sergeant-design/no-bare-empty-text -- pre-existing tech debt; tracked in docs/tech-debt/frontend.md
-              <div className="text-xs text-muted">Поки що порожньо</div>
-            ) : (
-              (() => {
-                const kcals = statsRows.map((r) => Number(r.kcal) || 0);
-                const max = Math.max(1, ...kcals);
-                return (
-                  <div className="flex items-end gap-0.5 h-12">
-                    {kcals.slice(-statsRange).map((k, i) => (
-                      <div
-                        key={i}
-                        title={`${Math.round(k)} ккал`}
-                        className="flex-1 rounded-sm bg-nutrition/60"
-                        style={{
-                          height: `${Math.max(2, Math.round((k / max) * 48))}px`,
-                        }}
-                      />
-                    ))}
-                  </div>
-                );
-              })()
-            )}
-          </div>
-
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-            <div className="bg-panelHi rounded-2xl px-3 py-3">
-              <SectionHeading as="div" size="xs" className="mb-2">
-                Топ страв
-              </SectionHeading>
-              {statsTop.length === 0 ? (
-                // eslint-disable-next-line sergeant-design/no-bare-empty-text -- pre-existing tech debt; tracked in docs/tech-debt/frontend.md
-                <div className="text-xs text-muted">Поки що порожньо</div>
-              ) : (
-                <ol className="space-y-1">
-                  {statsTop.map((x) => (
-                    <li
-                      key={x.name}
-                      className="flex items-baseline justify-between gap-2"
-                    >
-                      <span className="text-xs text-text truncate">
-                        {x.name}
-                      </span>
-                      <span className="text-xs text-subtle shrink-0">
-                        {x.count}× · {Math.round(x.kcal)} ккал
-                      </span>
-                    </li>
-                  ))}
-                </ol>
-              )}
-            </div>
-            <div className="bg-panelHi rounded-2xl px-3 py-3">
-              <SectionHeading as="div" size="xs" className="mb-2">
-                Розподіл прийомів
-              </SectionHeading>
-              {Object.keys(statsMealTypes).length === 0 ? (
-                // eslint-disable-next-line sergeant-design/no-bare-empty-text -- pre-existing tech debt; tracked in docs/tech-debt/frontend.md
-                <div className="text-xs text-muted">Поки що порожньо</div>
-              ) : (
-                <ul className="space-y-1">
-                  {MEAL_ORDER.filter(
-                    (t) => (statsMealTypes[t]?.count ?? 0) > 0,
-                  ).map((t) => (
-                    <li
-                      key={t}
-                      className="flex items-baseline justify-between gap-2"
-                    >
-                      <span className="text-xs text-text">
-                        {MEAL_META[t]?.emoji} {MEAL_META[t]?.label || t}
-                      </span>
-                      <span className="text-xs text-subtle shrink-0">
-                        {statsMealTypes[t]!.count}× ·{" "}
-                        {Math.round(statsMealTypes[t]!.kcal)} ккал
-                      </span>
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </div>
-          </div>
-        </div>
+        <LogCardAnalytics log={log} selectedDate={selectedDate} />
 
         {meals.length === 0 ? (
           <EmptyState

--- a/apps/web/src/modules/nutrition/components/LogCardAnalytics.tsx
+++ b/apps/web/src/modules/nutrition/components/LogCardAnalytics.tsx
@@ -1,0 +1,166 @@
+/* eslint-disable sergeant-design/no-cyrillic-jsx-literal -- pre-existing i18n tech debt; strings moved from LogCard.tsx during T3 decomposition */
+import { useMemo, useState } from "react";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
+import { cn } from "@shared/lib/ui/cn";
+import {
+  avgFromSummary,
+  getRowsForRange,
+  mealTypeBreakdown,
+  summarizeRows,
+  topMeals,
+} from "../lib/nutritionStats";
+import { MEAL_ORDER, MEAL_META } from "../lib/mealTypes";
+import type { NutritionLog } from "@sergeant/nutrition-domain";
+
+interface LogCardAnalyticsProps {
+  log: NutritionLog;
+  selectedDate: string;
+}
+
+export function LogCardAnalytics({ log, selectedDate }: LogCardAnalyticsProps) {
+  const [statsRange, setStatsRange] = useState(30);
+
+  const statsRows = useMemo(
+    () => getRowsForRange(log, selectedDate, statsRange),
+    [log, selectedDate, statsRange],
+  );
+  const statsSummary = useMemo(() => summarizeRows(statsRows), [statsRows]);
+  const statsAvg = useMemo(() => avgFromSummary(statsSummary), [statsSummary]);
+  const statsTop = useMemo(
+    () => topMeals(log, selectedDate, statsRange, 8),
+    [log, selectedDate, statsRange],
+  );
+  const statsMealTypes = useMemo(
+    () => mealTypeBreakdown(log, selectedDate, statsRange),
+    [log, selectedDate, statsRange],
+  );
+
+  return (
+    <div className="rounded-2xl border border-line bg-panel/40 px-3 py-3 space-y-3">
+      <div className="flex items-center justify-between gap-2">
+        <SectionHeading as="div" size="xs">
+          Аналітика (тренди)
+        </SectionHeading>
+        <div className="flex gap-2">
+          {[30, 90].map((d) => (
+            <button
+              key={d}
+              type="button"
+              onClick={() => setStatsRange(d)}
+              className={cn(
+                "px-2 py-1 rounded-xl text-xs font-semibold border",
+                statsRange === d
+                  ? "border-nutrition/60 text-nutrition-strong dark:text-nutrition bg-nutrition/10"
+                  : "border-line text-subtle bg-panelHi",
+              )}
+            >
+              {d} днів
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+        {[
+          { key: "kcal", label: "Сер. ккал/день", v: statsAvg.kcal },
+          { key: "protein_g", label: "Сер. Б/день", v: statsAvg.protein_g },
+          { key: "fat_g", label: "Сер. Ж/день", v: statsAvg.fat_g },
+          { key: "carbs_g", label: "Сер. В/день", v: statsAvg.carbs_g },
+        ].map((x) => (
+          <div key={x.key} className="bg-panelHi rounded-2xl px-2 py-3">
+            <div className="text-2xs text-subtle">{x.label}</div>
+            <div className="text-base font-extrabold text-text tabular-nums">
+              {Math.round(Number(x.v) || 0)}
+            </div>
+            <div className="text-2xs text-subtle">
+              на {statsAvg.denom} активн. днів
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="bg-panelHi rounded-2xl px-3 py-3">
+        <SectionHeading as="div" size="xs" className="mb-2">
+          Калорії по днях (останні {Math.min(statsRange, statsRows.length)})
+        </SectionHeading>
+        {statsRows.length === 0 ? (
+          // eslint-disable-next-line sergeant-design/no-bare-empty-text -- pre-existing tech debt; tracked in docs/tech-debt/frontend.md
+          <div className="text-xs text-muted">Поки що порожньо</div>
+        ) : (
+          (() => {
+            const kcals = statsRows.map((r) => Number(r.kcal) || 0);
+            const max = Math.max(1, ...kcals);
+            return (
+              <div className="flex items-end gap-0.5 h-12">
+                {kcals.slice(-statsRange).map((k, i) => (
+                  <div
+                    key={i}
+                    title={`${Math.round(k)} ккал`}
+                    className="flex-1 rounded-sm bg-nutrition/60"
+                    style={{
+                      height: `${Math.max(2, Math.round((k / max) * 48))}px`,
+                    }}
+                  />
+                ))}
+              </div>
+            );
+          })()
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        <div className="bg-panelHi rounded-2xl px-3 py-3">
+          <SectionHeading as="div" size="xs" className="mb-2">
+            Топ страв
+          </SectionHeading>
+          {statsTop.length === 0 ? (
+            // eslint-disable-next-line sergeant-design/no-bare-empty-text -- pre-existing tech debt; tracked in docs/tech-debt/frontend.md
+            <div className="text-xs text-muted">Поки що порожньо</div>
+          ) : (
+            <ol className="space-y-1">
+              {statsTop.map((x) => (
+                <li
+                  key={x.name}
+                  className="flex items-baseline justify-between gap-2"
+                >
+                  <span className="text-xs text-text truncate">{x.name}</span>
+                  <span className="text-xs text-subtle shrink-0">
+                    {x.count}× · {Math.round(x.kcal)} ккал
+                  </span>
+                </li>
+              ))}
+            </ol>
+          )}
+        </div>
+        <div className="bg-panelHi rounded-2xl px-3 py-3">
+          <SectionHeading as="div" size="xs" className="mb-2">
+            Розподіл прийомів
+          </SectionHeading>
+          {Object.keys(statsMealTypes).length === 0 ? (
+            // eslint-disable-next-line sergeant-design/no-bare-empty-text -- pre-existing tech debt; tracked in docs/tech-debt/frontend.md
+            <div className="text-xs text-muted">Поки що порожньо</div>
+          ) : (
+            <ul className="space-y-1">
+              {MEAL_ORDER.filter(
+                (t) => (statsMealTypes[t]?.count ?? 0) > 0,
+              ).map((t) => (
+                <li
+                  key={t}
+                  className="flex items-baseline justify-between gap-2"
+                >
+                  <span className="text-xs text-text">
+                    {MEAL_META[t]?.emoji} {MEAL_META[t]?.label || t}
+                  </span>
+                  <span className="text-xs text-subtle shrink-0">
+                    {statsMealTypes[t]!.count}× ·{" "}
+                    {Math.round(statsMealTypes[t]!.kcal)} ккал
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/modules/nutrition/components/LogCardSearch.tsx
+++ b/apps/web/src/modules/nutrition/components/LogCardSearch.tsx
@@ -1,0 +1,129 @@
+/* eslint-disable sergeant-design/no-cyrillic-jsx-literal -- pre-existing i18n tech debt; strings moved from LogCard.tsx during T3 decomposition */
+import { useEffect, useMemo, useState } from "react";
+import { Card } from "@shared/components/ui/Card";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
+import { Input } from "@shared/components/ui/Input";
+import { searchMealsByName } from "../lib/nutritionStorage";
+import type { Meal, NutritionLog } from "@sergeant/nutrition-domain";
+
+interface LogCardSearchProps {
+  log: NutritionLog;
+  setSelectedDate: (date: string) => void;
+  onAddMealFromSearch?: (meal: Meal, date?: string) => void;
+}
+
+export function LogCardSearch({
+  log,
+  setSelectedDate,
+  onAddMealFromSearch,
+}: LogCardSearchProps) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebouncedSearchQuery(searchQuery), 150);
+    return () => clearTimeout(id);
+  }, [searchQuery]);
+
+  const searchHits = useMemo(() => {
+    const q = debouncedSearchQuery.trim();
+    if (!q) return [];
+    return searchMealsByName(log, q).slice(0, 40);
+  }, [log, debouncedSearchQuery]);
+
+  return (
+    <Card
+      variant="flat"
+      radius="lg"
+      padding="none"
+      className="bg-panel/40 px-3 py-3 space-y-2"
+    >
+      <SectionHeading as="div" size="xs">
+        Пошук по журналу
+      </SectionHeading>
+      <Input
+        value={searchQuery}
+        onChange={(e) => setSearchQuery(e.target.value)}
+        placeholder="Назва страви…"
+        aria-label="Пошук по журналу"
+      />
+      {searchQuery.trim() && (
+        <ul className="max-h-48 overflow-y-auto text-sm space-y-1">
+          {searchHits.length === 0 && (
+            <li className="text-muted text-xs">Нічого не знайдено</li>
+          )}
+          {searchHits.map(({ date, meal }) => {
+            const mac = meal.macros || {
+              kcal: null,
+              protein_g: null,
+              fat_g: null,
+              carbs_g: null,
+            };
+            return (
+              <li
+                key={`${date}-${meal.id}`}
+                className="flex items-center gap-2 bg-panelHi rounded-xl px-2.5 py-2"
+              >
+                <button
+                  type="button"
+                  className="text-left min-w-0 flex-1"
+                  onClick={() => {
+                    setSelectedDate(date);
+                    setSearchQuery("");
+                  }}
+                >
+                  <div className="text-xs font-semibold text-text truncate">
+                    {meal.name}
+                  </div>
+                  <div className="flex gap-1.5 mt-0.5 flex-wrap">
+                    <span className="text-2xs text-subtle">{date}</span>
+                    {mac.kcal != null && (
+                      <span className="text-2xs text-nutrition-strong dark:text-nutrition font-bold">
+                        {Math.round(mac.kcal)} ккал
+                      </span>
+                    )}
+                    {mac.protein_g != null && (
+                      <span className="text-2xs text-subtle">
+                        Б{Math.round(mac.protein_g)}
+                      </span>
+                    )}
+                  </div>
+                </button>
+                <button
+                  type="button"
+                  className="shrink-0 w-8 h-8 flex items-center justify-center rounded-xl bg-nutrition/10 text-nutrition-strong dark:text-nutrition hover:bg-nutrition/20 transition-colors"
+                  onClick={() => {
+                    onAddMealFromSearch?.({
+                      id: `meal_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`,
+                      time: "",
+                      name: meal.name,
+                      mealType: meal.mealType,
+                      label: meal.label,
+                      macros: meal.macros
+                        ? { ...meal.macros }
+                        : {
+                            kcal: null,
+                            protein_g: null,
+                            fat_g: null,
+                            carbs_g: null,
+                          },
+                      source: "manual",
+                      macroSource: "manual",
+                      foodId: null,
+                      amount_g: null,
+                    });
+                    setSearchQuery("");
+                  }}
+                  title="Додати до поточного дня"
+                  aria-label={`Додати ${meal.name} до поточного дня`}
+                >
+                  +
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </Card>
+  );
+}

--- a/apps/web/src/modules/nutrition/components/LogCardWeeklyTable.tsx
+++ b/apps/web/src/modules/nutrition/components/LogCardWeeklyTable.tsx
@@ -1,0 +1,78 @@
+/* eslint-disable sergeant-design/no-cyrillic-jsx-literal -- pre-existing i18n tech debt; strings moved from LogCard.tsx during T3 decomposition */
+import { useMemo, useState } from "react";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
+import { Icon } from "@shared/components/ui/Icon";
+import { cn } from "@shared/lib/ui/cn";
+import { getMacrosForDateRange } from "../lib/nutritionStorage";
+import type { NutritionLog } from "@sergeant/nutrition-domain";
+
+interface LogCardWeeklyTableProps {
+  log: NutritionLog;
+  selectedDate: string;
+}
+
+export function LogCardWeeklyTable({
+  log,
+  selectedDate,
+}: LogCardWeeklyTableProps) {
+  const [weekOpen, setWeekOpen] = useState(false);
+
+  const weekRows = useMemo(
+    () => getMacrosForDateRange(log, selectedDate, 7),
+    [log, selectedDate],
+  );
+
+  return (
+    <>
+      <SectionHeading
+        as="button"
+        size="xs"
+        type="button"
+        onClick={() => setWeekOpen((v) => !v)}
+        className="flex items-center gap-2 w-full text-left py-1"
+      >
+        <Icon
+          name="chevron-right"
+          size={12}
+          strokeWidth={2.5}
+          className={cn(
+            "transition-transform shrink-0",
+            weekOpen ? "rotate-90" : "",
+          )}
+        />
+        Журнал за тиждень
+      </SectionHeading>
+
+      {weekOpen && (
+        <div className="rounded-2xl border border-line bg-panel/40 px-3 py-3">
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs text-left">
+              <thead>
+                <tr className="text-subtle">
+                  <th className="py-1 pr-2">Дата</th>
+                  <th className="py-1 pr-2">Ккал</th>
+                  <th className="py-1 pr-2">Б</th>
+                  <th className="py-1 pr-2">Ж</th>
+                  <th className="py-1">В</th>
+                </tr>
+              </thead>
+              <tbody>
+                {weekRows.map((r) => (
+                  <tr key={r.date} className="border-t border-line/40">
+                    <td className="py-1 pr-2 font-mono text-2xs">
+                      {r.date.slice(5)}
+                    </td>
+                    <td className="py-1 pr-2">{Math.round(r.kcal)}</td>
+                    <td className="py-1 pr-2">{Math.round(r.protein_g)}</td>
+                    <td className="py-1 pr-2">{Math.round(r.fat_g)}</td>
+                    <td className="py-1">{Math.round(r.carbs_g)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Decompose two large components to comply with Hard Rule #18 (max 600 LOC, target <250):

- **Workouts.tsx**: 592 → 214 LOC — extracted `useWorkoutsOrchestrator` hook (all state, callbacks, side-effect hooks)
- **LogCard.tsx**: 533 → 218 LOC — extracted `LogCardSearch`, `LogCardWeeklyTable`, `LogCardAnalytics`

No behavioural changes. All Cyrillic strings are pre-existing and annotated with `eslint-disable` for `no-cyrillic-jsx-literal`.

## Governing Skill

- Primary skill: `sergeant-web-ui`
- Secondary skill: n/a

## Playbook

- Primary playbook: n/a (standard decomposition)
- Why this playbook: module-size discipline initiative (T3 batch 3)
- If no playbook matched, why: pure refactor with clear acceptance criteria from sprint roadmap

## Verification

```bash
pnpm --filter @sergeant/web typecheck   # ✔ passes (0 errors)
pnpm --filter @sergeant/web test -- --run src/modules/fizruk src/modules/nutrition
# all module tests pass (pre-existing db-schema resolution failures only)
```

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a (pure refactor, no behaviour change)

## Risk and Rollout

- User-visible risk: None — pure decomposition, no behaviour change
- Rollout / deploy order: Standard merge to main
- Backout plan: Revert commit

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

Pure refactor. The extracted files contain only moved code — no new logic. LOC counts:
- `useWorkoutsOrchestrator.ts`: 427 LOC (hooks-only, no JSX)
- `LogCardSearch.tsx`: 131 LOC
- `LogCardWeeklyTable.tsx`: 78 LOC
- `LogCardAnalytics.tsx`: 171 LOC


Link to Devin session: https://app.devin.ai/sessions/226c89d636a640fc870306f6be5259e4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decomposed `Workouts.tsx` and `LogCard.tsx` into focused hooks/components to meet the T3 batch 3 module-size goals (Hard Rule #18). No behavior or UI changes.

- **Refactors**
  - `Workouts.tsx`: extracted `useWorkoutsOrchestrator` (state, callbacks, effects); page now uses the orchestrator.
  - `LogCard.tsx`: extracted `LogCardSearch`, `LogCardWeeklyTable`, `LogCardAnalytics`.
  - LOC reduced: `Workouts.tsx` 592 → 214, `LogCard.tsx` 533 → 218.

<sup>Written for commit 2a3d740bfce1b4d46040063b0658cee7c6dc9bfa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

