### PR TITLE
feat(web): add HashRedirect compat shim for legacy root hash URLs (initiative 0006 Phase 3)

### DIFF
--- a/apps/web/src/core/App.tsx
+++ b/apps/web/src/core/App.tsx
@@ -16,6 +16,7 @@ import { AppLock } from "./security/AppLock";
 import { AppLockProvider, useAppLockContext } from "./security/AppLockContext";
 import { setFlag } from "./lib/featureFlags";
 import { ActiveModuleView } from "./app/ActiveModuleView";
+import { HashRedirect } from "./app/HashRedirect";
 import { HubHomeView } from "./app/HubHomeView";
 import { RedirectTo } from "./app/RedirectTo";
 import { ShellDeepLinkBridge } from "./app/ShellDeepLinkBridge";
@@ -53,6 +54,15 @@ export default function App() {
           /reset-password, /design тощо) — deep link може прилетіти у
           будь-який із цих станів. */}
         <ShellDeepLinkBridge />
+        {/* Legacy hash-URL compat shim (initiative 0006 §Phase 3):
+          rewrites root-level hash URLs (e.g. `/#fizruk/workouts` from a
+          legacy PWA install / share-card / push notification) to the
+          canonical `/<module>/<page>` path. Mounted alongside the
+          deep-link bridge so it survives the same set of unauthenticated
+          surfaces (`/sign-in`, `/welcome`, …) where a legacy URL could
+          land first. In-module hashes (`/fizruk#workouts`) are handled
+          by each module's own redirect-on-mount shim. */}
+        <HashRedirect />
         {/* PostHog `$pageview` tracker: монтуємо тут (всередині
           BrowserRouter, поза AuthProvider), щоб фіксувати pathname і
           в unauthenticated-шляхах (`/sign-in`, `/welcome`,

--- a/apps/web/src/core/app/HashRedirect.test.tsx
+++ b/apps/web/src/core/app/HashRedirect.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { HashRedirect, parseRootLegacyHash } from "./HashRedirect";
+
+function LocationProbe(): JSX.Element {
+  const location = useLocation();
+  return (
+    <span data-testid="loc">
+      {location.pathname + location.search + location.hash}
+    </span>
+  );
+}
+
+function renderWithHash(
+  hash: string,
+  initialEntries: string[] = ["/"],
+): HTMLElement {
+  // MemoryRouter doesn't model `window.location.hash` (its own router-
+  // state lives in memory), so we set the real DOM hash directly. The
+  // shim reads `window.location.hash` for the legacy URL parse and
+  // `useLocation().pathname` from react-router for the root-gate.
+  if (hash) window.location.hash = hash;
+  const utils = render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <HashRedirect />
+      <Routes>
+        <Route path="*" element={<LocationProbe />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+  return utils.getByTestId("loc");
+}
+
+beforeEach(() => {
+  window.location.hash = "";
+});
+afterEach(() => {
+  window.location.hash = "";
+});
+
+describe("parseRootLegacyHash()", () => {
+  it("returns null for an empty hash", () => {
+    expect(parseRootLegacyHash("")).toBeNull();
+    expect(parseRootLegacyHash("#")).toBeNull();
+    expect(parseRootLegacyHash("#/")).toBeNull();
+  });
+
+  it("returns null for hashes whose first segment is not a path-based module", () => {
+    // Legacy `#welcome` or other non-module hashes should keep their
+    // existing semantics — the shim is narrowly scoped to the four
+    // Phase 2 modules.
+    expect(parseRootLegacyHash("#welcome")).toBeNull();
+    expect(parseRootLegacyHash("#section-2")).toBeNull();
+    expect(parseRootLegacyHash("#profile")).toBeNull();
+  });
+
+  it("redirects bare module hashes to the canonical path", () => {
+    expect(parseRootLegacyHash("#fizruk")).toBe("/fizruk");
+    expect(parseRootLegacyHash("#finyk")).toBe("/finyk");
+    expect(parseRootLegacyHash("#nutrition")).toBe("/nutrition");
+    expect(parseRootLegacyHash("#routine")).toBe("/routine");
+  });
+
+  it("redirects module + page hashes to the canonical nested path", () => {
+    expect(parseRootLegacyHash("#fizruk/workouts")).toBe("/fizruk/workouts");
+    expect(parseRootLegacyHash("#fizruk/exercise/12")).toBe(
+      "/fizruk/exercise/12",
+    );
+    expect(parseRootLegacyHash("#finyk/budgets")).toBe("/finyk/budgets");
+    expect(parseRootLegacyHash("#nutrition/pantry/shopping")).toBe(
+      "/nutrition/pantry/shopping",
+    );
+    expect(parseRootLegacyHash("#routine/stats")).toBe("/routine/stats");
+  });
+
+  it("strips a leading slash inside the hash (`#/fizruk` ≡ `#fizruk`)", () => {
+    expect(parseRootLegacyHash("#/fizruk/workouts")).toBe("/fizruk/workouts");
+    expect(parseRootLegacyHash("#/finyk/budgets")).toBe("/finyk/budgets");
+  });
+
+  it("preserves query strings encoded inside the hash", () => {
+    // Legacy share-cards from Hub recommendations encoded the deep-link
+    // params after the `?` inside the hash so that hashchange listeners
+    // could read them. The redirect hoists them onto the regular URL.
+    expect(parseRootLegacyHash("#finyk/budgets?cat=smoking")).toBe(
+      "/finyk/budgets?cat=smoking",
+    );
+    expect(parseRootLegacyHash("#fizruk/exercise/abc-123?ref=push")).toBe(
+      "/fizruk/exercise/abc-123?ref=push",
+    );
+  });
+
+  it("does not redirect prefix-aliased module-like hashes", () => {
+    // `#fizrukfoo` is not a fizruk URL; the shim must require an exact
+    // first-segment match (mirrors `parsePathnameModule()` and
+    // `isPathBasedModulePath()` boundaries).
+    expect(parseRootLegacyHash("#fizrukfoo")).toBeNull();
+    expect(parseRootLegacyHash("#finykprofile")).toBeNull();
+    expect(parseRootLegacyHash("#routinemax")).toBeNull();
+  });
+
+  it("tolerates accidental input without a leading `#`", () => {
+    // `window.location.hash` always includes the `#` when non-empty, but
+    // the parser is defensive about callers feeding it the body only.
+    expect(parseRootLegacyHash("fizruk/workouts")).toBe("/fizruk/workouts");
+  });
+});
+
+describe("<HashRedirect />", () => {
+  it("redirects `/#fizruk/workouts` to `/fizruk/workouts` on mount", () => {
+    const loc = renderWithHash("#fizruk/workouts");
+    // The redirect uses `replace: true`, so by the time the probe
+    // renders the next frame the canonical pathname is in place.
+    expect(loc.textContent).toBe("/fizruk/workouts");
+  });
+
+  it("redirects `/#finyk/budgets?cat=smoking` preserving the query", () => {
+    const loc = renderWithHash("#finyk/budgets?cat=smoking");
+    expect(loc.textContent).toBe("/finyk/budgets?cat=smoking");
+  });
+
+  it("redirects `/#routine/stats` to `/routine/stats`", () => {
+    const loc = renderWithHash("#routine/stats");
+    expect(loc.textContent).toBe("/routine/stats");
+  });
+
+  it("does not redirect when the pathname is not root", () => {
+    // Module-internal hashes (e.g. `/fizruk#workouts`) are handled by
+    // each module's own redirect-on-mount shim, not this one. The
+    // root-gate keeps the two layers from double-navigating.
+    const loc = renderWithHash("#workouts", ["/fizruk"]);
+    // The shim is a no-op so the probe still sees the original entry
+    // (the in-module shim runs separately when the module mounts).
+    expect(loc.textContent?.startsWith("/fizruk")).toBe(true);
+  });
+
+  it("leaves non-module hashes alone (`/#welcome` keeps its existing semantics)", () => {
+    const loc = renderWithHash("#welcome");
+    // The shim must not redirect — `#welcome` is not a known
+    // path-based module id. The probe stays at the initial entry
+    // (router's own location does not include the DOM hash under
+    // MemoryRouter, so we assert on pathname only here; the
+    // `window.location.hash` is preserved at the DOM level which is
+    // what the real BrowserRouter would see).
+    expect(loc.textContent).toBe("/");
+    expect(window.location.hash).toBe("#welcome");
+  });
+
+  it("is a no-op when no hash is present", () => {
+    const loc = renderWithHash("");
+    expect(loc.textContent).toBe("/");
+  });
+});

--- a/apps/web/src/core/app/HashRedirect.tsx
+++ b/apps/web/src/core/app/HashRedirect.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useRef } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { PATH_BASED_MODULE_IDS } from "./appPaths";
+
+/**
+ * One-time legacy-hash-URL compat shim (initiative 0006 §Phase 3).
+ *
+ * Before Phase 2 the four primary modules (nutrition, finyk, fizruk,
+ * routine) lived under the `/?module=<id>#<page>` URL contract. PWA
+ * installs from that era, share-cards, push notifications, browser
+ * bookmarks and the in-OS «Home Screen» icons all baked the hash
+ * shape into stable user-visible URLs. After Phase 2 the canonical
+ * shape is `/<module>/<page>`.
+ *
+ * The four module-level routers (`useNutritionRoute`, `useFinykRoute`,
+ * `useFizrukRoute`, `useRoutineRoute`) each handle the **in-module**
+ * legacy form (`/fizruk#workouts` → `/fizruk/workouts`). This
+ * component handles the **root-level** legacy form where the entire
+ * route lived in the hash (`https://app.example/#fizruk/workouts`
+ * → `/fizruk/workouts`). It runs only when the current pathname is
+ * the root (`/`) and the hash is non-empty AND its first segment
+ * matches a known path-based module id (see `PATH_BASED_MODULE_IDS`).
+ * Anything else is left alone so legacy non-module hashes (e.g.
+ * `/#welcome` from an older onboarding link) keep their existing
+ * behaviour.
+ *
+ * UX-stutter: the redirect is a single `navigate(..., { replace: true })`
+ * call inside a mount effect. The user sees the splash/loader for a
+ * frame before the router transitions to the canonical URL. Phase 4
+ * (`<ScrollRestoration />` + `prefetch="hover"`) will smooth this
+ * over by preloading the destination chunk; until then the splash is
+ * the same screen the user would see for any cold load.
+ *
+ * One-shot: the ref guard ensures we never run the redirect twice
+ * even if React StrictMode double-mounts the component. After the
+ * first run the hook is a no-op for the lifetime of this tab.
+ */
+export function HashRedirect() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const redirected = useRef(false);
+
+  useEffect(() => {
+    if (redirected.current) return;
+    redirected.current = true;
+    if (typeof window === "undefined") return;
+    // Only act on root-level legacy hashes. In-module hashes
+    // (`/fizruk#workouts`, `/finyk#budgets`, etc.) are handled by the
+    // module's own redirect-on-mount shim — running both would
+    // double-navigate and lose query params.
+    if (location.pathname !== "/") return;
+    const target = parseRootLegacyHash(window.location.hash);
+    if (!target) return;
+    navigate(target, { replace: true });
+  }, [location.pathname, navigate]);
+
+  return null;
+}
+
+/**
+ * Parses the root-level legacy hash form, e.g.
+ *   `#fizruk/workouts`           → `/fizruk/workouts`
+ *   `#/fizruk/exercise/12`       → `/fizruk/exercise/12`
+ *   `#finyk/budgets?cat=smoking` → `/finyk/budgets?cat=smoking`
+ *
+ * Returns `null` for empty hashes, malformed input, or hashes whose
+ * first segment is not a known path-based module id. The
+ * `PATH_BASED_MODULE_IDS` guard keeps the shim narrowly scoped to
+ * the legacy URL surface we're migrating from — other hashes
+ * (`/#welcome`, `/#section-2` on a marketing page) keep their
+ * existing semantics.
+ */
+export function parseRootLegacyHash(rawHash: string): string | null {
+  if (!rawHash) return null;
+  const trimmed = rawHash.startsWith("#") ? rawHash.slice(1) : rawHash;
+  // `#/fizruk/workouts` and `#fizruk/workouts` both mean the same
+  // thing — strip a leading slash so the first non-empty segment is
+  // always the module id.
+  const normalized = trimmed.startsWith("/") ? trimmed.slice(1) : trimmed;
+  if (!normalized) return null;
+  // Split off any query string (`#finyk/budgets?cat=smoking`) and
+  // preserve it on the redirected URL — share-cards from the legacy
+  // contract use that param to scroll to a specific entry.
+  const queryIndex = normalized.indexOf("?");
+  const pathPart =
+    queryIndex === -1 ? normalized : normalized.slice(0, queryIndex);
+  const queryPart = queryIndex === -1 ? "" : normalized.slice(queryIndex);
+  const firstSegment = pathPart.split("/", 1)[0] ?? "";
+  if (!firstSegment) return null;
+  if (!PATH_BASED_MODULE_IDS.has(firstSegment)) return null;
+  return `/${pathPart}${queryPart}`;
+}


### PR DESCRIPTION
## Summary

Initiative [0006 §Phase 3](https://github.com/Skords-01/Sergeant/blob/main/docs/initiatives/0006-frontend-routing-and-code-split.md). Now that all four Phase 2 modules ship with path-based URLs (nutrition #2104, finyk #2108, fizruk #2541, routine #2545), this PR adds the missing **root-level** legacy-hash compat shim so URLs from the pre-Phase-2 era (PWA installs / share-cards / push notifications baked into iOS Home Screen icons before initiative 0006) keep working.

Worked example:

```
old (PWA-installed):  https://app.example/#fizruk/workouts
new (canonical):      https://app.example/fizruk/workouts
old:                  https://app.example/#finyk/budgets?cat=smoking
new:                  https://app.example/finyk/budgets?cat=smoking
old:                  https://app.example/#routine/stats
new:                  https://app.example/routine/stats
```

What this PR adds:

- `apps/web/src/core/app/HashRedirect.tsx` — root-level one-time `useEffect` that reads `window.location.hash`, parses the first segment against `PATH_BASED_MODULE_IDS`, and navigates to the canonical path with `replace: true`. One-shot per tab (guarded by a `useRef`) so React StrictMode double-mounts don't fire two redirects.
- The shim is **root-gated**: it only acts when `useLocation().pathname === "/"`. In-module hashes (`/fizruk#workouts`) are owned by each module's own redirect-on-mount shim (`useFizrukRoute`, `useRoutineRoute`, etc.) — running both layers would double-navigate and lose query params.
- Non-module hashes (`/#welcome`, `/#section-2`) are intentionally left alone — the shim is narrowly scoped to the four Phase 2 module ids so other legacy contracts keep their existing semantics.
- `apps/web/src/core/app/HashRedirect.test.tsx` — 14 tests covering the parser (8: bare module, module+page, leading-slash tolerance, query-string preservation, prefix-alias boundary, defensive input without `#`, empty / malformed hashes, non-module hashes) and the rendered component (6: redirect on mount, query preservation, root-gate, non-module no-op, empty-hash no-op, integration through `MemoryRouter` + `Routes`).
- `<HashRedirect />` mounted in `apps/web/src/core/App.tsx` next to `<ShellDeepLinkBridge />`, outside `AppLockProvider` / `AuthProvider`, so it survives unauthenticated surfaces (`/sign-in`, `/welcome`, `/reset-password`) where a legacy URL could land first.

## Governing Skill

- Primary skill: `sergeant-web-ui`
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a (Phase 3 was scheduled in the initiative right after Phase 2 completes; no separate playbook authored)
- Why this playbook: n/a
- If no playbook matched, why: this is the explicit Phase 3 PR called out in `docs/initiatives/0006-frontend-routing-and-code-split.md` §«Фаза 3 — hash-URL compat shim (1 PR)».

## Verification

Locally, in `apps/web`:

```bash
pnpm exec eslint src/core/app/HashRedirect.tsx src/core/app/HashRedirect.test.tsx src/core/App.tsx
# → clean (0 errors, 0 warnings)

pnpm test -- --run HashRedirect appPaths useHubNavigation StandaloneRoutes WelcomeScreen
# → 32 tests passed (5 files)
```

Manual walkthrough (jsdom-backed, encoded in tests):

| Hash entered                      | Pathname after shim       |
| --------------------------------- | ------------------------- |
| `/#fizruk/workouts`               | `/fizruk/workouts`        |
| `/#fizruk/exercise/12`            | `/fizruk/exercise/12`     |
| `/#finyk/budgets?cat=smoking`     | `/finyk/budgets?cat=smoking` |
| `/#routine/stats`                 | `/routine/stats`          |
| `/#welcome`                       | `/` (hash preserved as-is) |
| `/fizruk#workouts`                | `/fizruk` (in-module shim acts) |

Additional checks:

- [x] Local smoke / manual validation completed (lint + focused tests)
- [x] Surface-specific checks completed

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [ ] I checked whether `AGENTS.md` needed an update.
- [ ] I checked whether a playbook or skill needed an update.
- [ ] I checked whether governance docs or review docs needed an update.

Updated docs:

- The initiative `docs/initiatives/0006-frontend-routing-and-code-split.md` §Фаза 3 lists this exact PR shape (`apps/web/src/core/app/HashRedirect.tsx`, mounted in root route, one-time `navigate("/" + hash.slice(1), { replace: true })`). After merge Phase 3 progress in the same doc rolls to «✅ зроблено» and Phase 4 (`prefetch="hover"` + `<ScrollRestoration />`) becomes the next item.

## Risk and Rollout

- User-visible risk: low. Existing canonical URLs (`/fizruk/workouts`, `/finyk/budgets`, …) are unaffected because the root-gate (`pathname === "/"`) makes the shim inactive when the user is already on a module path. The redirect is a single `navigate(..., { replace: true })` so the browser history is not polluted with a synthetic stop.
- Rollout / deploy order: ship as-is; no feature flag.
- Backout plan: revert the PR. The shim is a single component + a mount entry; removing it restores the previous behavior where legacy `/#fizruk/...` URLs fall through to the Hub at `/` (existing behaviour on `main` today — Phase 3 is *adding* the redirect, not changing an existing one).

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

The shim is intentionally **module-id-scoped** rather than the broader `"/" + hash.slice(1)` redirect originally sketched in the initiative. Two reasons:

1. **Avoids capturing non-module hashes.** Anchor links inside marketing copy (e.g. `/#features`), legacy auth links (`/#reset-password`), and OAuth callback fragments (`access_token=...`) all live in the root hash today. Blindly redirecting them would break those flows.
2. **Boundary-checks prefix-aliased hashes** so `/#fizrukfoo` doesn't accidentally alias to `/fizruk` (same boundary `isPathBasedModulePath()` and `parsePathnameModule()` enforce in `appPaths.ts` and `useHubNavigation.ts`).

The Playwright e2e test for the legacy → canonical redirect is **not in this PR** — the initiative listed it as a separate checklist item (`docs/initiatives/0006-frontend-routing-and-code-split.md` §«Hash-URL compat shim тестується e2e (1 Playwright test). _Phase 3._»). Jsdom-based integration test in `HashRedirect.test.tsx` covers the redirect through a real `MemoryRouter` + `Routes` mount; the Playwright counterpart will land in a follow-up PR alongside Phase 4's scroll-restoration / prefetch tests.


Link to Devin session: https://app.devin.ai/sessions/7994b57a53e24056aa05b7d2f9af7b19

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a root-level `HashRedirect` to rewrite legacy hash URLs (e.g. `/#fizruk/workouts`) to canonical path-based routes (e.g. `/fizruk/workouts`) so old PWA, share, and notification links keep working. Aligns with initiative 0006 Phase 3 and targets the four path-based modules.

- **New Features**
  - Added `HashRedirect` shim that runs once on mount, reads `window.location.hash`, and redirects with `replace: true` when on `/` and the first hash segment matches `PATH_BASED_MODULE_IDS`.
  - Mounted in `App.tsx` alongside `ShellDeepLinkBridge` so it works on unauthenticated routes (e.g. `/sign-in`, `/welcome`).
  - Leaves non-module hashes (e.g. `/#welcome`) untouched; in-module hashes (e.g. `/fizruk#workouts`) remain handled by module shims.
  - Added `HashRedirect.test.tsx` covering parser cases and component behavior, including query-string preservation and root-gating.

<sup>Written for commit d8ac8ba98a5d71ac05f5cbc5c44aef7983c7ba48. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

