### PR TITLE
refactor(server): extract pantry prompt-builders, dedup 4 modules — T6

### DIFF
--- a/apps/server/src/lib/prompt-builders.test.ts
+++ b/apps/server/src/lib/prompt-builders.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { PANTRY_PRESETS, pantryPromptSection } from "./prompt-builders.js";
+
+describe("prompt-builders", () => {
+  it("PANTRY_PRESETS covers all four nutrition endpoints", () => {
+    expect(Object.keys(PANTRY_PRESETS).sort()).toEqual([
+      "dayPlan",
+      "recipes",
+      "shoppingList",
+      "weekPlan",
+    ]);
+  });
+
+  it("pantryPromptSection list preset renders bulleted list", () => {
+    const items = [{ name: "яйця", qty: "10", unit: "шт" }, { name: "молоко" }];
+    const result = pantryPromptSection({
+      pantry: items,
+      preset: "dayPlan",
+    });
+    expect(result).toContain("Наявні продукти:");
+    expect(result).toContain("\n- яйця");
+    expect(result).toContain("молоко");
+  });
+
+  it("pantryPromptSection flat preset renders comma-separated", () => {
+    const items = [{ name: "цукор" }, { name: "сіль" }];
+    const result = pantryPromptSection({
+      pantry: items,
+      preset: "shoppingList",
+    });
+    expect(result).toContain("Наявні продукти:");
+    expect(result).toContain("цукор, сіль");
+  });
+
+  it("pantryPromptSection respects custom label", () => {
+    const result = pantryPromptSection({
+      pantry: [{ name: "рис" }],
+      preset: "weekPlan",
+      label: "Продукти вдома",
+    });
+    expect(result.startsWith("Продукти вдома:")).toBe(true);
+  });
+
+  it("pantryPromptSection uses fallbackWhenEmpty from preset", () => {
+    const result = pantryPromptSection({
+      pantry: [],
+      preset: "dayPlan",
+    });
+    expect(result).toContain("продукти не вказані");
+  });
+});

--- a/apps/server/src/lib/prompt-builders.ts
+++ b/apps/server/src/lib/prompt-builders.ts
@@ -1,0 +1,61 @@
+import {
+  formatPantryForPrompt,
+  type PantryPromptFormatOptions,
+} from "./pantryFormat.js";
+
+/**
+ * Попередньо визначені пресети для `formatPantryForPrompt`. Кожен
+ * nutrition-ендпоінт використовує один із них — жодного інлайн-дублювання.
+ */
+export const PANTRY_PRESETS = {
+  dayPlan: {
+    itemFormat: "nameQuantity",
+    limit: 50,
+    joinWith: "\n- ",
+    fallbackWhenEmpty: "продукти не вказані",
+  },
+  recipes: {
+    itemFormat: "nameQuantityNotes",
+    limit: 60,
+    joinWith: "\n- ",
+  },
+  weekPlan: {
+    itemFormat: "nameOnly",
+    limit: 50,
+    joinWith: "\n- ",
+  },
+  shoppingList: {
+    itemFormat: "nameOnly",
+    joinWith: ", ",
+    fallbackWhenEmpty: "нічого",
+  },
+} as const satisfies Record<string, PantryPromptFormatOptions>;
+
+export type PantryPresetKey = keyof typeof PANTRY_PRESETS;
+
+export interface PantryPromptSectionOptions {
+  pantry: unknown;
+  preset: PantryPresetKey;
+  label?: string;
+}
+
+/**
+ * Будує секцію промпту з відформатованим списком комори. Повертає готовий
+ * рядок виду:
+ *
+ *   Наявні продукти:
+ *   - яйця — 10 шт
+ *   - молоко — 1 л
+ *
+ * Для flat-формату (shopping-list: `joinWith: ", "`) — без `- ` prefix.
+ */
+export function pantryPromptSection({
+  pantry,
+  preset,
+  label = "Наявні продукти",
+}: PantryPromptSectionOptions): string {
+  const opts = PANTRY_PRESETS[preset];
+  const formatted = formatPantryForPrompt(pantry, opts);
+  const isList = opts.joinWith.includes("\n");
+  return isList ? `${label}:\n- ${formatted}` : `${label}:\n${formatted}`;
+}

--- a/apps/server/src/modules/nutrition/day-plan.ts
+++ b/apps/server/src/modules/nutrition/day-plan.ts
@@ -7,7 +7,7 @@ import {
   anthropicMessages,
   extractAnthropicText,
 } from "../../lib/anthropic.js";
-import { formatPantryForPrompt } from "../../lib/pantryFormat.js";
+import { pantryPromptSection } from "../../lib/prompt-builders.js";
 
 type AnthropicErrorPayload = { error?: { message?: string } };
 type WithAnthropicKey = Request & { anthropicKey?: string };
@@ -140,11 +140,10 @@ export default async function handler(
   const fat = tgt.fat_g != null ? Number(tgt.fat_g) : null;
   const carbs = tgt.carbs_g != null ? Number(tgt.carbs_g) : null;
 
-  const pantryStr = formatPantryForPrompt(pantryIn, {
-    itemFormat: "nameQuantity",
-    limit: 50,
-    joinWith: "\n- ",
-    fallbackWhenEmpty: "продукти не вказані",
+  const pantrySec = pantryPromptSection({
+    pantry: pantryIn,
+    preset: "dayPlan",
+    label: "Наявні продукти (намагайся використовувати їх)",
   });
 
   const targetsStr =
@@ -159,8 +158,7 @@ export default async function handler(
   const prompt = `Мова: ${loc}.
 ${targetsStr}
 
-Наявні продукти (намагайся використовувати їх):
-- ${pantryStr}
+${pantrySec}
 
 ${regenStr}`;
 

--- a/apps/server/src/modules/nutrition/recommend-recipes.ts
+++ b/apps/server/src/modules/nutrition/recommend-recipes.ts
@@ -7,7 +7,7 @@ import {
   anthropicMessages,
   extractAnthropicText,
 } from "../../lib/anthropic.js";
-import { formatPantryForPrompt } from "../../lib/pantryFormat.js";
+import { pantryPromptSection } from "../../lib/prompt-builders.js";
 import { normalizeRecipes } from "../../lib/nutritionResponse.js";
 
 type AnthropicErrorPayload = { error?: { message?: string } };
@@ -58,10 +58,9 @@ export default async function handler(
   const exclude = String(prefs.exclude || "");
   const locale = String(prefs.locale || "uk-UA");
 
-  const pantry = formatPantryForPrompt(pantryIn, {
-    itemFormat: "nameQuantityNotes",
-    limit: 60,
-    joinWith: "\n- ",
+  const pantrySec = pantryPromptSection({
+    pantry: pantryIn,
+    preset: "recipes",
   });
 
   const prompt = `Мова: ${locale}.
@@ -70,8 +69,7 @@ export default async function handler(
 Час: ${Number.isFinite(timeMinutes) && timeMinutes > 0 ? timeMinutes : 25} хв.
 Не використовувати/алергени: ${exclude || "—"}.
 
-Наявні продукти:
-- ${pantry}
+${pantrySec}
 
 Поверни 3 рецепти.
 Обмеження формату:

--- a/apps/server/src/modules/nutrition/shopping-list.ts
+++ b/apps/server/src/modules/nutrition/shopping-list.ts
@@ -7,7 +7,7 @@ import {
   anthropicMessages,
   extractAnthropicText,
 } from "../../lib/anthropic.js";
-import { formatPantryForPrompt } from "../../lib/pantryFormat.js";
+import { pantryPromptSection } from "../../lib/prompt-builders.js";
 
 type AnthropicErrorPayload = { error?: { message?: string } };
 type WithAnthropicKey = Request & { anthropicKey?: string };
@@ -72,10 +72,10 @@ export default async function handler(
   const { recipes, weekPlan, pantryItems, locale } = parsed.data;
   const loc = String(locale || "uk-UA");
 
-  const pantryStr = formatPantryForPrompt(pantryItems, {
-    itemFormat: "nameOnly",
-    joinWith: ", ",
-    fallbackWhenEmpty: "нічого",
+  const pantrySec = pantryPromptSection({
+    pantry: pantryItems,
+    preset: "shoppingList",
+    label: "Що вже є в коморі (НЕ додавай до списку покупок)",
   });
 
   let ingredientsList = "";
@@ -110,8 +110,7 @@ export default async function handler(
 
   const prompt = `Мова: ${loc}.
 
-Що вже є в коморі (НЕ додавай до списку покупок):
-${pantryStr}
+${pantrySec}
 
 Страви / рецепти з яких треба скласти список покупок:
 ${ingredientsList}

--- a/apps/server/src/modules/nutrition/week-plan.ts
+++ b/apps/server/src/modules/nutrition/week-plan.ts
@@ -7,7 +7,7 @@ import {
   anthropicMessages,
   extractAnthropicText,
 } from "../../lib/anthropic.js";
-import { formatPantryForPrompt } from "../../lib/pantryFormat.js";
+import { pantryPromptSection } from "../../lib/prompt-builders.js";
 
 type AnthropicErrorPayload = { error?: { message?: string } };
 type WithAnthropicKey = Request & { anthropicKey?: string };
@@ -87,15 +87,14 @@ export default async function handler(
   const goal = String(prefs.goal || "balanced");
   const loc = String(locale || "uk-UA");
 
-  const pantry = formatPantryForPrompt(pantryIn, {
-    itemFormat: "nameOnly",
-    limit: 50,
-    joinWith: "\n- ",
+  const pantrySec = pantryPromptSection({
+    pantry: pantryIn,
+    preset: "weekPlan",
+    label: "Продукти вдома",
   });
 
   const prompt = `Мова: ${loc}. Ціль: ${goal}.
-Продукти вдома:
-- ${pantry}
+${pantrySec}
 
 Запропонуй приблизний план харчування на 7 днів і список покупок того, чого бракує (коротко, реалістично).`;
 

--- a/docs/audits/2026-04-28-implementation-roadmap.md
+++ b/docs/audits/2026-04-28-implementation-roadmap.md
@@ -443,8 +443,8 @@ describe("Capacitor Boundary Tests", () => {
 | -------------------- | -------------------------- | ----------------------------------- | --------------------------------------------------------------- |
 | `elapsedMs(start)`   | 4+ файли                   | Extract to `lib/timing.ts`          | ✅ Закрито. `lib/timing.ts` існує, використовується у 12 файлах |
 | OFF/USDA normalizers | barcode.ts, food-search.ts | Already done (PR #882)              | ✅ Закрито раніше                                               |
-| `pantry → prompt`    | 3 файли                    | Extract to `lib/prompt-builders.ts` | Потребує перевірки                                              |
-| FNV-1a hashing       | 2 файли                    | Extract to `lib/hash.ts`            | Частково: консолідовано у `lib/backupKey.ts`                    |
+| `pantry → prompt`    | 4 файли                    | Extract to `lib/prompt-builders.ts` | ✅ Закрито. `prompt-builders.ts` + presets, 0 інлайн-дублікатів |
+| FNV-1a hashing       | 2 файли                    | Extract to `lib/hash.ts`            | ✅ Закрито. HMAC-SHA256 у `lib/backupKey.ts`, FNV-1a видалено   |
 
 ---
 


### PR DESCRIPTION
## Summary

Extract `lib/prompt-builders.ts` with `PANTRY_PRESETS` (dayPlan, recipes, weekPlan, shoppingList) and `pantryPromptSection()` helper. Replace 4 inline `formatPantryForPrompt` calls + prompt-section embedding in:

- `modules/nutrition/day-plan.ts`
- `modules/nutrition/recommend-recipes.ts`
- `modules/nutrition/week-plan.ts`
- `modules/nutrition/shopping-list.ts`

Result: **0 inline `pantry → prompt` duplicates** in `apps/server/src/`. Also mark FNV-1a row as closed (HMAC-SHA256 in `lib/backupKey.ts`).

## Governing Skill

- Primary skill: sergeant-server-api
- Secondary skill: n/a

## Playbook

- Primary playbook: n/a
- Why this playbook: n/a
- If no playbook matched, why: T6 is a dedup/consolidation task with clear acceptance from the sprint roadmap.

## Verification

```bash
pnpm --filter @sergeant/server test -- --run src/lib/prompt-builders.test.ts src/modules/nutrition/ src/lib/pantryFormat.test.ts
# Test Files  11 passed (11)
#      Tests  102 passed (102)

pnpm --filter @sergeant/server typecheck
# Only pre-existing @sergeant/db-schema/pg errors (same on main)
```

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- `docs/audits/2026-04-28-implementation-roadmap.md` — marked `pantry → prompt` and `FNV-1a hashing` rows as ✅ Закрито

## Risk and Rollout

- User-visible risk: None — prompt output is semantically identical (same presets reproduce same strings)
- Rollout / deploy order: Standard deploy
- Backout plan: Revert commit

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

Prompt text sent to Anthropic is byte-identical before and after for all 4 endpoints (presets reproduce the exact same `formatPantryForPrompt` options). The only difference is where the format options live (inline → preset object).

Link to Devin session: https://app.devin.ai/sessions/226c89d636a640fc870306f6be5259e4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduped pantry-to-prompt formatting by adding `lib/prompt-builders.ts` with `PANTRY_PRESETS` and `pantryPromptSection`, now used by all four nutrition endpoints. Behavior is unchanged; prompts are byte-identical.

- **Refactors**
  - Added `PANTRY_PRESETS` (`dayPlan`, `recipes`, `weekPlan`, `shoppingList`) and `pantryPromptSection` helper in `lib/prompt-builders.ts`.
  - Replaced inline `formatPantryForPrompt` in `day-plan.ts`, `recommend-recipes.ts`, `week-plan.ts`, and `shopping-list.ts`.
  - Added unit tests for presets and helper.
  - Updated audit doc to mark pantry→prompt and FNV-1a rows as closed (HMAC-SHA256 in `lib/backupKey.ts`).

<sup>Written for commit 73edb9cf2adaf896fb838bdc20c9c3ce5765df3c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

