### PR TITLE
test(api-client): extend pact coverage with 5 persona endpoints

### DIFF
--- a/apps/server/src/__tests__/contracts/provider.test.ts
+++ b/apps/server/src/__tests__/contracts/provider.test.ts
@@ -15,13 +15,24 @@
 // either side was refactored without updating the other), this test
 // fails before the PR can merge.
 //
-// **Scope of v1 (PR-42):** 3 of 5 consumer interactions are
-// fully-verified via supertest replay (me / mono accounts / push
-// register-ios). The 2 AI-flow endpoints (`/api/v1/chat`,
-// `/api/v1/nutrition/analyze-photo`) are covered by the consumer pact
-// but skipped on the provider side here because their handler chains
-// require Anthropic + AI-quota stubs that are already covered by
-// dedicated tests in `apps/server/src/modules/chat/*.test.ts` and
+// **Coverage:** the pact file has 10 consumer interactions (5 from
+// PR-42, 5 added by the persona-extend PR). Of those, 8 are
+// fully-verified here via supertest replay against `createApp()`:
+//
+//   - GET  /api/v1/me                       (hub persona)
+//   - GET  /api/v1/mono/accounts             (finyk persona, bigint coercion)
+//   - GET  /api/v1/mono/sync-state           (finyk persona, NEW)
+//   - GET  /api/v1/mono/transactions         (finyk persona, bigint coercion, NEW)
+//   - GET  /api/v1/coach/memory              (hub persona, NEW)
+//   - GET  /api/v1/barcode                   (nutrition persona, NEW)
+//   - POST /api/v1/push/register             (fizruk persona, ios sibling)
+//   - POST /api/v1/nutrition/day-plan        (nutrition persona, Anthropic-stubbed, NEW)
+//
+// The remaining 2 (`/api/v1/chat`, `/api/v1/nutrition/analyze-photo`)
+// are covered by the consumer pact but skipped on the provider side
+// here because their handler chains require streaming or vision
+// Anthropic stubs that are already covered by dedicated tests in
+// `apps/server/src/modules/chat/*.test.ts` and
 // `apps/server/src/modules/nutrition/*.test.ts`. See
 // `docs/architecture/api-contracts.md § Extending coverage`.
 
@@ -34,6 +45,13 @@ import request from "supertest";
 // ── Mocks (must be hoisted ABOVE `import { createApp }`) ─────────────────────
 
 const { mockPool, queryMock, getSessionUserMock } = vi.hoisted(() => {
+  // Some handlers (`/api/mono/sync-state`, anything gated by the
+  // Anthropic stack) read env vars at MODULE-LOAD time, not per-request.
+  // Set them here so the imports below see a consistent configuration.
+  process.env["MONO_WEBHOOK_ENABLED"] = "true";
+  process.env["ANTHROPIC_API_KEY"] = "sk-pact-replay";
+  process.env["AI_QUOTA_DISABLED"] = "true";
+
   const queryMock = vi.fn().mockResolvedValue({ rows: [{ "?column?": 1 }] });
   const mockPool = {
     query: queryMock,
@@ -75,7 +93,23 @@ vi.mock("./../../http/rateLimit.js", async () => {
   };
 });
 
+// Anthropic handle for the day-plan replay. Reuses the shared mock
+// harness (`apps/server/src/test/__mocks__/anthropic.ts`) — same shape
+// every other handler test uses — so the day-plan handler's call to
+// `anthropicMessages` returns the exact JSON the pact expects without
+// ever touching api.anthropic.com.
+vi.mock("./../../lib/anthropic.js", async () =>
+  (
+    await import("./../../test/__mocks__/anthropic.js")
+  ).createAnthropicMockHandle(),
+);
+
 import { createApp } from "./../../app.js";
+import { anthropicMessages as _anthropicMessages } from "./../../lib/anthropic.js";
+import { anthropicResponses } from "./../../test/__mocks__/anthropic.js";
+import type { Mock } from "vitest";
+
+const anthropicMessages = _anthropicMessages as unknown as Mock;
 
 // ── Pact file loading ────────────────────────────────────────────────────────
 
@@ -138,6 +172,12 @@ function findInteraction(
 
 // ── Test env / mock reset ────────────────────────────────────────────────────
 
+// `ENV_KEYS` here are the per-test env vars (VAPID is module-load-once but
+// safe to reset between tests; everything else cleared too). The
+// MONO_WEBHOOK_ENABLED / ANTHROPIC_API_KEY / AI_QUOTA_DISABLED trio is
+// pinned at module-load by `vi.hoisted` above — those persist for the
+// whole file so the `env` singleton + the requireAnthropicKey/Quota
+// middlewares see them unconditionally.
 const ENV_KEYS = ["VAPID_PUBLIC_KEY", "VAPID_PRIVATE_KEY", "VAPID_EMAIL"];
 const savedEnv: Record<string, string | undefined> = {};
 for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
@@ -147,6 +187,7 @@ beforeEach(() => {
   queryMock.mockResolvedValue({ rows: [{ "?column?": 1 }] });
   getSessionUserMock.mockReset();
   getSessionUserMock.mockResolvedValue(null);
+  anthropicMessages.mockReset();
   for (const k of ENV_KEYS) delete process.env[k];
 });
 
@@ -162,16 +203,23 @@ afterAll(() => {
 const pact = loadPact();
 
 describe("Pact provider replay — consumer=sergeant-api-client, provider=sergeant-server", () => {
-  it("pact file has 5 expected consumer interactions", () => {
+  it("pact file has 10 expected consumer interactions", () => {
     expect(pact.consumer.name).toBe("sergeant-api-client");
     expect(pact.provider.name).toBe("sergeant-server");
-    expect(pact.interactions).toHaveLength(5);
+    expect(pact.interactions).toHaveLength(10);
     const expectedRoutes = new Set([
+      // PR-42 baseline (5)
       "GET /api/v1/me",
       "GET /api/v1/mono/accounts",
       "POST /api/v1/push/register",
       "POST /api/v1/nutrition/analyze-photo",
       "POST /api/v1/chat",
+      // persona-extend (5)
+      "GET /api/v1/mono/sync-state",
+      "GET /api/v1/mono/transactions",
+      "GET /api/v1/coach/memory",
+      "GET /api/v1/barcode",
+      "POST /api/v1/nutrition/day-plan",
     ]);
     const actualRoutes = new Set(
       pact.interactions.map((i) => `${i.request.method} ${i.request.path}`),
@@ -305,6 +353,319 @@ describe("Pact provider replay — consumer=sergeant-api-client, provider=sergea
     expect(res.body.ok).toBe(true);
   });
 
+  // ── GET /api/v1/mono/sync-state ────────────────────────────────────────────
+  //
+  // Handler runs **two** sequential SQL reads against `pool.query`:
+  //   1) SELECT status, webhook_registered_at, last_event_at, last_backfill_at FROM mono_connection
+  //   2) SELECT COUNT(*)::text AS count FROM mono_account
+  //
+  // We canned-respond in order so the handler assembles the exact wire
+  // shape the consumer pact declared. Gated behind `MONO_WEBHOOK_ENABLED`
+  // (pinned via `vi.hoisted` at the top of this file).
+  it("GET /api/v1/mono/sync-state replays against the real handler (finyk persona)", async () => {
+    const interaction = findInteraction(pact, "GET", "/api/v1/mono/sync-state");
+    const expected = interaction.response.body as {
+      status: string;
+      webhookActive: boolean;
+      lastEventAt: string | null;
+      lastBackfillAt: string | null;
+      accountsCount: number;
+    };
+
+    getSessionUserMock.mockResolvedValue({ id: "user-pact-001" });
+    queryMock
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            status: expected.status,
+            // webhookActive=true iff status='active' AND webhook_registered_at != null.
+            webhook_registered_at: expected.webhookActive
+              ? new Date("2026-05-10T00:00:00.000Z")
+              : null,
+            last_event_at: expected.lastEventAt,
+            last_backfill_at: expected.lastBackfillAt,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ count: String(expected.accountsCount) }],
+      });
+
+    const app = createApp();
+    const res = await request(app)
+      .get(interaction.request.path)
+      .set("Authorization", "Bearer pact-replay");
+
+    expect(res.status).toBe(interaction.response.status);
+    expect(res.body).toEqual(expected);
+  });
+
+  // ── GET /api/v1/mono/transactions ──────────────────────────────────────────
+  //
+  // Single SELECT against `mono_transaction`. We feed the handler stringified
+  // bigint columns (just like `pg` itself does in production) so the
+  // `normalizeMonoTransaction` coercion + Zod parse are actually exercised
+  // — Hard Rule #1 sibling-test for the transactions path.
+  it("GET /api/v1/mono/transactions replays against the real handler (finyk persona)", async () => {
+    const interaction = findInteraction(
+      pact,
+      "GET",
+      "/api/v1/mono/transactions",
+    );
+    interface PactTx {
+      userId: string;
+      monoAccountId: string;
+      monoTxId: string;
+      time: string;
+      amount: number;
+      operationAmount: number;
+      currencyCode: number;
+      mcc: number | null;
+      originalMcc: number | null;
+      hold: boolean | null;
+      description: string | null;
+      comment: string | null;
+      cashbackAmount: number | null;
+      commissionRate: number | null;
+      balance: number | null;
+      receiptId: string | null;
+      invoiceId: string | null;
+      counterEdrpou: string | null;
+      counterIban: string | null;
+      counterName: string | null;
+      categorySlug: string | null;
+      categoryOverridden: boolean;
+      source: string;
+      receivedAt: string;
+    }
+    const expected = interaction.response.body as {
+      data: PactTx[];
+      nextCursor: string | null;
+    };
+
+    getSessionUserMock.mockResolvedValue({ id: expected.data[0]!.userId });
+
+    // The handler asks for `LIMIT $N` with `limit + 1` (cursor-pagination
+    // peek). When we return `expected.data.length` rows (== limit), the
+    // handler decides `hasMore=false` and the nextCursor is `null`. Our
+    // pact says nextCursor="tx-pact-0002" (the second row's id), which
+    // means hasMore=TRUE; so we must return one extra peek row that the
+    // handler will trim off before serialising. Build that here.
+    const peekRow = {
+      ...expected.data[expected.data.length - 1]!,
+      monoTxId: expected.data[expected.data.length - 1]!.monoTxId + "-peek",
+    };
+    const sqlRows = [...expected.data, peekRow].map((tx) => ({
+      userId: tx.userId,
+      monoAccountId: tx.monoAccountId,
+      monoTxId: tx.monoTxId,
+      time: tx.time,
+      // `pg` returns bigint columns as **strings**. Force-string the
+      // bigint-typed fields so the normaliser's `toNumberOrNull` is
+      // actually exercised (otherwise the test "passes" by accident on
+      // typeof number).
+      amount: String(tx.amount),
+      operationAmount: String(tx.operationAmount),
+      currencyCode: tx.currencyCode,
+      mcc: tx.mcc,
+      originalMcc: tx.originalMcc,
+      hold: tx.hold,
+      description: tx.description,
+      comment: tx.comment,
+      cashbackAmount:
+        tx.cashbackAmount == null ? null : String(tx.cashbackAmount),
+      commissionRate:
+        tx.commissionRate == null ? null : String(tx.commissionRate),
+      balance: tx.balance == null ? null : String(tx.balance),
+      receiptId: tx.receiptId,
+      invoiceId: tx.invoiceId,
+      counterEdrpou: tx.counterEdrpou,
+      counterIban: tx.counterIban,
+      counterName: tx.counterName,
+      categorySlug: tx.categorySlug,
+      categoryOverridden: tx.categoryOverridden,
+      source: tx.source,
+      receivedAt: tx.receivedAt,
+    }));
+    queryMock.mockResolvedValueOnce({ rows: sqlRows });
+
+    const app = createApp();
+    const res = await request(app)
+      .get(interaction.request.path)
+      .query({ from: "2026-05-01", to: "2026-05-13", limit: "2" })
+      .set("Authorization", "Bearer pact-replay");
+
+    expect(res.status).toBe(interaction.response.status);
+    expect(res.body).toEqual(expected);
+    // Coercion didn't fall through to "stringified number".
+    expect(typeof res.body.data[0].amount).toBe("number");
+    expect(typeof res.body.data[0].balance).toBe("number");
+  });
+
+  // ── GET /api/v1/coach/memory ───────────────────────────────────────────────
+  //
+  // Single SELECT against `coach_memory WHERE user_id=$1`. Returns either
+  // `{ok:true, memory:null}` (no row) or `{ok:true, memory:<jsonb>}`. The
+  // contract locks the second variant so the weeklyDigests envelope is
+  // pinned for the hub-side `useCoachInsight` consumer.
+  it("GET /api/v1/coach/memory replays against the real handler (hub persona)", async () => {
+    const interaction = findInteraction(pact, "GET", "/api/v1/coach/memory");
+    const expected = interaction.response.body as {
+      ok: boolean;
+      memory: unknown;
+    };
+
+    getSessionUserMock.mockResolvedValue({ id: "user-pact-001" });
+    queryMock.mockResolvedValueOnce({
+      rows: [{ data: expected.memory }],
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .get(interaction.request.path)
+      .set("Authorization", "Bearer pact-replay");
+
+    expect(res.status).toBe(interaction.response.status);
+    expect(res.body).toEqual(expected);
+  });
+
+  // ── GET /api/v1/barcode ────────────────────────────────────────────────────
+  //
+  // Open Food Facts / USDA / UPCitemdb-backed handler. We don't want to
+  // hit upstream during contract replay, so we stub `globalThis.fetch`
+  // to return a canned OFF response. The handler's OFF branch fires
+  // first; on success the cascade short-circuits and the OFF product is
+  // returned, matching the pact's success envelope.
+  it("GET /api/v1/barcode replays against the real handler (nutrition persona)", async () => {
+    const interaction = findInteraction(pact, "GET", "/api/v1/barcode");
+    const expected = interaction.response.body as {
+      product: {
+        name: string;
+        brand: string | null;
+        kcal_100g: number | null;
+        protein_100g: number | null;
+        fat_100g: number | null;
+        carbs_100g: number | null;
+        servingSize: string | null;
+        servingGrams: number | null;
+        source: "off" | "usda" | "upcitemdb";
+        partial?: boolean;
+      };
+    };
+
+    // OFF JSON envelope. `status:1` + a `product` whose `nutriments` and
+    // `serving_*` fields normalise into the pact's expected product.
+    // `normalizeOFFBarcode` prefers `product_name_uk` over `product_name`
+    // — we use the UK name field to match production behaviour.
+    const offResponse = {
+      status: 1,
+      product: {
+        product_name_uk: expected.product.name,
+        product_name: expected.product.name,
+        brands: expected.product.brand,
+        nutriments: {
+          "energy-kcal_100g": expected.product.kcal_100g,
+          proteins_100g: expected.product.protein_100g,
+          fat_100g: expected.product.fat_100g,
+          carbohydrates_100g: expected.product.carbs_100g,
+        },
+        serving_size: expected.product.servingSize,
+        serving_quantity: expected.product.servingGrams,
+      },
+    };
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify(offResponse), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    try {
+      const app = createApp();
+      const res = await request(app)
+        .get(interaction.request.path)
+        .query({ barcode: "4820010840443" })
+        .set("Authorization", "Bearer pact-replay");
+
+      expect(res.status).toBe(interaction.response.status);
+      expect(res.body).toEqual(expected);
+      expect(res.body.product.source).toBe("off");
+      // Sanity: the OFF upstream was hit exactly once (USDA/UPCitemdb
+      // would be additional fetch calls — they must not be reached).
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  // ── POST /api/v1/nutrition/day-plan (Anthropic-stubbed) ────────────────────
+  //
+  // Anthropic-gated. We stub `anthropicMessages` (via the shared mock
+  // harness) to return the canned plan JSON the consumer pact recorded.
+  // The pact's `rawText: null` enforces that the handler's "JSON parse
+  // succeeded" branch fires (otherwise rawText would be the raw model
+  // output). `AI_QUOTA_DISABLED=true` + `ANTHROPIC_API_KEY=…` are
+  // pinned at module load via `vi.hoisted`.
+  it("POST /api/v1/nutrition/day-plan replays against the real handler with Anthropic stub (nutrition persona)", async () => {
+    const interaction = findInteraction(
+      pact,
+      "POST",
+      "/api/v1/nutrition/day-plan",
+    );
+    const expected = interaction.response.body as {
+      plan: {
+        meals: Array<{
+          type: string;
+          label: string;
+          name: string;
+          description: string;
+          ingredients: string[];
+          kcal: number | null;
+          protein_g: number | null;
+          fat_g: number | null;
+          carbs_g: number | null;
+        }>;
+        totalKcal: number | null;
+        totalProtein_g: number | null;
+        totalFat_g: number | null;
+        totalCarbs_g: number | null;
+        note: string;
+      };
+      rawText: string | null;
+    };
+
+    getSessionUserMock.mockResolvedValue({ id: "user-pact-001" });
+    // The pact envelope is `{ plan, rawText: null }`. The day-plan
+    // handler builds that envelope from the normalised plan + the raw
+    // model output — for rawText to be `null` the model JSON must
+    // already match the plan shape so `extractJsonFromText` succeeds.
+    // We hand the mock exactly that JSON.
+    anthropicMessages.mockResolvedValueOnce(
+      anthropicResponses.text(JSON.stringify(expected.plan)),
+    );
+
+    const app = createApp();
+    const res = await request(app)
+      .post(interaction.request.path)
+      .set("Authorization", "Bearer pact-replay")
+      .set("X-Requested-With", "XMLHttpRequest")
+      .send({
+        targets: { kcal: 2000, protein_g: 120, fat_g: 70, carbs_g: 220 },
+        pantry: [
+          { name: "milk", qty: 1, unit: "L" },
+          { name: "oats", qty: 500, unit: "g" },
+          { name: "eggs", qty: 6, unit: "pcs" },
+        ],
+        locale: "uk-UA",
+      });
+
+    expect(res.status).toBe(interaction.response.status);
+    expect(res.body).toEqual(expected);
+    // Sanity: the Anthropic stub was actually called (no real upstream).
+    expect(anthropicMessages).toHaveBeenCalledTimes(1);
+  });
+
   // ── AI-flow endpoints — explicit gap markers ───────────────────────────────
   //
   // The remaining two interactions in the pact (chat, nutrition
@@ -319,9 +680,9 @@ describe("Pact provider replay — consumer=sergeant-api-client, provider=sergea
   // extend coverage. See `docs/architecture/api-contracts.md
   // § Extending coverage`.
   it.todo(
-    "POST /api/v1/chat — replay against real chat handler (requires Anthropic stub)",
+    "POST /api/v1/chat — replay against real chat handler (requires streaming Anthropic stub)",
   );
   it.todo(
-    "POST /api/v1/nutrition/analyze-photo — replay against real handler (requires Anthropic + AI-quota stub)",
+    "POST /api/v1/nutrition/analyze-photo — replay against real handler (requires vision Anthropic stub)",
   );
 });

--- a/docs/architecture/api-contracts.md
+++ b/docs/architecture/api-contracts.md
@@ -2,6 +2,8 @@
 
 > **Last validated:** 2026-05-13 by @Skords-01 / Devin. **Next review:** 2026-08-11.
 > **Status:** Active
+>
+> **v2 (persona-extend) coverage:** 10 consumer interactions → 8 provider replays + 2 `it.todo` markers. Diff from PR-42 v1: +5 endpoints (`mono/sync-state`, `mono/transactions`, `coach/memory`, `barcode`, `nutrition/day-plan`).
 
 Pact-based **runtime** contract verification for `@sergeant/api-client ↔ @sergeant/server`. Доповнює, а не замінює, **type-level** sync через Hard Rule #3 ([`03-api-contract-server-client-test.md`](../governance/rules/03-api-contract-server-client-test.md)) + `pnpm api:check-openapi` / `pnpm api:check-openapi-types`.
 
@@ -134,17 +136,26 @@ jobs:
 4. **Запусти locally:** `pnpm --filter @sergeant/server test -- src/__tests__/contracts/provider.test.ts`.
 5. **Pre-PR:** `pnpm check` (включно з `format:check`, `lint`, `typecheck`, `test`, `build`).
 
-## 🚧 Coverage map (v1, PR-42)
+## 🚧 Coverage map (v2 — persona-extend)
 
-| Persona / endpoint                       | Consumer pact | Provider replay | Notes                                                              |
-| ---------------------------------------- | :-----------: | :-------------: | ------------------------------------------------------------------ |
-| `GET /api/v1/me` (hub / shell)           |       ✓       |        ✓        | Better Auth mock only.                                             |
-| `GET /api/v1/mono/accounts` (finyk)      |       ✓       |        ✓        | + pool mock з bigint-string-coercion exercise (Hard Rule #1).      |
-| `POST /api/v1/push/register` (fizruk)    |       ✓       |      ✓ ⁽¹⁾      | Provider verifies ios sibling-shape; web-shape потребує VAPID env. |
-| `POST /api/v1/nutrition/analyze-photo`   |       ✓       |     ⊘ todo      | Anthropic + AI-quota stubs — extend coverage окремою PR.           |
-| `POST /api/v1/chat` (hub, non-streaming) |       ✓       |     ⊘ todo      | Anthropic + AI-quota stubs — extend coverage окремою PR.           |
+| Persona / endpoint                                | Consumer pact | Provider replay | Notes                                                                                                           |
+| ------------------------------------------------- | :-----------: | :-------------: | --------------------------------------------------------------------------------------------------------------- |
+| `GET /api/v1/me` (hub / shell)                    |       ✓       |        ✓        | Better Auth mock only.                                                                                          |
+| `GET /api/v1/mono/accounts` (finyk)               |       ✓       |        ✓        | + pool mock з bigint-string-coercion exercise (Hard Rule #1).                                                   |
+| `GET /api/v1/mono/sync-state` (finyk) ⁽²⁾         |       ✓       |        ✓        | Two-query handler (`mono_connection` + `mono_account` count); gated by `MONO_WEBHOOK_ENABLED`.                  |
+| `GET /api/v1/mono/transactions` (finyk) ⁽²⁾       |       ✓       |        ✓        | + pool mock fed **string** bigints so `normalizeMonoTransaction` coercion is actually executed (Hard Rule #1).  |
+| `GET /api/v1/coach/memory` (hub) ⁽²⁾              |       ✓       |        ✓        | Locks the `{ ok, memory: <jsonb> }` envelope; memory blob interior is intentionally open.                       |
+| `GET /api/v1/barcode` (nutrition) ⁽²⁾             |       ✓       |        ✓        | Provider stubs `globalThis.fetch` to return a canned OFF JSON envelope; no real upstream hit.                   |
+| `POST /api/v1/push/register` (fizruk)             |       ✓       |      ✓ ⁽¹⁾      | Provider verifies ios sibling-shape; web-shape потребує VAPID env.                                              |
+| `POST /api/v1/nutrition/day-plan` (nutrition) ⁽²⁾ |       ✓       |      ✓ ⁽³⁾      | Anthropic-gated; `requireAnthropicKey` + `requireAiQuota` satisfied via `vi.hoisted` env + shared mock harness. |
+| `POST /api/v1/nutrition/analyze-photo`            |       ✓       |     ⊘ todo      | Vision Anthropic stub — extend coverage окремою PR.                                                             |
+| `POST /api/v1/chat` (hub, non-streaming)          |       ✓       |     ⊘ todo      | Streaming Anthropic stub — extend coverage окремою PR.                                                          |
 
 ⁽¹⁾ Provider replays `{platform: "ios"}` (same `{ ok, platform }` envelope). Це гарантує, що `PushRegisterResponseSchema` consumer-shape валідний для всіх трьох платформ; web-branch покритий module-load env у `apps/server/src/routes/pushTest.test.ts`.
+
+⁽²⁾ Added in the persona-extend PR (poverh PR-42). 5 new endpoints обрано за критерієм «real use в `apps/web/`» + cross-surface critical (`monoWebhookApi` + `nutritionApi` + `coachApi` — топ-3 за кількістю RQ-hooks). Routes як `fizruk/workouts/today` або `openclaw/health` не існують як public REST (`fizruk` — local-first CRDT-sync; `openclaw` — бот, який не консумить `@sergeant/api-client`).
+
+⁽³⁾ Anthropic-gated: provider-replay ніяк не торкається `api.anthropic.com`. Паттерн — `vi.mock("./../../lib/anthropic.js", () => createAnthropicMockHandle())` + `anthropicMessages.mockResolvedValueOnce(anthropicResponses.text(...))` зі спільного harness-у у `apps/server/src/test/__mocks__/anthropic.ts`. `ANTHROPIC_API_KEY` і `AI_QUOTA_DISABLED=true` піняться через `vi.hoisted` перед імпортом `createApp` — так `requireAnthropicKey` + `requireAiQuota` middleware-и пропускають запит до реального handler-а.
 
 ### `openclaw` — навмисно не покритий
 
@@ -160,9 +171,13 @@ OpenClaw — це Telegram-бот, який є **отримувачем webhook-
 
 Не редагуй pact JSON руками — він **виключно** регенерується consumer-тестами.
 
-## 🔮 Майбутні розширення (out of scope для PR-42)
+## 🔮 Майбутні розширення (поверх v2 persona-extend)
 
-1. **Anthropic + AI-quota stubs** для `chat` + `nutrition/analyze-photo` provider-replay (зняти `it.todo` маркери).
-2. **Pact matchers** (`like()`, `term()`) для полів, де ми навмисно хочемо схему, а не значення (наприклад, `requestId` ULID-strings).
-3. **Pact Broker** інтеграція — якщо буде потрібен contract-version-matrix на CI (web vs mobile vs openclaw consumers різних версій).
-4. **Streaming SSE контракт** для `/api/v1/chat` — Pact JSON не виражає SSE-фрейми; альтернатива — окремий `chat-stream.contract.test.ts` із власним адаптером.
+1. **Streaming Anthropic stub** для `POST /api/v1/chat` provider-replay (зняти `it.todo`). v2 уже довів — `nutrition/day-plan` ганяє Anthropic-stub без проблем; chat треба окремо через streaming-shape.
+2. **Vision Anthropic stub** для `POST /api/v1/nutrition/analyze-photo` provider-replay (зняти `it.todo`).
+3. **Pact matchers** (`like()`, `term()`) для полів, де ми навмисно хочемо схему, а не значення (наприклад, `requestId` ULID-strings, `nextCursor` опаковий рядок).
+4. **Pact Broker** інтеграція — якщо буде потрібен contract-version-matrix на CI (web vs mobile vs openclaw consumers різних версій).
+5. **Streaming SSE контракт** для `/api/v1/chat` — Pact JSON не виражає SSE-фрейми; альтернатива — окремий `chat-stream.contract.test.ts` із власним адаптером.
+6. **Fizruk + openclaw покриття** — обидві персони навмисно не покриті v2:
+   - **fizruk** — local-first CRDT sync через `/api/v2/sync/*`; sync-payload бінарний (Yjs), не JSON, тому Pact без custom encoder-а не підходить. Альтернатива — окремий contract test за байт-вовнішньою фіксурою.
+   - **openclaw** — Telegram-бот, що консумить власний internal-API (`/api/internal/openclaw/*`) через Bearer-ключ, а не через `@sergeant/api-client`. Якщо потрібна contract-валідація — це окрема (consumer=`sergeant-openclaw-bot`, provider=`sergeant-server-internal`) pact-пара, що жила б у `tools/console/src/__tests__/contracts/`.

--- a/packages/api-client/pacts/sergeant-api-client-sergeant-server.json
+++ b/packages/api-client/pacts/sergeant-api-client-sergeant-server.json
@@ -4,6 +4,97 @@
   },
   "interactions": [
     {
+      "description": "a GET /api/v1/barcode?barcode=4820010840443 request",
+      "providerStates": [
+        {
+          "name": "an authenticated session and barcode 4820010840443 is cached as 'Milk 2% Yagotynske' (source=off)"
+        }
+      ],
+      "request": {
+        "headers": {
+          "accept": "application/json"
+        },
+        "method": "GET",
+        "path": "/api/v1/barcode",
+        "query": {
+          "barcode": [
+            "4820010840443"
+          ]
+        }
+      },
+      "response": {
+        "body": {
+          "product": {
+            "brand": "Yagotynske",
+            "carbs_100g": 4.8,
+            "fat_100g": 2,
+            "kcal_100g": 52,
+            "name": "Milk 2%",
+            "protein_100g": 3.4,
+            "servingGrams": 250,
+            "servingSize": "250 ml",
+            "source": "off"
+          }
+        },
+        "headers": {
+          "Content-Type": "application/json",
+          "content-type": "application/json"
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "a GET /api/v1/coach/memory request",
+      "providerStates": [
+        {
+          "name": "an authenticated session for user-pact-001 with one weekly-digest entry in coach_memory"
+        }
+      ],
+      "request": {
+        "headers": {
+          "accept": "application/json"
+        },
+        "method": "GET",
+        "path": "/api/v1/coach/memory"
+      },
+      "response": {
+        "body": {
+          "memory": {
+            "lastInsightDate": "2026-05-12",
+            "lastInsightText": "Steady week — keep the momentum.",
+            "weeklyDigests": [
+              {
+                "finyk": {
+                  "summary": "Spending under budget by 8%."
+                },
+                "fizruk": {
+                  "summary": "3 workouts done."
+                },
+                "generatedAt": "2026-05-11T08:00:00.000Z",
+                "nutrition": {
+                  "summary": "Protein on target."
+                },
+                "overallRecommendations": [
+                  "Keep weekly cardio under 4 sessions."
+                ],
+                "routine": {
+                  "summary": "Sleep 7h average."
+                },
+                "weekKey": "2026-W19",
+                "weekRange": "2026-05-04..2026-05-10"
+              }
+            ]
+          },
+          "ok": true
+        },
+        "headers": {
+          "Content-Type": "application/json",
+          "content-type": "application/json"
+        },
+        "status": 200
+      }
+    },
+    {
       "description": "a GET /api/v1/me request",
       "providerStates": [
         {
@@ -67,6 +158,125 @@
             "userId": "user-pact-001"
           }
         ],
+        "headers": {
+          "Content-Type": "application/json",
+          "content-type": "application/json"
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "a GET /api/v1/mono/sync-state request",
+      "providerStates": [
+        {
+          "name": "an authenticated session for user-pact-001 with an active Monobank webhook (2 accounts)"
+        }
+      ],
+      "request": {
+        "headers": {
+          "accept": "application/json"
+        },
+        "method": "GET",
+        "path": "/api/v1/mono/sync-state"
+      },
+      "response": {
+        "body": {
+          "accountsCount": 2,
+          "lastBackfillAt": "2026-05-12T22:00:00.000Z",
+          "lastEventAt": "2026-05-13T08:30:00.000Z",
+          "status": "active",
+          "webhookActive": true
+        },
+        "headers": {
+          "Content-Type": "application/json",
+          "content-type": "application/json"
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "a GET /api/v1/mono/transactions request with limit=2 and a date range",
+      "providerStates": [
+        {
+          "name": "an authenticated session for user-pact-001 with 1 mono account and 2 transactions in 2026-05"
+        }
+      ],
+      "request": {
+        "headers": {
+          "accept": "application/json"
+        },
+        "method": "GET",
+        "path": "/api/v1/mono/transactions",
+        "query": {
+          "from": [
+            "2026-05-01"
+          ],
+          "limit": [
+            "2"
+          ],
+          "to": [
+            "2026-05-13"
+          ]
+        }
+      },
+      "response": {
+        "body": {
+          "data": [
+            {
+              "amount": -12345,
+              "balance": 4567890,
+              "cashbackAmount": 123,
+              "categoryOverridden": false,
+              "categorySlug": "groceries",
+              "comment": null,
+              "commissionRate": 0,
+              "counterEdrpou": null,
+              "counterIban": null,
+              "counterName": null,
+              "currencyCode": 980,
+              "description": "ATB Market",
+              "hold": false,
+              "invoiceId": null,
+              "mcc": 5411,
+              "monoAccountId": "acct-pact-001",
+              "monoTxId": "tx-pact-0001",
+              "operationAmount": -12345,
+              "originalMcc": 5411,
+              "receiptId": null,
+              "receivedAt": "2026-05-12T18:42:12.500Z",
+              "source": "webhook",
+              "time": "2026-05-12T18:42:11.000Z",
+              "userId": "user-pact-001"
+            },
+            {
+              "amount": 100000,
+              "balance": 4680235,
+              "cashbackAmount": null,
+              "categoryOverridden": false,
+              "categorySlug": null,
+              "comment": null,
+              "commissionRate": null,
+              "counterEdrpou": null,
+              "counterIban": null,
+              "counterName": null,
+              "currencyCode": 980,
+              "description": "Salary",
+              "hold": null,
+              "invoiceId": null,
+              "mcc": null,
+              "monoAccountId": "acct-pact-001",
+              "monoTxId": "tx-pact-0002",
+              "operationAmount": 100000,
+              "originalMcc": null,
+              "receiptId": null,
+              "receivedAt": "2026-05-11T09:14:01.250Z",
+              "source": "webhook",
+              "time": "2026-05-11T09:14:00.000Z",
+              "userId": "user-pact-001"
+            }
+          ],
+          "nextCursor": "2026-05-11T09:14:00.000Z:tx-pact-0002"
+        },
         "headers": {
           "Content-Type": "application/json",
           "content-type": "application/json"
@@ -167,6 +377,98 @@
               "Скільки сметани було?"
             ]
           }
+        },
+        "headers": {
+          "Content-Type": "application/json",
+          "content-type": "application/json"
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "a POST /api/v1/nutrition/day-plan request with targets and a small pantry",
+      "providerStates": [
+        {
+          "name": "an authenticated session with Anthropic key + AI quota available; pantry has milk, oats, eggs"
+        }
+      ],
+      "request": {
+        "body": {
+          "locale": "uk-UA",
+          "pantry": [
+            {
+              "name": "milk",
+              "qty": 1,
+              "unit": "L"
+            },
+            {
+              "name": "oats",
+              "qty": 500,
+              "unit": "g"
+            },
+            {
+              "name": "eggs",
+              "qty": 6,
+              "unit": "pcs"
+            }
+          ],
+          "targets": {
+            "carbs_g": 220,
+            "fat_g": 70,
+            "kcal": 2000,
+            "protein_g": 120
+          }
+        },
+        "headers": {
+          "Content-Type": "application/json",
+          "accept": "application/json",
+          "content-type": "application/json"
+        },
+        "method": "POST",
+        "path": "/api/v1/nutrition/day-plan"
+      },
+      "response": {
+        "body": {
+          "plan": {
+            "meals": [
+              {
+                "carbs_g": 65,
+                "description": "Тепла вівсяна каша з молоком 2% і ягодами.",
+                "fat_g": 10,
+                "ingredients": [
+                  "вівсянка 80г",
+                  "молоко 250мл",
+                  "ягоди 100г"
+                ],
+                "kcal": 420,
+                "label": "Сніданок",
+                "name": "Вівсянка з молоком",
+                "protein_g": 18,
+                "type": "breakfast"
+              },
+              {
+                "carbs_g": 40,
+                "description": "З 3 яєць, шпинатом, чорним хлібом.",
+                "fat_g": 24,
+                "ingredients": [
+                  "яйця 3шт",
+                  "шпинат 80г",
+                  "хліб 60г"
+                ],
+                "kcal": 540,
+                "label": "Обід",
+                "name": "Омлет з овочами",
+                "protein_g": 32,
+                "type": "lunch"
+              }
+            ],
+            "note": "Партіальний план — лише сніданок і обід для прикладу.",
+            "totalCarbs_g": 105,
+            "totalFat_g": 34,
+            "totalKcal": 960,
+            "totalProtein_g": 50
+          },
+          "rawText": null
         },
         "headers": {
           "Content-Type": "application/json",

--- a/packages/api-client/src/__tests__/contracts/barcode.contract.test.ts
+++ b/packages/api-client/src/__tests__/contracts/barcode.contract.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment node
+//
+// Consumer contract: `GET /api/v1/barcode?barcode=…` — Open Food Facts
+// / USDA / UPCitemdb-backed product lookup by EAN/UPC (nutrition
+// persona). Used when the user scans a product in the food log.
+//
+// Why this contract: no LLM, no quota — a pg-backed cache + upstream
+// fan-out. Locks the success-envelope shape (`{ product: {...} }`
+// where every macro is `number | null` and `source` is the strict
+// enum from `BarcodeProductSchema`). A drift on `source` or on a
+// nullable macro would break the food-log UI's "uncertain values"
+// indicator.
+//
+// Schema lives in `@sergeant/shared` (`BarcodeLookupResponseSchema` /
+// `BarcodeProductSchema`).
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { PactV4 } from "@pact-foundation/pact";
+
+import { createHttpClient } from "../../httpClient";
+import { createBarcodeEndpoints } from "../../endpoints/barcode";
+import { createPact } from "./_pact";
+
+describe("contract @ GET /api/v1/barcode", () => {
+  let pact: PactV4;
+  beforeAll(() => {
+    pact = createPact();
+  });
+  afterAll(() => {});
+
+  it("returns a BarcodeLookupSuccess for a known product (nutrition persona)", async () => {
+    await pact
+      .addInteraction()
+      .given(
+        "an authenticated session and barcode 4820010840443 is cached as 'Milk 2% Yagotynske' (source=off)",
+      )
+      .uponReceiving("a GET /api/v1/barcode?barcode=4820010840443 request")
+      .withRequest("GET", "/api/v1/barcode", (req) => {
+        req.headers({ accept: "application/json" });
+        req.query({ barcode: "4820010840443" });
+      })
+      .willRespondWith(200, (res) => {
+        res.headers({ "content-type": "application/json" });
+        res.jsonBody({
+          product: {
+            name: "Milk 2%",
+            brand: "Yagotynske",
+            kcal_100g: 52,
+            protein_100g: 3.4,
+            fat_100g: 2,
+            carbs_100g: 4.8,
+            servingSize: "250 ml",
+            servingGrams: 250,
+            source: "off",
+          },
+        });
+      })
+      .executeTest(async (mockServer) => {
+        const http = createHttpClient({ baseUrl: mockServer.url });
+        const barcode = createBarcodeEndpoints(http);
+        const out = await barcode.lookup("4820010840443");
+        expect(out.product).toBeDefined();
+        // Discriminate the success branch — the api-client's response
+        // type is a union with the 404/error envelope.
+        const product = out.product!;
+        expect(product.name).toBe("Milk 2%");
+        expect(product.brand).toBe("Yagotynske");
+        expect(product.source).toBe("off");
+        expect(product.kcal_100g).toBe(52);
+        // Macros + serving-size invariants — every numeric field must be
+        // a `number`, not a stringified one (Hard Rule #1 sibling-rule
+        // for upstream-driven floats).
+        expect(typeof product.protein_100g).toBe("number");
+        expect(typeof product.servingGrams).toBe("number");
+      });
+  });
+});

--- a/packages/api-client/src/__tests__/contracts/coach-memory.contract.test.ts
+++ b/packages/api-client/src/__tests__/contracts/coach-memory.contract.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment node
+//
+// Consumer contract: `GET /api/v1/coach/memory` — coach memory blob
+// (hub persona). The web/insights surface reads this on every Hub
+// dashboard open and on the weekly-digest flow to assemble the
+// "what does the coach remember about me" snapshot before calling
+// `postInsight` (see `apps/web/src/core/insights/useCoachInsight.ts`).
+//
+// Why this contract: session-only, no Anthropic — the lightest hub
+// READ. The shape is intentionally open (`memory: unknown`) because
+// the blob's interior changes with weekly digest growth, but the
+// envelope `{ ok: true, memory: <blob | null> }` is the stable
+// integration surface every hub feature depends on.
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { PactV4 } from "@pact-foundation/pact";
+
+import { createHttpClient } from "../../httpClient";
+import { createCoachEndpoints } from "../../endpoints/coach";
+import { createPact } from "./_pact";
+
+describe("contract @ GET /api/v1/coach/memory", () => {
+  let pact: PactV4;
+  beforeAll(() => {
+    pact = createPact();
+  });
+  afterAll(() => {});
+
+  it("returns the coach memory blob for an authenticated user (hub persona)", async () => {
+    await pact
+      .addInteraction()
+      .given(
+        "an authenticated session for user-pact-001 with one weekly-digest entry in coach_memory",
+      )
+      .uponReceiving("a GET /api/v1/coach/memory request")
+      .withRequest("GET", "/api/v1/coach/memory", (req) => {
+        req.headers({ accept: "application/json" });
+      })
+      .willRespondWith(200, (res) => {
+        res.headers({ "content-type": "application/json" });
+        res.jsonBody({
+          ok: true,
+          memory: {
+            weeklyDigests: [
+              {
+                weekKey: "2026-W19",
+                weekRange: "2026-05-04..2026-05-10",
+                generatedAt: "2026-05-11T08:00:00.000Z",
+                finyk: { summary: "Spending under budget by 8%." },
+                fizruk: { summary: "3 workouts done." },
+                nutrition: { summary: "Protein on target." },
+                routine: { summary: "Sleep 7h average." },
+                overallRecommendations: [
+                  "Keep weekly cardio under 4 sessions.",
+                ],
+              },
+            ],
+            lastInsightDate: "2026-05-12",
+            lastInsightText: "Steady week — keep the momentum.",
+          },
+        });
+      })
+      .executeTest(async (mockServer) => {
+        const http = createHttpClient({ baseUrl: mockServer.url });
+        const coach = createCoachEndpoints(http);
+        const out = (await coach.getMemory()) as {
+          ok?: boolean;
+          memory?: unknown;
+        };
+        // The api-client types declare `{ memory?: unknown }`; the
+        // contract pins the *envelope* (ok=true) and the *root shape*
+        // of the memory blob. Field-level invariants for the blob
+        // interior are checked elsewhere (modules/chat/coach.test.ts).
+        expect(out.ok).toBe(true);
+        expect(out.memory).toBeDefined();
+        const mem = out.memory as {
+          weeklyDigests: Array<{ weekKey: string }>;
+        };
+        expect(mem.weeklyDigests).toHaveLength(1);
+        expect(mem.weeklyDigests[0]!.weekKey).toBe("2026-W19");
+      });
+  });
+});

--- a/packages/api-client/src/__tests__/contracts/mono-syncState.contract.test.ts
+++ b/packages/api-client/src/__tests__/contracts/mono-syncState.contract.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment node
+//
+// Consumer contract: `GET /api/v1/mono/sync-state` — Monobank webhook
+// connection state (status / webhookActive / lastEventAt /
+// lastBackfillAt / accountsCount). Hot endpoint for the **finyk
+// persona** — `useMonobankWebhook` polls it on every Finyk dashboard
+// open + every reconnect attempt (see `apps/web/src/modules/finyk/`).
+//
+// Schema lives in `@sergeant/shared` (`MonoSyncStateSchema`). Drift on
+// any field silently breaks the "Connect Monobank" gate (UI keeps
+// rendering the form even when the row is `active`).
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { PactV4 } from "@pact-foundation/pact";
+
+import { createHttpClient } from "../../httpClient";
+import { createMonoWebhookEndpoints } from "../../endpoints/mono";
+import { createPact } from "./_pact";
+
+describe("contract @ GET /api/v1/mono/sync-state", () => {
+  let pact: PactV4;
+  beforeAll(() => {
+    pact = createPact();
+  });
+  afterAll(() => {});
+
+  it("returns MonoSyncState for a connected, active webhook (finyk persona)", async () => {
+    await pact
+      .addInteraction()
+      .given(
+        "an authenticated session for user-pact-001 with an active Monobank webhook (2 accounts)",
+      )
+      .uponReceiving("a GET /api/v1/mono/sync-state request")
+      .withRequest("GET", "/api/v1/mono/sync-state", (req) => {
+        req.headers({ accept: "application/json" });
+      })
+      .willRespondWith(200, (res) => {
+        res.headers({ "content-type": "application/json" });
+        res.jsonBody({
+          status: "active",
+          webhookActive: true,
+          lastEventAt: "2026-05-13T08:30:00.000Z",
+          lastBackfillAt: "2026-05-12T22:00:00.000Z",
+          accountsCount: 2,
+        });
+      })
+      .executeTest(async (mockServer) => {
+        const http = createHttpClient({ baseUrl: mockServer.url });
+        const mono = createMonoWebhookEndpoints(http);
+        const state = await mono.syncState();
+        expect(state.status).toBe("active");
+        expect(state.webhookActive).toBe(true);
+        expect(state.lastEventAt).toBe("2026-05-13T08:30:00.000Z");
+        expect(state.lastBackfillAt).toBe("2026-05-12T22:00:00.000Z");
+        expect(state.accountsCount).toBe(2);
+      });
+  });
+});

--- a/packages/api-client/src/__tests__/contracts/mono-transactions.contract.test.ts
+++ b/packages/api-client/src/__tests__/contracts/mono-transactions.contract.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment node
+//
+// Consumer contract: `GET /api/v1/mono/transactions` — paginated
+// Monobank transactions feed (finyk persona). Used by
+// `monoTransactionsLoader` in the Finyk transactions list (infinite
+// scroll, filter by `from`/`to`/`accountId`).
+//
+// Why this contract: exercises **two** bigint→number coercions in one
+// envelope (`amount`, `operationAmount`, `cashbackAmount`,
+// `commissionRate`, `balance` are all minor-units `number`s on the
+// wire, but `pg` returns them as strings — see Hard Rule #1). Drift
+// here would manifest as silent string concatenation in the UI (e.g.
+// "−123" + "+45" = "−12345").
+//
+// Schema lives in `@sergeant/shared` (`MonoTransactionsPageSchema` +
+// `MonoTransactionDtoSchema`).
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { PactV4 } from "@pact-foundation/pact";
+
+import { createHttpClient } from "../../httpClient";
+import { createMonoWebhookEndpoints } from "../../endpoints/mono";
+import { createPact } from "./_pact";
+
+describe("contract @ GET /api/v1/mono/transactions", () => {
+  let pact: PactV4;
+  beforeAll(() => {
+    pact = createPact();
+  });
+  afterAll(() => {});
+
+  it("returns a paginated MonoTransactionsPage (finyk persona)", async () => {
+    await pact
+      .addInteraction()
+      .given(
+        "an authenticated session for user-pact-001 with 1 mono account and 2 transactions in 2026-05",
+      )
+      .uponReceiving(
+        "a GET /api/v1/mono/transactions request with limit=2 and a date range",
+      )
+      .withRequest("GET", "/api/v1/mono/transactions", (req) => {
+        req.headers({ accept: "application/json" });
+        req.query({
+          from: "2026-05-01",
+          to: "2026-05-13",
+          limit: "2",
+        });
+      })
+      .willRespondWith(200, (res) => {
+        res.headers({ "content-type": "application/json" });
+        res.jsonBody({
+          data: [
+            {
+              userId: "user-pact-001",
+              monoAccountId: "acct-pact-001",
+              monoTxId: "tx-pact-0001",
+              time: "2026-05-12T18:42:11.000Z",
+              amount: -12345,
+              operationAmount: -12345,
+              currencyCode: 980,
+              mcc: 5411,
+              originalMcc: 5411,
+              hold: false,
+              description: "ATB Market",
+              comment: null,
+              cashbackAmount: 123,
+              commissionRate: 0,
+              balance: 4567890,
+              receiptId: null,
+              invoiceId: null,
+              counterEdrpou: null,
+              counterIban: null,
+              counterName: null,
+              categorySlug: "groceries",
+              categoryOverridden: false,
+              source: "webhook",
+              receivedAt: "2026-05-12T18:42:12.500Z",
+            },
+            {
+              userId: "user-pact-001",
+              monoAccountId: "acct-pact-001",
+              monoTxId: "tx-pact-0002",
+              time: "2026-05-11T09:14:00.000Z",
+              amount: 100000,
+              operationAmount: 100000,
+              currencyCode: 980,
+              mcc: null,
+              originalMcc: null,
+              hold: null,
+              description: "Salary",
+              comment: null,
+              cashbackAmount: null,
+              commissionRate: null,
+              balance: 4680235,
+              receiptId: null,
+              invoiceId: null,
+              counterEdrpou: null,
+              counterIban: null,
+              counterName: null,
+              categorySlug: null,
+              categoryOverridden: false,
+              source: "webhook",
+              receivedAt: "2026-05-11T09:14:01.250Z",
+            },
+          ],
+          nextCursor: "2026-05-11T09:14:00.000Z:tx-pact-0002",
+        });
+      })
+      .executeTest(async (mockServer) => {
+        const http = createHttpClient({ baseUrl: mockServer.url });
+        const mono = createMonoWebhookEndpoints(http);
+        const page = await mono.transactions({
+          from: "2026-05-01",
+          to: "2026-05-13",
+          limit: 2,
+        });
+        expect(page.data).toHaveLength(2);
+        // bigint-as-number invariant (Hard Rule #1) — must already be
+        // a number on the wire; the api-client does NO coercion.
+        expect(typeof page.data[0]!.amount).toBe("number");
+        expect(typeof page.data[0]!.balance).toBe("number");
+        expect(page.data[0]!.amount).toBe(-12345);
+        expect(page.data[1]!.amount).toBe(100000);
+        // Cursor format is `<time>:<monoTxId>` — both the time and the id
+        // of the last row in the page are needed to break ties on equal
+        // `time` and resume pagination deterministically.
+        expect(page.nextCursor).toBe("2026-05-11T09:14:00.000Z:tx-pact-0002");
+      });
+  });
+});

--- a/packages/api-client/src/__tests__/contracts/nutrition-day-plan.contract.test.ts
+++ b/packages/api-client/src/__tests__/contracts/nutrition-day-plan.contract.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment node
+//
+// Consumer contract: `POST /api/v1/nutrition/day-plan` — generate
+// a one-day meal plan (nutrition persona). LLM-gated (Anthropic) —
+// see `apps/server/src/modules/nutrition/day-plan.ts`. The api-client
+// returns `NutritionDayPlanResponse` with a `plan` whose meals carry
+// nullable macro fields + a stable meal-type enum.
+//
+// Why this contract: anchors the **response envelope** (plan.meals[],
+// totalKcal/Protein/Fat/Carbs, note + optional rawText) so a future
+// LLM-prompt refactor that accidentally drops `note` or returns
+// `rawText: ""` instead of `null` is caught at PR-time. The matching
+// provider-side replay stubs the Anthropic call (see
+// `apps/server/src/__tests__/contracts/provider.test.ts`).
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { PactV4 } from "@pact-foundation/pact";
+
+import { createHttpClient } from "../../httpClient";
+import { createNutritionEndpoints } from "../../endpoints/nutrition";
+import { createPact } from "./_pact";
+
+describe("contract @ POST /api/v1/nutrition/day-plan", () => {
+  let pact: PactV4;
+  beforeAll(() => {
+    pact = createPact();
+  });
+  afterAll(() => {});
+
+  it("returns a normalized NutritionDayPlan for the given targets (nutrition persona)", async () => {
+    await pact
+      .addInteraction()
+      .given(
+        "an authenticated session with Anthropic key + AI quota available; pantry has milk, oats, eggs",
+      )
+      .uponReceiving(
+        "a POST /api/v1/nutrition/day-plan request with targets and a small pantry",
+      )
+      .withRequest("POST", "/api/v1/nutrition/day-plan", (req) => {
+        req.headers({
+          accept: "application/json",
+          "content-type": "application/json",
+        });
+        req.jsonBody({
+          targets: { kcal: 2000, protein_g: 120, fat_g: 70, carbs_g: 220 },
+          pantry: [
+            { name: "milk", qty: 1, unit: "L" },
+            { name: "oats", qty: 500, unit: "g" },
+            { name: "eggs", qty: 6, unit: "pcs" },
+          ],
+          locale: "uk-UA",
+        });
+      })
+      .willRespondWith(200, (res) => {
+        res.headers({ "content-type": "application/json" });
+        res.jsonBody({
+          plan: {
+            meals: [
+              {
+                type: "breakfast",
+                label: "Сніданок",
+                name: "Вівсянка з молоком",
+                description: "Тепла вівсяна каша з молоком 2% і ягодами.",
+                ingredients: ["вівсянка 80г", "молоко 250мл", "ягоди 100г"],
+                kcal: 420,
+                protein_g: 18,
+                fat_g: 10,
+                carbs_g: 65,
+              },
+              {
+                type: "lunch",
+                label: "Обід",
+                name: "Омлет з овочами",
+                description: "З 3 яєць, шпинатом, чорним хлібом.",
+                ingredients: ["яйця 3шт", "шпинат 80г", "хліб 60г"],
+                kcal: 540,
+                protein_g: 32,
+                fat_g: 24,
+                carbs_g: 40,
+              },
+            ],
+            totalKcal: 960,
+            totalProtein_g: 50,
+            totalFat_g: 34,
+            totalCarbs_g: 105,
+            note: "Партіальний план — лише сніданок і обід для прикладу.",
+          },
+          rawText: null,
+        });
+      })
+      .executeTest(async (mockServer) => {
+        const http = createHttpClient({ baseUrl: mockServer.url });
+        const nutrition = createNutritionEndpoints(http);
+        const out = await nutrition.dayPlan({
+          targets: { kcal: 2000, protein_g: 120, fat_g: 70, carbs_g: 220 },
+          pantry: [
+            { name: "milk", qty: 1, unit: "L" },
+            { name: "oats", qty: 500, unit: "g" },
+            { name: "eggs", qty: 6, unit: "pcs" },
+          ],
+          locale: "uk-UA",
+        });
+        expect(out.plan.meals).toHaveLength(2);
+        expect(out.plan.meals[0]!.type).toBe("breakfast");
+        expect(out.plan.meals[1]!.type).toBe("lunch");
+        // Numeric envelope (Hard Rule #1 sibling — LLM JSON often
+        // arrives stringified; the normalizer in day-plan.ts must coerce).
+        expect(typeof out.plan.totalKcal).toBe("number");
+        expect(out.plan.totalKcal).toBe(960);
+        expect(out.plan.note).toContain("Партіальний");
+        expect(out.rawText).toBeNull();
+      });
+  });
+});


### PR DESCRIPTION
## Summary

Поверх PR-42 (#2675) додає 5 нових consumer-driven Pact-контрактів для endpoint-ів з найвищим cross-surface usage у `@sergeant/api-client` (виміряно `grep`-ом `apps/web/` за RQ hook-ами + import-аналізом). Pact-файл росте з 5 → 10 interactions; provider-replay — з 3 → 8 (плюс 2 збережені `it.todo` під streaming/vision Anthropic stubs).

**Нові endpoint-и:**

| Endpoint | Persona | Provider replay |
| --- | --- | --- |
| `GET /api/v1/mono/sync-state` | finyk | two-query handler (`mono_connection` + count) під `MONO_WEBHOOK_ENABLED` |
| `GET /api/v1/mono/transactions` | finyk | pool mock пожує **string** bigint-и → нормалізатор coerce-ить → `typeof === "number"` (Hard Rule #1 exercised at wire-level) |
| `GET /api/v1/coach/memory` | hub | замикає `{ ok, memory }` envelope (jsonb interior open) |
| `GET /api/v1/barcode` | nutrition | `vi.spyOn(globalThis, "fetch")` для OFF upstream — без живого мережевого hit-у |
| `POST /api/v1/nutrition/day-plan` | nutrition | Anthropic-gated — `vi.mock(./../../lib/anthropic.js)` через `createAnthropicMockHandle()`; `ANTHROPIC_API_KEY` + `AI_QUOTA_DISABLED` крутяться через `vi.hoisted` |

**Не включено (документовано як майбутні pact-пари):**
- `fizruk` — local-first CRDT sync через `/api/v2/sync/*`; payload бінарний (Yjs), Pact без custom encoder не підходить.
- `openclaw` — Telegram-бот, що консумить `/api/internal/openclaw/*` з Bearer-key, не через `@sergeant/api-client`. Окрема consumer/provider пара під `tools/console/src/__tests__/contracts/`.

**Не торкається** PR-42 інфраструктури (PactV4 mock, V3 spec, supertest replay), env-vars/migrations, server-handler-ів.

## Governing Skill

- Primary skill: `.agents/skills/sergeant-server-api/SKILL.md` — contract triplet (Hard Rule #3) + bigint coercion (Hard Rule #1).
- Secondary skill: n/a.

## Playbook

- Primary playbook: n/a — extend PR-42 (#2675) встановлений pattern.
- Why this playbook: PR-42 уже зафіксував conventions (one pact-file, V3 spec, supertest replay, `findInteraction` helper). Цей PR — pure scale-out, не вимагає нового playbook.

## Verification

```bash
$ pnpm --filter @sergeant/api-client test -- --run src/__tests__/contracts/
 Test Files  10 passed (10)
      Tests  10 passed (10)
   Duration  3.59s

$ pnpm --filter @sergeant/server test -- --run src/__tests__/contracts/provider.test.ts
 Test Files  1 passed (1)
      Tests  9 passed | 2 todo (11)
   Duration  2.18s

$ pnpm format:check
# Усе passes після prettier --write на 3 touched-файла.

$ pnpm --filter @sergeant/openclaw lint
# Pre-existing на main (`tsconfig.node.json` resolve + `import/extensions`).

$ pnpm --filter @sergeant/server typecheck
# Pre-existing на main (`src/obs/tracing.ts` — `Resource` legacy import).
```

Pre-existing failures підтверджено `git stash -u` + повтор на чистому HEAD origin/main.

Additional checks:

- [x] Local smoke / manual validation completed (consumer + provider контракт тести пройшли локально)
- [x] Surface-specific checks completed (pact JSON регенерується deterministic, bigint coercion на wire-level вірифіковано)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update — n/a (контракт-pipeline не міняється, тільки coverage).
- [x] I checked whether a playbook or skill needed an update — n/a.
- [x] I checked whether governance docs or review docs needed an update — n/a.

Updated docs:

- `docs/architecture/api-contracts.md` — v2 coverage map (10 endpoints), Anthropic-stub pattern, fizruk/openclaw out-of-scope rationale, оновлений future-work список.

## Risk and Rollout

- User-visible risk: нуль — pure test additions, нема runtime/handler змін.
- Rollout / deploy order: deploy-as-is через CI.
- Backout plan: revert single commit.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

- Pact JSON у `packages/api-client/pacts/sergeant-api-client-sergeant-server.json` регенерується consumer-suite-ом — не редагуй руками.
- `vi.hoisted` env-блок у `apps/server/src/__tests__/contracts/provider.test.ts` — це необхідна умова, бо `requireAnthropicKey`/`requireAiQuota`/`MONO_WEBHOOK_ENABLED` читаються при module-load, не per-request.
- 2 `it.todo` — streaming `/api/v1/chat` + vision `/api/v1/nutrition/analyze-photo` — навмисно деферрено, бо потребують власних harness-ів (streaming не виражається у Pact JSON, vision потребує base64 fixture).

Link to Devin session: https://app.devin.ai/sessions/2765108a015c48038fe4a3bbfd851a0c

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend Pact test coverage in `@sergeant/api-client` with 5 high-usage endpoints and update provider replays in `@sergeant/server` to verify them. Pact interactions grow from 5 to 10; provider replays from 3 to 8, with 2 streaming/vision endpoints left as TODO.

- **New Features**
  - Added consumer contracts for: `GET /api/v1/mono/sync-state`, `GET /api/v1/mono/transactions`, `GET /api/v1/coach/memory`, `GET /api/v1/barcode`, `POST /api/v1/nutrition/day-plan`.
  - Provider replay now verifies all 5 new endpoints (8 total): hoisted `MONO_WEBHOOK_ENABLED`, `ANTHROPIC_API_KEY`, `AI_QUOTA_DISABLED`; Anthropic stub via shared mock; `globalThis.fetch` stub for OFF; exercises string→number bigint coercion for Mono transactions.
  - Pact file updated to 10 interactions; `POST /api/v1/chat` (streaming) and `POST /api/v1/nutrition/analyze-photo` (vision) remain `it.todo`.

<sup>Written for commit 209caf62397287b0bb7754fe1de337bada2a5cbf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

