### PR TITLE
fix(mobile): wrap root layout with ErrorBoundary + Expo Router segment export

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -12,6 +12,8 @@ import { SafeAreaProvider } from "react-native-safe-area-context";
 import { ApiClientProvider } from "@sergeant/api-client/react";
 
 import { apiClient } from "@/api/apiClient";
+import { ErrorBoundary as RootErrorBoundary } from "@/core/ErrorBoundary";
+import { SegmentErrorBoundary } from "@/core/SegmentErrorBoundary";
 import { SyncStatusOverlay } from "@/core/SyncStatusOverlay";
 import { bootSyncEngineWriter } from "@/core/syncEngine/singleton";
 import { ColorSchemeBridge } from "@/core/theme/ColorSchemeBridge";
@@ -178,22 +180,56 @@ export default function RootLayout() {
   }
 
   return (
+    // The boundary sits *inside* `GestureHandlerRootView` so the
+    // gesture-handler root is always mounted (a throw inside the
+    // providers below must not detach RNGH from the native side —
+    // otherwise the fallback's own `<Button>` press wouldn't work).
+    // Every other provider is below the boundary so a render-time
+    // throw in `QueryProvider`'s persister rehydration, the
+    // `ApiClientProvider`, or one of the side-effect bridges
+    // (`IdentityBridge`, `PushRegistrar`, …) is caught and routed
+    // through `captureError` instead of bubbling to Expo Router's
+    // red-box / a native crash.
     <GestureHandlerRootView style={{ flex: 1 }}>
       <SafeAreaProvider>
-        <QueryProvider>
-          <ApiClientProvider client={apiClient}>
-            <IdentityBridge />
-            <ToastProvider>
-              <ColorSchemeBridge />
-              <DynamicStatusBar />
-              <RootShell />
-              <ToastContainer />
-              <PushRegistrar />
-              <AnalyticsIdentityBridge />
-            </ToastProvider>
-          </ApiClientProvider>
-        </QueryProvider>
+        <RootErrorBoundary>
+          <QueryProvider>
+            <ApiClientProvider client={apiClient}>
+              <IdentityBridge />
+              <ToastProvider>
+                <ColorSchemeBridge />
+                <DynamicStatusBar />
+                <RootShell />
+                <ToastContainer />
+                <PushRegistrar />
+                <AnalyticsIdentityBridge />
+              </ToastProvider>
+            </ApiClientProvider>
+          </QueryProvider>
+        </RootErrorBoundary>
       </SafeAreaProvider>
     </GestureHandlerRootView>
   );
 }
+
+/**
+ * Expo Router segment-level error boundary.
+ *
+ * Expo Router uses the named `ErrorBoundary` export from a layout
+ * file (`docs.expo.dev/router/error-handling/`) to render a fallback
+ * when *route children* throw during render. This is a different
+ * surface from the in-tree class boundary above:
+ *
+ * - The class boundary in `RootLayout` catches throws from the
+ *   providers (`QueryProvider`, `ApiClientProvider`, etc).
+ * - This named export catches throws from the screens declared inside
+ *   `<Stack>` (`(tabs)`, `(auth)`, `settings`, `assistant`, …).
+ *
+ * Together they form a defence-in-depth pair so no render-time error
+ * inside the mobile tree reaches Expo Router's default red-box.
+ *
+ * The actual fallback markup lives in `SegmentErrorBoundary` so it can
+ * be unit-tested without dragging the entire mobile provider stack
+ * into Jest.
+ */
+export const ErrorBoundary = SegmentErrorBoundary;

--- a/apps/mobile/src/core/ErrorBoundary.test.tsx
+++ b/apps/mobile/src/core/ErrorBoundary.test.tsx
@@ -2,6 +2,8 @@ import { fireEvent, render } from "@testing-library/react-native";
 import type { ReactNode } from "react";
 import { Text } from "react-native";
 
+import { captureError } from "@/lib/observability";
+
 import { ErrorBoundary } from "./ErrorBoundary";
 
 jest.mock("expo-router", () => ({
@@ -9,10 +11,20 @@ jest.mock("expo-router", () => ({
   router: { replace: jest.fn() },
 }));
 
+jest.mock("@/lib/observability", () => ({
+  __esModule: true,
+  captureError: jest.fn(),
+}));
+
+const mockedCaptureError = captureError as jest.MockedFunction<
+  typeof captureError
+>;
+
 // Silence the expected `console.error` the boundary emits + React's own
 // "The above error occurred in..." for a cleaner test report.
 let consoleSpy: jest.SpyInstance;
 beforeEach(() => {
+  mockedCaptureError.mockReset();
   consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
 });
 afterEach(() => {
@@ -118,5 +130,19 @@ describe("ErrorBoundary", () => {
       (call) => call[0] === "[ErrorBoundary] caught error",
     );
     expect(matched).toBe(true);
+  });
+
+  it("forwards the caught error to `captureError` from @/lib/observability", () => {
+    render(
+      <ErrorBoundary>
+        <Thrower boom />
+      </ErrorBoundary>,
+    );
+
+    expect(mockedCaptureError).toHaveBeenCalledTimes(1);
+    const [forwardedError, context] = mockedCaptureError.mock.calls[0] ?? [];
+    expect(forwardedError).toBeInstanceOf(Error);
+    expect((forwardedError as Error).message).toBe("kaboom");
+    expect(context).toMatchObject({ componentStack: expect.any(String) });
   });
 });

--- a/apps/mobile/src/core/ErrorBoundary.tsx
+++ b/apps/mobile/src/core/ErrorBoundary.tsx
@@ -57,7 +57,15 @@ interface ErrorBoundaryState {
   error: Error | null;
 }
 
-function DefaultErrorFallback({ error, resetError }: FallbackProps) {
+/**
+ * Default fallback rendered when no `fallback` prop is supplied.
+ *
+ * Exported as `RootErrorFallback` so the Expo Router segment-level
+ * boundary in `app/_layout.tsx` (which receives `{ error, retry }`
+ * directly, not via a React error boundary) can reuse the same Card
+ * + Button + reset semantics without duplicating the markup.
+ */
+export function RootErrorFallback({ error, resetError }: FallbackProps) {
   return (
     <View className="flex-1 bg-bg dark:bg-bg items-stretch justify-center p-6">
       <Card variant="default" padding="lg">
@@ -134,9 +142,7 @@ export class ErrorBoundary extends Component<
       if (Fallback !== undefined) {
         return Fallback;
       }
-      return (
-        <DefaultErrorFallback error={error} resetError={this.resetError} />
-      );
+      return <RootErrorFallback error={error} resetError={this.resetError} />;
     }
     return children;
   }

--- a/apps/mobile/src/core/SegmentErrorBoundary.test.tsx
+++ b/apps/mobile/src/core/SegmentErrorBoundary.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render } from "@testing-library/react-native";
+
+import { SegmentErrorBoundary } from "./SegmentErrorBoundary";
+
+jest.mock("expo-router", () => ({
+  __esModule: true,
+  router: { replace: jest.fn() },
+}));
+
+describe("SegmentErrorBoundary (Expo Router named export)", () => {
+  it("renders the Ukrainian Card fallback with the thrown error's message", () => {
+    const { getByText } = render(
+      <SegmentErrorBoundary
+        error={new Error("route boom")}
+        retry={() => Promise.resolve()}
+      />,
+    );
+    expect(getByText("Щось пішло не так")).toBeTruthy();
+    expect(getByText("route boom")).toBeTruthy();
+    expect(getByText("Перезавантажити")).toBeTruthy();
+  });
+
+  it("calls `retry` when the user taps the reset button (fire-and-forget)", () => {
+    const retry = jest.fn(() => Promise.resolve());
+    const { getByText } = render(
+      <SegmentErrorBoundary error={new Error("route boom")} retry={retry} />,
+    );
+
+    fireEvent.press(getByText("Перезавантажити"));
+
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not throw when `retry` returns a rejected promise", async () => {
+    const retry = jest.fn(() =>
+      Promise.reject(new Error("retry failed")).catch(() => {
+        /* swallow rejection — the fallback fires retry as
+         * fire-and-forget, so the caller is responsible for
+         * logging. Test scope: only verify the press handler
+         * itself doesn't synchronously rethrow. */
+      }),
+    );
+    const { getByText } = render(
+      <SegmentErrorBoundary error={new Error("route boom")} retry={retry} />,
+    );
+
+    expect(() => fireEvent.press(getByText("Перезавантажити"))).not.toThrow();
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/src/core/SegmentErrorBoundary.tsx
+++ b/apps/mobile/src/core/SegmentErrorBoundary.tsx
@@ -1,0 +1,44 @@
+/**
+ * Sergeant Hub-core — Expo Router segment-level error boundary.
+ *
+ * Expo Router uses the named `ErrorBoundary` export from a layout file
+ * (`docs.expo.dev/router/error-handling/`) to render a fallback when
+ * *route children* throw during render. That signature is `{ error,
+ * retry: () => Promise<unknown> }`, which is different from the
+ * in-tree React class boundary in `./ErrorBoundary.tsx` (which uses
+ * `{ error, resetError }`).
+ *
+ * This helper bridges the two so the same Card + Button + reset
+ * markup is rendered for both surfaces. Keeping it in its own module
+ * (instead of inline in `app/_layout.tsx`) makes the wiring easy to
+ * unit-test without dragging the entire mobile provider stack into
+ * Jest — see `SegmentErrorBoundary.test.tsx`.
+ */
+
+import { RootErrorFallback } from "./ErrorBoundary";
+
+export interface SegmentErrorBoundaryProps {
+  error: Error;
+  retry: () => Promise<unknown>;
+}
+
+/**
+ * Stable wrapper around `RootErrorFallback` for Expo Router's
+ * segment-level error boundary export. `retry` is async by design —
+ * re-mounting the segment may need to wait on data loaders — but the
+ * fallback fires it synchronously and discards the returned promise
+ * so the press handler stays `() => void`-shaped.
+ */
+export function SegmentErrorBoundary({
+  error,
+  retry,
+}: SegmentErrorBoundaryProps) {
+  return (
+    <RootErrorFallback
+      error={error}
+      resetError={() => {
+        void retry();
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

Mobile root layout (`apps/mobile/app/_layout.tsx`) previously mounted **no top-level React error boundary**, so a render-time throw in any provider (`QueryProvider`'s persister rehydration, `ApiClientProvider`, `ToastProvider`, `PushRegistrar`, etc.) escaped to Expo Router's default red-box / native crash and never reached `Sentry.captureException` via `captureError`. Per-module boundaries exist (e.g. `app/(tabs)/finyk/_layout.tsx` mounts `ModuleErrorBoundary`) but they cannot catch errors in their own parents.

This PR wires **defence-in-depth coverage** on the mobile root:

1. `RootLayout`'s provider tree is now wrapped in the in-tree class `ErrorBoundary` from `src/core/ErrorBoundary` (positioned **inside** `GestureHandlerRootView` so the gesture-handler root stays mounted while the fallback renders).
2. A new `SegmentErrorBoundary` helper bridges Expo Router's `{ error, retry }` signature onto the same `RootErrorFallback` markup and is re-exported as the named `ErrorBoundary` export from `app/_layout.tsx` — per [Expo Router error-handling docs](https://docs.expo.dev/router/error-handling/), this name is automatically picked up to catch render throws in screens declared inside `<Stack>` (`(tabs)`, `(auth)`, `settings`, `assistant`).
3. The default fallback (previously `DefaultErrorFallback`, private) is renamed and exported as `RootErrorFallback` so both surfaces reuse the same Card + Button + reset semantics.

Together (1) and (2) cover the two surfaces:

| Surface | Caught by | Notes |
| --- | --- | --- |
| Provider throws (`QueryProvider`, `ApiClientProvider`, `ToastProvider`, side-effect bridges) | Inline `<RootErrorBoundary>` in `RootLayout` | Routes through `captureError` → Sentry |
| Route-screen throws (`(tabs)/finyk`, `(auth)/sign-in`, `settings`, …) | Named `ErrorBoundary` export | Routes through `retry` to remount the segment |

## Governing Skill

- Primary skill: `.agents/skills/sergeant-mobile-expo` (mobile surface)
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a — surgical fix, no large refactor playbook applies
- Why this playbook: small, targeted reliability hardening
- If no playbook matched, why: targeted bug-class fix surfaced by T4 mobile QA audit

## Verification

```bash
pnpm --filter @sergeant/mobile typecheck       # exit 0
pnpm --filter @sergeant/mobile lint            # exit 0
NODE_OPTIONS=--max-old-space-size=4096 \
  pnpm --filter @sergeant/mobile test --workers=2 \
    --testPathPattern="(ErrorBoundary|SegmentErrorBoundary)"
#   3 suites passed, 15 tests passed
pnpm --filter @sergeant/mobile exec prettier --check \
  app/_layout.tsx src/core/{SegmentErrorBoundary,ErrorBoundary}{,.test}.tsx
#   All matched files use Prettier code style!
```

Additional checks:

- [x] Local smoke / manual validation completed (`SegmentErrorBoundary.test.tsx` covers the new helper; `ErrorBoundary.test.tsx` now asserts `captureError` is invoked with `componentStack` context)
- [x] Surface-specific checks completed (`pnpm --filter @sergeant/mobile {typecheck,lint}` are green)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. — No public contract change; behaviour change is internal hardening only.
- [x] I checked whether `AGENTS.md` needed an update. — n/a
- [x] I checked whether a playbook or skill needed an update. — n/a
- [x] I checked whether governance docs or review docs needed an update. — n/a

Updated docs:

- n/a

## Risk and Rollout

- User-visible risk: **low**. The boundary only renders on a render-time throw — previously the app crashed; now it shows a Ukrainian "Щось пішло не так" Card with a reset button. No happy-path code paths change.
- Rollout / deploy order: lands with the next mobile dev-client build (no EAS config change).
- Backout plan: revert this single commit — files are additive (`SegmentErrorBoundary.tsx`, `.test.tsx`) and the `_layout.tsx` wrap is a 6-line diff.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian. — Fallback strings preserved as Ukrainian (`Щось пішло не так` / `Перезавантажити`).
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

- Discovered during the [T4 mobile QA audit](https://app.devin.ai/sessions/97aa97e1190c43ac98999f4cc2f0cd0d) (finding #1 — "Root layout mounts no ErrorBoundary").
- The Expo Router named export deliberately re-uses the same fallback as the class boundary — both routes converge on `RootErrorFallback` so users see one consistent error UI no matter which surface threw.
- The `SegmentErrorBoundary` helper exists primarily to keep the wiring unit-testable. The whole of `app/_layout.tsx` is not Jest-testable in isolation (jest config scopes `testMatch` to `src/**` + `plugins/**`, and the layout pulls in dozens of side-effect-only imports including expo-splash-screen and gesture-handler), so the extraction keeps the round-trip cheap.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add top-level error handling to the mobile app so render-time errors in providers and routes no longer crash to the red box; instead they show a consistent fallback and are sent to Sentry via `captureError`.

- **Bug Fixes**
  - Wrapped the provider tree in the in-tree `ErrorBoundary` (inside `GestureHandlerRootView`) to catch provider throws and forward them to `captureError`.
  - Exported a segment-level `ErrorBoundary` via new `SegmentErrorBoundary` from `app/_layout.tsx` to handle `expo-router` screen throws using `retry`.
  - Renamed and exported `RootErrorFallback` to share the same fallback UI across both surfaces; added tests for `captureError` forwarding and retry wiring.

<sup>Written for commit 229ac555dab9ed6c7d6c16ab3fb8f26cd3b7a676. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

