### PR TITLE
feat(design-tokens): add e0..e5 elevation scale and z-index tier tokens

### DIFF
--- a/apps/web/eslint.i18n-allowlist.json
+++ b/apps/web/eslint.i18n-allowlist.json
@@ -26,6 +26,7 @@
   "apps/web/src/core/designShowcase/sections/Celebration.tsx",
   "apps/web/src/core/designShowcase/sections/Colors.tsx",
   "apps/web/src/core/designShowcase/sections/DataDisplay.tsx",
+  "apps/web/src/core/designShowcase/sections/Elevation.tsx",
   "apps/web/src/core/designShowcase/sections/Feedback.tsx",
   "apps/web/src/core/designShowcase/sections/Forms.tsx",
   "apps/web/src/core/designShowcase/sections/Motion.tsx",

--- a/apps/web/src/core/DesignShowcase.tsx
+++ b/apps/web/src/core/DesignShowcase.tsx
@@ -6,6 +6,7 @@ import { TypographySection } from "./designShowcase/sections/Typography";
 import { ButtonsSection } from "./designShowcase/sections/Buttons";
 import { BadgesSection } from "./designShowcase/sections/Badges";
 import { CardsSection } from "./designShowcase/sections/Cards";
+import { ElevationSection } from "./designShowcase/sections/Elevation";
 import { FormsSection } from "./designShowcase/sections/Forms";
 import { DataDisplaySection } from "./designShowcase/sections/DataDisplay";
 import { NavigationSection } from "./designShowcase/sections/Navigation";
@@ -58,6 +59,7 @@ export function DesignShowcase() {
         <ButtonsSection />
         <BadgesSection />
         <CardsSection />
+        <ElevationSection />
         <FormsSection />
         <DataDisplaySection />
         <NavigationSection />

--- a/apps/web/src/core/designShowcase/_shared.tsx
+++ b/apps/web/src/core/designShowcase/_shared.tsx
@@ -8,6 +8,7 @@ export const NAV_SECTIONS = [
   { id: "buttons", label: "Кнопки" },
   { id: "badges", label: "Бейджі" },
   { id: "cards", label: "Карти" },
+  { id: "elevation", label: "Елевація" },
   { id: "forms", label: "Форми" },
   { id: "data", label: "Дані" },
   { id: "navigation", label: "Навігація" },

--- a/apps/web/src/core/designShowcase/sections/Colors.tsx
+++ b/apps/web/src/core/designShowcase/sections/Colors.tsx
@@ -53,19 +53,10 @@ export function ColorsSection() {
         </div>
       </Group>
 
-      <Group label="Тіні">
-        <div className="flex flex-wrap gap-4">
-          <div className="shadow-soft bg-panel rounded-2xl border border-line px-4 py-3 text-xs text-muted font-mono">
-            shadow-soft
-          </div>
-          <div className="shadow-card bg-panel rounded-2xl border border-line px-4 py-3 text-xs text-muted font-mono">
-            shadow-card
-          </div>
-          <div className="shadow-float bg-panel rounded-2xl border border-line px-4 py-3 text-xs text-muted font-mono">
-            shadow-float
-          </div>
-        </div>
-      </Group>
+      {/* Тіні winnowed out of Colors and promoted into its own
+          standalone "Елевація" section — see ElevationSection. The
+          legacy aliases (`shadow-soft / card / float`) are documented
+          there alongside the canonical `shadow-e0..shadow-e5` scale. */}
     </Sec>
   );
 }

--- a/apps/web/src/core/designShowcase/sections/Elevation.tsx
+++ b/apps/web/src/core/designShowcase/sections/Elevation.tsx
@@ -1,0 +1,194 @@
+import { useState } from "react";
+import { cn } from "@shared/lib/ui/cn";
+import { Sec, Group } from "../_shared";
+
+/**
+ * Elevation showcase — renders all six `shadow-eN` levels in two
+ * panes (light + forced-dark) so contributors can scan how a level
+ * reads across themes without toggling the global app theme.
+ *
+ * Each tile labels:
+ *   - the Tailwind utility (`shadow-eN`)
+ *   - the role this level represents
+ *   - the paired `z-*` tier (per `zTier` in design tokens) so the
+ *     coupling between elevation and stacking is visible.
+ *
+ * Authoring rule lives in design-system.md § 4 and the canonical
+ * recipe in `packages/design-tokens/tokens.js` → `elevation`.
+ *
+ * Note on the dark pane: we wrap it in a local `.dark` class so the
+ * CSS variables in `apps/web/src/styles/theme.css` (`--shadow-eN`,
+ * `--c-panel`, `--c-line`, `--c-text`, …) resolve from the dark
+ * branch — that lets us reuse the same semantic utilities
+ * (`bg-surface`, `border-border`, `text-fg`, `text-fg-subtle`) on
+ * both panes without ever reaching for raw hex (Hard Rule #11) or
+ * `dark:` overrides (Hard Rule #13).
+ */
+
+type Step = {
+  level: "e0" | "e1" | "e2" | "e3" | "e4" | "e5";
+  role: string;
+  zTier: string;
+  zNumeric: string;
+  shadowClass: string;
+};
+
+const STEPS: readonly Step[] = [
+  {
+    level: "e0",
+    role: "Flat — фон, секції, інпути",
+    zTier: "z-base",
+    zNumeric: "0",
+    shadowClass: "shadow-e0",
+  },
+  {
+    level: "e1",
+    role: "Raised — Card, рядки списку",
+    zTier: "z-base",
+    zNumeric: "0",
+    shadowClass: "shadow-e1",
+  },
+  {
+    level: "e2",
+    role: "Interactive — hover Card / Button",
+    zTier: "z-base",
+    zNumeric: "0",
+    shadowClass: "shadow-e2",
+  },
+  {
+    level: "e3",
+    role: "Overlay — Popover, Menu, Tooltip",
+    zTier: "z-dropdown",
+    zNumeric: "50",
+    shadowClass: "shadow-e3",
+  },
+  {
+    level: "e4",
+    role: "Modal — Modal, Sheet, Drawer",
+    zTier: "z-modal",
+    zNumeric: "200",
+    shadowClass: "shadow-e4",
+  },
+  {
+    level: "e5",
+    role: "Toast — Toast, Snackbar",
+    zTier: "z-toast",
+    zNumeric: "300",
+    shadowClass: "shadow-e5",
+  },
+];
+
+function ElevationTile({ step }: { step: Step }) {
+  return (
+    <div className="flex flex-col gap-2">
+      <div
+        className={cn(
+          "h-24 rounded-2xl border border-border bg-surface flex flex-col items-center justify-center gap-1 px-3 text-center",
+          step.shadowClass,
+        )}
+      >
+        <span className="text-xs font-extrabold font-mono text-fg">
+          shadow-{step.level}
+        </span>
+        <span className="text-2xs font-mono text-fg-subtle">
+          {step.zTier} · {step.zNumeric}
+        </span>
+      </div>
+      <span className="text-2xs text-fg-subtle leading-tight">{step.role}</span>
+    </div>
+  );
+}
+
+export function ElevationSection() {
+  // Local toggle for the inline recipe debug panel. Independent of
+  // theme — both panes always render so contributors can compare
+  // light vs dark side by side without flipping the global theme.
+  const [showInline, setShowInline] = useState(false);
+
+  return (
+    <Sec id="elevation" title="Елевація та шари">
+      <p className="text-sm text-fg-muted leading-relaxed -mt-2 max-w-prose">
+        Семантична шкала <code className="font-mono">shadow-e0..shadow-e5</code>{" "}
+        — єдине джерело правди для глибини. Рівень елевації завжди йде в парі з{" "}
+        <code className="font-mono">z-*</code> тіром (Card на сторінці —{" "}
+        <code className="font-mono">z-base</code>, попап —{" "}
+        <code className="font-mono">z-dropdown</code>, Modal/Sheet —{" "}
+        <code className="font-mono">z-modal</code>, Toast —{" "}
+        <code className="font-mono">z-toast</code>). Темна тема перемикається
+        автоматично через CSS-змінні — не пиши{" "}
+        <code className="font-mono">dark:shadow-*</code> (Hard Rule #13).
+      </p>
+
+      <Group label="Light">
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-4 bg-bg p-5 rounded-2xl border border-border">
+          {STEPS.map((step) => (
+            <ElevationTile key={step.level} step={step} />
+          ))}
+        </div>
+      </Group>
+
+      <Group label="Dark">
+        {/* `.dark` rebinds --shadow-e* + --c-* tokens to the dark
+            recipe, so the children below reuse the same semantic
+            utilities as the light pane without any raw-palette
+            forks (Hard Rule #13). */}
+        <div className="dark grid grid-cols-2 sm:grid-cols-3 gap-4 bg-bg p-5 rounded-2xl border border-border">
+          {STEPS.map((step) => (
+            <ElevationTile key={step.level} step={step} />
+          ))}
+        </div>
+      </Group>
+
+      <Group label="Legacy aliases (back-compat)">
+        <p className="text-xs text-fg-muted mb-3 max-w-prose">
+          Існуючі утиліти{" "}
+          <code className="font-mono">shadow-soft / card / float</code>{" "}
+          продовжують працювати — внутрішньо вони мапляться на{" "}
+          <code className="font-mono">e4 / e1 / e3</code>. Новий код має
+          використовувати <code className="font-mono">shadow-eN</code>.
+        </p>
+        <div className="flex flex-wrap gap-4">
+          <div className="shadow-card bg-surface rounded-2xl border border-border px-4 py-3 text-xs text-fg-muted font-mono">
+            shadow-card → e1
+          </div>
+          <div className="shadow-float bg-surface rounded-2xl border border-border px-4 py-3 text-xs text-fg-muted font-mono">
+            shadow-float → e3
+          </div>
+          <div className="shadow-soft bg-surface rounded-2xl border border-border px-4 py-3 text-xs text-fg-muted font-mono">
+            shadow-soft → e4
+          </div>
+        </div>
+      </Group>
+
+      <Group label="Debug">
+        <button
+          type="button"
+          onClick={() => setShowInline((v) => !v)}
+          className={cn(
+            "px-3 py-1.5 rounded-xl text-xs font-semibold border border-border bg-surface text-fg-muted",
+            "hover:bg-surface-muted",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/45 focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
+            "transition-colors",
+          )}
+          aria-expanded={showInline}
+        >
+          {showInline
+            ? "Сховати посилання на recipes"
+            : "Показати посилання на recipes"}
+        </button>
+        {showInline && (
+          <ul className="mt-3 space-y-1 text-2xs text-fg-subtle font-mono leading-relaxed">
+            {STEPS.map((step) => (
+              <li key={step.level}>
+                <span className="text-fg">--shadow-{step.level}</span>: див.{" "}
+                <code>
+                  packages/design-tokens/tokens.js → elevation.{step.level}
+                </code>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Group>
+    </Sec>
+  );
+}

--- a/apps/web/src/shared/components/ui/Card.test.tsx
+++ b/apps/web/src/shared/components/ui/Card.test.tsx
@@ -20,12 +20,15 @@ afterEach(cleanup);
  */
 describe("Card", () => {
   describe("defaults", () => {
-    it("renders with bg-panel, shadow-card, border, rounded-3xl, p-4", () => {
+    it("renders with bg-panel, shadow-e1, border, rounded-3xl, p-4", () => {
       const { container } = render(<Card>body</Card>);
       const el = container.firstElementChild!;
       expect(el.className).toContain("bg-panel");
       expect(el.className).toContain("border-line");
-      expect(el.className).toContain("shadow-card");
+      // Semantic elevation scale — default Card sits at e1 (raised).
+      // The legacy `shadow-card` alias still resolves to the same CSS
+      // var, but new code (and this primitive) uses the explicit token.
+      expect(el.className).toContain("shadow-e1");
       expect(el.className).toContain("rounded-3xl");
       expect(el.className).toContain("p-4");
     });
@@ -57,21 +60,24 @@ describe("Card", () => {
       const { container } = render(<Card variant="default">x</Card>);
       const cls = container.firstElementChild!.className;
       expect(cls).toContain("bg-panel");
-      expect(cls).toContain("shadow-card");
+      expect(cls).toContain("shadow-e1");
     });
 
     it("variant='flat' drops the shadow", () => {
       const { container } = render(<Card variant="flat">x</Card>);
       const cls = container.firstElementChild!.className;
       expect(cls).toContain("bg-panel");
+      // No elevation utility on a flat card (no `shadow-e*`, no legacy
+      // alias). Asserting both surfaces guards against accidental drift.
+      expect(cls).not.toMatch(/\bshadow-e\d\b/);
       expect(cls).not.toContain("shadow-card");
       expect(cls).not.toContain("shadow-float");
     });
 
-    it("variant='elevated' uses shadow-float", () => {
+    it("variant='elevated' lifts to elevation e3 (overlay tier)", () => {
       const { container } = render(<Card variant="elevated">x</Card>);
       const cls = container.firstElementChild!.className;
-      expect(cls).toContain("shadow-float");
+      expect(cls).toContain("shadow-e3");
     });
 
     it("variant='ghost' is transparent without border", () => {
@@ -179,7 +185,9 @@ describe("Card", () => {
       );
       const cls = container.firstElementChild!.className;
       expect(cls).toContain("transition-interactive");
-      expect(cls).toContain("hover:shadow-float");
+      // Hover lifts the card from elevation e1 → e2 (still in the
+      // page-level z-base tier, no z-index bump on hover).
+      expect(cls).toContain("hover:shadow-e2");
       expect(cls).toContain("border-finyk-soft-border");
     });
 

--- a/apps/web/src/shared/components/ui/Card.tsx
+++ b/apps/web/src/shared/components/ui/Card.tsx
@@ -101,15 +101,22 @@ const paddings: Record<CardPadding, string> = {
 // ─── Non-module surfaces ──────────────────────────────────────────────
 // Reach for these when the card is **not** branded for a module.
 // Padding and radius are layered on top of these by the wrapper below.
+// Maps onto the semantic elevation scale (e0..e5) from
+// `packages/design-tokens`. `default` is e1 (raised card), `interactive`
+// rests at e1 and lifts to e2 on hover (matches the new hover-lift
+// contract), and `elevated` sits at e3 so it reads as a clearly higher
+// surface than a default card. The `shadow-card` / `shadow-float`
+// aliases still resolve here for back-compat in product code, but
+// new code below uses the explicit `shadow-eN` utilities.
 const NON_MODULE_PROMINENCE: Record<
   Exclude<CardProminence, "hero" | "soft" | "tinted">,
   string
 > = {
-  default: "bg-panel border border-line shadow-card",
+  default: "bg-panel border border-line shadow-e1",
   interactive:
-    "bg-panel border border-line shadow-card transition-interactive hover:shadow-float hover:-translate-y-0.5 active:scale-[0.99] cursor-pointer",
+    "bg-panel border border-line shadow-e1 transition-interactive hover:shadow-e2 hover:-translate-y-0.5 active:scale-[0.99] cursor-pointer",
   flat: "bg-panel border border-line",
-  elevated: "bg-panel border border-line shadow-float",
+  elevated: "bg-panel border border-line shadow-e3",
   ghost: "bg-transparent border border-transparent",
 };
 

--- a/apps/web/src/shared/components/ui/Modal.tsx
+++ b/apps/web/src/shared/components/ui/Modal.tsx
@@ -168,7 +168,11 @@ export function Modal({
         aria-describedby={description ? descriptionId : undefined}
         onPointerDown={(e) => e.stopPropagation()}
         className={cn(
-          "relative w-full bg-surface border border-line rounded-3xl shadow-float",
+          // Elevation e4 — modal/sheet tier. Pairs with the default
+          // `zIndex={200}` prop (`zTier.modal`); a Modal must always
+          // sit at e4+z-modal so it clears every dropdown, popover
+          // and sticky header.
+          "relative w-full bg-surface border border-line rounded-3xl shadow-e4",
           "flex flex-col max-h-[min(90vh,calc(100dvh-2rem))]",
           "motion-safe:animate-scale-in",
           sizes[size],

--- a/apps/web/src/shared/components/ui/Sheet.tsx
+++ b/apps/web/src/shared/components/ui/Sheet.tsx
@@ -161,7 +161,11 @@ export function Sheet({
         style={panelStyle}
         onPointerDown={(e) => e.stopPropagation()}
         className={cn(
-          "relative w-full max-w-lg bg-panel border-t border-line rounded-t-3xl shadow-soft",
+          // Elevation e4 — same modal tier as <Modal>. Sheets are the
+          // mobile/coarse-pointer counterpart of Modal; they share the
+          // same z-modal stacking tier so a Sheet over a popover
+          // always reads as the higher surface.
+          "relative w-full max-w-lg bg-panel border-t border-line rounded-t-3xl shadow-e4",
           "flex flex-col max-h-[90vh]",
           "motion-safe:animate-slide-up",
           panelClassName,
@@ -180,7 +184,10 @@ export function Sheet({
             {...swipe.bind}
             role="presentation"
           >
-            <div className="w-12 h-sheet-handle bg-line/70 rounded-full" aria-hidden />
+            <div
+              className="w-12 h-sheet-handle bg-line/70 rounded-full"
+              aria-hidden
+            />
           </div>
         )}
         <div

--- a/apps/web/src/shared/components/ui/Toast.tsx
+++ b/apps/web/src/shared/components/ui/Toast.tsx
@@ -196,7 +196,10 @@ function ToastRow({ toast, dismiss, pause, resume }: ToastRowProps) {
   return (
     <div
       className={cn(
-        "text-style-label pointer-events-auto w-full px-4 py-3 rounded-2xl shadow-float relative overflow-hidden",
+        // Elevation e5 — toast tier. Toasts are the top-most
+        // ephemeral surface; pairing with `z-toast` (300) keeps them
+        // above modals/sheets even when both stacks are visible.
+        "text-style-label pointer-events-auto w-full px-4 py-3 rounded-2xl shadow-e5 relative overflow-hidden",
         "flex items-center gap-2.5 outline-none",
         "focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
         "touch-pan-y", // allow vertical scroll, capture horizontal swipe

--- a/apps/web/src/styles/theme.css
+++ b/apps/web/src/styles/theme.css
@@ -60,16 +60,43 @@
     --c-subtle: 107 100 93; /* #6b645d — warm stone (tertiary), WCAG AA ≥4.5:1 on panel/panel-hi/bg */
     --c-primary: 28 25 23; /* #1c1917 — ink (same as text) */
 
-    /* Shadows — softer, warmer, more organic */
-    --shadow-card:
-      0 1px 3px rgba(28, 25, 23, 0.04), 0 4px 16px rgba(28, 25, 23, 0.08),
+    /* ═══════════════════════════════════════════════════════════════════
+       ELEVATION SCALE — e0..e5
+       Single source of truth for shadow depth across the app. Pair each
+       level with the matching `z-*` tier (see `zTier` in
+       `packages/design-tokens/tokens.js`). Dark counterparts live in
+       `.dark { ... }` further down — consumers never need `dark:shadow-*`
+       (Hard Rule #13). Recipes mirror `elevation.{eN}.light` from
+       `packages/design-tokens/tokens.js`; keep the two in sync.
+       ═══════════════════════════════════════════════════════════════════ */
+    --shadow-e0: none;
+
+    --shadow-e1:
+      0 1px 2px rgba(28, 25, 23, 0.04), 0 2px 6px rgba(28, 25, 23, 0.06),
       inset 0 1px 0 rgba(255, 255, 255, 0.9);
 
-    --shadow-float:
-      0 2px 8px rgba(28, 25, 23, 0.06), 0 12px 40px rgba(28, 25, 23, 0.12),
+    --shadow-e2:
+      0 1px 3px rgba(28, 25, 23, 0.06), 0 6px 16px rgba(28, 25, 23, 0.1),
+      inset 0 1px 0 rgba(255, 255, 255, 0.9);
+
+    --shadow-e3:
+      0 2px 8px rgba(28, 25, 23, 0.08), 0 12px 24px rgba(28, 25, 23, 0.14),
       inset 0 1px 0 rgba(255, 255, 255, 0.85);
 
-    --shadow-soft: 0 8px 32px rgba(28, 25, 23, 0.12);
+    --shadow-e4:
+      0 4px 16px rgba(28, 25, 23, 0.1), 0 24px 48px rgba(28, 25, 23, 0.18),
+      inset 0 1px 0 rgba(255, 255, 255, 0.85);
+
+    --shadow-e5:
+      0 8px 24px rgba(28, 25, 23, 0.12), 0 32px 64px rgba(28, 25, 23, 0.22),
+      inset 0 1px 0 rgba(255, 255, 255, 0.85);
+
+    /* Legacy shadow aliases — forwarded onto the new scale so old call
+       sites (`shadow-card` / `shadow-float` / `shadow-soft`) keep
+       working unchanged. New code should prefer `shadow-eN`. */
+    --shadow-card: var(--shadow-e1);
+    --shadow-float: var(--shadow-e3);
+    --shadow-soft: var(--shadow-e4);
 
     /* Module glow drop-shadows for bottom nav icons (active state). */
     --shadow-finyk-nav: 0 0 8px rgba(16, 185, 129, 0.3);
@@ -251,15 +278,31 @@
     --c-subtle: 135 128 121; /* #878079 — readable tertiary (was #57534e) */
     --c-primary: 250 247 241; /* reversed */
 
-    --shadow-card:
-      0 1px 3px rgba(0, 0, 0, 0.25), 0 4px 16px rgba(0, 0, 0, 0.35),
+    /* Dark counterparts of the elevation scale. In dark mode the
+       surface itself can't get darker than the bg, so we lean on a
+       stronger shadow + a brighter inset top edge to read a level up.
+       Same `eN` level = same perceived prominence across themes. */
+    --shadow-e0: none;
+
+    --shadow-e1:
+      0 1px 2px rgba(0, 0, 0, 0.3), 0 2px 6px rgba(0, 0, 0, 0.35),
       inset 0 1px 0 rgba(255, 255, 255, 0.03);
 
-    --shadow-float:
-      0 2px 8px rgba(0, 0, 0, 0.3), 0 12px 40px rgba(0, 0, 0, 0.45),
-      inset 0 1px 0 rgba(255, 255, 255, 0.03);
+    --shadow-e2:
+      0 2px 4px rgba(0, 0, 0, 0.35), 0 8px 20px rgba(0, 0, 0, 0.45),
+      inset 0 1px 0 rgba(255, 255, 255, 0.04);
 
-    --shadow-soft: 0 8px 32px rgba(0, 0, 0, 0.5);
+    --shadow-e3:
+      0 3px 10px rgba(0, 0, 0, 0.4), 0 14px 30px rgba(0, 0, 0, 0.55),
+      inset 0 1px 0 rgba(255, 255, 255, 0.05);
+
+    --shadow-e4:
+      0 6px 18px rgba(0, 0, 0, 0.45), 0 28px 56px rgba(0, 0, 0, 0.65),
+      inset 0 1px 0 rgba(255, 255, 255, 0.06);
+
+    --shadow-e5:
+      0 10px 28px rgba(0, 0, 0, 0.5), 0 36px 72px rgba(0, 0, 0, 0.7),
+      inset 0 1px 0 rgba(255, 255, 255, 0.07);
 
     /* Dark-theme overrides for the new semantic tokens added above.
        `border-strong` now clears the 3:1 UI-contrast threshold so

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -1,6 +1,6 @@
 # Sergeant Design System
 
-> **Last validated:** 2026-05-05 by @Skords-01. **Next review:** 2026-08-03.
+> **Last validated:** 2026-05-13 by @Skords-01. **Next review:** 2026-08-11.
 > **Status:** Active
 
 Єдина візуальна мова для хаба з 4 модулями: **ФІНІК**, **ФІЗРУК**, **Рутина**,
@@ -227,16 +227,73 @@ Tailwind `spacing` (базова шкала 4px) + кастомні:
 Правило: **одна картка — один радіус**. Не змішуй `rounded-xl`
 header + `rounded-2xl` body.
 
-### Тіні
+### Тіні (елеваційна шкала e0..e5)
 
-| Клас           | Джерело                   | Коли                     |
-| -------------- | ------------------------- | ------------------------ |
-| `shadow-soft`  | `--shadow-soft`           | Фонова підсвітка блоку   |
-| `shadow-card`  | `--shadow-card`           | Дефолт для `Card`        |
-| `shadow-float` | `--shadow-float`          | Hover, плаваючі елементи |
-| `shadow-glow`  | Tailwind (брендовий blur) | CTA, акценти, фокуси     |
+Семантична шкала єдине джерело правди для глибини. Розподіл рівнів —
+в [`packages/design-tokens/tokens.js`](../../packages/design-tokens/tokens.js) →
+`elevation`; CSS-змінні лежать в
+[`apps/web/src/styles/theme.css`](../../apps/web/src/styles/theme.css)
+і автоматично перемикаються в `.dark` — ніяких `dark:shadow-*`
+(Hard Rule #13).
 
-Темна тема має власні значення змінних — не додавай `dark:shadow-*`.
+| Клас        | Рівень      | Коли                                     | Z-tier       |
+| ----------- | ----------- | ---------------------------------------- | ------------ |
+| `shadow-e0` | Flat        | Фон сторінки, секції, інпути             | `z-base`     |
+| `shadow-e1` | Raised      | Дефолт `Card`, рядки списку, панелі      | `z-base`     |
+| `shadow-e2` | Interactive | Hover підйом карток / pressables         | `z-base`     |
+| `shadow-e3` | Overlay     | Popover, dropdown, tooltip, menu         | `z-dropdown` |
+| `shadow-e4` | Modal       | `<Modal>`, `<Sheet>`, drawer             | `z-modal`    |
+| `shadow-e5` | Toast       | `<Toast>`, snackbar (top-most ephemeral) | `z-toast`    |
+
+Парний z-index тір (`zTier` в токенах):
+
+| Семантика  | Клас         | Значення | Призначення                               |
+| ---------- | ------------ | -------- | ----------------------------------------- |
+| `base`     | `z-base`     | `0`      | Контент сторінки, картки, кнопки (e0..e2) |
+| `dropdown` | `z-dropdown` | `50`     | Попапи, меню, tooltip (e3)                |
+| `sticky`   | `z-sticky`   | `100`    | Sticky header / toolbar                   |
+| `overlay`  | `z-overlay`  | `150`    | Non-modal overlays, scrim під модалкою    |
+| `modal`    | `z-modal`    | `200`    | Modal, Sheet, drawer (e4)                 |
+| `toast`    | `z-toast`    | `300`    | Toast, snackbar (e5)                      |
+
+Правило: **рівень елевації рухається в парі з z-tier**. Якщо піднімаєш
+shadow до e4 — бери `z-modal`. Їх розсинхронізація = popover під модалкою
+або toast під drawer-ом.
+
+#### ДО ї НЕ ТРЕБА
+
+**ДО** — вибирай найменший рівень, який передає роль елемента. Дефолтний Card — e1.
+
+```tsx
+<Card prominence="interactive">  {/* shadow-e1, hover → shadow-e2 */}
+  <Stat label="Баланс" value="₴12 345" />
+</Card>
+
+<Modal>                            {/* shadow-e4 + z-modal */}
+  <CelebrationCopy />
+</Modal>
+
+<Toast>                            {/* shadow-e5 + z-toast */}
+  Запис збережено.
+</Toast>
+```
+
+**НЕ ТРЕБА** — не додавай `dark:shadow-*`, не копіюй raw `boxShadow` в inline-style,
+не бери `shadow-e4` для плоскої картки "щоб було popping". Що більший рівень —
+тим вище має бути z-tier.
+
+```tsx
+/* ⛔ НЕ ТРЕБА — вибиває візуальну ієрархію */
+<Card className="shadow-e4" />                          /* картка не має важити як Modal */
+<div className="shadow-card dark:shadow-2xl" />         /* парні dark: — Hard Rule #13 */
+<div className="shadow-e3 z-toast" />                   /* попап на toast тірі — розсинхрон з e3 */
+```
+
+#### Legacy aliases
+
+Наявні класи `shadow-soft / shadow-card / shadow-float / shadow-glow` продовжують
+працювати — вони внутрішньо мапляться на нову шкалу (`card → e1`,
+`float → e3`, `soft → e4`). Новий код має вживати явний `shadow-eN`.
 
 ---
 

--- a/packages/design-tokens/__snapshots__/tokens.test.js.snap
+++ b/packages/design-tokens/__snapshots__/tokens.test.js.snap
@@ -139,6 +139,35 @@ exports[`@sergeant/design-tokens — tokens.js > chartPalette / chartPaletteList
 }
 `;
 
+exports[`@sergeant/design-tokens — tokens.js > elevation recipes snapshot — light + dark per level 1`] = `
+{
+  "e0": {
+    "dark": "none",
+    "light": "none",
+  },
+  "e1": {
+    "dark": "0 1px 2px rgba(0, 0, 0, 0.30), 0 2px 6px rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.03)",
+    "light": "0 1px 2px rgba(28, 25, 23, 0.04), 0 2px 6px rgba(28, 25, 23, 0.06), inset 0 1px 0 rgba(255, 255, 255, 0.9)",
+  },
+  "e2": {
+    "dark": "0 2px 4px rgba(0, 0, 0, 0.35), 0 8px 20px rgba(0, 0, 0, 0.45), inset 0 1px 0 rgba(255, 255, 255, 0.04)",
+    "light": "0 1px 3px rgba(28, 25, 23, 0.06), 0 6px 16px rgba(28, 25, 23, 0.10), inset 0 1px 0 rgba(255, 255, 255, 0.9)",
+  },
+  "e3": {
+    "dark": "0 3px 10px rgba(0, 0, 0, 0.40), 0 14px 30px rgba(0, 0, 0, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.05)",
+    "light": "0 2px 8px rgba(28, 25, 23, 0.08), 0 12px 24px rgba(28, 25, 23, 0.14), inset 0 1px 0 rgba(255, 255, 255, 0.85)",
+  },
+  "e4": {
+    "dark": "0 6px 18px rgba(0, 0, 0, 0.45), 0 28px 56px rgba(0, 0, 0, 0.65), inset 0 1px 0 rgba(255, 255, 255, 0.06)",
+    "light": "0 4px 16px rgba(28, 25, 23, 0.10), 0 24px 48px rgba(28, 25, 23, 0.18), inset 0 1px 0 rgba(255, 255, 255, 0.85)",
+  },
+  "e5": {
+    "dark": "0 10px 28px rgba(0, 0, 0, 0.50), 0 36px 72px rgba(0, 0, 0, 0.70), inset 0 1px 0 rgba(255, 255, 255, 0.07)",
+    "light": "0 8px 24px rgba(28, 25, 23, 0.12), 0 32px 64px rgba(28, 25, 23, 0.22), inset 0 1px 0 rgba(255, 255, 255, 0.85)",
+  },
+}
+`;
+
 exports[`@sergeant/design-tokens — tokens.js > moduleAccentRgb is stable (snapshot) 1`] = `
 {
   "finyk": {
@@ -204,5 +233,16 @@ exports[`@sergeant/design-tokens — tokens.js > statusColors + statusHex pair m
   "info": "#0ea5e9",
   "success": "#10b981",
   "warning": "#f59e0b",
+}
+`;
+
+exports[`@sergeant/design-tokens — tokens.js > zTier snapshot — exact numeric assignment 1`] = `
+{
+  "base": "0",
+  "dropdown": "50",
+  "modal": "200",
+  "overlay": "150",
+  "sticky": "100",
+  "toast": "300",
 }
 `;

--- a/packages/design-tokens/index.d.ts
+++ b/packages/design-tokens/index.d.ts
@@ -86,3 +86,32 @@ export type ChartHexKey =
 
 /** Chart hex tokens — semantic names for inline-styled chart primitives. */
 export declare const chartHex: Readonly<Record<ChartHexKey, string>>;
+
+/** Semantic elevation levels — pair each level with the matching z-tier. */
+export type ElevationLevel = "e0" | "e1" | "e2" | "e3" | "e4" | "e5";
+
+/** Per-level shadow recipe with light + dark counterparts. */
+export interface ElevationStep {
+  readonly light: string;
+  readonly dark: string;
+}
+
+/**
+ * Elevation scale — semantic shadow contract. Consumers should prefer
+ * the `shadow-eN` Tailwind utility (backed by CSS vars defined in
+ * `apps/web/src/styles/theme.css`); this export exists for non-Tailwind
+ * call sites (e.g. raw `boxShadow` style props, mobile shadow-spec).
+ */
+export declare const elevation: Readonly<Record<ElevationLevel, ElevationStep>>;
+
+/** Semantic z-index tiers — match an `elevation.eN` level to its tier. */
+export type ZTier =
+  | "base"
+  | "dropdown"
+  | "sticky"
+  | "overlay"
+  | "modal"
+  | "toast";
+
+/** Z-index tier values (numeric strings) keyed by semantic tier. */
+export declare const zTier: Readonly<Record<ZTier, string>>;

--- a/packages/design-tokens/tailwind-preset.js
+++ b/packages/design-tokens/tailwind-preset.js
@@ -16,6 +16,7 @@ import {
   chartPalette,
   moduleColors,
   statusColors,
+  zTier,
 } from "./tokens.js";
 
 /** @type {import('tailwindcss').Config} */
@@ -317,12 +318,36 @@ const preset = {
       },
 
       // ═══════════════════════════════════════════════════════════════════
-      // BOX SHADOWS — Soft, layered, premium feel
+      // BOX SHADOWS — Semantic elevation scale e0..e5
+      //
+      // The `e0..e5` scale is the canonical elevation contract — see
+      // `elevation` token in `./tokens.js` for the per-level light/dark
+      // recipe. CSS variables `--shadow-e0..--shadow-e5` are defined in
+      // `apps/web/src/styles/theme.css` and flip with `.dark`, so call
+      // sites use a single `shadow-eN` utility — never `dark:shadow-*`.
+      //
+      // Legacy aliases (`soft` / `card` / `float`) are preserved as
+      // pointers into the new scale so existing call sites keep
+      // working unchanged: `shadow-card === shadow-e1`,
+      // `shadow-float === shadow-e3`, `shadow-soft === shadow-e4`.
+      // New code should prefer `shadow-eN` for the explicit semantic
+      // level. See docs/design/design-system.md § 4.
       // ═══════════════════════════════════════════════════════════════════
       boxShadow: {
-        soft: "var(--shadow-soft)",
-        card: "var(--shadow-card)",
-        float: "var(--shadow-float)",
+        // Semantic elevation scale (preferred for new code).
+        e0: "var(--shadow-e0)",
+        e1: "var(--shadow-e1)",
+        e2: "var(--shadow-e2)",
+        e3: "var(--shadow-e3)",
+        e4: "var(--shadow-e4)",
+        e5: "var(--shadow-e5)",
+        // Legacy aliases — kept for back-compat, mapped 1:1 to the new
+        // scale via the same CSS vars (so a theme tweak to `--shadow-eN`
+        // propagates to every consumer regardless of which name they
+        // import).
+        soft: "var(--shadow-e4)",
+        card: "var(--shadow-e1)",
+        float: "var(--shadow-e3)",
         glow: "0 0 0 3px rgba(16, 185, 129, 0.15)", // emerald glow
         "glow-teal": "0 0 0 3px rgba(20, 184, 166, 0.15)",
         "glow-coral": "0 0 0 3px rgba(249, 112, 102, 0.15)",
@@ -607,18 +632,39 @@ const preset = {
       },
 
       // ═══════════════════════════════════════════════════════════════════
-      // Z-INDEX — Layering system
+      // Z-INDEX — Semantic stacking tier (paired with elevation scale)
+      //
+      // Authoring rule: an element at elevation `eN` must use the
+      // matching `z-*` tier. e0/e1/e2 → `z-base`, e3 → `z-dropdown`,
+      // e4 → `z-modal`, e5 → `z-toast`. Mismatched pairs are how
+      // popovers slide under modals and toasts get hidden by drawers.
+      // See docs/design/design-system.md § 4 and `zTier` in tokens.js.
+      //
+      // Legacy numeric scale (`z-100`/`200`/`300`/`400` and the
+      // `z-header`/`modal`/`toast`/`tooltip` aliases) is preserved so
+      // existing call sites keep working unchanged.
       // ═══════════════════════════════════════════════════════════════════
       zIndex: {
+        // Raw numeric scale (legacy — kept for back-compat).
         0: "0",
         10: "10",
         20: "20",
         30: "30",
         40: "40",
         50: "50",
-        header: "100",
-        modal: "200",
-        toast: "300",
+        100: "100",
+        // Semantic tier — preferred for new code.
+        base: zTier.base,
+        dropdown: zTier.dropdown,
+        sticky: zTier.sticky,
+        overlay: zTier.overlay,
+        modal: zTier.modal,
+        toast: zTier.toast,
+        // Legacy tier aliases (kept so existing `z-header` / `z-modal`
+        // / `z-toast` / `z-tooltip` call sites keep working). `header`
+        // is an alias of `sticky`; `tooltip` is an alias of `toast`
+        // (highest non-modal tier — preserves the historical order).
+        header: zTier.sticky,
         tooltip: "400",
       },
     },

--- a/packages/design-tokens/tokens.js
+++ b/packages/design-tokens/tokens.js
@@ -173,6 +173,95 @@ export const statusHex = {
 };
 
 /**
+ * Elevation scale — semantic, layered shadows for the entire surface
+ * stack. Each level pairs a `light` and `dark` recipe; consumers read
+ * the corresponding CSS variable (`--shadow-e0…--shadow-e5`) so the
+ * shadow flips automatically when `.dark` is toggled — never use
+ * `dark:shadow-*` Tailwind variants (Hard Rule #13).
+ *
+ * Semantics (level → typical role → matching z-index tier):
+ *   e0  flat        no shadow — page background / sections / inputs    z-base
+ *   e1  raised      default `Card`, list rows, panels                  z-base
+ *   e2  interactive hover lift on cards / buttons / pressables         z-base
+ *   e3  overlay     popovers, dropdowns, menus, segmented hover        z-dropdown
+ *   e4  modal       Modal panels, Sheets, drawers                      z-modal
+ *   e5  toast       Toasts, snackbars, top-most ephemeral surfaces     z-toast
+ *
+ * Why two themes:
+ *   In light mode the shadow is the dominant depth cue (soft warm
+ *   umber with a faint inset top highlight to mimic a physical
+ *   surface). In dark mode the surface itself can't get darker than
+ *   the background, so we lean on a *stronger* shadow + a brighter
+ *   inset top edge to read a level up. Same level → same perceived
+ *   prominence across themes.
+ *
+ * Authoring rule:
+ *   Always pick the smallest level that conveys the role. Don't reach
+ *   for `e4` on a card just because it should "pop"; that's how the
+ *   UI started looking flat and amateur — every surface used the same
+ *   muddy `shadow-card`. The pairing with z-index tier is intentional:
+ *   if you bump elevation, you bump the z-tier too (and vice versa).
+ */
+export const elevation = {
+  e0: {
+    light: "none",
+    dark: "none",
+  },
+  e1: {
+    light:
+      "0 1px 2px rgba(28, 25, 23, 0.04), 0 2px 6px rgba(28, 25, 23, 0.06), inset 0 1px 0 rgba(255, 255, 255, 0.9)",
+    dark: "0 1px 2px rgba(0, 0, 0, 0.30), 0 2px 6px rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.03)",
+  },
+  e2: {
+    light:
+      "0 1px 3px rgba(28, 25, 23, 0.06), 0 6px 16px rgba(28, 25, 23, 0.10), inset 0 1px 0 rgba(255, 255, 255, 0.9)",
+    dark: "0 2px 4px rgba(0, 0, 0, 0.35), 0 8px 20px rgba(0, 0, 0, 0.45), inset 0 1px 0 rgba(255, 255, 255, 0.04)",
+  },
+  e3: {
+    light:
+      "0 2px 8px rgba(28, 25, 23, 0.08), 0 12px 24px rgba(28, 25, 23, 0.14), inset 0 1px 0 rgba(255, 255, 255, 0.85)",
+    dark: "0 3px 10px rgba(0, 0, 0, 0.40), 0 14px 30px rgba(0, 0, 0, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.05)",
+  },
+  e4: {
+    light:
+      "0 4px 16px rgba(28, 25, 23, 0.10), 0 24px 48px rgba(28, 25, 23, 0.18), inset 0 1px 0 rgba(255, 255, 255, 0.85)",
+    dark: "0 6px 18px rgba(0, 0, 0, 0.45), 0 28px 56px rgba(0, 0, 0, 0.65), inset 0 1px 0 rgba(255, 255, 255, 0.06)",
+  },
+  e5: {
+    light:
+      "0 8px 24px rgba(28, 25, 23, 0.12), 0 32px 64px rgba(28, 25, 23, 0.22), inset 0 1px 0 rgba(255, 255, 255, 0.85)",
+    dark: "0 10px 28px rgba(0, 0, 0, 0.50), 0 36px 72px rgba(0, 0, 0, 0.70), inset 0 1px 0 rgba(255, 255, 255, 0.07)",
+  },
+};
+
+/**
+ * Z-index tier — semantic stacking levels that must move in lockstep
+ * with the elevation scale. Authoring rule: an element at elevation
+ * `eN` belongs in the matching `z-*` tier (e0/e1/e2 → base, e3 →
+ * dropdown, e4 → modal, e5 → toast). Mismatched pairs are how
+ * popovers end up under modals and toasts get hidden by drawers.
+ *
+ * Numeric values are spaced so future intermediate tiers can be
+ * inserted without renumbering. `sticky` sits above `dropdown`
+ * because a sticky header should still cover a body-level popover.
+ *
+ *   z-base       0    — page content, cards, buttons, e0..e2 surfaces
+ *   z-dropdown  50    — popovers, tooltips, menus, e3 surfaces
+ *   z-sticky   100    — sticky headers, sticky table headers
+ *   z-overlay  150    — non-modal overlays, scrims behind a modal
+ *   z-modal    200    — Modal, Sheet, drawer (e4 surfaces)
+ *   z-toast    300    — Toasts, snackbars (e5 surfaces; always on top)
+ */
+export const zTier = {
+  base: "0",
+  dropdown: "50",
+  sticky: "100",
+  overlay: "150",
+  modal: "200",
+  toast: "300",
+};
+
+/**
  * Chart hex tokens — semantic names for inline-styled chart primitives
  * that accept a raw `"#rrggbb"` string (SVG `fill` / `stroke`, canvas
  * contexts, `style={{ color }}`). Each key maps to exactly one design

--- a/packages/design-tokens/tokens.test.js
+++ b/packages/design-tokens/tokens.test.js
@@ -14,10 +14,12 @@ import {
   chartHex,
   chartPalette,
   chartPaletteList,
+  elevation,
   moduleAccentRgb,
   moduleColors,
   statusColors,
   statusHex,
+  zTier,
 } from "./tokens.js";
 import {
   colors as mobileColors,
@@ -68,6 +70,53 @@ describe("@sergeant/design-tokens — tokens.js", () => {
 
   it("chartPaletteList length === Object.keys(chartPalette).length", () => {
     expect(chartPaletteList.length).toBe(Object.keys(chartPalette).length);
+  });
+
+  it("elevation scale exposes the canonical e0..e5 keys with light+dark recipes", () => {
+    // Lock the public surface — adding a level (e.g. `e6`) is a
+    // breaking change for every consumer; renaming an existing one is
+    // not allowed without a coordinated docs/refactor pass.
+    expect(Object.keys(elevation)).toEqual([
+      "e0",
+      "e1",
+      "e2",
+      "e3",
+      "e4",
+      "e5",
+    ]);
+    for (const step of Object.values(elevation)) {
+      expect(typeof step.light).toBe("string");
+      expect(typeof step.dark).toBe("string");
+    }
+    // e0 is the only "flat" level — both themes resolve to `none`.
+    expect(elevation.e0.light).toBe("none");
+    expect(elevation.e0.dark).toBe("none");
+  });
+
+  it("elevation recipes snapshot — light + dark per level", () => {
+    expect(elevation).toMatchSnapshot();
+  });
+
+  it("zTier exposes the canonical base..toast stacking tier", () => {
+    expect(Object.keys(zTier)).toEqual([
+      "base",
+      "dropdown",
+      "sticky",
+      "overlay",
+      "modal",
+      "toast",
+    ]);
+    // Numerically monotonic — popovers must always sit below modals,
+    // modals always below toasts, etc. We compare as integers because
+    // CSS variables expect a unit-less string and a typo (e.g. "20O")
+    // would silently sort wrong as a string.
+    const ordered = ["base", "dropdown", "sticky", "overlay", "modal", "toast"];
+    const values = ordered.map((t) => Number(zTier[t]));
+    expect(values).toEqual([...values].sort((a, b) => a - b));
+  });
+
+  it("zTier snapshot — exact numeric assignment", () => {
+    expect(zTier).toMatchSnapshot();
   });
 });
 


### PR DESCRIPTION
## Summary

Introduces a proper layered Elevation & Shadow system so the UI stops looking flat. Replaces the unsemantic `shadow-soft / card / float / glow` trio with a canonical six-level scale (`shadow-e0..shadow-e5`) wired through CSS variables — light vs dark switches automatically with **zero** `dark:shadow-*` overrides (Hard Rule #13). A parallel semantic z-index tier (`z-base / z-dropdown / z-sticky / z-overlay / z-modal / z-toast`) is added; the contract is that elevation level and z-tier move in lockstep.

**Elevation contract:**

| Level | Role | Paired z-tier |
| ----- | ---- | ------------- |
| `e0`  | Flat — backgrounds, sections, inputs | `z-base` (0) |
| `e1`  | Raised — Card default, list rows | `z-base` (0) |
| `e2`  | Interactive — Card / Button hover lift | `z-base` (0) |
| `e3`  | Overlay — Popover, Menu, Tooltip | `z-dropdown` (50) |
| `e4`  | Modal — Modal, Sheet, Drawer | `z-modal` (200) |
| `e5`  | Toast — Toast, Snackbar | `z-toast` (300) |

### What changed

- `packages/design-tokens/tokens.js` — exports `elevation` (light + dark recipes per level) and `zTier` (semantic stacking).
- `packages/design-tokens/tailwind-preset.js` — exposes `shadow-e0..e5` and `z-base/dropdown/sticky/overlay/modal/toast`. Legacy `shadow-soft / card / float / glow` alias the new scale via the same CSS vars (no breaking change).
- `apps/web/src/styles/theme.css` — defines `--shadow-e0..--shadow-e5` for both `:root` and `.dark`. Legacy `--shadow-soft/card/float` re-aliased to `var(--shadow-eN)`.
- `Card` default → `shadow-e1`; hover lift `e1 → e2`; `elevated` → `shadow-e3`. `Modal` panel `shadow-float` → `shadow-e4`. `Sheet` panel `shadow-soft` → `shadow-e4`. `Toast` `shadow-float` → `shadow-e5`.
- New DesignShowcase `Elevation` section renders all 6 levels side-by-side in light AND dark panes (dark pane uses a local `.dark` scope so semantic tokens resolve from the dark branch — no raw hex, no `dark:` overrides).
- `docs/design/design-system.md` (Ukrainian) — freshness header bumped to 2026-05-13. Shadow section rewritten with elevation + z-tier docs and a ДО/НЕ ТРЕБА pair.

### Screenshots

**Page in light theme:**

![Elevation section, page in light theme](https://app.devin.ai/attachments/00a36d0f-3fbc-45b7-a2f3-90594be1dec9/elevation-light-and-dark.png)

**Page in dark theme:**

![Elevation section, page in dark theme](https://app.devin.ai/attachments/6b0512b4-3e14-4785-85f9-254ae9328187/elevation-page-dark-theme.png)

## Governing Skill

- Primary skill: `.agents/skills/sergeant-web-ui/SKILL.md`.
- Secondary skill (if truly needed): n/a.

## Playbook

- Primary playbook: none.
- Why this playbook: n/a.
- If no playbook matched, why: single-track design-system change.

## Verification

```bash
pnpm --filter @sergeant/web lint            # 0 errors, 0 warnings
pnpm --filter @sergeant/web typecheck       # green
pnpm --filter @sergeant/web test            # 2709 tests in 253 files, all pass
pnpm --filter @sergeant/web build           # Vite build green
```

Additional checks:

- [x] Local smoke / manual validation completed.
- [x] Surface-specific checks completed.

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- `docs/design/design-system.md`

## Risk and Rollout

- User-visible risk: Low. Card, Modal, Sheet, Toast use the new shadow recipe (visual refinement). Shape and z-index unchanged. Legacy aliases keep working.
- Rollout / deploy order: Single PR.
- Backout plan: Revert this PR.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

Dark-pane technique in `Elevation.tsx` uses a local `.dark` class wrapper. Pre-existing failures in `pnpm lint` (env-single-source on `apps/server`) and `pnpm --filter @sergeant/web size` (bundle 879.88 KB vs 820 KB gate) both already fail on `main` — confirmed locally.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a six‑level elevation scale (`shadow-e0..e5`) and semantic z-index tiers that replace the old shadow classes. Core UI now uses the new tokens, and light/dark switches automatically via CSS variables (no `dark:` overrides).

- **New Features**
  - `@sergeant/design-tokens`: exports `elevation` (light/dark recipes per level) and `zTier` (semantic stacking tiers).
  - Tailwind preset: adds `shadow-e0..e5` and `z-base/dropdown/sticky/overlay/modal/toast`; legacy `shadow-card/float/soft` map to `e1/e3/e4`.
  - Theme: defines `--shadow-e0..--shadow-e5` for light and dark in `theme.css`, so shadows adapt without `dark:shadow-*`.
  - Components: `Card` default `e1` (hover `e2`, elevated `e3`); `Modal` and `Sheet` use `e4`; `Toast` uses `e5`.
  - Showcase/Docs/Tests: new Elevation section in the design showcase, shadows removed from Colors; design-system docs updated with the elevation + z-tier pairing rule; token snapshots and Card tests updated.

<sup>Written for commit e61d44a7b24c3e10e2038bd0b96396f5a06fae64. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

