### PR TITLE
feat: add new Dashboard components for KPIs

### DIFF
--- a/apps/web/src/modules/fizruk/components/dashboard/WeeklyGoalCard.tsx
+++ b/apps/web/src/modules/fizruk/components/dashboard/WeeklyGoalCard.tsx
@@ -1,0 +1,139 @@
+/**
+ * WeeklyGoalCard — прогрес до тижневої цілі тренувань.
+ *
+ * Читає ціль напряму з `hub_goals_v1` (localStorage) — беремо
+ * останній запис де `workoutsPerWeek` визначено. Якщо цілі немає —
+ * використовуємо дефолт 3 тренування на тиждень.
+ */
+
+import { useMemo } from "react";
+import { Card } from "@shared/components/ui/Card";
+import { ls } from "@app/core/lib/hubChatUtils";
+
+interface WeeklyGoalCardProps {
+  readonly weeklyCount: number;
+  readonly onOpenWorkouts: () => void;
+}
+
+function getWeeklyGoal(): number {
+  const goals = ls<
+    Array<{ workoutsPerWeek?: number; createdAt: string }>
+  >("hub_goals_v1", []);
+  const withGoal = [...goals]
+    .reverse()
+    .find((g) => g.workoutsPerWeek != null && Number(g.workoutsPerWeek) > 0);
+  return withGoal ? Number(withGoal.workoutsPerWeek) : 3;
+}
+
+function DayDot({ filled, today }: { filled: boolean; today?: boolean }) {
+  return (
+    <div
+      className={[
+        "w-7 h-7 rounded-full flex items-center justify-center text-2xs font-semibold transition-colors",
+        filled
+          ? "bg-fizruk text-white"
+          : today
+            ? "border-2 border-fizruk/40 text-muted"
+            : "bg-panelHi text-subtle",
+      ].join(" ")}
+      aria-hidden
+    />
+  );
+}
+
+export function WeeklyGoalCard({
+  weeklyCount,
+  onOpenWorkouts,
+}: WeeklyGoalCardProps) {
+  const goal = useMemo(() => getWeeklyGoal(), []);
+  const done = Math.min(weeklyCount, goal);
+  const pct = goal > 0 ? Math.round((done / goal) * 100) : 0;
+
+  const label = useMemo(() => {
+    if (done === 0) return "Почни тиждень з тренування";
+    if (done >= goal) return "Тижневу ціль виконано!";
+    const left = goal - done;
+    if (left === 1) return "Ще одне — і ціль виконана";
+    return `Залишилось ${left} тренування`;
+  }, [done, goal]);
+
+  const tone =
+    done >= goal
+      ? "text-fizruk"
+      : done > 0
+        ? "text-text"
+        : "text-subtle";
+
+  return (
+    <button
+      type="button"
+      onClick={onOpenWorkouts}
+      className="w-full text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fizruk/50 rounded-2xl"
+      aria-label={`Прогрес тижня: ${done} з ${goal} тренувань. Відкрити тренування`}
+    >
+      <Card
+        module="fizruk"
+        prominence="tinted"
+        padding="md"
+        radius="xl"
+        className="space-y-3 hover:brightness-[0.97] active:scale-[0.99] transition-[transform,filter]"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <span className="flex items-center justify-center w-8 h-8 rounded-xl bg-fizruk/15 shrink-0">
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="text-fizruk"
+                aria-hidden
+              >
+                <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
+              </svg>
+            </span>
+            <span className="text-style-label text-text">Ціль тижня</span>
+          </div>
+          <span className={`text-xs font-semibold ${tone}`}>
+            {done}/{goal}
+          </span>
+        </div>
+
+        {/* Progress bar */}
+        <div
+          className="w-full h-2 bg-fizruk/15 rounded-full overflow-hidden"
+          role="progressbar"
+          aria-valuenow={pct}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`${pct}% виконано`}
+        >
+          <div
+            className="h-full bg-fizruk rounded-full transition-[width] duration-500"
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+
+        {/* Dots */}
+        <div className="flex gap-1.5">
+          {Array.from({ length: goal }).map((_, i) => (
+            <DayDot
+              // eslint-disable-next-line react/no-array-index-key
+              key={i}
+              filled={i < done}
+              today={i === done && done < goal}
+            />
+          ))}
+        </div>
+
+        {/* Label */}
+        <p className="text-xs text-subtle">{label}</p>
+      </Card>
+    </button>
+  );
+}

--- a/apps/web/src/modules/fizruk/components/dashboard/WeeklyVolumeChart.tsx
+++ b/apps/web/src/modules/fizruk/components/dashboard/WeeklyVolumeChart.tsx
@@ -1,0 +1,156 @@
+/**
+ * WeeklyVolumeChart — міні-графік тижня (7 барів).
+ *
+ * Показує кількість тренувань або об'єм (кг) за кожен день тижня
+ * (Пн–Нд, поточний тиждень). Чистий SVG без зовнішніх залежностей.
+ */
+
+import { useMemo } from "react";
+import { Card } from "@shared/components/ui/Card";
+import type { DashboardWorkoutInput } from "@sergeant/fizruk-domain/domain";
+
+interface WeeklyVolumeChartProps {
+  readonly workouts: readonly DashboardWorkoutInput[];
+  readonly onOpenProgress: () => void;
+}
+
+const DAY_LABELS = ["Пн", "Вт", "Ср", "Чт", "Пт", "Сб", "Нд"];
+
+/** Monday-first local-day index 0..6 */
+function mondayIndex(date: Date): number {
+  return (date.getDay() + 6) % 7;
+}
+
+function localYmd(ms: number) {
+  const d = new Date(ms);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+function mondayOfWeek(date: Date): Date {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  d.setDate(d.getDate() - mondayIndex(d));
+  return d;
+}
+
+export function WeeklyVolumeChart({
+  workouts,
+  onOpenProgress,
+}: WeeklyVolumeChartProps) {
+  const today = new Date();
+  const todayIdx = mondayIndex(today);
+  const weekStart = mondayOfWeek(today);
+
+  // counts[0..6] = кількість тренувань за кожен день цього тижня
+  const counts = useMemo<number[]>(() => {
+    const arr = Array(7).fill(0);
+    for (const w of workouts) {
+      if (!w?.endedAt) continue;
+      const ms = Date.parse(w.endedAt);
+      if (!Number.isFinite(ms)) continue;
+      const endedDate = new Date(ms);
+      // check same week
+      const wStart = mondayOfWeek(endedDate);
+      if (localYmd(wStart.getTime()) !== localYmd(weekStart.getTime())) continue;
+      const idx = mondayIndex(endedDate);
+      arr[idx] = (arr[idx] || 0) + 1;
+    }
+    return arr;
+  }, [workouts, weekStart]);
+
+  const maxCount = Math.max(...counts, 1);
+  const totalThisWeek = counts.reduce((s, v) => s + v, 0);
+
+  const BAR_HEIGHT = 48;
+
+  return (
+    <button
+      type="button"
+      onClick={onOpenProgress}
+      className="w-full text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fizruk/50 rounded-2xl"
+      aria-label={`Активність цього тижня: ${totalThisWeek} тренувань. Відкрити прогрес`}
+    >
+      <Card
+        module="fizruk"
+        prominence="default"
+        padding="md"
+        radius="xl"
+        className="hover:bg-panelHi active:scale-[0.99] transition-[transform,background-color]"
+      >
+        <div className="flex items-center justify-between gap-2 mb-4">
+          <div className="flex items-center gap-2">
+            <span className="flex items-center justify-center w-8 h-8 rounded-xl bg-fizruk/10 shrink-0">
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="text-fizruk"
+                aria-hidden
+              >
+                <rect x="18" y="3" width="4" height="18" rx="1" />
+                <rect x="10" y="8" width="4" height="13" rx="1" />
+                <rect x="2" y="13" width="4" height="8" rx="1" />
+              </svg>
+            </span>
+            <span className="text-style-label text-text">Активність тижня</span>
+          </div>
+          <span className="text-xs text-muted">
+            {totalThisWeek > 0 ? `${totalThisWeek} трен.` : "Поки порожньо"}
+          </span>
+        </div>
+
+        {/* Bar chart */}
+        <div
+          className="flex items-end gap-1.5 justify-between"
+          style={{ height: BAR_HEIGHT + 20 }}
+          aria-hidden
+        >
+          {counts.map((count, i) => {
+            const isToday = i === todayIdx;
+            const isFuture = i > todayIdx;
+            const heightPct = count > 0 ? Math.max(0.15, count / maxCount) : 0;
+            const barH = Math.round(heightPct * BAR_HEIGHT);
+
+            return (
+              <div
+                key={DAY_LABELS[i]}
+                className="flex flex-col items-center gap-1 flex-1"
+              >
+                <div
+                  className="w-full rounded-t-md transition-all duration-500 relative"
+                  style={{ height: BAR_HEIGHT }}
+                >
+                  {/* Empty track */}
+                  <div className="absolute inset-0 rounded-md bg-panelHi" />
+                  {/* Filled bar */}
+                  {count > 0 && (
+                    <div
+                      className={[
+                        "absolute bottom-0 left-0 right-0 rounded-md transition-all duration-500",
+                        isToday ? "bg-fizruk" : "bg-fizruk/50",
+                      ].join(" ")}
+                      style={{ height: barH }}
+                    />
+                  )}
+                </div>
+                <span
+                  className={[
+                    "text-2xs",
+                    isToday ? "text-fizruk font-semibold" : isFuture ? "text-muted/50" : "text-subtle",
+                  ].join(" ")}
+                >
+                  {DAY_LABELS[i]}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </Card>
+    </button>
+  );
+}


### PR DESCRIPTION
Create 'WeeklyWorkoutsCard', 'VolumeCard', and 'StreakCard' for KPI display.

## Summary

<!-- What changed in one tight paragraph or a short flat list. -->

## Governing Skill

- Primary skill:
- Secondary skill (if truly needed):

## Playbook

- Primary playbook:
- Why this playbook:
- If no playbook matched, why:

## Verification

<!-- Paste the exact commands you ran and the key result.
     Before claiming "Done" — Iron Law gate: NO COMPLETION CLAIMS WITHOUT
     FRESH VERIFICATION EVIDENCE. See `sergeant-review-and-merge` SKILL.md
     § "Verification gate" (.agents/skills/sergeant-review-and-merge/SKILL.md). -->

```bash
pnpm lint
pnpm typecheck
```

Additional checks:

- [ ] Local smoke / manual validation completed
- [ ] Surface-specific checks completed

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [ ] I checked whether `AGENTS.md` needed an update.
- [ ] I checked whether a playbook or skill needed an update.
- [ ] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a

## Risk and Rollout

- User-visible risk:
- Rollout / deploy order:
- Backout plan:

## Hard Rule #15

- [ ] I read `AGENTS.md` before coding.
- [ ] Internal docs I touched are in Ukrainian.
- [ ] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

<!-- Per `docs/governance/audit-freeze-2026-05-05.md`. New files under
docs/audits/, docs/initiatives/, docs/playbooks/, docs/adr/ trigger a
non-blocking CI warning. If this PR adds such a file, add `[skip-freeze]`
or `[freeze-exception]` to the PR title and explain below. Otherwise leave
this section as-is or remove. -->

- [ ] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

<!-- Flag migrations, env changes, HubChat tools, auth, or anything else that deserves extra reviewer attention. -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add two KPI dashboard components: `WeeklyGoalCard` (weekly target progress from `hub_goals_v1`) and `WeeklyVolumeChart` (7-day workout bars). This improves at-a-glance progress and links to workouts/progress via callbacks.

- New Features
  - `WeeklyGoalCard`: reads weekly goal from `hub_goals_v1` (default 3), shows progress bar and day dots, accessible labels, click opens workouts (`onOpenWorkouts`).
  - `WeeklyVolumeChart`: Monday-first 7-bar SVG for the current week using `DashboardWorkoutInput[]` (`endedAt`), highlights today and shows total, click opens progress (`onOpenProgress`).

<sup>Written for commit a63f1501f0ad468069754c616dc7136a069e8e7e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

