### PR TITLE
feat(web): migrate fizruk module to /fizruk/* path-based route (initiative 0006 Phase 2.c)

### DIFF
--- a/apps/web/src/core/app/appPaths.test.ts
+++ b/apps/web/src/core/app/appPaths.test.ts
@@ -13,31 +13,33 @@ describe("PATH_BASED_MODULE_IDS", () => {
     // pick it up automatically.
     expect(PATH_BASED_MODULE_IDS.has("nutrition")).toBe(true);
     expect(PATH_BASED_MODULE_IDS.has("finyk")).toBe(true);
+    expect(PATH_BASED_MODULE_IDS.has("fizruk")).toBe(true);
   });
 
   it("does not include modules still on the legacy `?module=<id>` URL contract", () => {
-    expect(PATH_BASED_MODULE_IDS.has("fizruk")).toBe(false);
     expect(PATH_BASED_MODULE_IDS.has("routine")).toBe(false);
   });
 });
 
 describe("isPathBasedModulePath()", () => {
-  it("matches the bare module root (`/finyk`, `/nutrition`)", () => {
+  it("matches the bare module root (`/finyk`, `/nutrition`, `/fizruk`)", () => {
     expect(isPathBasedModulePath("/finyk")).toBe(true);
     expect(isPathBasedModulePath("/nutrition")).toBe(true);
+    expect(isPathBasedModulePath("/fizruk")).toBe(true);
   });
 
-  it("matches nested module URLs (`/finyk/budgets`, `/nutrition/log`)", () => {
+  it("matches nested module URLs (`/finyk/budgets`, `/nutrition/log`, `/fizruk/exercise/12`)", () => {
     expect(isPathBasedModulePath("/finyk/budgets")).toBe(true);
     expect(isPathBasedModulePath("/finyk/budgets?cat=smoking")).toBe(true);
     expect(isPathBasedModulePath("/nutrition/log")).toBe(true);
     expect(isPathBasedModulePath("/nutrition/pantry/shopping")).toBe(true);
+    expect(isPathBasedModulePath("/fizruk/workouts")).toBe(true);
+    expect(isPathBasedModulePath("/fizruk/exercise/12")).toBe(true);
   });
 
   it("does not match modules that have not migrated yet", () => {
-    expect(isPathBasedModulePath("/fizruk")).toBe(false);
     expect(isPathBasedModulePath("/routine")).toBe(false);
-    expect(isPathBasedModulePath("/fizruk/exercise/12")).toBe(false);
+    expect(isPathBasedModulePath("/routine/today")).toBe(false);
   });
 
   it("does not match prefix-aliased URLs (boundary check)", () => {

--- a/apps/web/src/core/app/appPaths.ts
+++ b/apps/web/src/core/app/appPaths.ts
@@ -62,12 +62,13 @@ export const KNOWN_PATHS: ReadonlySet<string> = new Set([
  * set. When a new module migrates, add it here once; both consumers
  * pick it up automatically.
  *
- * Order: nutrition (PR #2104), finyk (PR #2108); fizruk + routine
- * are still on `?module=<id>` until later 0006 PRs.
+ * Order: nutrition (PR #2104), finyk (PR #2108), fizruk (Phase 2.c);
+ * routine is still on `?module=<id>` until a later 0006 PR.
  */
 export const PATH_BASED_MODULE_IDS: ReadonlySet<string> = new Set([
   "nutrition",
   "finyk",
+  "fizruk",
 ]);
 
 /**

--- a/apps/web/src/core/app/router.tsx
+++ b/apps/web/src/core/app/router.tsx
@@ -59,6 +59,13 @@ export const router = createBrowserRouter([
     },
   },
   {
+    path: "/fizruk/*",
+    lazy: async () => {
+      const m = await import("../../modules/fizruk/route");
+      return m.route;
+    },
+  },
+  {
     path: "*",
     element: <App />,
   },

--- a/apps/web/src/modules/fizruk/FizrukApp.tsx
+++ b/apps/web/src/modules/fizruk/FizrukApp.tsx
@@ -2,8 +2,7 @@ import { useEffect } from "react";
 import { ModuleShell, StorageErrorBanner } from "@shared/components/layout";
 import { ModuleBottomNav } from "@shared/components/ui/ModuleBottomNav";
 import { useModuleFirstRun } from "../../core/onboarding/useModuleFirstRun";
-// eslint-disable-next-line sergeant-design/no-hash-router-in-modules -- pre-existing hash-router callsite; migration tracked in initiative 0006.
-import { useHashRoute } from "@shared/hooks/useHashRoute";
+import { useFizrukRoute } from "./hooks/useFizrukRoute";
 import { usePwaAction } from "@shared/hooks/usePwaAction";
 import { useExerciseCatalog } from "./hooks/useExerciseCatalog";
 import { useFizrukProgramStart } from "./hooks/useFizrukProgramStart";
@@ -19,7 +18,7 @@ import {
 import { FIZRUK_NAV } from "./shell/fizrukNav";
 import { FizrukHeader } from "./shell/FizrukHeader";
 import { FizrukRouter } from "./shell/FizrukRouter";
-import { FIZRUK_PAGES, type FizrukPage } from "./shell/fizrukRoute";
+import { type FizrukPage } from "./shell/fizrukRoute";
 
 interface FizrukAppProps {
   onBackToHub?: () => void;
@@ -36,11 +35,7 @@ export default function FizrukApp({
   pwaAction,
   onPwaActionConsumed,
 }: FizrukAppProps = {}) {
-  // eslint-disable-next-line sergeant-design/no-hash-router-in-modules -- pre-existing hash-router callsite; migration tracked in initiative 0006.
-  const { page, segments, navigate } = useHashRoute<FizrukPage>({
-    defaultPage: "dashboard",
-    validPages: FIZRUK_PAGES,
-  });
+  const { page, segments, navigate } = useFizrukRoute("dashboard");
   const exerciseId =
     page === "exercise" && segments[0] ? segments[0] : undefined;
 

--- a/apps/web/src/modules/fizruk/hooks/useFizrukRoute.ts
+++ b/apps/web/src/modules/fizruk/hooks/useFizrukRoute.ts
@@ -1,0 +1,107 @@
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import {
+  fizrukRoutePath,
+  parseFizrukSegments,
+  parseLegacyFizrukHash,
+  type FizrukPage,
+} from "../lib/fizrukRouter";
+
+/**
+ * Path-based router for the Fizruk module (initiative 0006 §Phase 2.c —
+ * migration of `useHashRoute<FizrukPage>` → react-router). Page id (plus
+ * optional `exercise/<id>` tail segment) lives in the URL pathname so
+ * deep-links from other modules (PWA action handlers, Hub recommendations,
+ * push notifications) can target a specific Fizruk page directly.
+ *
+ * Public shape mirrors `useHashRoute<FizrukPage>` (`{ page, segments,
+ * navigate }`) so the call-site swap in `FizrukApp.tsx` is a one-line
+ * import change. Behaviour difference: `navigate` writes the pathname via
+ * `react-router` instead of mutating `window.location.hash`.
+ *
+ * Accepted legacy shapes (one-time redirect on mount):
+ *   - `/fizruk#workouts`            → `/fizruk/workouts`
+ *   - `/fizruk#exercise/abc-123`    → `/fizruk/exercise/abc-123`
+ *   - `/fizruk#/workouts`           → `/fizruk/workouts`
+ *   - `/?module=fizruk#workouts`    → `/fizruk/workouts` (works because
+ *     `useHubNavigation` re-runs once the path updates).
+ *
+ * Unknown ids fall back to `defaultPage` (default `"dashboard"`).
+ */
+export interface UseFizrukRouteResult {
+  page: FizrukPage;
+  /** Extra path segment after `<page>/` — used by `exercise/<id>`. */
+  segments: readonly string[];
+  navigate: (next: FizrukPage | string) => void;
+}
+
+/**
+ * Splits the pathname into fizruk route segments. The route is mounted as
+ * `/fizruk/*` in `apps/web/src/core/app/router.tsx`, so:
+ *   `/fizruk`                      → `[]`
+ *   `/fizruk/workouts`             → `["workouts"]`
+ *   `/fizruk/exercise/abc-123`     → `["exercise", "abc-123"]`
+ *
+ * Anything outside `/fizruk` returns `[]` (the hook treats it as the
+ * default `dashboard` tab — this branch only fires during transient
+ * navigations, the `<App />` shell unmounts FizrukApp before the next
+ * render in practice).
+ */
+function pathnameToSegments(pathname: string): string[] {
+  if (!pathname.startsWith("/fizruk")) return [];
+  const tail = pathname.slice("/fizruk".length);
+  if (tail === "" || tail === "/") return [];
+  if (!tail.startsWith("/")) return [];
+  return tail.slice(1).split("/").filter(Boolean);
+}
+
+export function useFizrukRoute(
+  defaultPage: FizrukPage = "dashboard",
+): UseFizrukRouteResult {
+  const location = useLocation();
+  const navigateRR = useNavigate();
+
+  const parsed = useMemo(() => {
+    const segs = pathnameToSegments(location.pathname);
+    if (segs.length === 0) return { page: defaultPage, segment: undefined };
+    return parseFizrukSegments(segs);
+  }, [location.pathname, defaultPage]);
+
+  const page = parsed.page;
+  const segments = useMemo<readonly string[]>(
+    () => (parsed.segment ? [parsed.segment] : []),
+    [parsed.segment],
+  );
+
+  // Hash compat: when a legacy URL (`/fizruk#workouts`,
+  // `/fizruk#exercise/abc-123`, `/?module=fizruk#workouts`) lands on this
+  // hook, rewrite to the equivalent path-based URL and clear the hash.
+  // One-shot per mount — afterwards all navigation is path-based.
+  const compatRedirected = useRef(false);
+  useEffect(() => {
+    if (compatRedirected.current) return;
+    compatRedirected.current = true;
+    const legacy = parseLegacyFizrukHash();
+    if (!legacy) return;
+    const target = fizrukRoutePath(legacy.page, legacy.segment);
+    navigateRR(target, { replace: true });
+  }, [navigateRR]);
+
+  const navigate = useCallback(
+    (next: FizrukPage | string) => {
+      // Accept either a typed `FizrukPage` (`navigate("workouts")`) or a
+      // `<page>/<segment>` string (`navigate("exercise/abc-123")`) — the
+      // legacy `useHashRoute` hook supported both, so the call-sites in
+      // `FizrukApp.tsx` / `FizrukRouter.tsx` rely on the same shape.
+      const raw = String(next || "").trim();
+      const parts = raw.split("/").filter(Boolean);
+      const result = parseFizrukSegments(parts);
+      const target = fizrukRoutePath(result.page, result.segment);
+      if (location.pathname === target) return;
+      navigateRR(target, { replace: false });
+    },
+    [location.pathname, navigateRR],
+  );
+
+  return { page, segments, navigate };
+}

--- a/apps/web/src/modules/fizruk/lib/fizrukRouter.ts
+++ b/apps/web/src/modules/fizruk/lib/fizrukRouter.ts
@@ -1,0 +1,107 @@
+// Eight top-level pages mirror `FIZRUK_NAV` in `shell/fizrukNav.ts`. Order
+// loosely follows the bottom-nav surface order (dashboard / atlas / workouts
+// / programs / body — with body branching to progress/measurements and
+// workouts branching to exercise/<id>).
+export type FizrukPage =
+  | "dashboard"
+  | "atlas"
+  | "workouts"
+  | "progress"
+  | "measurements"
+  | "programs"
+  | "body"
+  | "exercise";
+
+const VALID_FIZRUK_PAGES: readonly FizrukPage[] = [
+  "dashboard",
+  "atlas",
+  "workouts",
+  "progress",
+  "measurements",
+  "programs",
+  "body",
+  "exercise",
+];
+
+export interface ParsedFizrukRoute {
+  page: FizrukPage;
+  /** Tail segment after `<page>/` — used by `exercise/<id>`. */
+  segment?: string;
+  redirectFrom?: string;
+}
+
+/**
+ * Parse the fizruk route segments (page + optional exercise id) from any
+ * source — react-router pathname (`/fizruk/workouts` → `["workouts"]`,
+ * `/fizruk/exercise/abc-123` → `["exercise", "abc-123"]`), legacy hash
+ * (`#workouts` → `["workouts"]`, `#exercise/abc-123` → `["exercise",
+ * "abc-123"]`), or programmatic input. Centralises the validation rules so
+ * the path-router (`useFizrukRoute`) and the one-time hash-compat shim
+ * share them.
+ *
+ * Returns `{ page: "dashboard" }` for empty / unknown / malformed inputs.
+ */
+export function parseFizrukSegments(
+  segments: readonly string[],
+): ParsedFizrukRoute {
+  const page = segments[0];
+  if (!page) return { page: "dashboard" };
+  if (!VALID_FIZRUK_PAGES.includes(page as FizrukPage)) {
+    return { page: "dashboard" };
+  }
+  const tail = segments[1];
+  if (page === "exercise" && tail) {
+    return { page: "exercise", segment: tail };
+  }
+  return { page: page as FizrukPage };
+}
+
+/**
+ * Build the route suffix **inside** the `/fizruk` namespace
+ * (e.g. `"workouts"`, `"exercise/abc-123"`, `""`). Callers prepend
+ * `/fizruk/` (or use `fizrukRoutePath`) and feed the result to
+ * `navigate()`.
+ *
+ * `dashboard` is the default landing tab — encoded as the empty suffix so
+ * the URL stays `/fizruk` rather than the redundant `/fizruk/dashboard`.
+ */
+export function buildFizrukPath(
+  next: FizrukPage | null | undefined,
+  segment?: string,
+): string {
+  const page = next || "dashboard";
+  if (page === "dashboard") return "";
+  if (segment) return `${page}/${segment}`;
+  return page;
+}
+
+/** Absolute path for navigation: `/fizruk`, `/fizruk/workouts`, … */
+export function fizrukRoutePath(
+  next: FizrukPage | null | undefined,
+  segment?: string,
+): string {
+  const suffix = buildFizrukPath(next, segment);
+  return suffix ? `/fizruk/${suffix}` : "/fizruk";
+}
+
+/**
+ * Legacy hash-URL parser. Kept ONLY for the one-time redirect-on-mount
+ * compat shim (`useFizrukRoute`) — when a user lands on `/fizruk#workouts`
+ * or `/?module=fizruk#exercise/abc-123` (PWA install / share-card / push
+ * notification / Hub recommendation from before initiative 0006 §Phase 2),
+ * the shim reads the hash here and rewrites the URL to the canonical
+ * `/fizruk/...` form. New navigation is path-based; do NOT call this from
+ * new code.
+ *
+ * Returns `null` (not a `dashboard`-fallback) when no hash exists, so the
+ * caller can distinguish "no legacy hash to migrate" from "hash matched
+ * but landed on the default tab".
+ */
+export function parseLegacyFizrukHash(): ParsedFizrukRoute | null {
+  if (typeof window === "undefined") return null;
+  const raw = (window.location.hash || "").replace(/^#\/?/, "").trim();
+  if (!raw) return null;
+  const segments = raw.split("/").filter(Boolean);
+  if (segments.length === 0) return null;
+  return parseFizrukSegments(segments);
+}

--- a/apps/web/src/modules/fizruk/route.tsx
+++ b/apps/web/src/modules/fizruk/route.tsx
@@ -1,0 +1,40 @@
+import App from "../../core/App";
+
+/**
+ * Top-level route entry for the **Fizruk** domain
+ * (initiative 0006 — frontend routing, Phase 2.c).
+ *
+ * Why this file exists despite re-using `<App />` as the element: data-router
+ * configs expect tree-shaped {@link import("react-router-dom").RouteObject}
+ * entries, and the migration plan ([initiative 0006 §Phase 2](../../../../../docs/initiatives/0006-frontend-routing-and-code-split.md))
+ * wants **per-module owned route definitions** (`apps/web/src/modules/<mod>/route.tsx`)
+ * so that future PRs can replace `element: <App />` with a domain-local layout
+ * (`element: <FizrukLayout />`) without touching the central `router.tsx`.
+ *
+ * For now we keep the `<App />` element so the existing provider tree
+ * (`ToastProvider`, `AuthProvider`, `ApiClientProvider`, …) and the FSM in
+ * `useHubNavigation` mount once and identically for both Hub URLs (`/`,
+ * `/?module=fizruk`) and the new path-based ones (`/fizruk`,
+ * `/fizruk/workouts`, `/fizruk/exercise/<id>`). `useHubNavigation` reads
+ * `useLocation().pathname` and, when it sees `/fizruk[/...]`, sets
+ * `activeModule = "fizruk"` — so `<App />` renders `<ActiveModuleView>` →
+ * `<FizrukApp />` exactly as it did under the legacy `?module=fizruk` URL
+ * contract. Inside `<FizrukApp />` the new `useFizrukRoute()` hook reads
+ * the pathname segments to derive the page id (`dashboard` / `atlas` /
+ * `workouts` / `progress` / `measurements` / `programs` / `body` /
+ * `exercise/<id>`) — replacing the `useHashRoute<FizrukPage>` callsite.
+ *
+ * Lazy import: this module file is loaded eagerly by `router.tsx`'s
+ * `lazy: () => import("...")` only when the user actually navigates to a
+ * `/fizruk/*` path. Because `<App />` itself stays in the main bundle
+ * (it owns the Hub), there is no chunk split happening through this entry
+ * **yet** — the actual `FizrukApp` chunk is still produced by the
+ * `lazyDefault(() => import("../../modules/fizruk/FizrukApp"))` call in
+ * `ActiveModuleView.tsx`. Phase 5 of 0006 will move the lazy boundary into
+ * this file (replace `element: <App />` with a `<Lazy>` wrapper around
+ * `FizrukApp`) once the provider tree is lifted into a sibling
+ * `<RootLayout>` route.
+ */
+export const route = {
+  Component: App,
+};


### PR DESCRIPTION
## Summary

Initiative [0006 §Phase 2.c](https://github.com/Skords-01/Sergeant/blob/main/docs/initiatives/0006-frontend-routing-and-code-split.md) — migrate the Fizruk module from `useHashRoute<FizrukPage>` to react-router. Same shape as the nutrition (#2104) and finyk (#2108) Phase 2 PRs.

- Add `apps/web/src/modules/fizruk/lib/fizrukRouter.ts` — pure pathname parser/builder + legacy-hash dictionary. Models the eight Fizruk pages (`dashboard / atlas / workouts / progress / measurements / programs / body / exercise`) plus the `exercise/<id>` tail-segment shape.
- Add `apps/web/src/modules/fizruk/hooks/useFizrukRoute.ts` — react-router-backed replacement for the old `useHashRoute<FizrukPage>` callsite. Mirrors the legacy hook signature (`{ page, segments, navigate }`) so `FizrukApp.tsx` swap is a one-line import change. Accepts both typed `FizrukPage` (`navigate("workouts")`) and raw `"<page>/<segment>"` strings (`navigate("exercise/abc-123")`) — same dual contract `useHashRoute` had.
- Add `apps/web/src/modules/fizruk/route.tsx` + register `/fizruk/*` in `apps/web/src/core/app/router.tsx` (RouteObject reuses `<App />` like Phase 2.a/2.b PRs — provider tree mounts once for both Hub and `/fizruk` URLs).
- Extend `PATH_BASED_MODULE_IDS` in `apps/web/src/core/app/appPaths.ts` with `fizruk` so `useHubNavigation` recognises `/fizruk[/...]` as `activeModule = fizruk` and emits clean `/fizruk` URLs from `openModule(...)`. `isPathBasedModulePath` in `appPaths` exempts `/fizruk` from the standalone-route 404 fallback.
- One-time hash-compat shim inside `useFizrukRoute` rewrites legacy `/fizruk#workouts`, `/fizruk#exercise/<id>` and `/?module=fizruk#workouts` URLs to canonical `/fizruk/...` on mount (`navigate(target, { replace: true })`).
- Update `appPaths.test.ts` to assert fizruk is path-based.

Behavioural NOOP: new navigation emits clean `/fizruk` URLs; old hash-bearing deep-links (PWA install, share-cards, push notifications) still land on the correct page through the redirect-on-mount shim. Phase 2 progress after this: `3/4` modules migrated; `routine` remains (separate PR).

## Governing Skill

- Primary skill: `sergeant-web-ui`
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a (mirrors the existing Phase 2.a / 2.b migrations of nutrition and finyk; no playbook authored)
- Why this playbook: n/a
- If no playbook matched, why: this is an established 4-PR sequence; the canonical reference is the in-repo PRs #2104 (nutrition) and #2108 (finyk), which this PR mirrors.

## Verification

Locally, in `apps/web`:

```bash
pnpm exec eslint src/modules/fizruk/FizrukApp.tsx src/modules/fizruk/hooks/useFizrukRoute.ts src/modules/fizruk/lib/fizrukRouter.ts src/modules/fizruk/route.tsx src/core/app/appPaths.ts src/core/app/router.tsx
# → clean (0 errors, 0 warnings)

pnpm test -- --run useHubNavigation appPaths StandaloneRoutes fizruk
# → 200 tests passed (24 files)
```

`pnpm --filter @sergeant/web typecheck` fails on `WeeklyGoalCard.tsx:11 — Cannot find module '@app/core/lib/hubChatUtils'` — this error reproduces on `origin/main` without the changes in this PR (pre-existing, unrelated to the routing migration).

Additional checks:

- [x] Local smoke / manual validation completed (lint + focused tests)
- [x] Surface-specific checks completed

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [ ] I checked whether `AGENTS.md` needed an update.
- [ ] I checked whether a playbook or skill needed an update.
- [ ] I checked whether governance docs or review docs needed an update.

Updated docs:

- Initiative 0006 references this PR organically via the Phase 2 progress counter in the §Критерії DONE section; a follow-up PR rolls up Phase 2 status when routine lands too.

## Risk and Rollout

- User-visible risk: low. Existing deep-links (`/?module=fizruk#workouts`, `/fizruk#exercise/<id>`) keep working via the redirect-on-mount shim. New navigation emits the clean `/fizruk` URLs. Browser history entries change shape but back/forward still works (`navigate` calls match the previous `window.location.hash = ...` push-pop semantics).
- Rollout / deploy order: ship together; no feature flag.
- Backout plan: revert the PR. The hook signature is intentionally compatible with the old `useHashRoute<FizrukPage>` so the call-site swap is the only behaviour-bearing change.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

The `/fizruk/exercise/<id>` URL means we now have a non-trivial tail-segment shape (the `parseFizrukSegments` function validates that `exercise` is the only page that accepts a tail). The hook returns `segments: readonly string[]` carrying just `[id]` so `FizrukApp`'s existing `exerciseId = page === "exercise" && segments[0]` derivation is bit-for-bit unchanged.


Link to Devin session: https://app.devin.ai/sessions/7994b57a53e24056aa05b7d2f9af7b19

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the Fizruk module to path-based routing under /fizruk/* using react-router for cleaner URLs and consistent navigation. Legacy hash deep links are auto-redirected, so behavior is unchanged.

- **New Features**
  - Added `useFizrukRoute` hook and `fizrukRouter` utilities to parse/build routes and mirror the old `useHashRoute<FizrukPage>` API.
  - Registered `/fizruk/*` in the app router reusing `<App />`, and switched `FizrukApp` to the new hook.
  - Added a one-time hash-compat redirect for `/fizruk#...` and `/?module=fizruk#...` to `/fizruk/...`.
  - Marked `fizruk` as path-based in `PATH_BASED_MODULE_IDS` and updated `isPathBasedModulePath` tests.
  - Supported `exercise/<id>` tail segments; existing `[id]` handling stays the same.

<sup>Written for commit 145bd855e670ae899a7b642cd2705070064a05aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

