### PR TITLE
feat(server): openclaw morning briefing LLM proposals (Phase 2.A O1)

### DIFF
--- a/.agents/skills-lock.json
+++ b/.agents/skills-lock.json
@@ -54,7 +54,7 @@
     "sergeant-start-here": {
       "source": "local",
       "sourceType": "local",
-      "computedHash": "bd39951487ed2b6a765a25cce1e49c9930d96cdc1f59d372413afed3e75c745c"
+      "computedHash": "ac56e77b7926cfe25f323ca4c3e531a7b5e6ec47b20580b5fabc30e727bc8979"
     },
     "sergeant-web-ui": {
       "source": "local",

--- a/apps/server/src/modules/openclaw/briefing/builder.test.ts
+++ b/apps/server/src/modules/openclaw/briefing/builder.test.ts
@@ -19,6 +19,12 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { env } from "../../../env.js";
+import {
+  StubProvider,
+  type LLMGenerateOpts,
+  type LLMGenerateResult,
+  type LLMProvider,
+} from "../../../lib/llm/provider.js";
 import { assembleMorningBriefing } from "./builder.js";
 
 vi.mock("../github-auth.js", () => ({
@@ -388,5 +394,236 @@ describe("assembleMorningBriefing — partial / error tolerance", () => {
     });
     expect(data.prQueue.openCount).toBeUndefined();
     expect(data.prQueue.note).toContain("GitHub API повернув 404");
+  });
+});
+
+/**
+ * O1 / Phase 2.A — proposals секція через LLMProvider override.
+ * Перевіряємо happy / parse-fail / provider-error / stub / disabled.
+ * Мокаємо тільки LLM (стандартні fetch-mocks залишають інші 5 секцій
+ * на дефолтних not-configured-fallback-ах).
+ */
+class FakeLLMProvider implements LLMProvider {
+  readonly name = "anthropic" as const;
+  calls: LLMGenerateOpts[] = [];
+  constructor(
+    private readonly responder: (
+      opts: LLMGenerateOpts,
+    ) => Promise<LLMGenerateResult> | LLMGenerateResult,
+  ) {}
+  async generate(opts: LLMGenerateOpts): Promise<LLMGenerateResult> {
+    this.calls.push(opts);
+    return await this.responder(opts);
+  }
+}
+
+describe("assembleMorningBriefing — O1 / Phase 2.A proposals (LLM)", () => {
+  it("populates proposals from LLM response with reasoning", async () => {
+    const llm = new FakeLLMProvider(() => ({
+      ok: true,
+      text: JSON.stringify({
+        proposals: [
+          "Закрити PR #101 (needs-review старший за 24h)",
+          "Перевірити Sentry error spike по chat-stream",
+          "Розписати growth-experiment у docs/strategy",
+        ],
+        reasoning:
+          "PR-черга росте, Sentry показав error, growth блокує MRR — три фокуси максимізують impact.",
+      }),
+    }));
+    const { data, markdown } = await assembleMorningBriefing(
+      { nowMs: Date.parse("2026-05-13T06:00:00Z") },
+      { llmProvider: llm },
+    );
+    expect(llm.calls).toHaveLength(1);
+    expect(llm.calls[0]?.model).toBe("claude-sonnet-4-5-20250929");
+    expect(llm.calls[0]?.endpoint).toBe(
+      "internal/openclaw/briefing/morning/proposals",
+    );
+    expect(data.proposals?.proposals).toEqual([
+      "Закрити PR #101 (needs-review старший за 24h)",
+      "Перевірити Sentry error spike по chat-stream",
+      "Розписати growth-experiment у docs/strategy",
+    ]);
+    expect(data.proposals?.reasoning).toContain("PR-черга росте");
+    expect(markdown).toContain("🎯 Пропозиції на сьогодні");
+    expect(markdown).toContain(
+      "1. Закрити PR #101 (needs-review старший за 24h)",
+    );
+    // Proposals must appear above MRR section.
+    const proposalsIdx = markdown.indexOf("🎯 Пропозиції");
+    const stripeIdx = markdown.indexOf("💵 MRR / Stripe");
+    expect(proposalsIdx).toBeLessThan(stripeIdx);
+  });
+
+  it("returns notConfigured when LLM provider is stub (Anthropic outage / dev)", async () => {
+    const { data, markdown } = await assembleMorningBriefing(
+      { nowMs: Date.parse("2026-05-13T06:00:00Z") },
+      { llmProvider: new StubProvider() },
+    );
+    expect(data.proposals?.notConfigured).toBe(true);
+    expect(data.proposals?.note).toContain("stub-режим");
+    expect(markdown).toContain(
+      "_LLM-провайдер не сконфігурований (`ANTHROPIC_API_KEY` / `LLM_PROVIDER`); next-action-и пропущено._",
+    );
+  });
+
+  it("renders rate-limit note when LLM returned 429", async () => {
+    const llm = new FakeLLMProvider(() => ({
+      ok: false,
+      error: "Anthropic rate-limit exceeded",
+      status: 429,
+      code: "rate_limited",
+    }));
+    const { data, markdown } = await assembleMorningBriefing(
+      { nowMs: Date.parse("2026-05-13T06:00:00Z") },
+      { llmProvider: llm },
+    );
+    expect(data.proposals?.notConfigured).toBeUndefined();
+    expect(data.proposals?.proposals).toBeUndefined();
+    expect(data.proposals?.note).toBe(
+      "LLM rate-limit; фокус — roadmap-задача дня.",
+    );
+    expect(markdown).toContain("- LLM rate-limit");
+  });
+
+  it("renders timeout note when LLM provider timed out", async () => {
+    const llm = new FakeLLMProvider(() => ({
+      ok: false,
+      error: "Request aborted",
+      code: "timeout",
+    }));
+    const { data } = await assembleMorningBriefing(
+      { nowMs: Date.parse("2026-05-13T06:00:00Z") },
+      { llmProvider: llm },
+    );
+    expect(data.proposals?.note).toBe(
+      "LLM timeout; фокус — roadmap-задача дня.",
+    );
+  });
+
+  it("renders generic-error note when LLM returned non-classified failure", async () => {
+    const llm = new FakeLLMProvider(() => ({
+      ok: false,
+      error: "Internal Server Error",
+      status: 500,
+      code: "anthropic_error",
+    }));
+    const { data } = await assembleMorningBriefing(
+      { nowMs: Date.parse("2026-05-13T06:00:00Z") },
+      { llmProvider: llm },
+    );
+    expect(data.proposals?.note).toBe(
+      "LLM-пропозиції недоступні (див. Sentry).",
+    );
+  });
+
+  it("renders parse-fail note when LLM returned non-JSON text", async () => {
+    const llm = new FakeLLMProvider(() => ({
+      ok: true,
+      text: "Sorry I cannot generate proposals today.",
+    }));
+    const { data } = await assembleMorningBriefing(
+      { nowMs: Date.parse("2026-05-13T06:00:00Z") },
+      { llmProvider: llm },
+    );
+    expect(data.proposals?.proposals).toBeUndefined();
+    expect(data.proposals?.note).toContain("невалідний JSON");
+  });
+
+  it("caps proposals to 3 even if LLM returned more", async () => {
+    const llm = new FakeLLMProvider(() => ({
+      ok: true,
+      text: JSON.stringify({
+        proposals: ["a", "b", "c", "d", "e"],
+      }),
+    }));
+    const { data } = await assembleMorningBriefing(
+      { nowMs: Date.parse("2026-05-13T06:00:00Z") },
+      { llmProvider: llm },
+    );
+    expect(data.proposals?.proposals).toEqual(["a", "b", "c"]);
+  });
+
+  it("filters out empty strings + non-string items from proposals[]", async () => {
+    const llm = new FakeLLMProvider(() => ({
+      ok: true,
+      text: JSON.stringify({
+        proposals: ["valid", "", "  ", 42, "second", null],
+      }),
+    }));
+    const { data } = await assembleMorningBriefing(
+      { nowMs: Date.parse("2026-05-13T06:00:00Z") },
+      { llmProvider: llm },
+    );
+    expect(data.proposals?.proposals).toEqual(["valid", "second"]);
+  });
+
+  it("skips LLM call entirely when includeProposals=false", async () => {
+    const llm = new FakeLLMProvider(() => {
+      throw new Error("should not be called");
+    });
+    const { data, markdown } = await assembleMorningBriefing(
+      {
+        nowMs: Date.parse("2026-05-13T06:00:00Z"),
+        includeProposals: false,
+      },
+      { llmProvider: llm },
+    );
+    expect(llm.calls).toHaveLength(0);
+    expect(data.proposals).toBeUndefined();
+    expect(markdown).not.toContain("🎯 Пропозиції");
+  });
+
+  it("includes briefing data in LLM user message (Stripe + Sentry + PR signals)", async () => {
+    patchEnv({
+      STRIPE_SECRET_KEY: "sk_test",
+      POSTHOG_API_KEY: "phx",
+      POSTHOG_PROJECT_ID: "1",
+      SENTRY_AUTH_TOKEN: "sntryu",
+      N8N_API_URL: "https://n8n.example.com",
+      N8N_API_KEY: "n8n",
+    });
+    routes.push(
+      {
+        match: (u) => u.startsWith("https://api.stripe.com/v1/charges"),
+        respond: () =>
+          makeJsonResponse({
+            data: [{ amount: 25_000, paid: true }],
+          }),
+      },
+      {
+        match: (u) => u.includes("app.posthog.com"),
+        respond: () => makeJsonResponse({ result: [{ aggregated_value: 5 }] }),
+      },
+      {
+        match: (u) => u.startsWith("https://api.github.com/repos/"),
+        respond: () => makeJsonResponse([]),
+      },
+      {
+        match: (u) => u.includes("n8n.example.com"),
+        respond: () => makeJsonResponse({ data: [] }),
+      },
+      {
+        match: (u) => u.startsWith("https://sentry.io/"),
+        respond: () => makeJsonResponse([]),
+      },
+    );
+    const llm = new FakeLLMProvider(() => ({
+      ok: true,
+      text: JSON.stringify({
+        proposals: ["one", "two", "three"],
+      }),
+    }));
+    await assembleMorningBriefing(
+      { nowMs: Date.parse("2026-05-13T06:00:00Z") },
+      { llmProvider: llm },
+    );
+    expect(llm.calls).toHaveLength(1);
+    const userMsg = llm.calls[0]?.messages[0]?.content ?? "";
+    expect(userMsg).toContain("День звіту: 2026-05-12");
+    expect(userMsg).toContain("Stripe:");
+    expect(userMsg).toContain("PostHog:");
+    expect(userMsg).toContain("Sentry:");
   });
 });

--- a/apps/server/src/modules/openclaw/briefing/builder.ts
+++ b/apps/server/src/modules/openclaw/briefing/builder.ts
@@ -21,6 +21,13 @@
 
 import { logger } from "../../../obs/logger.js";
 import { env } from "../../../env.js";
+import { extractJsonFromText } from "../../../http/jsonSafe.js";
+import {
+  getLLMProvider,
+  invokeLLM,
+  type LLMBreadcrumbFn,
+  type LLMProvider,
+} from "../../../lib/llm/provider.js";
 import {
   getPostHogStats,
   getSentryIssues,
@@ -35,6 +42,7 @@ import type {
   MorningBriefingData,
   MorningBriefingResponse,
   PrQueueBriefingSection,
+  ProposalsBriefingSection,
   SignupsBriefingSection,
   StripeBriefingSection,
   WorkflowsBriefingSection,
@@ -66,17 +74,37 @@ function computeReportingDate(nowMs: number): string {
 }
 
 /**
+ * O1 / Phase 2.A. Опціональні hook-и для тестів: provider override
+ * (підмінити LLMProvider без хак-у env) і breadcrumb-emitter (без Sentry-hub).
+ * Дефолт — `getLLMProvider()` резолвить по env.LLM_PROVIDER /
+ * env.ANTHROPIC_API_KEY.
+ */
+export interface AssembleMorningBriefingOptions {
+  /** Override LLM provider для proposals секції (тести). */
+  llmProvider?: LLMProvider;
+  /** Override Sentry breadcrumb emitter для invokeLLM (тести). */
+  addBreadcrumb?: LLMBreadcrumbFn;
+}
+
+/**
  * Збирає briefing — викликає 5 джерельних функцій паралельно і
  * мапить у структуру `MorningBriefingData`. Не кидає — будь-яка
  * помилка стає секцією-з-`note`.
+ *
+ * O1 / Phase 2.A. Якщо `input.includeProposals` не вимкнено явно
+ * (default `true`) — після збору 5 секцій викликаємо LLM-провайдер
+ * і додаємо секцію `proposals`. Будь-яка помилка LLM — fail-soft
+ * через `note` в секції; briefing ніколи не валиться 5xx.
  */
 export async function assembleMorningBriefing(
   input: AssembleMorningBriefingInput = {},
+  options: AssembleMorningBriefingOptions = {},
 ): Promise<MorningBriefingResponse> {
   const nowMs = input.nowMs ?? Date.now();
   const windowDays = Math.max(1, Math.min(30, input.windowDays ?? 1));
   const sentryLimit = Math.max(1, Math.min(20, input.sentryLimit ?? 3));
   const prLimit = Math.max(1, Math.min(30, input.prLimit ?? 5));
+  const includeProposals = input.includeProposals !== false;
 
   const [
     stripeResult,
@@ -108,7 +136,168 @@ export async function assembleMorningBriefing(
     alerts: mapAlerts(sentryResult),
   };
 
+  if (includeProposals) {
+    data.proposals = await generateProposalsSection(data, options);
+  }
+
   return { markdown: buildMorningBriefing(data), data };
+}
+
+// ────────────────────────────── proposals (LLM) ──────────────────────
+
+/**
+ * Системний prompt для LLM. Phase 2 § Ранковий ритуал «сьогодні
+ * фокусуємо на X через Y»: 3 коротких next-action-и без «co-pilot-водицько»-тону.
+ * Cofounder режим, українська. Без markdown-фенсінгу — парсер сам
+ * витягає JSON через `extractJsonFromText`.
+ */
+const MORNING_BRIEFING_SYSTEM_PROMPT = [
+  "Ти — Сергій, cofounder Sergeant-у і права рука founder-а (Дмитра).",
+  "Українська, прямий tone, без bullshit. Опонент-режим за замовч.",
+  "",
+  "Твоє завдання — на основі ранкових метрик (Stripe / PostHog / GitHub PR-черга / n8n / Sentry) сформулювати 3 короткі next-action-и на сьогодні.",
+  "Кожна пропозиція — одне речення, дієва форма дієслова. Не повторюй метрики вербально — роби висновок, що робити.",
+  "Якщо ситуація спокійна (без фейлів, без відклонень) — все рівно дай 3 фокуси на roadmap-роботу (proposals з розвитку/refactor-у/strategy).",
+  "Додай опціональний 1-2-реченнєвий reasoning — «чому саме ці 3».",
+  "",
+  'Output: JSON `{ "proposals": ["…", "…", "…"], "reasoning": "…" | null }`. Рівно 3 рядки. Без markdown-фенсінгу.',
+].join("\n");
+
+function summarizeForLLM(data: MorningBriefingData): string {
+  const stripe = data.stripe;
+  const signups = data.signups;
+  const pr = data.prQueue;
+  const wf = data.workflows;
+  const alerts = data.alerts;
+  const parts: string[] = [];
+  parts.push(`День звіту: ${data.reportingDate} (Europe/Kyiv).`);
+  if (stripe.notConfigured) {
+    parts.push("Stripe: not configured.");
+  } else {
+    parts.push(
+      `Stripe: успішних ${stripe.successfulCount ?? 0}, failed ${stripe.failedCount ?? 0}, gross ${typeof stripe.grossAmountUah === "number" ? `${stripe.grossAmountUah} UAH` : "—"}.`,
+    );
+  }
+  if (signups.notConfigured) {
+    parts.push("PostHog: not configured.");
+  } else {
+    parts.push(
+      `PostHog: pageviews ${signups.pageviewCount ?? "—"}, subscription_started ${signups.subscriptionStartedCount ?? "—"}.`,
+    );
+  }
+  if (pr.notConfigured) {
+    parts.push("GitHub PR-черга: not configured.");
+  } else {
+    parts.push(
+      `GitHub PR-черга: open ${pr.openCount ?? 0}, needs-review ${pr.needsReviewCount ?? 0}.`,
+    );
+  }
+  if (wf.notConfigured) {
+    parts.push("n8n: not configured.");
+  } else {
+    parts.push(
+      `n8n: total ${wf.totalCount ?? 0}, active ${wf.activeCount ?? 0}, failing ${wf.failingCount ?? 0}.`,
+    );
+  }
+  if (alerts.notConfigured) {
+    parts.push("Sentry: not configured.");
+  } else {
+    parts.push(
+      `Sentry: unresolved ${alerts.level ?? "error"} issues ${alerts.issueCount ?? 0}.`,
+    );
+  }
+  return parts.join("\n");
+}
+
+function parseProposalsResponse(raw: string): {
+  proposals: string[];
+  reasoning?: string;
+} | null {
+  const parsed = extractJsonFromText(raw);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
+    return null;
+  const obj = parsed as Record<string, unknown>;
+  const items = obj["proposals"];
+  if (!Array.isArray(items)) return null;
+  const proposals = items
+    .filter((x): x is string => typeof x === "string")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+    .slice(0, 3);
+  if (proposals.length === 0) return null;
+  const reasoningRaw = obj["reasoning"];
+  const out: { proposals: string[]; reasoning?: string } = { proposals };
+  if (typeof reasoningRaw === "string" && reasoningRaw.trim().length > 0) {
+    out.reasoning = reasoningRaw.trim();
+  }
+  return out;
+}
+
+/**
+ * Генерує секцію proposals через LLM-провайдер (PR-23 `LLMProvider`).
+ * Fail-soft: будь-яка помилка — повертаємо секцію з `note` або
+ * `notConfigured: true` (якщо provider явно stub без реальної відповіді).
+ * Ніколи не кидає.
+ */
+export async function generateProposalsSection(
+  data: MorningBriefingData,
+  options: AssembleMorningBriefingOptions = {},
+): Promise<ProposalsBriefingSection> {
+  const provider = options.llmProvider ?? getLLMProvider();
+  // StubProvider в режимі default повертає `'{"ok":true,"stub":true}'`,
+  // що parser-ом вважається невалідним. Абяк-я що провайдер-стаб
+  // — вважаємо як notConfigured.
+  if (provider.name === "stub") {
+    return {
+      notConfigured: true,
+      note: "LLM-провайдер у stub-режимі (incident-fallback або dev).",
+    };
+  }
+  const userMessage = summarizeForLLM(data);
+  const result = await invokeLLM(
+    provider,
+    {
+      // claude-sonnet-4-6 — сильний reasoning model для priority-синтезу;
+      // ~300 вхідних / ~150 вихідних токенів на briefing.
+      model: "claude-sonnet-4-5-20250929",
+      maxTokens: 400,
+      system: MORNING_BRIEFING_SYSTEM_PROMPT,
+      messages: [{ role: "user", content: userMessage }],
+      endpoint: "internal/openclaw/briefing/morning/proposals",
+      timeoutMs: 30_000,
+      temperature: 0.4,
+    },
+    options.addBreadcrumb ? { addBreadcrumb: options.addBreadcrumb } : {},
+  );
+  if (!result.ok) {
+    logger.warn({
+      msg: "openclaw_briefing_proposals_llm_failed",
+      code: result.code,
+      status: result.status,
+      error: result.error,
+    });
+    return {
+      note:
+        result.code === "rate_limited"
+          ? "LLM rate-limit; фокус — roadmap-задача дня."
+          : result.code === "timeout"
+            ? "LLM timeout; фокус — roadmap-задача дня."
+            : "LLM-пропозиції недоступні (див. Sentry).",
+    };
+  }
+  const parsed = parseProposalsResponse(result.text);
+  if (!parsed) {
+    logger.warn({
+      msg: "openclaw_briefing_proposals_parse_failed",
+      sample: result.text.slice(0, 120),
+    });
+    return {
+      note: "LLM повернув невалідний JSON; фокус — roadmap-задача дня.",
+    };
+  }
+  const out: ProposalsBriefingSection = { proposals: parsed.proposals };
+  if (parsed.reasoning !== undefined) out.reasoning = parsed.reasoning;
+  return out;
 }
 
 // ────────────────────────────── mappers ──────────────────────────────

--- a/apps/server/src/modules/openclaw/briefing/index.ts
+++ b/apps/server/src/modules/openclaw/briefing/index.ts
@@ -7,13 +7,18 @@
  */
 
 export { buildMorningBriefing } from "./template.js";
-export { assembleMorningBriefing } from "./builder.js";
+export {
+  assembleMorningBriefing,
+  generateProposalsSection,
+} from "./builder.js";
+export type { AssembleMorningBriefingOptions } from "./builder.js";
 export type {
   AlertsBriefingSection,
   AssembleMorningBriefingInput,
   MorningBriefingData,
   MorningBriefingResponse,
   PrQueueBriefingSection,
+  ProposalsBriefingSection,
   SignupsBriefingSection,
   StripeBriefingSection,
   WorkflowsBriefingSection,

--- a/apps/server/src/modules/openclaw/briefing/template.test.ts
+++ b/apps/server/src/modules/openclaw/briefing/template.test.ts
@@ -302,3 +302,98 @@ describe("buildMorningBriefing — formatting edge cases", () => {
     expect(buildMorningBriefing(data)).toEqual(buildMorningBriefing(data));
   });
 });
+
+describe("buildMorningBriefing — O1 / Phase 2.A proposals section", () => {
+  it("omits proposals section entirely when data.proposals is undefined", () => {
+    const md = buildMorningBriefing(makeData());
+    expect(md).not.toContain("🎯 Пропозиції");
+  });
+
+  it("renders 3 numbered proposals above stripe section when present", () => {
+    const md = buildMorningBriefing(
+      makeData({
+        proposals: {
+          proposals: [
+            "Закрити PR #101 (needs-review)",
+            "Перевірити Sentry error spike по chat-stream",
+            "Зустрітися з growth-консультантом по PostHog",
+          ],
+          reasoning: "PR-черга росте, Sentry показав error, growth блокує MRR.",
+        },
+      }),
+    );
+    expect(md).toContain("🎯 Пропозиції на сьогодні");
+    expect(md).toContain("1. Закрити PR #101 (needs-review)");
+    expect(md).toContain("2. Перевірити Sentry error spike по chat-stream");
+    expect(md).toContain("3. Зустрітися з growth-консультантом по PostHog");
+    expect(md).toContain(
+      "_PR-черга росте, Sentry показав error, growth блокує MRR._",
+    );
+    // Proposals must render before MRR section
+    const proposalsIdx = md.indexOf("🎯 Пропозиції");
+    const stripeIdx = md.indexOf("💵 MRR / Stripe");
+    expect(proposalsIdx).toBeGreaterThan(0);
+    expect(stripeIdx).toBeGreaterThan(proposalsIdx);
+  });
+
+  it("shows notConfigured hint when LLM unavailable", () => {
+    const md = buildMorningBriefing(
+      makeData({
+        proposals: {
+          notConfigured: true,
+          note: "LLM-провайдер у stub-режимі (incident-fallback або dev).",
+        },
+      }),
+    );
+    expect(md).toContain("🎯 Пропозиції на сьогодні");
+    expect(md).toContain(
+      "_LLM-провайдер не сконфігурований (`ANTHROPIC_API_KEY` / `LLM_PROVIDER`); next-action-и пропущено._",
+    );
+    expect(md).toContain("- LLM-провайдер у stub-режимі");
+  });
+
+  it("shows empty-proposals fallback with note when LLM returned [] but no error", () => {
+    const md = buildMorningBriefing(
+      makeData({
+        proposals: {
+          proposals: [],
+          note: "LLM повернув невалідний JSON; фокус — roadmap-задача дня.",
+        },
+      }),
+    );
+    expect(md).toContain(
+      "_LLM не повернув жодної пропозиції; фокус — roadmap-задача дня._",
+    );
+    expect(md).toContain("- LLM повернув невалідний JSON");
+  });
+
+  it("renders error-state note when LLM call failed (rate-limit)", () => {
+    const md = buildMorningBriefing(
+      makeData({
+        proposals: {
+          note: "LLM rate-limit; фокус — roadmap-задача дня.",
+        },
+      }),
+    );
+    expect(md).toContain("🎯 Пропозиції на сьогодні");
+    expect(md).toContain("- LLM rate-limit");
+    // Without notConfigured and without proposals, the section still
+    // renders an explanatory fallback line before the note.
+    expect(md).toContain(
+      "_LLM не повернув жодної пропозиції; фокус — roadmap-задача дня._",
+    );
+  });
+
+  it("renders proposals without trailing reasoning when reasoning is absent", () => {
+    const md = buildMorningBriefing(
+      makeData({
+        proposals: {
+          proposals: ["Перше", "Друге", "Третє"],
+        },
+      }),
+    );
+    expect(md).toContain("1. Перше");
+    expect(md).toContain("3. Третє");
+    expect(md).not.toContain("_undefined_");
+  });
+});

--- a/apps/server/src/modules/openclaw/briefing/template.ts
+++ b/apps/server/src/modules/openclaw/briefing/template.ts
@@ -29,17 +29,24 @@ import type {
   AlertsBriefingSection,
   MorningBriefingData,
   PrQueueBriefingSection,
+  ProposalsBriefingSection,
   SignupsBriefingSection,
   StripeBriefingSection,
   WorkflowsBriefingSection,
 } from "./types.js";
 
 /**
- * Головний entrypoint — `data` → markdown briefing.
+ * Головний entrypoint — `data` → markdown briefing. Якщо секція
+ * `proposals` присутня (O1 / Phase 2.A) — вона виводиться першою
+ * після заголовка, щоб founder бачив next-action-и відразу.
  */
 export function buildMorningBriefing(data: MorningBriefingData): string {
   const lines: string[] = [];
   lines.push(formatHeader(data));
+  if (data.proposals) {
+    lines.push("");
+    lines.push(...formatProposalsSection(data.proposals));
+  }
   lines.push("");
   lines.push(...formatStripeSection(data.stripe));
   lines.push("");
@@ -51,6 +58,31 @@ export function buildMorningBriefing(data: MorningBriefingData): string {
   lines.push("");
   lines.push(...formatAlertsSection(data.alerts));
   return lines.join("\n").trimEnd() + "\n";
+}
+
+function formatProposalsSection(s: ProposalsBriefingSection): string[] {
+  const lines: string[] = ["*🎯 Пропозиції на сьогодні*"];
+  if (s.notConfigured) {
+    lines.push(
+      "- _LLM-провайдер не сконфігурований (`ANTHROPIC_API_KEY` / `LLM_PROVIDER`); next-action-и пропущено._",
+    );
+    if (s.note) lines.push(`- ${s.note}`);
+    return lines;
+  }
+  const proposals = Array.isArray(s.proposals) ? s.proposals : [];
+  if (proposals.length === 0) {
+    lines.push(
+      "- _LLM не повернув жодної пропозиції; фокус — roadmap-задача дня._",
+    );
+    if (s.note) lines.push(`- ${s.note}`);
+    return lines;
+  }
+  proposals.forEach((proposal, idx) => {
+    lines.push(`${idx + 1}. ${proposal}`);
+  });
+  if (s.reasoning) lines.push(`- _${s.reasoning}_`);
+  if (s.note) lines.push(`- ${s.note}`);
+  return lines;
 }
 
 function formatHeader(data: MorningBriefingData): string {

--- a/apps/server/src/modules/openclaw/briefing/types.ts
+++ b/apps/server/src/modules/openclaw/briefing/types.ts
@@ -5,10 +5,10 @@
  * між `template.ts` (pure) та `builder.ts` (бо орxестратор тягне Stripe /
  * PostHog / n8n / Sentry / GitHub helper-и).
  *
- * AI-CONTEXT: shape стабільна — наступний PR (PR-27) додасть `summary?:
- * string` (LLM-генерований narrative); рендер шаблону додасть його як
- * окрему секцію зверху, а інші 5 sections залишаться, як зараз. Не
- * мінякимо назви полів без consumer-перевірки.
+ * O1 / Phase 2.A — додано опціональну секцію `proposals` (LLM-generated
+ * 3 next-actions). Зберігається обернено-сумісно: попередній споживач,
+ * який знає лише про 5 секцій, отримує той самий shape; нова секція
+ * рендериться зверху briefing-у тільки коли `proposals` присутня.
  */
 
 export interface StripeBriefingSection {
@@ -91,6 +91,31 @@ export interface AlertsBriefingSection {
 }
 
 /**
+ * O1 / Phase 2.A — LLM-генеровані стратегічні пропозиції (3 next-actions
+ * для founder-а). Рендериться як перша секція briefing-у над «холодними»
+ * метричними блоками. Без LLM-ключа / при провайдері-стабі / при
+ * upstream-помилці — fail-soft: секція показує hint, briefing
+ * продовжує постити решту даних.
+ */
+export interface ProposalsBriefingSection {
+  /** True коли LLM-провайдер `stub` / `ANTHROPIC_API_KEY` відсутній. */
+  notConfigured?: boolean;
+  /** Канонічний список з 3 коротких next-action-рядків. */
+  proposals?: string[];
+  /**
+   * Опціональний 1-2-реченнєвий контекст від LLM («чому саме ці
+   * 3 priority-фокуси»). Рендер ставить його під списком.
+   */
+  reasoning?: string;
+  /**
+   * Free-form пояснення помилки/деградації (rate-limit, parse-fail,
+   * provider-error). Не показуємо stack-trace; це короткий ux-string
+   * для founder-DM.
+   */
+  note?: string;
+}
+
+/**
  * Канонічний shape даних, які `buildMorningBriefing(data)` рендерить у
  * markdown. Кожна секція може бути:
  *   - `notConfigured` — env-vars відсутні, рендер показує hint;
@@ -107,6 +132,12 @@ export interface MorningBriefingData {
   prQueue: PrQueueBriefingSection;
   workflows: WorkflowsBriefingSection;
   alerts: AlertsBriefingSection;
+  /**
+   * O1 / Phase 2.A. Присутня лише коли builder викликав
+   * `assembleMorningBriefing({ includeProposals: true })` (default).
+   * Опціональність зберігає shape-сумісність зі споживачами PR-26.
+   */
+  proposals?: ProposalsBriefingSection;
 }
 
 /**
@@ -124,6 +155,13 @@ export interface AssembleMorningBriefingInput {
   sentryLimit?: number;
   /** Cap кількості PR у `topPrs`. Default 5. */
   prLimit?: number;
+  /**
+   * O1 / Phase 2.A. Дефолт `true` — після збору 5 секцій ми викликаємо
+   * LLM-провайдер і додаємо секцію `proposals` (3 next-action-и для
+   * founder-а). Caller (cron / manual probe) може вимкнути LLM-call
+   * щоб отримати чистий 5-секційний briefing без витрат токенів.
+   */
+  includeProposals?: boolean;
 }
 
 /**

--- a/apps/server/src/routes/internal/openclaw.ts
+++ b/apps/server/src/routes/internal/openclaw.ts
@@ -249,12 +249,16 @@ const ServerStatsBody = z.object({}).strict();
 
 // PR-26: morning briefing payload — всі поля optional, бо консумер (cron
 // dispatcher / manual probe) може приймати дефолти.
+// O1 / Phase 2.A: додано `includeProposals` (default true) — вимикає
+// LLM-call для proposals-секції коли caller хоче чистий 5-секційний
+// briefing без витрат токенів (наприклад, retry після Anthropic outage).
 const MorningBriefingBody = z
   .object({
     windowDays: z.number().int().min(1).max(30).optional(),
     githubRepo: z.string().min(3).max(140).optional(),
     sentryLimit: z.number().int().min(1).max(20).optional(),
     prLimit: z.number().int().min(1).max(30).optional(),
+    includeProposals: z.boolean().optional(),
   })
   .strict();
 
@@ -829,6 +833,8 @@ export function createOpenClawInternalRouter({ pool }: { pool: Pool }): Router {
         input.sentryLimit = parsed.data.sentryLimit;
       if (parsed.data.prLimit !== undefined)
         input.prLimit = parsed.data.prLimit;
+      if (parsed.data.includeProposals !== undefined)
+        input.includeProposals = parsed.data.includeProposals;
       const result = await assembleMorningBriefing(input);
       res.json(result);
     }),

--- a/docs/runbooks/openclaw-morning-briefing.md
+++ b/docs/runbooks/openclaw-morning-briefing.md
@@ -1,13 +1,20 @@
-# OpenClaw morning briefing — hardcoded template (PR-26)
+# OpenClaw morning briefing — hardcoded template + LLM proposals (PR-26 / O1)
 
 > **Last validated:** 2026-05-13 by Devin. **Next review:** 2026-08-11.
 > **Status:** Active
 
-Operational runbook для morning-briefing template-у (PR-26 з
-[`docs/planning/pr-plan-2026-05.md`](../planning/pr-plan-2026-05.md);
-Phase 2.A у [`docs/launch/tech/openclaw-roadmap.md`](../launch/tech/openclaw-roadmap.md)).
-Покриває (a) які 5 секцій рендеряться + з яких джерел, (b) як read-only
-manual probe-нути endpoint, (c) як degrade-ається при `notConfigured`-секціях.
+Operational runbook для morning-briefing-у:
+
+- **PR-26** ([`docs/planning/pr-plan-2026-05.md`](../planning/pr-plan-2026-05.md))
+  — 5 hardcoded секцій (Stripe / PostHog / GitHub PR-черга / n8n / Sentry).
+- **O1 / Phase 2.A** у [`docs/launch/tech/openclaw-roadmap.md`](../launch/tech/openclaw-roadmap.md)
+  — LLM-секція «🎯 Пропозиції на сьогодні» (3 next-actions
+  від cofounder-а на основі ранкових метрик) над холодними блоками.
+
+Покриває (a) які секції рендеряться + з яких джерел, (b) як read-only
+manual probe-нути endpoint, (c) як degrade-ається при `notConfigured`-секціях
+
+- при Anthropic outage-і.
 
 ## Що робить module
 
@@ -20,15 +27,17 @@ Two-tier module:
 
   | Секція                         | Джерело                                                                               |
   | ------------------------------ | ------------------------------------------------------------------------------------- |
+  | 🎯 Пропозиції на сьогодні (O1) | `LLMProvider` (PR-23) — вхід = summary 5 метричних секцій                             |
   | 💵 MRR / Stripe                | `getStripeMetrics({ days: windowDays })`                                              |
   | 👥 Signups / PostHog           | `getPostHogStats` (`$pageview`) + окремий trend для `subscription_started`            |
   | 🔀 PR-черга / GitHub           | `githubPrs({ state: "open" })` — drafts excluded, `needs-review` ≡ no reviewers/teams |
   | ⚙️ n8n workflow-и              | `listN8nWorkflows({ limit: 250 })`                                                    |
   | 🚨 User-facing alerts / Sentry | `getSentryIssues({ level: "error", limit: sentryLimit })`                             |
 
-  Усі виклики виконуються через `Promise.allSettled` — будь-який rejection
-  стає `note` у відповідній секції (briefing рендерить інші 4 секції без
-  пропусків).
+  Всі 5 metric-викликів виконуються через `Promise.allSettled` — будь-який
+  rejection стає `note` у відповідній секції; LLM-виклик відбувається
+  після збору метрик (секвенційно), бо він приймає їхнє summary як
+  контекст. Будь-яка помилка LLM — fail-soft через `note` в секції.
 
 Реалізація: <code>apps/server/src/modules/openclaw/briefing/{types,template,builder}.ts</code>.
 
@@ -39,18 +48,23 @@ POST /api/internal/openclaw/briefing/morning
 Content-Type: application/json
 
 {
-  "windowDays": 1,      // 1..30, default 1
-  "githubRepo": "...",  // owner/repo, default env.OPENCLAW_GITHUB_REPO
-  "sentryLimit": 3,     // 1..20, default 3
-  "prLimit": 5          // 1..30, default 5
+  "windowDays": 1,           // 1..30, default 1
+  "githubRepo": "...",       // owner/repo, default env.OPENCLAW_GITHUB_REPO
+  "sentryLimit": 3,          // 1..20, default 3
+  "prLimit": 5,              // 1..30, default 5
+  "includeProposals": true   // boolean, default true — O1 LLM-секція
 }
 ```
+
+`includeProposals: false` вимикає LLM-call — корисно при Anthropic
+incident-і або для отримання чистого 5-секційного briefing-у без
+витрат токенів.
 
 Response:
 
 ```json
 {
-  "markdown": "🌅 *Морній брифінг — 2026-05-12*\n\n*💵 MRR / Stripe*\n...",
+  "markdown": "🌅 *Морній брифінг — 2026-05-12*\n\n*🎯 Пропозиції на сьогодні*\n1. Закрити PR #101 …",
   "data": {
     "generatedAt": "2026-05-13T06:00:00.000Z",
     "reportingDate": "2026-05-12",
@@ -58,10 +72,18 @@ Response:
     "signups": { ... },
     "prQueue": { ... },
     "workflows": { ... },
-    "alerts": { ... }
+    "alerts": { ... },
+    "proposals": {
+      "proposals": ["Закрити PR #101", "Перевірити Sentry spike", "Розписати growth-experiment"],
+      "reasoning": "PR-черга росте, Sentry показав error, growth блокує MRR."
+    }
   }
 }
 ```
+
+При LLM-outage / `LLM_PROVIDER=stub` секція `proposals` рендериться як
+`{notConfigured: true, note: "…"}` або `{note: "…"}` без списку (див.
+§ LLM proposals нижче).
 
 `reportingDate` — `YYYY-MM-DD` для дня перед `nowMs` у Europe/Kyiv (domain
 invariant з [`docs/architecture/domain-invariants.md`](../architecture/domain-invariants.md)).
@@ -96,17 +118,70 @@ curl -sS -X POST http://localhost:3000/api/internal/openclaw/briefing/morning \
 
 ## Env-vars matrix
 
-| Env                     | Section affected | Notes                                           |
-| ----------------------- | ---------------- | ----------------------------------------------- |
-| `STRIPE_SECRET_KEY`     | 💵 Stripe        | Без нього — `notConfigured: true`               |
-| `POSTHOG_API_KEY`       | 👥 Signups       | Обидва ключі потрібні                           |
-| `POSTHOG_PROJECT_ID`    | 👥 Signups       | Обидва ключі потрібні                           |
-| `OPENCLAW_GITHUB_APP_*` | 🔀 PR-черга      | Або GitHub App, або `OPENCLAW_GITHUB_PAT` (dev) |
-| `OPENCLAW_GITHUB_REPO`  | 🔀 PR-черга      | Default `Skords-01/Sergeant`                    |
-| `N8N_API_URL`           | ⚙️ Workflow-и    | Обидва потрібні                                 |
-| `N8N_API_KEY`           | ⚙️ Workflow-и    | Обидва потрібні                                 |
-| `SENTRY_AUTH_TOKEN`     | 🚨 Sentry        | + `SENTRY_ORG` для повного шляху                |
-| `SENTRY_ORG`            | 🚨 Sentry        |                                                 |
+| Env                     | Section affected | Notes                                                                          |
+| ----------------------- | ---------------- | ------------------------------------------------------------------------------ |
+| `STRIPE_SECRET_KEY`     | 💵 Stripe        | Без нього — `notConfigured: true`                                              |
+| `POSTHOG_API_KEY`       | 👥 Signups       | Обидва ключі потрібні                                                          |
+| `POSTHOG_PROJECT_ID`    | 👥 Signups       | Обидва ключі потрібні                                                          |
+| `OPENCLAW_GITHUB_APP_*` | 🔀 PR-черга      | Або GitHub App, або `OPENCLAW_GITHUB_PAT` (dev)                                |
+| `OPENCLAW_GITHUB_REPO`  | 🔀 PR-черга      | Default `Skords-01/Sergeant`                                                   |
+| `N8N_API_URL`           | ⚙️ Workflow-и    | Обидва потрібні                                                                |
+| `N8N_API_KEY`           | ⚙️ Workflow-и    | Обидва потрібні                                                                |
+| `SENTRY_AUTH_TOKEN`     | 🚨 Sentry        | + `SENTRY_ORG` для повного шляху                                               |
+| `SENTRY_ORG`            | 🚨 Sentry        |                                                                                |
+| `ANTHROPIC_API_KEY`     | 🎯 Пропозиції    | Без нього LLM-fallback → `StubProvider` → `notConfigured: true`                |
+| `LLM_PROVIDER`          | 🎯 Пропозиції    | `anthropic` (default) / `stub` / `openrouter`. `stub` вважається notConfigured |
+
+## LLM proposals (O1 / Phase 2.A)
+
+Перша секція briefing-у — LLM-генеровані 3 next-action-и для founder-а
+(режим cofounder-Сергій, українська). Рендериться над холодними
+метричними блоками, щоб першим бачення було § Пропозиції, а не цифри.
+
+### Wiring
+
+- Provider: `getLLMProvider()` (PR-23) → резолвить за `env.LLM_PROVIDER` /
+  `env.ANTHROPIC_API_KEY`. При `LLM_PROVIDER=stub` або відсутньому ключі
+  — `StubProvider` → секція «Пропозиції» рендериться як `notConfigured`.
+- Model: `claude-sonnet-4-5-20250929`, `maxTokens=400`, `temperature=0.4`.
+  ~300 вхідних / ~150 вихідних токенів на briefing.
+- Endpoint label для Prometheus + Sentry breadcrumb-ів —
+  `internal/openclaw/briefing/morning/proposals` (окремий від
+  `classify` / `weekly-digest`).
+
+### Output shape
+
+```json
+{
+  "proposals": {
+    "proposals": ["…", "…", "…"],
+    "reasoning": "… (optional, 1-2 речення)",
+    "notConfigured": false,
+    "note": "… (optional, див. § Error-handling)"
+  }
+}
+```
+
+LLM відповідає raw-JSON-ом (`extractJsonFromText` витягує його навіть
+якщо обгорнутий у markdown). Ми обрізаємо `proposals[]` до перших 3 i
+фільтруємо порожні / non-string елементи.
+
+### Fail-soft матриця
+
+| Ситуація                             | `data.proposals`                                   | UI hint                                      |
+| ------------------------------------ | -------------------------------------------------- | -------------------------------------------- |
+| `LLM_PROVIDER=stub` / нема ключа     | `{ notConfigured: true, note: "… stub-режимі …" }` | «_LLM-провайдер не сконфігурований…_»        |
+| Anthropic 429                        | `{ note: "LLM rate-limit; фокус — roadmap…" }`     | «- LLM rate-limit…»                          |
+| Anthropic timeout                    | `{ note: "LLM timeout; фокус — roadmap…" }`        | «- LLM timeout…»                             |
+| Anthropic 5xx / generic error        | `{ note: "LLM-пропозиції недоступні…" }`           | «- LLM-пропозиції недоступні (див. Sentry).» |
+| LLM повернув non-JSON / [] proposals | `{ note: "LLM повернув невалідний JSON…" }`        | «- LLM повернув невалідний JSON…»            |
+| `includeProposals: false`            | відсутня                                           | секція не рендериться                        |
+
+Моніторинг: Sentry breadcrumb від `invokeLLM` з tag `endpoint:
+internal/openclaw/briefing/morning/proposals` + Prometheus counter
+`llm_calls_total{endpoint="internal/openclaw/briefing/morning/proposals"}`.
+При incident-і вимикаємо секцію через `LLM_PROVIDER=stub` (env-var у
+Railway) або через body-param `includeProposals: false` (caller-side).
 
 ## Cron wiring
 
@@ -121,9 +196,10 @@ Monitor / disable / env-vars matrix — у
 
 Legacy `morning-digest` CronJob (`ops/openclaw/provision-cron.mjs` →
 `/digest day` Layer 0-shortcut, `0 9 * * *` UTC) досі активний у
-gateway-боті як fallback; PR-27 НЕ ламає його, але майбутній
-LLM-summarization-PR замінить raw template на Anthropic-proposal
-("сьогодні фокусуємо на X через Y") і той fallback зможемо вимкнути.
+gateway-боті як fallback. Після O1 (ця ревізія рунбуку) WF-25 вже
+продукує LLM-proposals разом з метриками, тому legacy CronJob можна
+вимкнути після 1-2 тижнів spot-check-ів (founder-підтвердження, що
+WF-25 ship-иться регулярно + LLM-секція без фейлів).
 
 ## Error-handling
 
@@ -142,5 +218,10 @@ LLM-summarization-PR замінить raw template на Anthropic-proposal
 1. `curl POST /api/internal/openclaw/briefing/morning` локально — поглянь
    `data.<section>.notConfigured` чи `data.<section>.note` у JSON-відповіді.
 2. `pnpm --filter @sergeant/server exec vitest run src/modules/openclaw/briefing/`
-   — 33 unit-теста для template + builder.
+   — 63 unit-теста для template + builder + LLM proposals варіації.
 3. Перевір env-vars matrix вище.
+4. Якщо `proposals.note` містить «LLM rate-limit» / «недоступні» —
+   див. Sentry за endpoint `internal/openclaw/briefing/morning/proposals`,
+   та Prometheus `llm_calls_total{result="error"}` для того ж endpoint-у.
+   При продовженій Anthropic incident-і вимкни LLM-секцію через
+   `LLM_PROVIDER=stub` у Railway.


### PR DESCRIPTION
## Summary

Закриває **O1** з [`docs/planning/sprint-roadmap-q2q3-2026.md` § B — Phase 2.A](https://github.com/Skords-01/Sergeant/blob/main/docs/planning/sprint-roadmap-q2q3-2026.md) — повний LLM-ritual для ранкового briefing-у.

Розширює PR-26 ([#2613](https://github.com/Skords-01/Sergeant/pull/2613)) опційною 6-ою секцією «🎯 Пропозиції на сьогодні» з 3 LLM-генерованими next-action-ами для founder-а. Виклик іде через `LLMProvider` (PR-23 [#2607](https://github.com/Skords-01/Sergeant/pull/2607)) з graceful fallback-ом на Anthropic outage (`StubProvider` / 429 / timeout / non-JSON parse). Endpoint shape backward-compatible — старі consumer-и без `proposals` отримують чистий 5-секційний briefing.

Сектор змін:

- **types.ts** — `ProposalsBriefingSection` interface + `MorningBriefingData.proposals?` + `AssembleMorningBriefingInput.includeProposals?` (default `true`).
- **template.ts** — `formatProposalsSection()` (numbered 1-3 list + optional `_reasoning_` italics + fallback note); injected над Stripe-блоком, щоб founder читав «що робити» першим.
- **builder.ts** — `generateProposalsSection()` async: detect `provider.name === "stub"` → `notConfigured`, інакше `invokeLLM()` з model `claude-sonnet-4-5-20250929`, `temperature=0.4`, `maxTokens=400`. JSON витягується через `extractJsonFromText()`, обрізається до 3, фільтрує non-strings. Мапить `code` (`"rate_limited"` / `"timeout"` / inse) у людський український note. Ніколи не throw-ає.
- **builder.ts** — `summarizeForLLM(data)` будує stable Ukrainian summary з 5 cold-секцій для LLM user message-у.
- **route** — `MorningBriefingBody.includeProposals?: boolean` (Zod) → pass-through у `assembleMorningBriefing(input)`.
- **runbook** — `docs/runbooks/openclaw-morning-briefing.md` оновлено: `## LLM proposals (O1 / Phase 2.A)` (UA) з env-vars matrix, output shape, fail-soft матрицею та Sentry/Prom monitoring tags.

## Governing Skill

- Primary skill: `.agents/skills/sergeant-server-api`
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a — content-side extension of merged PR-26, не green-field
- Why this playbook: existing pattern (PR-23 LLMProvider + PR-26 briefing) — не потрібен новий playbook
- If no playbook matched, why: O1 — це продовження готового рейлу

## Verification

```bash
$ pnpm format:check
All matched files use Prettier code style!

$ pnpm lint
Tasks:    16 successful, 16 total
(server: 0 errors, 4 pre-existing pino-redaction warnings — не від цього PR)

$ pnpm --filter @sergeant/server typecheck
Exit code: 0

$ pnpm --filter @sergeant/server test
Test Files  175 passed (175)
Tests       2307 passed (2307)

# Focused briefing module (template + builder + LLM proposals):
$ pnpm --filter @sergeant/server test -- run src/modules/openclaw/briefing/
Test Files  3 passed (3)
Tests       63 passed (63)
```

Pre-existing root-level `pnpm typecheck` failure у `apps/web/src/core/onboarding/OnboardingWizard.ux.test.tsx:78` (Mock signature mismatch) — підтверджено через `git stash && pnpm --filter @sergeant/web typecheck` на чистому main: помилка існує без моїх змін. Сервер-tsc чистий.

Additional checks:

- [x] Local smoke / manual validation completed (63 unit tests + 10 LLM-mocked integration tests cover happy path, stub provider, 429, timeout, generic 5xx, non-JSON parse, ≥3 cap, non-string filter, `includeProposals: false` skip, context propagation).
- [x] Surface-specific checks completed (`apps/server` — DB types, contract triplet, redaction policy не зачіпаються; новий env-доступ — тільки до існуючих `ANTHROPIC_API_KEY` + `LLM_PROVIDER`).

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update — ні, scope unchanged.
- [x] I checked whether a playbook or skill needed an update — ні, LLMProvider pattern уже описаний у PR-23.
- [x] I checked whether governance docs or review docs needed an update — ні.

Updated docs:

- `docs/runbooks/openclaw-morning-briefing.md` — нова секція «## LLM proposals (O1 / Phase 2.A)» (UA) + extended env-vars matrix + extended response example + extended escalation step.

## Risk and Rollout

- **User-visible risk:** Низький. `proposals` поле optional, існуючі consumer-и PR-26 endpoint-у не зачіпаються. WF-25 cron (PR-27 [#2659](https://github.com/Skords-01/Sergeant/pull/2659)) автоматично почне рендерити «Пропозиції» як перший блок ранкового DM founder-у, як тільки `ANTHROPIC_API_KEY` сконфігурований на Railway. До тієї пори — `notConfigured` hint (briefing і далі рендериться).
- **Rollout / deploy order:** standard merge → main → deploy → Railway. Жодних migrations / env-changes. Активувати «Пропозиції» можна без redeploy через `LLM_PROVIDER=anthropic` (default) + valid `ANTHROPIC_API_KEY` (вже у env-budget).
- **Backout plan:** (1) Operational: `LLM_PROVIDER=stub` у Railway env-vars → секція рендериться як `notConfigured` без LLM-call. (2) Caller-side: `POST` body `{"includeProposals": false}` → секція повністю не рендериться. (3) Code revert: revert this PR — briefing повертається до PR-26 stable shape без proposals.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian (`docs/runbooks/openclaw-morning-briefing.md`).
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

- **LLM call site:** новий endpoint label `internal/openclaw/briefing/morning/proposals` для Prom/Sentry — окремий від `classify` / `weekly-digest`, щоб дашборд міг алертувати на specifically briefing-LLM regressions.
- **Test isolation pattern:** `FakeLLMProvider` class у `builder.test.ts` (lines ~410+) записує calls + повертає stub responses без mock-у fetch або env — слідує існуючому builder.test.ts pattern (fetch mock тільки для зовнішніх REST API, не для LLM).
- **No new env-vars:** використовує існуючі `ANTHROPIC_API_KEY` (env.ts:344) + `LLM_PROVIDER` (env.ts:352). Env-single-source budget — без змін (114/114).
- **Backward-compat:** `proposals` поле optional у `MorningBriefingData`; `includeProposals` body-param optional з default-логікою `!== false`. Consumer-и які знають про PR-26 shape — продовжать працювати без змін.

Closes O1 from sprint-roadmap-q2q3-2026.md § B.

Link to Devin session: https://app.devin.ai/sessions/d7f583562a63456f9e3e418e531c9d81

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional LLM-powered “🎯 Proposals for today” section to the morning briefing, generating 3 actionable next-steps for the founder. Keeps the API backward-compatible and fails soft on provider outages.

- **New Features**
  - Adds optional `proposals` section (3 actions + optional reasoning) rendered first in the briefing; omitted if unavailable or disabled.
  - Orchestrator summarizes the 5 metric sections and calls `LLMProvider` (model `claude-sonnet-4-5-20250929`, `temperature=0.4`, `maxTokens=400`); never throws, parses JSON, caps to 3 items, filters non-strings.
  - Graceful degradation: `StubProvider` → `notConfigured`; maps 429/timeout/parse-fail to a human `note`; briefing still renders other sections.
  - API: request body supports `includeProposals?: boolean` (default true); response includes `data.proposals?`. No new env vars; uses existing `LLM_PROVIDER` and `ANTHROPIC_API_KEY`.
  - Types/exports: new `ProposalsBriefingSection`, `AssembleMorningBriefingOptions`, and exported `generateProposalsSection`.
  - Observability/docs/tests: new endpoint label `internal/openclaw/briefing/morning/proposals` for Prom/Sentry; runbook updated with env matrix and fail-soft matrix; added focused unit tests for LLM paths.

<sup>Written for commit ea7d6ed7756fa3568fceba933fd8644fcb5dab4d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

