### PR TITLE
feat(web): migrate routine module to /routine/* path-based route (initiative 0006 Phase 2.d)

### DIFF
--- a/apps/web/src/core/app/appPaths.test.ts
+++ b/apps/web/src/core/app/appPaths.test.ts
@@ -14,32 +14,31 @@ describe("PATH_BASED_MODULE_IDS", () => {
     expect(PATH_BASED_MODULE_IDS.has("nutrition")).toBe(true);
     expect(PATH_BASED_MODULE_IDS.has("finyk")).toBe(true);
     expect(PATH_BASED_MODULE_IDS.has("fizruk")).toBe(true);
+    expect(PATH_BASED_MODULE_IDS.has("routine")).toBe(true);
   });
 
-  it("does not include modules still on the legacy `?module=<id>` URL contract", () => {
-    expect(PATH_BASED_MODULE_IDS.has("routine")).toBe(false);
+  it("does not include unknown / non-domain ids", () => {
+    expect(PATH_BASED_MODULE_IDS.has("welcome")).toBe(false);
+    expect(PATH_BASED_MODULE_IDS.has("profile")).toBe(false);
   });
 });
 
 describe("isPathBasedModulePath()", () => {
-  it("matches the bare module root (`/finyk`, `/nutrition`, `/fizruk`)", () => {
+  it("matches the bare module root (`/finyk`, `/nutrition`, `/fizruk`, `/routine`)", () => {
     expect(isPathBasedModulePath("/finyk")).toBe(true);
     expect(isPathBasedModulePath("/nutrition")).toBe(true);
     expect(isPathBasedModulePath("/fizruk")).toBe(true);
+    expect(isPathBasedModulePath("/routine")).toBe(true);
   });
 
-  it("matches nested module URLs (`/finyk/budgets`, `/nutrition/log`, `/fizruk/exercise/12`)", () => {
+  it("matches nested module URLs (`/finyk/budgets`, `/nutrition/log`, `/fizruk/exercise/12`, `/routine/stats`)", () => {
     expect(isPathBasedModulePath("/finyk/budgets")).toBe(true);
     expect(isPathBasedModulePath("/finyk/budgets?cat=smoking")).toBe(true);
     expect(isPathBasedModulePath("/nutrition/log")).toBe(true);
     expect(isPathBasedModulePath("/nutrition/pantry/shopping")).toBe(true);
     expect(isPathBasedModulePath("/fizruk/workouts")).toBe(true);
     expect(isPathBasedModulePath("/fizruk/exercise/12")).toBe(true);
-  });
-
-  it("does not match modules that have not migrated yet", () => {
-    expect(isPathBasedModulePath("/routine")).toBe(false);
-    expect(isPathBasedModulePath("/routine/today")).toBe(false);
+    expect(isPathBasedModulePath("/routine/stats")).toBe(true);
   });
 
   it("does not match prefix-aliased URLs (boundary check)", () => {

--- a/apps/web/src/core/app/appPaths.ts
+++ b/apps/web/src/core/app/appPaths.ts
@@ -62,13 +62,14 @@ export const KNOWN_PATHS: ReadonlySet<string> = new Set([
  * set. When a new module migrates, add it here once; both consumers
  * pick it up automatically.
  *
- * Order: nutrition (PR #2104), finyk (PR #2108), fizruk (Phase 2.c);
- * routine is still on `?module=<id>` until a later 0006 PR.
+ * Order: nutrition (PR #2104), finyk (PR #2108), fizruk (PR #2541),
+ * routine (Phase 2.d). All four Phase 2 modules now path-based.
  */
 export const PATH_BASED_MODULE_IDS: ReadonlySet<string> = new Set([
   "nutrition",
   "finyk",
   "fizruk",
+  "routine",
 ]);
 
 /**

--- a/apps/web/src/core/app/router.tsx
+++ b/apps/web/src/core/app/router.tsx
@@ -66,6 +66,13 @@ export const router = createBrowserRouter([
     },
   },
   {
+    path: "/routine/*",
+    lazy: async () => {
+      const m = await import("../../modules/routine/route");
+      return m.route;
+    },
+  },
+  {
     path: "*",
     element: <App />,
   },

--- a/apps/web/src/modules/routine/hooks/useRoutineRoute.ts
+++ b/apps/web/src/modules/routine/hooks/useRoutineRoute.ts
@@ -1,0 +1,86 @@
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import {
+  parseLegacyRoutineHash,
+  parseRoutineSegments,
+  routineRoutePath,
+  type RoutinePage,
+} from "../lib/routineRouter";
+
+/**
+ * Path-based router for the Routine module (initiative 0006 §Phase 2.d
+ * migration of the raw `window.location.hash` deep-link shim → react-router).
+ *
+ * Page id lives in the URL pathname (`/routine`, `/routine/stats`) so deep
+ * links from other modules (e.g. Fizruk «Запланувати тренування» → calendar)
+ * can target a specific Routine tab directly. The hash deep-link
+ * (`/routine#calendar`, `/routine#stats`) is rewritten on mount via the
+ * one-time compat shim and afterwards the URL is path-based.
+ *
+ * Returns `{ page, navigate }` — the call site in `useRoutineAppState.ts`
+ * still keeps a `useLocalStorageState`-backed "last-active tab" memory; this
+ * hook overrides that memory whenever the pathname points at a specific
+ * tab, so bookmarking `/routine/stats` lands on stats regardless of what
+ * the user picked last time.
+ */
+export interface UseRoutineRouteResult {
+  page: RoutinePage;
+  navigate: (next: RoutinePage) => void;
+}
+
+export function useRoutineRoute(
+  defaultPage: RoutinePage = "calendar",
+): UseRoutineRouteResult {
+  const location = useLocation();
+  const navigateRR = useNavigate();
+
+  const page = useMemo<RoutinePage>(() => {
+    const segments = pathnameToSegments(location.pathname);
+    if (segments.length === 0) return defaultPage;
+    return parseRoutineSegments(segments).page;
+  }, [location.pathname, defaultPage]);
+
+  // Hash compat: when a legacy URL (`/routine#calendar`, `/routine#stats`,
+  // `/?module=routine#stats`) lands here, rewrite to the equivalent
+  // path-based URL and clear the hash. One-shot per mount — afterwards all
+  // navigation is path-based.
+  const compatRedirected = useRef(false);
+  useEffect(() => {
+    if (compatRedirected.current) return;
+    compatRedirected.current = true;
+    const legacy = parseLegacyRoutineHash();
+    if (!legacy) return;
+    const target = routineRoutePath(legacy.page);
+    navigateRR(target, { replace: true });
+  }, [navigateRR]);
+
+  const navigate = useCallback(
+    (next: RoutinePage) => {
+      const target = routineRoutePath(next);
+      if (location.pathname === target) return;
+      navigateRR(target, { replace: false });
+    },
+    [location.pathname, navigateRR],
+  );
+
+  return { page, navigate };
+}
+
+/**
+ * Splits the pathname into routine route segments. The route is mounted as
+ * `/routine/*` in `apps/web/src/core/app/router.tsx`, so:
+ *   `/routine`        → `[]`
+ *   `/routine/stats`  → `["stats"]`
+ *
+ * Anything outside `/routine` returns `[]` (the hook treats it as the
+ * default `calendar` tab — this branch only fires during transient
+ * navigations, the `<App />` shell unmounts RoutineApp before the next
+ * render in practice).
+ */
+function pathnameToSegments(pathname: string): string[] {
+  if (!pathname.startsWith("/routine")) return [];
+  const tail = pathname.slice("/routine".length);
+  if (tail === "" || tail === "/") return [];
+  if (!tail.startsWith("/")) return [];
+  return tail.slice(1).split("/").filter(Boolean);
+}

--- a/apps/web/src/modules/routine/lib/routineRouter.ts
+++ b/apps/web/src/modules/routine/lib/routineRouter.ts
@@ -1,0 +1,74 @@
+// Two top-level pages — calendar (default) and stats. Same shape as the
+// existing `RoutineMainTab` from `context/RoutineCalendarContext.tsx`,
+// re-exported here so consumers can pick either type symbol.
+//
+// Initiative 0006 §Phase 2.d — migrate routine from `useLocalStorageState`
+// + raw `window.location.hash` deep-link shim to react-router. Pathname is
+// now the canonical source of truth (`/routine` → calendar, `/routine/stats`
+// → stats); localStorage is kept as a "last-active tab" memory but is no
+// longer the URL-shaping authority.
+export type RoutinePage = "calendar" | "stats";
+
+const VALID_ROUTINE_PAGES: readonly RoutinePage[] = ["calendar", "stats"];
+
+export interface ParsedRoutineRoute {
+  page: RoutinePage;
+}
+
+/**
+ * Parse the routine route segments (page only; routine has no sub-tabs).
+ * Centralises the rules so the path-router (`useRoutineRoute`) and the
+ * one-time hash-compat shim share the same parsing.
+ *
+ * Returns `{ page: "calendar" }` for empty / unknown / malformed inputs.
+ */
+export function parseRoutineSegments(
+  segments: readonly string[],
+): ParsedRoutineRoute {
+  const page = segments[0];
+  if (!page) return { page: "calendar" };
+  if (!VALID_ROUTINE_PAGES.includes(page as RoutinePage)) {
+    return { page: "calendar" };
+  }
+  return { page: page as RoutinePage };
+}
+
+/**
+ * Build the route suffix **inside** the `/routine` namespace (`"stats"`,
+ * `""`). Callers prepend `/routine/` (or use `routineRoutePath`).
+ *
+ * `calendar` is the default landing tab — encoded as the empty suffix so
+ * the URL stays `/routine` rather than the redundant `/routine/calendar`.
+ */
+export function buildRoutinePath(next: RoutinePage | null | undefined): string {
+  const page = next || "calendar";
+  if (page === "calendar") return "";
+  return page;
+}
+
+/** Absolute path for navigation: `/routine`, `/routine/stats`. */
+export function routineRoutePath(next: RoutinePage | null | undefined): string {
+  const suffix = buildRoutinePath(next);
+  return suffix ? `/routine/${suffix}` : "/routine";
+}
+
+/**
+ * Legacy hash-URL parser. Kept ONLY for the one-time redirect-on-mount
+ * compat shim (`useRoutineRoute`) — when a user lands on `/routine#stats`
+ * (PWA install / share-card / push notification / Fizruk «Запланувати
+ * тренування» link from before initiative 0006 §Phase 2.d), the shim reads
+ * the hash here and rewrites the URL to `/routine/stats`. New navigation
+ * is path-based; do NOT call this from new code.
+ *
+ * Returns `null` (not a `calendar`-fallback) when no hash exists, so the
+ * caller can distinguish "no legacy hash to migrate" from "hash matched
+ * but landed on the default tab".
+ */
+export function parseLegacyRoutineHash(): ParsedRoutineRoute | null {
+  if (typeof window === "undefined") return null;
+  const raw = (window.location.hash || "").replace(/^#\/?/, "").trim();
+  if (!raw) return null;
+  const segments = raw.split("/").filter(Boolean);
+  if (segments.length === 0) return null;
+  return parseRoutineSegments(segments);
+}

--- a/apps/web/src/modules/routine/route.tsx
+++ b/apps/web/src/modules/routine/route.tsx
@@ -1,0 +1,40 @@
+import App from "../../core/App";
+
+/**
+ * Top-level route entry for the **Routine** domain
+ * (initiative 0006 — frontend routing, Phase 2.d).
+ *
+ * Why this file exists despite re-using `<App />` as the element: data-router
+ * configs expect tree-shaped {@link import("react-router-dom").RouteObject}
+ * entries, and the migration plan ([initiative 0006 §Phase 2](../../../../../docs/initiatives/0006-frontend-routing-and-code-split.md))
+ * wants **per-module owned route definitions** (`apps/web/src/modules/<mod>/route.tsx`)
+ * so that future PRs can replace `element: <App />` with a domain-local layout
+ * (`element: <RoutineLayout />`) without touching the central `router.tsx`.
+ *
+ * For now we keep the `<App />` element so the existing provider tree
+ * (`ToastProvider`, `AuthProvider`, `ApiClientProvider`, …) and the FSM in
+ * `useHubNavigation` mount once and identically for both Hub URLs (`/`,
+ * `/?module=routine`) and the new path-based ones (`/routine`,
+ * `/routine/stats`). `useHubNavigation` reads `useLocation().pathname` and,
+ * when it sees `/routine[/...]`, sets `activeModule = "routine"` — so
+ * `<App />` renders `<ActiveModuleView>` → `<RoutineApp />` exactly as it
+ * did under the legacy `?module=routine` URL contract. Inside `<RoutineApp />`
+ * the new `useRoutineRoute()` hook reads the pathname segments to derive
+ * the main-tab id (`calendar` / `stats`) — replacing the raw
+ * `window.location.hash` deep-link shim that previously seeded the
+ * `useLocalStorageState`-backed tab.
+ *
+ * Lazy import: this module file is loaded eagerly by `router.tsx`'s
+ * `lazy: () => import("...")` only when the user actually navigates to a
+ * `/routine/*` path. Because `<App />` itself stays in the main bundle
+ * (it owns the Hub), there is no chunk split happening through this entry
+ * **yet** — the actual `RoutineApp` chunk is still produced by the
+ * `lazyDefault(() => import("../../modules/routine/RoutineApp"))` call in
+ * `ActiveModuleView.tsx`. Phase 5 of 0006 will move the lazy boundary into
+ * this file (replace `element: <App />` with a `<Lazy>` wrapper around
+ * `RoutineApp`) once the provider tree is lifted into a sibling
+ * `<RootLayout>` route.
+ */
+export const route = {
+  Component: App,
+};

--- a/apps/web/src/modules/routine/useRoutineAppState.ts
+++ b/apps/web/src/modules/routine/useRoutineAppState.ts
@@ -19,6 +19,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   useTransition,
   type Dispatch,
@@ -29,6 +30,7 @@ import { requestCloudPull } from "@shared/lib/modules/cloudPullRequest";
 import { useToast } from "@shared/hooks/useToast";
 import { hapticTap, hapticSuccess } from "@shared/lib/adapters/haptic";
 import { useLocalStorageState } from "@shared/hooks/useLocalStorageState";
+import { useRoutineRoute } from "./hooks/useRoutineRoute";
 import { useFinykHubPreview } from "../../core/hub/useFinykHubPreview";
 import { useModuleFirstRun } from "../../core/onboarding/useModuleFirstRun";
 import {
@@ -144,7 +146,19 @@ export function useRoutineAppState({
 
   useRoutineReminders(routine);
 
-  const [mainTab, setMainTab] = useLocalStorageState<RoutineMainTab>(
+  // Path-based mainTab: `/routine` → calendar, `/routine/stats` → stats.
+  // The `useRoutineRoute` hook owns:
+  //   - the pathname → mainTab derivation,
+  //   - the one-time hash-compat shim (rewrites legacy `/routine#calendar`,
+  //     `/routine#stats`, `/?module=routine#stats` to `/routine/<tab>`),
+  //   - the typed `navigate(tab)` setter (history push).
+  // The `useLocalStorageState`-backed "last-active tab" is still kept as
+  // a memory layer so that opening Hub → Routine (bare `/routine`) after a
+  // refresh lands on the previously active tab. The URL is otherwise
+  // canonical: bookmarking `/routine/stats` always opens stats regardless
+  // of the stored value.
+  const route = useRoutineRoute("calendar");
+  const [persistedTab, setPersistedTab] = useLocalStorageState<RoutineMainTab>(
     STORAGE_KEYS.ROUTINE_MAIN_TAB,
     "calendar",
     {
@@ -152,31 +166,34 @@ export function useRoutineAppState({
       validate: (v): v is RoutineMainTab => v === "calendar" || v === "stats",
     },
   );
-
-  // Deep-link: коли модуль відкритий з hash `#calendar` чи `#stats`
-  // (напр. з Fizruk → «Запланувати тренування»), форсуємо вкладку
-  // незалежно від попередньо збереженої у localStorage. Прибираємо
-  // hash після застосування, щоб back-навігація / refresh не
-  // повторювали стрибок.
+  const mainTab: RoutineMainTab = route.page;
+  // One-shot on mount: when the user lands on bare `/routine` (no tab in
+  // the path, no legacy hash), restore the last-active tab from
+  // localStorage. Subsequent tab changes go through `setMainTab` →
+  // `route.navigate(...)`, which writes both the URL and localStorage.
+  const restoredFromPersistRef = useRef(false);
   useEffect(() => {
-    let raw = "";
-    try {
-      raw = (window.location.hash || "").replace(/^#\/?/, "").toLowerCase();
-    } catch {
-      return;
-    }
-    if (raw !== "calendar" && raw !== "stats") return;
-    setMainTab(raw);
-    try {
-      const next = `${window.location.pathname}${window.location.search}`;
-      window.history.replaceState(null, "", next);
-    } catch {
-      /* noop */
-    }
-    // Один раз на mount — наступні переходи між вкладками — через
-    // RoutineBottomNav, без url hash.
+    if (restoredFromPersistRef.current) return;
+    restoredFromPersistRef.current = true;
+    if (typeof window === "undefined") return;
+    const pathTail = window.location.pathname.replace(/^\/routine\/?/, "");
+    if (pathTail !== "") return;
+    if (window.location.hash) return;
+    if (persistedTab === "calendar") return;
+    route.navigate(persistedTab);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+  const setMainTab: Dispatch<SetStateAction<RoutineMainTab>> = useCallback(
+    (next) => {
+      const resolved =
+        typeof next === "function"
+          ? (next as (prev: RoutineMainTab) => RoutineMainTab)(mainTab)
+          : next;
+      setPersistedTab(resolved);
+      route.navigate(resolved);
+    },
+    [mainTab, route, setPersistedTab],
+  );
 
   const time = useRoutineTimeState();
   const [tagFilter, setTagFilter] = useState<string | null>(null);


### PR DESCRIPTION
## Summary

Initiative [0006 §Phase 2.d](https://github.com/Skords-01/Sergeant/blob/main/docs/initiatives/0006-frontend-routing-and-code-split.md) — last Phase 2 module migrates from the raw `window.location.hash` deep-link shim to react-router. Same shape as the nutrition (#2104), finyk (#2108) and fizruk (#2541) Phase 2 PRs.

- Add `apps/web/src/modules/routine/lib/routineRouter.ts` — pure pathname parser/builder + legacy-hash dictionary. Models the two Routine main-tabs (`calendar` / `stats`).
- Add `apps/web/src/modules/routine/hooks/useRoutineRoute.ts` — react-router-backed hook returning `{ page, navigate }`. One-time hash-compat shim rewrites legacy `/routine#calendar`, `/routine#stats` and `/?module=routine#stats` URLs to canonical `/routine/...` on mount.
- Add `apps/web/src/modules/routine/route.tsx` + register `/routine/*` in `apps/web/src/core/app/router.tsx` (RouteObject reuses `<App />` like Phase 2.a/2.b/2.c PRs — provider tree mounts once for both Hub and `/routine` URLs).
- Extend `PATH_BASED_MODULE_IDS` in `apps/web/src/core/app/appPaths.ts` with `routine` so `useHubNavigation` recognises `/routine[/stats]` as `activeModule = routine`. After this PR all four Phase 2 modules (`nutrition / finyk / fizruk / routine`) are path-based.
- Replace the raw `window.location.hash` deep-link `useEffect` in `useRoutineAppState.ts` with `useRoutineRoute()`. The mainTab now derives from the URL pathname; `setMainTab(tab)` does both a `localStorage.setItem(...)` and a history push (`/routine/stats` etc.). localStorage memory for the last-active tab is kept as a one-shot mount fallback for bare `/routine` visits, so Hub → Routine after a refresh still returns to the previously active tab. The URL is canonical: bookmarking `/routine/stats` always opens stats regardless of the stored value.
- Update `appPaths.test.ts` to assert all 4 Phase 2 modules are path-based and to drop the "not yet migrated" assertion (was load-bearing only while one of the four was still on the legacy contract).

Behavioural NOOP for end-users: tab switches go through history push instead of localStorage-only writes, legacy hash URLs (`/routine#stats`) keep working through the redirect-on-mount shim, and the persisted last-tab fallback keeps `Hub → Routine` returning to the previously active tab.

## Governing Skill

- Primary skill: `sergeant-web-ui`
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a (mirrors the existing Phase 2.a / 2.b / 2.c migrations of nutrition, finyk and fizruk; no playbook authored)
- Why this playbook: n/a
- If no playbook matched, why: this is an established 4-PR sequence; canonical references in-repo are PRs #2104, #2108 and #2541.

## Verification

Locally, in `apps/web`:

```bash
pnpm exec eslint src/modules/routine src/core/app/appPaths.ts src/core/app/router.tsx
# → clean (0 errors, 0 warnings)

pnpm test -- --run routine appPaths useHubNavigation StandaloneRoutes
# → 227 tests passed (17 files)
```

`pnpm --filter @sergeant/web typecheck` reproduces the pre-existing `WeeklyGoalCard.tsx:11 — Cannot find module '@app/core/lib/hubChatUtils'` error from `origin/main` (unrelated to this PR, also present on PRs #2541 etc.).

Additional checks:

- [x] Local smoke / manual validation completed (lint + focused tests)
- [x] Surface-specific checks completed

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [ ] I checked whether `AGENTS.md` needed an update.
- [ ] I checked whether a playbook or skill needed an update.
- [ ] I checked whether governance docs or review docs needed an update.

Updated docs:

- Initiative 0006 references this PR organically via the Phase 2 progress counter — `4/4` modules path-based after merge. The follow-up PR rolls up Phase 2 done status and moves to Phase 3 (hash-redirect shim).

## Risk and Rollout

- User-visible risk: low. Existing deep-links (`/?module=routine#stats`, `/routine#stats`) keep working via the redirect-on-mount shim. New navigation emits the clean `/routine` / `/routine/stats` URLs. Tab persistence across refreshes is preserved via the localStorage memory fallback.
- Rollout / deploy order: ship together; no feature flag.
- Backout plan: revert the PR. The hook signature is intentionally narrow (`{ page, navigate }`) so the `useRoutineAppState.ts` call-site rewind is small.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

The `useRoutineAppState.ts` change deliberately keeps the `useLocalStorageState` memory layer rather than dropping it: that preserves the "Hub → Routine returns to the tab you last used" behavior (the previous code shipped this implicitly via `useLocalStorageState`). The URL becomes canonical (bookmarking `/routine/stats` always wins), but bare `/routine` from the Hub still respects the stored value via a one-shot mount redirect. If the reviewer prefers the simpler URL-only model (URL is the only source of truth; bare `/routine` always = calendar), the diff to that variant is removing the `restoredFromPersistRef` `useEffect` and the `setPersistedTab` call from `setMainTab`.


Link to Devin session: https://app.devin.ai/sessions/7994b57a53e24056aa05b7d2f9af7b19

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated Routine to path-based routing at `/routine/*` with react-router, replacing the old hash deep-link shim. Legacy links (e.g. `/routine#stats`) redirect once to the canonical path; tab changes now update the URL, with `localStorage` used only as a fallback for bare `/routine`.

- **Refactors**
  - Added `useRoutineRoute` hook returning `{ page, navigate }` with a one-time hash-to-path redirect.
  - Added `routineRouter.ts` for parsing/building routine routes.
  - Registered `/routine/*` in the app router and added module `route.tsx` (reuses `<App />`).
  - Added `routine` to `PATH_BASED_MODULE_IDS`; updated `appPaths` tests.
  - Replaced the hash-based effect in `useRoutineAppState.ts` with path-derived tabs and history pushes.

<sup>Written for commit f096c1ea4895a3903fbc02218a8dc75816a45309. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

