### PR TITLE
feat(openclaw): /openclaw status debug snapshot command

### DIFF
--- a/docs/runbooks/openclaw-morning-briefing.md
+++ b/docs/runbooks/openclaw-morning-briefing.md
@@ -226,6 +226,40 @@ category `openclaw.ritual` (events: `ritual.help`, `ritual.unknown_mode`,
 `ritual.<mode>.start`, `ritual.<mode>.success`, `ritual.<mode>.endpoint_failed`,
 `ritual.<mode>.not_implemented`).
 
+## Manual trigger — `/openclaw status`
+
+Sibling info-command для debug snapshot OpenClaw state-у. Handler — той
+самий файл (`handler-info-commands.ts`), pure runner — `status-runner.ts`,
+renderer — `status-format.ts`. Compact HTML payload (≤30 рядків) у founder
+DM, корисний для smoke-test після redeploy і ad-hoc діагностики.
+
+- `/openclaw` або `/openclaw status` — рендерить snapshot з 5 секцій:
+  - **Persona** — `DEFAULT_PERSONA` (`cofounder`) + список 4-х
+    спеціалістських persona-allowlist (ADR-0033 Phase 2.5).
+  - **Budget** — поточний `spentUsd / budgetUsd` + `remainingUsd` через
+    `POST /api/internal/openclaw/budget` (той самий що `/budget`).
+  - **n8n WF** — counts active/paused + перші 3 active WF-ID через
+    `POST /api/internal/openclaw/n8n/list`. Якщо credentials unset —
+    «n8n credentials not configured».
+  - **Last 10 invocations** — рядки з status-glyph + trigger + relative
+    time + truncated user-message через
+    `POST /api/internal/openclaw/invocations/list` (`limit: 10`).
+  - **Last error (Sentry)** — top-1 issue з level=error через
+    `POST /api/internal/openclaw/metrics/sentry`. Якщо `SENTRY_AUTH_TOKEN`
+    unset — «Sentry not configured».
+- `/openclaw help` — довідка з переліком підкоманд; audit-row НЕ
+  створюється.
+
+Audit-row у `openclaw_invocations` для `status`: `trigger="dm"` +
+`metadata.slashCommand="/openclaw"` + `metadata.subcommand="status"`.
+4 fetch-и запускаються паралельно (`Promise.all`); кожна секція
+fail-soft рендериться окремо — якщо одне джерело впало, інші
+рендеряться нормально.
+
+Sentry breadcrumb-и під category `openclaw.status` (events:
+`openclaw.help`, `openclaw.unknown_subcommand`, `openclaw.status.start`,
+`openclaw.status.success`).
+
 ## Error-handling
 
 - **rejected promise** (network error, 5xx upstream) → секція рендерить

--- a/tools/openclaw/src/openclaw/commands.ts
+++ b/tools/openclaw/src/openclaw/commands.ts
@@ -108,6 +108,10 @@ export const OPENCLAW_BOT_COMMANDS: ReadonlyArray<BotCommandSpec> = [
     command: "ai_cost",
     description: "AI spend rollup: today/week/month + budget + top endpoints",
   },
+  {
+    command: "openclaw",
+    description: "Debug snapshot: persona / WF / invocations / budget",
+  },
   { command: "reset", description: "Start a new cofounder session" },
 ];
 

--- a/tools/openclaw/src/openclaw/handler-constants.ts
+++ b/tools/openclaw/src/openclaw/handler-constants.ts
@@ -178,6 +178,7 @@ export const HELP_TEXT = [
   "/budget — поточний денний spend",
   "/ritual [morning|weekly|monthly|help] — ad-hoc ritual trigger (WF-25 mirror)",
   "/ai_cost — AI-spend rollup: today/week/month + budget + top endpoints",
+  "/openclaw [status|help] — debug snapshot: persona / WF / invocations / budget / Sentry",
   "/reset — почати нову сесію",
   "/help — ця довідка",
   "",

--- a/tools/openclaw/src/openclaw/handler-info-commands.ts
+++ b/tools/openclaw/src/openclaw/handler-info-commands.ts
@@ -25,6 +25,7 @@ import {
   type PendingAlertItem,
 } from "./alerts-format.js";
 import { executeRitualCommand } from "./ritual-runner.js";
+import { executeOpenclawStatusCommand } from "./status-runner.js";
 import type { HandlerContext } from "./handler-context.js";
 import {
   HELP_TEXT,
@@ -432,6 +433,118 @@ export function registerInfoCommands(ctx: HandlerContext): void {
             `${serverUrl}/api/internal/openclaw/briefing/morning`,
             internalApiKey,
             {},
+          );
+          return { ok: r.ok, status: r.status, data: r.data };
+        },
+        async openInvocation(input) {
+          const r = await postJson<OpenInvocationResponse>(
+            `${serverUrl}/api/internal/openclaw/invocations/open`,
+            internalApiKey,
+            input,
+          );
+          return {
+            ok: r.ok,
+            status: r.status,
+            invocationId: r.data?.invocationId ?? null,
+          };
+        },
+        async finalizeInvocation(input) {
+          const r = await postJson(
+            `${serverUrl}/api/internal/openclaw/invocations/finalize`,
+            internalApiKey,
+            input,
+          );
+          return { ok: r.ok, status: r.status };
+        },
+      },
+      addBreadcrumb: (b) => Sentry.addBreadcrumb(b),
+    });
+
+    await c.reply(result.reply, { parse_mode: "HTML" });
+  });
+
+  // PR-/openclaw-status: debug/health snapshot для founder DM.
+  //
+  // Implementation: всі 4 fetch-and-merge гілки + audit life-cycle
+  // живуть у pure `executeOpenclawStatusCommand` (status-runner.ts), щоб
+  // handler лишався thin shim над grammy. Compact Markdown payload
+  // (≤30 рядків) у founder DM — для smoke-test після redeploy і ad-hoc
+  // діагностики.
+  bot.command("openclaw", async (c) => {
+    if (!isAllowedDmContext(c)) return;
+    if (!rateLimiter.allow(String(c.from?.id))) {
+      await c.reply("Rate limit exceeded. Спробуй за хвилину.");
+      return;
+    }
+
+    const argument = (c.match ?? "").toString();
+    const founderTgUserId =
+      parseFounderTgUserId(process.env["OPENCLAW_FOUNDER_TG_USER_ID"]) ??
+      c.from?.id ??
+      0;
+
+    const result = await executeOpenclawStatusCommand({
+      rawArgument: argument,
+      founderUserId,
+      founderTgUserId,
+      ...(c.chat?.id !== undefined ? { telegramChatId: c.chat.id } : {}),
+      fetcher: {
+        async listInvocations() {
+          const r = await postJson<{
+            invocations: Array<{
+              id: number;
+              invoked_at: string;
+              trigger: string;
+              user_message: string;
+              status: string;
+              cost_usd: number;
+              duration_ms: number;
+              iterations: number;
+              tone_mode: string | null;
+            }>;
+          }>(
+            `${serverUrl}/api/internal/openclaw/invocations/list`,
+            internalApiKey,
+            { founderUserId, limit: 10 },
+          );
+          return { ok: r.ok, status: r.status, data: r.data };
+        },
+        async listN8nWorkflows() {
+          const r = await postJson<{
+            workflows: Array<{
+              id: string;
+              name: string;
+              active: boolean;
+              tier: string;
+              category: string | null;
+              updatedAt: string | null;
+            }>;
+            notConfigured?: boolean;
+          }>(`${serverUrl}/api/internal/openclaw/n8n/list`, internalApiKey, {});
+          return { ok: r.ok, status: r.status, data: r.data };
+        },
+        async getBudget() {
+          const r = await postJson<BudgetResponse>(
+            `${serverUrl}/api/internal/openclaw/budget`,
+            internalApiKey,
+            { founderUserId },
+          );
+          return { ok: r.ok, status: r.status, data: r.data };
+        },
+        async getSentryIssues() {
+          const r = await postJson<{
+            notConfigured?: boolean;
+            issues?: Array<{
+              title: string;
+              level: string;
+              count: string;
+              permalink: string;
+            }>;
+            note?: string;
+          }>(
+            `${serverUrl}/api/internal/openclaw/metrics/sentry`,
+            internalApiKey,
+            { level: "error", limit: 5 },
           );
           return { ok: r.ok, status: r.status, data: r.data };
         },

--- a/tools/openclaw/src/openclaw/status-format.test.ts
+++ b/tools/openclaw/src/openclaw/status-format.test.ts
@@ -1,0 +1,511 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatRelativeUa,
+  formatStatusSnapshot,
+  htmlEscape,
+  OPENCLAW_HELP_TEXT,
+  parseOpenclawCommand,
+  type StatusSnapshot,
+} from "./status-format.js";
+import { ALL_PERSONAS, DEFAULT_PERSONA } from "../agents/personas.js";
+
+// ─────────────────────────────────────────────────────────────────────────
+// parseOpenclawCommand
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("parseOpenclawCommand", () => {
+  it("defaults to status when input is empty", () => {
+    expect(parseOpenclawCommand("")).toEqual({
+      subcommand: "status",
+      rawArgument: "",
+    });
+    expect(parseOpenclawCommand("   ")).toEqual({
+      subcommand: "status",
+      rawArgument: "",
+    });
+  });
+
+  it("parses status / help case-insensitively", () => {
+    expect(parseOpenclawCommand("status").subcommand).toBe("status");
+    expect(parseOpenclawCommand("STATUS").subcommand).toBe("status");
+    expect(parseOpenclawCommand("Status").subcommand).toBe("status");
+    expect(parseOpenclawCommand("help").subcommand).toBe("help");
+    expect(parseOpenclawCommand("HELP").subcommand).toBe("help");
+  });
+
+  it("returns unknown + Ukrainian error for unrecognized token", () => {
+    const parsed = parseOpenclawCommand("debug");
+    expect(parsed.subcommand).toBe("unknown");
+    expect(parsed.rawArgument).toBe("debug");
+    expect(parsed.error).toContain("Невідома підкоманда");
+    expect(parsed.error).toContain("«debug»");
+  });
+
+  it("ignores tokens after the first one", () => {
+    expect(parseOpenclawCommand("status extra args").subcommand).toBe("status");
+    expect(parseOpenclawCommand("help me out").subcommand).toBe("help");
+  });
+
+  it("preserves rawArgument with original casing", () => {
+    expect(parseOpenclawCommand("Status").rawArgument).toBe("Status");
+    expect(parseOpenclawCommand("DEBUG-X").rawArgument).toBe("DEBUG-X");
+  });
+
+  it("handles nullish input defensively", () => {
+    // @ts-expect-error — runtime null guard
+    expect(parseOpenclawCommand(null).subcommand).toBe("status");
+    // @ts-expect-error — runtime undefined guard
+    expect(parseOpenclawCommand(undefined).subcommand).toBe("status");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// OPENCLAW_HELP_TEXT
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("OPENCLAW_HELP_TEXT", () => {
+  it("lists status + help subcommands", () => {
+    expect(OPENCLAW_HELP_TEXT).toContain("/openclaw status");
+    expect(OPENCLAW_HELP_TEXT).toContain("/openclaw help");
+  });
+
+  it("mentions all 5 snapshot data sources", () => {
+    expect(OPENCLAW_HELP_TEXT).toContain("persona");
+    expect(OPENCLAW_HELP_TEXT).toContain("invocations");
+    expect(OPENCLAW_HELP_TEXT).toContain("n8n");
+    expect(OPENCLAW_HELP_TEXT).toContain("budget");
+    expect(OPENCLAW_HELP_TEXT).toContain("Sentry");
+  });
+
+  it("uses HTML-safe formatting (no raw < > outside code-tags)", () => {
+    // Strip code tags and ensure no stray HTML brackets.
+    const stripped = OPENCLAW_HELP_TEXT.replace(/<[^>]+>/g, "");
+    expect(stripped).not.toMatch(/[<>]/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// htmlEscape
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("htmlEscape", () => {
+  it("escapes &, <, > characters", () => {
+    expect(htmlEscape("a<b>c&d")).toBe("a&lt;b&gt;c&amp;d");
+  });
+
+  it("leaves ASCII / cyrillic alphanumerics intact", () => {
+    expect(htmlEscape("Привіт world 123")).toBe("Привіт world 123");
+  });
+
+  it("handles empty string", () => {
+    expect(htmlEscape("")).toBe("");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// formatRelativeUa
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("formatRelativeUa", () => {
+  const now = new Date("2026-05-13T12:00:00Z");
+
+  it("returns 'щойно' for sub-minute deltas", () => {
+    const t = new Date(now.getTime() - 30_000).toISOString();
+    expect(formatRelativeUa(t, now)).toBe("щойно");
+  });
+
+  it("returns 'щойно' for future timestamps (defensive)", () => {
+    const t = new Date(now.getTime() + 60_000).toISOString();
+    expect(formatRelativeUa(t, now)).toBe("щойно");
+  });
+
+  it("formats minutes/hours/days/months/years in Ukrainian", () => {
+    const min = new Date(now.getTime() - 5 * 60_000).toISOString();
+    const hour = new Date(now.getTime() - 3 * 3600_000).toISOString();
+    const yesterday = new Date(now.getTime() - 25 * 3600_000).toISOString();
+    const fewDays = new Date(now.getTime() - 5 * 86_400_000).toISOString();
+    const months = new Date(now.getTime() - 90 * 86_400_000).toISOString();
+    const yearAgo = new Date(now.getTime() - 365 * 86_400_000).toISOString();
+
+    expect(formatRelativeUa(min, now)).toBe("5 хв тому");
+    expect(formatRelativeUa(hour, now)).toBe("3 год тому");
+    expect(formatRelativeUa(yesterday, now)).toBe("вчора");
+    expect(formatRelativeUa(fewDays, now)).toBe("5 дн тому");
+    expect(formatRelativeUa(months, now)).toBe("3 міс тому");
+    expect(formatRelativeUa(yearAgo, now)).toBe("1 р тому");
+  });
+
+  it("returns '?' for null/invalid input", () => {
+    expect(formatRelativeUa(null)).toBe("?");
+    expect(formatRelativeUa("not a date")).toBe("?");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// formatStatusSnapshot — section coverage
+// ─────────────────────────────────────────────────────────────────────────
+
+const NOW = new Date("2026-05-13T12:00:00Z");
+
+function baseSnapshot(overrides: Partial<StatusSnapshot> = {}): StatusSnapshot {
+  return {
+    generatedAtIso: NOW.toISOString(),
+    activePersona: DEFAULT_PERSONA,
+    allowedPersonas: ALL_PERSONAS,
+    invocations: { data: [], error: null },
+    workflows: { data: [], error: null, notConfigured: false },
+    budget: { data: null, error: null },
+    lastError: { data: null, error: null, notConfigured: false },
+    ...overrides,
+  };
+}
+
+describe("formatStatusSnapshot", () => {
+  it("renders the OpenClaw status header", () => {
+    const out = formatStatusSnapshot(baseSnapshot(), NOW);
+    expect(out).toContain("<b>🦅 OpenClaw status</b>");
+  });
+
+  it("renders default persona + sibling personas", () => {
+    const out = formatStatusSnapshot(baseSnapshot(), NOW);
+    expect(out).toContain("<code>cofounder</code>");
+    // Has the other-personas comma-list with at least 'ops' and 'finance'.
+    expect(out).toContain("ops");
+    expect(out).toContain("finance");
+  });
+
+  it("renders budget OK section when within cap", () => {
+    const out = formatStatusSnapshot(
+      baseSnapshot({
+        budget: {
+          data: {
+            spentUsd: 0.5432,
+            budgetUsd: 5,
+            remainingUsd: 4.4568,
+            allowed: true,
+          },
+          error: null,
+        },
+      }),
+      NOW,
+    );
+    expect(out).toContain("$0.5432 / $5.00");
+    expect(out).toContain("$4.4568");
+    expect(out).toContain("OK");
+  });
+
+  it("renders budget exceeded warning", () => {
+    const out = formatStatusSnapshot(
+      baseSnapshot({
+        budget: {
+          data: {
+            spentUsd: 4.95,
+            budgetUsd: 5,
+            remainingUsd: 0.05,
+            allowed: false,
+          },
+          error: null,
+        },
+      }),
+      NOW,
+    );
+    expect(out).toContain("⚠️ exceeded");
+  });
+
+  it("renders budget недоступно when fetch failed", () => {
+    const out = formatStatusSnapshot(
+      baseSnapshot({ budget: { data: null, error: "HTTP 500" } }),
+      NOW,
+    );
+    expect(out).toContain("Budget");
+    expect(out).toContain("недоступно");
+    expect(out).toContain("HTTP 500");
+  });
+
+  it("renders empty workflows as '—'", () => {
+    const out = formatStatusSnapshot(baseSnapshot(), NOW);
+    expect(out).toMatch(/n8n WF:[\s\S]*—/);
+  });
+
+  it("renders not-configured workflows hint", () => {
+    const out = formatStatusSnapshot(
+      baseSnapshot({
+        workflows: { data: null, error: null, notConfigured: true },
+      }),
+      NOW,
+    );
+    expect(out).toContain("n8n credentials not configured");
+  });
+
+  it("renders active+paused workflow counts + first 3 IDs", () => {
+    const out = formatStatusSnapshot(
+      baseSnapshot({
+        workflows: {
+          data: [
+            { id: "WF-25", name: "Morning briefing", active: true, tier: "A" },
+            { id: "WF-26", name: "Strategic mode", active: true, tier: "C" },
+            { id: "WF-30", name: "AI memory digest", active: true, tier: "A" },
+            { id: "WF-99", name: "Legacy stuff", active: false, tier: "B" },
+          ],
+          error: null,
+          notConfigured: false,
+        },
+      }),
+      NOW,
+    );
+    expect(out).toContain("3 active");
+    expect(out).toContain("1 paused");
+    expect(out).toContain("<code>WF-25</code>");
+    expect(out).toContain("<code>WF-26</code>");
+    expect(out).toContain("<code>WF-30</code>");
+  });
+
+  it("renders +N more suffix when active > 3", () => {
+    const out = formatStatusSnapshot(
+      baseSnapshot({
+        workflows: {
+          data: Array.from({ length: 7 }, (_, i) => ({
+            id: `WF-${10 + i}`,
+            name: `Workflow ${i}`,
+            active: true,
+            tier: "A",
+          })),
+          error: null,
+          notConfigured: false,
+        },
+      }),
+      NOW,
+    );
+    expect(out).toContain("7 active");
+    expect(out).toContain("+4 more");
+  });
+
+  it("renders workflows error as недоступно", () => {
+    const out = formatStatusSnapshot(
+      baseSnapshot({
+        workflows: { data: null, error: "HTTP 502", notConfigured: false },
+      }),
+      NOW,
+    );
+    expect(out).toMatch(/n8n WF:[\s\S]*недоступно/);
+    expect(out).toContain("HTTP 502");
+  });
+
+  it("renders invocations with status glyph + trigger + relative time", () => {
+    const out = formatStatusSnapshot(
+      baseSnapshot({
+        invocations: {
+          data: [
+            {
+              id: 1,
+              invokedAt: new Date(NOW.getTime() - 5 * 60_000).toISOString(),
+              trigger: "morning_ritual",
+              status: "success",
+              userMessage: "/ritual morning",
+              durationMs: 1200,
+              costUsd: 0.0123,
+              toneMode: null,
+            },
+            {
+              id: 2,
+              invokedAt: new Date(NOW.getTime() - 2 * 3600_000).toISOString(),
+              trigger: "dm",
+              status: "error",
+              userMessage: "/openclaw status",
+              durationMs: 300,
+              costUsd: 0,
+              toneMode: null,
+            },
+          ],
+          error: null,
+        },
+      }),
+      NOW,
+    );
+    expect(out).toContain("✅");
+    expect(out).toContain("❌");
+    expect(out).toContain("<code>morning_ritual</code>");
+    expect(out).toContain("<code>dm</code>");
+    expect(out).toContain("5 хв тому");
+    expect(out).toContain("2 год тому");
+  });
+
+  it("truncates long user messages in invocations", () => {
+    const longMsg = "/openclaw status " + "x".repeat(100);
+    const out = formatStatusSnapshot(
+      baseSnapshot({
+        invocations: {
+          data: [
+            {
+              id: 1,
+              invokedAt: NOW.toISOString(),
+              trigger: "dm",
+              status: "success",
+              userMessage: longMsg,
+              durationMs: 0,
+              costUsd: 0,
+              toneMode: null,
+            },
+          ],
+          error: null,
+        },
+      }),
+      NOW,
+    );
+    expect(out).toContain("…");
+    // Ensure full 100x didn't leak.
+    expect(out).not.toContain("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
+  });
+
+  it("caps invocations rendering at 10 even when more passed", () => {
+    const data = Array.from({ length: 15 }, (_, i) => ({
+      id: i + 1,
+      invokedAt: NOW.toISOString(),
+      trigger: "dm",
+      status: "success",
+      userMessage: `msg ${i}`,
+      durationMs: 0,
+      costUsd: 0,
+      toneMode: null,
+    }));
+    const out = formatStatusSnapshot(
+      baseSnapshot({ invocations: { data, error: null } }),
+      NOW,
+    );
+    expect((out.match(/✅/g) ?? []).length).toBe(10);
+  });
+
+  it("renders invocations error as недоступно", () => {
+    const out = formatStatusSnapshot(
+      baseSnapshot({
+        invocations: { data: null, error: "HTTP 503" },
+      }),
+      NOW,
+    );
+    expect(out).toContain("недоступно");
+    expect(out).toContain("HTTP 503");
+  });
+
+  it("renders 'немає errors' when sentry empty", () => {
+    const out = formatStatusSnapshot(baseSnapshot(), NOW);
+    expect(out).toContain("немає errors");
+  });
+
+  it("renders sentry notConfigured hint", () => {
+    const out = formatStatusSnapshot(
+      baseSnapshot({
+        lastError: { data: null, error: null, notConfigured: true },
+      }),
+      NOW,
+    );
+    expect(out).toContain("Sentry not configured");
+  });
+
+  it("renders last sentry error with level + title + count", () => {
+    const out = formatStatusSnapshot(
+      baseSnapshot({
+        lastError: {
+          data: {
+            title: "TypeError: cannot read property foo of undefined",
+            level: "error",
+            count: "12",
+            permalink: "https://sentry.io/issue/1",
+          },
+          error: null,
+          notConfigured: false,
+        },
+      }),
+      NOW,
+    );
+    expect(out).toContain("<code>error</code>");
+    expect(out).toContain("TypeError");
+    expect(out).toContain("×12");
+  });
+
+  it("escapes HTML characters in user-controlled fields", () => {
+    const out = formatStatusSnapshot(
+      baseSnapshot({
+        invocations: {
+          data: [
+            {
+              id: 1,
+              invokedAt: NOW.toISOString(),
+              trigger: "dm",
+              status: "success",
+              userMessage: "<script>alert('xss')</script>",
+              durationMs: 0,
+              costUsd: 0,
+              toneMode: null,
+            },
+          ],
+          error: null,
+        },
+      }),
+      NOW,
+    );
+    expect(out).not.toContain("<script>");
+    expect(out).toContain("&lt;script&gt;");
+  });
+
+  it("stays ≤ 30 visible lines for a typical fully-populated snapshot", () => {
+    const out = formatStatusSnapshot(
+      baseSnapshot({
+        invocations: {
+          data: Array.from({ length: 10 }, (_, i) => ({
+            id: i + 1,
+            invokedAt: new Date(NOW.getTime() - i * 60_000).toISOString(),
+            trigger: i % 2 === 0 ? "dm" : "morning_ritual",
+            status: i === 0 ? "error" : "success",
+            userMessage: `msg-${i}`,
+            durationMs: 100,
+            costUsd: 0.01,
+            toneMode: null,
+          })),
+          error: null,
+        },
+        workflows: {
+          data: Array.from({ length: 5 }, (_, i) => ({
+            id: `WF-${20 + i}`,
+            name: `WF ${i}`,
+            active: i < 4,
+            tier: "A",
+          })),
+          error: null,
+          notConfigured: false,
+        },
+        budget: {
+          data: {
+            spentUsd: 0.5,
+            budgetUsd: 5,
+            remainingUsd: 4.5,
+            allowed: true,
+          },
+          error: null,
+        },
+        lastError: {
+          data: {
+            title: "OperationalError",
+            level: "error",
+            count: "3",
+            permalink: "x",
+          },
+          error: null,
+          notConfigured: false,
+        },
+      }),
+      NOW,
+    );
+    const lines = out.split("\n");
+    expect(lines.length).toBeLessThanOrEqual(30);
+  });
+
+  it("renders generatedAt as relative time", () => {
+    const fiveMinAgo = new Date(NOW.getTime() - 5 * 60_000).toISOString();
+    const out = formatStatusSnapshot(
+      baseSnapshot({ generatedAtIso: fiveMinAgo }),
+      NOW,
+    );
+    expect(out).toContain("snapshot @ 5 хв тому");
+  });
+});

--- a/tools/openclaw/src/openclaw/status-format.ts
+++ b/tools/openclaw/src/openclaw/status-format.ts
@@ -1,0 +1,332 @@
+/**
+ * `/openclaw` slash-command parser + status snapshot renderer (pure, no I/O).
+ *
+ * `/openclaw status` — debug/health snapshot для founder DM: яка persona
+ * дефолтна, які workflow-и активні у n8n, останні invocation-и
+ * `openclaw_invocations`, AI-budget state і останній Sentry error. Для
+ * ad-hoc diagnostics + smoke-test після redeploy.
+ *
+ * Modes:
+ *   - `/openclaw` (default) → status
+ *   - `/openclaw status` → render snapshot
+ *   - `/openclaw help` → usage card
+ *
+ * Парсер exhaustive: будь-який невідомий token мапиться у
+ * `subcommand: "unknown"` + людський error-message.
+ *
+ * Renderer compact HTML, ≤30 рядків (вимога з task-у). Кожна секція
+ * fail-soft рендериться окремо — якщо одне з 5 джерел впало, інші
+ * рендеряться нормально, та секція показує "недоступно (HTTP NNN)".
+ */
+
+import type { OpenClawPersona } from "../agents/personas.js";
+
+export type OpenclawSubcommand = "status" | "help" | "unknown";
+
+export interface ParsedOpenclawCommand {
+  /** Розв'язана підкоманда. `unknown` коли token не зрозумілий. */
+  subcommand: OpenclawSubcommand;
+  /** Сирий argument-токен, як ввів user (для логування / debug-у). */
+  rawArgument: string;
+  /** Людський error-message для невідомого token-а. Undefined для valid. */
+  error?: string;
+}
+
+/**
+ * Парсить argument після `/openclaw` (тобто `c.match` у grammy). Першим
+ * не-whitespace token-ом визначається підкоманда.
+ *
+ * Empty input → status (default subcommand), так щоб `/openclaw` без
+ * аргументів "просто працював".
+ */
+export function parseOpenclawCommand(
+  rawArgument: string,
+): ParsedOpenclawCommand {
+  const trimmed = (rawArgument ?? "").trim();
+  if (trimmed.length === 0) {
+    return { subcommand: "status", rawArgument: "" };
+  }
+  const firstToken = trimmed.split(/\s+/)[0]?.toLowerCase() ?? "";
+  switch (firstToken) {
+    case "status":
+    case "help":
+      return { subcommand: firstToken, rawArgument: trimmed };
+    default:
+      return {
+        subcommand: "unknown",
+        rawArgument: trimmed,
+        error: `Невідома підкоманда «${firstToken}». Доступні: status, help.`,
+      };
+  }
+}
+
+/**
+ * Help text для `/openclaw help`. HTML-format щоб гармонувати з HELP_TEXT
+ * у `handler-constants.ts`.
+ */
+export const OPENCLAW_HELP_TEXT = [
+  "<b>/openclaw</b> — debug/health snapshot для OpenClaw.",
+  "",
+  "Usage:",
+  "  <code>/openclaw</code> — те саме, що <code>/openclaw status</code>",
+  "  <code>/openclaw status</code> — поточний state (persona / WF / invocations / budget / Sentry)",
+  "  <code>/openclaw help</code> — ця довідка",
+  "",
+  "Snapshot включає:",
+  "  • default persona + дозволені 5 personas (ADR-0033, Phase 2.5)",
+  "  • last 10 invocations з <code>openclaw_invocations</code>",
+  "  • active n8n workflows (Tier A/B/C/D, з manifest.json)",
+  "  • daily AI budget — spent / cap / залишок",
+  "  • останній Sentry error (level: error)",
+].join("\n");
+
+// ─────────────────────────────────────────────────────────────────────────
+// Snapshot types — shape passed to formatStatusSnapshot()
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface InvocationRow {
+  id: number;
+  invokedAt: string;
+  trigger: string;
+  status: string;
+  userMessage: string;
+  durationMs: number;
+  costUsd: number;
+  toneMode: string | null;
+}
+
+export interface WorkflowRow {
+  id: string;
+  name: string;
+  active: boolean;
+  tier: string;
+}
+
+export interface BudgetState {
+  spentUsd: number;
+  budgetUsd: number;
+  remainingUsd: number;
+  allowed: boolean;
+}
+
+export interface SentryIssue {
+  title: string;
+  level: string;
+  count: string;
+  permalink: string;
+}
+
+/**
+ * Aggregated snapshot, готовий до рендерингу. Кожна з 5 секцій
+ * незалежна: пара `{data, error, notConfigured?}` — рівно одна з них
+ * non-null. Якщо все три null — секція рендерить "—".
+ */
+export interface StatusSnapshot {
+  generatedAtIso: string;
+  activePersona: OpenClawPersona;
+  allowedPersonas: ReadonlyArray<OpenClawPersona>;
+  invocations: {
+    data: ReadonlyArray<InvocationRow> | null;
+    error: string | null;
+  };
+  workflows: {
+    data: ReadonlyArray<WorkflowRow> | null;
+    error: string | null;
+    notConfigured: boolean;
+  };
+  budget: {
+    data: BudgetState | null;
+    error: string | null;
+  };
+  lastError: {
+    data: SentryIssue | null;
+    error: string | null;
+    notConfigured: boolean;
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// HTML rendering primitives
+// ─────────────────────────────────────────────────────────────────────────
+
+const HTML_ESCAPE_MAP: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+};
+
+/** Escape HTML entities. Telegram HTML mode allows only &amp; &lt; &gt;. */
+export function htmlEscape(s: string): string {
+  return s.replace(/[&<>]/g, (ch) => HTML_ESCAPE_MAP[ch] ?? ch);
+}
+
+/**
+ * Human-readable relative time (UA): "5 хв тому", "2 год тому", "вчора".
+ * Empty / invalid ISO → "?".
+ */
+export function formatRelativeUa(
+  iso: string | null,
+  now: Date = new Date(),
+): string {
+  if (!iso) return "?";
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return "?";
+  const diffMs = now.getTime() - t;
+  if (diffMs < 0) return "щойно";
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 1) return "щойно";
+  if (minutes < 60) return `${minutes} хв тому`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} год тому`;
+  const days = Math.floor(hours / 24);
+  if (days === 1) return "вчора";
+  if (days < 30) return `${days} дн тому`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months} міс тому`;
+  return `${Math.floor(months / 12)} р тому`;
+}
+
+/** Truncate to `max` chars з ellipsis. Stable для коротших inputs. */
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return `${s.slice(0, Math.max(0, max - 1))}…`;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Main renderer
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Render the full snapshot as a compact HTML message. Target ≤ 30 рядків
+ * (task-вимога). Розбито на 5 sub-renderers, що рендерять окремі секції;
+ * вони не throw-ають і завжди повертають single-line або multi-line stub
+ * у разі error / not-configured.
+ */
+export function formatStatusSnapshot(
+  snapshot: StatusSnapshot,
+  now: Date = new Date(),
+): string {
+  const lines: string[] = [];
+  lines.push("<b>🦅 OpenClaw status</b>");
+  lines.push("");
+  lines.push(renderPersonaLine(snapshot));
+  lines.push(renderBudgetLine(snapshot.budget));
+  lines.push("");
+  lines.push("<b>n8n WF:</b>");
+  lines.push(renderWorkflowsBlock(snapshot.workflows));
+  lines.push("");
+  lines.push("<b>Last 10 invocations:</b>");
+  lines.push(renderInvocationsBlock(snapshot.invocations, now));
+  lines.push("");
+  lines.push("<b>Last error (Sentry):</b>");
+  lines.push(renderLastErrorBlock(snapshot.lastError));
+  lines.push("");
+  lines.push(
+    `<i>snapshot @ ${htmlEscape(formatRelativeUa(snapshot.generatedAtIso, now))}</i>`,
+  );
+  return lines.join("\n");
+}
+
+function renderPersonaLine(snapshot: StatusSnapshot): string {
+  const others = snapshot.allowedPersonas
+    .filter((p) => p !== snapshot.activePersona)
+    .join(", ");
+  return [
+    "<b>Persona:</b> <code>",
+    htmlEscape(snapshot.activePersona),
+    "</code> (default)",
+    others ? ` · також: <code>${htmlEscape(others)}</code>` : "",
+  ].join("");
+}
+
+function renderBudgetLine(budget: StatusSnapshot["budget"]): string {
+  if (budget.error) {
+    return `<b>Budget:</b> недоступно (${htmlEscape(budget.error)})`;
+  }
+  if (!budget.data) {
+    return "<b>Budget:</b> —";
+  }
+  const { spentUsd, budgetUsd, remainingUsd, allowed } = budget.data;
+  const status = allowed ? "OK" : "⚠️ exceeded";
+  return [
+    `<b>Budget:</b> $${spentUsd.toFixed(4)} / $${budgetUsd.toFixed(2)}`,
+    ` (залишок $${remainingUsd.toFixed(4)}, ${status})`,
+  ].join("");
+}
+
+function renderWorkflowsBlock(workflows: StatusSnapshot["workflows"]): string {
+  if (workflows.notConfigured) {
+    return "  <i>n8n credentials not configured</i>";
+  }
+  if (workflows.error) {
+    return `  недоступно (${htmlEscape(workflows.error)})`;
+  }
+  if (!workflows.data || workflows.data.length === 0) {
+    return "  —";
+  }
+  const active = workflows.data.filter((w) => w.active);
+  const inactive = workflows.data.filter((w) => !w.active);
+  const activeLabel = active.length === 0 ? "—" : `${active.length} active`;
+  const inactiveLabel =
+    inactive.length === 0 ? "" : ` · ${inactive.length} paused`;
+  // Compact: counts on header line + first few active workflow names.
+  const sampleNames = active
+    .slice(0, 3)
+    .map((w) => `<code>${htmlEscape(w.id)}</code>`)
+    .join(", ");
+  const moreSuffix = active.length > 3 ? `, +${active.length - 3} more` : "";
+  return [
+    `  ${activeLabel}${inactiveLabel}`,
+    sampleNames ? `\n  ${sampleNames}${moreSuffix}` : "",
+  ].join("");
+}
+
+function renderInvocationsBlock(
+  invocations: StatusSnapshot["invocations"],
+  now: Date,
+): string {
+  if (invocations.error) {
+    return `  недоступно (${htmlEscape(invocations.error)})`;
+  }
+  if (!invocations.data || invocations.data.length === 0) {
+    return "  —";
+  }
+  return invocations.data
+    .slice(0, 10)
+    .map((row) => renderInvocationLine(row, now))
+    .join("\n");
+}
+
+function renderInvocationLine(row: InvocationRow, now: Date): string {
+  const when = formatRelativeUa(row.invokedAt, now);
+  const statusGlyph = STATUS_GLYPH[row.status] ?? "·";
+  const message = truncate(row.userMessage.replace(/\s+/g, " "), 40);
+  return [
+    `  ${statusGlyph} <code>${htmlEscape(row.trigger)}</code>`,
+    ` · ${htmlEscape(when)} · ${htmlEscape(message)}`,
+  ].join("");
+}
+
+const STATUS_GLYPH: Record<string, string> = {
+  success: "✅",
+  error: "❌",
+  budget_exceeded: "💸",
+  iteration_cap: "🔁",
+  allowlist_fail: "🛑",
+  dm_only_violation: "🚷",
+};
+
+function renderLastErrorBlock(lastError: StatusSnapshot["lastError"]): string {
+  if (lastError.notConfigured) {
+    return "  <i>Sentry not configured</i>";
+  }
+  if (lastError.error) {
+    return `  недоступно (${htmlEscape(lastError.error)})`;
+  }
+  if (!lastError.data) {
+    return "  немає errors";
+  }
+  const { title, level, count } = lastError.data;
+  const compactTitle = truncate(title.replace(/\s+/g, " "), 60);
+  return `  <code>${htmlEscape(level)}</code> · ${htmlEscape(compactTitle)} (×${htmlEscape(count)})`;
+}

--- a/tools/openclaw/src/openclaw/status-runner.test.ts
+++ b/tools/openclaw/src/openclaw/status-runner.test.ts
@@ -1,0 +1,446 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  executeOpenclawStatusCommand,
+  type BudgetResponse,
+  type InvocationsListResponse,
+  type N8nListResponse,
+  type SentryIssuesResponse,
+  type StatusFetcher,
+} from "./status-runner.js";
+
+// ─────────────────────────────────────────────────────────────────────────
+// Helpers: build a fully-functional StatusFetcher mock
+// ─────────────────────────────────────────────────────────────────────────
+
+interface FakeFetcherOverrides {
+  invocations?: InvocationsListResponse;
+  invocationsStatus?: number;
+  invocationsOk?: boolean;
+  workflows?: N8nListResponse;
+  workflowsStatus?: number;
+  workflowsOk?: boolean;
+  budget?: BudgetResponse;
+  budgetStatus?: number;
+  budgetOk?: boolean;
+  sentry?: SentryIssuesResponse;
+  sentryStatus?: number;
+  sentryOk?: boolean;
+  openInvocationId?: number | null;
+  openInvocationOk?: boolean;
+  finalizeOk?: boolean;
+}
+
+function buildFetcher(overrides: FakeFetcherOverrides = {}): {
+  fetcher: StatusFetcher;
+  calls: {
+    listInvocations: ReturnType<typeof vi.fn>;
+    listN8nWorkflows: ReturnType<typeof vi.fn>;
+    getBudget: ReturnType<typeof vi.fn>;
+    getSentryIssues: ReturnType<typeof vi.fn>;
+    openInvocation: ReturnType<typeof vi.fn>;
+    finalizeInvocation: ReturnType<typeof vi.fn>;
+  };
+} {
+  const listInvocations = vi.fn(async () => ({
+    ok: overrides.invocationsOk ?? true,
+    status: overrides.invocationsStatus ?? 200,
+    data:
+      overrides.invocations ?? ({ invocations: [] } as InvocationsListResponse),
+  }));
+  const listN8nWorkflows = vi.fn(async () => ({
+    ok: overrides.workflowsOk ?? true,
+    status: overrides.workflowsStatus ?? 200,
+    data: overrides.workflows ?? ({ workflows: [] } as N8nListResponse),
+  }));
+  const getBudget = vi.fn(async () => ({
+    ok: overrides.budgetOk ?? true,
+    status: overrides.budgetStatus ?? 200,
+    data:
+      overrides.budget ??
+      ({
+        allowed: true,
+        spentUsd: 0.12,
+        budgetUsd: 5,
+        remainingUsd: 4.88,
+      } as BudgetResponse),
+  }));
+  const getSentryIssues = vi.fn(async () => ({
+    ok: overrides.sentryOk ?? true,
+    status: overrides.sentryStatus ?? 200,
+    data: overrides.sentry ?? ({ issues: [] } as SentryIssuesResponse),
+  }));
+  const openInvocation = vi.fn(async () => ({
+    ok: overrides.openInvocationOk ?? true,
+    status: 200,
+    invocationId:
+      overrides.openInvocationId !== undefined
+        ? overrides.openInvocationId
+        : 42,
+  }));
+  const finalizeInvocation = vi.fn(async () => ({
+    ok: overrides.finalizeOk ?? true,
+    status: 200,
+  }));
+  return {
+    fetcher: {
+      listInvocations,
+      listN8nWorkflows,
+      getBudget,
+      getSentryIssues,
+      openInvocation,
+      finalizeInvocation,
+    },
+    calls: {
+      listInvocations,
+      listN8nWorkflows,
+      getBudget,
+      getSentryIssues,
+      openInvocation,
+      finalizeInvocation,
+    },
+  };
+}
+
+const NOW = new Date("2026-05-13T12:00:00Z");
+
+function baseDeps(
+  overrides: Partial<Parameters<typeof executeOpenclawStatusCommand>[0]> = {},
+) {
+  const { fetcher } = buildFetcher();
+  return {
+    rawArgument: "",
+    founderUserId: "founder-1",
+    founderTgUserId: 12345,
+    telegramChatId: 67890,
+    fetcher,
+    now: () => NOW,
+    ...overrides,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// help + unknown subcommands
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("executeOpenclawStatusCommand — help/unknown", () => {
+  it("returns OPENCLAW_HELP_TEXT for /openclaw help without audit", async () => {
+    const { fetcher, calls } = buildFetcher();
+    const result = await executeOpenclawStatusCommand({
+      ...baseDeps(),
+      rawArgument: "help",
+      fetcher,
+    });
+    expect(result.subcommand).toBe("help");
+    expect(result.invocationId).toBeNull();
+    expect(result.ok).toBe(true);
+    expect(result.reply).toContain("/openclaw status");
+    expect(calls.openInvocation).not.toHaveBeenCalled();
+    expect(calls.finalizeInvocation).not.toHaveBeenCalled();
+    expect(calls.listInvocations).not.toHaveBeenCalled();
+  });
+
+  it("emits Sentry breadcrumb for /openclaw help", async () => {
+    const breadcrumbs: Array<Record<string, unknown>> = [];
+    await executeOpenclawStatusCommand({
+      ...baseDeps(),
+      rawArgument: "help",
+      addBreadcrumb: (b) => breadcrumbs.push(b),
+    });
+    expect(breadcrumbs).toHaveLength(1);
+    expect(breadcrumbs[0]).toMatchObject({
+      category: "openclaw.status",
+      message: "openclaw.help",
+      level: "info",
+    });
+  });
+
+  it("returns unknown-subcommand reply + help-text without audit", async () => {
+    const { fetcher, calls } = buildFetcher();
+    const result = await executeOpenclawStatusCommand({
+      ...baseDeps(),
+      rawArgument: "debug",
+      fetcher,
+    });
+    expect(result.subcommand).toBe("unknown");
+    expect(result.invocationId).toBeNull();
+    expect(result.ok).toBe(false);
+    expect(result.reply).toContain("Невідома підкоманда");
+    expect(result.reply).toContain("«debug»");
+    expect(result.reply).toContain("/openclaw status"); // help block appended
+    expect(calls.openInvocation).not.toHaveBeenCalled();
+  });
+
+  it("emits warning Sentry breadcrumb for unknown subcommand", async () => {
+    const breadcrumbs: Array<Record<string, unknown>> = [];
+    await executeOpenclawStatusCommand({
+      ...baseDeps(),
+      rawArgument: "xyz",
+      addBreadcrumb: (b) => breadcrumbs.push(b),
+    });
+    expect(breadcrumbs).toHaveLength(1);
+    expect(breadcrumbs[0]).toMatchObject({
+      category: "openclaw.status",
+      message: "openclaw.unknown_subcommand",
+      level: "warning",
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// status — happy path
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("executeOpenclawStatusCommand — status happy path", () => {
+  it("opens audit-row with trigger=dm + slashCommand metadata", async () => {
+    const { fetcher, calls } = buildFetcher();
+    await executeOpenclawStatusCommand({
+      ...baseDeps(),
+      rawArgument: "status",
+      fetcher,
+    });
+    expect(calls.openInvocation).toHaveBeenCalledTimes(1);
+    expect(calls.openInvocation).toHaveBeenCalledWith({
+      founderUserId: "founder-1",
+      founderTgUserId: 12345,
+      trigger: "dm",
+      userMessage: "/openclaw status",
+      metadata: {
+        telegramChatId: 67890,
+        slashCommand: "/openclaw",
+        subcommand: "status",
+      },
+    });
+  });
+
+  it("defaults to status when rawArgument is empty", async () => {
+    const result = await executeOpenclawStatusCommand({
+      ...baseDeps(),
+      rawArgument: "",
+    });
+    expect(result.subcommand).toBe("status");
+    expect(result.ok).toBe(true);
+  });
+
+  it("fans out all 4 data fetches in parallel", async () => {
+    const { fetcher, calls } = buildFetcher();
+    await executeOpenclawStatusCommand({
+      ...baseDeps(),
+      rawArgument: "status",
+      fetcher,
+    });
+    expect(calls.listInvocations).toHaveBeenCalledTimes(1);
+    expect(calls.listN8nWorkflows).toHaveBeenCalledTimes(1);
+    expect(calls.getBudget).toHaveBeenCalledTimes(1);
+    expect(calls.getSentryIssues).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders rendered snapshot with persona + budget + workflows + invocations + sentry", async () => {
+    const { fetcher } = buildFetcher({
+      invocations: {
+        invocations: [
+          {
+            id: 1,
+            invoked_at: new Date(NOW.getTime() - 5 * 60_000).toISOString(),
+            trigger: "morning_ritual",
+            user_message: "/ritual",
+            status: "success",
+            cost_usd: 0.0234,
+            duration_ms: 1500,
+            iterations: 3,
+            tone_mode: null,
+          },
+        ],
+      },
+      workflows: {
+        workflows: [
+          {
+            id: "WF-25",
+            name: "Morning briefing",
+            active: true,
+            tier: "A",
+            category: "ritual",
+            updatedAt: NOW.toISOString(),
+          },
+        ],
+      },
+      budget: {
+        allowed: true,
+        spentUsd: 0.55,
+        budgetUsd: 5,
+        remainingUsd: 4.45,
+      },
+      sentry: {
+        issues: [
+          {
+            title: "AnthropicTimeout",
+            level: "error",
+            count: "7",
+            permalink: "https://sentry.io/x",
+          },
+        ],
+      },
+    });
+    const result = await executeOpenclawStatusCommand({
+      ...baseDeps(),
+      rawArgument: "status",
+      fetcher,
+    });
+    expect(result.subcommand).toBe("status");
+    expect(result.ok).toBe(true);
+    expect(result.reply).toContain("<b>🦅 OpenClaw status</b>");
+    expect(result.reply).toContain("<code>cofounder</code>");
+    expect(result.reply).toContain("$0.5500 / $5.00");
+    expect(result.reply).toContain("<code>WF-25</code>");
+    expect(result.reply).toContain("morning_ritual");
+    expect(result.reply).toContain("AnthropicTimeout");
+  });
+
+  it("finalizes audit-row with success after rendering", async () => {
+    const { fetcher, calls } = buildFetcher();
+    const result = await executeOpenclawStatusCommand({
+      ...baseDeps(),
+      rawArgument: "status",
+      fetcher,
+    });
+    expect(calls.finalizeInvocation).toHaveBeenCalledTimes(1);
+    expect(calls.finalizeInvocation).toHaveBeenCalledWith({
+      invocationId: 42,
+      status: "success",
+      assistantResponse: result.reply,
+      errorMessage: null,
+    });
+  });
+
+  it("skips finalize when openInvocation returned null invocationId", async () => {
+    const { fetcher, calls } = buildFetcher({ openInvocationId: null });
+    await executeOpenclawStatusCommand({
+      ...baseDeps(),
+      rawArgument: "status",
+      fetcher,
+    });
+    expect(calls.finalizeInvocation).not.toHaveBeenCalled();
+  });
+
+  it("emits openclaw.status.start + openclaw.status.success breadcrumbs", async () => {
+    const breadcrumbs: Array<Record<string, unknown>> = [];
+    await executeOpenclawStatusCommand({
+      ...baseDeps(),
+      rawArgument: "status",
+      addBreadcrumb: (b) => breadcrumbs.push(b),
+    });
+    expect(breadcrumbs.map((b) => b["message"])).toEqual([
+      "openclaw.status.start",
+      "openclaw.status.success",
+    ]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// status — fail-soft per data source
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("executeOpenclawStatusCommand — fail-soft per source", () => {
+  it("renders snapshot when invocations fetch returned HTTP 500", async () => {
+    const { fetcher } = buildFetcher({
+      invocationsOk: false,
+      invocationsStatus: 500,
+    });
+    const result = await executeOpenclawStatusCommand({
+      ...baseDeps(),
+      rawArgument: "status",
+      fetcher,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.reply).toContain("недоступно");
+    expect(result.reply).toContain("HTTP 500");
+  });
+
+  it("renders not-configured hint when n8n returned notConfigured", async () => {
+    const { fetcher } = buildFetcher({
+      workflows: { workflows: [], notConfigured: true },
+    });
+    const result = await executeOpenclawStatusCommand({
+      ...baseDeps(),
+      rawArgument: "status",
+      fetcher,
+    });
+    expect(result.reply).toContain("n8n credentials not configured");
+  });
+
+  it("renders Sentry not-configured hint", async () => {
+    const { fetcher } = buildFetcher({
+      sentry: { notConfigured: true, note: "no token" },
+    });
+    const result = await executeOpenclawStatusCommand({
+      ...baseDeps(),
+      rawArgument: "status",
+      fetcher,
+    });
+    expect(result.reply).toContain("Sentry not configured");
+  });
+
+  it("renders budget недоступно when budget fetch fails", async () => {
+    const { fetcher } = buildFetcher({
+      budgetOk: false,
+      budgetStatus: 502,
+    });
+    const result = await executeOpenclawStatusCommand({
+      ...baseDeps(),
+      rawArgument: "status",
+      fetcher,
+    });
+    expect(result.reply).toContain("Budget");
+    expect(result.reply).toContain("HTTP 502");
+  });
+
+  it("still finalizes audit-row even when individual sources fail", async () => {
+    const { fetcher, calls } = buildFetcher({
+      invocationsOk: false,
+      invocationsStatus: 500,
+      workflowsOk: false,
+      workflowsStatus: 503,
+      budgetOk: false,
+      sentryOk: false,
+    });
+    const result = await executeOpenclawStatusCommand({
+      ...baseDeps(),
+      rawArgument: "status",
+      fetcher,
+    });
+    expect(result.ok).toBe(true);
+    expect(calls.finalizeInvocation).toHaveBeenCalledTimes(1);
+    expect(calls.finalizeInvocation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "success",
+        errorMessage: null,
+      }),
+    );
+  });
+
+  it("does not crash when addBreadcrumb is undefined", async () => {
+    const result = await executeOpenclawStatusCommand({
+      ...baseDeps(),
+      rawArgument: "status",
+    });
+    expect(result.ok).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// snapshot shape — persona inclusion
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("executeOpenclawStatusCommand — persona snapshot", () => {
+  it("includes all 5 personas including cofounder in rendered text", async () => {
+    const result = await executeOpenclawStatusCommand({
+      ...baseDeps(),
+      rawArgument: "status",
+    });
+    expect(result.reply).toContain("cofounder");
+    expect(result.reply).toContain("ops");
+    expect(result.reply).toContain("growth");
+    expect(result.reply).toContain("eng");
+    expect(result.reply).toContain("finance");
+  });
+});

--- a/tools/openclaw/src/openclaw/status-runner.ts
+++ b/tools/openclaw/src/openclaw/status-runner.ts
@@ -1,0 +1,389 @@
+/**
+ * Orchestrator для `/openclaw status` slash-command-у.
+ *
+ * Full lifecycle handler-у (parse-input → optional audit-open → fan-out
+ * 4 fetch-ів паралельно → render snapshot → optional audit-finalize →
+ * reply) як pure async function, що приймає всі залежності через
+ * `StatusRunnerDeps`. Це дозволяє unit-тестувати lifecycle без grammy
+ * `Bot` / `Context` instance-у.
+ *
+ * Окремо від `handler-info-commands.ts` тримаємо щоб:
+ *   1. `handler-info-commands.ts` лишався тонким shim-ом над grammy;
+ *   2. усі 4 fetch-and-merge гілки + audit life-cycle покривались
+ *      Vitest-ом, не лише `parseOpenclawCommand`.
+ *
+ * Audit-rows пишемо у `openclaw_invocations` через ту саму pair
+ * endpoint-ів, що й `/alerts` / `/ritual`. Trigger завжди `dm`
+ * (info-команда), розрізнення по `metadata.slashCommand = "/openclaw"`.
+ *
+ * Sentry breadcrumb на кожен trigger (`openclaw.status.*`). Якщо
+ * `SENTRY_DSN` не виставлений — `Sentry.addBreadcrumb` no-op (див.
+ * `obs/sentry.ts`).
+ */
+
+import { ALL_PERSONAS, DEFAULT_PERSONA } from "../agents/personas.js";
+import {
+  formatStatusSnapshot,
+  OPENCLAW_HELP_TEXT,
+  parseOpenclawCommand,
+  type InvocationRow,
+  type OpenclawSubcommand,
+  type ParsedOpenclawCommand,
+  type SentryIssue,
+  type StatusSnapshot,
+  type WorkflowRow,
+} from "./status-format.js";
+
+// ─────────────────────────────────────────────────────────────────────────
+// Fetcher abstraction
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Сирий response shape від `/api/internal/openclaw/invocations/list`.
+ * Mirrored від `listRecentInvocations()` у
+ * `apps/server/src/modules/openclaw/store.ts`.
+ */
+export interface InvocationsListResponse {
+  invocations: Array<{
+    id: number;
+    invoked_at: string;
+    trigger: string;
+    user_message: string;
+    status: string;
+    cost_usd: number;
+    duration_ms: number;
+    iterations: number;
+    tone_mode: string | null;
+  }>;
+}
+
+/**
+ * Сирий response від `/api/internal/openclaw/n8n/list`. Mirrored від
+ * `listN8nWorkflows()` у `apps/server/src/modules/openclaw/n8n.ts`.
+ */
+export interface N8nListResponse {
+  workflows: Array<{
+    id: string;
+    name: string;
+    active: boolean;
+    tier: string;
+    category: string | null;
+    updatedAt: string | null;
+  }>;
+  notConfigured?: boolean;
+}
+
+/**
+ * Сирий response від `/api/internal/openclaw/budget`. Mirrored від
+ * `checkDailyBudget()` у `apps/server/src/modules/openclaw/budget.ts`.
+ */
+export interface BudgetResponse {
+  allowed: boolean;
+  spentUsd: number;
+  budgetUsd: number;
+  remainingUsd: number;
+  reason?: string;
+}
+
+/**
+ * Сирий response від `/api/internal/openclaw/metrics/sentry`. Mirrored
+ * від `getSentryIssues()` у `apps/server/src/modules/openclaw/tools.ts`.
+ */
+export interface SentryIssuesResponse {
+  notConfigured?: boolean;
+  issues?: Array<{
+    title: string;
+    level: string;
+    count: string;
+    permalink: string;
+  }>;
+  note?: string;
+}
+
+/**
+ * Fetcher abstraction. У production injection-кою стає тонкий wrapper
+ * над `postJson` з handler-constants.ts; у тестах — vi.fn(). Всі 4
+ * data-fetch-методи можуть падати/повертати notConfigured — orchestrator
+ * фільтрує і завжди render-ить.
+ */
+export interface StatusFetcher {
+  listInvocations(): Promise<{
+    ok: boolean;
+    status: number;
+    data: InvocationsListResponse | null;
+  }>;
+  listN8nWorkflows(): Promise<{
+    ok: boolean;
+    status: number;
+    data: N8nListResponse | null;
+  }>;
+  getBudget(): Promise<{
+    ok: boolean;
+    status: number;
+    data: BudgetResponse | null;
+  }>;
+  getSentryIssues(): Promise<{
+    ok: boolean;
+    status: number;
+    data: SentryIssuesResponse | null;
+  }>;
+  openInvocation(input: {
+    founderUserId: string;
+    founderTgUserId: number;
+    trigger: "dm";
+    userMessage: string;
+    metadata: Record<string, unknown>;
+  }): Promise<{ ok: boolean; status: number; invocationId: number | null }>;
+  finalizeInvocation(input: {
+    invocationId: number;
+    status: "success" | "error";
+    assistantResponse: string | null;
+    errorMessage: string | null;
+  }): Promise<{ ok: boolean; status: number }>;
+}
+
+/**
+ * Sentry breadcrumb sink — приймає вже зрендерений breadcrumb-record.
+ * У production — `Sentry.addBreadcrumb({...})`, у тестах — vi.fn().
+ */
+export type StatusBreadcrumbFn = (breadcrumb: {
+  category: string;
+  message: string;
+  level: "info" | "warning" | "error";
+  data?: Record<string, unknown>;
+}) => void;
+
+export interface StatusRunnerDeps {
+  /** Argument-частина after `/openclaw` (тобто `c.match`). */
+  rawArgument: string;
+  /** Better Auth opaque user-id founder-а (з env / OpenClaw config). */
+  founderUserId: string;
+  /** Telegram user-id founder-а (з allowlist-у, для audit-row-и). */
+  founderTgUserId: number;
+  /** Telegram chat-id (для metadata-аудиту). Optional. */
+  telegramChatId?: number;
+  /** Injection-pointable fetcher. */
+  fetcher: StatusFetcher;
+  /** Injection-pointable Sentry breadcrumb sink. */
+  addBreadcrumb?: StatusBreadcrumbFn;
+  /** Override clock — для детерміністичних тестів. */
+  now?: () => Date;
+}
+
+export interface StatusRunResult {
+  /** Final reply payload (HTML), готовий до `c.reply(reply, { parse_mode: "HTML" })`. */
+  reply: string;
+  /** Підкоманда, яку реально виконали. */
+  subcommand: OpenclawSubcommand;
+  /** ID audit-row-и у `openclaw_invocations`. `null` для help/unknown. */
+  invocationId: number | null;
+  /** Чи зайшли у happy-path (status — завжди true, навіть якщо джерела впали). */
+  ok: boolean;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Main entry point
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Виконує `/openclaw <subcommand>`. Не throw-ає — будь-який збій
+ * мапиться у audit-error (для status) + помічається у Sentry-breadcrumb.
+ */
+export async function executeOpenclawStatusCommand(
+  deps: StatusRunnerDeps,
+): Promise<StatusRunResult> {
+  const parsed = parseOpenclawCommand(deps.rawArgument);
+  const emitBreadcrumb = deps.addBreadcrumb ?? (() => undefined);
+  const now = deps.now ?? (() => new Date());
+
+  if (parsed.subcommand === "help") {
+    emitBreadcrumb({
+      category: "openclaw.status",
+      message: "openclaw.help",
+      level: "info",
+      data: { rawArgument: parsed.rawArgument },
+    });
+    return {
+      reply: OPENCLAW_HELP_TEXT,
+      subcommand: "help",
+      invocationId: null,
+      ok: true,
+    };
+  }
+
+  if (parsed.subcommand === "unknown") {
+    emitBreadcrumb({
+      category: "openclaw.status",
+      message: "openclaw.unknown_subcommand",
+      level: "warning",
+      data: { rawArgument: parsed.rawArgument },
+    });
+    return {
+      reply: `${parsed.error ?? "Невідома підкоманда."}\n\n${OPENCLAW_HELP_TEXT}`,
+      subcommand: "unknown",
+      invocationId: null,
+      ok: false,
+    };
+  }
+
+  // === status — main path ============================================
+  const userMessage = `/openclaw ${parsed.rawArgument || "status"}`.trim();
+
+  emitBreadcrumb({
+    category: "openclaw.status",
+    message: "openclaw.status.start",
+    level: "info",
+    data: {
+      founderTgUserId: deps.founderTgUserId,
+      telegramChatId: deps.telegramChatId ?? null,
+    },
+  });
+
+  const openRes = await deps.fetcher.openInvocation({
+    founderUserId: deps.founderUserId,
+    founderTgUserId: deps.founderTgUserId,
+    trigger: "dm",
+    userMessage,
+    metadata: {
+      telegramChatId: deps.telegramChatId ?? null,
+      slashCommand: "/openclaw",
+      subcommand: "status",
+    },
+  });
+  const invocationId = openRes.invocationId;
+
+  const [invsRes, wfRes, budgetRes, sentryRes] = await Promise.all([
+    deps.fetcher.listInvocations(),
+    deps.fetcher.listN8nWorkflows(),
+    deps.fetcher.getBudget(),
+    deps.fetcher.getSentryIssues(),
+  ]);
+
+  const snapshot: StatusSnapshot = {
+    generatedAtIso: now().toISOString(),
+    activePersona: DEFAULT_PERSONA,
+    allowedPersonas: ALL_PERSONAS,
+    invocations: mapInvocations(invsRes),
+    workflows: mapWorkflows(wfRes),
+    budget: mapBudget(budgetRes),
+    lastError: mapLastError(sentryRes),
+  };
+
+  const reply = formatStatusSnapshot(snapshot, now());
+
+  if (invocationId != null) {
+    await deps.fetcher.finalizeInvocation({
+      invocationId,
+      status: "success",
+      assistantResponse: reply,
+      errorMessage: null,
+    });
+  }
+
+  emitBreadcrumb({
+    category: "openclaw.status",
+    message: "openclaw.status.success",
+    level: "info",
+    data: {
+      replyChars: reply.length,
+      invocationsCount: snapshot.invocations.data?.length ?? 0,
+      workflowsCount: snapshot.workflows.data?.length ?? 0,
+      budgetOk: snapshot.budget.data?.allowed ?? null,
+      lastErrorPresent: snapshot.lastError.data !== null,
+    },
+  });
+
+  return {
+    reply,
+    subcommand: "status",
+    invocationId,
+    ok: true,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Section mappers — convert HTTP-response shapes to snapshot sections
+// ─────────────────────────────────────────────────────────────────────────
+
+function mapInvocations(res: {
+  ok: boolean;
+  status: number;
+  data: InvocationsListResponse | null;
+}): StatusSnapshot["invocations"] {
+  if (!res.ok || !res.data) {
+    return { data: null, error: `HTTP ${res.status}` };
+  }
+  const rows: InvocationRow[] = res.data.invocations.map((r) => ({
+    id: r.id,
+    invokedAt: r.invoked_at,
+    trigger: r.trigger,
+    status: r.status,
+    userMessage: r.user_message,
+    durationMs: r.duration_ms,
+    costUsd: r.cost_usd,
+    toneMode: r.tone_mode,
+  }));
+  return { data: rows, error: null };
+}
+
+function mapWorkflows(res: {
+  ok: boolean;
+  status: number;
+  data: N8nListResponse | null;
+}): StatusSnapshot["workflows"] {
+  if (!res.ok || !res.data) {
+    return { data: null, error: `HTTP ${res.status}`, notConfigured: false };
+  }
+  if (res.data.notConfigured) {
+    return { data: null, error: null, notConfigured: true };
+  }
+  const rows: WorkflowRow[] = res.data.workflows.map((w) => ({
+    id: w.id,
+    name: w.name,
+    active: w.active,
+    tier: w.tier,
+  }));
+  return { data: rows, error: null, notConfigured: false };
+}
+
+function mapBudget(res: {
+  ok: boolean;
+  status: number;
+  data: BudgetResponse | null;
+}): StatusSnapshot["budget"] {
+  if (!res.ok || !res.data) {
+    return { data: null, error: `HTTP ${res.status}` };
+  }
+  const { spentUsd, budgetUsd, remainingUsd, allowed } = res.data;
+  return { data: { spentUsd, budgetUsd, remainingUsd, allowed }, error: null };
+}
+
+function mapLastError(res: {
+  ok: boolean;
+  status: number;
+  data: SentryIssuesResponse | null;
+}): StatusSnapshot["lastError"] {
+  if (!res.ok || !res.data) {
+    return { data: null, error: `HTTP ${res.status}`, notConfigured: false };
+  }
+  if (res.data.notConfigured) {
+    return { data: null, error: null, notConfigured: true };
+  }
+  const issues = res.data.issues ?? [];
+  if (issues.length === 0) {
+    return { data: null, error: null, notConfigured: false };
+  }
+  const first = issues[0];
+  if (!first) {
+    return { data: null, error: null, notConfigured: false };
+  }
+  const issue: SentryIssue = {
+    title: first.title,
+    level: first.level,
+    count: first.count,
+    permalink: first.permalink,
+  };
+  return { data: issue, error: null, notConfigured: false };
+}
+
+export type { ParsedOpenclawCommand };


### PR DESCRIPTION
## Summary

Manual-trigger debug snapshot command `/openclaw status` для founder DM, sibling-команда до `/ritual` (#2704). Compact HTML payload (≤30 рядків) з 5 секцій:

- **Persona** — `DEFAULT_PERSONA` (`cofounder`) + `ALL_PERSONAS` allowlist (ADR-0033 Phase 2.5).
- **Budget** — `spentUsd / budgetUsd / remainingUsd` через `POST /api/internal/openclaw/budget` (re-use endpoint-а `/budget`).
- **n8n WF** — counts active/paused + перші 3 active WF-ID через `POST /api/internal/openclaw/n8n/list`. `notConfigured` → «n8n credentials not configured».
- **Last 10 invocations** — status-glyph + trigger + relative time + truncated user-message через `POST /api/internal/openclaw/invocations/list`.
- **Last error (Sentry)** — top-1 issue з level=error через `POST /api/internal/openclaw/metrics/sentry`. `SENTRY_AUTH_TOKEN` unset → «Sentry not configured».

Subcommands: `/openclaw` (default → status), `/openclaw status`, `/openclaw help`, `/openclaw <unknown>` (error + help).

Implementation pattern наслідує `/ritual` (#2704): pure parser/renderer у `status-format.ts` + injectable orchestrator у `status-runner.ts` + thin grammy shim у `handler-info-commands.ts`. 4 fetch-и паралельно (`Promise.all`); кожна секція fail-soft рендериться окремо — якщо одне джерело впало, інші рендеряться нормально.

## Governing Skill

- Primary skill: `.agents/skills/sergeant-server-api/SKILL.md` (Telegram bot handler, internal endpoints)
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a — feature implementation, no specific playbook matched
- Why this playbook: n/a
- If no playbook matched, why: `/openclaw status` — добавлення sibling-команди до існуючого info-handler-set-у; pattern уже встановлений `/ritual` (#2704) і `/alerts` (PR-O5)

## Verification

```bash
pnpm --filter @sergeant/openclaw test -- --run    # 469 passed (51 нових)
pnpm --filter @sergeant/openclaw lint             # clean
pnpm --filter @sergeant/openclaw typecheck        # clean
pnpm format:check                                 # touched files clean
```

Additional checks:

- [x] Local smoke / manual validation completed — unit tests cover happy + fail-soft + audit lifecycle + breadcrumb emission
- [x] Surface-specific checks completed — `handler-info-commands.ts` остається <600 lines (Hard Rule #18)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- `docs/runbooks/openclaw-morning-briefing.md` — нова секція «## Manual trigger — /openclaw status» (UA): описує 5 секцій snapshot-у, audit-row shape (`trigger="dm"` + `metadata.slashCommand="/openclaw"`), Sentry breadcrumb categories (`openclaw.status.*`), fail-soft behaviour.

## Risk and Rollout

- **User-visible risk**: Низький — нова info-команда, founder-only, не модифікує state. 4 fetch-и в parallel — кожен fail-soft (HTTP 5xx → «недоступно», `notConfigured` → hint), не падає 5xx.
- **Rollout / deploy order**: Стандартний — після merge OpenClaw bot починає reєструвати `/openclaw` у Telegram BotFather command-popup-і automatically (через `registerOpenClawBotCommands` на bootstrap-і).
- **Backout plan**: Revert PR — `bot.command("openclaw", …)` зникає, popup auto-cleanup на наступний bot-restart. Існуючі invocation-rows з `metadata.slashCommand="/openclaw"` лишаться у DB як history (no schema change).

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

- **Audit-row trigger**: `/openclaw status` пише з `trigger="dm"` (info-команда), розрізнення від звичайних DM-conversation-ів через `metadata.slashCommand="/openclaw"` + `metadata.subcommand="status"`. Запити `/openclaw help` / `/openclaw <unknown>` НЕ створюють audit-row-и (як `/help` / `/ritual help`).
- **Persona snapshot — read-only**: показує `DEFAULT_PERSONA` як «активну» — per-session active persona не зберігається у state-table (personas — stateless через `/cofounder` / `/ops` / etc. switching). Out of scope для цього PR.
- **HTML escaping**: `htmlEscape` застосовується до user-controlled fields (`userMessage`, `trigger`, sentry `title` / `level`); workflow ID-и тримаються у `<code>` для рендерингу як inline-code. Test для XSS prevention включений.
- **Test pattern**: `buildFetcher({...})` helper повертає `{fetcher, calls}` — тести через `calls.<method>` перевіряють arg shapes + call counts без mock-internals leak-у.
- **Module budget**: `handler-info-commands.ts` — 549 lines (під 600-line cap по Hard Rule #18). Якщо у наступному PR-і додається ще одна info-команда — extract у `handler-openclaw-status-commands.ts` подібно до `handler-strategy-commands.ts`.

Link to Devin session: https://app.devin.ai/sessions/d7f583562a63456f9e3e418e531c9d81

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a founder-only `/openclaw status` command that sends a compact HTML debug snapshot in Telegram DM. It shows persona, AI budget, n8n workflows, recent invocations, and the last Sentry error with parallel fetches and fail‑soft behavior.

- **New Features**
  - Commands: `/openclaw` (defaults to `status`), `/openclaw status`, `/openclaw help`, unknown → error + help.
  - Snapshot: default persona + allowlist; budget via `POST /api/internal/openclaw/budget`; n8n active/paused counts + first 3 IDs via `POST /api/internal/openclaw/n8n/list`; last 10 invocations via `POST /api/internal/openclaw/invocations/list`; top error via `POST /api/internal/openclaw/metrics/sentry` (or “not configured”).
  - Implementation: pure parser/renderer in `status-format.ts`, injectable orchestrator in `status-runner.ts`, thin wiring in `handler-info-commands.ts`; command added to `OPENCLAW_BOT_COMMANDS`; help updated.
  - Audit & telemetry: opens an audit row with `trigger="dm"` and `metadata.slashCommand="/openclaw"`; help/unknown not audited; Sentry breadcrumbs under `openclaw.status`.
  - Safety: founder allowlist + rate limit, read-only, HTML-escaped fields, compact HTML (≤30 lines), each section renders even if others fail.
  - Docs/tests: runbook updated; unit tests for parser, rendering, fail-soft, audit lifecycle, and breadcrumbs.

<sup>Written for commit 28a8d18ac05deb0acb806dc2d4643d0878ffafeb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

