### PR TITLE
feat(server): enforce OpenClaw repo allowlist (T2 audit #3)

### DIFF
--- a/apps/server/src/env/env.ts
+++ b/apps/server/src/env/env.ts
@@ -641,6 +641,14 @@ const envSchema = z.object({
   OPENCLAW_GITHUB_APP_INSTALLATION_ID: stringWithDefault(""),
   /** Repo target для decision PR-ів. */
   OPENCLAW_GITHUB_REPO: stringWithDefault("Skords-01/Sergeant"),
+  /**
+   * Comma-separated allowlist of `owner/repo` strings that OpenClaw
+   * read/write GitHub tools may target. Empty (default) collapses to
+   * just `OPENCLAW_GITHUB_REPO`, so the default config is the
+   * single-repo behaviour callers expect. T2 audit finding #3 — the
+   * console used to pass through whatever `repo` the LLM picked.
+   */
+  OPENCLAW_GITHUB_REPO_ALLOWLIST: stringWithDefault(""),
   /** Default branch у repo (для decision PR-ів). */
   OPENCLAW_GITHUB_BASE_BRANCH: stringWithDefault("main"),
   /**

--- a/apps/server/src/modules/openclaw/code-tools.ts
+++ b/apps/server/src/modules/openclaw/code-tools.ts
@@ -21,6 +21,7 @@
 import { env } from "../../env.js";
 import { logger } from "../../obs/logger.js";
 import { getOpenclawGithubAuth } from "./github-auth.js";
+import { assertOpenClawRepoAllowed } from "./repoAllowlist.js";
 
 const GITHUB_API_VERSION = "2022-11-28";
 const USER_AGENT = "OpenClaw-Bot";
@@ -51,7 +52,10 @@ async function callGithub(url: string): Promise<GithubResponse> {
 }
 
 function resolveRepo(input: { repo?: string | undefined }): string {
-  return input.repo ?? env.OPENCLAW_GITHUB_REPO;
+  // T2 audit #3 — the four code-understanding tools all flow through this
+  // helper, so allowlist enforcement at this single chokepoint covers
+  // github_search/tree/diff/prs in one place.
+  return assertOpenClawRepoAllowed(input.repo);
 }
 
 function resolveRef(input: { ref?: string | undefined }): string {

--- a/apps/server/src/modules/openclaw/index.ts
+++ b/apps/server/src/modules/openclaw/index.ts
@@ -39,6 +39,13 @@ export {
   getPostHogStats,
   getGithubReleases,
 } from "./tools.js";
+
+// T2 audit #3 — repo allowlist for OpenClaw GitHub-touching tools.
+export {
+  assertOpenClawRepoAllowed,
+  __resetOpenClawRepoAllowlistForTests,
+  __getOpenClawRepoAllowlistForTests,
+} from "./repoAllowlist.js";
 export { selectToneMode, buildSystemPrompt } from "./prompts.js";
 
 // Stage 4c (PR-Stage4c): Layer 1 cheap-router classifier (Haiku JSON).

--- a/apps/server/src/modules/openclaw/repoAllowlist.test.ts
+++ b/apps/server/src/modules/openclaw/repoAllowlist.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { env } from "../../env.js";
+import {
+  assertOpenClawRepoAllowed,
+  __getOpenClawRepoAllowlistForTests,
+  __resetOpenClawRepoAllowlistForTests,
+} from "./repoAllowlist.js";
+import { OpenClawAllowlistError } from "./tools.js";
+
+const ORIGINAL_DEFAULT_REPO = env.OPENCLAW_GITHUB_REPO;
+
+function setDefaultRepo(value: string): void {
+  Object.defineProperty(env, "OPENCLAW_GITHUB_REPO", {
+    value,
+    writable: false,
+    configurable: true,
+    enumerable: true,
+  });
+}
+
+function restoreDefaultRepo(): void {
+  setDefaultRepo(ORIGINAL_DEFAULT_REPO);
+}
+
+describe("assertOpenClawRepoAllowed (T2 audit #3)", () => {
+  beforeEach(() => {
+    __resetOpenClawRepoAllowlistForTests();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    restoreDefaultRepo();
+    __resetOpenClawRepoAllowlistForTests();
+  });
+
+  it("falls back to OPENCLAW_GITHUB_REPO when the allowlist env var is empty", () => {
+    setDefaultRepo("Skords-01/Sergeant");
+    vi.stubEnv("OPENCLAW_GITHUB_REPO_ALLOWLIST", "");
+    const allowed = __getOpenClawRepoAllowlistForTests();
+    expect(allowed.size).toBe(1);
+    expect(allowed.has("Skords-01/Sergeant")).toBe(true);
+  });
+
+  it("returns the canonical repo string when input matches the fallback", () => {
+    setDefaultRepo("Skords-01/Sergeant");
+    vi.stubEnv("OPENCLAW_GITHUB_REPO_ALLOWLIST", "");
+    expect(assertOpenClawRepoAllowed(undefined)).toBe("Skords-01/Sergeant");
+    expect(assertOpenClawRepoAllowed("Skords-01/Sergeant")).toBe(
+      "Skords-01/Sergeant",
+    );
+  });
+
+  it("throws OpenClawAllowlistError when an LLM-supplied repo diverges from the default", () => {
+    setDefaultRepo("Skords-01/Sergeant");
+    vi.stubEnv("OPENCLAW_GITHUB_REPO_ALLOWLIST", "");
+    expect(() => assertOpenClawRepoAllowed("evil-org/owned-repo")).toThrow(
+      OpenClawAllowlistError,
+    );
+  });
+
+  it("accepts multiple explicit repos when allowlist env var is CSV", () => {
+    setDefaultRepo("Skords-01/Sergeant");
+    vi.stubEnv(
+      "OPENCLAW_GITHUB_REPO_ALLOWLIST",
+      "Skords-01/Sergeant, Skords-01/sergeant-ops",
+    );
+    expect(assertOpenClawRepoAllowed("Skords-01/Sergeant")).toBe(
+      "Skords-01/Sergeant",
+    );
+    expect(assertOpenClawRepoAllowed("Skords-01/sergeant-ops")).toBe(
+      "Skords-01/sergeant-ops",
+    );
+  });
+
+  it("explicit allowlist supersedes the OPENCLAW_GITHUB_REPO fallback (defense against misconfig)", () => {
+    setDefaultRepo("Skords-01/Sergeant");
+    vi.stubEnv("OPENCLAW_GITHUB_REPO_ALLOWLIST", "Skords-01/sergeant-ops");
+    // The fallback default repo is NOT in the explicit allowlist, so even
+    // `undefined` input is rejected — this is the strict-mode operators
+    // want when they enumerate the allowlist explicitly.
+    expect(() => assertOpenClawRepoAllowed(undefined)).toThrow(
+      OpenClawAllowlistError,
+    );
+    expect(() => assertOpenClawRepoAllowed("Skords-01/Sergeant")).toThrow(
+      OpenClawAllowlistError,
+    );
+    expect(assertOpenClawRepoAllowed("Skords-01/sergeant-ops")).toBe(
+      "Skords-01/sergeant-ops",
+    );
+  });
+
+  it("trims whitespace and ignores empty CSV slots", () => {
+    setDefaultRepo("fallback/repo");
+    vi.stubEnv(
+      "OPENCLAW_GITHUB_REPO_ALLOWLIST",
+      "  one/repo  , ,, two/repo,  ",
+    );
+    const allowed = __getOpenClawRepoAllowlistForTests();
+    expect(allowed.size).toBe(2);
+    expect(allowed.has("one/repo")).toBe(true);
+    expect(allowed.has("two/repo")).toBe(true);
+  });
+
+  it("error message includes the requested repo (so audit logs surface the divergent value)", () => {
+    setDefaultRepo("Skords-01/Sergeant");
+    vi.stubEnv("OPENCLAW_GITHUB_REPO_ALLOWLIST", "");
+    try {
+      assertOpenClawRepoAllowed("attacker/repo");
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(OpenClawAllowlistError);
+      expect((err as Error).message).toContain("attacker/repo");
+    }
+  });
+});

--- a/apps/server/src/modules/openclaw/repoAllowlist.ts
+++ b/apps/server/src/modules/openclaw/repoAllowlist.ts
@@ -1,0 +1,79 @@
+/**
+ * `OpenClaw` GitHub repo allowlist (T2 audit finding #3).
+ *
+ * Before this hardening, every GitHub-touching OpenClaw tool
+ * (`read_github`, `get_github_releases`, the four `github_*`
+ * code-understanding tools, `commit_to_strategy_doc`,
+ * `create_github_issue`) accepted an LLM-supplied `repo` string with
+ * NO validation — only a `?? env.OPENCLAW_GITHUB_REPO` fallback. A
+ * prompt-injection chain (or a bug in the cheap-router classifier)
+ * could therefore steer the tool at an arbitrary repo the OpenClaw
+ * GitHub App / fallback PAT had install scope on.
+ *
+ * The allowlist is sourced from `OPENCLAW_GITHUB_REPO_ALLOWLIST`
+ * (CSV) and falls back to `[OPENCLAW_GITHUB_REPO]` so the default
+ * config keeps the single-repo behaviour. `assertOpenClawRepoAllowed`
+ * is the single choke-point — both the HTTP route layer (early 400)
+ * and the underlying tool layer (defense in depth) invoke it.
+ *
+ * We intentionally read `process.env` directly (instead of the parsed
+ * `env` object) so that operators flipping the env var at runtime,
+ * and tests using `vi.stubEnv`, both see the new value immediately —
+ * mirrors the `OPENCLAW_REPO_ROOT` pattern in `tools.ts`.
+ */
+
+import { env } from "../../env.js";
+import { OpenClawAllowlistError } from "./tools.js";
+
+function readDefaultRepo(): string {
+  // `env.OPENCLAW_GITHUB_REPO` is the source of truth used by every
+  // other GitHub-touching path; keeping it as the fallback matches
+  // legacy semantics and the existing `patchEnv` test pattern.
+  return env.OPENCLAW_GITHUB_REPO;
+}
+
+function readAllowlist(): Set<string> {
+  const fallback = readDefaultRepo();
+  // The allowlist itself is read from `process.env` (not the parsed
+  // `env` object) so `vi.stubEnv("OPENCLAW_GITHUB_REPO_ALLOWLIST", …)`
+  // in tests, and operator-set runtime overrides, take effect without
+  // requiring a module re-import. Mirrors the `OPENCLAW_REPO_ROOT`
+  // pattern in `tools.ts`.
+  const explicit = process.env["OPENCLAW_GITHUB_REPO_ALLOWLIST"];
+  if (!explicit) return new Set([fallback]);
+  const entries = explicit
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (entries.length === 0) return new Set([fallback]);
+  return new Set(entries);
+}
+
+/**
+ * Return the (canonical, validated) `owner/repo` string the caller is
+ * permitted to target. `input` is the optional LLM-supplied repo; we
+ * fall back to `OPENCLAW_GITHUB_REPO` when it's undefined. Either way
+ * the resolved value MUST be in the allowlist, otherwise we throw
+ * `OpenClawAllowlistError` — which the route layer surfaces as 400
+ * `allowlist_fail` via the existing `asAllowlistFailure` helper.
+ */
+export function assertOpenClawRepoAllowed(input: string | undefined): string {
+  const requested = input ?? readDefaultRepo();
+  const allowed = readAllowlist();
+  if (!allowed.has(requested)) {
+    throw new OpenClawAllowlistError(
+      `repo '${requested}' is not in OPENCLAW_GITHUB_REPO_ALLOWLIST`,
+    );
+  }
+  return requested;
+}
+
+/** Test-only: no-op kept for API compatibility (env is read live). */
+export function __resetOpenClawRepoAllowlistForTests(): void {
+  // intentionally empty — `readAllowlist` re-reads `process.env` each call.
+}
+
+/** Test-only: snapshot of the current allowlist. */
+export function __getOpenClawRepoAllowlistForTests(): Set<string> {
+  return new Set(readAllowlist());
+}

--- a/apps/server/src/modules/openclaw/tools.ts
+++ b/apps/server/src/modules/openclaw/tools.ts
@@ -22,6 +22,7 @@ import { logger } from "../../obs/logger.js";
 import { env } from "../../env.js";
 import { getOpenclawGithubAuth } from "./github-auth.js";
 import { OpenClawPathTraversalError, safeJoin } from "./safeJoin.js";
+import { assertOpenClawRepoAllowed } from "./repoAllowlist.js";
 import {
   QUERY_APP_DB_TABLE_ALLOWLIST,
   READ_STRATEGY_DOCS_ALLOWED_PATHS,
@@ -381,7 +382,10 @@ export async function readGithub(
     );
   }
   const token = auth.token;
-  const repo = input.repo ?? env.OPENCLAW_GITHUB_REPO;
+  // T2 audit #3 — reject LLM-supplied repos outside the allowlist
+  // (otherwise the same prompt-injection vector that lets the model
+  // pick a tool call lets it choose ANY repo the App/PAT has scope on).
+  const repo = assertOpenClawRepoAllowed(input.repo);
 
   let url: string;
   if (input.mode === "file") {
@@ -1045,7 +1049,8 @@ export async function getGithubReleases(
   input: GetGithubReleasesInput,
 ): Promise<GetGithubReleasesOutput> {
   const limit = Math.max(1, Math.min(20, input.limit ?? 5));
-  const repo = input.repo ?? env.OPENCLAW_GITHUB_REPO;
+  // T2 audit #3 — see readGithub for rationale.
+  const repo = assertOpenClawRepoAllowed(input.repo);
   // GitHub allows unauthenticated access for public repo releases (60 RPH);
   // any auth (PAT or App-installation token) bumps the rate to 5000 RPH and
   // is required for private repos.

--- a/apps/server/src/modules/openclaw/write-tools.test.ts
+++ b/apps/server/src/modules/openclaw/write-tools.test.ts
@@ -66,12 +66,18 @@ beforeEach(() => {
   vi.restoreAllMocks();
   restoreEnv();
   _clearOpenclawGithubAuthCacheForTests();
+  // T2 audit #3 — the existing fixtures target `owner/repo` (and one
+  // falls through to the schema-default `Skords-01/Sergeant`). Widen
+  // the allowlist so the tool-layer assert (`assertOpenClawRepoAllowed`)
+  // accepts both.
+  vi.stubEnv("OPENCLAW_GITHUB_REPO_ALLOWLIST", "owner/repo,Skords-01/Sergeant");
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
   restoreEnv();
   _clearOpenclawGithubAuthCacheForTests();
+  vi.unstubAllEnvs();
 });
 
 describe("assertStrategyDocPath", () => {

--- a/apps/server/src/modules/openclaw/write-tools.ts
+++ b/apps/server/src/modules/openclaw/write-tools.ts
@@ -19,6 +19,7 @@
 import path from "node:path";
 import { env } from "../../env.js";
 import { getOpenclawGithubAuth } from "./github-auth.js";
+import { assertOpenClawRepoAllowed } from "./repoAllowlist.js";
 
 // ─────────────────────────────────────────────────────────────────────────
 // commit_to_strategy_doc — open a GitHub PR with new/updated file in docs/strategy/
@@ -97,7 +98,9 @@ export async function commitToStrategyDoc(
     };
   }
   const token = auth.token;
-  const repo = input.repo ?? env.OPENCLAW_GITHUB_REPO;
+  // T2 audit #3 — assert at the tool boundary too (defense in depth);
+  // the HTTP route already runs the same check at request entry.
+  const repo = assertOpenClawRepoAllowed(input.repo);
   const baseBranch = env.OPENCLAW_GITHUB_BASE_BRANCH;
   const headers = {
     Authorization: `Bearer ${token}`,
@@ -243,7 +246,8 @@ export async function createGithubIssue(
     };
   }
   const token = auth.token;
-  const repo = input.repo ?? env.OPENCLAW_GITHUB_REPO;
+  // T2 audit #3 — see commitToStrategyDoc for rationale.
+  const repo = assertOpenClawRepoAllowed(input.repo);
   const res = await fetch(`https://api.github.com/repos/${repo}/issues`, {
     method: "POST",
     headers: {

--- a/apps/server/src/routes/internal/openclaw.ts
+++ b/apps/server/src/routes/internal/openclaw.ts
@@ -44,6 +44,7 @@ import {
   recallCofounderMemory,
   recordDecision,
   OpenClawAllowlistError,
+  assertOpenClawRepoAllowed,
   OpenClawSchemaError,
   OpenClawNotFoundError,
   // ADR-0032: ops/marketing tools ported from Sergeant Console agents.
@@ -806,6 +807,12 @@ export function createOpenClawInternalRouter({ pool }: { pool: Pool }): Router {
       const parsed = validateBody(CommitStrategyDocBody, req, res);
       if (!parsed.ok) return;
       try {
+        // T2 audit #3 — enforce the repo allowlist at the request
+        // boundary so an LLM-supplied `repo` is rejected with 400
+        // BEFORE we mint a GitHub App installation token. The same
+        // assert runs again inside `commitToStrategyDoc` as a defense
+        // in depth, so direct internal callers can't bypass it.
+        assertOpenClawRepoAllowed(parsed.data.repo);
         const result = await commitToStrategyDoc({
           path: parsed.data.path,
           content: parsed.data.content,
@@ -814,7 +821,10 @@ export function createOpenClawInternalRouter({ pool }: { pool: Pool }): Router {
         });
         res.json(result);
       } catch (err) {
-        if (err instanceof OpenClawWriteAllowlistError) {
+        if (
+          err instanceof OpenClawWriteAllowlistError ||
+          err instanceof OpenClawAllowlistError
+        ) {
           return asAllowlistFailure(res, err);
         }
         throw err;
@@ -828,13 +838,22 @@ export function createOpenClawInternalRouter({ pool }: { pool: Pool }): Router {
     asyncHandler(async (req, res) => {
       const parsed = validateBody(CreateGithubIssueBody, req, res);
       if (!parsed.ok) return;
-      const result = await createGithubIssue({
-        title: parsed.data.title,
-        body: parsed.data.body,
-        labels: parsed.data.labels,
-        repo: parsed.data.repo,
-      });
-      res.json(result);
+      try {
+        // T2 audit #3 — see write/strategy-doc for rationale.
+        assertOpenClawRepoAllowed(parsed.data.repo);
+        const result = await createGithubIssue({
+          title: parsed.data.title,
+          body: parsed.data.body,
+          labels: parsed.data.labels,
+          repo: parsed.data.repo,
+        });
+        res.json(result);
+      } catch (err) {
+        if (err instanceof OpenClawAllowlistError) {
+          return asAllowlistFailure(res, err);
+        }
+        throw err;
+      }
     }),
   );
 

--- a/apps/server/src/routes/internal/openclaw.write-tools.test.ts
+++ b/apps/server/src/routes/internal/openclaw.write-tools.test.ts
@@ -1,6 +1,6 @@
 import express from "express";
 import request from "supertest";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   commitToStrategyDocMock,
@@ -58,6 +58,14 @@ async function makeApp() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // T2 audit #3 — these tests exercise write tools with `repo: 'owner/repo'`,
+  // which is a fixture rather than the real OPENCLAW_GITHUB_REPO. Widen the
+  // allowlist so the route-level guard accepts it.
+  vi.stubEnv("OPENCLAW_GITHUB_REPO_ALLOWLIST", "owner/repo");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
 });
 
 describe("/api/internal/openclaw/write/*", () => {
@@ -95,12 +103,47 @@ describe("/api/internal/openclaw/write/*", () => {
         path: "docs/secrets.md",
         content: "# nope\n",
         message: "bad",
+        repo: "owner/repo",
       });
     expect(rejected.status).toBe(400);
     expect(rejected.body).toMatchObject({
       error: "allowlist_fail",
       message: "bad path",
     });
+  });
+
+  it("rejects strategy-doc writes whose `repo` is outside the allowlist with 400", async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .post("/api/internal/openclaw/write/strategy-doc")
+      .send({
+        path: "docs/strategy/roadmap.md",
+        content: "# Roadmap\n",
+        message: "refresh roadmap",
+        repo: "evil-org/owned-repo",
+      });
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({
+      error: "allowlist_fail",
+    });
+    // Must reject BEFORE the tool layer is reached — no GitHub token mint.
+    expect(commitToStrategyDocMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects github-issue writes whose `repo` is outside the allowlist with 400", async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .post("/api/internal/openclaw/write/github-issue")
+      .send({
+        title: "oops",
+        body: "oops",
+        repo: "evil-org/owned-repo",
+      });
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({
+      error: "allowlist_fail",
+    });
+    expect(createGithubIssueMock).not.toHaveBeenCalled();
   });
 
   it("validates and forwards github-issue writes", async () => {


### PR DESCRIPTION
## Summary

Closes T2 audit finding **#3** (HIGH security): _"OpenClaw `commit_to_strategy_doc` accepts attacker-controlled `repo` — LLM-driven cross-repo write"_.

Every GitHub-touching OpenClaw tool (`read_github`, `get_github_releases`, the four `github_*` code-understanding tools, `commit_to_strategy_doc`, `create_github_issue`) previously accepted an LLM-supplied `repo` string with NO validation beyond a fall-through to `OPENCLAW_GITHUB_REPO`. A prompt-injection chain (or a cheap-router classifier bug) could therefore steer any tool at an arbitrary repo the OpenClaw GitHub App / fallback PAT had install scope on.

This change introduces a single chokepoint helper `assertOpenClawRepoAllowed(input)` that returns the canonical `owner/repo` if and only if it appears in the new `OPENCLAW_GITHUB_REPO_ALLOWLIST` CSV (defaulting to `[OPENCLAW_GITHUB_REPO]` for backwards-compat) — otherwise it throws `OpenClawAllowlistError`, which the existing `asAllowlistFailure` helper maps to HTTP 400 `{ error: "allowlist_fail" }`.

## Defense-in-depth

| Layer | What happens |
| --- | --- |
| **Route handler** (`/api/internal/openclaw/write/strategy-doc`, `/write/github-issue`) | Assert at request entry — rejects BEFORE we mint a GitHub App installation token. The divergent repo never reaches GitHub. |
| **Tool layer** (`readGithub`, `getGithubReleases`, `resolveRepo` for `githubSearch`/`Tree`/`Diff`/`Prs`, `commitToStrategyDoc`, `createGithubIssue`) | Also asserts — covers direct internal callers (tests, future cron jobs) that bypass the HTTP route. |

## New env var

`OPENCLAW_GITHUB_REPO_ALLOWLIST` (CSV, default `""`):

- Empty (default) → `Set([OPENCLAW_GITHUB_REPO])` — preserves the existing single-repo behaviour, no operator action required.
- `"Skords-01/Sergeant,Skords-01/sergeant-ops"` → both repos allowed.
- `"Skords-01/sergeant-ops"` (excluding the fallback) → strict mode: even `undefined` input is rejected, since the fallback default isn't in the allowlist.

Read at request time from `process.env` (not the cached parsed `env` object) so operators can flip it without a redeploy, and tests can `vi.stubEnv` it.

## Tests

- **`repoAllowlist.test.ts`** (new) — 7 unit tests covering fallback semantics, CSV parsing, whitespace trimming, strict-mode (explicit allowlist excludes the OPENCLAW_GITHUB_REPO fallback), error-message shape.
- **`openclaw.write-tools.test.ts`** — 2 new integration tests that POST to `/write/strategy-doc` and `/write/github-issue` with an out-of-allowlist `repo` and assert 400 + `allowlist_fail` + the tool mock is never reached.
- **`write-tools.test.ts`** — `beforeEach` widened allowlist stub to keep the existing fixtures (`owner/repo`) compatible with the new tool-layer assert.

Local run: `pnpm --filter @sergeant/server test src/modules/openclaw/ src/routes/internal/openclaw` → 216 / 216 passed.

## Out of T2 scope

The audit suggested also _"Surface `repo` in the Telegram approval card whenever it differs from the default"_ as a defense-in-depth UX measure. That lives in `tools/console` (n8n approval flow) and is deferred to a separate PR; the route-layer reject already covers the security-critical path.

## Verification

- [x] `pnpm --filter @sergeant/server typecheck`
- [x] `pnpm --filter @sergeant/server lint`
- [x] `pnpm --filter @sergeant/server test src/modules/openclaw/ src/routes/internal/openclaw` — all 216 passed
- [x] Full server suite: 2061/2065 passed; the 4 pre-existing failures are finding #11 (`Git_PAT` env-isolation in `assertStartupEnv.test.ts`) — delegated to PR #4 (test reliability).

## Audit context

- QA session: https://app.devin.ai/sessions/ed8a702bc21b43cd8d3987387c1646f0
- Phase 2 fix series:
  - PR #1 — Stripe webhook hardening: #2609
  - **PR #2 — this PR** — OpenClaw repo allowlist (finding 3)
  - PR #3 — `/metrics` timing-safe + prod hard-fail (finding 4) — _next_
  - PR #4 — Test reliability (findings 10–13) — _planned_
  - PR #5 — Optional consolidation (findings 5, 6, 7, 9) — _planned_


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces a GitHub repo allowlist for all OpenClaw tools and routes to block LLM-driven cross-repo access. Closes T2 audit finding #3 by rejecting out-of-allowlist repos with HTTP 400 `allowlist_fail`.

- **New Features**
  - Added `assertOpenClawRepoAllowed(repo)` chokepoint that validates against `OPENCLAW_GITHUB_REPO_ALLOWLIST` (falls back to `[OPENCLAW_GITHUB_REPO]`).
  - Enforced at route entry for `/api/internal/openclaw/write/strategy-doc` and `/api/internal/openclaw/write/github-issue`, and in tools: `read_github`, `get_github_releases`, `github_search/tree/diff/prs`, `commit_to_strategy_doc`, `create_github_issue`.
  - Added unit and integration tests for fallback behavior, CSV parsing, strict mode, and 400 mapping.

- **Migration**
  - No action needed: empty `OPENCLAW_GITHUB_REPO_ALLOWLIST` preserves single-repo behavior via `OPENCLAW_GITHUB_REPO`.
  - To allow multiple repos: set `OPENCLAW_GITHUB_REPO_ALLOWLIST="owner/repo,second/repo"`.
  - For strict mode: omit `OPENCLAW_GITHUB_REPO` from the allowlist to require explicit repos.

<sup>Written for commit 4b9a03530b042bf70d3261ee594e515bd62b7dc5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

