### PR TITLE
refactor(server): wire LLMProvider у OpenClaw classify (read-only fallback) [PR-24]

### DIFF
--- a/apps/server/src/env/env.ts
+++ b/apps/server/src/env/env.ts
@@ -352,6 +352,22 @@ const envSchema = z.object({
   LLM_PROVIDER: z
     .enum(["anthropic", "openrouter", "stub"])
     .default("anthropic"),
+  /**
+   * PR-24 — окремий provider для read-only OpenClaw paths (зараз: `before_dispatch`
+   * classify; пізніше — інші read-only flows). Дозволяє перемкнути саме classifier
+   * у `stub`-mode (повертає plausible default `{"class":"chat"}`) НЕ зачіпаючи
+   * головний `LLM_PROVIDER`, який обслуговує chat/coach/nutrition.
+   *
+   * Use-cases:
+   * - Anthropic-incident: `LLM_READONLY_PROVIDER=stub` тимчасово; chat-flow
+   *   обслуговується головним provider-ом окремо (PR-25 wires weekly-digest).
+   * - Local-dev без `ANTHROPIC_API_KEY` — class-detection деградує у `chat`,
+   *   решта endpoints працює як раніше.
+   * - E2E-тести — детермінований шлях без витрат токенів.
+   */
+  LLM_READONLY_PROVIDER: z
+    .enum(["anthropic", "openrouter", "stub"])
+    .default("anthropic"),
   /** AI request timeout (мс). */
   AI_TIMEOUT_MS: intFromEnv(180_000),
   /** Max AI retries on transient errors. */

--- a/apps/server/src/lib/llm/provider.test.ts
+++ b/apps/server/src/lib/llm/provider.test.ts
@@ -16,9 +16,11 @@ import { anthropicMessages as anthropicMessagesMock } from "../anthropic.js";
 import {
   AnthropicProvider,
   getLLMProvider,
+  invokeLLM,
   StubProvider,
   type LLMGenerateOpts,
   type LLMGenerateResult,
+  type LLMProvider,
 } from "./provider.js";
 
 type AnthropicMock = ReturnType<typeof vi.fn> & {
@@ -273,5 +275,141 @@ describe("getLLMProvider factory", () => {
     const p = getLLMProvider();
     // Test runs without real ANTHROPIC_API_KEY → factory повертає stub.
     expect(p.name).toBe("stub");
+  });
+});
+
+describe("invokeLLM observability wrapper (PR-24)", () => {
+  function fakeProvider(
+    name: "anthropic" | "stub" | "openrouter",
+    result: LLMGenerateResult,
+  ): LLMProvider {
+    return {
+      name,
+      generate: () => Promise.resolve(result),
+    };
+  }
+
+  it("emits Sentry breadcrumb з category=llm.provider на ok-path", async () => {
+    const breadcrumbs: Array<{
+      category: string;
+      level: string;
+      data: Record<string, unknown>;
+    }> = [];
+
+    const result = await invokeLLM(
+      fakeProvider("anthropic", { ok: true, text: "hello" }),
+      { ...baseOpts({ endpoint: "internal/test" }) },
+      { addBreadcrumb: (b) => breadcrumbs.push(b) },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(breadcrumbs).toHaveLength(1);
+    expect(breadcrumbs[0]).toMatchObject({
+      category: "llm.provider",
+      level: "info",
+      data: {
+        provider: "anthropic",
+        endpoint: "internal/test",
+        outcome: "ok",
+        model: "claude-haiku-4-5-20251001",
+      },
+    });
+  });
+
+  it("emits Sentry breadcrumb level=warning + code/error на error-path", async () => {
+    const breadcrumbs: Array<{
+      level: string;
+      data: Record<string, unknown>;
+    }> = [];
+
+    const result = await invokeLLM(
+      fakeProvider("anthropic", {
+        ok: false,
+        error: "boom",
+        code: "anthropic_error",
+        status: 502,
+      }),
+      { ...baseOpts({ endpoint: "internal/test" }) },
+      { addBreadcrumb: (b) => breadcrumbs.push(b) },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(breadcrumbs[0]).toMatchObject({
+      level: "warning",
+      data: {
+        outcome: "error",
+        code: "anthropic_error",
+        error: "boom",
+      },
+    });
+  });
+
+  it("outcome=missing_api_key коли AnthropicProvider не має ключа", async () => {
+    const breadcrumbs: Array<{
+      data: Record<string, unknown>;
+    }> = [];
+    const provider = new AnthropicProvider("");
+    await invokeLLM(
+      provider,
+      { ...baseOpts({ endpoint: "internal/test" }) },
+      { addBreadcrumb: (b) => breadcrumbs.push(b) },
+    );
+    expect(breadcrumbs[0]?.data).toMatchObject({
+      outcome: "missing_api_key",
+      code: "missing_api_key",
+    });
+  });
+
+  it("outcome=rate_limited при code=rate_limited", async () => {
+    const breadcrumbs: Array<{ data: Record<string, unknown> }> = [];
+    await invokeLLM(
+      fakeProvider("anthropic", {
+        ok: false,
+        error: "429",
+        code: "rate_limited",
+        status: 429,
+      }),
+      { ...baseOpts({ endpoint: "internal/test" }) },
+      { addBreadcrumb: (b) => breadcrumbs.push(b) },
+    );
+    expect(breadcrumbs[0]?.data).toMatchObject({ outcome: "rate_limited" });
+  });
+
+  it("outcome=timeout при code=timeout (AbortError)", async () => {
+    const breadcrumbs: Array<{ data: Record<string, unknown> }> = [];
+    await invokeLLM(
+      fakeProvider("anthropic", {
+        ok: false,
+        error: "aborted",
+        code: "timeout",
+      }),
+      { ...baseOpts({ endpoint: "internal/test" }) },
+      { addBreadcrumb: (b) => breadcrumbs.push(b) },
+    );
+    expect(breadcrumbs[0]?.data).toMatchObject({ outcome: "timeout" });
+  });
+
+  it("endpoint default-иться на 'unknown' коли opts.endpoint не передано", async () => {
+    const breadcrumbs: Array<{ data: Record<string, unknown> }> = [];
+    await invokeLLM(
+      fakeProvider("stub", { ok: true, text: "ok" }),
+      baseOpts(),
+      { addBreadcrumb: (b) => breadcrumbs.push(b) },
+    );
+    expect(breadcrumbs[0]?.data).toMatchObject({ endpoint: "unknown" });
+  });
+
+  it("повертає той самий result без модифікації (метрики — sidecar)", async () => {
+    const fixed: LLMGenerateResult = {
+      ok: true,
+      text: "hello",
+      usage: { inputTokens: 11, outputTokens: 22 },
+    };
+    const result = await invokeLLM(
+      fakeProvider("anthropic", fixed),
+      baseOpts(),
+      { addBreadcrumb: () => {} },
+    );
+    expect(result).toEqual(fixed);
   });
 });

--- a/apps/server/src/lib/llm/provider.ts
+++ b/apps/server/src/lib/llm/provider.ts
@@ -16,6 +16,8 @@
 // мають інші вимоги до latency / outcome-tracking.
 
 import { env } from "../../env/env.js";
+import { llmProviderInvocationsTotal } from "../../obs/metrics.js";
+import { Sentry } from "../../sentry.js";
 import { anthropicMessages, extractAnthropicText } from "../anthropic.js";
 
 /**
@@ -295,4 +297,99 @@ export function getLLMProvider(
     return new StubProvider(override.stubResponse);
   }
   return new AnthropicProvider(apiKey);
+}
+
+// ─── Observability wrapper ───────────────────────────────────────────
+// PR-24: wraps `provider.generate()` зі стандартизованими Prometheus +
+// Sentry-breadcrumb-сигналами. Це — єдина точка, де провайдер-абстракція
+// зустрічається з observability-шаром, тому що `LLMProvider` сам по собі
+// має бути pure (jaak-test-able), а instrumentation залежить від
+// runtime-side-effects (prom-client registry, Sentry hub).
+//
+// Виклик через `invokeLLM(provider, opts)` замість прямого `provider.generate(opts)`:
+//   - інкрементує `llm_provider_invocations_total{provider, endpoint, outcome}`;
+//   - кладе Sentry breadcrumb (`category="llm.provider"`) з outcome/code.
+//
+// Outcome-мапа:
+//   ok            — provider повернув `ok: true`
+//   missing_api_key — AnthropicProvider не зміг (apiKey=='')
+//   rate_limited  — code='rate_limited' (HTTP 429)
+//   timeout       — code='timeout' (AbortError)
+//   error         — будь-який інший failure
+
+/**
+ * Тип callback-а для тестів — дозволяє підмінити breadcrumb-emitter без
+ * stub-ування глобального Sentry. У production — `Sentry.addBreadcrumb`.
+ */
+export type LLMBreadcrumbFn = (b: {
+  category: string;
+  level: "info" | "warning" | "error";
+  message: string;
+  data: Record<string, unknown>;
+}) => void;
+
+export interface InvokeLLMOptions {
+  /** Override Sentry breadcrumb emitter (for tests). */
+  addBreadcrumb?: LLMBreadcrumbFn;
+}
+
+function outcomeFromResult(result: LLMGenerateResult): string {
+  if (result.ok) return "ok";
+  if (result.code === "missing_api_key") return "missing_api_key";
+  if (result.code === "rate_limited") return "rate_limited";
+  if (result.code === "timeout") return "timeout";
+  return "error";
+}
+
+/**
+ * Wraps `provider.generate(opts)` з Prometheus + Sentry sidecars. Повертає
+ * той самий `LLMGenerateResult` — ця функція НЕ змінює бізнес-логіку, лише
+ * додає observability.
+ *
+ * Виклик ідемпотентний: помилка sidecar-а (Prom-registry / Sentry-hub
+ * unavailable) ловиться і не пробивається до caller-а.
+ */
+export async function invokeLLM(
+  provider: LLMProvider,
+  opts: LLMGenerateOpts,
+  invokeOpts: InvokeLLMOptions = {},
+): Promise<LLMGenerateResult> {
+  const endpoint = opts.endpoint ?? "unknown";
+  const result = await provider.generate(opts);
+  const outcome = outcomeFromResult(result);
+
+  try {
+    llmProviderInvocationsTotal.inc({
+      provider: provider.name,
+      endpoint,
+      outcome,
+    });
+  } catch {
+    /* metrics never break a request */
+  }
+
+  const breadcrumb: Parameters<LLMBreadcrumbFn>[0] = {
+    category: "llm.provider",
+    level: result.ok ? "info" : "warning",
+    message: `llm_provider_invocation provider=${provider.name} endpoint=${endpoint} outcome=${outcome}`,
+    data: {
+      provider: provider.name,
+      endpoint,
+      outcome,
+      model: opts.model,
+      ...(result.ok ? {} : { code: result.code, error: result.error }),
+    },
+  };
+  const emit =
+    invokeOpts.addBreadcrumb ??
+    ((b) => {
+      try {
+        Sentry.addBreadcrumb(b);
+      } catch {
+        /* Sentry не ініціалізований у деяких env — no-op */
+      }
+    });
+  emit(breadcrumb);
+
+  return result;
 }

--- a/apps/server/src/modules/openclaw/classify.test.ts
+++ b/apps/server/src/modules/openclaw/classify.test.ts
@@ -1,30 +1,53 @@
 /**
  * Unit tests for `classifyMessage` + `parseClassification` (Stage 4c).
  *
- * Wrapper-call (`anthropicMessages`) is mocked; we cover both happy paths
- * (valid JSON, markdown-fenced JSON, partial fields) and resilience
- * fallbacks (parse errors → `{ class: "chat" }`, upstream not-ok → throw).
+ * PR-24: classifyMessage тепер ходить через `LLMProvider` (PR-23). Тести
+ * передають `options.provider` (DI) щоб уникнути HTTP-mock-у. Стара
+ * `anthropicMessages` обгортка все ще задіяна як backend для
+ * `AnthropicProvider`, але classify-тести моделюють provider напряму.
  */
 
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
-const { anthropicMessagesMock } = vi.hoisted(() => ({
-  anthropicMessagesMock: vi.fn(),
-}));
-
-vi.mock("../../lib/anthropic.js", () => ({
-  anthropicMessages: anthropicMessagesMock,
-}));
+import { describe, expect, it } from "vitest";
+import type {
+  LLMGenerateOpts,
+  LLMGenerateResult,
+  LLMProvider,
+  LLMProviderName,
+} from "../../lib/llm/provider.js";
 
 const {
   classifyMessage,
   parseClassification,
   DEFAULT_CHEAP_ROUTER_SYSTEM_PROMPT,
 } = await import("./classify.js");
+
+/**
+ * Тестова реалізація `LLMProvider`, що повертає попередньо сконфігуровані
+ * results. Дозволяє асерти `.calls[0]` для перевірки переданих args без
+ * мок-фреймворків над глобальним module-import-ом.
+ */
+function makeFakeProvider(
+  name: LLMProviderName,
+  next: () => LLMGenerateResult | Promise<LLMGenerateResult>,
+): LLMProvider & { calls: LLMGenerateOpts[] } {
+  const calls: LLMGenerateOpts[] = [];
+  return {
+    name,
+    calls,
+    async generate(opts: LLMGenerateOpts): Promise<LLMGenerateResult> {
+      calls.push(opts);
+      return Promise.resolve(next());
+    },
+  };
+}
+
+function okResult(text: string): LLMGenerateResult {
+  return { ok: true, text, usage: { inputTokens: 0, outputTokens: 0 } };
+}
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, "../../../../..");
@@ -35,15 +58,6 @@ const CHEAP_ROUTER_MD_PATH = path.join(
 
 function stripHtmlComments(text: string): string {
   return text.replace(/<!--[\s\S]*?-->/g, "");
-}
-
-function makeResponse(text: string, ok = true, status = 200) {
-  return {
-    response: { ok, status } as Response,
-    data: {
-      content: [{ type: "text", text }],
-    } as unknown as Record<string, unknown>,
-  };
 }
 
 describe("parseClassification", () => {
@@ -127,69 +141,149 @@ describe("parseClassification", () => {
   });
 });
 
-describe("classifyMessage", () => {
-  beforeEach(() => {
-    anthropicMessagesMock.mockReset();
-  });
-
-  it("uses the default system prompt when none provided", async () => {
-    anthropicMessagesMock.mockResolvedValueOnce(
-      makeResponse(JSON.stringify({ class: "chat", chat_response: "ok" })),
+describe("classifyMessage (PR-24, via LLMProvider)", () => {
+  it("uses the default system prompt when none provided (anthropic-mode happy path)", async () => {
+    const provider = makeFakeProvider("anthropic", () =>
+      okResult(JSON.stringify({ class: "chat", chat_response: "ok" })),
     );
 
-    const result = await classifyMessage({ userMessage: "Привіт" }, "key");
+    const result = await classifyMessage({ userMessage: "Привіт" }, "key", {
+      provider,
+    });
 
     expect(result).toEqual({ class: "chat", chat_response: "ok" });
-    expect(anthropicMessagesMock).toHaveBeenCalledTimes(1);
-    const callArgs = anthropicMessagesMock.mock.calls[0];
-    expect(callArgs?.[0]).toBe("key");
-    expect(callArgs?.[1]).toMatchObject({
+    expect(provider.calls).toHaveLength(1);
+    const opts = provider.calls[0]!;
+    expect(opts).toMatchObject({
       model: "claude-haiku-4-5-20251001",
-      max_tokens: 200,
+      maxTokens: 200,
+      endpoint: "internal/openclaw/classify",
+      timeoutMs: 10_000,
     });
-    // Default prompt is the persona-aware Ukrainian classifier instructions.
-    expect(callArgs?.[1]?.system).toContain("Ти — Сергій");
-    expect(callArgs?.[1]?.system).toContain("класифікуй кожне повідомлення");
+    expect(opts.system).toContain("Ти — Сергій");
+    expect(opts.system).toContain("класифікуй кожне повідомлення");
   });
 
   it("uses the override system prompt when provided", async () => {
-    anthropicMessagesMock.mockResolvedValueOnce(
-      makeResponse(JSON.stringify({ class: "thinking" })),
+    const provider = makeFakeProvider("anthropic", () =>
+      okResult(JSON.stringify({ class: "thinking" })),
     );
 
     await classifyMessage(
       { userMessage: "Test", systemPrompt: "CUSTOM PROMPT" },
       "key",
+      { provider },
     );
 
-    expect(anthropicMessagesMock.mock.calls[0]?.[1]?.system).toBe(
-      "CUSTOM PROMPT",
-    );
+    expect(provider.calls[0]?.system).toBe("CUSTOM PROMPT");
   });
 
   it("throws when userMessage is empty/whitespace", async () => {
-    await expect(classifyMessage({ userMessage: "  " }, "key")).rejects.toThrow(
-      /userMessage is required/,
-    );
-    expect(anthropicMessagesMock).not.toHaveBeenCalled();
+    const provider = makeFakeProvider("anthropic", () => okResult("{}"));
+    await expect(
+      classifyMessage({ userMessage: "  " }, "key", { provider }),
+    ).rejects.toThrow(/userMessage is required/);
+    expect(provider.calls).toHaveLength(0);
   });
 
-  it("throws when upstream returns non-ok", async () => {
-    anthropicMessagesMock.mockResolvedValueOnce(makeResponse("", false, 503));
+  it("throws when provider повертає ok=false (Anthropic 5xx / rate-limit)", async () => {
+    const provider = makeFakeProvider("anthropic", () => ({
+      ok: false,
+      error: "rate-limited",
+      status: 429,
+      code: "rate_limited",
+    }));
 
-    await expect(classifyMessage({ userMessage: "hi" }, "key")).rejects.toThrow(
-      /upstream not ok \(status=503\)/,
-    );
+    await expect(
+      classifyMessage({ userMessage: "hi" }, "key", { provider }),
+    ).rejects.toThrow(/code=rate_limited.*status=429/);
   });
 
-  it("falls back to { class: chat } on missing content (parse fallback)", async () => {
-    anthropicMessagesMock.mockResolvedValueOnce({
-      response: { ok: true, status: 200 } as Response,
-      data: {} as Record<string, unknown>,
+  it("falls back to { class: chat } on empty content (parse fallback)", async () => {
+    const provider = makeFakeProvider("anthropic", () => okResult(""));
+    const result = await classifyMessage({ userMessage: "hi" }, "key", {
+      provider,
+    });
+    expect(result).toEqual({ class: "chat" });
+  });
+
+  it("stub-mode: provider name=stub → повертає plausible default { class: chat }", async () => {
+    // StubProvider у classifyMessage конфігурується факторі-ом з
+    // text=STUB_CLASSIFY_RESPONSE='{"class":"chat"}'. Імітуємо це fake-провайдером.
+    const provider = makeFakeProvider("stub", () =>
+      okResult('{"class":"chat"}'),
+    );
+
+    const result = await classifyMessage({ userMessage: "Привіт" }, "key", {
+      provider,
     });
 
-    const result = await classifyMessage({ userMessage: "hi" }, "key");
     expect(result).toEqual({ class: "chat" });
+    expect(provider.calls).toHaveLength(1);
+    expect(provider.name).toBe("stub");
+  });
+
+  it("Sentry breadcrumb emitted з category=llm.provider та provider/endpoint/outcome", async () => {
+    const breadcrumbs: Array<{
+      category: string;
+      level: string;
+      message: string;
+      data: Record<string, unknown>;
+    }> = [];
+    const provider = makeFakeProvider("anthropic", () =>
+      okResult('{"class":"chat"}'),
+    );
+
+    await classifyMessage({ userMessage: "hi" }, "key", {
+      provider,
+      addBreadcrumb: (b) => breadcrumbs.push(b),
+    });
+
+    expect(breadcrumbs).toHaveLength(1);
+    expect(breadcrumbs[0]).toMatchObject({
+      category: "llm.provider",
+      level: "info",
+      data: {
+        provider: "anthropic",
+        endpoint: "internal/openclaw/classify",
+        outcome: "ok",
+        model: "claude-haiku-4-5-20251001",
+      },
+    });
+  });
+
+  it("Sentry breadcrumb на error-path має level=warning + code/error data", async () => {
+    const breadcrumbs: Array<{
+      category: string;
+      level: string;
+      message: string;
+      data: Record<string, unknown>;
+    }> = [];
+    const provider = makeFakeProvider("anthropic", () => ({
+      ok: false,
+      error: "anthropic down",
+      code: "anthropic_error",
+      status: 502,
+    }));
+
+    await expect(
+      classifyMessage({ userMessage: "hi" }, "key", {
+        provider,
+        addBreadcrumb: (b) => breadcrumbs.push(b),
+      }),
+    ).rejects.toThrow();
+
+    expect(breadcrumbs).toHaveLength(1);
+    expect(breadcrumbs[0]).toMatchObject({
+      level: "warning",
+      data: {
+        provider: "anthropic",
+        endpoint: "internal/openclaw/classify",
+        outcome: "error",
+        code: "anthropic_error",
+        error: "anthropic down",
+      },
+    });
   });
 });
 

--- a/apps/server/src/modules/openclaw/classify.ts
+++ b/apps/server/src/modules/openclaw/classify.ts
@@ -30,8 +30,14 @@
  *     `class: "chat"` без `chat_response` і просто пропускає до Layer 2.
  */
 
+import { env } from "../../env/env.js";
 import { extractJsonFromText } from "../../http/jsonSafe.js";
-import { anthropicMessages } from "../../lib/anthropic.js";
+import {
+  getLLMProvider,
+  invokeLLM,
+  type LLMBreadcrumbFn,
+  type LLMProvider,
+} from "../../lib/llm/provider.js";
 
 /**
  * Allowed classification classes. Must stay in sync with the plugin-side
@@ -159,16 +165,42 @@ export function parseClassification(raw: string): CheapRouterClassification {
 }
 
 /**
- * Pure helper — calls Haiku, parses the response, returns the classification.
- * Throws on upstream not-ok (caller maps to 502). On parse failure or empty
- * content silently returns `{ class: "chat" }` so the plugin always gets a
+ * Default stub-response для read-only classifier-у: `class=chat` без
+ * `chat_response`. Caller (plugin hook) трактує це як "не вгадав, нехай
+ * Layer 2 повний agent відіграє". Підходить для:
+ *   - `LLM_READONLY_PROVIDER=stub` у production під час Anthropic outage;
+ *   - dev/preview без `ANTHROPIC_API_KEY`;
+ *   - e2e-тестів — детермінований, безкоштовний шлях.
+ */
+const STUB_CLASSIFY_RESPONSE = JSON.stringify({ class: "chat" });
+
+/**
+ * PR-24 optional knobs:
+ * - `provider` — підмінити provider у тестах (DI); default = factory
+ *   `getLLMProvider({ provider: env.LLM_READONLY_PROVIDER })`.
+ * - `addBreadcrumb` — підмінити Sentry breadcrumb emitter у тестах.
+ */
+export interface ClassifyMessageOptions {
+  provider?: LLMProvider;
+  addBreadcrumb?: LLMBreadcrumbFn;
+}
+
+/**
+ * Pure helper — calls Haiku через `LLMProvider`-абстракцію (PR-23/24),
+ * parses the response, returns the classification. Throws on upstream
+ * not-ok (caller maps to 502). On parse failure or empty content
+ * silently returns `{ class: "chat" }` so the plugin always gets a
  * predictable shape — failures should never crash a `before_dispatch` hook.
  *
  * `apiKey` parametrised for testability (mirrors `categorizeTransaction`).
+ * Provider override доступний через `options.provider` (для тестів). Якщо
+ * `env.LLM_READONLY_PROVIDER=stub` — повертає `{ class: "chat" }` без
+ * жодного HTTP-callu, що ідеально для Anthropic-outage / dev-без-ключа.
  */
 export async function classifyMessage(
   args: ClassifyMessageArgs,
   apiKey: string,
+  options: ClassifyMessageOptions = {},
 ): Promise<CheapRouterClassification> {
   const userMessage = args.userMessage?.trim();
   if (!userMessage) {
@@ -177,28 +209,35 @@ export async function classifyMessage(
 
   const systemPrompt = args.systemPrompt ?? DEFAULT_CHEAP_ROUTER_SYSTEM_PROMPT;
 
-  const { response, data } = await anthropicMessages(
-    apiKey,
+  const provider =
+    options.provider ??
+    getLLMProvider({
+      provider: env.LLM_READONLY_PROVIDER,
+      anthropicApiKey: apiKey,
+      stubResponse: { text: STUB_CLASSIFY_RESPONSE },
+    });
+
+  const result = await invokeLLM(
+    provider,
     {
       // claude-haiku-4-5 — найдешевший актуальний tier ($1 / $5 per M tokens
       // на 2026-05; ~$0.0002 / classification з 200/80 input/output split).
       // Той самий model, що використовує `routes/internal/categorize.ts`.
       model: "claude-haiku-4-5-20251001",
-      max_tokens: 200,
+      maxTokens: 200,
       system: systemPrompt,
       messages: [{ role: "user", content: userMessage }],
+      endpoint: "internal/openclaw/classify",
+      timeoutMs: 10_000,
     },
-    { endpoint: "internal/openclaw/classify", timeoutMs: 10_000 },
+    options.addBreadcrumb ? { addBreadcrumb: options.addBreadcrumb } : {},
   );
 
-  if (!response?.ok) {
-    const status = response?.status ?? 0;
-    throw new Error(`classifyMessage: upstream not ok (status=${status})`);
+  if (!result.ok) {
+    throw new Error(
+      `classifyMessage: provider error (code=${result.code ?? "unknown"}, status=${result.status ?? 0})`,
+    );
   }
 
-  const text =
-    (data as { content?: Array<{ type: string; text?: string }> }).content?.[0]
-      ?.text ?? "";
-
-  return parseClassification(text);
+  return parseClassification(result.text);
 }

--- a/apps/server/src/obs/metrics.ts
+++ b/apps/server/src/obs/metrics.ts
@@ -645,6 +645,19 @@ export const aiRequestDurationMs = new client.Histogram({
   registers: [register],
 });
 
+// PR-24: per-LLMProvider invocation counter. Окремо від `ai_requests_total`,
+// бо той вимагає `model`/`endpoint`/`outcome` labels від raw Anthropic-шляху,
+// а тут трекаємо саме provider-abstraction-шар: який provider пішов на call
+// і чи завершився ok. Endpoint-tag допомагає окремо рахувати classify-шлях
+// (PR-24) і weekly-digest (PR-25).
+// outcome=ok|error|missing_api_key|rate_limited|timeout
+export const llmProviderInvocationsTotal = new client.Counter({
+  name: "llm_provider_invocations_total",
+  help: "LLMProvider abstraction invocations by provider / endpoint / outcome",
+  labelNames: ["provider", "endpoint", "outcome"],
+  registers: [register],
+});
+
 // ───────────────────────── Frontend web-vitals ────────────────
 // LCP/INP/FCP/TTFB — таймінгові метрики в мілісекундах. Рейтинг обчислюється
 // клієнтом за порогами `web-vitals` package (Google Core Web Vitals):

--- a/docs/integrations/env-vars.md
+++ b/docs/integrations/env-vars.md
@@ -119,7 +119,22 @@ Tool-use квота (окремий bucket у `ai_usage_daily`). Кожен ви
 - `stub` — `StubProvider`, no-op повертає `{"ok":true,"stub":true}` JSON. Призначення: e2e-тести без real-Anthropic-калькування, локальний dev без ключа, інцидент-recovery під час Anthropic-outage (read-only OpenClaw paths-ів).
 - `openrouter` — зарезервовано під майбутню імплементацію (OpenRouter fallback). Поки що деградує у `stub`, щоб неочікуваний env не валив app.
 
-Wire-up call-sites — окремі PR-24 (OpenClaw `classify`) і PR-25 (`weekly-digest`). Інші Anthropic-call-sites (chat, coach, nutrition) поки що працюють напряму через `anthropicMessages()`, як і раніше.
+PR-25 (`weekly-digest`) — наступний wire-up. Інші Anthropic-call-sites (chat, coach, nutrition) поки що працюють напряму через `anthropicMessages()`, як і раніше.
+
+### `LLM_READONLY_PROVIDER` _(optional, default `anthropic`)_
+
+**PR-24** — окремий provider для read-only OpenClaw paths (зараз: `before_dispatch` cheap-router classifier у [`apps/server/src/modules/openclaw/classify.ts`](../../apps/server/src/modules/openclaw/classify.ts); пізніше — інші read-only flows). Дозволяє перемкнути саме classifier у fallback-режим, **не зачіпаючи** основний `LLM_PROVIDER`, який обслуговує chat/coach/nutrition.
+
+Значення такі самі, як у `LLM_PROVIDER`:
+
+- `anthropic` (default) — повний шлях через `anthropicMessages()`.
+- `stub` — повертає plausible default `{"class":"chat"}` без HTTP-callu. Idey для:
+  - **Anthropic-outage:** classifier деградує у `chat`-default, чат-flow продовжує працювати окремо (Layer 2 повний agent).
+  - **Local-dev без `ANTHROPIC_API_KEY`:** не падає на classify-розі.
+  - **E2E-тести:** детермінований, безкоштовний шлях без витрат токенів.
+- `openrouter` — зарезервовано, поки що деградує у stub (PR-26+).
+
+**Спостережуваність (PR-24).** Кожен виклик `LLMProvider.generate()` через обгортку [`invokeLLM()`](../../apps/server/src/lib/llm/provider.ts) інкрементує Prom-counter `llm_provider_invocations_total{provider,endpoint,outcome}` (outcome: `ok|error|missing_api_key|rate_limited|timeout`) + кладе Sentry breadcrumb `category=llm.provider, level=info|warning` з provider/endpoint/outcome/model. Дашборд `ai-cost` (PR-13) використовує цей counter для розщеплення runtime-distribution між Anthropic vs stub-режимами.
 
 ### `AI_TIMEOUT_MS`, `AI_MAX_RETRIES`, `AI_CIRCUIT_BREAKER_THRESHOLD`, `AI_CIRCUIT_BREAKER_RESET_MS` _(optional)_
 


### PR DESCRIPTION
## Summary

**PR-24** з [`docs/planning/pr-plan-2026-05.md`](https://github.com/Skords-01/Sergeant/blob/main/docs/planning/pr-plan-2026-05.md) — перший wire-up call-site із PR-23 (#2607). OpenClaw cheap-router classifier (`before_dispatch` hook, [`apps/server/src/modules/openclaw/classify.ts`](apps/server/src/modules/openclaw/classify.ts)) тепер викликає `LLMProvider`-абстракцію замість прямого `anthropicMessages()`. Це дозволяє перемкнути classify-шлях у `stub`-mode **без зачіпання** головного `LLM_PROVIDER`, що обслуговує chat/coach/nutrition flows.

**Use-cases:**

- **Anthropic-outage:** `LLM_READONLY_PROVIDER=stub` → classify повертає `{class:"chat"}` за замовч → Layer 2 повний agent відіграє chat-flow окремо (через основний `LLM_PROVIDER`).
- **Local-dev без `ANTHROPIC_API_KEY`:** classifier не падає (factory деградує у stub автоматично).
- **E2E-тести:** детермінований, безкоштовний шлях.

**Не зачеплено** інші Anthropic-call-sites (chat, coach, nutrition) — PR-25 (`weekly-digest`) наступний у плані.

### Зміни

| Файл | Що змінилося |
| --- | --- |
| `apps/server/src/modules/openclaw/classify.ts` | викликає `getLLMProvider({provider: env.LLM_READONLY_PROVIDER, anthropicApiKey, stubResponse: {text: '{"class":"chat"}'}})`; новий `ClassifyMessageOptions` (DI: `provider`, `addBreadcrumb`); error-message формат `code=…, status=…` |
| `apps/server/src/lib/llm/provider.ts` | **новий `invokeLLM(provider, opts, {addBreadcrumb?})`** — sidecar Prom-counter + Sentry breadcrumb (`category="llm.provider"`); outcome-mapping: `ok|error|missing_api_key|rate_limited|timeout` |
| `apps/server/src/env/env.ts` | новий `LLM_READONLY_PROVIDER` enum (default `anthropic`) — окремий від `LLM_PROVIDER`, щоб classify-toggle не зачіпав основні flows |
| `apps/server/src/obs/metrics.ts` | новий counter `llm_provider_invocations_total{provider,endpoint,outcome}` |
| `docs/integrations/env-vars.md` | docs `LLM_READONLY_PROVIDER` + observability нотатки (Prom counter + breadcrumb shape) |

### Спостережуваність

Кожен виклик через `invokeLLM()`:

- **Prom counter** `llm_provider_invocations_total{provider,endpoint,outcome}` — використовується у дашборді `ai-cost` (PR-13) для розщеплення runtime distribution між Anthropic vs stub.
- **Sentry breadcrumb** `category=llm.provider, level=info|warning` із data: `{provider, endpoint, outcome, model, code?, error?}`.

## Governing Skill

- Primary skill: `.agents/skills/sergeant-server-api/SKILL.md`
- Secondary skill: n/a

## Playbook

- Primary playbook: n/a — atomic refactor + observability wire-up.
- Why this playbook: Не один із зареєстрованих recipes (data/migrations/release/etc).
- If no playbook matched, why: Stage 4c flow — pluggable LLM wire-up без зміни external API.

## Verification

```bash
pnpm --filter @sergeant/server exec vitest run \
  src/lib/llm/provider.test.ts \
  src/modules/openclaw/classify.test.ts
# 42 passed (24 provider + 18 classify, includes 7 нових invokeLLM-тестів)

pnpm --filter @sergeant/server test
# 2144 passed; 1 pre-existing failure у src/modules/mono/connection.test.ts
# (mock з obs/logger.js — НЕ цей PR; підтверджено на main)

pnpm --filter @sergeant/server exec eslint src/lib/llm src/modules/openclaw \
  src/env/env.ts src/obs/metrics.ts
# 0 errors

pnpm exec prettier --check apps/server/src/lib/llm/* \
  apps/server/src/modules/openclaw/classify*.ts \
  apps/server/src/env/env.ts apps/server/src/obs/metrics.ts \
  docs/integrations/env-vars.md
# All matched files use Prettier code style!
```

Note про `pnpm typecheck`: pre-existing помилка у `apps/server/src/obs/tracing.ts:43` (`resourceFromAttributes` not exported) — не наслідок цього PR (zero touch у tracing/OpenTelemetry coде, окремий deps-fix PR).

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed (lint/format/test loop pass)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update. — No (internal lib + env-var; не змінює scope-enum або hard rules).
- [x] I checked whether a playbook or skill needed an update. — No (specialist skill `sergeant-server-api` залишається канонічним).
- [x] I checked whether governance docs or review docs needed an update. — No.

Updated docs:

- `docs/integrations/env-vars.md` — додано секцію `LLM_READONLY_PROVIDER` + observability нотатки (Prom counter + Sentry breadcrumb).

## Risk and Rollout

- **User-visible risk:** Zero. PR не змінює external API — classify тепер ходить через abstraction layer з тим самим Anthropic-backend (default `LLM_READONLY_PROVIDER=anthropic`). Існуючі тести на classify route (`/api/internal/openclaw/classify`) не зачеплені.
- **Rollout / deploy order:** Стандартний (merge → Railway autodeploy). `LLM_READONLY_PROVIDER` env-var опціональний — default `anthropic` зберігає поточну поведінку.
- **Backout plan:** Revert PR; OpenClaw classify-route повернеться до прямого `anthropicMessages()` шляху. Observability counter не отримуватиме нових samples, але існуючі залишаються у Prometheus history.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

- **Тести.** 18 classify-тестів перероблено на DI (`options.provider` — fake-провайдер) замість мок-у `anthropicMessages` модуля. Це чистіше: тестується саме `classifyMessage()` логіка, без проміжного wrapper-у. Provider-tests залишилися мокати `anthropicMessages` напряму (бо тестують `AnthropicProvider` adapter).
- **Sentry breadcrumb sink.** `invokeLLM()` за замовч пише у глобальний `Sentry.addBreadcrumb()`, але приймає `addBreadcrumb` override (для тестів). Помилка під час breadcrumb-emit-у ловиться try/catch — observability ніколи не падає request.
- **Outcome map.** Свідомо короткий enum: `ok|error|missing_api_key|rate_limited|timeout`. Якщо `code` у `LLMGenerateResult` — `anthropic_error`/`anthropic_throw` — це мапиться у `error` outcome (тобто Prom-counter аґрегує всі anthropic-fail-причини як `error`, deep-investigation — через Sentry breadcrumb `code` data field).
- **Чому окремий `LLM_READONLY_PROVIDER`, а не один глобальний.** Classify — read-only path-у (cheap fallback ОК), а chat/coach/nutrition потребують live AI. Один глобальний switch був би небезпечно coarse-grained — `LLM_PROVIDER=stub` зніс би основні flow-и. PR-25 (`weekly-digest`) теж потрапляє у read-only sphere — буде використовувати `LLM_READONLY_PROVIDER` за тим самим патерном.


Link to Devin session: https://app.devin.ai/sessions/29f7a6ee50f24e228948a80569e247d1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires the OpenClaw classifier to `LLMProvider` with a read‑only fallback controlled by `LLM_READONLY_PROVIDER`, so classify can safely degrade to a stub without affecting chat/coach/nutrition. Adds lightweight metrics and breadcrumbs for provider calls.

- **Refactors**
  - Replaced direct `anthropicMessages()` in `classify` with `LLMProvider` + `invokeLLM`; stub returns `{"class":"chat"}`; kept model, timeout, and endpoint semantics.
  - Added `invokeLLM(provider, opts)` that records `llm_provider_invocations_total{provider,endpoint,outcome}` and a Sentry breadcrumb (`category=llm.provider`).
  - Introduced `LLM_READONLY_PROVIDER` (default `anthropic`) separate from `LLM_PROVIDER`; supports `stub` for outages, local dev without a key, and e2e tests.
  - Switched classify tests to DI via `options.provider`; updated `docs/integrations/env-vars.md`.

<sup>Written for commit ea4af2e8389cf48c4c1425ffcfddf079d7c4e71b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

