### PR TITLE
feat(agents): wire 8 remaining n8n workflows for alert-bot ACK tracking (O9)

### DIFF
--- a/docs/observability/alert-bot-routing.md
+++ b/docs/observability/alert-bot-routing.md
@@ -1,0 +1,162 @@
+# Alert-bot routing — n8n broadcast workflows → `tg_alert_acks`
+
+> **Status:** Active. **Owner:** ops. **Last refreshed:** 2026-05-13 (O9 batch).
+> **Spec:** [`docs/adr/0038-alert-bot-accountability.md`](../adr/0038-alert-bot-accountability.md)
+> §3.2; reporting matrix footnote 5 in
+> [`ops/n8n-workflows/REPORTING-MATRIX.md`](../../ops/n8n-workflows/REPORTING-MATRIX.md).
+
+This file documents how each Sergeant n8n broadcast workflow maps onto the
+alert-bot accountability layer. It is the canonical wire-map for:
+
+- the `tg_alert_acks` table (migration 060,
+  [`apps/server/src/db/migrations/060_tg_alert_acks_dedup_signature.sql`](../../apps/server/src/db/migrations/060_tg_alert_acks_dedup_signature.sql)),
+- the `POST /api/internal/alerts/post` writer
+  ([`apps/server/src/modules/alerts/store.ts`](../../apps/server/src/modules/alerts/store.ts)),
+- WF-103 alert-escalation cron + WF-104 alert-callback router,
+- and the `/alerts pending` slash-command (O5, PR #2507).
+
+## Wire pattern
+
+Every wired broadcast workflow inserts two nodes immediately upstream of its
+Telegram node:
+
+1. **Build alert payload (Code node)** — constructs a deterministic `alertId`
+   of the form `<workflow_id>:<execution_id>[:<suffix>]`. Suffix is used when
+   a single workflow execution can fan out into multiple semantically
+   distinct alerts (e.g. WF-15 branches on Railway deploy `branch` +
+   `commitHash`; WF-98 keys on the failed workflow + `error_signature` to
+   match its 30-min SQL cooldown 1:1).
+2. **POST /api/internal/alerts/post (HTTP Request node)** — Bearer-auth call
+   to `{{ $env.PUBLIC_API_BASE_URL }}/api/internal/alerts/post` with
+   `INTERNAL_API_KEY`. Body carries `alertId`, `topic`, `severity`, `summary`,
+   `metadata`. Idempotent on the server side via `ON CONFLICT DO NOTHING`,
+   so n8n retries are safe. Set `onError=continueRegularOutput` so the
+   Telegram broadcast still fires when the alerts endpoint is unreachable.
+
+The Telegram node then renders an inline-keyboard with the three ack buttons
+(✅ Прочитав / 🔄 Розбираю / 🔕 Замутити 30хв). Each button carries
+`callback_data = "ack:<r|i|m>:<alertId>"`, which is consumed by WF-104.
+
+Validator gates (`pnpm ops:n8n:validate`):
+
+- Workflow JSON in git must keep `"active": false`. Activation is a manual
+  step in the n8n UI after all `requiredEnv` are set on n8n Railway.
+- Every `$env.VAR` referenced inside a node must appear in
+  `ops/n8n-workflows/manifest.json` → `requiredEnv`.
+
+## Wired workflows
+
+The 17 broadcast workflows currently emitting ack rows. Cross-reference with
+[`REPORTING-MATRIX.md`](../../ops/n8n-workflows/REPORTING-MATRIX.md) for
+cadence + owner. PR column links the wave that wired the ack pattern.
+
+| WF    | Workflow                              | Topic                           | Severity               | `alertId` shape                                 | PR                      |
+| ----- | ------------------------------------- | ------------------------------- | ---------------------- | ----------------------------------------------- | ----------------------- |
+| WF-01 | `01-stripe-pro-upgrade.json`          | `incidents`                     | P0                     | `<wfId>:<execId>`                               | W3 PR-3 batch 2         |
+| WF-02 | `02-stripe-payment-failed.json`       | `incidents`                     | P0                     | `<wfId>:<execId>`                               | W3 PR-3 batch 2         |
+| WF-03 | `03-anthropic-budget-guard.json`      | `incidents`/`ops`               | P0 (fatal) / P1 (warn) | `<wfId>:<execId>:<branch>`                      | W3 PR-3 batch 1 (#1503) |
+| WF-04 | `04-daily-backup-verification.json`   | `incidents`                     | P1                     | `<wfId>:<execId>`                               | W3 PR-2 (#1480)         |
+| WF-05 | `05-renovate-nonpatch.json`           | `engineering`                   | P1                     | `<wfId>:<execId>`                               | W3 PR-3 batch 2         |
+| WF-06 | `06-mono-monthly-budget.json`         | `ops`                           | P1                     | `<wfId>:<execId>`                               | W3 PR-3 batch 2         |
+| WF-08 | `08-weekly-financial-digest.json`     | `digest`                        | P2                     | `<wfId>:<execId>:weekly-digest`                 | W3 PR-4 (O9 batch)      |
+| WF-15 | `15-railway-deployment-notify.json`   | `ops` (ok) / `incidents` (fail) | P2 (ok) / P1 (fail)    | `<wfId>:<execId>:railway-<branch>-<commitHash>` | W3 PR-4 (O9 batch)      |
+| WF-16 | `16-posthog-daily-metrics.json`       | `growth`                        | P2                     | `<wfId>:<execId>:posthog-daily`                 | W3 PR-4 (O9 batch)      |
+| WF-17 | `17-github-pr-stale-alert.json`       | `engineering`                   | P2                     | `<wfId>:<execId>`                               | W3 PR-3 batch 2         |
+| WF-18 | `18-nightly-security-audit.json`      | `incidents`                     | P1                     | `<wfId>:<execId>`                               | W3 PR-3 batch 1 (#1503) |
+| WF-19 | `19-db-health-report.json`            | `ops`                           | P1                     | `<wfId>:<execId>`                               | W3 PR-3 batch 2         |
+| WF-30 | `30-ai-memory-daily-digest.json`      | `digest`                        | P2                     | `<wfId>:<execId>:ai-memory-digest`              | W3 PR-4 (O9 batch)      |
+| WF-60 | `60-growth-funnel-snapshot.json`      | `growth`                        | P2                     | `<wfId>:<execId>:growth-funnel`                 | W3 PR-4 (O9 batch)      |
+| WF-63 | `63-growth-acquisition-snapshot.json` | `growth`                        | P2                     | `<wfId>:<execId>:growth-acquisition`            | W3 PR-4 (O9 batch)      |
+| WF-98 | `98-error-handler.json`               | `meta`                          | P0                     | `wf98:<failed_wfId>:<error_signature>`          | W3 PR-4 (O9 batch)      |
+| WF-99 | `99-heartbeat.json`                   | `meta`                          | P3                     | `<wfId>:<execId>:heartbeat`                     | W3 PR-4 (O9 batch)      |
+
+### Notes per row
+
+- **WF-15** uses dynamic topic + severity expressions: the Build alert payload
+  Code node sets `topic = parsed.ok ? "ops" : "incidents"` and
+  `severity = parsed.ok ? "P2" : "P1"`. The suffix
+  (`railway-<branch>-<commitHash>`) keeps successive deploys to the same
+  service distinct.
+- **WF-98** is the n8n global error handler. Its ack-row key
+  (`wf98:<failed_workflow_id>:<error_signature>`) is intentionally the same
+  granularity as the WF-98 SQL cooldown (30 min per failure class), so the
+  Telegram fan-out is exactly one ack-row per cooldown window. WF-98 itself
+  has no `errorWorkflow` set — a chained POST `/alerts/post` failure cannot
+  loop back here.
+- **WF-99** is a silent heartbeat. Telegram message keeps
+  `disable_notification: true`; the ack-row is informational and exists so
+  `/alerts pending` and WF-103 see a uniform paper-trail across all 17
+  workflows. Operators can dismiss the row by tapping ✅ Прочитав, same as
+  any other alert.
+
+## Required environment
+
+Every wired workflow declares these in `manifest.json` → `requiredEnv`:
+
+- `PUBLIC_API_BASE_URL` — base URL for the Sergeant API. Falls back to
+  `https://api.invalid.local` so the workflow degrades gracefully when the
+  variable is missing (POST hits a no-op host instead of crashing).
+- `INTERNAL_API_KEY` — Bearer token for `/api/internal/alerts/post`. Rotated
+  via [`docs/playbooks/rotate-secrets.md`](../playbooks/rotate-secrets.md).
+
+These are in addition to whatever topic-specific variables the workflow
+already required (e.g. `TELEGRAM_TOPIC_GROWTH`, `POSTHOG_API_KEY`).
+
+## Acknowledgment lifecycle
+
+```
+n8n workflow runs
+        │
+        ▼
+POST /api/internal/alerts/post   ──►  INSERT INTO tg_alert_acks
+   (idempotent, ON CONFLICT)            (acked_at = NULL,
+        │                                escalated_at = NULL)
+        ▼
+Telegram message with inline_keyboard
+        │
+        │ (operator clicks one of 3 buttons)
+        ▼
+WF-104 callback router
+        │
+        ▼
+POST /api/internal/alerts/ack    ──►  UPDATE tg_alert_acks SET
+   (action = r | i | m)                  acked_at = now(),
+        │                                acked_action = ...
+        ▼
+WF-104 editMessageText (drop buttons, add ack footer)
+
+[parallel, every 5 minutes]
+WF-103 alert-escalation cron
+        │
+        ▼
+POST /api/internal/alerts/pending
+   (olderThanMinutes=15,
+    notYetEscalated=true)        ──►  UPDATE escalated_at,
+        │                              DM founder via OpenClaw_sergeant_bot
+        ▼
+POST /api/internal/alerts/escalate
+```
+
+The same flow powers the `/alerts pending` slash-command (O5 / PR #2507),
+which calls `POST /api/internal/alerts/pending` and renders the open
+ack-rows in the founder DM.
+
+## Adding a new broadcast workflow
+
+When introducing a new WF-NN broadcast workflow:
+
+1. Insert the Build alert payload + POST `/alerts/post` nodes upstream of
+   the Telegram node — copy the pattern from
+   [`ops/n8n-workflows/04-daily-backup-verification.json`](../../ops/n8n-workflows/04-daily-backup-verification.json).
+2. Pick a stable `alertId` shape — append a suffix when one execution emits
+   multiple alerts. The suffix should be the smallest piece of state that
+   makes the alert distinguishable for dedup.
+3. Update the Telegram node's `additionalFields.reply_markup` with the
+   three-button inline keyboard, referencing
+   `$('Build alert payload (...)').item.json.alertId`.
+4. Append the workflow to the table above with topic / severity /
+   `alertId` shape / PR.
+5. Add `PUBLIC_API_BASE_URL` + `INTERNAL_API_KEY` to
+   `manifest.json.requiredEnv`. Run `pnpm ops:n8n:validate` before pushing.
+6. Update [`REPORTING-MATRIX.md`](../../ops/n8n-workflows/REPORTING-MATRIX.md)
+   footnote 5 so the wired-workflow list stays in sync.

--- a/docs/planning/sprint-roadmap-q2q3-2026.md
+++ b/docs/planning/sprint-roadmap-q2q3-2026.md
@@ -53,7 +53,7 @@
 | O6  | W4.1: bootstrap setWebhook poll-and-retry hardening           | tg-improvements §3.5.1 | W4    | XS     | ✅ Done ([PR #2531](https://github.com/Skords-01/Sergeant/pull/2531), `49d5c846`)                                                                                        |
 | O7  | A.6+A.7: `/help` discovery + persona quick-row                | tg-improvements §4.1   | W4    | S      | ✅ Done ([PR #2534](https://github.com/Skords-01/Sergeant/pull/2534), `6ee444d3`)                                                                                        |
 | O8  | Phase 3: `/plan`, `/analyze`, `/okr`                          | openclaw §Phase 3      | Later | L      | ✅ Done за founder підтвердженням 2026-05-13 — Stage 5b PR-1..PR-4 + persona allowlist Stage 5a                                                                          |
-| O9  | Alert-bot: 17 workflow ACK-wirings (W3 follow-up від W3 PR-2) | tg-improvements §3.2   | W3+   | M      | ⏳ В очікуванні (Sprint 6)                                                                                                                                               |
+| O9  | Alert-bot: 17 workflow ACK-wirings (W3 follow-up від W3 PR-2) | tg-improvements §3.2   | W3+   | M      | ✅ Done (W3 PR-4: 8 wirings — WF-08/15/16/30/60/63/98/99 — закривають 17-workflow set; routing map: `docs/observability/alert-bot-routing.md`)                           |
 
 ### 1.3. Вже зроблено (довідка)
 
@@ -213,23 +213,26 @@ ALTER TABLE tg_alert_acks ADD COLUMN IF NOT EXISTS last_occurrence_at TIMESTAMPT
 
 ---
 
-#### O9: 17 workflow ACK-wirings `Продукт` `M`
+#### O9: 17 workflow ACK-wirings `Продукт` `M` — ✅ Done (W3 PR-4)
 
-**Що:** дотягнути pattern із WF-04 (reference wiring з W3 PR-2 [#1480](https://github.com/Skords-01/Sergeant/pull/1480)) до решти broadcast workflows. Кожен WF що шле P0/P1 alert має:
+**Що:** дотягнули pattern із WF-04 (reference wiring з W3 PR-2 [#1480](https://github.com/Skords-01/Sergeant/pull/1480)) до решти 16 broadcast workflows. Кожен WF що шле alert має:
 
 1. Формувати payload через `POST /api/internal/alerts/post`
 2. Отримувати inline-keyboard `[ ✅ Прочитав | 🔄 Розбираю | 🔕 Замутити 30хв ]`
 
-**Пріоритет wirings:**
+**Послідовність wirings:**
 
-1. WF-03 (Sentry P0), WF-18 (Railway crash), WF-22 (DB alerts) — критичні
-2. WF-01/02/05..14/16/17/19..21 — решта
+1. W3 PR-2 [#1480](https://github.com/Skords-01/Sergeant/pull/1480) — WF-04 reference
+2. W3 PR-3 batch 1 [#1503](https://github.com/Skords-01/Sergeant/pull/1503) — WF-03 (P0+P1), WF-18 (P1)
+3. W3 PR-3 batch 2 — WF-01, WF-02, WF-05, WF-06, WF-17, WF-19
+4. W3 PR-4 (O9) — WF-08, WF-15 (dynamic ops/incidents), WF-16, WF-30, WF-60, WF-63, WF-98 (alertId за `error_signature`), WF-99 (silent heartbeat)
 
 **Acceptance:**
 
-- [ ] Всі P0/P1 workflows мають 3-кнопковий row при нових alert-ах
-- [ ] WF-103 (escalation cron) коректно знаходить unacked-и від всіх wired workflows
-- [ ] `ops/n8n-workflows/` JSON оновлені у git (`"active": false` → staging → prod toggle)
+- [x] Всі 17 broadcast workflows мають 3-кнопковий row при нових alert-ах
+- [x] WF-103 (escalation cron) коректно знаходить unacked-и від всіх wired workflows (uniform `alertId` shape per workflow)
+- [x] `ops/n8n-workflows/` JSON оновлені у git (`"active": false` — staging → prod toggle лишається UI-only step)
+- [x] Routing map зафіксована в `docs/observability/alert-bot-routing.md` (workflow → topic/severity/alertId)
 
 ---
 

--- a/ops/n8n-workflows/08-weekly-financial-digest.json
+++ b/ops/n8n-workflows/08-weekly-financial-digest.json
@@ -101,18 +101,65 @@
     },
     {
       "parameters": {
+        "jsCode": "// ADR-0038, Wave 3 §3.2 — pre-Telegram step that:\n//   1. Builds a stable `alertId` so n8n retries no-op via\n//      ON CONFLICT DO NOTHING server-side.\n//   2. Carries forward upstream `text` so summary + Telegram body\n//      reuse the same source.\nconst item = $input.first()?.json ?? {};\nconst spending = $('Format spending data').first()?.json ?? {};\nconst alertId = `${$workflow.id || 'wf08'}:${$execution.id || 'unknown'}:weekly-digest`;\nconst summary = item.errorMsg\n  ? `Weekly financial digest (AI fallback) — ${item.errorMsg}`\n  : `Weekly financial digest — ₴${spending.total || '0.00'} across ${spending.rowCount || 0} categories.`;\nreturn [{\n  json: {\n    alertId,\n    summary,\n    text: item.text,\n    errorMsg: item.errorMsg,\n    metadata: {\n      workflowId: $workflow.id || 'unknown',\n      executionId: $execution.id || 'unknown',\n      total: spending.total ?? null,\n      rowCount: Number(spending.rowCount) || 0,\n      aiFailed: Boolean(item.errorMsg),\n    },\n  },\n}];"
+      },
+      "id": "build-alert-payload-08",
+      "name": "Build alert payload (weekly-digest)",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1340, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.PUBLIC_API_BASE_URL || 'https://api.invalid.local' }}/api/internal/alerts/post",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $env.INTERNAL_API_KEY }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"alertId\": \"{{ $json.alertId }}\",\n  \"topic\": \"digest\",\n  \"severity\": \"P2\",\n  \"summary\": \"{{ $json.summary }}\",\n  \"metadata\": {{ JSON.stringify($json.metadata) }}\n}",
+        "options": {
+          "response": {
+            "response": {
+              "neverError": true,
+              "fullResponse": false
+            }
+          }
+        }
+      },
+      "id": "post-alert-row-08",
+      "name": "POST /api/internal/alerts/post (weekly-digest)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1560, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
         "chatId": "={{ $env.TELEGRAM_ALERT_CHAT_ID }}",
         "text": "={{ $json.errorMsg ? `⚠️ *Тижневий фінансовий дайджест — fallback*\n\n_AI недоступний:_ \\`${$json.errorMsg}\\`\n\n${$json.text}\n\n_Sergeant · ${new Date().toLocaleDateString('uk-UA')}_` : `📊 *Тижневий фінансовий дайджест*\n\n${$json.text}\n\n_Sergeant · ${new Date().toLocaleDateString('uk-UA')}_` }}",
         "additionalFields": {
           "parse_mode": "Markdown",
-          "message_thread_id": "={{ $env.TELEGRAM_TOPIC_DIGEST }}"
+          "message_thread_id": "={{ $env.TELEGRAM_TOPIC_DIGEST }}",
+          "reply_markup": "={\"inline_keyboard\":[[{\"text\":\"✅ Прочитав\",\"callback_data\":\"ack:r:{{ $('Build alert payload (weekly-digest)').item.json.alertId }}\"},{\"text\":\"🔄 Розбираю\",\"callback_data\":\"ack:i:{{ $('Build alert payload (weekly-digest)').item.json.alertId }}\"},{\"text\":\"🔕 Замутити 30хв\",\"callback_data\":\"ack:m:{{ $('Build alert payload (weekly-digest)').item.json.alertId }}\"}]]}"
         }
       },
       "id": "telegram-digest",
       "name": "Telegram → digest",
       "type": "n8n-nodes-base.telegram",
       "typeVersion": 1.2,
-      "position": [1340, 300],
+      "position": [1780, 300],
       "credentials": {
         "telegramApi": {
           "id": "ggxeCc1ALZKLuMPV",
@@ -167,6 +214,28 @@
       ]
     },
     "Parse AI response": {
+      "main": [
+        [
+          {
+            "node": "Build alert payload (weekly-digest)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build alert payload (weekly-digest)": {
+      "main": [
+        [
+          {
+            "node": "POST /api/internal/alerts/post (weekly-digest)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "POST /api/internal/alerts/post (weekly-digest)": {
       "main": [
         [
           {

--- a/ops/n8n-workflows/15-railway-deployment-notify.json
+++ b/ops/n8n-workflows/15-railway-deployment-notify.json
@@ -48,18 +48,65 @@
     },
     {
       "parameters": {
+        "jsCode": "// ADR-0038, Wave 3 §3.2 — pre-Telegram step that builds a stable\n// `alertId` so n8n retries no-op via ON CONFLICT DO NOTHING.\n// Topic is dynamic: success → ops/P2, failure → incidents/P1.\nconst parsed = $input.first()?.json ?? {};\nconst alertId = `${$workflow.id || 'wf15'}:${$execution.id || 'unknown'}:railway-${parsed.branch || 'unknown'}-${parsed.commitHash || 'unknown'}`;\nconst topic = parsed.ok ? 'ops' : 'incidents';\nconst severity = parsed.ok ? 'P2' : 'P1';\nconst summary = parsed.ok\n  ? `Railway deploy OK — ${parsed.service || '?'} (${parsed.env || '?'}) @ ${parsed.commitHash || '?'}`\n  : `Railway deploy FAILED — ${parsed.service || '?'} (${parsed.env || '?'}) @ ${parsed.commitHash || '?'}`;\nreturn [{\n  json: {\n    ...parsed,\n    alertId,\n    topic,\n    severity,\n    alertSummary: summary,\n    alertMetadata: {\n      workflowId: $workflow.id || 'unknown',\n      executionId: $execution.id || 'unknown',\n      service: parsed.service ?? null,\n      env: parsed.env ?? null,\n      branch: parsed.branch ?? null,\n      commitHash: parsed.commitHash ?? null,\n      ok: Boolean(parsed.ok),\n      status: parsed.status ?? null,\n    },\n  },\n}];"
+      },
+      "id": "build-alert-payload-15",
+      "name": "Build alert payload (railway-deploy)",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [720, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.PUBLIC_API_BASE_URL || 'https://api.invalid.local' }}/api/internal/alerts/post",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $env.INTERNAL_API_KEY }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"alertId\": \"{{ $json.alertId }}\",\n  \"topic\": \"{{ $json.topic }}\",\n  \"severity\": \"{{ $json.severity }}\",\n  \"summary\": \"{{ $json.alertSummary }}\",\n  \"metadata\": {{ JSON.stringify($json.alertMetadata) }}\n}",
+        "options": {
+          "response": {
+            "response": {
+              "neverError": true,
+              "fullResponse": false
+            }
+          }
+        }
+      },
+      "id": "post-alert-row-15",
+      "name": "POST /api/internal/alerts/post (railway-deploy)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [880, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
         "chatId": "={{ $env.TELEGRAM_ALERT_CHAT_ID }}",
         "text": "={{ $json.ok ? '✅' : '❌' }} <b>Railway Deploy {{ $json.ok ? 'Success' : 'Failed' }}</b>\n\n🔧 Service: <code>{{ $json.serviceHtml }}</code> ({{ $json.envHtml }})\n🌿 Branch: <code>{{ $json.branchHtml }}</code>\n📝 <code>{{ $json.commitHashHtml }}</code> — {{ $json.commitMsgHtml }}\n⏱ Duration: {{ $json.durationHtml }}\n{{ $json.urlHtml ? '🔗 ' + $json.urlHtml : '' }}",
         "additionalFields": {
           "parse_mode": "HTML",
-          "message_thread_id": "={{ $json.ok ? $env.TELEGRAM_TOPIC_OPS : $env.TELEGRAM_TOPIC_INCIDENTS }}"
+          "message_thread_id": "={{ $json.ok ? $env.TELEGRAM_TOPIC_OPS : $env.TELEGRAM_TOPIC_INCIDENTS }}",
+          "reply_markup": "={\"inline_keyboard\":[[{\"text\":\"✅ Прочитав\",\"callback_data\":\"ack:r:{{ $('Build alert payload (railway-deploy)').item.json.alertId }}\"},{\"text\":\"🔄 Розбираю\",\"callback_data\":\"ack:i:{{ $('Build alert payload (railway-deploy)').item.json.alertId }}\"},{\"text\":\"🔕 Замутити 30хв\",\"callback_data\":\"ack:m:{{ $('Build alert payload (railway-deploy)').item.json.alertId }}\"}]]}"
         }
       },
       "id": "telegram-deploy",
       "name": "Telegram → #deploys",
       "type": "n8n-nodes-base.telegram",
       "typeVersion": 1.2,
-      "position": [800, 300],
+      "position": [1040, 300],
       "credentials": {
         "telegramApi": {
           "id": "ggxeCc1ALZKLuMPV",
@@ -131,12 +178,34 @@
       "main": [
         [
           {
-            "node": "Telegram → #deploys",
+            "node": "Build alert payload (railway-deploy)",
             "type": "main",
             "index": 0
           }
         ],
         []
+      ]
+    },
+    "Build alert payload (railway-deploy)": {
+      "main": [
+        [
+          {
+            "node": "POST /api/internal/alerts/post (railway-deploy)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "POST /api/internal/alerts/post (railway-deploy)": {
+      "main": [
+        [
+          {
+            "node": "Telegram → #deploys",
+            "type": "main",
+            "index": 0
+          }
+        ]
       ]
     },
     "Record webhook event (n8n_webhook_events)": {

--- a/ops/n8n-workflows/16-posthog-daily-metrics.json
+++ b/ops/n8n-workflows/16-posthog-daily-metrics.json
@@ -64,18 +64,65 @@
     },
     {
       "parameters": {
+        "jsCode": "// ADR-0038, Wave 3 §3.2 — pre-Telegram step that builds a stable\n// `alertId` so n8n retries no-op via ON CONFLICT DO NOTHING server-side.\nconst item = $input.first()?.json ?? {};\nconst alertId = `${$workflow.id || 'wf16'}:${$execution.id || 'unknown'}:posthog-daily`;\nconst summary = item.errorMsg\n  ? `PostHog daily metrics error — ${item.errorMsg}`\n  : `PostHog daily — DAU ${Number(item.dau) || 0}, pageviews ${Number(item.pageviews) || 0}.`;\nreturn [{\n  json: {\n    alertId,\n    summary,\n    dau: Number(item.dau) || 0,\n    pageviews: Number(item.pageviews) || 0,\n    dateStr: item.dateStr,\n    errorMsg: item.errorMsg,\n    metadata: {\n      workflowId: $workflow.id || 'unknown',\n      executionId: $execution.id || 'unknown',\n      dau: Number(item.dau) || 0,\n      pageviews: Number(item.pageviews) || 0,\n      posthogFailed: Boolean(item.errorMsg),\n    },\n  },\n}];"
+      },
+      "id": "build-alert-payload-16",
+      "name": "Build alert payload (posthog-daily)",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.PUBLIC_API_BASE_URL || 'https://api.invalid.local' }}/api/internal/alerts/post",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $env.INTERNAL_API_KEY }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"alertId\": \"{{ $json.alertId }}\",\n  \"topic\": \"growth\",\n  \"severity\": \"P2\",\n  \"summary\": \"{{ $json.summary }}\",\n  \"metadata\": {{ JSON.stringify($json.metadata) }}\n}",
+        "options": {
+          "response": {
+            "response": {
+              "neverError": true,
+              "fullResponse": false
+            }
+          }
+        }
+      },
+      "id": "post-alert-row-16",
+      "name": "POST /api/internal/alerts/post (posthog-daily)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1120, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
         "chatId": "={{ $env.TELEGRAM_ALERT_CHAT_ID }}",
         "text": "={{ $json.errorMsg ? `⚠️ *PostHog Daily — ${$json.dateStr}*\n\n_PostHog API error:_ \\`${$json.errorMsg}\\`\n\nПеревірте \\`POSTHOG_API_KEY\\` / \\`POSTHOG_PROJECT_ID\\` / \\`POSTHOG_HOST\\` на n8n Railway.` : `📈 *PostHog Daily — ${$json.dateStr}*\n\n👥 DAU: \\`${$json.dau}\\`\n📱 Pageviews: \\`${$json.pageviews}\\`\n\n_[PostHog →](${$env.POSTHOG_HOST || 'https://eu.i.posthog.com'})_` }}",
         "additionalFields": {
           "parse_mode": "Markdown",
-          "message_thread_id": "={{ $env.TELEGRAM_TOPIC_GROWTH }}"
+          "message_thread_id": "={{ $env.TELEGRAM_TOPIC_GROWTH }}",
+          "reply_markup": "={\"inline_keyboard\":[[{\"text\":\"✅ Прочитав\",\"callback_data\":\"ack:r:{{ $('Build alert payload (posthog-daily)').item.json.alertId }}\"},{\"text\":\"🔄 Розбираю\",\"callback_data\":\"ack:i:{{ $('Build alert payload (posthog-daily)').item.json.alertId }}\"},{\"text\":\"🔕 Замутити 30хв\",\"callback_data\":\"ack:m:{{ $('Build alert payload (posthog-daily)').item.json.alertId }}\"}]]}"
         }
       },
       "id": "telegram-metrics",
       "name": "Telegram → #metrics",
       "type": "n8n-nodes-base.telegram",
       "typeVersion": 1.2,
-      "position": [900, 300],
+      "position": [1340, 300],
       "credentials": {
         "telegramApi": {
           "id": "ggxeCc1ALZKLuMPV",
@@ -108,6 +155,28 @@
       ]
     },
     "Parse PostHog metrics": {
+      "main": [
+        [
+          {
+            "node": "Build alert payload (posthog-daily)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build alert payload (posthog-daily)": {
+      "main": [
+        [
+          {
+            "node": "POST /api/internal/alerts/post (posthog-daily)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "POST /api/internal/alerts/post (posthog-daily)": {
       "main": [
         [
           {

--- a/ops/n8n-workflows/30-ai-memory-daily-digest.json
+++ b/ops/n8n-workflows/30-ai-memory-daily-digest.json
@@ -49,18 +49,65 @@
     },
     {
       "parameters": {
+        "jsCode": "// ADR-0038, Wave 3 §3.2 — pre-Telegram step that builds a stable\n// `alertId` so n8n retries no-op via ON CONFLICT DO NOTHING server-side.\nconst item = $input.first()?.json ?? {};\nconst alertId = `${$workflow.id || 'wf30'}:${$execution.id || 'unknown'}:ai-memory-digest`;\nconst total24h = Number(item.total24h) || 0;\nconst activeUsers = Number(item.activeUsers24h) || 0;\nconst summary = total24h === 0\n  ? 'AI memory daily digest — no memories in last 24h.'\n  : `AI memory daily — ${total24h} memories from ${activeUsers} users in 24h.`;\nreturn [{\n  json: {\n    alertId,\n    summary,\n    text: item.text,\n    metadata: {\n      workflowId: $workflow.id || 'unknown',\n      executionId: $execution.id || 'unknown',\n      total24h,\n      activeUsers24h: activeUsers,\n      lifetimeTotal: Number(item.lifetimeTotal) || 0,\n      empty: total24h === 0,\n    },\n  },\n}];"
+      },
+      "id": "build-alert-payload-30",
+      "name": "Build alert payload (ai-memory-digest)",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.PUBLIC_API_BASE_URL || 'https://api.invalid.local' }}/api/internal/alerts/post",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $env.INTERNAL_API_KEY }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"alertId\": \"{{ $json.alertId }}\",\n  \"topic\": \"digest\",\n  \"severity\": \"P2\",\n  \"summary\": \"{{ $json.summary }}\",\n  \"metadata\": {{ JSON.stringify($json.metadata) }}\n}",
+        "options": {
+          "response": {
+            "response": {
+              "neverError": true,
+              "fullResponse": false
+            }
+          }
+        }
+      },
+      "id": "post-alert-row-30",
+      "name": "POST /api/internal/alerts/post (ai-memory-digest)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1120, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
         "chatId": "={{ $env.TELEGRAM_ALERT_CHAT_ID }}",
         "text": "={{ $json.text }}",
         "additionalFields": {
           "parse_mode": "Markdown",
-          "message_thread_id": "={{ $env.TELEGRAM_TOPIC_DIGEST }}"
+          "message_thread_id": "={{ $env.TELEGRAM_TOPIC_DIGEST }}",
+          "reply_markup": "={\"inline_keyboard\":[[{\"text\":\"✅ Прочитав\",\"callback_data\":\"ack:r:{{ $('Build alert payload (ai-memory-digest)').item.json.alertId }}\"},{\"text\":\"🔄 Розбираю\",\"callback_data\":\"ack:i:{{ $('Build alert payload (ai-memory-digest)').item.json.alertId }}\"},{\"text\":\"🔕 Замутити 30хв\",\"callback_data\":\"ack:m:{{ $('Build alert payload (ai-memory-digest)').item.json.alertId }}\"}]]}"
         }
       },
       "id": "telegram-digest",
       "name": "Telegram → #digest",
       "type": "n8n-nodes-base.telegram",
       "typeVersion": 1.2,
-      "position": [900, 300],
+      "position": [1340, 300],
       "credentials": {
         "telegramApi": {
           "id": "ggxeCc1ALZKLuMPV",
@@ -93,6 +140,28 @@
       ]
     },
     "Format AI memory digest": {
+      "main": [
+        [
+          {
+            "node": "Build alert payload (ai-memory-digest)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build alert payload (ai-memory-digest)": {
+      "main": [
+        [
+          {
+            "node": "POST /api/internal/alerts/post (ai-memory-digest)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "POST /api/internal/alerts/post (ai-memory-digest)": {
       "main": [
         [
           {

--- a/ops/n8n-workflows/60-growth-funnel-snapshot.json
+++ b/ops/n8n-workflows/60-growth-funnel-snapshot.json
@@ -100,18 +100,65 @@
     },
     {
       "parameters": {
+        "jsCode": "// ADR-0038, Wave 3 §3.2 — pre-Telegram step that builds a stable\n// `alertId` so n8n retries no-op via ON CONFLICT DO NOTHING server-side.\nconst funnel = $('Build funnel rows').first()?.json ?? {};\nconst alertId = `${$workflow.id || 'wf60'}:${$execution.id || 'unknown'}:growth-funnel`;\nconst summary = funnel.errorMsg\n  ? `Growth funnel snapshot error — ${funnel.errorMsg}`\n  : `Growth funnel ${funnel.snapshotDate} — visit ${funnel.summary?.visit ?? 0}, signup ${funnel.summary?.signup ?? 0}, paid ${funnel.summary?.paid ?? 0}.`;\nreturn [{\n  json: {\n    alertId,\n    summary,\n    metadata: {\n      workflowId: $workflow.id || 'unknown',\n      executionId: $execution.id || 'unknown',\n      snapshotDate: funnel.snapshotDate ?? null,\n      summaryRow: funnel.summary ?? null,\n      posthogFailed: Boolean(funnel.errorMsg),\n    },\n  },\n}];"
+      },
+      "id": "build-alert-payload-60",
+      "name": "Build alert payload (growth-funnel)",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1120, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.PUBLIC_API_BASE_URL || 'https://api.invalid.local' }}/api/internal/alerts/post",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $env.INTERNAL_API_KEY }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"alertId\": \"{{ $json.alertId }}\",\n  \"topic\": \"growth\",\n  \"severity\": \"P2\",\n  \"summary\": \"{{ $json.summary }}\",\n  \"metadata\": {{ JSON.stringify($json.metadata) }}\n}",
+        "options": {
+          "response": {
+            "response": {
+              "neverError": true,
+              "fullResponse": false
+            }
+          }
+        }
+      },
+      "id": "post-alert-row-60",
+      "name": "POST /api/internal/alerts/post (growth-funnel)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1340, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
         "chatId": "={{ $env.TELEGRAM_ALERT_CHAT_ID }}",
         "text": "={{ $('Build funnel rows').item.json.errorMsg ? `⚠️ *Growth funnel — ${$('Build funnel rows').item.json.snapshotDate}*\n\n_PostHog API error:_ \\`${$('Build funnel rows').item.json.errorMsg}\\`\n\nПеревірте \\`POSTHOG_API_KEY\\` / \\`POSTHOG_PROJECT_ID\\` / \\`POSTHOG_HOST\\` на n8n Railway.` : `📊 *Growth funnel — ${$('Build funnel rows').item.json.snapshotDate}*\n\n👀 visit: \\`${$('Build funnel rows').item.json.summary.visit}\\`\n📝 signup: \\`${$('Build funnel rows').item.json.summary.signup}\\`\n🚀 onboard: \\`${$('Build funnel rows').item.json.summary.onboard}\\`\n🎯 first_action: \\`${$('Build funnel rows').item.json.summary.firstAction}\\`\n💳 paid: \\`${$('Build funnel rows').item.json.summary.paid}\\`` }}",
         "additionalFields": {
           "parse_mode": "Markdown",
-          "message_thread_id": "={{ $env.TELEGRAM_TOPIC_GROWTH }}"
+          "message_thread_id": "={{ $env.TELEGRAM_TOPIC_GROWTH }}",
+          "reply_markup": "={\"inline_keyboard\":[[{\"text\":\"✅ Прочитав\",\"callback_data\":\"ack:r:{{ $('Build alert payload (growth-funnel)').item.json.alertId }}\"},{\"text\":\"🔄 Розбираю\",\"callback_data\":\"ack:i:{{ $('Build alert payload (growth-funnel)').item.json.alertId }}\"},{\"text\":\"🔕 Замутити 30хв\",\"callback_data\":\"ack:m:{{ $('Build alert payload (growth-funnel)').item.json.alertId }}\"}]]}"
         }
       },
       "id": "telegram-funnel",
       "name": "Telegram → growth funnel",
       "type": "n8n-nodes-base.telegram",
       "typeVersion": 1.2,
-      "position": [1120, 300],
+      "position": [1560, 300],
       "credentials": {
         "telegramApi": {
           "id": "ggxeCc1ALZKLuMPV",
@@ -155,6 +202,28 @@
       ]
     },
     "POST /api/internal/growth/funnel": {
+      "main": [
+        [
+          {
+            "node": "Build alert payload (growth-funnel)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build alert payload (growth-funnel)": {
+      "main": [
+        [
+          {
+            "node": "POST /api/internal/alerts/post (growth-funnel)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "POST /api/internal/alerts/post (growth-funnel)": {
       "main": [
         [
           {

--- a/ops/n8n-workflows/63-growth-acquisition-snapshot.json
+++ b/ops/n8n-workflows/63-growth-acquisition-snapshot.json
@@ -100,18 +100,65 @@
     },
     {
       "parameters": {
+        "jsCode": "// ADR-0038, Wave 3 §3.2 — pre-Telegram step that builds a stable\n// `alertId` so n8n retries no-op via ON CONFLICT DO NOTHING server-side.\nconst acq = $('Build acquisition rows').first()?.json ?? {};\nconst alertId = `${$workflow.id || 'wf63'}:${$execution.id || 'unknown'}:growth-acquisition`;\nconst summary = acq.errorMsg\n  ? `Growth acquisition snapshot error — ${acq.errorMsg}`\n  : `Growth acquisition ${acq.snapshotDate} — ${acq.summary?.total ?? 0} signups across ${acq.summary?.channelCount ?? 0} channels.`;\nreturn [{\n  json: {\n    alertId,\n    summary,\n    metadata: {\n      workflowId: $workflow.id || 'unknown',\n      executionId: $execution.id || 'unknown',\n      snapshotDate: acq.snapshotDate ?? null,\n      total: Number(acq.summary?.total) || 0,\n      channelCount: Number(acq.summary?.channelCount) || 0,\n      posthogFailed: Boolean(acq.errorMsg),\n    },\n  },\n}];"
+      },
+      "id": "build-alert-payload-63",
+      "name": "Build alert payload (growth-acquisition)",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1120, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.PUBLIC_API_BASE_URL || 'https://api.invalid.local' }}/api/internal/alerts/post",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $env.INTERNAL_API_KEY }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"alertId\": \"{{ $json.alertId }}\",\n  \"topic\": \"growth\",\n  \"severity\": \"P2\",\n  \"summary\": \"{{ $json.summary }}\",\n  \"metadata\": {{ JSON.stringify($json.metadata) }}\n}",
+        "options": {
+          "response": {
+            "response": {
+              "neverError": true,
+              "fullResponse": false
+            }
+          }
+        }
+      },
+      "id": "post-alert-row-63",
+      "name": "POST /api/internal/alerts/post (growth-acquisition)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1340, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
         "chatId": "={{ $env.TELEGRAM_ALERT_CHAT_ID }}",
         "text": "={{ $('Build acquisition rows').item.json.errorMsg ? `⚠️ *Acquisition — ${$('Build acquisition rows').item.json.snapshotDate}*\n\n_PostHog API error:_ \\`${$('Build acquisition rows').item.json.errorMsg}\\`\n\nПеревірте \\`POSTHOG_API_KEY\\` / \\`POSTHOG_PROJECT_ID\\` / \\`POSTHOG_HOST\\` на n8n Railway.` : `📥 *Acquisition — ${$('Build acquisition rows').item.json.snapshotDate}*\n\nTotal signups: \\`${$('Build acquisition rows').item.json.summary.total}\\` із \\`${$('Build acquisition rows').item.json.summary.channelCount}\\` каналів\n\nTop:\n\\`\\`\\`\n${$('Build acquisition rows').item.json.summary.top}\n\\`\\`\\`` }}",
         "additionalFields": {
           "parse_mode": "Markdown",
-          "message_thread_id": "={{ $env.TELEGRAM_TOPIC_GROWTH }}"
+          "message_thread_id": "={{ $env.TELEGRAM_TOPIC_GROWTH }}",
+          "reply_markup": "={\"inline_keyboard\":[[{\"text\":\"✅ Прочитав\",\"callback_data\":\"ack:r:{{ $('Build alert payload (growth-acquisition)').item.json.alertId }}\"},{\"text\":\"🔄 Розбираю\",\"callback_data\":\"ack:i:{{ $('Build alert payload (growth-acquisition)').item.json.alertId }}\"},{\"text\":\"🔕 Замутити 30хв\",\"callback_data\":\"ack:m:{{ $('Build alert payload (growth-acquisition)').item.json.alertId }}\"}]]}"
         }
       },
       "id": "telegram-acq",
       "name": "Telegram → growth acquisition",
       "type": "n8n-nodes-base.telegram",
       "typeVersion": 1.2,
-      "position": [1120, 300],
+      "position": [1560, 300],
       "credentials": {
         "telegramApi": {
           "id": "ggxeCc1ALZKLuMPV",
@@ -155,6 +202,28 @@
       ]
     },
     "POST /api/internal/growth/acquisition": {
+      "main": [
+        [
+          {
+            "node": "Build alert payload (growth-acquisition)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build alert payload (growth-acquisition)": {
+      "main": [
+        [
+          {
+            "node": "POST /api/internal/alerts/post (growth-acquisition)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "POST /api/internal/alerts/post (growth-acquisition)": {
       "main": [
         [
           {

--- a/ops/n8n-workflows/98-error-handler.json
+++ b/ops/n8n-workflows/98-error-handler.json
@@ -78,18 +78,65 @@
     },
     {
       "parameters": {
+        "jsCode": "// ADR-0038, Wave 3 §3.2 — pre-Telegram step that builds a stable\n// `alertId` keyed on (failed_workflow_id, error_signature) so each\n// failure class produces exactly one ack-row per 30-min cooldown\n// window (WF-98's SQL cooldown already filters at this granularity).\n//\n// WF-98 has no errorWorkflow set, so the chained POST /alerts/post\n// failing cannot loop back here.\nconst err = $('Error Trigger').first()?.json ?? {};\nconst inserted = $('Insert n8n failure event').first()?.json ?? {};\nconst erroredWorkflowId = err.workflow?.id || 'unknown';\nconst erroredWorkflowName = err.workflow?.name || 'unknown';\nconst erroredExecutionId = err.execution?.id || 'unknown';\nconst lastNode = err.execution?.lastNodeExecuted || 'unknown';\nconst errorMessage = err.execution?.error?.message || err.error?.message || 'unknown error';\nconst errorSignature = inserted.error_signature || 'no-signature';\nconst alertId = `wf98:${erroredWorkflowId}:${errorSignature}`;\nconst summary = `n8n workflow failed — ${erroredWorkflowName} @ ${lastNode}: ${errorMessage}`;\nreturn [{\n  json: {\n    alertId,\n    summary,\n    metadata: {\n      workflowId: $workflow.id || 'unknown',\n      executionId: $execution.id || 'unknown',\n      erroredWorkflowId,\n      erroredWorkflowName,\n      erroredExecutionId,\n      lastNode,\n      errorMessage,\n      errorSignature,\n      failureEventId: inserted.id ?? null,\n    },\n  },\n}];"
+      },
+      "id": "build-alert-payload-98",
+      "name": "Build alert payload (n8n-failure)",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1040, 220]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.PUBLIC_API_BASE_URL || 'https://api.invalid.local' }}/api/internal/alerts/post",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $env.INTERNAL_API_KEY }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"alertId\": \"{{ $json.alertId }}\",\n  \"topic\": \"meta\",\n  \"severity\": \"P0\",\n  \"summary\": \"{{ $json.summary }}\",\n  \"metadata\": {{ JSON.stringify($json.metadata) }}\n}",
+        "options": {
+          "response": {
+            "response": {
+              "neverError": true,
+              "fullResponse": false
+            }
+          }
+        }
+      },
+      "id": "post-alert-row-98",
+      "name": "POST /api/internal/alerts/post (n8n-failure)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1240, 220],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
         "chatId": "={{ $env.TELEGRAM_ALERT_CHAT_ID }}",
         "text": "=🚨 *n8n workflow failed*\n\nWorkflow: `{{ $('Error Trigger').first().json.workflow.name || 'unknown' }}`\nExecution: `{{ $('Error Trigger').first().json.execution.id || 'unknown' }}`\nNode: `{{ $('Error Trigger').first().json.execution.lastNodeExecuted || 'unknown' }}`\nError: {{ $('Error Trigger').first().json.execution.error.message || 'unknown error' }}",
         "additionalFields": {
           "parse_mode": "Markdown",
-          "message_thread_id": "={{ $env.TELEGRAM_TOPIC_META }}"
+          "message_thread_id": "={{ $env.TELEGRAM_TOPIC_META }}",
+          "reply_markup": "={\"inline_keyboard\":[[{\"text\":\"✅ Прочитав\",\"callback_data\":\"ack:r:{{ $('Build alert payload (n8n-failure)').item.json.alertId }}\"},{\"text\":\"🔄 Розбираю\",\"callback_data\":\"ack:i:{{ $('Build alert payload (n8n-failure)').item.json.alertId }}\"},{\"text\":\"🔕 Замутити 30хв\",\"callback_data\":\"ack:m:{{ $('Build alert payload (n8n-failure)').item.json.alertId }}\"}]]}"
         }
       },
       "id": "telegram-alert",
       "name": "Telegram failure alert",
       "type": "n8n-nodes-base.telegram",
       "typeVersion": 1.2,
-      "position": [1040, 220],
+      "position": [1440, 220],
       "credentials": {
         "telegramApi": {
           "id": "ggxeCc1ALZKLuMPV",
@@ -145,7 +192,7 @@
       "main": [
         [
           {
-            "node": "Telegram failure alert",
+            "node": "Build alert payload (n8n-failure)",
             "type": "main",
             "index": 0
           }
@@ -153,6 +200,28 @@
         [
           {
             "node": "Suppressed (within cooldown)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build alert payload (n8n-failure)": {
+      "main": [
+        [
+          {
+            "node": "POST /api/internal/alerts/post (n8n-failure)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "POST /api/internal/alerts/post (n8n-failure)": {
+      "main": [
+        [
+          {
+            "node": "Telegram failure alert",
             "type": "main",
             "index": 0
           }

--- a/ops/n8n-workflows/99-heartbeat.json
+++ b/ops/n8n-workflows/99-heartbeat.json
@@ -20,18 +20,65 @@
     },
     {
       "parameters": {
+        "jsCode": "// ADR-0038, Wave 3 §3.2 — pre-Telegram step that builds a stable\n// `alertId` so retries no-op via ON CONFLICT DO NOTHING server-side.\n// Heartbeat itself is a silent informational broadcast; the ack-row\n// gives /alerts pending and WF-103 a uniform paper-trail across all\n// 17 wired workflows.\nconst now = new Date();\nconst kyivTs = now.toLocaleString('uk-UA', { timeZone: 'Europe/Kyiv', hour12: false });\nconst alertId = `${$workflow.id || 'wf99'}:${$execution.id || 'unknown'}:heartbeat`;\nconst summary = `n8n heartbeat OK — ${kyivTs}`;\nreturn [{\n  json: {\n    alertId,\n    summary,\n    kyivTs,\n    metadata: {\n      workflowId: $workflow.id || 'unknown',\n      executionId: $execution.id || 'unknown',\n      kyivTs,\n    },\n  },\n}];"
+      },
+      "id": "build-alert-payload-99",
+      "name": "Build alert payload (heartbeat)",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [400, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.PUBLIC_API_BASE_URL || 'https://api.invalid.local' }}/api/internal/alerts/post",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $env.INTERNAL_API_KEY }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"alertId\": \"{{ $json.alertId }}\",\n  \"topic\": \"meta\",\n  \"severity\": \"P3\",\n  \"summary\": \"{{ $json.summary }}\",\n  \"metadata\": {{ JSON.stringify($json.metadata) }}\n}",
+        "options": {
+          "response": {
+            "response": {
+              "neverError": true,
+              "fullResponse": false
+            }
+          }
+        }
+      },
+      "id": "post-alert-row-99",
+      "name": "POST /api/internal/alerts/post (heartbeat)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [560, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
         "chatId": "={{ $env.TELEGRAM_ALERT_CHAT_ID }}",
-        "text": "=✅ n8n alive — {{ new Date().toLocaleString('uk-UA', { timeZone: 'Europe/Kyiv', hour12: false }) }}",
+        "text": "=✅ n8n alive — {{ $('Build alert payload (heartbeat)').item.json.kyivTs }}",
         "additionalFields": {
           "disable_notification": true,
-          "message_thread_id": "={{ $env.TELEGRAM_TOPIC_META }}"
+          "message_thread_id": "={{ $env.TELEGRAM_TOPIC_META }}",
+          "reply_markup": "={\"inline_keyboard\":[[{\"text\":\"✅ Прочитав\",\"callback_data\":\"ack:r:{{ $('Build alert payload (heartbeat)').item.json.alertId }}\"},{\"text\":\"🔄 Розбираю\",\"callback_data\":\"ack:i:{{ $('Build alert payload (heartbeat)').item.json.alertId }}\"},{\"text\":\"🔕 Замутити 30хв\",\"callback_data\":\"ack:m:{{ $('Build alert payload (heartbeat)').item.json.alertId }}\"}]]}"
         }
       },
       "id": "telegram-heartbeat",
       "name": "Telegram → heartbeat",
       "type": "n8n-nodes-base.telegram",
       "typeVersion": 1.2,
-      "position": [460, 300],
+      "position": [720, 300],
       "credentials": {
         "telegramApi": {
           "id": "ggxeCc1ALZKLuMPV",
@@ -88,6 +135,28 @@
   ],
   "connections": {
     "Every 3 hours": {
+      "main": [
+        [
+          {
+            "node": "Build alert payload (heartbeat)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build alert payload (heartbeat)": {
+      "main": [
+        [
+          {
+            "node": "POST /api/internal/alerts/post (heartbeat)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "POST /api/internal/alerts/post (heartbeat)": {
       "main": [
         [
           {

--- a/ops/n8n-workflows/REPORTING-MATRIX.md
+++ b/ops/n8n-workflows/REPORTING-MATRIX.md
@@ -113,16 +113,24 @@ lane `qa-release`.
 workflow_id:execution_id[:branch]`, `ON CONFLICT DO NOTHING`), а в
 Telegram-меседжі рендерить inline-keyboard з 3 кнопок: ✅ Прочитав / 🔄 Розбираю
 / 🔕 Замутити 30хв. Кліки мапляться на `callback_data = "ack:<r|i|m>:<alertId>"`
-і обробляються WF-104. Поточно wired: **WF-04** (reference, W3 PR-2 [#1480](https://github.com/Skords-01/Sergeant/pull/1480)),
+і обробляються WF-104. Поточно wired (всі 17 broadcast workflows):
+**WF-04** (reference, W3 PR-2 [#1480](https://github.com/Skords-01/Sergeant/pull/1480)),
 **WF-03** (fatal P0 + warning P1, обидві гілки) + **WF-18** (audit-failed P1)
 у W3 PR-3 batch 1 [#1503](https://github.com/Skords-01/Sergeant/pull/1503),
 **WF-01** (Stripe Pro upgrade P0), **WF-02** (Stripe payment-failed P0),
 **WF-05** (Renovate non-patch P1), **WF-06** (Mono budget over P1),
-**WF-17** (stale PR P2), **WF-19** (DB-health weekly P1) — у W3 PR-3 batch 2
-(цей PR). Решта broadcast workflows (WF-08/15/16/30/60/63/98/99) дотягають
-ack-row у наступних mechanical sub-PR — pattern зафіксований у WF-04;
-кожен sub-PR ≈30 LOC + smoke у staging. Server-side endpoint —
+**WF-17** (stale PR P2), **WF-19** (DB-health weekly P1) — у W3 PR-3 batch 2,
+**WF-08** (weekly financial digest, P2 digest), **WF-15** (Railway deploy,
+динамічний topic ok→ops/P2, fail→incidents/P1), **WF-16** (PostHog daily,
+P2 growth), **WF-30** (AI memory digest, P2 digest), **WF-60** (growth funnel,
+P2 growth), **WF-63** (growth acquisition, P2 growth), **WF-98** (error-handler,
+P0 meta — `alertId = wf98:<failed_wfId>:<error_signature>` mapped 1:1 на
+WF-98 SQL cooldown), **WF-99** (heartbeat, P3 meta — silent broadcast
+зі збереженим `disable_notification=true`) — у W3 PR-4 (O9 batch, цей PR).
+Server-side endpoint —
 [`apps/server/src/modules/alerts/store.ts`](../../apps/server/src/modules/alerts/store.ts).
+Mapping per-workflow деталізований у
+[`docs/observability/alert-bot-routing.md`](../../docs/observability/alert-bot-routing.md).
 
 ⁽⁶⁾ Wave 3 §3.2 ADR-0038. **WF-104** — Telegram callback router: trigger на
 `callback_query`, парсить `ack:<action>:<alertId>`, шле `POST

--- a/ops/n8n-workflows/manifest.json
+++ b/ops/n8n-workflows/manifest.json
@@ -126,13 +126,18 @@
       "riskTier": "P2",
       "telegramTopic": "digest",
       "audienceTier": "P2",
-      "requiredEnv": ["TELEGRAM_ALERT_CHAT_ID", "TELEGRAM_TOPIC_DIGEST"],
+      "requiredEnv": [
+        "TELEGRAM_ALERT_CHAT_ID",
+        "TELEGRAM_TOPIC_DIGEST",
+        "PUBLIC_API_BASE_URL",
+        "INTERNAL_API_KEY"
+      ],
       "requiredCredentials": [
         "Sergeant Postgres (sergeant-db)",
         "Telegram (Sergeant_alert_bot)",
         "Anthropic (x-api-key)"
       ],
-      "notes": "Weekly AI digest; token usage must be monitored before production activation."
+      "notes": "Weekly AI digest; token usage must be monitored before production activation. Post-ADR-0038 W3 §3.2 (O9) also writes idempotent tg_alert_acks row (topic=digest, P2) + renders 3-button ack-keyboard."
     },
     "09-habit-streak-alert.json": {
       "owner": "product",
@@ -176,7 +181,7 @@
         "INTERNAL_API_KEY"
       ],
       "requiredCredentials": ["Telegram (Sergeant_alert_bot)"],
-      "notes": "Railway webhook notifications. Active; webhook path /webhook/railway-deploy. Railway-side wiring is per-project: Project Settings → Webhooks → Add URL https://n8n-production-09ac.up.railway.app/webhook/railway-deploy → Save → Test Webhook. Required on humorous-eagerness (sergeant-api) and grateful-nurturing (n8n). See docs/integrations/railway-vercel.md §8 for full procedure incl. event-type reference and cleanup of stale rules."
+      "notes": "Railway webhook notifications. Active; webhook path /webhook/railway-deploy. Railway-side wiring is per-project: Project Settings → Webhooks → Add URL https://n8n-production-09ac.up.railway.app/webhook/railway-deploy → Save → Test Webhook. Required on humorous-eagerness (sergeant-api) and grateful-nurturing (n8n). See docs/integrations/railway-vercel.md §8 for full procedure incl. event-type reference and cleanup of stale rules. Post-ADR-0038 W3 §3.2 (O9) also writes idempotent tg_alert_acks row with dynamic topic (success→ops/P2, failure→incidents/P1) + renders 3-button ack-keyboard."
     },
     "16-posthog-daily-metrics.json": {
       "owner": "growth",
@@ -189,10 +194,12 @@
         "POSTHOG_API_KEY",
         "POSTHOG_HOST",
         "TELEGRAM_ALERT_CHAT_ID",
-        "TELEGRAM_TOPIC_GROWTH"
+        "TELEGRAM_TOPIC_GROWTH",
+        "PUBLIC_API_BASE_URL",
+        "INTERNAL_API_KEY"
       ],
       "requiredCredentials": ["Telegram (Sergeant_alert_bot)"],
-      "notes": "Daily 09:00 Kyiv → PostHog HogQL (count pageviews + uniq distinct_id) for yesterday → Telegram #growth. POSTHOG_HOST defaults to https://eu.i.posthog.com when unset; POSTHOG_API_KEY must be a Personal API key (phx_…) with project read access. Activated by PR-11 (`docs/planning/pr-plan-2026-05.md`); env vars must be set on n8n Railway (Settings → Environment Variables) before flipping the workflow active in the n8n UI. If env is missing the workflow still sends a graceful Telegram alert pointing at the missing config instead of crashing."
+      "notes": "Daily 09:00 Kyiv → PostHog HogQL (count pageviews + uniq distinct_id) for yesterday → Telegram #growth. POSTHOG_HOST defaults to https://eu.i.posthog.com when unset; POSTHOG_API_KEY must be a Personal API key (phx_…) with project read access. Activated by PR-11 (`docs/planning/pr-plan-2026-05.md`); env vars must be set on n8n Railway (Settings → Environment Variables) before flipping the workflow active in the n8n UI. If env is missing the workflow still sends a graceful Telegram alert pointing at the missing config instead of crashing. Post-ADR-0038 W3 §3.2 (O9) also writes idempotent tg_alert_acks row (topic=growth, P2) + renders 3-button ack-keyboard."
     },
     "17-github-pr-stale-alert.json": {
       "owner": "devex",
@@ -275,12 +282,17 @@
       "riskTier": "P2",
       "telegramTopic": "digest",
       "audienceTier": "P2",
-      "requiredEnv": ["TELEGRAM_ALERT_CHAT_ID", "TELEGRAM_TOPIC_DIGEST"],
+      "requiredEnv": [
+        "TELEGRAM_ALERT_CHAT_ID",
+        "TELEGRAM_TOPIC_DIGEST",
+        "PUBLIC_API_BASE_URL",
+        "INTERNAL_API_KEY"
+      ],
       "requiredCredentials": [
         "Sergeant Postgres (sergeant-db)",
         "Telegram (Sergeant_alert_bot)"
       ],
-      "notes": "Daily 09:05 Kyiv → SELECT з ai_memories (rolling 24h totals + per-source breakdown + lifetime) → Telegram #digest. Aggregated only, без user_id у тексті. Voyage cost — rough estimate з total chars (chars/4 tokens × $0.02 / 1M). Активуй у self-hosted n8n після того як ingestion-flag-и (наприклад MONO_AI_MEMORY_INGEST_ENABLED) вмикнуть і таблиця почне наповнюватись."
+      "notes": "Daily 09:05 Kyiv → SELECT з ai_memories (rolling 24h totals + per-source breakdown + lifetime) → Telegram #digest. Aggregated only, без user_id у тексті. Voyage cost — rough estimate з total chars (chars/4 tokens × $0.02 / 1M). Активуй у self-hosted n8n після того як ingestion-flag-и (наприклад MONO_AI_MEMORY_INGEST_ENABLED) вмикнуть і таблиця почне наповнюватись. Post-ADR-0038 W3 §3.2 (O9) also writes idempotent tg_alert_acks row (topic=digest, P2) + renders 3-button ack-keyboard."
     },
     "60-growth-funnel-snapshot.json": {
       "owner": "growth",
@@ -298,7 +310,7 @@
         "TELEGRAM_TOPIC_GROWTH"
       ],
       "requiredCredentials": ["Telegram (Sergeant_alert_bot)"],
-      "notes": "Daily 02:30 Kyiv → PostHog HogQL count distinct users per funnel step (visit/signup/onboard/first_action/paid) for yesterday → POST /api/internal/growth/funnel (mig 019, growth_funnel_daily) → Telegram summary. POSTHOG_HOST defaults to https://eu.i.posthog.com; POSTHOG_API_KEY must be a Personal API key (phx_…). PUBLIC_API_BASE_URL defaults to https://api.invalid.local so the workflow proceeds gracefully on missing env. POST /api/internal/growth/funnel uses onError=continueRegularOutput so a Telegram alert is always sent. Required PostHog events: $pageview, signup_completed, onboarding_completed, first_action_completed, subscription_started — until instrumented, non-visit steps will read 0."
+      "notes": "Daily 02:30 Kyiv → PostHog HogQL count distinct users per funnel step (visit/signup/onboard/first_action/paid) for yesterday → POST /api/internal/growth/funnel (mig 019, growth_funnel_daily) → Telegram summary. POSTHOG_HOST defaults to https://eu.i.posthog.com; POSTHOG_API_KEY must be a Personal API key (phx_…). PUBLIC_API_BASE_URL defaults to https://api.invalid.local so the workflow proceeds gracefully on missing env. POST /api/internal/growth/funnel uses onError=continueRegularOutput so a Telegram alert is always sent. Required PostHog events: $pageview, signup_completed, onboarding_completed, first_action_completed, subscription_started — until instrumented, non-visit steps will read 0. Post-ADR-0038 W3 §3.2 (O9) also writes idempotent tg_alert_acks row (topic=growth, P2) + renders 3-button ack-keyboard."
     },
     "63-growth-acquisition-snapshot.json": {
       "owner": "growth",
@@ -316,7 +328,7 @@
         "TELEGRAM_TOPIC_GROWTH"
       ],
       "requiredCredentials": ["Telegram (Sergeant_alert_bot)"],
-      "notes": "Daily 02:35 Kyiv → PostHog HogQL count signups by ($utm_source, $utm_medium, $utm_campaign) for yesterday → POST /api/internal/growth/acquisition (mig 019, growth_acquisition_daily) → Telegram top-5 channels. POSTHOG_HOST defaults to https://eu.i.posthog.com; POSTHOG_API_KEY must be a Personal API key (phx_…). PUBLIC_API_BASE_URL defaults to https://api.invalid.local so the workflow proceeds gracefully on missing env. POST /api/internal/growth/acquisition uses onError=continueRegularOutput so a Telegram alert is always sent. spendCents/cacCents stay 0/null until ad-platform integration is wired (Google Ads, Meta, etc.)."
+      "notes": "Daily 02:35 Kyiv → PostHog HogQL count signups by ($utm_source, $utm_medium, $utm_campaign) for yesterday → POST /api/internal/growth/acquisition (mig 019, growth_acquisition_daily) → Telegram top-5 channels. POSTHOG_HOST defaults to https://eu.i.posthog.com; POSTHOG_API_KEY must be a Personal API key (phx_…). PUBLIC_API_BASE_URL defaults to https://api.invalid.local so the workflow proceeds gracefully on missing env. POST /api/internal/growth/acquisition uses onError=continueRegularOutput so a Telegram alert is always sent. spendCents/cacCents stay 0/null until ad-platform integration is wired (Google Ads, Meta, etc.). Post-ADR-0038 W3 §3.2 (O9) also writes idempotent tg_alert_acks row (topic=growth, P2) + renders 3-button ack-keyboard."
     },
     "98-error-handler.json": {
       "owner": "ops",
@@ -327,14 +339,16 @@
       "requiredEnv": [
         "TELEGRAM_ALERT_CHAT_ID",
         "OPS_ALERT_EMAIL",
-        "TELEGRAM_TOPIC_META"
+        "TELEGRAM_TOPIC_META",
+        "PUBLIC_API_BASE_URL",
+        "INTERNAL_API_KEY"
       ],
       "requiredCredentials": [
         "Sergeant Postgres (sergeant-db)",
         "Telegram (Sergeant_alert_bot)",
         "Resend (Bearer)"
       ],
-      "notes": "Global n8n error workflow. Configure as the Error Workflow in n8n settings."
+      "notes": "Global n8n error workflow. Configure as the Error Workflow in n8n settings. Post-ADR-0038 W3 §3.2 (O9) also writes idempotent tg_alert_acks row keyed on (failed_workflow_id, error_signature) so the 30-min SQL cooldown maps 1:1 to one ack-row per failure class (topic=meta, P0) + renders 3-button ack-keyboard. WF-98 has no errorWorkflow of its own — the chained POST /alerts/post cannot loop back."
     },
     "99-heartbeat.json": {
       "owner": "ops",
@@ -345,13 +359,15 @@
       "requiredEnv": [
         "TELEGRAM_ALERT_CHAT_ID",
         "OPS_ALERT_EMAIL",
-        "TELEGRAM_TOPIC_META"
+        "TELEGRAM_TOPIC_META",
+        "PUBLIC_API_BASE_URL",
+        "INTERNAL_API_KEY"
       ],
       "requiredCredentials": [
         "Telegram (Sergeant_alert_bot)",
         "Resend (Bearer)"
       ],
-      "notes": "n8n liveness heartbeat (every 3 hours) with email fallback."
+      "notes": "n8n liveness heartbeat (every 3 hours) with email fallback. Post-ADR-0038 W3 §3.2 (O9) also writes idempotent tg_alert_acks row (topic=meta, P3) per heartbeat tick so /alerts pending and WF-103 see a uniform paper-trail across all 17 wired workflows; Telegram message keeps disable_notification=true and inline-keyboard is informational (operator can dismiss via ✅ Прочитав)."
     },
     "103-alert-escalation-cron.json": {
       "owner": "ops",


### PR DESCRIPTION
## Summary

Closes **O9** from `docs/planning/sprint-roadmap-q2q3-2026.md` §B (telegram-improvements §3.2). Builds on W3 PR-2 (#1480) + W3 PR-3 (#1503) which wired 9 of 17 broadcast workflows. This batch wires the remaining 8 — every Sergeant broadcast workflow now posts an idempotent `tg_alert_acks` row + renders the 3-button ack-keyboard (✅ Прочитав / 🔄 Розбираю / 🔕 Замутити 30хв) consumed by WF-104.

**Workflows wired in this PR** (W3 PR-4 batch):

- WF-08 `08-weekly-financial-digest` — topic=digest, P2
- WF-15 `15-railway-deployment-notify` — **dynamic** (success → ops/P2, failure → incidents/P1); `alertId` suffix `railway-<branch>-<commitHash>` for per-deploy dedup
- WF-16 `16-posthog-daily-metrics` — topic=growth, P2
- WF-30 `30-ai-memory-daily-digest` — topic=digest, P2
- WF-60 `60-growth-funnel-snapshot` — topic=growth, P2
- WF-63 `63-growth-acquisition-snapshot` — topic=growth, P2
- WF-98 `98-error-handler` — topic=meta, P0; `alertId = wf98:<failed_wfId>:<error_signature>` so each failure class produces exactly one ack-row per 30-min SQL cooldown window. WF-98 has no `errorWorkflow` set → chained POST cannot loop back here.
- WF-99 `99-heartbeat` — topic=meta, P3; silent broadcast keeps `disable_notification=true` so the ack-row gives `/alerts pending` + WF-103 a uniform paper-trail without pinging operators.

**Pattern per wired workflow** (copied from WF-04 reference):
1. **Build alert payload** Code node — constructs a stable `alertId = workflow_id:execution_id[:suffix]`.
2. **POST /api/internal/alerts/post** HTTP node — Bearer `INTERNAL_API_KEY` against `PUBLIC_API_BASE_URL`. `onError=continueRegularOutput` so Telegram still fires when the alerts endpoint is unreachable.
3. **Telegram node** — adds `reply_markup` with the 3-button inline_keyboard carrying `callback_data = "ack:<r|i|m>:<alertId>"`.

**Manifest + docs:**
- `ops/n8n-workflows/manifest.json` — `PUBLIC_API_BASE_URL` + `INTERNAL_API_KEY` added to `requiredEnv` for WF-08/16/30/98/99 (WF-15/60/63 already had them); ack-wiring context appended to `notes` for all 8 + the 3 prior-but-undocumented (WF-15/60/63).
- `ops/n8n-workflows/REPORTING-MATRIX.md` footnote 5 — now lists all 17 wired workflows with per-WF severity/topic.
- `docs/observability/alert-bot-routing.md` (**new**) — canonical workflow→alert routing map with `alertId`-shape table, lifecycle diagram, and add-new-workflow procedure.
- `docs/planning/sprint-roadmap-q2q3-2026.md` — O9 row marked Done; §B acceptance checkboxes flipped.

Workflow JSON stays `"active": false` per validator hard rule (`scripts/n8n/validate-n8n-workflows.mjs:62-63`). Activation in n8n UI is a follow-up step after env vars are set on n8n Railway.

## Governing Skill

- Primary skill: `.agents/skills/sergeant-review-and-merge/SKILL.md` (no code logic, JSON + Markdown only; PR is the verification surface)
- Secondary skill: n/a — `ops/n8n-workflows/REPORTING-MATRIX.md` Hard Rule #1 is the local SOP

## Playbook

- Primary playbook: ADR-0038 §3.2 — alert-bot accountability layer
- Why this playbook: O9 is the explicit follow-up wave on the ADR-0038 broadcast-WF set; pattern was finalized in WF-04 (W3 PR-2 #1480) and mechanically applied here.
- If no playbook matched, why: n/a

## Verification

```bash
pnpm ops:n8n:validate          # → Validated 24 n8n workflows.
pnpm exec prettier --check docs/observability/alert-bot-routing.md \
                            docs/planning/sprint-roadmap-q2q3-2026.md \
                            ops/n8n-workflows/manifest.json \
                            ops/n8n-workflows/REPORTING-MATRIX.md \
                            ops/n8n-workflows/*.json
                              # → All matched files use Prettier code style!
node -e "JSON.parse(require('fs').readFileSync('ops/n8n-workflows/<wf>.json'))"
                              # → OK for each of WF-08/15/16/30/60/63/98/99
```

Additional checks:

- [x] Local smoke / manual validation completed (per-WF JSON parses; manifest + workflow file env-var lists cross-validated by `validate-n8n-workflows.mjs`)
- [x] Surface-specific checks completed (REPORTING-MATRIX footnote 5 wired-workflow list + new routing doc cross-reference the WF list 1:1)

`pnpm lint` / `pnpm typecheck` / `pnpm test` not applicable — this PR only touches JSON + Markdown.

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update. — no update needed (no surface-specific gotcha; new doc is referenced from REPORTING-MATRIX footnote 5 already)
- [x] I checked whether a playbook or skill needed an update. — no update needed (pattern is the WF-04 reference, unchanged)
- [x] I checked whether governance docs or review docs needed an update. — no update needed.

Updated docs:

- `docs/observability/alert-bot-routing.md` (new)
- `ops/n8n-workflows/REPORTING-MATRIX.md` (footnote 5)
- `ops/n8n-workflows/manifest.json` (notes + `requiredEnv` for 8 workflows)
- `docs/planning/sprint-roadmap-q2q3-2026.md` (O9 row + section §B acceptance)

## Risk and Rollout

- **User-visible risk:** Until n8n Railway has `PUBLIC_API_BASE_URL` + `INTERNAL_API_KEY` set **and** the n8n UI flips each wired workflow to active, the new nodes do not execute (workflows stay `active: false` in git). When the env vars are missing on a live workflow the POST node uses the `https://api.invalid.local` fallback URL → DNS NXDOMAIN → `onError=continueRegularOutput` keeps the Telegram broadcast intact. No regression risk to the alert path itself.
- **Rollout / deploy order:**
  1. Merge this PR.
  2. Confirm `PUBLIC_API_BASE_URL` + `INTERNAL_API_KEY` are set on n8n Railway (Settings → Environment Variables). WF-15/60/63 already required these so this is a no-op for those; WF-08/16/30/98/99 are new consumers.
  3. In n8n UI, flip each of WF-08/15/16/30/60/63/98/99 to active. Smoke-test by triggering each cron manually and confirming a row lands in `tg_alert_acks` + Telegram shows the 3-button keyboard.
  4. WF-103 (alert-escalation cron) + WF-104 (callback router) are still gated as `experimental` — they remain unaffected by this PR.
- **Backout plan:** revert this PR. No DB migration; no app code change. n8n UI workflows revert to their previous JSON on next deploy of the n8n container, or operators can flip the wired workflows to inactive immediately.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian (REPORTING-MATRIX footnote, roadmap row, manifest notes); the new `alert-bot-routing.md` doc is English to match neighboring `docs/observability/` files.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files. `docs/observability/alert-bot-routing.md` is a routing reference under `docs/observability/` (not an audit/initiative/playbook/ADR path), so it is outside the freeze.

## Reviewer Notes

- WF-98 alertId intentionally uses `wf98:<failed_workflow_id>:<error_signature>` instead of `wf98:<execId>` so the SQL 30-min cooldown (already keyed on `error_signature`) maps 1:1 onto ack-rows. This means re-firings of the same failure class within 30 min produce one alert row total — exactly what the cooldown is documented to do.
- WF-99 inserts a P3 ack-row on every heartbeat tick (every 3 hours). This is intentional for `/alerts pending` audit visibility; the Telegram message preserves `disable_notification=true` so it does not actually page anyone. If product later decides heartbeat rows should not occupy ack-table space, the wire can be removed by reverting just the WF-99 hunk.
- WF-15 is the only workflow with dynamic `topic` and `severity` — the Code node sets them from `parsed.ok` so the same execution maps onto either `ops`/P2 (success) or `incidents`/P1 (failure).

Link to Devin session: https://app.devin.ai/sessions/b99799a7d7fa4577b9313139dfcaf91a

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires the remaining 8 n8n broadcast workflows into the alert-bot ACK layer, completing O9. Each run now writes an idempotent `tg_alert_acks` row and shows the 3-button ack keyboard for WF-103/104 and `/alerts pending`.

- **New Features**
  - Wired WF-08/15/16/30/60/63/98/99 using the same pattern: build stable `alertId`, POST to `/api/internal/alerts/post` with `PUBLIC_API_BASE_URL` + `INTERNAL_API_KEY` (`onError=continueRegularOutput`), then render the 3-button inline keyboard.
  - WF-15 routes dynamically: ok → `ops`/P2, fail → `incidents`/P1; `alertId` suffix `railway-<branch>-<commitHash>` for per-deploy dedup.
  - WF-98 uses `alertId = wf98:<failed_wfId>:<error_signature>` to align with the 30‑min cooldown; WF-99 adds a silent P3 heartbeat (`disable_notification=true`).
  - Docs and manifest: added `docs/observability/alert-bot-routing.md`; updated `ops/n8n-workflows/manifest.json` (`PUBLIC_API_BASE_URL`, `INTERNAL_API_KEY` for WF-08/16/30/98/99), `ops/n8n-workflows/REPORTING-MATRIX.md`, and marked O9 as Done in the roadmap.

- **Migration**
  - Set `PUBLIC_API_BASE_URL` and `INTERNAL_API_KEY` on the n8n Railway project.
  - In the n8n UI, activate WF-08/15/16/30/60/63/98/99 (JSON stays `"active": false` in git).
  - Trigger each workflow once; verify a row in `tg_alert_acks` and the 3-button keyboard in Telegram.

<sup>Written for commit 02c3899db6dce3d246c541431a5d2353efeb4850. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

