### PR TITLE
feat(console): add Sentry breadcrumb on webhook W4.1 race recovery — O6

### DIFF
--- a/tools/console/src/openclaw/bootstrap.test.ts
+++ b/tools/console/src/openclaw/bootstrap.test.ts
@@ -6,6 +6,13 @@ import {
   validateWebhookConfig,
 } from "./bootstrap.js";
 
+const { mockAddBreadcrumb } = vi.hoisted(() => ({
+  mockAddBreadcrumb: vi.fn(),
+}));
+vi.mock("../obs/sentry.js", () => ({
+  Sentry: { addBreadcrumb: mockAddBreadcrumb },
+}));
+
 const SECRET_OK = "a".repeat(32);
 
 function makeBotMock(initialUrl = "") {
@@ -148,6 +155,43 @@ describe("registerOpenClawWebhook", () => {
       }),
     ).rejects.toThrow(/must use https/);
     expect(setWebhook).not.toHaveBeenCalled();
+  });
+
+  it("emits Sentry breadcrumb on successful recovery after W4.1 race", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockAddBreadcrumb.mockClear();
+    const { bot, getWebhookInfo } = makeBotMock();
+    let calls = 0;
+    getWebhookInfo.mockImplementation(async () => {
+      calls += 1;
+      return {
+        url: calls === 1 ? "" : "https://x.example/webhook",
+        has_custom_certificate: false,
+        pending_update_count: 0,
+      };
+    });
+    await registerOpenClawWebhook(bot as never, {
+      url: "https://x.example/webhook",
+      secretToken: SECRET_OK,
+    });
+    expect(mockAddBreadcrumb).toHaveBeenCalledTimes(1);
+    expect(mockAddBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: "openclaw.webhook",
+        level: "info",
+        data: expect.objectContaining({ attempt: 2 }),
+      }),
+    );
+  });
+
+  it("does not emit Sentry breadcrumb on first-attempt success", async () => {
+    mockAddBreadcrumb.mockClear();
+    const { bot } = makeBotMock();
+    await registerOpenClawWebhook(bot as never, {
+      url: "https://x.example/webhook",
+      secretToken: SECRET_OK,
+    });
+    expect(mockAddBreadcrumb).not.toHaveBeenCalled();
   });
 
   it("retries setWebhook when getWebhookInfo reports an empty url (W4.1 race)", async () => {

--- a/tools/console/src/openclaw/bootstrap.ts
+++ b/tools/console/src/openclaw/bootstrap.ts
@@ -12,6 +12,7 @@
  * if Telegram already has the same config.
  */
 import type { Bot } from "grammy";
+import { Sentry } from "../obs/sentry.js";
 
 export interface OpenClawWebhookConfig {
   /** Public HTTPS URL Telegram should POST updates to. */
@@ -113,7 +114,17 @@ export async function registerOpenClawWebhook(
     });
     const info = await bot.api.getWebhookInfo();
     lastInfoUrl = info.url ?? "";
-    if (lastInfoUrl === config.url) return;
+    if (lastInfoUrl === config.url) {
+      if (attempt > 1) {
+        Sentry.addBreadcrumb({
+          category: "openclaw.webhook",
+          message: `[openclaw] webhook recovered after race (attempt ${attempt})`,
+          level: "info",
+          data: { url: config.url, attempt },
+        });
+      }
+      return;
+    }
     if (attempt >= WEBHOOK_VERIFY_MAX_ATTEMPTS) break;
     const delayMs = Math.min(
       WEBHOOK_VERIFY_BASE_DELAY_MS * 2 ** (attempt - 1),


### PR DESCRIPTION
## Summary

Add a Sentry breadcrumb when the W4.1 webhook race self-heals on retry (attempt > 1). This provides structured observability for post-mortems — the existing `console.warn` is useful for log-grepping but Sentry breadcrumbs appear automatically in error context without dedicated log search.

Changes:
- `bootstrap.ts`: after successful retry, call `Sentry.addBreadcrumb` with category `openclaw.webhook`, level `info`, and attempt number
- `bootstrap.test.ts`: 2 new tests — breadcrumb emitted on recovery, not on first-try success

## Governing Skill

- Primary skill: n/a (console/bot infra)
- Secondary skill: n/a

## Playbook

- Primary playbook: n/a
- Why this playbook: n/a
- If no playbook matched, why: small observability enhancement with clear acceptance criteria from sprint roadmap O6

## Verification

```bash
pnpm --filter @sergeant/console typecheck   # ✔ passes
pnpm --filter @sergeant/console test -- --run src/openclaw/bootstrap.test.ts
# ✔ 17 passed (15 existing + 2 new)
```

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a

## Risk and Rollout

- User-visible risk: None — adds a Sentry breadcrumb only; no behaviour change
- Rollout / deploy order: Standard merge to main
- Backout plan: Revert commit

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

Minimal change — one `Sentry.addBreadcrumb` call + `vi.mock` for the Sentry module in tests.


Link to Devin session: https://app.devin.ai/sessions/226c89d636a640fc870306f6be5259e4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Sentry breadcrumb in `@sergeant/console` when the OpenClaw webhook recovers after the W4.1 race on retry (attempt > 1) to improve post‑mortem tracing. No behavior change; this only adds observability.

- **New Features**
  - Emit `openclaw.webhook` info breadcrumb on successful retry with url and attempt number; do not emit on first-try success. Tests cover both cases.

<sup>Written for commit 49d5c84657c4a6b4ef814569364404fa520a3c25. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for webhook verification retry scenarios with Sentry telemetry.

* **Chores**
  * Enhanced error tracking and diagnostics for webhook registration, now emitting telemetry on successful recovery after retry attempts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Skords-01/Sergeant/pull/2531)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->