### PR TITLE
fix(ci): install Railway CLI under bash in db-backup-verify

### DIFF
--- a/.github/workflows/db-backup-verify.yml
+++ b/.github/workflows/db-backup-verify.yml
@@ -68,8 +68,14 @@ jobs:
       # project). When absent the workflow gracefully falls back to a
       # migration-only verify (schema integrity without production data).
       - name: Install Railway CLI
+        # NOTE: install.sh has `#!/usr/bin/env bash` shebang and uses bash parameter
+        # substitution (e.g. `${value//pat/repl}` at line 141), so piping it to `sh`
+        # (dash on Ubuntu runners) aborts with `sh: 141: Bad substitution` and the
+        # whole step exits 2. Pipe to `bash` explicitly.
         run: |
-          curl -fsSL https://raw.githubusercontent.com/railwayapp/cli/master/install.sh | sh
+          curl -fsSL https://raw.githubusercontent.com/railwayapp/cli/master/install.sh | bash
+          export PATH="$HOME/.railway/bin:$PATH"
+          echo "$HOME/.railway/bin" >> "$GITHUB_PATH"
           railway --version
 
       - name: Pull latest Railway dump


### PR DESCRIPTION
## Summary

The weekly `db-backup-verify` workflow has been failing every run since the Railway CLI install step started piping the upstream `install.sh` to `sh`. The script declares `#!/usr/bin/env bash` and uses bash-only parameter substitution (`${value//pat/repl}` at line 141 of the current `master`); when GitHub-hosted Ubuntu runners pipe it to `sh` (which is `dash`), the shell aborts with:

```
sh: 141: Bad substitution
##[error]Process completed with exit code 2.
```

Evidence — run 25621875537 ("Install Railway CLI" step):

```
> Installing railway, please wait…
✓ railway was installed successfully to ~/.railway/bin/railway
sh: 141: Bad substitution
##[error]Process completed with exit code 2.
```

That kills the whole job before "Pull latest Railway dump" even starts — the root cause of #2305 (no FK orphan / migration ledger / CRDT-tombstone smoke test ever ran; the issue body's 7 possible failure modes all turned out to be a single shell-compat regression in step 1).

Fix:

1. Pipe to `bash` instead of `sh`.
2. Prepend `$HOME/.railway/bin` to `PATH` for this step and append it to `$GITHUB_PATH` for the subsequent "Pull latest Railway dump" step — the installer drops the binary there but does not (and cannot, from inside a piped subshell) modify the runner's PATH.

Closes #2305.

## Governing Skill

- Primary skill: `sergeant-bugfix-and-regression` (CI red-fix on an ops surface).
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: `docs/playbooks/fix-failing-ci.md`.
- Why this playbook: a single workflow job has been deterministically red for at least one full weekly cycle; root cause is a shell-portability regression in an install step, not a flaky test.
- If no playbook matched, why: n/a

## Verification

Reproduced the failure mode locally against the upstream installer to confirm the root cause and the fix:

```bash
# 1. Confirm shebang + line 141 of the upstream installer.
curl -fsSL https://raw.githubusercontent.com/railwayapp/cli/master/install.sh \
  | sed -n '1p;138,145p'
# → #!/usr/bin/env bash
# → shell_quote() { local value="$1"; value=${value//\'/\'\\\'\'}; ... }
#   (bash-only parameter substitution — fails under dash)

# 2. Reproduce the previous CI failure under dash.
curl -fsSL https://raw.githubusercontent.com/railwayapp/cli/master/install.sh | sh
# → sh: 141: Bad substitution (exit 2)

# 3. Verify the fix under bash.
curl -fsSL https://raw.githubusercontent.com/railwayapp/cli/master/install.sh | bash
ls "$HOME/.railway/bin/railway" && "$HOME/.railway/bin/railway" --version
# → /home/ubuntu/.railway/bin/railway
# → railway 4.58.0

# 4. Prettier on the changed manifest.
pnpm exec prettier --check .github/workflows/db-backup-verify.yml
# → All matched files use Prettier code style!
```

The fix is yaml-only inside a single workflow file — there is no app code to lint/typecheck/test. CI will exercise the workflow itself on the next scheduled run; if anyone wants to verify sooner, "Weekly DB backup verify" supports `workflow_dispatch`.

Additional checks:

- [x] Local smoke / manual validation completed (steps 1–4 above)
- [x] Surface-specific checks completed (prettier on the touched workflow file)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a — no behavior change visible from the runbook (`docs/runbooks/database-backup-restore.md` already says "weekly verify pulls a Railway dump, restores into ephemeral pg, runs invariants"); only the install-step plumbing changes.

## Risk and Rollout

- User-visible risk: none — this is an internal scheduled workflow with no user-facing surface.
- Rollout / deploy order: merge → next Sunday 04:00 UTC run, or manual `workflow_dispatch`.
- Backout plan: revert the commit; the workflow returns to the previous (deterministically failing) state.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian — n/a, no docs touched.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

- After this lands, the next weekly run (or a manual `workflow_dispatch`) should reach at least the "Pull latest Railway dump" step. If `RAILWAY_TOKEN` is unset the workflow falls back to migration-only verify as designed; if it is set and a downstream invariant trips, that will be a real (different) failure to triage — not the same shell-compat one.
- The `echo "$HOME/.railway/bin" >> "$GITHUB_PATH"` line is what lets the later "Pull latest Railway dump" step's `railway variable list` find the binary; the `export PATH=...` is for the `railway --version` sanity check inside the same step.

— Devin session: https://app.devin.ai/sessions/f82858aefc914dd6b3de3ee40f567323 — requested by @dmytro.s.stakhov


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install the Railway CLI under bash and add it to PATH in the `db-backup-verify` workflow to fix the shell error that stopped the job before pulling the latest dump. This unblocks the weekly backup verification.

- **Bug Fixes**
  - Pipe the installer to `bash` instead of `sh` to avoid dash’s “Bad substitution” error.
  - Add `$HOME/.railway/bin` to `PATH` and `$GITHUB_PATH` so current and later steps can run `railway`.

<sup>Written for commit dd69633a87fe0085761300fdbc4b0e5028620f7b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

