### PR TITLE
chore(deps): patch esbuild and ajv security advisories via pnpm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,9 @@
       "uuid": "^14.0.0",
       "@tootallnate/once": ">=3.0.1",
       "@types/node": "^20",
-      "protobufjs@>=8.0.0 <8.0.2": ">=8.0.2"
+      "protobufjs@>=8.0.0 <8.0.2": ">=8.0.2",
+      "esbuild@<0.25.0": ">=0.25.0",
+      "ajv@>=7.0.0-alpha.0 <8.18.0": ">=8.18.0"
     },
     "patchedDependencies": {
       "@expo/cli@0.22.28": "patches/@expo__cli@0.22.28.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,8 @@ overrides:
   '@tootallnate/once': '>=3.0.1'
   '@types/node': ^20
   protobufjs@>=8.0.0 <8.0.2: '>=8.0.2'
+  esbuild@<0.25.0: '>=0.25.0'
+  ajv@>=7.0.0-alpha.0 <8.18.0: '>=8.18.0'
 
 patchedDependencies:
   '@expo/cli@0.22.28':
@@ -1022,7 +1024,7 @@ packages:
     resolution: {integrity: sha512-TajUJwGWbDwkCx/CZi7tRE8PVB7simCvKJfHUsSdvps+aTM/PDPP4gkLmKnc+x3CE//y9i/nj74GqdL/hwk7Iw==}
     engines: {node: '>=10'}
     peerDependencies:
-      ajv: '>=8'
+      ajv: '>=8.18.0'
 
   '@argos-ci/api-client@0.19.0':
     resolution: {integrity: sha512-6nxyWg0DBqBeRMIV/Efa881yHYPtFuzonkY5ckLwnOnAZqhk3pz6tVAn1WILJ/pL4eZvA98nQQt9WVofA+Mrfw==}
@@ -2152,12 +2154,6 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.18.20':
-    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
@@ -2174,12 +2170,6 @@ packages:
     resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.18.20':
-    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
-    engines: {node: '>=12'}
-    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.12':
@@ -2200,12 +2190,6 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.18.20':
-    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
@@ -2224,12 +2208,6 @@ packages:
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.18.20':
-    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.25.12':
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
@@ -2246,12 +2224,6 @@ packages:
     resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.18.20':
-    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.12':
@@ -2272,12 +2244,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.18.20':
-    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.25.12':
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
@@ -2294,12 +2260,6 @@ packages:
     resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.18.20':
-    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -2320,12 +2280,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.18.20':
-    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.25.12':
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
@@ -2342,12 +2296,6 @@ packages:
     resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.18.20':
-    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
-    engines: {node: '>=12'}
-    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.12':
@@ -2368,12 +2316,6 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.18.20':
-    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.25.12':
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
@@ -2390,12 +2332,6 @@ packages:
     resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.18.20':
-    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.12':
@@ -2416,12 +2352,6 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.18.20':
-    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.25.12':
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
@@ -2438,12 +2368,6 @@ packages:
     resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
     engines: {node: '>=18'}
     cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.18.20':
-    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -2464,12 +2388,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.18.20':
-    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.25.12':
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
@@ -2488,12 +2406,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.18.20':
-    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
@@ -2510,12 +2422,6 @@ packages:
     resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
     engines: {node: '>=18'}
     cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.18.20':
-    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.25.12':
@@ -2554,12 +2460,6 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.18.20':
-    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-
   '@esbuild/netbsd-x64@0.25.12':
     resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
@@ -2594,12 +2494,6 @@ packages:
     resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.18.20':
-    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -2638,12 +2532,6 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.18.20':
-    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-
   '@esbuild/sunos-x64@0.25.12':
     resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
@@ -2661,12 +2549,6 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
-
-  '@esbuild/win32-arm64@0.18.20':
-    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
 
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
@@ -2686,12 +2568,6 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.18.20':
-    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.25.12':
     resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
@@ -2708,12 +2584,6 @@ packages:
     resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.18.20':
-    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.12':
@@ -5184,7 +5054,7 @@ packages:
   '@storybook/csf-plugin@10.3.6':
     resolution: {integrity: sha512-9kBf7VRdRqTSIYo+rPtVn5yjYYyK8kP2QhEYx3oiXvfwy4RexmbJnhk/tXa/lNiTqukA1TqaWQ2+5MqF4fu6YQ==}
     peerDependencies:
-      esbuild: '*'
+      esbuild: '>=0.25.0'
       rollup: '*'
       storybook: ^10.3.6
       vite: '*'
@@ -6158,7 +6028,7 @@ packages:
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
-      ajv: ^8.0.0
+      ajv: '>=8.18.0'
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -6166,13 +6036,10 @@ packages:
   ajv-keywords@5.1.0:
     resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
     peerDependencies:
-      ajv: ^8.8.2
+      ajv: '>=8.18.0'
 
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
-
-  ajv@8.11.0:
-    resolution: {integrity: sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==}
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
@@ -7797,11 +7664,6 @@ packages:
 
   es-toolkit@1.46.1:
     resolution: {integrity: sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==}
-
-  esbuild@0.18.20:
-    resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
-    engines: {node: '>=12'}
-    hasBin: true
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -14727,7 +14589,7 @@ snapshots:
 
   '@esbuild-kit/core-utils@3.3.2':
     dependencies:
-      esbuild: 0.18.20
+      esbuild: 0.28.0
       source-map-support: 0.5.21
 
   '@esbuild-kit/esm-loader@2.6.5':
@@ -14744,9 +14606,6 @@ snapshots:
   '@esbuild/aix-ppc64@0.28.0':
     optional: true
 
-  '@esbuild/android-arm64@0.18.20':
-    optional: true
-
   '@esbuild/android-arm64@0.25.12':
     optional: true
 
@@ -14754,9 +14613,6 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.28.0':
-    optional: true
-
-  '@esbuild/android-arm@0.18.20':
     optional: true
 
   '@esbuild/android-arm@0.25.12':
@@ -14768,9 +14624,6 @@ snapshots:
   '@esbuild/android-arm@0.28.0':
     optional: true
 
-  '@esbuild/android-x64@0.18.20':
-    optional: true
-
   '@esbuild/android-x64@0.25.12':
     optional: true
 
@@ -14778,9 +14631,6 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.28.0':
-    optional: true
-
-  '@esbuild/darwin-arm64@0.18.20':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.12':
@@ -14792,9 +14642,6 @@ snapshots:
   '@esbuild/darwin-arm64@0.28.0':
     optional: true
 
-  '@esbuild/darwin-x64@0.18.20':
-    optional: true
-
   '@esbuild/darwin-x64@0.25.12':
     optional: true
 
@@ -14802,9 +14649,6 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.28.0':
-    optional: true
-
-  '@esbuild/freebsd-arm64@0.18.20':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.12':
@@ -14816,9 +14660,6 @@ snapshots:
   '@esbuild/freebsd-arm64@0.28.0':
     optional: true
 
-  '@esbuild/freebsd-x64@0.18.20':
-    optional: true
-
   '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
@@ -14826,9 +14667,6 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.28.0':
-    optional: true
-
-  '@esbuild/linux-arm64@0.18.20':
     optional: true
 
   '@esbuild/linux-arm64@0.25.12':
@@ -14840,9 +14678,6 @@ snapshots:
   '@esbuild/linux-arm64@0.28.0':
     optional: true
 
-  '@esbuild/linux-arm@0.18.20':
-    optional: true
-
   '@esbuild/linux-arm@0.25.12':
     optional: true
 
@@ -14850,9 +14685,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.28.0':
-    optional: true
-
-  '@esbuild/linux-ia32@0.18.20':
     optional: true
 
   '@esbuild/linux-ia32@0.25.12':
@@ -14864,9 +14696,6 @@ snapshots:
   '@esbuild/linux-ia32@0.28.0':
     optional: true
 
-  '@esbuild/linux-loong64@0.18.20':
-    optional: true
-
   '@esbuild/linux-loong64@0.25.12':
     optional: true
 
@@ -14874,9 +14703,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.28.0':
-    optional: true
-
-  '@esbuild/linux-mips64el@0.18.20':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.12':
@@ -14888,9 +14714,6 @@ snapshots:
   '@esbuild/linux-mips64el@0.28.0':
     optional: true
 
-  '@esbuild/linux-ppc64@0.18.20':
-    optional: true
-
   '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
@@ -14898,9 +14721,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.28.0':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.18.20':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.12':
@@ -14912,9 +14732,6 @@ snapshots:
   '@esbuild/linux-riscv64@0.28.0':
     optional: true
 
-  '@esbuild/linux-s390x@0.18.20':
-    optional: true
-
   '@esbuild/linux-s390x@0.25.12':
     optional: true
 
@@ -14922,9 +14739,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.28.0':
-    optional: true
-
-  '@esbuild/linux-x64@0.18.20':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
@@ -14945,9 +14759,6 @@ snapshots:
   '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
-  '@esbuild/netbsd-x64@0.18.20':
-    optional: true
-
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
@@ -14964,9 +14775,6 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.0':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.18.20':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -14987,9 +14795,6 @@ snapshots:
   '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
-  '@esbuild/sunos-x64@0.18.20':
-    optional: true
-
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
@@ -14997,9 +14802,6 @@ snapshots:
     optional: true
 
   '@esbuild/sunos-x64@0.28.0':
-    optional: true
-
-  '@esbuild/win32-arm64@0.18.20':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
@@ -15011,9 +14813,6 @@ snapshots:
   '@esbuild/win32-arm64@0.28.0':
     optional: true
 
-  '@esbuild/win32-ia32@0.18.20':
-    optional: true
-
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
@@ -15021,9 +14820,6 @@ snapshots:
     optional: true
 
   '@esbuild/win32-ia32@0.28.0':
-    optional: true
-
-  '@esbuild/win32-x64@0.18.20':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
@@ -19161,13 +18957,6 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  ajv@8.11.0:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
-      uri-js: 4.4.1
-
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -20816,31 +20605,6 @@ snapshots:
 
   es-toolkit@1.46.1: {}
 
-  esbuild@0.18.20:
-    optionalDependencies:
-      '@esbuild/android-arm': 0.18.20
-      '@esbuild/android-arm64': 0.18.20
-      '@esbuild/android-x64': 0.18.20
-      '@esbuild/darwin-arm64': 0.18.20
-      '@esbuild/darwin-x64': 0.18.20
-      '@esbuild/freebsd-arm64': 0.18.20
-      '@esbuild/freebsd-x64': 0.18.20
-      '@esbuild/linux-arm': 0.18.20
-      '@esbuild/linux-arm64': 0.18.20
-      '@esbuild/linux-ia32': 0.18.20
-      '@esbuild/linux-loong64': 0.18.20
-      '@esbuild/linux-mips64el': 0.18.20
-      '@esbuild/linux-ppc64': 0.18.20
-      '@esbuild/linux-riscv64': 0.18.20
-      '@esbuild/linux-s390x': 0.18.20
-      '@esbuild/linux-x64': 0.18.20
-      '@esbuild/netbsd-x64': 0.18.20
-      '@esbuild/openbsd-x64': 0.18.20
-      '@esbuild/sunos-x64': 0.18.20
-      '@esbuild/win32-arm64': 0.18.20
-      '@esbuild/win32-ia32': 0.18.20
-      '@esbuild/win32-x64': 0.18.20
-
   esbuild@0.25.12:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.25.12
@@ -21296,7 +21060,7 @@ snapshots:
 
   expo-dev-launcher@5.0.35(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.5(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.5(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(graphql@16.14.0)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.5(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)):
     dependencies:
-      ajv: 8.11.0
+      ajv: 8.20.0
       expo: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.5(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.5(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(graphql@16.14.0)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.5(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
       expo-dev-menu: 6.0.25(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.5(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.5(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(graphql@16.14.0)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.5(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))
       expo-manifests: 0.15.8(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.5(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.5(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(graphql@16.14.0)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.5(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))

--- a/pnpm-overrides.md
+++ b/pnpm-overrides.md
@@ -1,6 +1,6 @@
 # pnpm Overrides Rationale
 
-> **Last validated:** 2026-05-11 by @claude. **Next review:** 2026-08-09.
+> **Last validated:** 2026-05-13 by @Skords-01. **Next review:** 2026-08-11.
 > **Status:** Active
 
 Документація кожного запису в `pnpm.overrides` кореневого `package.json`.
@@ -105,3 +105,34 @@ by ADR-0050.
 на Node 22 LTS.
 
 **Last reviewed:** 2026-05-11
+
+---
+
+## `esbuild@<0.25.0` → `>=0.25.0`
+
+**Why:** GHSA-67mh-4wv8-2f99 — `esbuild <=0.24.2` dev-server CSRF: будь-який сайт міг
+надсилати запити до локального esbuild dev-server і читати відповідь. У нашому tree
+вразливий `esbuild@0.18.20` потрапляв транзитивно через `@esbuild-kit/core-utils@3.3.2`
+(deprecated package, тягнеться через `tsx`/`@esbuild-kit/esm-loader`). Selector form
+бампає лише вразливу sub-range (`<0.25.0`), не чіпаючи direct dev dep на
+`esbuild@^0.28.0` в `apps/server` та інші модерні версії в tree.
+
+**Drop when:** `@esbuild-kit/core-utils` або відповідні залежники оновлять transitive pin
+на `esbuild >=0.25.0`, або `tsx` мігрує з deprecated `@esbuild-kit/*` на власний loader.
+
+**Last reviewed:** 2026-05-13
+
+---
+
+## `ajv@>=7.0.0-alpha.0 <8.18.0` → `>=8.18.0`
+
+**Why:** GHSA-9wv6-86v2-598j — `ajv` `>=7.0.0-alpha.0, <8.18.0` має ReDoS у обробці
+`$data` references. У нашому tree вразливий `ajv@8.11.0` потрапляв через
+`expo-dev-launcher@5.0.35` (apps/mobile). Selector form бампає лише sub-range з v7/v8
+до 8.18+, не торкаючись `ajv@6.15.0` (необхідний для ESLint 9 / `@eslint/eslintrc`),
+оскільки ajv 6 і 8 — несумісні API (constructor signature, schema validation).
+
+**Drop when:** `expo-dev-launcher` або відповідні залежники оновлять transitive pin на
+`ajv >=8.18.0`, або ajv 6.x вийде з tree (потребує заміни ESLint).
+
+**Last reviewed:** 2026-05-13

--- a/scripts/check-pnpm-overrides.mjs
+++ b/scripts/check-pnpm-overrides.mjs
@@ -17,6 +17,12 @@
 // `package.json -> pnpm.overrides` it runs `pnpm why <name> -r --json`
 // and asserts that exactly one major is resolved across the workspace.
 //
+// Override key syntax: plain `pkg` or pnpm's selector form
+// `pkg@<source-range>` (e.g. `protobufjs@>=8.0.0 <8.0.2`) which scopes
+// the override to a specific sub-range of the dependency graph. For
+// selector overrides the single-major check doesn't apply — instead we
+// verify the override eliminated the targeted sub-range from the tree.
+//
 // Run from CI (`pnpm lint:pnpm-overrides`) and locally before opening a
 // PR that changes `pnpm.overrides` or bumps a package whose major is
 // pinned here.
@@ -24,6 +30,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { execFileSync } from "node:child_process";
+import semver from "semver";
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 const pkgPath = join(repoRoot, "package.json");
@@ -58,9 +65,22 @@ function majorOf(v) {
   return m ? m[1] : v;
 }
 
+/**
+ * Parse override key into `{ name, sourceRange }`. Override keys may be
+ * plain (`pkg`, `@scope/pkg`) or pnpm's selector form (`pkg@<range>`,
+ * `@scope/pkg@<range>`) — see https://pnpm.io/package_json#pnpmoverrides.
+ */
+function parseOverrideKey(key) {
+  const scoped = key.startsWith("@");
+  const atIdx = scoped ? key.indexOf("@", 1) : key.indexOf("@");
+  if (atIdx === -1) return { name: key, sourceRange: null };
+  return { name: key.slice(0, atIdx), sourceRange: key.slice(atIdx + 1) };
+}
+
 const failures = [];
-for (const name of overrideNames) {
-  const range = overrides[name];
+for (const key of overrideNames) {
+  const range = overrides[key];
+  const { name, sourceRange } = parseOverrideKey(key);
   let raw;
   try {
     raw = execFileSync("pnpm", ["why", name, "-r", "--json"], {
@@ -76,7 +96,7 @@ for (const name of overrideNames) {
     const stderr = /** @type {{stderr?: Buffer | string}} */ (err).stderr;
     const stderrStr = stderr ? String(stderr) : "";
     failures.push(
-      `${name}: override "${range}" but no package depends on ${name} — drop the override.\n  pnpm output: ${stderrStr.trim().slice(0, 200)}`,
+      `${key}: override "${range}" but no package depends on ${name} — drop the override.\n  pnpm output: ${stderrStr.trim().slice(0, 200)}`,
     );
     continue;
   }
@@ -84,7 +104,7 @@ for (const name of overrideNames) {
   try {
     parsed = JSON.parse(raw);
   } catch (err) {
-    failures.push(`${name}: failed to parse pnpm-why output: ${String(err)}`);
+    failures.push(`${key}: failed to parse pnpm-why output: ${String(err)}`);
     continue;
   }
   const versions = new Set();
@@ -102,20 +122,41 @@ for (const name of overrideNames) {
   }
   if (versions.size === 0) {
     failures.push(
-      `${name}: override "${range}" resolved to NO version — the pin is unsatisfiable.`,
+      `${key}: override "${range}" resolved to NO version — the pin is unsatisfiable.`,
+    );
+    continue;
+  }
+  if (sourceRange) {
+    // Selector form: the override only targets versions matching
+    // `sourceRange`. Success means the override eliminated them.
+    const stillMatching = Array.from(versions).filter((v) => {
+      try {
+        return semver.satisfies(v, sourceRange, { includePrerelease: true });
+      } catch {
+        return false;
+      }
+    });
+    if (stillMatching.length > 0) {
+      failures.push(
+        `${key}: selector override "${range}" did NOT eliminate targeted versions; still in tree: ${stillMatching.sort().join(", ")}.`,
+      );
+      continue;
+    }
+    console.log(
+      `[check-pnpm-overrides] ${key}: selector override "${range}" eliminated targeted sub-range; remaining: ${Array.from(versions).sort().join(", ")}. OK.`,
     );
     continue;
   }
   const majors = new Set(Array.from(versions, majorOf));
   if (majors.size > 1) {
     failures.push(
-      `${name}: override "${range}" still allows multiple majors in the tree: ${Array.from(versions).sort().join(", ")}.`,
+      `${key}: override "${range}" still allows multiple majors in the tree: ${Array.from(versions).sort().join(", ")}.`,
     );
     continue;
   }
   const onlyVersion = Array.from(versions)[0];
   console.log(
-    `[check-pnpm-overrides] ${name}: override "${range}" → 1 major (${onlyVersion}). OK.`,
+    `[check-pnpm-overrides] ${key}: override "${range}" → 1 major (${onlyVersion}). OK.`,
   );
 }
 
@@ -129,5 +170,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  `\n[check-pnpm-overrides] OK — ${overrideNames.length} override(s) resolve to a single major each.`,
+  `\n[check-pnpm-overrides] OK — all ${overrideNames.length} override(s) validated.`,
 );


### PR DESCRIPTION
## Summary

Patch the two open security advisories whose patched versions did not reach the workspace via direct deps. Uses pnpm selector-form overrides scoped to the exact vulnerable sub-ranges, so direct deps and untargeted versions stay put.

| Advisory | Vulnerable | Patched | Path in tree | Fix in this PR |
| --- | --- | --- | --- | --- |
| [GHSA-67mh-4wv8-2f99](https://github.com/advisories/GHSA-67mh-4wv8-2f99) — `esbuild` dev-server CSRF | `esbuild <=0.24.2` | `>=0.25.0` | `@esbuild-kit/core-utils@3.3.2` → `esbuild@0.18.20` | `"esbuild@<0.25.0": ">=0.25.0"` |
| [GHSA-9wv6-86v2-598j](https://github.com/advisories/GHSA-9wv6-86v2-598j) — `ajv` ReDoS on `$data` refs | `ajv >=7.0.0-alpha.0 <8.18.0` | `>=8.18.0` | `expo-dev-launcher@5.0.35` → `ajv@8.11.0` | `"ajv@>=7.0.0-alpha.0 <8.18.0": ">=8.18.0"` |

The three OpenTelemetry advisories the original task listed (`sdk-node`, `auto-instrumentations-node`, `exporter-prometheus` < `0.217.0` / `0.75.0`) were already patched on `main` via #2555; Renovate's PRs #2427 and #2426 autoclosed after that fix. Verified by `pnpm why` — current resolved versions are `sdk-node@0.217.0`, `auto-instrumentations-node@0.75.0`, `exporter-prometheus@0.217.0` (transitive via `sdk-node`).

Commits:

- `bca6fe10` — `chore(root): support selector syntax in check-pnpm-overrides`. Parser extracts bare package name + source range; for selector overrides, validates the override eliminated the targeted sub-range (semver.satisfies) instead of single-major. Unblocks the existing `protobufjs@>=8.0.0 <8.0.2` override which was silently failing the check.
- `7204db68` — `chore(deps): patch esbuild and ajv security advisories via pnpm overrides`. Adds the two overrides + `pnpm-overrides.md` rationale entries.

## Governing Skill

- Primary skill: `.agents/skills/sergeant-deploy-and-observability/SKILL.md` (OTel runtime context); deps-only changes routed via root `AGENTS.md` § "Soft rules" ("Dependency bumps — separate PRs").
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a (no playbook explicitly covers security-only `pnpm.overrides` bumps).
- Why this playbook: n/a
- If no playbook matched, why: `docs/playbooks/README.md` does not list a `dependency-security-bump` recipe. Closest is `docs/governance/pnpm-overrides-policy.md` (referenced from `pnpm-overrides.md`), which this PR follows by adding `**Why** / **Drop when** / **Last reviewed**` entries.

## Verification

```bash
# script support for selector overrides (was silently failing before)
pnpm lint:pnpm-overrides
# → 11 overrides validated OK, including protobufjs/esbuild/ajv selectors

pnpm typecheck       # 17/17 turbo tasks successful
pnpm --filter @sergeant/server build   # dist-server/index.js 15.7mb ⚠️ — built OK
pnpm --filter @sergeant/web build      # 149 precache entries, built OK
```

`pnpm format:check`, `pnpm lint`, and `pnpm --filter @sergeant/server test` all fail **identically on `main`** (12 pre-existing format issues, env-single-source migration debt, 69/1796 vitest failures). Confirmed by checking out `main` and re-running each — no new failures introduced by this PR.

Lockfile diff is scoped to the two overrides:

```
pnpm-lock.yaml | 252 ++--------------------- (15 +, 240 -)
```

The deletions are the `@esbuild/*-*@0.18.20` platform-specific entries (no longer referenced after `@esbuild-kit/core-utils` was forced to `esbuild >=0.25.0`).

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed (`lint:pnpm-overrides` newly passes for the existing protobufjs entry; observability code paths unchanged)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. → `pnpm-overrides.md` rationale entries for `esbuild` and `ajv`.
- [x] I checked whether `AGENTS.md` needed an update. → No (hard rules and scope enum unchanged).
- [x] I checked whether a playbook or skill needed an update. → No (no existing playbook for `pnpm.overrides` security bumps; `pnpm-overrides.md` + `docs/governance/pnpm-overrides-policy.md` cover the workflow).
- [x] I checked whether governance docs or review docs needed an update. → No (override policy unchanged).

Updated docs:

- `pnpm-overrides.md` — added rationale entries (`**Why** / **Drop when** / **Last reviewed: 2026-05-13**`) for `esbuild@<0.25.0` and `ajv@>=7.0.0-alpha.0 <8.18.0`.

## Risk and Rollout

- User-visible risk: **low**. Both overrides are scoped to vulnerable sub-ranges only; direct deps (`esbuild@^0.28.0` in `apps/server`) and untargeted versions (`ajv@6.15.0` for ESLint) are untouched. `pnpm install` regeneration was successful; `pnpm why` confirms transitives now resolve to safe versions (`esbuild` 0.25.12/0.27.7/0.28.0; `ajv` 8.18.0/8.20.0). The deprecated `@esbuild-kit/core-utils@3.3.2` is build-time-only via `tsx`/`@esbuild-kit/esm-loader` — no runtime exposure on the server hot path.
- Rollout / deploy order: standard. No env-var changes, no DB migrations, no API contract changes.
- Backout plan: revert this PR. The pre-existing `pnpm-overrides.md` entries and `check-pnpm-overrides.mjs` selector-syntax support remain neutral if `package.json` overrides are reverted.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian. → `pnpm-overrides.md` entries written in Ukrainian, matching existing style.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

- The `check-pnpm-overrides.mjs` change in `bca6fe10` is a small enabling fix — kept in this PR because adding selector overrides without it would make `lint:pnpm-overrides` report 3 false-positive failures (including the pre-existing `protobufjs` entry, which has been silently broken since #2555). Splitting it into a separate PR would block this one on a follow-up.
- Renovate PRs **#2426** and **#2427** are already closed (autoclosed by Renovate after #2555 superseded them) — no action needed there.
- No OpenTelemetry call-sites were touched. The `apps/server/src/observability/**` files and `apps/server/src/obs/{metrics,tracing}.ts` are unchanged.
- Dependabot will continue to show 3 advisories until it re-scans `main` — those will clear (or be re-evaluated) after this PR merges.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Patch `esbuild` and `ajv` security advisories using scoped `pnpm` overrides, and fix the `check-pnpm-overrides` script to validate selector overrides. This closes dev-server CSRF and ReDoS risks without changing our direct deps.

- **Dependencies**
  - Add override `esbuild@<0.25.0` → `>=0.25.0` (GHSA-67mh-4wv8-2f99); stops `@esbuild-kit/core-utils@3.3.2` from resolving `0.18.20`.
  - Add override `ajv@>=7.0.0-alpha.0 <8.18.0` → `>=8.18.0` (GHSA-9wv6-86v2-598j); bumps transitives pulled by `expo-dev-launcher`.
  - Lockfile prunes old `@esbuild/*` 0.18.20 platform packages; direct `esbuild@^0.28.0` and `ajv@6.15.0` remain unchanged.
  - Documented both overrides in `pnpm-overrides.md`.

- **Bug Fixes**
  - Update `scripts/check-pnpm-overrides.mjs` to parse selector-form keys and verify the targeted sub-range is eliminated; prevents false negatives on entries like `protobufjs@>=8.0.0 <8.0.2`.

<sup>Written for commit 7204db68ff63903a642260bda7d465054dbcd50e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

