### PR TITLE
test(server): fix 4 test-reliability findings (T2 audit #10-#13)

### DIFF
--- a/apps/server/src/env/__tests__/assertStartupEnv.test.ts
+++ b/apps/server/src/env/__tests__/assertStartupEnv.test.ts
@@ -3,9 +3,20 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 // Re-imports `env/env.ts` from scratch each test so the zod schema reads the
 // current `process.env` snapshot. Without this every test would see whatever
 // state the first import froze.
+//
+// T2 audit finding #11 — Hard Rule #20 (`assertStartupEnv`) inspects
+// `process.env.Git_PAT` / `process.env.OPENCLAW_GITHUB_PAT` directly to
+// catch leftover platform secrets that bypass Zod. Devin/CI runners
+// inherit `Git_PAT` from the parent shell, which leaked into the
+// "does NOT throw in production" baseline cases and flipped them to
+// failures non-deterministically by host env. We explicitly stub both
+// keys to empty BEFORE applying `envOverrides`, so the negative-path
+// cases (which set them non-empty themselves) still win.
 async function loadAssertStartupEnv(
   envOverrides: Record<string, string> = {},
 ): Promise<() => void> {
+  vi.stubEnv("Git_PAT", "");
+  vi.stubEnv("OPENCLAW_GITHUB_PAT", "");
   for (const [k, v] of Object.entries(envOverrides)) vi.stubEnv(k, v);
   vi.resetModules();
   const mod = await import("../env.js");

--- a/apps/server/src/modules/mono/connection.test.ts
+++ b/apps/server/src/modules/mono/connection.test.ts
@@ -21,6 +21,15 @@ vi.mock("../../obs/logger.js", () => ({
     warn: vi.fn(),
     error: vi.fn(),
   },
+  // T2 audit #10 — `historyFetch.ts` (called via `setImmediate` from
+  // `connectHandler`) re-exports `redactKeyNames` / `redactPaths` for
+  // ESLint-time PII discipline; mocking the logger without these breaks
+  // module load with `No "redactKeyNames" export is defined`. Provide
+  // empty arrays — they're not exercised by the connect/disconnect/
+  // sync-state assertions, they only need to exist for the import to
+  // resolve.
+  redactKeyNames: [] as string[],
+  redactPaths: [] as string[],
 }));
 
 vi.mock("../../obs/metrics.js", () => ({

--- a/apps/server/src/routes/__snapshots__/registerRoutes.test.ts.snap
+++ b/apps/server/src/routes/__snapshots__/registerRoutes.test.ts.snap
@@ -112,6 +112,7 @@ exports[`registerRoutes > mounts the stable set of /api/* endpoints (snapshot) 1
   "POST /api/internal/seo/pagespeed",
   "POST /api/internal/seo/rank-snapshot",
   "POST /api/internal/seo/sitemap-health",
+  "POST /api/internal/webhook-events/record",
   "POST /api/metrics/web-vitals",
   "POST /api/mono/backfill",
   "POST /api/mono/connect",

--- a/apps/server/src/routes/internal/openclaw.test.ts
+++ b/apps/server/src/routes/internal/openclaw.test.ts
@@ -437,19 +437,22 @@ describe("/api/internal/openclaw/snapshot/refresh", () => {
 // повертає classification JSON. 503 коли ANTHROPIC_API_KEY відсутній;
 // 502 коли Haiku фейлить — щоб plugin escalates до Layer 2 fail-closed.
 describe("/api/internal/openclaw/classify", () => {
-  const originalKey = process.env["ANTHROPIC_API_KEY"];
-
+  // T2 audit follow-up — these tests previously mutated
+  // `process.env.ANTHROPIC_API_KEY` directly, but the route reads the
+  // parsed `env.ANTHROPIC_API_KEY` (captured at first env-module load),
+  // so the assignment never reached the handler in vitest workers
+  // where env.js had already been cached by an earlier suite. Switch
+  // to `vi.stubEnv` + `vi.resetModules()` so each test gets a fresh
+  // env snapshot before `makeApp()` dynamic-imports the router.
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env["ANTHROPIC_API_KEY"] = "test-key";
+    vi.stubEnv("ANTHROPIC_API_KEY", "test-key");
+    vi.resetModules();
   });
 
   afterEach(() => {
-    if (originalKey === undefined) {
-      delete process.env["ANTHROPIC_API_KEY"];
-    } else {
-      process.env["ANTHROPIC_API_KEY"] = originalKey;
-    }
+    vi.unstubAllEnvs();
+    vi.resetModules();
   });
 
   it("returns classification JSON for a routine_metrics question", async () => {
@@ -500,7 +503,8 @@ describe("/api/internal/openclaw/classify", () => {
   });
 
   it("returns 503 when ANTHROPIC_API_KEY is not configured", async () => {
-    delete process.env["ANTHROPIC_API_KEY"];
+    vi.stubEnv("ANTHROPIC_API_KEY", "");
+    vi.resetModules();
     const app = await makeApp();
     const res = await request(app)
       .post("/api/internal/openclaw/classify")


### PR DESCRIPTION
## Summary

Closes T2 audit findings **#10, #11, #12, #13** (test-reliability). Brings the full `@sergeant/server` suite from `2061/2281 passing` (4 failures + 1 silent file-load failure + 5 cascade failures) to **`2281/2281` green**.

## Findings addressed

### #10 — `mono/connection.test.ts` failed to load
The file was already fixed at the `vi.hoisted()` level (audit suggestion #1 had landed before this PR), but it still failed module load with:
```
No "redactKeyNames" export is defined on the "../../obs/logger.js" mock
```
The deferred `historyFetch.ts` (called via `setImmediate` from `connectHandler`) re-exports `redactKeyNames` / `redactPaths` for ESLint-time PII discipline. Added empty arrays to the logger mock so module resolution succeeds. The 16 mono connection / disconnect / sync-state tests now run and pass.

### #11 — `assertStartupEnv.test.ts` Git_PAT env-isolation
Hard Rule #20 (`assertStartupEnv`) inspects `process.env.Git_PAT` and `process.env.OPENCLAW_GITHUB_PAT` directly to catch leftover platform secrets that bypass Zod. Devin/CI runners inherit `Git_PAT` from the parent shell, which leaked into the "does NOT throw in production" baseline cases (4 false failures by host env).

`loadAssertStartupEnv` now stubs both keys to empty BEFORE applying `envOverrides`, so negative-path cases (which set them non-empty themselves) still win.

### #12 — `registerRoutes.test.ts` snapshot drift
The Hard Rule #3 contract snapshot was missing `POST /api/internal/webhook-events/record`. Refreshed via `vitest -u`. The audit-flagged `/api/internal/openclaw/classify` entry already lives in the snapshot, so only the new `webhook-events` line needed adding.

The `internal/*` routes are not mirrored in `@sergeant/api-client` by design (called only by the n8n console), so no api-client contract update is required.

### #13 — `classify.test.ts` drift gate
The byte-for-byte drift gate against `ops/openclaw/cheap-router.system.md` now passes (resolved upstream since the audit ran — no change required here). Verified explicitly: `pnpm --filter @sergeant/server test src/modules/openclaw/classify.test.ts` → 18/18 passed.

## Adjacent fix uncovered while validating #11

**`routes/internal/openclaw.test.ts > /classify`** previously mutated `process.env.ANTHROPIC_API_KEY` directly, but the route reads the parsed `env.ANTHROPIC_API_KEY` (captured at first env-module load), so the assignment never reached the handler in vitest workers where `env.js` had already been cached by an earlier suite. All 5 happy-path tests returned 503 (api-key-missing) instead of their expected status.

Switched to `vi.stubEnv` + `vi.resetModules()` so each test gets a fresh env snapshot before `makeApp()` dynamic-imports the router. This pattern matches the working setup already in `assertStartupEnv.test.ts`.

## Verification

- [x] `pnpm --filter @sergeant/server test` → **2281 / 2281** passed.
- [x] `pnpm --filter @sergeant/server typecheck` → clean.
- [x] `pnpm --filter @sergeant/server lint` → clean (4 pre-existing fs-filename warnings, none in changed files).

## Audit context

- QA session: https://app.devin.ai/sessions/ed8a702bc21b43cd8d3987387c1646f0
- Phase 2 fix series:
  - PR #1 — Stripe webhook hardening: #2609
  - PR #2 — OpenClaw repo allowlist: #2627
  - PR #3 — `/metrics` token hardening: #2632
  - **PR #4 — this PR** — Test reliability (findings 10–13)
  - PR #5 — Optional consolidation (findings 5, 6, 7, 9) — _next_


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes T2 audit test-reliability issues and stabilizes env-dependent tests. The `@sergeant/server` suite is now fully green (2281/2281).

- **Bug Fixes**
  - #10: Add `redactKeyNames`/`redactPaths` to the `../../obs/logger.js` mock so `historyFetch.ts` loads; mono connection tests now run and pass.
  - #11: In `loadAssertStartupEnv`, stub `Git_PAT` and `OPENCLAW_GITHUB_PAT` to empty before overrides to prevent CI env leaks.
  - #12: Refresh route snapshot to include POST /api/internal/webhook-events/record.
  - Adjacent: For `/api/internal/openclaw/classify` tests, switch to `vi.stubEnv` + `vi.resetModules()` to bypass cached env; fixes 5 false 503s.

<sup>Written for commit e1bdd08c453625eabcd7b715f3eedfeb6b7c6061. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

