### PR TITLE
fix(web): portal Sheet/Modal to body and dim the scrim consistently

### DIFF
--- a/apps/web/src/shared/components/ui/Modal.tsx
+++ b/apps/web/src/shared/components/ui/Modal.tsx
@@ -158,7 +158,13 @@ export function Modal({
         tabIndex={dismissOnOverlayClick ? 0 : -1}
         onClick={dismissOnOverlayClick ? onClose : undefined}
         onKeyDown={dismissOnOverlayClick ? handleOverlayKey : undefined}
-        className="absolute inset-0 bg-text/40 backdrop-blur-sm"
+        // `bg-text` resolves to a near-white in dark mode and a near-black
+        // in light mode, so `bg-text/40` *lightens* the page on dark and
+        // dims on light — opposite of what a modal scrim is supposed to
+        // do. Switch to the same `bg-black/40 backdrop-blur-sm` Sheet has
+        // used since portaling so both primitives behave consistently
+        // across themes.
+        className="absolute inset-0 bg-black/40 backdrop-blur-sm"
       />
       <div
         ref={panelRef}

--- a/apps/web/src/shared/components/ui/Sheet.test.tsx
+++ b/apps/web/src/shared/components/ui/Sheet.test.tsx
@@ -57,19 +57,40 @@ describe("Sheet", () => {
   });
 
   it("renders a drag-handle by default and omits it when hideHandle=true", () => {
-    const { container, rerender } = render(
+    const { rerender } = render(
       <Sheet open onClose={() => {}} title="T">
         body
       </Sheet>,
     );
+    // Sheet is portaled to <body>, so query against the document, not the
+    // RTL container (which only owns the mount wrapper).
     const handleSelector = 'div[aria-hidden][class*="rounded-full"]';
-    expect(container.querySelector(handleSelector)).not.toBeNull();
+    expect(document.body.querySelector(handleSelector)).not.toBeNull();
     rerender(
       <Sheet open onClose={() => {}} title="T" hideHandle>
         body
       </Sheet>,
     );
-    expect(container.querySelector(handleSelector)).toBeNull();
+    expect(document.body.querySelector(handleSelector)).toBeNull();
+  });
+
+  it("portals the sheet to document.body so it escapes a transformed ancestor", () => {
+    // Mirrors the real-world `.page-enter` containing-block bug: the
+    // ancestor below has a non-`none` `transform`, which would anchor a
+    // non-portaled `position: fixed` overlay to its box (rendering the
+    // sheet clipped above or below the viewport). Portaling to <body>
+    // bypasses every such ancestor; the sheet must live outside the host
+    // node. Mirrors Modal's identical contract test for parity.
+    const { container, getByRole } = render(
+      <div style={{ transform: "translateY(0)" }}>
+        <Sheet open onClose={() => {}} title="Portaled">
+          body
+        </Sheet>
+      </div>,
+    );
+    const dialog = getByRole("dialog");
+    expect(container.contains(dialog)).toBe(false);
+    expect(document.body.contains(dialog)).toBe(true);
   });
 
   it("locks body scroll while open and restores on unmount", () => {

--- a/apps/web/src/shared/components/ui/Sheet.tsx
+++ b/apps/web/src/shared/components/ui/Sheet.tsx
@@ -5,6 +5,7 @@ import {
   type CSSProperties,
   type ReactNode,
 } from "react";
+import { createPortal } from "react-dom";
 import { cn } from "../../lib/ui/cn";
 import { useDialogFocusTrap } from "../../hooks/useDialogFocusTrap";
 import { useSwipeToDismiss } from "../../hooks/useSwipeToDismiss";
@@ -115,6 +116,7 @@ export function Sheet({
   }, [open, title, announce]);
 
   if (!open) return null;
+  if (typeof document === "undefined") return null;
 
   // Lift the panel above the module bottom nav (set via the
   // `--bottom-nav-height` CSS variable on ModuleShell) plus the iOS
@@ -141,7 +143,17 @@ export function Sheet({
         transition: "transform 200ms cubic-bezier(0.32, 0.72, 0, 1)",
       };
 
-  return (
+  // Portal the sheet to <body> so it escapes every ancestor stacking /
+  // containing-block context. Several hub routes wrap their root in a
+  // `.page-enter` element whose entry animation keeps
+  // `transform: translateY(0)` via `animation-fill-mode: both`. Per the
+  // CSS spec, any non-`none` `transform` on an ancestor establishes a
+  // new containing block — which means our `position: fixed` overlay is
+  // anchored to that ancestor's box instead of the viewport, and the
+  // sheet renders clipped above or below the visible area. Mirrors the
+  // identical fix applied to `Modal` (see its inline comment for the
+  // full root-cause writeup).
+  const sheet = (
     <div
       className="fixed inset-0 flex items-end justify-center motion-safe:animate-fade-in"
       style={{ zIndex }}
@@ -180,7 +192,10 @@ export function Sheet({
             {...swipe.bind}
             role="presentation"
           >
-            <div className="w-12 h-sheet-handle bg-line/70 rounded-full" aria-hidden />
+            <div
+              className="w-12 h-sheet-handle bg-line/70 rounded-full"
+              aria-hidden
+            />
           </div>
         )}
         <div
@@ -246,4 +261,6 @@ export function Sheet({
       </div>
     </div>
   );
+
+  return createPortal(sheet, document.body);
 }


### PR DESCRIPTION
## Summary

Two related fixes on the Sheet/Modal primitives, both captured in the T1 web/UX QA audit (https://app.devin.ai/sessions/eb480334e4c14cc398ceb79ec0a170ce):

1. **Sheet portal (T1-001, T1-002 — both `high`).** The Hub first-action chooser sheet (green sniper FAB) and Finyk Manual Expense Sheet rendered clipped above / below the viewport. Root cause: several hub routes wrap their root in a `.page-enter` element whose entry animation keeps `transform: translateY(0)` via `animation-fill-mode: both`. Per the CSS spec, any non-`none` `transform` on an ancestor establishes a new containing block — which means our `position: fixed` overlay was anchored to that ancestor's box instead of the viewport. Portaling the sheet to `document.body` bypasses every such ancestor, the same fix Modal already applied (see Modal.tsx's inline comment for the original writeup).
2. **Modal scrim dim (T1-006 — `low`).** The Modal scrim used `bg-text/40 backdrop-blur-sm`, but the `text` token resolves to a near-white in dark mode (and near-black in light mode), so the overlay *lightens* the page on dark and dims on light — the opposite of what a modal scrim should do. Switch to the `bg-black/40 backdrop-blur-sm` Sheet has been using so both primitives behave consistently across themes.

Files touched:

- `apps/web/src/shared/components/ui/Sheet.tsx` — wrap JSX in a portal to `document.body`; SSR guard; 13-line inline comment mirroring Modal's existing rationale.
- `apps/web/src/shared/components/ui/Sheet.test.tsx` — fix drag-handle test to query `document.body` (sheet is now portaled out of RTL's container); add a new portal-escape contract test that wraps Sheet in a transformed ancestor and asserts the dialog lives outside the host node.
- `apps/web/src/shared/components/ui/Modal.tsx` — single-line class swap on the scrim + comment explaining why.

## Governing Skill

- Primary skill: `.agents/skills/sergeant-web-ui/SKILL.md`
- Secondary skill (if truly needed): —

## Playbook

- Primary playbook: —
- Why this playbook: focused primitive bugfix; covered by the standard pre-PR matrix.
- If no playbook matched, why: the regressions live inside `apps/web/src/shared/components/ui/`; relevant guidance is in `sergeant-web-ui` and Modal's existing inline writeup.

## Verification

```bash
pnpm exec prettier --check apps/web/src/shared/components/ui/Sheet.tsx apps/web/src/shared/components/ui/Sheet.test.tsx apps/web/src/shared/components/ui/Modal.tsx
# All matched files use Prettier code style!

pnpm --filter @sergeant/web test -- --run Sheet Modal
# Test Files  3 passed (3)
# Tests       22 passed (22)

pnpm --filter @sergeant/web typecheck
# Exit code: 0

pnpm --filter @sergeant/web lint
# Exit code: 0
```

Repo-wide `pnpm lint` is currently red on `main` because of an unrelated `process.env` budget regression (`Disallowed process.env reads grew: 117 > budget 114`) — flagged by a parallel T5 session. My diff does not add any `process.env` reads.

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed (web)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a — both fixes are explained with inline comments next to the changed code; the portal-escape rationale was already documented at length on `Modal.tsx` and is now mirrored on `Sheet.tsx`.

## Risk and Rollout

- User-visible risk: low. The sheet is now portaled to `<body>`, which is exactly what Modal has been doing. Stacking, `aria-modal` semantics, and the existing CSS transitions are preserved (verified by the existing Sheet test suite + the new contract test).
- Rollout / deploy order: ship with the next normal web deploy.
- Backout plan: revert this PR. No data migrations, no env changes.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

- This is the first of three focused PRs splitting fixable findings from the T1 web/UX QA audit. The other two cover the platform-aware shortcut glyph (T1-004) and the Settings inner-tab URL mirror (T1-009); they are opened separately.
- The new `Sheet.test.tsx` contract test mirrors Modal's portal contract verbatim — if Modal grows a similar test later, both primitives will have parity coverage.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Portal the `Sheet` to `document.body` to escape transformed ancestors and fix clipping; switch the `Modal` scrim to `bg-black/40` for consistent dimming in all themes. Addresses T1-001, T1-002, and T1-006.

- **Bug Fixes**
  - `Sheet`: render via `createPortal` to `document.body` with an SSR guard to avoid `.page-enter` transform anchoring; updated tests and added a portal-escape contract test.
  - `Modal`: scrim class changed from `bg-text/40` to `bg-black/40 backdrop-blur-sm` for correct, consistent dimming in light and dark mode.

<sup>Written for commit 24efea3278d6cf12c8b22b15120bd69d86d4683f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

