### PR TITLE
feat(console): /help inline-keyboard + persona quick-row on /start — O7

### DIFF
--- a/tools/console/src/openclaw/handler-commands.ts
+++ b/tools/console/src/openclaw/handler-commands.ts
@@ -50,9 +50,12 @@ import {
   COMMAND_PROMPTS,
   DISPATCHER_COMMANDS,
   HELP_TEXT,
+  PERSONA_CALLBACK_PREFIX,
   PERSONA_COMMANDS,
   PERSONA_LABEL,
   WRITE_TOOL_LABEL,
+  buildHelpKeyboard,
+  buildPersonaQuickRow,
   parseApprovalCallback,
   postJson,
   type BudgetResponse,
@@ -149,12 +152,18 @@ export function registerOpenClawCommands(deps: RegisterCommandsDeps): void {
 
   bot.command("start", async (ctx) => {
     if (!isAllowedDmContext(ctx)) return; // silent ignore у non-DM
-    await ctx.reply(HELP_TEXT, { parse_mode: "HTML" });
+    await ctx.reply(HELP_TEXT, {
+      parse_mode: "HTML",
+      reply_markup: buildPersonaQuickRow(),
+    });
   });
 
   bot.command("help", async (ctx) => {
     if (!isAllowedDmContext(ctx)) return;
-    await ctx.reply(HELP_TEXT, { parse_mode: "HTML" });
+    await ctx.reply(HELP_TEXT, {
+      parse_mode: "HTML",
+      reply_markup: buildHelpKeyboard(),
+    });
   });
 
   bot.command("reset", async (ctx) => {
@@ -787,6 +796,35 @@ export function registerOpenClawCommands(deps: RegisterCommandsDeps): void {
   // "expired" answer-callback rather than executing.
   bot.on("callback_query:data", async (ctx) => {
     const data = ctx.callbackQuery.data;
+
+    // O7: persona quick-row + help keyboard callbacks
+    if (data.startsWith(PERSONA_CALLBACK_PREFIX)) {
+      if (!isAllowedDmContext(ctx)) {
+        await ctx.answerCallbackQuery({
+          text: "Access denied.",
+          show_alert: true,
+        });
+        return;
+      }
+      const persona = data.slice(PERSONA_CALLBACK_PREFIX.length);
+      await ctx.answerCallbackQuery();
+      await ctx.reply(`/${persona}`);
+      return;
+    }
+    if (data.startsWith("oc:cmd:")) {
+      if (!isAllowedDmContext(ctx)) {
+        await ctx.answerCallbackQuery({
+          text: "Access denied.",
+          show_alert: true,
+        });
+        return;
+      }
+      const cmd = data.slice("oc:cmd:".length);
+      await ctx.answerCallbackQuery();
+      await ctx.reply(`/${cmd}`);
+      return;
+    }
+
     const parsed = parseApprovalCallback(data);
     if (!parsed) {
       // Not ours — answer empty so the spinner stops, but otherwise

--- a/tools/console/src/openclaw/handler-constants.ts
+++ b/tools/console/src/openclaw/handler-constants.ts
@@ -11,6 +11,7 @@
  */
 
 import type Anthropic from "@anthropic-ai/sdk";
+import { InlineKeyboard } from "grammy";
 import type { Bot } from "grammy";
 import type { OpenClawPersona } from "../agents/personas.js";
 import type { ApprovalRecord, WriteToolName } from "./approval-store.js";
@@ -270,6 +271,47 @@ export function summariseWriteInput(record: ApprovalRecord): string {
       return `issue=${issue}${until}`;
     }
   }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Inline keyboards — O7: /help discovery + persona quick-row
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Persona quick-row for /start (boot) message: one button per specialist
+ * persona. Tapping a button sends the command as a new message via
+ * `switch_inline_current_chat` — but for DM bots the simplest approach
+ * is to rely on Telegram's deep-link trick: the button text IS the
+ * slash-command, so the founder taps it and knows to type it. We use
+ * `callback_data` with an `oc:persona:` prefix instead so we can handle
+ * the tap without requiring the user to type.
+ */
+export const PERSONA_CALLBACK_PREFIX = "oc:persona:";
+
+export function buildPersonaQuickRow(): InlineKeyboard {
+  return new InlineKeyboard()
+    .text("🔧 /ops", `${PERSONA_CALLBACK_PREFIX}ops`)
+    .text("📈 /growth", `${PERSONA_CALLBACK_PREFIX}growth`)
+    .text("⚙️ /eng", `${PERSONA_CALLBACK_PREFIX}eng`)
+    .text("💰 /finance", `${PERSONA_CALLBACK_PREFIX}finance`);
+}
+
+/**
+ * Full help inline keyboard — two rows:
+ * Row 1: persona commands
+ * Row 2: common operational commands
+ */
+export function buildHelpKeyboard(): InlineKeyboard {
+  return new InlineKeyboard()
+    .text("🔧 /ops", `${PERSONA_CALLBACK_PREFIX}ops`)
+    .text("📈 /growth", `${PERSONA_CALLBACK_PREFIX}growth`)
+    .text("⚙️ /eng", `${PERSONA_CALLBACK_PREFIX}eng`)
+    .text("💰 /finance", `${PERSONA_CALLBACK_PREFIX}finance`)
+    .row()
+    .text("🤝 /cofounder", `${PERSONA_CALLBACK_PREFIX}cofounder`)
+    .text("🏛 /council", "oc:cmd:council")
+    .text("📊 /metrics", "oc:cmd:metrics")
+    .text("📋 /digest", "oc:cmd:digest");
 }
 
 // ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Implements O7 from the sprint roadmap: `/help` discovery and persona quick-row.

- **`/help`** now includes an `InlineKeyboard` with two rows:
  - Row 1: persona shortcuts — 🔧 /ops, 📈 /growth, ⚙️ /eng, 💰 /finance
  - Row 2: common commands — 🤝 /cofounder, 🏛 /council, 📊 /metrics, 📋 /digest
- **`/start`** (boot message) shows a single persona quick-row (ops, growth, eng, finance)
- **Callback handler** routes `oc:persona:` and `oc:cmd:` callback data — tapping a button echoes the slash-command back in chat

## Governing Skill

- Primary skill: n/a (console/bot infra)
- Secondary skill: n/a

## Playbook

- Primary playbook: n/a
- Why this playbook: n/a
- If no playbook matched, why: feature from sprint roadmap O7 with clear acceptance criteria

## Verification

```bash
pnpm --filter @sergeant/console typecheck   # ✔ passes
pnpm --filter @sergeant/console test -- --run
# ✔ 300 tests passed (22 suites)
```

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a (sprint roadmap O7 acceptance criteria will be checked off by reviewer)

## Risk and Rollout

- User-visible risk: Low — adds keyboard buttons to existing `/help` and `/start` messages
- Rollout / deploy order: Standard merge to main
- Backout plan: Revert commit

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

- `handler-constants.ts`: new `buildPersonaQuickRow()` and `buildHelpKeyboard()` builders + `PERSONA_CALLBACK_PREFIX` constant
- `handler-commands.ts`: updated `/start` and `/help` to attach keyboards; callback handler extended with persona/cmd routing
- No new dependencies — uses grammy's `InlineKeyboard` already in use for approval buttons


Link to Devin session: https://app.devin.ai/sessions/226c89d636a640fc870306f6be5259e4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements O7 by adding inline keyboards to `/help` and `/start` for faster command discovery; tapping a button echoes the slash command into chat.

- **New Features**
  - `/help`: two-row `InlineKeyboard` — personas (🔧 /ops, 📈 /growth, ⚙️ /eng, 💰 /finance) and common commands (🤝 /cofounder, 🏛 /council, 📊 /metrics, 📋 /digest).
  - `/start`: single persona quick-row.
  - Callback handling for `oc:persona:` and `oc:cmd:` routes taps to send the corresponding slash command.

<sup>Written for commit 6ee444d3e013fa42da01ad372c1d89fb782c3533. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

