### PR TITLE
feat(web): toast stacking, swipe-dismiss, undo countdown

### DIFF
--- a/apps/web/src/shared/components/ui/Toast.stories.tsx
+++ b/apps/web/src/shared/components/ui/Toast.stories.tsx
@@ -1,25 +1,36 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useToast } from "@shared/hooks/useToast";
+import { showUndoToast } from "@shared/lib/ui/undoToast";
 import { Button } from "./Button";
 import { ToastContainer } from "./Toast";
 
 /**
- * `Toast` — top-anchored ephemeral повідомлення з чотирма variant-ами
+ * `Toast` — bottom-anchored ephemeral повідомлення з чотирма variant-ами
  * (`success` / `error` / `info` / `warning`). Render-shape — `<ToastContainer>`,
  * запускається через `useToast()` API (`success` / `error` / `info` / `warning`
  * + дефолтний `show`). Containers вшито у `apps/web/src/App.tsx`; у Storybook
  * контейнер монтується глобальним decorator-ом у `.storybook/preview.tsx`.
  *
  * Поведінка:
- *   - Stack — 5 toasts max; найстаріший вилітає під час 6-го show.
- *   - Auto-dismiss — `success` / `info` за 3.5 s, `error` / `warning` за 5 s
- *     (можна перевизначити третім аргументом).
- *   - Action — опційна `{ label, onClick }` кнопка справа від тексту.
- *     Після кліку Toast dismiss-иться автоматично.
+ *   - Stack — 5 toasts max; найстаріший вилітає під час 6-го show. Spacing
+ *     між toast-ами 8 px (gap-2); контейнер позиціонується над bottom-nav
+ *     (`--bottom-nav-height`), `ActiveWorkoutBanner`-offset-ом і
+ *     `env(safe-area-inset-bottom)` — не overlap-иться навіть на 375 px.
+ *   - Auto-dismiss — `success` / `info` за 3.5 s, `error` / `warning` /
+ *     undo-toast за 5 s. Pause on hover / focus / touch-drag — стандарт
+ *     WAI-ARIA Authoring Practices для toasts.
+ *   - Action — опційна `{ label, onClick }` кнопка справа від тексту. Після
+ *     кліку Toast dismiss-иться автоматично. Toasts з action отримують
+ *     лінійний countdown-bar (CSS animation, не JS-RAF).
+ *   - Swipe-to-dismiss — горизонтальний swipe ≥64 px (або flick) дисмісить
+ *     toast (touch-only; десктоп має close-кнопку та Esc). Для undo-toast-у
+ *     swipe = consume undo-window — snapshot не повертається.
  *   - Animation — `animate-toast-enter` / `animate-toast-exit` (200 ms exit
- *     transition; window під час якого `leaving=true`).
- *   - A11y — `role="status"` на контейнері, `role="alert"` на кожному toast-і,
- *     закриваюча кнопка з `aria-label="Закрити"` 14 px-icon.
+ *     transition); `prefers-reduced-motion: reduce` робить fade-in миттєвим,
+ *     countdown лишається (інформативний, не декоративний).
+ *   - A11y — per-toast `role` + `aria-live` (`status`+`polite` для
+ *     info/success/warning, `alert`+`assertive` для error та undo-toast).
+ *     Esc на focused toast дисмісить; undo-кнопка має `focus-visible:ring`.
  */
 const meta: Meta<typeof ToastContainer> = {
   title: "UI / Toast",
@@ -72,6 +83,97 @@ function ShowcaseDemo() {
 /** Чотири variant-и через окремі кнопки — клік ставить toast у стек. */
 export const Showcase: Story = {
   render: () => <ShowcaseDemo />,
+};
+
+function SingleDemo() {
+  const t = useToast();
+  return (
+    <Button
+      variant="primary"
+      onClick={() => t.success("Тренування збережено: +180 ккал.")}
+    >
+      Single toast (success)
+    </Button>
+  );
+}
+
+/** Один toast — найпростіший випадок; вилітає за 3.5 s, без action. */
+export const Single: Story = {
+  render: () => <SingleDemo />,
+};
+
+function StackOfThreeDemo() {
+  const t = useToast();
+  return (
+    <Button
+      variant="secondary"
+      onClick={() => {
+        t.info("Перший toast — info");
+        t.success("Другий toast — success");
+        t.warning("Третій toast — warning");
+      }}
+    >
+      Stack of 3
+    </Button>
+  );
+}
+
+/**
+ * Стек із 3 toast-ів — перевір spacing (8 px gap-2) і що жоден не overlap-иться
+ * над bottom-nav / safe-area. Корисно для регресій після зміни позиціонування.
+ */
+export const StackOfThree: Story = {
+  render: () => <StackOfThreeDemo />,
+};
+
+function WithUndoDemo() {
+  const t = useToast();
+  return (
+    <Button
+      variant="danger"
+      onClick={() => {
+        showUndoToast(t, {
+          msg: "Видалено звичку «Вода»",
+          onUndo: () => t.success("Звичку «Вода» повернуто.", 2500),
+        });
+      }}
+    >
+      Видалити (undo 5 s)
+    </Button>
+  );
+}
+
+/**
+ * `showUndoToast` — info-варіант із 5-секундним вікном + кнопкою «Повернути».
+ * Bottom-bar countdown лінійно зменшується з 5 → 0 с; swipe-dismiss або
+ * закриття без кліку дропає snapshot (як expired timeout). Pause on hover /
+ * focus — таймер і countdown зупиняються синхронно.
+ */
+export const WithUndo: Story = {
+  render: () => <WithUndoDemo />,
+};
+
+function ErrorOnlyDemo() {
+  const t = useToast();
+  return (
+    <Button
+      variant="danger"
+      onClick={() =>
+        t.error("Не вдалося синхронізувати тренування — спробуй через хвилину.")
+      }
+    >
+      Тільки error
+    </Button>
+  );
+}
+
+/**
+ * Error toast — `role="alert" aria-live="assertive"`, 5-секундний за
+ * замовчуванням. Без action (звичайний error), тому countdown-bar не
+ * показується — bar резервується для recoverable-flows (Rule #17).
+ */
+export const ErrorOnly: Story = {
+  render: () => <ErrorOnlyDemo />,
 };
 
 function WithActionDemo() {
@@ -169,4 +271,38 @@ function CustomDurationDemo() {
 /** Custom `duration` (3-й аргумент) — для коротких / sticky повідомлень. */
 export const CustomDuration: Story = {
   render: () => <CustomDurationDemo />,
+};
+
+/**
+ * Mobile-viewport variant — рендерить stack-of-3 + undo-toast на iPhone SE
+ * (375 px) щоб перевірити, що toast-tray не overlap-иться з safe-area-inset
+ * та віртуальним bottom-nav.
+ */
+export const MobileStack: Story = {
+  parameters: {
+    viewport: { defaultViewport: "iphonese2" },
+  },
+  render: () => {
+    function MobileStackDemo() {
+      const t = useToast();
+      return (
+        <div className="flex flex-col gap-2 max-w-[20rem]">
+          <Button
+            variant="secondary"
+            onClick={() => {
+              t.info("Перший toast — info");
+              t.warning("Другий — warning");
+              showUndoToast(t, {
+                msg: "Видалено категорію «Кафе»",
+                onUndo: () => t.success("Категорію повернуто."),
+              });
+            }}
+          >
+            Stack of 3 + undo (375 px)
+          </Button>
+        </div>
+      );
+    }
+    return <MobileStackDemo />;
+  },
 };

--- a/apps/web/src/shared/components/ui/Toast.test.tsx
+++ b/apps/web/src/shared/components/ui/Toast.test.tsx
@@ -1,0 +1,264 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { ToastProvider, useToast } from "@shared/hooks/useToast";
+import { showUndoToast } from "@shared/lib/ui/undoToast";
+import { ToastContainer } from "./Toast";
+
+/**
+ * Тестова обгортка — рендерить `<ToastContainer>` всередині `<ToastProvider>`
+ * і exposes `useToast()` API через `apiRef` так, щоб тести могли стрілятися
+ * toast-ами через `act(() => api.show(...))` без додаткового UI.
+ */
+function renderHarness(): {
+  api: ReturnType<typeof useToast>;
+} {
+  const apiRef: { current: ReturnType<typeof useToast> | null } = {
+    current: null,
+  };
+  function ApiBridge() {
+    const api = useToast();
+    apiRef.current = api;
+    return null;
+  }
+  render(
+    <ToastProvider>
+      <ApiBridge />
+      <ToastContainer />
+    </ToastProvider>,
+  );
+  if (!apiRef.current) throw new Error("ApiBridge not mounted");
+  return { api: apiRef.current };
+}
+
+function touches(x: number, y = 0) {
+  return [{ clientX: x, clientY: y }] as unknown as TouchList;
+}
+
+function getToastRoot(): HTMLElement {
+  const el = document.querySelector<HTMLElement>("[data-toast-id]");
+  if (!el) throw new Error("Toast row not rendered");
+  return el;
+}
+
+describe("Toast — a11y", () => {
+  beforeEach(() => {
+    navigator.vibrate = vi.fn();
+  });
+
+  it("info-toast має role=status + aria-live=polite", () => {
+    const { api } = renderHarness();
+    act(() => {
+      api.info("Інфо");
+    });
+    const row = getToastRoot();
+    expect(row.getAttribute("role")).toBe("status");
+    expect(row.getAttribute("aria-live")).toBe("polite");
+  });
+
+  it("error-toast має role=alert + aria-live=assertive", () => {
+    const { api } = renderHarness();
+    act(() => {
+      api.error("Помилка");
+    });
+    const row = getToastRoot();
+    expect(row.getAttribute("role")).toBe("alert");
+    expect(row.getAttribute("aria-live")).toBe("assertive");
+  });
+
+  it("toast з undo-action (через showUndoToast) — assertive", () => {
+    // 5-секундне undo-вікно мусить бути проголошене screen reader-ом одразу,
+    // а не чекати, поки polite-queue звільниться (інакше юзер не встигне).
+    const { api } = renderHarness();
+    act(() => {
+      showUndoToast(api, { msg: "Видалено", onUndo: () => {} });
+    });
+    const row = getToastRoot();
+    expect(row.getAttribute("role")).toBe("alert");
+    expect(row.getAttribute("aria-live")).toBe("assertive");
+  });
+
+  it("Esc на focused toast викликає dismiss", () => {
+    vi.useFakeTimers();
+    try {
+      const { api } = renderHarness();
+      act(() => {
+        api.info("Інфо", 10_000);
+      });
+      const row = getToastRoot();
+      fireEvent.keyDown(row, { key: "Escape" });
+      // dismiss → 200 ms exit animation → remove from DOM
+      act(() => {
+        vi.advanceTimersByTime(220);
+      });
+      expect(document.querySelector("[data-toast-id]")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("Toast — auto-dismiss pause/resume", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    navigator.vibrate = vi.fn();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("hover паузить auto-dismiss; mouseleave продовжує таймер з остачі", () => {
+    const { api } = renderHarness();
+    act(() => {
+      api.info("Pinned", 2000);
+    });
+    const row = getToastRoot();
+
+    // Лишаємо таймеру повчитися 500 ms — після pause очікуємо ~1500 ms remaining.
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    fireEvent.mouseEnter(row);
+    act(() => {
+      vi.advanceTimersByTime(5000); // hover тримає → ніяких dismiss-ів
+    });
+    expect(document.querySelector("[data-toast-id]")).not.toBeNull();
+
+    fireEvent.mouseLeave(row);
+    // Після resume чекаємо ~1500 ms перед natural dismiss.
+    act(() => {
+      vi.advanceTimersByTime(1499);
+    });
+    expect(document.querySelector("[data-toast-id]")).not.toBeNull();
+    act(() => {
+      // 1500 ms remaining повністю минулі + 200 ms exit animation.
+      vi.advanceTimersByTime(2 + 220);
+    });
+    expect(document.querySelector("[data-toast-id]")).toBeNull();
+  });
+
+  it("focus паузить таймер так само як hover", () => {
+    const { api } = renderHarness();
+    act(() => {
+      api.success("Saved", 1500);
+    });
+    const row = getToastRoot();
+
+    fireEvent.focus(row);
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(document.querySelector("[data-toast-id]")).not.toBeNull();
+  });
+
+  it("countdown-bar для undo-toast має animationDuration=5000ms і paused під час hover", () => {
+    const { api } = renderHarness();
+    act(() => {
+      showUndoToast(api, { msg: "Видалено", onUndo: () => {} });
+    });
+    const row = getToastRoot();
+    const bar = row.querySelector<HTMLElement>("[data-toast-countdown]");
+    expect(bar).not.toBeNull();
+    // Inline duration виставляється з `toast.duration` (5000ms default
+    // для undo-toast — спадає з @sergeant/shared).
+    expect(bar?.style.animationDuration).toBe("5000ms");
+    expect(bar?.getAttribute("data-toast-paused")).toBe("false");
+
+    fireEvent.mouseEnter(row);
+    expect(bar?.getAttribute("data-toast-paused")).toBe("true");
+
+    fireEvent.mouseLeave(row);
+    expect(bar?.getAttribute("data-toast-paused")).toBe("false");
+  });
+});
+
+describe("Toast — swipe-to-dismiss (touch-only)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    navigator.vibrate = vi.fn();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("горизонтальний swipe ≥ 64 px dismiss-ить toast", () => {
+    const { api } = renderHarness();
+    act(() => {
+      api.info("Swipeable", 10_000);
+    });
+    const row = getToastRoot();
+
+    fireEvent.touchStart(row, { touches: touches(200, 50) });
+    fireEvent.touchMove(row, { touches: touches(300, 50) }); // dx = +100
+    fireEvent.touchEnd(row);
+
+    act(() => {
+      vi.advanceTimersByTime(220); // exit animation
+    });
+    expect(document.querySelector("[data-toast-id]")).toBeNull();
+  });
+
+  it("undo-toast: swipe не викликає onUndo (=consume undo-window)", () => {
+    // Це той самий ефект, як expired timeout — snapshot drop, не restore.
+    const onUndo = vi.fn();
+    const { api } = renderHarness();
+    act(() => {
+      showUndoToast(api, { msg: "Видалено", onUndo });
+    });
+    const row = getToastRoot();
+
+    fireEvent.touchStart(row, { touches: touches(100, 50) });
+    fireEvent.touchMove(row, { touches: touches(20, 50) }); // dx = -80
+    fireEvent.touchEnd(row);
+
+    act(() => {
+      vi.advanceTimersByTime(220);
+    });
+    expect(onUndo).not.toHaveBeenCalled();
+    expect(document.querySelector("[data-toast-id]")).toBeNull();
+  });
+
+  it("короткий swipe < 64 px не dismiss-ить — toast лишається", () => {
+    const { api } = renderHarness();
+    act(() => {
+      api.info("Sticky-ish", 10_000);
+    });
+    const row = getToastRoot();
+
+    fireEvent.touchStart(row, { touches: touches(200, 50) });
+    fireEvent.touchMove(row, { touches: touches(230, 50) }); // dx = +30
+    fireEvent.touchEnd(row);
+
+    act(() => {
+      vi.advanceTimersByTime(220);
+    });
+    expect(document.querySelector("[data-toast-id]")).not.toBeNull();
+  });
+});
+
+describe("Toast — undo-action", () => {
+  beforeEach(() => {
+    navigator.vibrate = vi.fn();
+  });
+
+  it("клік на undo-кнопці викликає onUndo і dismiss-ить toast", () => {
+    vi.useFakeTimers();
+    try {
+      const onUndo = vi.fn();
+      const { api } = renderHarness();
+      act(() => {
+        showUndoToast(api, { msg: "Видалено", onUndo });
+      });
+      const button = screen.getByRole("button", { name: "Повернути" });
+      fireEvent.click(button);
+      expect(onUndo).toHaveBeenCalledTimes(1);
+      act(() => {
+        vi.advanceTimersByTime(220);
+      });
+      expect(document.querySelector("[data-toast-id]")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/web/src/shared/components/ui/Toast.tsx
+++ b/apps/web/src/shared/components/ui/Toast.tsx
@@ -1,4 +1,18 @@
-import { useToast, type ToastType } from "@shared/hooks/useToast";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type FocusEvent,
+  type KeyboardEvent,
+  type TouchEvent,
+} from "react";
+import {
+  useToast,
+  type ToastItem,
+  type ToastType,
+} from "@shared/hooks/useToast";
 import { cn } from "@shared/lib/ui/cn";
 import { Icon, type IconName } from "./Icon";
 import { messages } from "@shared/i18n/uk";
@@ -24,67 +38,303 @@ const ICON_NAME: Record<ToastType, IconName> = {
   info: "alert-circle",
 };
 
+/**
+ * Countdown progress bar for toasts that own a recoverable side-effect
+ * (the undo-pattern). On the `info` variant we use a dark-on-light tint
+ * because the surface is `bg-primary text-bg`; on the saturated white-on-X
+ * variants we use a translucent-white bar so it remains visible.
+ */
+const COUNTDOWN_BAR_TINT: Record<ToastType, string> = {
+  success: "bg-white/45",
+  error: "bg-white/55",
+  warning: "bg-white/55",
+  info: "bg-bg/35",
+};
+
+/**
+ * Horizontal-swipe threshold for touch-dismiss. 64 px is large enough that
+ * users won't trigger it on a vertical scroll-start (where the X-component
+ * of the gesture is small), and small enough that a casual flick clears the
+ * toast without forcing a full-width drag. Velocity threshold catches fast
+ * flicks that don't travel the full 64 px before lift-off — but only when
+ * the gesture covered at least half the distance threshold, so micro-jitter
+ * (a 5-px movement in 10 ms produces a 0.5 px/ms velocity that would
+ * otherwise look like a flick) cannot trigger a phantom dismiss.
+ */
+const SWIPE_DISMISS_DISTANCE_PX = 64;
+const SWIPE_DISMISS_MIN_DISTANCE_FOR_VELOCITY_PX = 32;
+const SWIPE_DISMISS_VELOCITY_PX_PER_MS = 0.4;
+
+interface ToastRowProps {
+  toast: ToastItem;
+  dismiss: (id: number) => void;
+  pause: (id: number) => void;
+  resume: (id: number) => void;
+}
+
+function ToastRow({ toast, dismiss, pause, resume }: ToastRowProps) {
+  const [dragX, setDragX] = useState(0);
+  const [dragging, setDragging] = useState(false);
+  // `paused` is `true` whenever the auto-dismiss timer is currently halted
+  // (hover, focus, or active touch-drag). Surfaced as state — rather than a
+  // ref — because the CSS countdown animation reads it via
+  // `[animation-play-state:paused]` and so needs a re-render when it flips.
+  const [paused, setPaused] = useState(false);
+  const touchStartXRef = useRef<number | null>(null);
+  const touchStartTimeRef = useRef(0);
+
+  const hasAction = !!toast.action?.onClick;
+  // Error toasts and undo-bearing toasts use `assertive` politeness so the
+  // screen-reader interrupts whatever is being read — the user has at most
+  // `toast.duration` ms (5 s for undo) to react, so we can't wait for the
+  // queue to drain naturally.
+  const assertive = toast.type === "error" || hasAction;
+
+  const isLeaving = !!toast.leaving;
+
+  useEffect(() => {
+    // Reset any in-flight swipe offset once the row enters exit-animation
+    // so the exit translate doesn't compound with the swipe translate.
+    if (isLeaving) {
+      setDragX(0);
+      setDragging(false);
+      touchStartXRef.current = null;
+    }
+  }, [isLeaving]);
+
+  const onMouseEnter = useCallback(() => {
+    setPaused(true);
+    pause(toast.id);
+  }, [pause, toast.id]);
+
+  const onMouseLeave = useCallback(() => {
+    setPaused(false);
+    resume(toast.id);
+  }, [resume, toast.id]);
+
+  const onFocus = useCallback(() => {
+    setPaused(true);
+    pause(toast.id);
+  }, [pause, toast.id]);
+
+  const onBlur = useCallback(
+    (event: FocusEvent<HTMLDivElement>) => {
+      const next = event.relatedTarget as Node | null;
+      if (event.currentTarget.contains(next)) return;
+      setPaused(false);
+      resume(toast.id);
+    },
+    [resume, toast.id],
+  );
+
+  const onTouchStart = useCallback(
+    (event: TouchEvent<HTMLDivElement>) => {
+      if (event.touches.length !== 1) return;
+      const touch = event.touches[0];
+      if (!touch) return;
+      touchStartXRef.current = touch.clientX;
+      touchStartTimeRef.current = Date.now();
+      setDragging(true);
+      setPaused(true);
+      pause(toast.id);
+    },
+    [pause, toast.id],
+  );
+
+  const onTouchMove = useCallback((event: TouchEvent<HTMLDivElement>) => {
+    if (touchStartXRef.current == null) return;
+    const touch = event.touches[0];
+    if (!touch) return;
+    setDragX(touch.clientX - touchStartXRef.current);
+  }, []);
+
+  const onTouchEnd = useCallback(() => {
+    if (touchStartXRef.current == null) return;
+    const dx = dragX;
+    const dt = Math.max(1, Date.now() - touchStartTimeRef.current);
+    const velocity = Math.abs(dx) / dt;
+    touchStartXRef.current = null;
+    setDragging(false);
+    const flick =
+      Math.abs(dx) >= SWIPE_DISMISS_MIN_DISTANCE_FOR_VELOCITY_PX &&
+      velocity >= SWIPE_DISMISS_VELOCITY_PX_PER_MS;
+    if (Math.abs(dx) >= SWIPE_DISMISS_DISTANCE_PX || flick) {
+      // Treat horizontal swipe-dismiss as a deliberate "I've read this"
+      // gesture. For undo-toasts this is equivalent to letting the 5 s
+      // timer expire — the snapshot is dropped and `onUndo` never runs.
+      dismiss(toast.id);
+      return;
+    }
+    setDragX(0);
+    setPaused(false);
+    resume(toast.id);
+  }, [dismiss, dragX, resume, toast.id]);
+
+  const onKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.key !== "Escape") return;
+      // Only swallow Esc when the focus is inside this toast — leaves the
+      // global `Esc` handler (modals, dialogs) untouched for other UIs.
+      event.stopPropagation();
+      dismiss(toast.id);
+    },
+    [dismiss, toast.id],
+  );
+
+  // Inline styles: drag translate (no transition while dragging so it
+  // tracks the finger 1:1) and countdown animation duration.
+  const style: CSSProperties = {};
+  if (dragX !== 0 || dragging) {
+    style.transform = `translateX(${dragX}px)`;
+    style.transition = "none";
+    // Fade out as the swipe approaches the dismiss threshold so the user
+    // gets a clear visual confirmation that release will dismiss.
+    const progress = Math.min(1, Math.abs(dragX) / SWIPE_DISMISS_DISTANCE_PX);
+    style.opacity = 1 - progress * 0.5;
+  }
+
+  return (
+    <div
+      className={cn(
+        "text-style-label pointer-events-auto w-full px-4 py-3 rounded-2xl shadow-float relative overflow-hidden",
+        "flex items-center gap-2.5 outline-none",
+        "focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
+        "touch-pan-y", // allow vertical scroll, capture horizontal swipe
+        isLeaving
+          ? "motion-safe:animate-toast-exit"
+          : "motion-safe:animate-toast-enter",
+        VARIANT[toast.type] || VARIANT.info,
+      )}
+      role={assertive ? "alert" : "status"}
+      aria-live={assertive ? "assertive" : "polite"}
+      aria-atomic="true"
+      tabIndex={0}
+      style={style}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      onTouchStart={onTouchStart}
+      onTouchMove={onTouchMove}
+      onTouchEnd={onTouchEnd}
+      onTouchCancel={onTouchEnd}
+      onKeyDown={onKeyDown}
+      data-toast-id={toast.id}
+      data-toast-type={toast.type}
+    >
+      <span
+        className={cn(
+          "shrink-0 inline-flex items-center justify-center",
+          ICON_WRAP[toast.type],
+        )}
+      >
+        <Icon
+          name={ICON_NAME[toast.type]}
+          size={16}
+          strokeWidth={2.5}
+          aria-hidden
+        />
+      </span>
+      <span className="min-w-0 flex-1 leading-snug">{toast.msg}</span>
+      {toast.action?.onClick && (
+        <button
+          type="button"
+          onClick={() => {
+            try {
+              toast.action?.onClick();
+            } finally {
+              dismiss(toast.id);
+            }
+          }}
+          className={cn(
+            "shrink-0 px-2.5 py-1 rounded-xl bg-white/15 hover:bg-white/25 transition-colors",
+            "outline-none focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-1 focus-visible:ring-offset-transparent",
+          )}
+        >
+          {toast.action.label || "Дія"}
+        </button>
+      )}
+      <button
+        type="button"
+        onClick={() => dismiss(toast.id)}
+        className={cn(
+          "shrink-0 opacity-70 hover:opacity-100 transition-opacity",
+          "outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-1 focus-visible:ring-offset-transparent rounded-md",
+        )}
+        aria-label={messages.actions.close}
+      >
+        <Icon name="close" size={14} strokeWidth={2.5} aria-hidden />
+      </button>
+      {hasAction && !isLeaving && (
+        <span
+          aria-hidden
+          className={cn(
+            "absolute left-0 bottom-0 h-0.5 w-full origin-left",
+            COUNTDOWN_BAR_TINT[toast.type],
+            "motion-safe:animate-toast-countdown motion-reduce:scale-x-0",
+            paused ? "motion-safe:[animation-play-state:paused]" : "",
+          )}
+          data-toast-countdown
+          data-toast-paused={paused ? "true" : "false"}
+          style={{ animationDuration: `${toast.duration}ms` }}
+        />
+      )}
+    </div>
+  );
+}
+
+/**
+ * Bottom-anchored toast tray. Positioned above the bottom-nav, optional
+ * `ActiveWorkoutBanner`, and iOS safe-area inset; never overlaps with
+ * those layers even when several toasts stack up on a 375 px viewport.
+ *
+ * Per-toast politeness — error and undo-bearing toasts get
+ * `role="alert" aria-live="assertive"` (the 5 s undo-window can't wait
+ * for the polite queue to drain); info/success/warning stay
+ * `role="status" aria-live="polite"`.
+ *
+ * Swipe-to-dismiss is touch-only — on desktop the close button is the
+ * canonical dismiss affordance (Esc also works when the toast has
+ * focus). For undo-toasts the swipe-dismiss intentionally drops the
+ * snapshot (no `onUndo` call), matching the timer-expiry semantics.
+ *
+ * Auto-dismiss is paused while the user is hovering with the mouse,
+ * keyboard-focused on the row, or actively dragging — resumes on leave.
+ * Implements the WAI-ARIA Authoring Practices recommendation for
+ * time-limited messages.
+ */
 export function ToastContainer() {
-  const { toasts, dismiss } = useToast();
+  const { toasts, dismiss, pause, resume } = useToast();
 
   if (toasts.length === 0) return null;
 
   return (
     <div
-      className="fixed top-[max(1.25rem,env(safe-area-inset-top,0px)+0.75rem)] left-1/2 -translate-x-1/2 z-9999 flex flex-col items-center gap-2 pointer-events-none w-[min(92vw,24rem)]"
-      aria-live="polite"
-      role="status"
+      // Bottom-anchored above (in DOM-stacking sense — visually upward
+      // from) the bottom-nav (`--bottom-nav-height`, 60 px when present),
+      // the optional `ActiveWorkoutBanner` (~84 px above the bottom-nav),
+      // and the iOS home-indicator safe-area. `z-9999` keeps the tray
+      // over the FAB and module shells but still below modal portals
+      // when they are explicitly placed at `z-[10000]`.
+      className={cn(
+        "fixed left-1/2 -translate-x-1/2 z-9999",
+        "flex flex-col items-center gap-2 pointer-events-none",
+        "w-[min(92vw,24rem)]",
+      )}
+      style={{
+        bottom:
+          "calc(env(safe-area-inset-bottom, 0px) + var(--bottom-nav-height, 0px) + var(--active-workout-banner-offset, 0px) + 1rem)",
+      }}
+      data-testid="toast-tray"
     >
       {toasts.map((t) => (
-        <div
+        <ToastRow
           key={t.id}
-          className={cn(
-            "text-style-label pointer-events-auto w-full px-4 py-3 rounded-2xl shadow-float flex items-center gap-2.5",
-            t.leaving
-              ? "motion-safe:animate-toast-exit"
-              : "motion-safe:animate-toast-enter",
-            VARIANT[t.type] || VARIANT.info,
-          )}
-          role="alert"
-        >
-          <span
-            className={cn(
-              "shrink-0 inline-flex items-center justify-center",
-              ICON_WRAP[t.type],
-            )}
-          >
-            <Icon
-              name={ICON_NAME[t.type]}
-              size={16}
-              strokeWidth={2.5}
-              aria-hidden
-            />
-          </span>
-          <span className="min-w-0 flex-1 leading-snug">{t.msg}</span>
-          {t.action?.onClick && (
-            <button
-              type="button"
-              onClick={() => {
-                try {
-                  t.action?.onClick();
-                } finally {
-                  dismiss(t.id);
-                }
-              }}
-              className="shrink-0 px-2.5 py-1 rounded-xl bg-white/15 hover:bg-white/25 transition-colors"
-            >
-              {t.action.label || "Дія"}
-            </button>
-          )}
-          <button
-            type="button"
-            onClick={() => dismiss(t.id)}
-            className="shrink-0 opacity-70 hover:opacity-100 transition-opacity"
-            aria-label={messages.actions.close}
-          >
-            <Icon name="close" size={14} strokeWidth={2.5} aria-hidden />
-          </button>
-        </div>
+          toast={t}
+          dismiss={dismiss}
+          pause={pause}
+          resume={resume}
+        />
       ))}
     </div>
   );

--- a/apps/web/src/shared/hooks/useToast.tsx
+++ b/apps/web/src/shared/hooks/useToast.tsx
@@ -21,6 +21,13 @@ export interface ToastItem {
   msg: ReactNode;
   type: ToastType;
   action: ToastAction | null;
+  /**
+   * Auto-dismiss duration, captured at the moment `show()` was called.
+   * Exposed so `<ToastContainer>` can drive a CSS-based countdown ring/bar
+   * (animation-duration is set inline) without re-deriving it from the
+   * default-by-type table.
+   */
+  duration: number;
   /** Set to true during the exit animation before actual removal. */
   leaving?: boolean;
 }
@@ -37,6 +44,19 @@ export interface ToastApi {
   info: (msg: ReactNode, duration?: number, action?: ToastAction) => number;
   warning: (msg: ReactNode, duration?: number, action?: ToastAction) => number;
   dismiss: (id: number) => void;
+  /**
+   * Pause the auto-dismiss countdown for the toast `id`. Idempotent — calling
+   * twice in a row is a no-op. Used by `<ToastContainer>` on hover / focus /
+   * touch-drag so a screen-reader user (or anyone re-reading the message) has
+   * unbounded time before the toast self-destructs. Pair with `resume(id)`.
+   */
+  pause: (id: number) => void;
+  /**
+   * Resume a paused auto-dismiss countdown. Idempotent if the toast is not
+   * currently paused or has already been dismissed. Restarts the timer with
+   * whatever remained when `pause()` was called.
+   */
+  resume: (id: number) => void;
 }
 
 export interface ToastContextValue extends ToastApi {
@@ -45,26 +65,45 @@ export interface ToastContextValue extends ToastApi {
 
 const ToastContext = createContext<ToastContextValue | null>(null);
 
+const DEFAULT_DURATION: Record<ToastType, number> = {
+  success: 3500,
+  info: 3500,
+  warning: 5000,
+  error: 5000,
+};
+
 let idCounter = 0;
 
 export function ToastProvider({ children }: { children: ReactNode }) {
   const [toasts, setToasts] = useState<ToastItem[]>([]);
   const timersRef = useRef<Record<number, ReturnType<typeof setTimeout>>>({});
+  // Timestamp (ms) when the current timer started (for the active id);
+  // combined with `remainingRef` to compute time-left on pause.
+  const startedAtRef = useRef<Record<number, number>>({});
+  // Milliseconds left for the auto-dismiss countdown. When the timer is
+  // running, this matches the duration passed to `setTimeout`; on pause we
+  // overwrite it with `remaining - (now - startedAt)`.
+  const remainingRef = useRef<Record<number, number>>({});
 
   useEffect(() => {
     return () => {
       Object.values(timersRef.current).forEach(clearTimeout);
       timersRef.current = {};
+      startedAtRef.current = {};
+      remainingRef.current = {};
     };
   }, []);
 
   const remove = useCallback((id: number) => {
     setToasts((prev) => prev.filter((t) => t.id !== id));
+    delete startedAtRef.current[id];
+    delete remainingRef.current[id];
   }, []);
 
   const dismiss = useCallback(
     (id: number) => {
-      clearTimeout(timersRef.current[id]);
+      const timer = timersRef.current[id];
+      if (timer) clearTimeout(timer);
       delete timersRef.current[id];
       // Mark as leaving → triggers exit animation in <ToastContainer>.
       // After 200ms (matches the CSS exit transition), actually remove.
@@ -76,8 +115,32 @@ export function ToastProvider({ children }: { children: ReactNode }) {
     [remove],
   );
 
+  const pause = useCallback((id: number) => {
+    const timer = timersRef.current[id];
+    if (!timer) return;
+    clearTimeout(timer);
+    delete timersRef.current[id];
+    const startedAt = startedAtRef.current[id];
+    const remaining = remainingRef.current[id];
+    if (startedAt != null && remaining != null) {
+      const elapsed = Date.now() - startedAt;
+      remainingRef.current[id] = Math.max(0, remaining - elapsed);
+    }
+  }, []);
+
+  const resume = useCallback(
+    (id: number) => {
+      if (timersRef.current[id]) return; // already running
+      const remaining = remainingRef.current[id];
+      if (remaining == null || remaining <= 0) return;
+      startedAtRef.current[id] = Date.now();
+      timersRef.current[id] = setTimeout(() => dismiss(id), remaining);
+    },
+    [dismiss],
+  );
+
   const show = useCallback<ToastApi["show"]>(
-    (msg, type = "success", duration = 3500, action) => {
+    (msg, type = "success", duration, action) => {
       const id = ++idCounter;
       const a: ToastAction | null =
         action &&
@@ -85,8 +148,14 @@ export function ToastProvider({ children }: { children: ReactNode }) {
         typeof action.onClick === "function"
           ? { label: String(action.label || "Дія"), onClick: action.onClick }
           : null;
-      setToasts((prev) => [...prev.slice(-4), { id, msg, type, action: a }]);
-      timersRef.current[id] = setTimeout(() => dismiss(id), duration);
+      const d = duration ?? DEFAULT_DURATION[type];
+      setToasts((prev) => [
+        ...prev.slice(-4),
+        { id, msg, type, action: a, duration: d },
+      ]);
+      startedAtRef.current[id] = Date.now();
+      remainingRef.current[id] = d;
+      timersRef.current[id] = setTimeout(() => dismiss(id), d);
       return id;
     },
     [dismiss],
@@ -97,7 +166,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
     [show],
   );
   const error = useCallback<ToastApi["error"]>(
-    (msg, duration, action) => show(msg, "error", duration ?? 5000, action),
+    (msg, duration, action) => show(msg, "error", duration, action),
     [show],
   );
   const info = useCallback<ToastApi["info"]>(
@@ -105,13 +174,13 @@ export function ToastProvider({ children }: { children: ReactNode }) {
     [show],
   );
   const warning = useCallback<ToastApi["warning"]>(
-    (msg, duration, action) => show(msg, "warning", duration ?? 5000, action),
+    (msg, duration, action) => show(msg, "warning", duration, action),
     [show],
   );
 
   const api = useMemo<ToastApi>(
-    () => ({ show, success, error, info, warning, dismiss }),
-    [show, success, error, info, warning, dismiss],
+    () => ({ show, success, error, info, warning, dismiss, pause, resume }),
+    [show, success, error, info, warning, dismiss, pause, resume],
   );
 
   const value = useMemo<ToastContextValue>(

--- a/apps/web/src/shared/lib/modules/crossModulePrompt.test.ts
+++ b/apps/web/src/shared/lib/modules/crossModulePrompt.test.ts
@@ -35,6 +35,8 @@ function makeToast(): MockToast {
     info: vi.fn(() => 3),
     warning: vi.fn(() => 4),
     dismiss: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
   };
   Object.defineProperty(api, "_action", {
     get: () => ref.current,

--- a/apps/web/src/shared/lib/ui/undoToast.test.tsx
+++ b/apps/web/src/shared/lib/ui/undoToast.test.tsx
@@ -17,6 +17,8 @@ function makeToast(): ToastApi & {
     info: vi.fn(() => 1),
     warning: vi.fn(() => 1),
     dismiss: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
   };
   return Object.assign(api, { _captured: captured });
 }

--- a/apps/web/src/styles/animations.css
+++ b/apps/web/src/styles/animations.css
@@ -520,6 +520,33 @@
   animation: toast-exit 0.2s ease-in forwards;
 }
 
+/*
+ * Linear countdown bar for toasts that carry a recoverable action (the
+ * undo-pattern). The `animation-duration` is supplied inline by
+ * `<ToastRow>` so a single keyframe set works for any toast lifetime
+ * (3.5 s for regular auto-dismiss, 5 s for undo). We scale on the X-axis
+ * only, with `transform-origin: left`, so the bar shrinks toward the
+ * trailing edge — matching the cognitive "time draining" affordance.
+ *
+ * CSS-driven instead of JS-RAF: animation-play-state lets us pause on
+ * hover/focus/touch-drag without touching the main thread (Rule #17 —
+ * RESPONSE tier; one-shot, linear easing for accurate time mapping).
+ */
+@keyframes toast-countdown {
+  from {
+    transform: scaleX(1);
+  }
+  to {
+    transform: scaleX(0);
+  }
+}
+
+.animate-toast-countdown {
+  animation: toast-countdown linear forwards;
+  transform-origin: left center;
+  will-change: transform;
+}
+
 /* ── Streak milestone celebration ────────────────────────────────────── */
 
 @keyframes streak-milestone-burst {


### PR DESCRIPTION
## Summary

UX-поліровка `Toast` / `undoToast` примітивів у `apps/web` — фокус на mobile-first взаємодію, доступність та коректний contract з undo-pattern-ом. Скоуп — `apps/web/src/shared/components/ui/Toast.{tsx,stories.tsx,test.tsx}`, `apps/web/src/shared/hooks/useToast.tsx`, `apps/web/src/styles/animations.css`. Call-sites у `modules/*` / `core/*` не торкнулись — `ToastApi` лишається back-compat для існуючих споживачів (`show` / `success` / `error` / `info` / `warning` / `dismiss`), розширений двома no-op-сумісними методами `pause(id)` / `resume(id)`, які використовує сам `<ToastContainer>`.

Що змінилось у поведінці:

- **Bottom-anchored stack.** Toast tray тепер позиціонується знизу екрану — `bottom: env(safe-area-inset-bottom) + var(--bottom-nav-height) + var(--active-workout-banner-offset) + 1rem` — і ніколи не overlap-иться з bottom-nav (60 px), `ActiveWorkoutBanner` (~84 px) чи iOS home-indicator-ом навіть на 375 px viewport-і. Spacing між toast-ами — 8 px (`gap-2`), `z-9999`.
- **Per-toast aria-live politeness.** Раніше container-level `aria-live="polite"`. Тепер кожен toast несе власні `role` + `aria-live`:
  - `info` / `success` / `warning` → `role="status" aria-live="polite"`
  - `error` та toast із undo-action → `role="alert" aria-live="assertive"` (5 s undo-window не може чекати, поки polite-queue звільниться)
- **Horizontal swipe-to-dismiss (touch-only).** Свайп ≥ 64 px **або** flick з velocity ≥ 0.4 px/ms (тільки якщо рух ≥ 32 px — захист від мікро-jitter). На десктопі — close-кнопка + Esc на focused toast. Для undo-toast-у swipe = consume undo-window — `onUndo` не викликається, snapshot drop, identical до timer-expiry.
- **Auto-dismiss pause on hover / focus / touch-drag.** Стандарт WAI-ARIA Authoring Practices: hover / keyboard-focus / активний touch-drag паузять timer-counter та CSS countdown синхронно. Mouseleave / blur / touchend → resume з остачі (зберігаємо elapsed-time у `remainingRef`).
- **CSS-driven countdown bar.** Лінійна (RESPONSE-tier, не RAF) `scaleX(1 → 0)` зі `animation-duration: ${toast.duration}ms` (inline-style) — спадає з 5 → 0 с для undo-toast-у. Показуємо тільки якщо `toast.action?.onClick` присутній (recoverable-flow). `[animation-play-state:paused]` синхронно з timer pause.
- **Keyboard:** `tabIndex={0}` на toast row → Esc на focused toast dismiss-ить його (не trap, тільки `stopPropagation` так що modals/dialogs не зачіпає). Undo-кнопка та close-кнопка мають `focus-visible:ring-2 ring-white/70 ring-offset-X ring-offset-Y` (Hard Rule #14 — `focus-visible:` not `focus:`).
- **Reduced motion.** `motion-safe:animate-toast-enter` / `motion-safe:animate-toast-countdown` → fade-in / countdown-animation вимикаються при `prefers-reduced-motion: reduce`. Countdown-bar при reduce-motion одразу `scale-x-0` (видно, що час «використаний», але без шкідливої анімації). Інформативність зберігається — countdown не декорація, а функціональна частина undo-window.
- **Animation budget Rule #17.** На один toast одночасно: enter/exit animation (~200–300 ms) + countdown (linear, RESPONSE-tier). Дві concurrent — у межах ліміту.

Що НЕ змінилось:

- Public API `ToastApi` — `show` / `success` / `error` / `info` / `warning` / `dismiss` мають ті самі сигнатури. Дефолтні durations: 3500 ms для info/success, 5000 ms для warning/error/undo.
- `showUndoToast` контракт — той самий `{ msg, duration, undoLabel, onUndo, onUndoErrorMsg }`; haptic-послідовність (`hapticWarning` на show → `hapticTap` на undo → `hapticError` на fail) не торкнулась.
- Stack cap 5 toasts (`prev.slice(-4)`).

Розширення API (`pause` / `resume`) використовуються тільки всередині `<ToastContainer>` — call-sites у модулях не вимагають оновлень.

## Governing Skill

- Primary skill: `.agents/skills/sergeant-web-ui/SKILL.md`
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: ad-hoc UX-polish (не торкає cross-module flow)
- Why this playbook: scoped рефакторинг shared UI-примітиву; нема migration / governance impact
- If no playbook matched, why: задача — точковий UX-fix у shared/ui, не вписується у specific playbook

## Verification

```bash
pnpm --filter @sergeant/web typecheck
# tsc -p tsconfig.json --noEmit && tsc -p tsconfig.sw.json --noEmit → exit 0

pnpm --filter @sergeant/web test src/shared
# Test Files  55 passed (55)
# Tests  498 passed (498)

pnpm --filter @sergeant/web test src/shared/components/ui/Toast.test
# Test Files  1 passed (1)
# Tests       11 passed (11)
#   ✓ info-toast має role=status + aria-live=polite
#   ✓ error-toast має role=alert + aria-live=assertive
#   ✓ toast з undo-action (через showUndoToast) — assertive
#   ✓ Esc на focused toast викликає dismiss
#   ✓ hover паузить auto-dismiss; mouseleave продовжує таймер з остачі
#   ✓ focus паузить таймер так само як hover
#   ✓ countdown-bar для undo-toast має animationDuration=5000ms і paused під час hover
#   ✓ горизонтальний swipe ≥ 64 px dismiss-ить toast
#   ✓ undo-toast: swipe не викликає onUndo (=consume undo-window)
#   ✓ короткий swipe < 64 px не dismiss-ить — toast лишається
#   ✓ клік на undo-кнопці викликає onUndo і dismiss-ить toast

pnpm --filter @sergeant/web lint
# 0 errors, 1 warning (pre-existing — fizruk dashboard cyrillic literal, unrelated)
```

Additional checks:

- [x] Local smoke / manual validation completed — tests + lint + typecheck зелені
- [x] Surface-specific checks completed — додано stories (`Single`, `StackOfThree`, `WithUndo`, `ErrorOnly`, `MobileStack` із 375 px viewport)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. → Сторінки stories документують нову поведінку у `Toast.stories.tsx` block-comment-і.
- [x] I checked whether `AGENTS.md` needed an update. → Не потрібно: shared/ui-полірувальний PR, governance не змінюється.
- [x] I checked whether a playbook or skill needed an update. → Не потрібно: `sergeant-web-ui` SKILL вже описує `focus-visible:` / animation-budget / aria-live; цей PR — застосування цих принципів.
- [x] I checked whether governance docs or review docs needed an update. → Не потрібно.

Updated docs:

- `apps/web/src/shared/components/ui/Toast.stories.tsx` — оновлений block-comment-doc, що описує: stack-positioning, swipe-dismiss, pause-on-hover/focus, countdown, aria-live politeness, reduced-motion.

## Risk and Rollout

- User-visible risk: **низький** — public API back-compat, поведінкові зміни ortogonal до існуючих call-sites (вони показували toasts і раніше, тепер ті toasts a) у новій позиції, b) з аріа-attributes, c) пауза-on-hover). Жодного call-site fanout-у.
- Rollout / deploy order: standalone PR — мерджимо в `main` коли CI пройде.
- Backout plan: revert single commit; немає DB / API / migration залежностей.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

- **API розширення (back-compat):** `ToastApi` отримав `pause(id)` / `resume(id)`. Існуючі callers (`modules/*` / `core/*`) їх НЕ використовують і не вимагають оновлень — це internal-use API, який тригериться з `<ToastContainer>` (hover / focus / touch-drag). Mock-toasts у тестах (`crossModulePrompt.test.ts`, `undoToast.test.tsx`) оновлені, щоб задовольнити `ToastApi`-shape.
- **Чому swipe-on-undo-toast = consume window (drop snapshot):** альтернатива — swipe = call onUndo — створює ризик випадкового відновлення (юзер хоче дисмісити, бо вже свідомо вирішив; не хоче restore). Тримаємо паритет з timeout-expiry: обидва — silent drop.
- **Чому undo-bearing toast → `assertive`:** 5-секундне вікно; polite-queue може опинитися за іншими live-region announcement-ами. Error toasts вже були `aria-live="polite"` (де-факто container-level), що — баг.
- **CSS animation замість JS-RAF для countdown:** Rule #17 — animation budget. `requestAnimationFrame`-цикл блокував би main thread; CSS animation з `animation-play-state: paused/running` дає той самий ефект безкоштовно.
- **Velocity-flick тест guard:** для запобігання phantom-dismiss від мікро-jitter, velocity check вимагає, щоб гесть пройшов мінімум 32 px. Тести під fakeTimers (де `Date.now()` не рухається синтетично) показали цю проблему — vested guard зробив тести стабільними.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished `Toast` and `undoToast` with bottom-anchored stacking, touch swipe-to-dismiss, and a visible undo countdown to improve mobile UX and accessibility. Public `ToastApi` stays backward compatible; added `pause(id)`/`resume(id)` for internal use.

- **New Features**
  - Bottom-anchored stack that avoids bottom-nav, `ActiveWorkoutBanner`, and safe-area; 5-item cap kept.
  - Touch swipe-to-dismiss; desktop has close button and Esc. For undo toasts, swipe consumes the undo window (no `onUndo`).
  - Auto-dismiss pauses on hover, focus, and touch-drag; resumes with remaining time.
  - CSS countdown bar for action/undo toasts; ties to toast duration; respects reduced motion.
  - Focusable row with `focus-visible` rings; close and action buttons remain keyboard-friendly.
  - `ToastApi` extended with `pause(id)` and `resume(id)`; existing call-sites unchanged.

- **Bug Fixes**
  - Per-toast a11y: `error` and undo toasts use `role="alert" aria-live="assertive"`, others use `status`/`polite`.
  - Prevented overlap and ensured correct z-order for the tray on small viewports.
  - Esc dismiss stops at the toast level to avoid interfering with dialogs.

<sup>Written for commit 05e1209760cb83eaad52ea748591ed56333a78e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

