### PR TITLE
fix(web): use nutrition variant for macro labels in meal sheet

### DIFF
--- a/apps/web/src/modules/nutrition/components/meal-sheet/MacrosEditor.tsx
+++ b/apps/web/src/modules/nutrition/components/meal-sheet/MacrosEditor.tsx
@@ -98,7 +98,12 @@ export function MacrosEditor({
           ] as const
         ).map(({ key, label, placeholder }) => (
           <div key={key}>
-            <SectionHeading as="div" size="xs" className="mb-1">
+            <SectionHeading
+              as="div"
+              size="xs"
+              variant="nutrition"
+              className="mb-1"
+            >
               {label}
             </SectionHeading>
             <Input


### PR DESCRIPTION
Labels (Ккал, Білки, Жири, Вуглев.) were subtle-grey and hard to read. Switch SectionHeading to variant="nutrition" so they get the module-branded tint.

## Summary

<!-- What changed in one tight paragraph or a short flat list. -->

## Governing Skill

- Primary skill:
- Secondary skill (if truly needed):

## Playbook

- Primary playbook:
- Why this playbook:
- If no playbook matched, why:

## Verification

<!-- Paste the exact commands you ran and the key result.
     Before claiming "Done" — Iron Law gate: NO COMPLETION CLAIMS WITHOUT
     FRESH VERIFICATION EVIDENCE. See `sergeant-review-and-merge` SKILL.md
     § "Verification gate" (.agents/skills/sergeant-review-and-merge/SKILL.md). -->

```bash
pnpm lint
pnpm typecheck
```

Additional checks:

- [ ] Local smoke / manual validation completed
- [ ] Surface-specific checks completed

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [ ] I checked whether `AGENTS.md` needed an update.
- [ ] I checked whether a playbook or skill needed an update.
- [ ] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a

## Risk and Rollout

- User-visible risk:
- Rollout / deploy order:
- Backout plan:

## Hard Rule #15

- [ ] I read `AGENTS.md` before coding.
- [ ] Internal docs I touched are in Ukrainian.
- [ ] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

<!-- Per `docs/governance/audit-freeze-2026-05-05.md`. New files under
docs/audits/, docs/initiatives/, docs/playbooks/, docs/adr/ trigger a
non-blocking CI warning. If this PR adds such a file, add `[skip-freeze]`
or `[freeze-exception]` to the PR title and explain below. Otherwise leave
this section as-is or remove. -->

- [ ] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

<!-- Flag migrations, env changes, HubChat tools, auth, or anything else that deserves extra reviewer attention. -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make macro labels in the meal sheet easier to read by rendering `SectionHeading` with the nutrition variant. Labels now use the module tint (not subtle grey) for better contrast.

<sup>Written for commit 3e135af38414e41663dad98e6ae26a59e5a41af4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the visual styling of the macro nutrient section heading in the nutrition module for improved consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Skords-01/Sergeant/pull/2536)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->