### PR TITLE
fix(server): harden Stripe webhook verification

### DIFF
--- a/apps/server/src/env/__tests__/assertStartupEnv.test.ts
+++ b/apps/server/src/env/__tests__/assertStartupEnv.test.ts
@@ -170,3 +170,49 @@ describe("assertStartupEnv — Hard Rule #20: no OpenClaw PAT in production", ()
     expect(() => assertStartupEnv()).not.toThrow();
   });
 });
+
+describe("assertStartupEnv — STRIPE_WEBHOOK_SECRET hard-fail (T2 audit #1)", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  // PROD_BASELINE only stubs the keys it sets — Devin/CI shells may export
+  // `Git_PAT` / `OPENCLAW_GITHUB_PAT`, which would trigger Hard Rule #20 and
+  // make these tests non-hermetic. Stub them to empty explicitly.
+  const STRIPE_BASELINE = {
+    ...PROD_BASELINE,
+    OPENCLAW_GITHUB_PAT: "",
+    Git_PAT: "",
+  };
+
+  it("throws in production when STRIPE_SECRET_KEY is set but STRIPE_WEBHOOK_SECRET is missing", async () => {
+    const assertStartupEnv = await loadAssertStartupEnv({
+      ...STRIPE_BASELINE,
+      STRIPE_SECRET_KEY: "sk_live_xxx",
+    });
+    expect(() => assertStartupEnv()).toThrow(/STRIPE_WEBHOOK_SECRET/);
+  });
+
+  it("does NOT throw in production when both Stripe vars are set", async () => {
+    const assertStartupEnv = await loadAssertStartupEnv({
+      ...STRIPE_BASELINE,
+      STRIPE_SECRET_KEY: "sk_live_xxx",
+      STRIPE_WEBHOOK_SECRET: "whsec_xxx",
+    });
+    expect(() => assertStartupEnv()).not.toThrow();
+  });
+
+  it("does NOT throw in production when neither Stripe var is set (billing not wired)", async () => {
+    const assertStartupEnv = await loadAssertStartupEnv(STRIPE_BASELINE);
+    expect(() => assertStartupEnv()).not.toThrow();
+  });
+
+  it("does NOT throw in NODE_ENV=development when STRIPE_SECRET_KEY is set without webhook secret", async () => {
+    const assertStartupEnv = await loadAssertStartupEnv({
+      NODE_ENV: "development",
+      STRIPE_SECRET_KEY: "sk_test_xxx",
+    });
+    expect(() => assertStartupEnv()).not.toThrow();
+  });
+});

--- a/apps/server/src/env/env.ts
+++ b/apps/server/src/env/env.ts
@@ -843,6 +843,22 @@ export function assertStartupEnv(): void {
     );
   }
 
+  // T2 audit finding #1 — Stripe webhook secret enforcement. If billing is
+  // wired (STRIPE_SECRET_KEY is set) then STRIPE_WEBHOOK_SECRET MUST also
+  // be set in production; otherwise `verifyStripeSignature` had no secret
+  // to compare against and the legacy non-prod fall-back was returning
+  // `true` (accept-all) — every staging / preview deploy was effectively
+  // an open billing-state write endpoint. Hard-fail at boot so the
+  // misconfig surfaces immediately instead of silently mutating
+  // subscription rows weeks later.
+  if (isProduction && process.env["STRIPE_SECRET_KEY"]) {
+    if (!process.env["STRIPE_WEBHOOK_SECRET"]) {
+      throw new Error(
+        "STRIPE_WEBHOOK_SECRET is required in production when STRIPE_SECRET_KEY is set. Without it the Stripe webhook endpoint cannot verify signatures and any caller can mutate billing state. Set the value from Stripe Dashboard → Developers → Webhooks → Signing secret.",
+      );
+    }
+  }
+
   // H9: AI_QUOTA_DISABLED is a billing kill-switch — fine in CI/test where e2e
   // hammers real Anthropic without burning user quota, catastrophic in
   // production where it disables every per-user / per-IP cap. The advisory

--- a/apps/server/src/modules/billing/stripe.test.ts
+++ b/apps/server/src/modules/billing/stripe.test.ts
@@ -1,9 +1,22 @@
+import { createHmac } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   processStripeWebhook,
+  verifyStripeSignature,
   __setPostHogCaptureForTesting,
 } from "./stripe.js";
 import type { capturePostHogEvent } from "../../lib/posthogCapture.js";
+
+function signedHeader(
+  secret: string,
+  timestampSeconds: number,
+  payload: Buffer,
+): string {
+  const v1 = createHmac("sha256", secret)
+    .update(`${timestampSeconds}.${payload.toString("utf8")}`)
+    .digest("hex");
+  return `t=${timestampSeconds},v1=${v1}`;
+}
 
 function createClient(rowCount: number) {
   const query = vi.fn().mockResolvedValue({ rowCount, rows: [] });
@@ -268,5 +281,84 @@ describe("subscription_started PostHog capture (PR-09)", () => {
     expect(result).toEqual({ ok: true, duplicate: false });
     expect(client.query).toHaveBeenLastCalledWith("COMMIT");
     expect(capture).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("verifyStripeSignature (T2 audit hardening)", () => {
+  const SECRET = "whsec_test_1234567890abcdef";
+  const payload = Buffer.from(`{"id":"evt_1","type":"ping"}`);
+
+  beforeEach(() => {
+    delete process.env["STRIPE_WEBHOOK_SECRET"];
+    delete process.env["STRIPE_WEBHOOK_TOLERANCE_SECONDS"];
+  });
+
+  afterEach(() => {
+    delete process.env["STRIPE_WEBHOOK_SECRET"];
+    delete process.env["STRIPE_WEBHOOK_TOLERANCE_SECONDS"];
+  });
+
+  it("returns false when STRIPE_WEBHOOK_SECRET is unset (no accept-all in non-prod)", () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    const header = signedHeader(SECRET, nowSec, payload);
+    expect(verifyStripeSignature(payload, header)).toBe(false);
+  });
+
+  it("returns true for a freshly-signed payload when secret is set", () => {
+    process.env["STRIPE_WEBHOOK_SECRET"] = SECRET;
+    const nowSec = Math.floor(Date.now() / 1000);
+    const header = signedHeader(SECRET, nowSec, payload);
+    expect(verifyStripeSignature(payload, header)).toBe(true);
+  });
+
+  it("returns false for a payload signed 10 minutes ago (replay outside tolerance)", () => {
+    process.env["STRIPE_WEBHOOK_SECRET"] = SECRET;
+    const tenMinutesAgo = Math.floor(Date.now() / 1000) - 600;
+    const header = signedHeader(SECRET, tenMinutesAgo, payload);
+    expect(verifyStripeSignature(payload, header)).toBe(false);
+  });
+
+  it("returns false for a future-dated signature outside tolerance", () => {
+    process.env["STRIPE_WEBHOOK_SECRET"] = SECRET;
+    const futureSec = Math.floor(Date.now() / 1000) + 600;
+    const header = signedHeader(SECRET, futureSec, payload);
+    expect(verifyStripeSignature(payload, header)).toBe(false);
+  });
+
+  it("accepts a borderline timestamp within tolerance (299s old)", () => {
+    process.env["STRIPE_WEBHOOK_SECRET"] = SECRET;
+    const nowSec = Math.floor(Date.now() / 1000) - 299;
+    const header = signedHeader(SECRET, nowSec, payload);
+    expect(verifyStripeSignature(payload, header)).toBe(true);
+  });
+
+  it("respects STRIPE_WEBHOOK_TOLERANCE_SECONDS override", () => {
+    process.env["STRIPE_WEBHOOK_SECRET"] = SECRET;
+    process.env["STRIPE_WEBHOOK_TOLERANCE_SECONDS"] = "60";
+    const tooOldSec = Math.floor(Date.now() / 1000) - 120;
+    const header = signedHeader(SECRET, tooOldSec, payload);
+    expect(verifyStripeSignature(payload, header)).toBe(false);
+  });
+
+  it("returns false on a tampered payload even when timestamp is fresh", () => {
+    process.env["STRIPE_WEBHOOK_SECRET"] = SECRET;
+    const nowSec = Math.floor(Date.now() / 1000);
+    const header = signedHeader(SECRET, nowSec, payload);
+    const tampered = Buffer.from(`{"id":"evt_1","type":"evil"}`);
+    expect(verifyStripeSignature(tampered, header)).toBe(false);
+  });
+
+  it("returns false when signature header is missing", () => {
+    process.env["STRIPE_WEBHOOK_SECRET"] = SECRET;
+    expect(verifyStripeSignature(payload, undefined)).toBe(false);
+  });
+
+  it("returns false when timestamp is non-numeric", () => {
+    process.env["STRIPE_WEBHOOK_SECRET"] = SECRET;
+    const v1 = createHmac("sha256", SECRET)
+      .update(`abc.${payload.toString("utf8")}`)
+      .digest("hex");
+    const header = `t=abc,v1=${v1}`;
+    expect(verifyStripeSignature(payload, header)).toBe(false);
   });
 });

--- a/apps/server/src/modules/billing/stripe.ts
+++ b/apps/server/src/modules/billing/stripe.ts
@@ -406,12 +406,41 @@ async function upsertSubscriptionEvent(
   );
 }
 
+/**
+ * Default replay-window tolerance for Stripe webhook timestamps, in seconds.
+ * Matches the value `stripe-node` uses for `constructEvent` (300s = 5 min).
+ * Override at runtime via `STRIPE_WEBHOOK_TOLERANCE_SECONDS` if your platform
+ * has unusual clock skew; values <= 0 disable the check (NOT recommended).
+ */
+export const DEFAULT_STRIPE_WEBHOOK_TOLERANCE_SECONDS = 300;
+
+function getStripeWebhookToleranceSeconds(): number {
+  const raw = process.env["STRIPE_WEBHOOK_TOLERANCE_SECONDS"];
+  if (!raw) return DEFAULT_STRIPE_WEBHOOK_TOLERANCE_SECONDS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) return DEFAULT_STRIPE_WEBHOOK_TOLERANCE_SECONDS;
+  return parsed;
+}
+
+/**
+ * Verify a Stripe webhook signature.
+ *
+ * Hardening (T2 audit findings 1 & 2):
+ *   1. If `STRIPE_WEBHOOK_SECRET` is unset we ALWAYS return `false`. The
+ *      previous behaviour of accepting any payload in non-production
+ *      effectively turned every staging / preview deploy into an
+ *      unauthenticated write endpoint into the billing DB.
+ *   2. The signed payload includes a timestamp; we enforce a tolerance
+ *      window (`STRIPE_WEBHOOK_TOLERANCE_SECONDS`, default 300s) so that
+ *      a captured signed body cannot be replayed indefinitely.
+ */
 export function verifyStripeSignature(
   rawPayload: Buffer,
   signatureHeader: string | undefined,
+  options: { now?: () => number; toleranceSeconds?: number } = {},
 ): boolean {
   const secret = process.env["STRIPE_WEBHOOK_SECRET"];
-  if (!secret) return process.env["NODE_ENV"] !== "production";
+  if (!secret) return false;
   if (!signatureHeader) return false;
   const parts = new Map(
     signatureHeader.split(",").map((part) => {
@@ -422,6 +451,16 @@ export function verifyStripeSignature(
   const timestamp = parts.get("t");
   const expected = parts.get("v1");
   if (!timestamp || !expected) return false;
+
+  const timestampSeconds = Number.parseInt(timestamp, 10);
+  if (!Number.isFinite(timestampSeconds)) return false;
+  const tolerance =
+    options.toleranceSeconds ?? getStripeWebhookToleranceSeconds();
+  if (tolerance > 0) {
+    const nowSeconds = Math.floor((options.now ?? Date.now)() / 1000);
+    if (Math.abs(nowSeconds - timestampSeconds) > tolerance) return false;
+  }
+
   const actual = createHmac("sha256", secret)
     .update(`${timestamp}.${rawPayload.toString("utf8")}`)
     .digest("hex");


### PR DESCRIPTION
## Summary

Closes two HIGH-severity findings from the T2 backend audit:

1. `verifyStripeSignature` previously accepted every payload in non-production deploys when `STRIPE_WEBHOOK_SECRET` was unset (`if (!secret) return process.env["NODE_ENV"] !== "production";`). Every staging / preview / Railway-preview deploy was effectively an unauthenticated billing-state write endpoint. The function now returns `false` unconditionally when the secret is missing, and `assertStartupEnv` hard-fails at boot in production when `STRIPE_SECRET_KEY` is set but `STRIPE_WEBHOOK_SECRET` is not.
2. The signed Stripe payload included a timestamp that was never checked — a captured signed body could be replayed indefinitely. Added a 5-minute tolerance window (matching `stripe-node`'s `constructEvent` default), tunable via `STRIPE_WEBHOOK_TOLERANCE_SECONDS`.

## Governing Skill

- Primary skill: `.agents/skills/sergeant-server-api/SKILL.md`
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a (security hardening)
- Why this playbook: n/a
- If no playbook matched, why: focused security fix surfaced by the T2 audit.

## Verification

```bash
pnpm --filter @sergeant/server typecheck   # exit 0
pnpm --filter @sergeant/server lint        # 0 errors
pnpm --filter @sergeant/server test        # 2065 passed, 4 failed (pre-existing Git_PAT)
```

Additional checks:

- [x] Local smoke / manual validation completed (9 new unit tests in `stripe.test.ts`; 4 new tests in `assertStartupEnv.test.ts`)
- [x] Surface-specific checks completed (no API contract triplet impact)

## Docs and Governance

- [x] I updated docs.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a (env-var doc inline in `stripe.ts`)

## Risk and Rollout

- User-visible risk: strictly safer in production. Operators with `STRIPE_SECRET_KEY` set but `STRIPE_WEBHOOK_SECRET` unset will get a hard boot error — intentional.
- Rollout / deploy order: verify `STRIPE_WEBHOOK_SECRET` is present in every prod env before merge. No DB migration.
- Backout plan: revert the commit.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

PR 1 of 4–5 follow-up PRs from the T2 backend QA audit ( https://app.devin.ai/sessions/ed8a702bc21b43cd8d3987387c1646f0 ).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens Stripe webhook verification to block unauthenticated writes and replay attacks. Webhooks now require a secret in all envs and must be within a 5‑minute window; production boots will fail if misconfigured.

- **Bug Fixes**
  - `verifyStripeSignature` now returns false when `STRIPE_WEBHOOK_SECRET` is missing (no accept-all in non‑prod).
  - Enforces a signed timestamp tolerance (default 300s, matches `stripe-node`; override via `STRIPE_WEBHOOK_TOLERANCE_SECONDS`).
  - `assertStartupEnv` throws in production if `STRIPE_SECRET_KEY` is set but `STRIPE_WEBHOOK_SECRET` is not.

- **Migration**
  - Set STRIPE_WEBHOOK_SECRET in all production envs where Stripe is enabled before deploy.
  - Optionally tune STRIPE_WEBHOOK_TOLERANCE_SECONDS if your clocks have unusual skew.

<sup>Written for commit 11619e8593c2405b78dbfa14ab60f53f24d30a63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

