### PR TITLE
fix(web): inline dot SVG so lightningcss can minify (url(%23id) -> direct circle)

### DIFF
--- a/apps/web/src/styles/background.css
+++ b/apps/web/src/styles/background.css
@@ -13,8 +13,9 @@
       rgb(243 244 246) 100%
     );
 
-    /* SVG-encoded dot grid pattern (tonal, subtle) */
-    --bg-dots: url('data:image/svg+xml,<svg width="80" height="80" xmlns="http://www.w3.org/2000/svg"><defs><pattern id="dots" x="0" y="0" width="80" height="80" patternUnits="userSpaceOnUse"><circle cx="40" cy="40" r="1.5" fill="rgba(0,0,0,0.03)"/></pattern></defs><rect width="80" height="80" fill="white"/><rect width="80" height="80" fill="url(%23dots)"/></svg>');
+    /* SVG-encoded dot tile (tonal, subtle). Tiled by background-repeat —
+       no <pattern>/url(#id) reference, so lightningcss can minify it safely. */
+    --bg-dots: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80"><circle cx="40" cy="40" r="1.5" fill="rgba(0,0,0,0.03)"/></svg>');
   }
 
   .dark {
@@ -26,14 +27,15 @@
       rgb(31 28 26) 100%
     );
 
-    /* Dark theme dot pattern (even more subtle on dark bg) */
-    --bg-dots: url('data:image/svg+xml,<svg width="80" height="80" xmlns="http://www.w3.org/2000/svg"><defs><pattern id="dots" x="0" y="0" width="80" height="80" patternUnits="userSpaceOnUse"><circle cx="40" cy="40" r="1.5" fill="rgba(255,255,255,0.02)"/></pattern></defs><rect width="80" height="80" fill="rgb(23 20 18)"/><rect width="80" height="80" fill="url(%23dots)"/></svg>');
+    /* Dark theme dot tile (even more subtle on dark bg). */
+    --bg-dots: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80"><circle cx="40" cy="40" r="1.5" fill="rgba(255,255,255,0.02)"/></svg>');
   }
 
-  /* Module shell background: gradient + dots pattern */
+  /* Module shell background: gradient + repeating dot tile */
   .module-bg {
-    background: var(--bg-gradient);
-    background-image: var(--bg-dots);
+    background-color: transparent;
+    background-image: var(--bg-dots), var(--bg-gradient);
+    background-repeat: repeat, no-repeat;
     background-attachment: fixed;
     background-size:
       80px 80px,


### PR DESCRIPTION
## Summary

Vercel build на `main` падав на стадії CSS-мініфікації (`vite v8` → `lightningcss`) через `url("%23dots")` всередині inline-SVG data URI в `apps/web/src/styles/background.css`:

```
[plugin vite:css-post]
SyntaxError: [lightningcss minify] Unexpected token Delim('%')
1  |  /*! tailwindcss v4.2.4 | MIT License | https://tailwindcss.com */
2  |  ...ill="white"/><rect width="80" height="80" fill="url("%23dots")"/></svg>")}.dark{...
   |                                                                 ^
```

Lightningcss парсить вміст рядка data-URI глибше за gzip-розмір і чхає на `%23` (URL-encoded `#`) як на нелегальний CSS токен у `url()`.

Сама `<pattern id="dots">` + `<rect fill="url(#dots)"/>` indirection була зайвою: SVG-плитка вже точно 80×80 (один тайл), а тайлінг роблю через CSS `background-repeat: repeat`. Тепер плитка малюється безпосередньо одним `<circle>`, без `url(%23id)` усередині data URI — візуальний результат ідентичний (1.5px коло в центрі 80×80 з тією ж альфою 0.03/0.02 для light/dark).

Зміни тільки в одному файлі `apps/web/src/styles/background.css` (+9 / −7).

## Governing Skill

- Primary skill: `sergeant-web-ui` (apps/web · Tailwind / styles)
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a — hotfix для впалого Vercel build (вузький CSS-фікс).
- Why this playbook: відсутній dedicated playbook для CSS-мінімізаторів; зміна локальна й мінімальна.
- If no playbook matched, why: точкова правка для повернення Vercel build до зеленого стану.

## Verification

Локально на цій гілці:

```bash
pnpm install --frozen-lockfile             # ok
pnpm --filter @sergeant/db-schema build    # ok (повторює перший крок Vercel)
pnpm --filter @sergeant/web build          # ok — раніше падав тут на lightningcss
pnpm exec prettier --check apps/web/src/styles/background.css   # ok
```

Бандл містить інлайн SVG-плитку без `%23dots` (грепнуто в `apps/server/dist/assets/index-*.css`):

```
cx=\"40\" cy=\"40\" r=\"1.5\" fill=\"rgba(0,0,0,0.03)\"/></svg>")}.dark{...
cx=\"40\" cy=\"40\" r=\"1.5\" fill=\"rgba(255,255,255,0.02)\"/></svg>")}.module-bg{back...
```

Additional checks:

- [x] Local smoke / manual validation completed (build pass + bundle inspection)
- [x] Surface-specific checks completed (prettier on touched file)

### Preexisting issue, **out of scope**

`pnpm --filter @sergeant/web lint` падає на `apps/web/src/modules/fizruk/components/dashboard/WeeklyGoalCard.tsx:34` (Rule #9 — `bg-fizruk` + `text-white` → треба `bg-fizruk-strong`). Це не з моєї зміни — `git blame` показує `a63f1501 feat: add new Dashboard components for KPIs` (commit на `main` від 2026-05-13 18:48, до цього PR). Окремий фікс краще зробити власним PR від відповідного автора, щоб не змішувати з критичним Vercel-фіксом.

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. (Зміна суто стилістична, поведінка візуально ідентична — змін у docs не потрібно.)
- [x] I checked whether `AGENTS.md` needed an update. — Не потрібно.
- [x] I checked whether a playbook or skill needed an update. — Не потрібно.
- [x] I checked whether governance docs or review docs needed an update. — Не потрібно.

Updated docs:

- n/a

## Risk and Rollout

- User-visible risk: дуже низький — візуально ідентичний `.module-bg` (gradient + dot pattern). Якщо є тест із pixel snapshot на цей шар — оновити.
- Rollout / deploy order: звичайний merge → Vercel preview / production пройде минулу точку падіння.
- Backout plan: revert single-file commit.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian. (Не торкався docs.)
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

- Корінь падіння — lightningcss минифайер у Vite 8 вже агресивно парсить вміст рядкових data URI; будь-який майбутній `url(...)` `%23`/`#` всередині data-URL знову вистрелить. Якщо коли-небудь знадобиться `<pattern>` всередині SVG, варіант — base64-кодування data URI (`data:image/svg+xml;base64,...`) як second line of defense.
- Lint-помилка в `WeeklyGoalCard.tsx` (`bg-fizruk` без `-strong`) — preexisting на `main`, окремим PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Vercel build by removing the `url(%23id)` reference inside the inline SVG so `lightningcss` can minify CSS without errors. The dot background now uses a single `<circle>` tile with CSS `background-repeat`; visuals are unchanged.

- **Bug Fixes**
  - Replaced `<pattern>`/`url(#dots)` with a direct `<circle>` in the data URI (`data:image/svg+xml;utf8,...`) to avoid `%23` inside `url()`.
  - Updated `.module-bg` to layer `--bg-dots` over the gradient and set `background-repeat: repeat, no-repeat`.
  - Scope: `apps/web/src/styles/background.css` only; local build passes.

<sup>Written for commit 0555e30b77caaa81d7f9f92cbeea24fbfb8a5677. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

