### PR TITLE
feat(console): setWebhook poll-and-retry with 5-attempt exp backoff [O6/B.6]

### DIFF
--- a/tools/console/src/openclaw/bootstrap.test.ts
+++ b/tools/console/src/openclaw/bootstrap.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   registerOpenClawWebhook,
   shouldUseWebhook,
@@ -6,11 +6,15 @@ import {
   validateWebhookConfig,
 } from "./bootstrap.js";
 
-const { mockAddBreadcrumb } = vi.hoisted(() => ({
+const { mockAddBreadcrumb, mockCaptureMessage } = vi.hoisted(() => ({
   mockAddBreadcrumb: vi.fn(),
+  mockCaptureMessage: vi.fn(),
 }));
 vi.mock("../obs/sentry.js", () => ({
-  Sentry: { addBreadcrumb: mockAddBreadcrumb },
+  Sentry: {
+    addBreadcrumb: mockAddBreadcrumb,
+    captureMessage: mockCaptureMessage,
+  },
 }));
 
 const SECRET_OK = "a".repeat(32);
@@ -130,6 +134,42 @@ describe("validateWebhookConfig", () => {
 });
 
 describe("registerOpenClawWebhook", () => {
+  beforeEach(() => {
+    mockAddBreadcrumb.mockClear();
+    mockCaptureMessage.mockClear();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /**
+   * Helper: drive a registerOpenClawWebhook() call to completion under
+   * `vi.useFakeTimers()`. The retry loop awaits each backoff via
+   * `setTimeout`, so we drain pending timers by interleaving
+   * `runAllTimersAsync` with the in-flight promise.
+   */
+  async function settleWithFakeTimers<T>(p: Promise<T>): Promise<T> {
+    let settled = false;
+    // Use `.then(onfulfilled, onrejected)` so we don't generate a new
+    // unhandled-rejection chain off `p` while we're still draining
+    // pending timers. The caller still `await`s `p` directly and
+    // observes the original resolution / rejection.
+    p.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+    while (!settled) {
+      await vi.advanceTimersByTimeAsync(60_000);
+      // yield to microtasks so the next attempt's setTimeout is scheduled
+      await Promise.resolve();
+    }
+    return p;
+  }
+
   it("calls setWebhook with secret_token + drop_pending_updates + allowed_updates and verifies via getWebhookInfo", async () => {
     const { bot, setWebhook, getWebhookInfo } = makeBotMock();
     await registerOpenClawWebhook(bot as never, {
@@ -159,7 +199,7 @@ describe("registerOpenClawWebhook", () => {
 
   it("emits Sentry breadcrumb on successful recovery after W4.1 race", async () => {
     vi.spyOn(console, "warn").mockImplementation(() => {});
-    mockAddBreadcrumb.mockClear();
+    vi.useFakeTimers();
     const { bot, getWebhookInfo } = makeBotMock();
     let calls = 0;
     getWebhookInfo.mockImplementation(async () => {
@@ -170,18 +210,39 @@ describe("registerOpenClawWebhook", () => {
         pending_update_count: 0,
       };
     });
-    await registerOpenClawWebhook(bot as never, {
-      url: "https://x.example/webhook",
-      secretToken: SECRET_OK,
-    });
-    expect(mockAddBreadcrumb).toHaveBeenCalledTimes(1);
-    expect(mockAddBreadcrumb).toHaveBeenCalledWith(
+    await settleWithFakeTimers(
+      registerOpenClawWebhook(bot as never, {
+        url: "https://x.example/webhook",
+        secretToken: SECRET_OK,
+      }),
+    );
+    // Two breadcrumbs total: one warning on the inter-attempt retry,
+    // one info on successful recovery.
+    expect(mockAddBreadcrumb).toHaveBeenCalledTimes(2);
+    expect(mockAddBreadcrumb).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        category: "openclaw.webhook",
+        level: "warning",
+        message: expect.stringMatching(/setWebhook retry.*reason=url_mismatch/),
+        data: expect.objectContaining({
+          attempt: 1,
+          maxAttempts: 5,
+          reason: "url_mismatch",
+          delayMs: 1_000,
+        }),
+      }),
+    );
+    expect(mockAddBreadcrumb).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({
         category: "openclaw.webhook",
         level: "info",
         data: expect.objectContaining({ attempt: 2 }),
       }),
     );
+    // Recovery path — no error-level captureMessage.
+    expect(mockCaptureMessage).not.toHaveBeenCalled();
   });
 
   it("does not emit Sentry breadcrumb on first-attempt success", async () => {
@@ -200,6 +261,7 @@ describe("registerOpenClawWebhook", () => {
     // verification read. The first verify returns url="", second
     // returns the expected URL.
     vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.useFakeTimers();
     const { bot, setWebhook, getWebhookInfo } = makeBotMock();
     let calls = 0;
     getWebhookInfo.mockImplementation(async () => {
@@ -210,10 +272,12 @@ describe("registerOpenClawWebhook", () => {
         pending_update_count: 0,
       };
     });
-    await registerOpenClawWebhook(bot as never, {
-      url: "https://x.example/webhook",
-      secretToken: SECRET_OK,
-    });
+    await settleWithFakeTimers(
+      registerOpenClawWebhook(bot as never, {
+        url: "https://x.example/webhook",
+        secretToken: SECRET_OK,
+      }),
+    );
     // Two setWebhook calls: first fails verification, second succeeds.
     expect(setWebhook).toHaveBeenCalledTimes(2);
     expect(getWebhookInfo).toHaveBeenCalledTimes(2);
@@ -227,8 +291,119 @@ describe("registerOpenClawWebhook", () => {
     });
   });
 
-  it("throws after WEBHOOK_VERIFY_MAX_ATTEMPTS if verification keeps failing", async () => {
+  // B.6 / O6 — retry semantics for Telegram API outage at boot.
+
+  it("retries setWebhook when the API call itself throws (transient outage, 2-retry success)", async () => {
     vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.useFakeTimers();
+    const { bot, setWebhook, getWebhookInfo } = makeBotMock();
+    let attemptCount = 0;
+    setWebhook.mockReset();
+    setWebhook.mockImplementation(async (_url: string) => {
+      attemptCount += 1;
+      if (attemptCount === 1) {
+        throw new Error("ETIMEDOUT api.telegram.org");
+      }
+      // 2nd attempt succeeds — getWebhookInfo will then return the URL
+      // we expect.
+      return true;
+    });
+    getWebhookInfo.mockImplementation(async () => ({
+      url: attemptCount >= 2 ? "https://x.example/webhook" : "",
+      has_custom_certificate: false,
+      pending_update_count: 0,
+    }));
+    await settleWithFakeTimers(
+      registerOpenClawWebhook(bot as never, {
+        url: "https://x.example/webhook",
+        secretToken: SECRET_OK,
+      }),
+    );
+    expect(setWebhook).toHaveBeenCalledTimes(2);
+    // Retry breadcrumb (warning, api_error) + recovery breadcrumb (info).
+    expect(mockAddBreadcrumb).toHaveBeenCalledTimes(2);
+    expect(mockAddBreadcrumb).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        level: "warning",
+        message: expect.stringMatching(/setWebhook retry.*reason=api_error/),
+        data: expect.objectContaining({
+          attempt: 1,
+          reason: "api_error",
+          apiError: "ETIMEDOUT api.telegram.org",
+          delayMs: 1_000,
+        }),
+      }),
+    );
+    expect(mockAddBreadcrumb).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        level: "info",
+        data: expect.objectContaining({ attempt: 2 }),
+      }),
+    );
+    expect(mockCaptureMessage).not.toHaveBeenCalled();
+  });
+
+  it("emits a breadcrumb on every retry, then an error-level captureMessage when all 5 attempts fail (api_error)", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.useFakeTimers();
+    const { bot, setWebhook, getWebhookInfo } = makeBotMock();
+    // Every setWebhook throws — simulate permanent Telegram outage.
+    setWebhook.mockReset();
+    setWebhook.mockRejectedValue(new Error("ECONNREFUSED api.telegram.org"));
+    await expect(
+      settleWithFakeTimers(
+        registerOpenClawWebhook(bot as never, {
+          url: "https://x.example/webhook",
+          secretToken: SECRET_OK,
+        }),
+      ),
+    ).rejects.toThrow(
+      /registration failed after 5 attempts.*ECONNREFUSED api.telegram.org/,
+    );
+    expect(setWebhook).toHaveBeenCalledTimes(5);
+    // getWebhookInfo never runs because setWebhook always throws first.
+    expect(getWebhookInfo).not.toHaveBeenCalled();
+    // 4 inter-attempt warning breadcrumbs (one before each of attempts 2..5).
+    const warningBreadcrumbs = mockAddBreadcrumb.mock.calls.filter(
+      ([arg]) => arg.level === "warning",
+    );
+    expect(warningBreadcrumbs).toHaveLength(4);
+    // First retry uses 1s backoff, then 2s, 5s, 10s — schedule check.
+    expect(warningBreadcrumbs.map(([arg]) => arg.data.delayMs)).toEqual([
+      1_000, 2_000, 5_000, 10_000,
+    ]);
+    expect(
+      warningBreadcrumbs.every(([arg]) => arg.data.reason === "api_error"),
+    ).toBe(true);
+    // No info breadcrumb — nothing recovered.
+    expect(
+      mockAddBreadcrumb.mock.calls.some(([arg]) => arg.level === "info"),
+    ).toBe(false);
+    // Final captureMessage at error level with tags + extras.
+    expect(mockCaptureMessage).toHaveBeenCalledTimes(1);
+    expect(mockCaptureMessage).toHaveBeenCalledWith(
+      expect.stringMatching(/setWebhook failed after 5 attempts/),
+      expect.objectContaining({
+        level: "error",
+        tags: expect.objectContaining({
+          module: "openclaw",
+          op: "setWebhook",
+          reason: "api_error",
+        }),
+        extra: expect.objectContaining({
+          url: "https://x.example/webhook",
+          attempts: 5,
+          lastApiError: "ECONNREFUSED api.telegram.org",
+        }),
+      }),
+    );
+  });
+
+  it("throws after WEBHOOK_VERIFY_MAX_ATTEMPTS if verification keeps failing (url_mismatch)", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.useFakeTimers();
     const { bot, setWebhook, getWebhookInfo } = makeBotMock();
     // Force every getWebhookInfo to keep reporting an empty URL.
     getWebhookInfo.mockResolvedValue({
@@ -237,13 +412,23 @@ describe("registerOpenClawWebhook", () => {
       pending_update_count: 0,
     });
     await expect(
-      registerOpenClawWebhook(bot as never, {
-        url: "https://x.example/webhook",
-        secretToken: SECRET_OK,
+      settleWithFakeTimers(
+        registerOpenClawWebhook(bot as never, {
+          url: "https://x.example/webhook",
+          secretToken: SECRET_OK,
+        }),
+      ),
+    ).rejects.toThrow(/verification failed after 5 attempts/);
+    expect(setWebhook).toHaveBeenCalledTimes(5);
+    expect(getWebhookInfo).toHaveBeenCalledTimes(5);
+    expect(mockCaptureMessage).toHaveBeenCalledTimes(1);
+    expect(mockCaptureMessage).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        level: "error",
+        tags: expect.objectContaining({ reason: "url_mismatch" }),
       }),
-    ).rejects.toThrow(/verification failed after 3 attempts/);
-    expect(setWebhook).toHaveBeenCalledTimes(3);
-    expect(getWebhookInfo).toHaveBeenCalledTimes(3);
+    );
   });
 });
 

--- a/tools/console/src/openclaw/bootstrap.ts
+++ b/tools/console/src/openclaw/bootstrap.ts
@@ -30,22 +30,39 @@ const MIN_SECRET_LEN = 32;
 const SECRET_RE = /^[A-Za-z0-9_-]+$/;
 
 /**
- * W4.1 hardening (docs/deploy/console.md, observed 2026-05-03 21:26 UTC):
- * during the first long-poll → webhook migration, the old long-poll
- * container's graceful-shutdown `getUpdates` raced with the new
- * container's `setWebhook` and silently cleared the webhook on
- * Telegram's side (`getWebhookInfo` then returned `url=""`). The bot
- * accepted updates again only after a manual second `setWebhook`.
+ * W4.1 / B.6 hardening (sprint-roadmap O6, tg-improvements-roadmap
+ * §4.4, observed 2026-05-03 21:26 UTC):
  *
- * To make this self-healing on every redeploy, after `setWebhook` we
- * verify with `getWebhookInfo` that Telegram actually retained the URL
- * we just set, and retry up to N times with exponential backoff if the
- * stored URL is wrong / empty. Caps total wall time so a permanent
- * Telegram outage doesn't block container start indefinitely.
+ * Two failure-modes are folded into one retry loop:
+ *
+ *   1. **URL-mismatch race.** During the first long-poll → webhook
+ *      migration, the old long-poll container's graceful-shutdown
+ *      `getUpdates` raced with the new container's `setWebhook` and
+ *      silently cleared the webhook on Telegram's side
+ *      (`getWebhookInfo` then returned `url=""`). The bot accepted
+ *      updates again only after a manual second `setWebhook`.
+ *   2. **Transient Telegram API outage at cold start.** A single
+ *      `setWebhook` call at boot used to be optimistic — if
+ *      `api.telegram.org` was unreachable for ~1s the bot started
+ *      _without_ a webhook and the operator only noticed when an
+ *      update never arrived. Now we retry both the `setWebhook` AND
+ *      the `getWebhookInfo` verification on any thrown error.
+ *
+ * Caps total wall time so a permanent Telegram outage doesn't block
+ * container start indefinitely (sum of the schedule below ≈ 48s).
  */
-const WEBHOOK_VERIFY_MAX_ATTEMPTS = 3;
-const WEBHOOK_VERIFY_BASE_DELAY_MS = 500;
-const WEBHOOK_VERIFY_MAX_DELAY_MS = 4_000;
+const WEBHOOK_VERIFY_MAX_ATTEMPTS = 5;
+/**
+ * Exponential backoff schedule applied _between_ attempts. With
+ * {@link WEBHOOK_VERIFY_MAX_ATTEMPTS} = 5 we use indices `0..3`
+ * (cumulative wall ≈ 18s). Index `4` (30s) is reserved so we can bump
+ * `MAX_ATTEMPTS` to 6 in the future without touching the constants.
+ *
+ * Ordered to match the user-spec — `[1s, 2s, 5s, 10s, 30s]`.
+ */
+const WEBHOOK_VERIFY_BACKOFF_DELAYS_MS = [
+  1_000, 2_000, 5_000, 10_000, 30_000,
+] as const;
 
 /**
  * Validate a `(url, secretToken)` pair the way Telegram does, _before_
@@ -90,15 +107,38 @@ function sleep(ms: number): Promise<void> {
 }
 
 /**
+ * Stringify an error for logs / Sentry breadcrumb. We deliberately do
+ * NOT include `err.stack` — Sentry already attaches the stack via
+ * `captureMessage` extras and a 4 KiB breadcrumb is too noisy.
+ */
+function errMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return typeof err === "string" ? err : JSON.stringify(err);
+}
+
+/**
  * Register the webhook with Telegram. Drops any pending updates queued
  * during long-poll mode so the founder doesn't receive a flood of stale
  * messages on the first boot after migration.
  *
  * After `setWebhook` we read back `getWebhookInfo` and confirm the URL
- * stuck — see W4.1 race comment above. On mismatch we retry the
- * `setWebhook` call (max {@link WEBHOOK_VERIFY_MAX_ATTEMPTS} attempts).
- * Verification failures are thrown so caller (`tools/console/src/index.ts`)
- * can decide between `process.exit(1)` and falling back to long-poll.
+ * stuck — see W4.1 / B.6 race + outage comments above. On mismatch OR
+ * any thrown error from the Telegram API we retry the whole pair (max
+ * {@link WEBHOOK_VERIFY_MAX_ATTEMPTS} attempts, backoff per
+ * {@link WEBHOOK_VERIFY_BACKOFF_DELAYS_MS}). Verification exhaustion
+ * is thrown so caller (`tools/console/src/index.ts`) can decide between
+ * `process.exit(1)` and falling back to long-poll.
+ *
+ * Observability:
+ *
+ *   - Each retry emits a `level="warning"` Sentry breadcrumb with the
+ *     failure reason (`api_error` vs `url_mismatch`).
+ *   - Final exhaustion emits a `level="error"` `Sentry.captureMessage`
+ *     so on-call sees "webhook never registered" as a first-class
+ *     Sentry issue (not just a process crash).
+ *   - Successful recovery after any retry still emits the existing
+ *     `[openclaw] webhook recovered after race` breadcrumb for parity
+ *     with W4.1.
  */
 export async function registerOpenClawWebhook(
   bot: Bot,
@@ -106,37 +146,91 @@ export async function registerOpenClawWebhook(
 ): Promise<void> {
   validateWebhookConfig(config);
   let lastInfoUrl = "";
+  let lastFailureReason: "api_error" | "url_mismatch" = "url_mismatch";
+  let lastApiError: string | undefined;
   for (let attempt = 1; attempt <= WEBHOOK_VERIFY_MAX_ATTEMPTS; attempt += 1) {
-    await bot.api.setWebhook(config.url, {
-      secret_token: config.secretToken,
-      drop_pending_updates: attempt === 1,
-      allowed_updates: ["message", "callback_query"],
-    });
-    const info = await bot.api.getWebhookInfo();
-    lastInfoUrl = info.url ?? "";
-    if (lastInfoUrl === config.url) {
-      if (attempt > 1) {
-        Sentry.addBreadcrumb({
-          category: "openclaw.webhook",
-          message: `[openclaw] webhook recovered after race (attempt ${attempt})`,
-          level: "info",
-          data: { url: config.url, attempt },
-        });
+    try {
+      await bot.api.setWebhook(config.url, {
+        secret_token: config.secretToken,
+        drop_pending_updates: attempt === 1,
+        allowed_updates: ["message", "callback_query"],
+      });
+      const info = await bot.api.getWebhookInfo();
+      lastInfoUrl = info.url ?? "";
+      if (lastInfoUrl === config.url) {
+        if (attempt > 1) {
+          Sentry.addBreadcrumb({
+            category: "openclaw.webhook",
+            message: `[openclaw] webhook recovered after race (attempt ${attempt})`,
+            level: "info",
+            data: { url: config.url, attempt },
+          });
+        }
+        return;
       }
-      return;
+      lastFailureReason = "url_mismatch";
+      lastApiError = undefined;
+    } catch (err) {
+      lastFailureReason = "api_error";
+      lastApiError = errMessage(err);
     }
     if (attempt >= WEBHOOK_VERIFY_MAX_ATTEMPTS) break;
-    const delayMs = Math.min(
-      WEBHOOK_VERIFY_BASE_DELAY_MS * 2 ** (attempt - 1),
-      WEBHOOK_VERIFY_MAX_DELAY_MS,
-    );
+    const delayMs =
+      WEBHOOK_VERIFY_BACKOFF_DELAYS_MS[attempt - 1] ??
+      WEBHOOK_VERIFY_BACKOFF_DELAYS_MS[
+        WEBHOOK_VERIFY_BACKOFF_DELAYS_MS.length - 1
+      ] ??
+      1_000;
+    const reasonDetail =
+      lastFailureReason === "api_error"
+        ? `api_error=${lastApiError ?? "<unknown>"}`
+        : `expected=${config.url} actual=${lastInfoUrl || "<empty>"}`;
+    Sentry.addBreadcrumb({
+      category: "openclaw.webhook",
+      message: `[openclaw] setWebhook retry (attempt ${attempt}/${WEBHOOK_VERIFY_MAX_ATTEMPTS}, reason=${lastFailureReason})`,
+      level: "warning",
+      data: {
+        url: config.url,
+        attempt,
+        maxAttempts: WEBHOOK_VERIFY_MAX_ATTEMPTS,
+        delayMs,
+        reason: lastFailureReason,
+        ...(lastApiError ? { apiError: lastApiError } : {}),
+      },
+    });
     console.warn(
-      `[openclaw] getWebhookInfo url mismatch after setWebhook ` +
+      `[openclaw] setWebhook ${lastFailureReason} ` +
         `(attempt ${attempt}/${WEBHOOK_VERIFY_MAX_ATTEMPTS}). ` +
-        `expected=${config.url} actual=${lastInfoUrl || "<empty>"}. ` +
-        `retrying in ${delayMs}ms (W4.1 race).`,
+        `${reasonDetail}. retrying in ${delayMs}ms (W4.1/B.6).`,
     );
     await sleep(delayMs);
+  }
+  // All attempts exhausted — surface to Sentry at error-level so
+  // on-call sees "webhook never registered" instead of just a process
+  // crash log line on Railway.
+  Sentry.captureMessage(
+    `[openclaw] setWebhook failed after ${WEBHOOK_VERIFY_MAX_ATTEMPTS} attempts`,
+    {
+      level: "error",
+      tags: {
+        module: "openclaw",
+        op: "setWebhook",
+        reason: lastFailureReason,
+      },
+      extra: {
+        url: config.url,
+        attempts: WEBHOOK_VERIFY_MAX_ATTEMPTS,
+        lastInfoUrl: lastInfoUrl || null,
+        lastApiError: lastApiError ?? null,
+      },
+    },
+  );
+  if (lastFailureReason === "api_error") {
+    throw new Error(
+      `OpenClaw webhook registration failed after ${WEBHOOK_VERIFY_MAX_ATTEMPTS} attempts: ` +
+        `Telegram API error — ${lastApiError ?? "<unknown>"}. ` +
+        `Check api.telegram.org reachability + OPENCLAW_BOT_TOKEN, then redeploy.`,
+    );
   }
   throw new Error(
     `OpenClaw webhook verification failed after ${WEBHOOK_VERIFY_MAX_ATTEMPTS} attempts: ` +


### PR DESCRIPTION
## Summary

Implements **O6** з [`docs/planning/sprint-roadmap-q2q3-2026.md`](docs/planning/sprint-roadmap-q2q3-2026.md) §1.2 (B.6) / [`docs/launch/tech/telegram-improvements-roadmap.md`](docs/launch/tech/telegram-improvements-roadmap.md) §4.4 / §3.5.1 (W4.1). Hardening of OpenClaw bot cold-start `setWebhook` call against transient Telegram API outages.

**Previously:** `registerOpenClawWebhook` уже retry-їв до 3× на URL-mismatch race (W4.1). АЛЕ будь-яка `setWebhook` / `getWebhookInfo` throw (ETIMEDOUT, ECONNREFUSED, 5xx) пропагувалась негайно — бот тихо стартував без webhook-а, якщо `api.telegram.org` був недосяжний ~1s на boot. Operator помічав це коли update вже ніколи не приходив.

**Now:** обидва failure-modes (url-mismatch race + API throw) злиті в одну retry-loop з 5 attempts і explicit exp-backoff schedule `[1s, 2s, 5s, 10s, 30s]`. Cumulative wall ≈ 18s (індекси 0..3 з 5-elem array); індекс 4 (30s) reserved щоб `MAX_ATTEMPTS=6` був one-line-bump.

### Observability

- Кожен retry → `level="warning"` Sentry breadcrumb з `{attempt, maxAttempts, delayMs, reason: "api_error" | "url_mismatch", apiError?}`.
- Successful recovery → existing `level="info"` `[openclaw] webhook recovered after race` (backwards-compat).
- Final exhaustion → `level="error"` `Sentry.captureMessage` з tags `{module: "openclaw", op: "setWebhook", reason}` + extras → on-call бачить "webhook never registered" як first-class Sentry-issue, не просто Railway-log-line.

## Governing Skill

- Primary skill: [`.agents/skills/sergeant-tools-console/SKILL.md`](.agents/skills/sergeant-tools-console/SKILL.md) (якщо існує — інакше fallback до root AGENTS.md для `tools/console`)
- Secondary skill: n/a — bootstrap.ts touch локальний, без cross-cutting concerns

## Playbook

- Primary playbook: n/a — bug-fix-style hardening, no existing playbook
- Why this playbook: n/a
- If no playbook matched, why: Спеціальний bootstrap retry pattern; якщо подібний pattern повториться, можна fold у новий `tools-console-bootstrap` playbook

## Verification

```bash
pnpm prettier --check tools/console/src/openclaw/bootstrap.ts tools/console/src/openclaw/bootstrap.test.ts
#   → All matched files use Prettier code style!
pnpm --filter @sergeant/console lint           # 0 errors, 0 warnings
pnpm --filter @sergeant/console typecheck      # OK
pnpm --filter @sergeant/console test           # 24 files, 331 tests passed
```

Additional checks:

- [x] Local smoke / manual validation completed (mocked Bot + vi.useFakeTimers + 19 bootstrap tests covering all branches: happy / 2-retry recovery / 5-attempt exhaustion / api_error / url_mismatch / breadcrumb levels)
- [x] Surface-specific checks completed (Sentry-no-op gracefully via `obs/sentry.ts` без DSN; `console.warn` для Railway logs; no PII leakage in breadcrumb data)

## Docs and Governance

- [x] Updated module-level JSDoc (W4.1 → W4.1/B.6 з description обох failure-modes + observability section)
- [x] Checked `AGENTS.md` — no updates needed (bot-bootstrap не cross-cutting)
- [x] Checked playbook / skill — no playbook for bootstrap retry yet
- [x] Checked governance docs — no updates needed; tg-improvements-roadmap §3.5.1 acceptance-criteria всі покриті

Updated docs:

- `tools/console/src/openclaw/bootstrap.ts` module-level JSDoc

## Risk and Rollout

**User-visible risk:** Дуже низький.

- Pure code-path change inside the bot's cold-start path. Не змінює зовнішніх контрактів (`/healthz`, `/webhook/openclaw`, env vars).
- При успішному cold-start (TG API доступне) — поведінка ідентична до попередньої версії (1 attempt, success, no retry, no breadcrumb).
- При flaky cold-start (TG transient outage) — replays додатково за 1s/2s/5s/10s. Worst-case wall = 18s до process exit замість instant exit.
- Sentry breadcrumb / captureMessage no-op без DSN (local dev / тестова Railway-environment).

**Rollout / deploy order:**
1. Merge PR → CI green → Railway redeploy console process автоматично.
2. Bot bootstrap використовує новий retry-flow.
3. Якщо TG API healthy — поведінка the same. Якщо ні — recovery в межах 18s.

**Backout plan:**
- Revert PR. Старий 3-attempt flow повертається.
- Без міграцій / без env-changes — instant rollback.

## Hard Rule #15

- [x] Прочитав AGENTS.md перед coding.
- [x] Internal docs (JSDoc українською у частині sections, English там де технічні терміни — слідую existing file convention).
- [x] Не використовував `--no-verify` (Husky lint-staged + commitlint пройшли; залишилось одне footer-blank warning від `Co-Authored-By` — non-blocking).

## Audit-freeze (until 2026-06-02)

- [x] Цей PR не додає нових top-level audit/initiative/playbook/ADR файлів — лише 2 файла-зміни у `tools/console/src/openclaw/`.

## Reviewer Notes

- **Backoff schedule semantics:** `BACKOFF_DELAYS_MS = [1s, 2s, 5s, 10s, 30s]` має 5 значень, але з `MAX_ATTEMPTS=5` використовуються лише індекси `0..3`. Документую в JSDoc: 30s reserved for future `MAX_ATTEMPTS=6` bump. Якщо preference — використати всі 5, треба бампнути MAX_ATTEMPTS до 6 (1 initial + 5 retries) — будь-який варіант приемний, поточний реалізую "5 attempts" literal interpretation.
- **Fake timers in tests:** Real backoff = 18s wall, неможливо тестувати під 5s timeout. Helper `settleWithFakeTimers` зливає `.then(succ, fail)` щоб уникнути unhandled-rejection warnings під час draining. Дослівно — це pattern з vitest docs для async retry loops.
- **Sentry `captureMessage`** уже використовується в `obs/sentry.ts`-namespace patterns (PR-05 / PR-14). Зі своїм же `@sentry/node` SDK exposed namespace, тести mock-ають `captureMessage` поруч з `addBreadcrumb`.
- **No env-changes / no migrations** — суто code-path hardening.

Link to Devin session: https://app.devin.ai/sessions/2765108a015c48038fe4a3bbfd851a0c

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens OpenClaw bot startup by adding a unified poll-and-retry flow for Telegram `setWebhook`. Handles both URL mismatch and transient API errors with up to 5 attempts, improving reliability and surfacing failures to Sentry.

- **New Features**
  - Unified retry loop for `setWebhook` + `getWebhookInfo`: 5 attempts with backoff [1s, 2s, 5s, 10s, 30s] (first 4 used; ~18s wall).
  - Retries on `url_mismatch` and on thrown API errors (e.g., ETIMEDOUT, ECONNREFUSED).
  - Sentry: warning breadcrumb on each retry; info breadcrumb on recovery; error `captureMessage` on final failure with tags/extras.
  - No external API changes, env changes, or migrations; healthy starts behave the same.

<sup>Written for commit 100ffaf3866f4bbcf71db2706d259c83a76b1304. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

