### PR TITLE
refactor(server): introduce LLMProvider abstraction (Anthropic + stub) [PR-23]

### DIFF
--- a/apps/server/src/env/env.ts
+++ b/apps/server/src/env/env.ts
@@ -342,6 +342,16 @@ const envSchema = z.object({
   // ── AI (Anthropic) ─────────────────────────────────────────────────
   /** API-ключ для Anthropic Claude. Без нього /api/chat повертає 500. */
   ANTHROPIC_API_KEY: stringWithDefault(""),
+  /**
+   * PR-23 — pluggable LLM provider. `anthropic` (default) використовує
+   * `AnthropicProvider`; `stub` повертає hardcoded JSON для read-only
+   * OpenClaw paths-у / e2e-тестів / Anthropic-incident-recovery; `openrouter`
+   * зарезервовано під майбутню імплементацію (поки що деградує у stub).
+   * Wire-up call-sites — окремі PR-24/25.
+   */
+  LLM_PROVIDER: z
+    .enum(["anthropic", "openrouter", "stub"])
+    .default("anthropic"),
   /** AI request timeout (мс). */
   AI_TIMEOUT_MS: intFromEnv(180_000),
   /** Max AI retries on transient errors. */

--- a/apps/server/src/lib/llm/provider.test.ts
+++ b/apps/server/src/lib/llm/provider.test.ts
@@ -1,0 +1,277 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../anthropic.js", () => ({
+  anthropicMessages: vi.fn(),
+  extractAnthropicText: vi.fn(
+    (data: { content?: Array<{ type: string; text?: string }> } | null) =>
+      (data?.content ?? [])
+        .filter((b) => b.type === "text")
+        .map((b) => b.text ?? "")
+        .join("\n")
+        .trim(),
+  ),
+}));
+
+import { anthropicMessages as anthropicMessagesMock } from "../anthropic.js";
+import {
+  AnthropicProvider,
+  getLLMProvider,
+  StubProvider,
+  type LLMGenerateOpts,
+  type LLMGenerateResult,
+} from "./provider.js";
+
+type AnthropicMock = ReturnType<typeof vi.fn> & {
+  mockResolvedValueOnce: (...args: unknown[]) => void;
+  mockRejectedValueOnce: (...args: unknown[]) => void;
+  mock: { calls: unknown[][] };
+};
+const anthropicMessagesM = anthropicMessagesMock as unknown as AnthropicMock;
+
+function baseOpts(override: Partial<LLMGenerateOpts> = {}): LLMGenerateOpts {
+  return {
+    model: "claude-haiku-4-5-20251001",
+    messages: [{ role: "user", content: "Hi" }],
+    maxTokens: 100,
+    ...override,
+  };
+}
+
+function okResponse(text: string, usage?: Record<string, number>) {
+  return {
+    response: { ok: true, status: 200 } as unknown as Response,
+    data: {
+      content: [{ type: "text", text }],
+      ...(usage ? { usage } : {}),
+    },
+  };
+}
+
+function errorResponse(
+  status: number,
+  message: string,
+): {
+  response: Response | null;
+  data: Record<string, unknown>;
+} {
+  return {
+    response: { ok: false, status } as unknown as Response,
+    data: { error: { message } },
+  };
+}
+
+describe("AnthropicProvider", () => {
+  beforeEach(() => {
+    anthropicMessagesM.mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns ok=false з code=missing_api_key коли apiKey пустий", async () => {
+    const provider = new AnthropicProvider("");
+    const result = await provider.generate(baseOpts());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("missing_api_key");
+      expect(result.error).toMatch(/ANTHROPIC_API_KEY/);
+    }
+    expect(anthropicMessagesM).not.toHaveBeenCalled();
+  });
+
+  it("повертає ok=true з text + usage коли response.ok", async () => {
+    anthropicMessagesM.mockResolvedValueOnce(
+      okResponse("hello world", {
+        input_tokens: 12,
+        output_tokens: 34,
+        cache_read_input_tokens: 5,
+      }),
+    );
+    const provider = new AnthropicProvider("sk-fake");
+    const result = await provider.generate(
+      baseOpts({ endpoint: "test", temperature: 0.2, system: "be terse" }),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.text).toBe("hello world");
+      expect(result.usage).toEqual({
+        inputTokens: 12,
+        outputTokens: 34,
+        cacheReadInputTokens: 5,
+      });
+    }
+    expect(anthropicMessagesM).toHaveBeenCalledOnce();
+    const [apiKey, payload, callOpts] = anthropicMessagesM.mock.calls[0]!;
+    expect(apiKey).toBe("sk-fake");
+    expect(payload).toMatchObject({
+      model: "claude-haiku-4-5-20251001",
+      max_tokens: 100,
+      temperature: 0.2,
+      system: "be terse",
+      messages: [{ role: "user", content: "Hi" }],
+    });
+    expect(callOpts).toMatchObject({ endpoint: "test" });
+  });
+
+  it("повертає ok=false з code=rate_limited на HTTP 429", async () => {
+    anthropicMessagesM.mockResolvedValueOnce(
+      errorResponse(429, "rate-limited by Anthropic"),
+    );
+    const provider = new AnthropicProvider("sk-fake");
+    const result = await provider.generate(baseOpts());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("rate_limited");
+      expect(result.status).toBe(429);
+      expect(result.error).toBe("rate-limited by Anthropic");
+    }
+  });
+
+  it("повертає ok=false з code=anthropic_error на HTTP 500", async () => {
+    anthropicMessagesM.mockResolvedValueOnce(
+      errorResponse(500, "upstream-down"),
+    );
+    const provider = new AnthropicProvider("sk-fake");
+    const result = await provider.generate(baseOpts());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("anthropic_error");
+      expect(result.status).toBe(500);
+    }
+  });
+
+  it("повертає ok=false якщо anthropicMessages кидає AbortError → code=timeout", async () => {
+    const err = new Error("aborted");
+    err.name = "AbortError";
+    anthropicMessagesM.mockRejectedValueOnce(err);
+    const provider = new AnthropicProvider("sk-fake");
+    const result = await provider.generate(baseOpts());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("timeout");
+    }
+  });
+
+  it("повертає ok=false з code=anthropic_throw для генеричної помилки", async () => {
+    anthropicMessagesM.mockRejectedValueOnce(new Error("network down"));
+    const provider = new AnthropicProvider("sk-fake");
+    const result = await provider.generate(baseOpts());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("anthropic_throw");
+      expect(result.error).toBe("network down");
+    }
+  });
+
+  it("прокидає signal/promptVersion/timeoutMs до anthropicMessages", async () => {
+    anthropicMessagesM.mockResolvedValueOnce(okResponse("ok"));
+    const controller = new AbortController();
+    const provider = new AnthropicProvider("sk-fake");
+    await provider.generate(
+      baseOpts({
+        signal: controller.signal,
+        promptVersion: "v3",
+        timeoutMs: 5000,
+      }),
+    );
+    const [, , callOpts] = anthropicMessagesM.mock.calls[0]!;
+    expect(callOpts).toMatchObject({
+      signal: controller.signal,
+      promptVersion: "v3",
+      timeoutMs: 5000,
+    });
+  });
+
+  it("не падає на response без usage", async () => {
+    anthropicMessagesM.mockResolvedValueOnce({
+      response: { ok: true, status: 200 } as unknown as Response,
+      data: { content: [{ type: "text", text: "no usage" }] },
+    });
+    const provider = new AnthropicProvider("sk-fake");
+    const result = await provider.generate(baseOpts());
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.text).toBe("no usage");
+      expect(result.usage).toBeUndefined();
+    }
+  });
+});
+
+describe("StubProvider", () => {
+  it("повертає дефолтний text та zero-usage без override", async () => {
+    const provider = new StubProvider();
+    const result = await provider.generate(baseOpts());
+    expect(result).toEqual<LLMGenerateResult>({
+      ok: true,
+      text: '{"ok":true,"stub":true}',
+      usage: { inputTokens: 0, outputTokens: 0 },
+    });
+  });
+
+  it("повертає custom text + usage коли передано в конструктор", async () => {
+    const provider = new StubProvider({
+      text: '{"class":"chat"}',
+      inputTokens: 200,
+      outputTokens: 50,
+    });
+    const result = await provider.generate(baseOpts());
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.text).toBe('{"class":"chat"}');
+      expect(result.usage).toEqual({ inputTokens: 200, outputTokens: 50 });
+    }
+  });
+
+  it("name='stub' (для logging / metrics labels)", () => {
+    expect(new StubProvider().name).toBe("stub");
+  });
+});
+
+describe("getLLMProvider factory", () => {
+  it("override.provider='stub' → StubProvider навіть якщо env=anthropic", () => {
+    const p = getLLMProvider({ provider: "stub" });
+    expect(p).toBeInstanceOf(StubProvider);
+    expect(p.name).toBe("stub");
+  });
+
+  it("override.provider='anthropic' + apiKey → AnthropicProvider", () => {
+    const p = getLLMProvider({
+      provider: "anthropic",
+      anthropicApiKey: "sk-test",
+    });
+    expect(p).toBeInstanceOf(AnthropicProvider);
+    expect(p.name).toBe("anthropic");
+  });
+
+  it("override.provider='anthropic' БЕЗ apiKey → fallback на StubProvider", () => {
+    const p = getLLMProvider({ provider: "anthropic", anthropicApiKey: "" });
+    expect(p).toBeInstanceOf(StubProvider);
+    expect(p.name).toBe("stub");
+  });
+
+  it("override.provider='openrouter' → fallback на StubProvider (reserved)", () => {
+    const p = getLLMProvider({ provider: "openrouter" });
+    expect(p).toBeInstanceOf(StubProvider);
+    expect(p.name).toBe("stub");
+  });
+
+  it("override.stubResponse прокидається у StubProvider", async () => {
+    const p = getLLMProvider({
+      provider: "stub",
+      stubResponse: { text: "custom-stub" },
+    });
+    const result = await p.generate(baseOpts());
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.text).toBe("custom-stub");
+    }
+  });
+
+  it("без override читає env.LLM_PROVIDER + env.ANTHROPIC_API_KEY", () => {
+    // env reads default = "anthropic"; ANTHROPIC_API_KEY = "" у test-env →
+    // factory деградує у stub. Це precondition для local-dev/test без ключа.
+    const p = getLLMProvider();
+    // Test runs without real ANTHROPIC_API_KEY → factory повертає stub.
+    expect(p.name).toBe("stub");
+  });
+});

--- a/apps/server/src/lib/llm/provider.ts
+++ b/apps/server/src/lib/llm/provider.ts
@@ -1,0 +1,298 @@
+// AI-CONTEXT: PR-23 (Phase 3 reliability). Зараз код прямо викликає
+// `anthropicMessages()` з `lib/anthropic.ts`. Якщо Anthropic падає (5xx,
+// circuit-breaker open, мережевий outage) — все що використовує LLM не
+// працює. `LLMProvider` — це тонкий interface, що дозволяє pluggable
+// fallback на іншого provider-а (OpenRouter, OpenAI) або no-op stub
+// для read-only OpenClaw-paths-ів і dev-tests, де живий ключ не потрібен.
+//
+// Цей PR (PR-23) НЕ міняє call-sites. Він лише вводить interface +
+// AnthropicProvider (existing logic) + StubProvider + factory. Wire-up:
+// PR-24 (OpenClaw classify → factory) і PR-25 (weekly-digest → factory).
+//
+// Контракт навмисно тонший за повний Anthropic Messages API: ми моделюємо
+// тільки те, що зараз використовують call-sites (single-shot generate з
+// system + messages + tools). Streaming — окремий interface майбутнього
+// `LLMStreamProvider`, тут не моделюємо, бо streaming-call-sites (chat.ts)
+// мають інші вимоги до latency / outcome-tracking.
+
+import { env } from "../../env/env.js";
+import { anthropicMessages, extractAnthropicText } from "../anthropic.js";
+
+/**
+ * Канонічний дискримінатор provider-у. Розширюємо по мірі додавання
+ * нових: `openrouter`, `openai`, `groq`, etc. Зберігаємо літерали (а не
+ * `string`), щоб TypeScript ловив typo у factory й runtime-config-у.
+ */
+export type LLMProviderName = "anthropic" | "openrouter" | "stub";
+
+/**
+ * Один message у multi-turn діалозі. Mirrors Anthropic Messages API
+ * shape — найпростіший common-denominator серед усіх провайдерів
+ * (OpenAI/OpenRouter використовують `role: "system"` як message, але
+ * у `generate()` system — окреме поле, тому тут лише user/assistant).
+ */
+export interface LLMMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+/**
+ * Параметри single-shot generation. Mapping під різні провайдери —
+ * відповідальність конкретної реалізації:
+ *
+ * | LLMGenerateOpts        | Anthropic                | OpenAI/OpenRouter         |
+ * | ---------------------- | ------------------------ | ------------------------- |
+ * | `model`                | `model`                  | `model`                   |
+ * | `system`               | top-level `system`       | first `{role:"system"}`   |
+ * | `messages`             | `messages`               | `messages` (без system)   |
+ * | `maxTokens`            | `max_tokens`             | `max_tokens`              |
+ * | `temperature`          | `temperature`            | `temperature`             |
+ * | `endpoint`             | `metadata.endpoint`-аналог | `metadata`-аналог       |
+ * | `timeoutMs`            | `AbortSignal` через сетер | те саме                  |
+ * | `signal`               | composeSignal             | composeSignal             |
+ * | `promptVersion`        | для cache-hit лічильника | (anthropic-specific)      |
+ */
+export interface LLMGenerateOpts {
+  /** Канонічний model-id (e.g. `claude-sonnet-4-6`). Передається `as-is`. */
+  model: string;
+  /** Optional system prompt (буде проброшений у відповідне поле провайдера). */
+  system?: string;
+  /** Multi-turn messages (без system — він окремо). */
+  messages: LLMMessage[];
+  /** Max output tokens. */
+  maxTokens: number;
+  /** Sampling temperature (`0` для деtermistic, `0.7` typical chat). */
+  temperature?: number | undefined;
+  /** Endpoint-tag для observability metrics (`day-hint`, `coach`, etc). */
+  endpoint?: string | undefined;
+  /** Request timeout у мс. Якщо `undefined` — provider вирішує default. */
+  timeoutMs?: number | undefined;
+  /**
+   * Зовнішній AbortSignal (зазвичай client-disconnect). Provider композить
+   * його зі своїм внутрішнім timeout-signal через `AbortSignal.any`.
+   */
+  signal?: AbortSignal | undefined;
+  /**
+   * Версія system-prompt-у для Anthropic prompt-cache outcome counter.
+   * Інші провайдери ігнорують.
+   */
+  promptVersion?: string | undefined;
+}
+
+/**
+ * Результат generate-виклику. Discriminated union на `ok` — caller-у
+ * не потрібно перевіряти HTTP-status / parse JSON / витягувати text:
+ * provider це робить, фарш-meta повертається уніфіковано.
+ *
+ * - `ok: true`  — успіх; `text` — стрипнутий content, `usage` — токени
+ *                 (якщо provider репортить).
+ * - `ok: false` — будь-який не-2xx або thrown error; `error` — короткий
+ *                 user-facing message, `status` — HTTP status (якщо є),
+ *                 `code` — provider-specific або канонічний (`"timeout"`,
+ *                 `"rate_limited"`, etc).
+ */
+export type LLMGenerateResult =
+  | {
+      ok: true;
+      text: string;
+      usage?: {
+        inputTokens?: number;
+        outputTokens?: number;
+        cacheReadInputTokens?: number;
+        cacheCreationInputTokens?: number;
+      };
+      /** Сирий response payload — для callers, яким потрібен `content[]` чи tools. */
+      raw?: Record<string, unknown>;
+    }
+  | {
+      ok: false;
+      error: string;
+      status?: number;
+      code?: string;
+      raw?: Record<string, unknown>;
+    };
+
+/**
+ * Канонічний interface — провайдери імплементують `name` (для логування /
+ * metrics labels) і `generate()`. `name` — `readonly` literal, щоб
+ * `provider.name === "stub"` робив type-narrowing у callers.
+ */
+export interface LLMProvider {
+  readonly name: LLMProviderName;
+  generate(opts: LLMGenerateOpts): Promise<LLMGenerateResult>;
+}
+
+// ─── AnthropicProvider ──────────────────────────────────────────────
+// Existing logic у `lib/anthropic.ts` залишається untouched: цей wrapper
+// просто адаптує shape (`payload`/`{response, data}` → `LLMGenerateOpts`/
+// `LLMGenerateResult`). Той самий retry/timeout/usage-recording flow.
+
+/**
+ * Anthropic-провайдер: бере `ANTHROPIC_API_KEY` з env у конструкторі або
+ * через override (тестабельно). Метрики, prompt-caching, DB-ledger —
+ * усе в `anthropicMessages()` залишається активним; ми лише адаптуємо
+ * shape для callers, що працюють через `LLMProvider`.
+ */
+export class AnthropicProvider implements LLMProvider {
+  readonly name = "anthropic" as const;
+
+  constructor(private readonly apiKey: string) {}
+
+  async generate(opts: LLMGenerateOpts): Promise<LLMGenerateResult> {
+    if (!this.apiKey) {
+      return {
+        ok: false,
+        error: "ANTHROPIC_API_KEY is not set",
+        code: "missing_api_key",
+      };
+    }
+    const payload: Record<string, unknown> = {
+      model: opts.model,
+      max_tokens: opts.maxTokens,
+      messages: opts.messages,
+    };
+    if (opts.system !== undefined) payload["system"] = opts.system;
+    if (opts.temperature !== undefined)
+      payload["temperature"] = opts.temperature;
+
+    const callOpts: Parameters<typeof anthropicMessages>[2] = {};
+    if (opts.timeoutMs !== undefined) callOpts.timeoutMs = opts.timeoutMs;
+    if (opts.endpoint !== undefined) callOpts.endpoint = opts.endpoint;
+    if (opts.signal !== undefined) callOpts.signal = opts.signal;
+    if (opts.promptVersion !== undefined)
+      callOpts.promptVersion = opts.promptVersion;
+
+    try {
+      const { response, data } = await anthropicMessages(
+        this.apiKey,
+        payload,
+        callOpts,
+      );
+      if (!response || !response.ok) {
+        const status = response?.status;
+        const errMsg =
+          (data as { error?: { message?: string } } | undefined)?.error
+            ?.message ||
+          (status ? `Anthropic returned HTTP ${status}` : "Anthropic error");
+        return {
+          ok: false,
+          error: errMsg,
+          ...(status !== undefined ? { status } : {}),
+          code: status === 429 ? "rate_limited" : "anthropic_error",
+          raw: data,
+        };
+      }
+      const text = extractAnthropicText(data);
+      const usage = (data as { usage?: Record<string, number> } | undefined)
+        ?.usage;
+      const result: LLMGenerateResult = {
+        ok: true,
+        text,
+        raw: data,
+      };
+      if (usage) {
+        const usageOut: NonNullable<
+          Extract<LLMGenerateResult, { ok: true }>["usage"]
+        > = {};
+        if (typeof usage["input_tokens"] === "number")
+          usageOut.inputTokens = usage["input_tokens"];
+        if (typeof usage["output_tokens"] === "number")
+          usageOut.outputTokens = usage["output_tokens"];
+        if (typeof usage["cache_read_input_tokens"] === "number")
+          usageOut.cacheReadInputTokens = usage["cache_read_input_tokens"];
+        if (typeof usage["cache_creation_input_tokens"] === "number")
+          usageOut.cacheCreationInputTokens =
+            usage["cache_creation_input_tokens"];
+        result.usage = usageOut;
+      }
+      return result;
+    } catch (e: unknown) {
+      const isAbort =
+        e instanceof Error &&
+        (e.name === "AbortError" ||
+          (e as { code?: string }).code === "ABORT_ERR");
+      return {
+        ok: false,
+        error: e instanceof Error ? e.message : String(e),
+        code: isAbort ? "timeout" : "anthropic_throw",
+      };
+    }
+  }
+}
+
+// ─── StubProvider ───────────────────────────────────────────────────
+// No-op, повертає hardcoded JSON-обгортку. Призначення:
+//   1) read-only OpenClaw paths (наприклад, `before_dispatch` classify
+//      коли LLM_PROVIDER=stub в e2e-tests або під час Anthropic outage —
+//      caller отримує `{ "class": "chat" }` дефолт через extractor).
+//   2) Unit-тести, де не треба викликати справжній HTTP.
+//   3) Локальний dev без `ANTHROPIC_API_KEY` — нічого не падає, лише
+//      stub-text-and-usage.
+
+/**
+ * StubProvider — повертає детерміністичний канонічний text. За замовчуванням:
+ * `'{"ok":true,"stub":true}'` (валідний JSON для callers, які `JSON.parse`).
+ * Може бути перекритий конструктором для test-specific responses.
+ */
+export class StubProvider implements LLMProvider {
+  readonly name = "stub" as const;
+
+  constructor(
+    private readonly response: {
+      text?: string;
+      inputTokens?: number;
+      outputTokens?: number;
+    } = {},
+  ) {}
+
+  generate(_opts: LLMGenerateOpts): Promise<LLMGenerateResult> {
+    return Promise.resolve({
+      ok: true,
+      text: this.response.text ?? '{"ok":true,"stub":true}',
+      usage: {
+        inputTokens: this.response.inputTokens ?? 0,
+        outputTokens: this.response.outputTokens ?? 0,
+      },
+    });
+  }
+}
+
+// ─── Factory ────────────────────────────────────────────────────────
+
+/**
+ * Резолвить активний provider за env-config. Правила:
+ *
+ * 1. `LLM_PROVIDER=stub` → `StubProvider` (для e2e/dev/incident).
+ * 2. `LLM_PROVIDER=anthropic` (default) і `ANTHROPIC_API_KEY` задано → `AnthropicProvider`.
+ * 3. `LLM_PROVIDER=anthropic` але `ANTHROPIC_API_KEY` ПУСТИЙ → fallback на `StubProvider`
+ *    (щоб local-dev / preview-env не падали з 500). У production цей шлях
+ *    супроводжується warning-логом у `env.ts` на startup-і.
+ *
+ * Конкретний key override (для тестів) — через override-аргумент.
+ */
+export interface GetLLMProviderOverride {
+  provider?: LLMProviderName;
+  anthropicApiKey?: string;
+  stubResponse?: ConstructorParameters<typeof StubProvider>[0];
+}
+
+export function getLLMProvider(
+  override: GetLLMProviderOverride = {},
+): LLMProvider {
+  const provider = override.provider ?? env.LLM_PROVIDER;
+  if (provider === "stub") {
+    return new StubProvider(override.stubResponse);
+  }
+  if (provider === "openrouter") {
+    // Reserved — імплементація у майбутньому PR (OpenRouter fallback).
+    // Поки що деградуємо у stub, щоб неочікуваний env не валив app.
+    return new StubProvider(override.stubResponse);
+  }
+  // provider === "anthropic"
+  const apiKey = override.anthropicApiKey ?? env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    // Fail-soft: dev/preview без ключа → stub.
+    return new StubProvider(override.stubResponse);
+  }
+  return new AnthropicProvider(apiKey);
+}

--- a/docs/integrations/env-vars.md
+++ b/docs/integrations/env-vars.md
@@ -111,6 +111,16 @@ Tool-use квота (окремий bucket у `ai_usage_daily`). Кожен ви
 - `AI_QUOTA_TOOL_DEFAULT_LIMIT=60` (default).
 - `AI_QUOTA_TOOL_LIMITS={"change_category":30,"create_debt":10,"create_receivable":10,"hide_transaction":30,"set_budget_limit":10,"set_monthly_plan":5,"mark_habit_done":30,"plan_workout":10,"create_habit":10}` — JSON з лімітами на кожен tool. Tool-и, не вказані у JSON, беруть `AI_QUOTA_TOOL_DEFAULT_LIMIT` (або unlimited якщо пусто).
 
+### `LLM_PROVIDER` _(optional, default `anthropic`)_
+
+**PR-23** — pluggable LLM-провайдер за [`apps/server/src/lib/llm/provider.ts`](../../apps/server/src/lib/llm/provider.ts). Дозволяє переключити сервер у fail-soft режим без зміни call-sites:
+
+- `anthropic` (default) — `AnthropicProvider`, тонкий wrapper навколо `anthropicMessages()` із PR-12 logic (retry, timeout, prompt-caching, USD-ledger). Якщо `ANTHROPIC_API_KEY` пустий → factory деградує у `stub` (warn-log на startup-і).
+- `stub` — `StubProvider`, no-op повертає `{"ok":true,"stub":true}` JSON. Призначення: e2e-тести без real-Anthropic-калькування, локальний dev без ключа, інцидент-recovery під час Anthropic-outage (read-only OpenClaw paths-ів).
+- `openrouter` — зарезервовано під майбутню імплементацію (OpenRouter fallback). Поки що деградує у `stub`, щоб неочікуваний env не валив app.
+
+Wire-up call-sites — окремі PR-24 (OpenClaw `classify`) і PR-25 (`weekly-digest`). Інші Anthropic-call-sites (chat, coach, nutrition) поки що працюють напряму через `anthropicMessages()`, як і раніше.
+
 ### `AI_TIMEOUT_MS`, `AI_MAX_RETRIES`, `AI_CIRCUIT_BREAKER_THRESHOLD`, `AI_CIRCUIT_BREAKER_RESET_MS` _(optional)_
 
 Тюнінг Anthropic-клієнта.


### PR DESCRIPTION
## Summary

**PR-23** з [`docs/planning/pr-plan-2026-05.md`](https://github.com/Skords-01/Sergeant/blob/main/docs/planning/pr-plan-2026-05.md) — Phase 3 reliability: pluggable `LLMProvider` interface, що звільняє server від прямої залежності на Anthropic-клієнт. Тепер call-sites зможуть retrieve provider через factory і fallback на `StubProvider` при outage / у read-only OpenClaw paths-ах / dev/e2e без `ANTHROPIC_API_KEY`.

**Цей PR НЕ міняє жодного call-site** — wire-up окремими PR-ами (PR-24 OpenClaw `classify`, PR-25 weekly-digest). Existing `anthropicMessages()` flow (retry / timeout / prompt-cache / PR-12 USD-ledger) залишається активним.

Зміни:

- **`apps/server/src/lib/llm/provider.ts`** (new):
  - `LLMProvider` interface + `LLMGenerateOpts` / `LLMGenerateResult` (discriminated union на `ok`)
  - `AnthropicProvider` — тонкий adapter навколо `anthropicMessages()` (зберігає всю PR-12 instrumentation)
  - `StubProvider` — повертає `{"ok":true,"stub":true}` (override-able через конструктор для test-specific responses)
  - `getLLMProvider(override?)` factory: читає `env.LLM_PROVIDER` та `env.ANTHROPIC_API_KEY`, **fail-soft** деградує у stub коли ключ пустий
- **`apps/server/src/env/env.ts`**: новий `LLM_PROVIDER` enum (`anthropic` default | `openrouter` reserved | `stub`)
- **`docs/integrations/env-vars.md`**: документація `LLM_PROVIDER` з повним provider-mapping таблицею

## Governing Skill

- Primary skill: `.agents/skills/sergeant-server-api/SKILL.md`
- Secondary skill: n/a

## Playbook

- Primary playbook: n/a — atomic feature change.
- Why this playbook: Не один із зареєстрованих recipes (data/migrations/release/etc).
- If no playbook matched, why: Чистий refactor server-lib з документацією.

## Verification

```bash
pnpm --filter @sergeant/server exec vitest run src/lib/llm    # 17 passed
pnpm --filter @sergeant/server test                            # 2073/2073 passed
pnpm --filter @sergeant/server exec eslint src/lib/llm src/env/env.ts  # 0 errors
pnpm exec prettier --check apps/server/src/lib/llm/* apps/server/src/env/env.ts docs/integrations/env-vars.md  # clean
```

Note про `pnpm typecheck`: показує **pre-existing** помилку у `apps/server/src/obs/tracing.ts:43` (`resourceFromAttributes` not exported from `@opentelemetry/resources`) — це не наслідок цього PR (zero touch у tracing/OpenTelemetry-coде). Окремий deps-fix PR.

Additional checks:

- [x] Local smoke / manual validation completed (factory + provider behaviour покриті unit-tests)
- [x] Surface-specific checks completed (lint/format/test loop pass)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update. — No (no new hard rule / scope; provider is internal lib API).
- [x] I checked whether a playbook or skill needed an update. — No (specialist skill `sergeant-server-api` still канонічний).
- [x] I checked whether governance docs or review docs needed an update. — No.

Updated docs:

- `docs/integrations/env-vars.md` — додано `LLM_PROVIDER` env-var з рендером очікуваних значень + посилання на `provider.ts`.

## Risk and Rollout

- **User-visible risk:** Zero. PR не змінює жодного call-site → all live endpoints (chat, coach, nutrition, OpenClaw classify, weekly digest) продовжують використовувати `anthropicMessages()` напряму, як і раніше. `LLM_PROVIDER` дефолт `anthropic` + дефолтний `ANTHROPIC_API_KEY` → no-op для existing prod.
- **Rollout / deploy order:** Стандартний (merge → Railway autodeploy). Окремих env-var-ів додавати **не треба** — default-и працюють.
- **Backout plan:** Revert PR; `LLMProvider` — це новий isolated module, нічого не залежить від нього у поточному mainline.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

- `getLLMProvider()` навмисно fail-soft (no-key → stub) щоб local-dev / preview-env не падали. У production warn-log у `env.ts` startup-нотифікує оператора (existing behaviour, не змінено).
- `openrouter` поки деградує у `stub` — це reserved placeholder для майбутньої реалізації. Краще тихий no-op ніж exception на типографську помилку у env.
- `LLMGenerateResult` — discriminated union (`ok: true | false`), щоб caller отримував type-narrowing замість optional-everything shape. Mirrors паттерн який вже є у sync/auth модулях.


Link to Devin session: https://app.devin.ai/sessions/29f7a6ee50f24e228948a80569e247d1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a pluggable LLM layer with an `LLMProvider` interface and factory, adding `AnthropicProvider` and a fail-soft `StubProvider`. Default behavior is unchanged; if `ANTHROPIC_API_KEY` is missing or `LLM_PROVIDER=stub`, we degrade to the stub instead of failing.

- **Refactors**
  - Added `LLMProvider` + `getLLMProvider()` factory reading `LLM_PROVIDER`; falls back to stub when the Anthropic key is empty; `openrouter` is reserved and currently maps to stub.
  - Implemented `AnthropicProvider` as a thin adapter over existing `anthropicMessages()` to keep retry/timeout/prompt-cache/usage tracking intact; added `StubProvider` returning `{"ok":true,"stub":true}` (override-able in tests).
  - Introduced `LLM_PROVIDER` env var (`anthropic` default | `stub` | `openrouter` reserved) and updated docs.
  - No call-sites changed; follow-ups will wire OpenClaw `classify` and weekly digest.

<sup>Written for commit 1603580484168228ada74808c030ddf55df1012d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

