### PR TITLE
Enhance Nutrition Start Page with card styling and textured backgrounds

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -22,6 +22,7 @@
    ═══════════════════════════════════════════════════════════════════════ */
 @import "@fontsource-variable/dm-sans" layer(base);
 @import "./styles/animations.css" layer(base);
+@import "./styles/background.css" layer(base);
 @import "./styles/module-surfaces.css";
 @import "tailwindcss";
 @import "./styles/theme.css";

--- a/apps/web/src/modules/nutrition/pages/NutritionStartPage.tsx
+++ b/apps/web/src/modules/nutrition/pages/NutritionStartPage.tsx
@@ -1,5 +1,6 @@
 import type { Dispatch, Ref, SetStateAction } from "react";
 import type { NutritionPrefs } from "@sergeant/nutrition-domain";
+import { Card } from "@shared/components/ui/Card";
 import { Icon } from "@shared/components/ui/Icon";
 import { SectionErrorBoundary } from "@shared/components/ui/SectionErrorBoundary";
 import { NutritionDashboard } from "../components/NutritionDashboard";
@@ -76,15 +77,46 @@ export function NutritionStartPage({
             if (!e.currentTarget.open) setPhotoCardForceOpen(false);
           }}
         >
-          <summary className="flex items-center gap-2 cursor-pointer select-none py-2 px-1 text-style-label text-text">
+          <Card
+            as="summary"
+            module="nutrition"
+            prominence="tinted"
+            padding="md"
+            radius="xl"
+            className="flex items-center gap-3 cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden"
+          >
+            <span className="flex items-center justify-center w-9 h-9 rounded-xl bg-nutrition/15 shrink-0">
+              <svg
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.6"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="text-nutrition-strong"
+                aria-hidden
+              >
+                <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" />
+                <circle cx="12" cy="13" r="4" />
+              </svg>
+            </span>
+            <div className="flex-1 min-w-0">
+              <div className="text-style-label text-text">
+                Аналіз фото страви
+              </div>
+              <div className="text-xs text-subtle mt-0.5">
+                ШІ визначить КБЖВ за фото
+              </div>
+            </div>
             <Icon
               name="chevron-right"
               size={16}
-              className="transition-transform group-open:rotate-90"
+              className="text-muted transition-transform group-open:rotate-90 shrink-0"
             />
-            Аналіз фото страви
-          </summary>
-          <div className="pt-1">
+          </Card>
+          <div className="pt-2">
             <PhotoAnalyzeCard
               busy={busy}
               analyzePhoto={photo.analyzePhoto}

--- a/apps/web/src/shared/components/layout/ModuleShell.tsx
+++ b/apps/web/src/shared/components/layout/ModuleShell.tsx
@@ -66,7 +66,7 @@ export function ModuleShell({
     <div
       style={shellStyle}
       className={cn(
-        "h-dvh flex flex-col bg-bg text-text overflow-hidden",
+        "h-dvh flex flex-col bg-bg text-text overflow-hidden module-bg",
         className,
       )}
     >

--- a/apps/web/src/styles/background.css
+++ b/apps/web/src/styles/background.css
@@ -1,0 +1,42 @@
+/* ═══════════════════════════════════════════════════════════════════════
+   BACKGROUND — Module & hub background with gradient + dot pattern.
+   SVG-encoded dot grid layered beneath subtle warm gradient for visual interest.
+   ═══════════════════════════════════════════════════════════════════════ */
+
+@layer base {
+  :root {
+    /* Light theme — warm ivory to cool ivory gradient with dot pattern */
+    --bg-gradient: linear-gradient(
+      135deg,
+      rgb(253 249 243) 0%,
+      rgb(248 247 246) 50%,
+      rgb(243 244 246) 100%
+    );
+
+    /* SVG-encoded dot grid pattern (tonal, subtle) */
+    --bg-dots: url('data:image/svg+xml,<svg width="80" height="80" xmlns="http://www.w3.org/2000/svg"><defs><pattern id="dots" x="0" y="0" width="80" height="80" patternUnits="userSpaceOnUse"><circle cx="40" cy="40" r="1.5" fill="rgba(0,0,0,0.03)"/></pattern></defs><rect width="80" height="80" fill="white"/><rect width="80" height="80" fill="url(%23dots)"/></svg>');
+  }
+
+  .dark {
+    /* Dark theme — deep warm to cool dark gradient */
+    --bg-gradient: linear-gradient(
+      135deg,
+      rgb(23 20 18) 0%,
+      rgb(28 24 22) 50%,
+      rgb(31 28 26) 100%
+    );
+
+    /* Dark theme dot pattern (even more subtle on dark bg) */
+    --bg-dots: url('data:image/svg+xml,<svg width="80" height="80" xmlns="http://www.w3.org/2000/svg"><defs><pattern id="dots" x="0" y="0" width="80" height="80" patternUnits="userSpaceOnUse"><circle cx="40" cy="40" r="1.5" fill="rgba(255,255,255,0.02)"/></pattern></defs><rect width="80" height="80" fill="rgb(23 20 18)"/><rect width="80" height="80" fill="url(%23dots)"/></svg>');
+  }
+
+  /* Module shell background: gradient + dots pattern */
+  .module-bg {
+    background: var(--bg-gradient);
+    background-image: var(--bg-dots);
+    background-attachment: fixed;
+    background-size:
+      80px 80px,
+      100% 100%;
+  }
+}


### PR DESCRIPTION
- Updated `<details>` elements on the `NutritionStartPage` to function as full-featured cards with frames, camera icons, and expand buttons.
- Added a modern textured gradient background with a subtle SVG dot pattern for hub and module layouts.

[v0 Session](https://v0.app/chat/1KijsEAdcav)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turned the Nutrition photo analysis entry into a full `Card` with icon and expand affordance. Added a textured gradient background with a subtle dot pattern to module pages.

- **New Features**
  - NutritionStartPage: Converted the photo analysis `<summary>` to a `Card` with a camera icon, label + sublabel, and a rotating chevron for expand/collapse.
  - Backgrounds: Introduced a light/dark gradient with an SVG dot texture; applied via `.module-bg` in `ModuleShell` and imported via `background.css`.

<sup>Written for commit d32a1aee0fd81e73ca1d8e2418ce963f55916c60. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

