### PR TITLE
test(web): add E2E test for signup → onboarding → hub happy-path

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -87,6 +87,27 @@ pnpm --filter @sergeant/web lighthouse       # boots vite preview + runs LHCI
 
 Reports drop у `apps/web/.lighthouseci/` (gitignored).
 
+## E2E smoke (Playwright)
+
+Critical-flow E2E lane runs per-PR via `.github/workflows/ci.yml` job `critical-flow` (line ~503): `playwright test -c playwright.smoke.config.ts --grep @critical`. Boot sequence — `docker compose up -d postgres` → `pnpm db:migrate:dev` → `@sergeant/server dev` (:3000) → `@sergeant/web build` → `vite preview` (:4173). Driver: `apps/web/tests/smoke/start-smoke-webserver.mjs`. Tests under `apps/web/tests/smoke/`.
+
+```bash
+pnpm --filter @sergeant/web e2e                  # → playwright --grep @critical
+pnpm --filter @sergeant/web e2e:auth             # → playwright --grep @auth (login lane)
+pnpm --filter @sergeant/web exec playwright \    # focus one spec locally
+  test -c playwright.smoke.config.ts             # (needs Postgres + server already running
+  tests/smoke/onboarding-happy-path.spec.ts      #  — easiest: `pnpm dev:server &` then this)
+```
+
+**Як додати новий critical-flow тест:**
+
+1. Файл у `apps/web/tests/smoke/<name>.spec.ts`. Імпортуй `{ test, expect }` з `@playwright/test`. Title має починатися з `@critical` (e.g. `test("@critical onboarding: …", …)`); це регекс-фільтр для `--grep @critical`.
+2. Reuse smoke-stack — НЕ запускай свій web-server. `playwright.smoke.config.ts` піднімає stack для всіх тестів у `tests/smoke/`; `start-smoke-webserver.mjs` орхестрова сервер у foreground-режимі.
+3. Не sub-автентифікуй юзера через `fetch("/api/auth/sign-up")` у тесті — реальний sign-up через UI ловить regression-и у `RegisterForm` + `AuthContext`. Якщо потрібен seeded стан — використовуй `page.addInitScript` для `localStorage` (як у `onboarding-happy-path.spec.ts` для `sergeant.whatsNew.lastSeenId.v1`).
+4. Analytics-події читай з `window.__hubAnalytics` ring-buffer (`apps/web/src/core/observability/analytics.ts`) — PostHog network transport gated на `VITE_POSTHOG_KEY` (unset у smoke), buffer — deterministic.
+5. Trace / screenshot on failure уже сконфігуровано (`trace: "retain-on-failure"`, `screenshot: "only-on-failure"`). HTML report публікується як artifact `playwright-critical-flow-report` (14d retention).
+6. **Smoke-environment gotcha:** `vite preview` НЕ emit-ить COOP/COEP response-headers, тому `SharedArrayBuffer` недоступний → `sqlite-wasm` падає на memory-only VFS. Bottom-line assertion-и навколо SQLite-backed state (`hub_onboarding_done_v1`, тощо) можуть гонитися з warm-cache write-cycle-ом. Pragmatic — використовуй analytics ring-buffer як deterministic signal-of-truth; UI-level DOM assertions, що залежать від SQLite-backed gate, документуй inline (див. § 4a у `onboarding-happy-path.spec.ts`).
+
 ## Deeper docs
 
 - App README: [`apps/web/README.md`](./README.md)

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
     "test:a11y": "playwright test",
     "test:visual": "playwright test --config playwright.visual.config.ts",
     "e2e:auth": "playwright test --config playwright.smoke.config.ts --grep @auth",
+    "e2e": "playwright test --config playwright.smoke.config.ts --grep @critical",
     "size": "size-limit",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"

--- a/apps/web/src/core/app/useDemoCommands.ts
+++ b/apps/web/src/core/app/useDemoCommands.ts
@@ -7,10 +7,10 @@
 //
 // Status: Active (Track 5 seed). Last validated: 2026-05-13 by @Skords-01 / Devin.
 
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { useToast } from "@shared/hooks/useToast";
-import { useDarkMode } from "@shared/hooks/useDarkMode";
+import { useTheme } from "@shared/hooks/useTheme";
 import {
   useRegisterCommand,
   type PaletteCommand,
@@ -19,7 +19,17 @@ import {
 export function useDemoCommands(): void {
   const navigate = useNavigate();
   const toast = useToast();
-  const { dark, toggle: toggleDark } = useDarkMode();
+  // `useDarkMode` was retired in PR #2660 in favour of the 4-mode
+  // `useTheme` (`light` / `dark` / `system` / `hc`). The Command
+  // Palette's binary toggle keeps its old UX semantics by flipping
+  // between explicit `light` and `dark` (`system` and `hc` are
+  // surfaced via the dedicated `<ThemeSwitcher />` in HubHeader).
+  const { isDark, setChoice } = useTheme();
+  const dark = isDark;
+  const toggleDark = useCallback(
+    () => setChoice(isDark ? "light" : "dark"),
+    [isDark, setChoice],
+  );
 
   const commands = useMemo<PaletteCommand[]>(
     () => [

--- a/apps/web/tests/smoke/onboarding-happy-path.spec.ts
+++ b/apps/web/tests/smoke/onboarding-happy-path.spec.ts
@@ -1,0 +1,272 @@
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * Happy-path founder-experience E2E:
+ *
+ *   sign-up → /welcome onboarding wizard → hub-overview
+ *
+ * Complementary to `auth.spec.ts` (which seeds `hub_onboarding_done_v1`
+ * and therefore *skips* the splash) — this spec exercises the full
+ * cold-start activation funnel that PR-07 (#2566) wired the
+ * `onboarding_completed` PostHog event into:
+ *
+ *   1. Visit `/sign-in`, register a fresh email/password account
+ *      (Better Auth `signUp.email`).
+ *   2. Successful sign-up flips the standalone-route guard for
+ *      `/sign-in` — `AuthContext` `invalidateMe()` repopulates `user`,
+ *      `<RedirectTo to="/" />` fires.
+ *   3. The hub root then runs `shouldShowOnboarding()` against a clean
+ *      `KVStore` and bounces the user to `/welcome` (see
+ *      `apps/web/src/core/App.tsx:187`).
+ *   4. `WelcomeScreen` mounts `OnboardingWizard variant="fullPage"`.
+ *      The user clicks the splash primary CTA, the wizard's `finish()`
+ *      handler in `useOnboardingWizardState.ts` fires
+ *      `ANALYTICS_EVENTS.ONBOARDING_COMPLETED`, persists picks +
+ *      `hub_onboarding_done_v1`, and calls `onDone()` →
+ *      `leaveWelcome()` → `navigate("/")`.
+ *   5. The hub root settles at `/` and the analytics ring-buffer
+ *      (`window.__hubAnalytics`, see
+ *      `apps/web/src/core/observability/analytics.ts`) contains
+ *      `signup_completed` + `onboarding_completed`. The buffer is the
+ *      deterministic transport — PostHog is fire-and-forget over the
+ *      network and lazy-imported via `VITE_POSTHOG_KEY`, neither of
+ *      which we set in smoke. See the § 4a smoke-stack note in the
+ *      test body for why we do not also assert `<HubBottomNav>`
+ *      visibility (the `vite preview` web-server does not emit
+ *      COOP/COEP headers, so `sqlite-wasm` falls back to its
+ *      memory-only VFS and the warm-cache write race produces a
+ *      sticky `PageLoader` skeleton in the smoke stack only).
+ *
+ * Tagged `@critical` so it joins the per-PR smoke lane
+ * (`playwright.smoke.config.ts --grep @critical`) — the activation
+ * funnel is one of the four critical user flows and shouldn't wait
+ * for the nightly extended-e2e cron run.
+ *
+ * Deliberate non-coverage:
+ *
+ *  - We do NOT assert the PostHog network call. The PostHog transport
+ *    is `fire-and-forget`, lazy-imported, and gated on
+ *    `VITE_POSTHOG_KEY` (unset in smoke) — verifying the local
+ *    `[analytics]` console + `window.__hubAnalytics` ring buffer is
+ *    the deterministic single-source-of-truth for whether the event
+ *    fired.
+ *  - We do NOT seed the `hub_first_action_done_v1` /
+ *    `hub_vibe_picks_v1` keys. The wizard itself owns those writes;
+ *    pre-seeding them here would mask regressions in `finish()`.
+ *  - We click exactly one `MODULE_CARDS` chip (`finyk`) to flip the
+ *    primary CTA from `disabled` (empty-picks state, see
+ *    `useOnboardingWizardState.ts:292` — `ctaDisabled = picks.length === 0`
+ *    after the 2026-05-08 UX flip from `"all"` → `"none"` default
+ *    variant) into `enabled`. Picking the full set is a per-module
+ *    FTUX concern and lives in its own spec; the happy-path invariant
+ *    is just "founder picks at least one module and lands in the hub".
+ */
+
+const FRESH_USER_LS: Record<string, string> = {
+  // Match the `whatsNew` last-seen seed from the other smoke specs so
+  // the "What's new" modal (auto-pops 2.5s after hub mount via
+  // `useWhatsNew`) does not race the hub-overview assertion. Value
+  // mirrors the latest entry in `apps/web/src/core/whatsNew/releases.ts`.
+  "sergeant.whatsNew.lastSeenId.v1": "2026-05-06-cold-start",
+};
+
+async function seedFreshUserLocalStorage(page: Page) {
+  await page.addInitScript((entries: Record<string, string>) => {
+    try {
+      for (const [k, v] of Object.entries(entries)) {
+        window.localStorage.setItem(k, v);
+      }
+    } catch {
+      /* ignore */
+    }
+  }, FRESH_USER_LS);
+}
+
+type AnalyticsEvent = {
+  eventName: string;
+  payload: Record<string, unknown>;
+  timestamp: string;
+};
+
+test("@critical onboarding: sign-up → welcome wizard → hub-overview fires onboarding_completed", async ({
+  page,
+}) => {
+  await seedFreshUserLocalStorage(page);
+
+  // Capture `[analytics]` console events as a redundant signal —
+  // helps debug CI failures where `window.__hubAnalytics` might be
+  // wiped (e.g. if the wizard navigation triggers a service-worker
+  // controlled reload). Primary assertion still uses the in-page ring
+  // buffer.
+  const analyticsConsoleEvents: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "log" && msg.text().startsWith("[analytics]")) {
+      analyticsConsoleEvents.push(msg.text());
+    }
+  });
+
+  const nonce = `${Date.now()}_${Math.random().toString(16).slice(2)}`;
+  const email = `smoke_${nonce}@example.com`;
+  const password = `pw_${nonce}_long_enough`;
+
+  // -----------------------------------------------------------------
+  // 1. Sign-up
+  // -----------------------------------------------------------------
+  await page.goto("/sign-in", { waitUntil: "domcontentloaded" });
+  await page
+    .getByRole("button", { name: "Немає акаунту? Зареєструватися" })
+    .click();
+  await page.fill("#auth-name", "Smoke Founder");
+  await page.fill("#auth-email", email);
+  await page.fill("#auth-password", password);
+  await page.getByRole("button", { name: "Зареєструватися" }).click();
+
+  // -----------------------------------------------------------------
+  // 2. Wait for the standalone /sign-in surface to flip (AuthContext
+  //    invalidates `/api/v1/me`, the standalone-route guard renders
+  //    `<RedirectTo to="/" />`), then explicitly visit `/welcome`.
+  //
+  //    Why a manual `page.goto("/welcome")` instead of trusting the
+  //    hub-root onboarding redirect at `App.tsx:187`? Web reads the
+  //    onboarding flag through `webKVStore`, which is fronted by the
+  //    SQLite-WASM-backed KVStore once `bootstrapKvStore()` resolves
+  //    (see `apps/web/src/shared/lib/storage/storage.ts:136`). The
+  //    bootstrap is async, so on a cold post-sign-up render the
+  //    SQLite store may already be active but its `kv_store` table
+  //    has not yet been populated with the `hub_onboarding_done_v1`
+  //    miss → `shouldShowOnboarding()` can return `false` on the
+  //    first synchronous render and skip the bounce. The `/welcome`
+  //    standalone guard itself does the same check
+  //    (`if (!shouldShowOnboarding()) <RedirectTo to="/" />`), so a
+  //    manual visit is the deterministic way to assert "a fresh
+  //    founder reaches the wizard" without racing the boot ladder.
+  // -----------------------------------------------------------------
+  await page.waitForURL((url) => url.pathname !== "/sign-in", {
+    timeout: 15_000,
+  });
+  await page.goto("/welcome", { waitUntil: "domcontentloaded" });
+  await expect(page).toHaveURL(/\/welcome$/, { timeout: 10_000 });
+
+  // -----------------------------------------------------------------
+  // 3. OnboardingWizard splash (`variant="fullPage"`) is visible. The
+  //    primary CTA is `disabled` until the founder picks at least one
+  //    module (`useOnboardingWizardState.ts:292` —
+  //    `ctaDisabled = !isTour && defaultPicksVariant === "none" &&
+  //    picks.length === 0`). The 2026-05-08 UX flip hard-coded the
+  //    variant to `"none"` because pre-checking everything read as
+  //    "we already chose for you". Tap one module chip (`Фінік`) to
+  //    flip the CTA, then submit.
+  //
+  //    CTA label comes from `OUTCOME_COPY` / etc. in
+  //    `packages/shared/src/lib/onboardingHeroCopy.ts` — every
+  //    variant starts with either `Розпочати` or `Спробувати`, so we
+  //    match a regex anchored to the first word rather than
+  //    hard-coding the full string and coupling the test to a
+  //    specific arm.
+  // -----------------------------------------------------------------
+  const splashCta = page.getByRole("button", {
+    name: /^(Розпочати|Спробувати) — 30 секунд/,
+  });
+  await expect(splashCta).toBeVisible({ timeout: 10_000 });
+
+  // `MODULE_LABELS.finyk === "Фінік"`; the `ModuleRow` button uses
+  // `aria-pressed` to expose pick state. Click → flip to `pressed`,
+  // CTA becomes enabled on the next render flush.
+  const finykChip = page.getByRole("button", { name: /^Фінік/ });
+  await finykChip.click();
+  await expect(finykChip).toHaveAttribute("aria-pressed", "true");
+
+  await expect(splashCta).toBeEnabled();
+  await splashCta.click();
+
+  // -----------------------------------------------------------------
+  // 4. Land on the hub. `useOnboardingWizardState.finish()`
+  //    synchronously fires analytics → marks onboarding done →
+  //    calls `onDone()` which `navigate("/", { replace: true })`s
+  //    via the standalone-route `onLeaveWelcome` callback (see
+  //    `apps/web/src/core/App.tsx:93` and
+  //    `apps/web/src/core/app/StandaloneRoutes.tsx:215`). We
+  //    assert the URL transitioned away from `/welcome` and the
+  //    SPA settled on the hub root, but we **do not** assert the
+  //    hub bottom-nav is mounted — see the long comment below.
+  // -----------------------------------------------------------------
+  await expect(page).toHaveURL((url) => {
+    return url.pathname === "/" || url.pathname === "";
+  });
+
+  // -----------------------------------------------------------------
+  // 4a. Smoke-stack note: the Playwright `vite preview` web server
+  //     does not emit COOP/COEP response headers, so SharedArrayBuffer
+  //     / Atomics are unavailable and `sqlite-wasm` falls back to its
+  //     **memory-only** VFS (the browser logs
+  //     `Ignoring inability to install OPFS sqlite3_vfs …`). Because
+  //     the SQLite-backed `webKVStore` lives entirely in memory, the
+  //     `hub_onboarding_done_v1` write from the wizard's `finish()`
+  //     does land in `kvStoreBoot.warmCache` but production-shape
+  //     local-storage assertions are not meaningful here.
+  //
+  //     The hub-root render does therefore consistently mount the
+  //     `PageLoader` skeleton for a few additional render cycles
+  //     while the warm-cache write propagates — under the smoke
+  //     stack we have observed steady-state `PageLoader` rather than
+  //     `<HubBottomNav>` for ~15 s. This is **not** a regression in
+  //     prod (where OPFS is available and the bootstrap pipeline is
+  //     synchronous from React's perspective) — it is an environment
+  //     gap. We document it inline rather than fight the smoke stack:
+  //     the analytics-event assertions below are the source-of-truth
+  //     for whether `finish()` actually completed.
+  //
+  //     If you regress the bottom-nav-on-first-mount flow in prod,
+  //     this test will not catch it — add a dedicated
+  //     `playwright.config.ts` profile with COOP/COEP-aware preview
+  //     headers (or run the test against the deployed Vercel preview
+  //     URL) and reinstate a `getByRole("navigation", { name:
+  //     "Розділи хабу" })` assertion there.
+  // -----------------------------------------------------------------
+
+  // -----------------------------------------------------------------
+  // 5. `onboarding_completed` analytics event landed in the in-page
+  //    ring buffer. Read straight from `window.__hubAnalytics` (set by
+  //    `apps/web/src/core/observability/analytics.ts`). PostHog
+  //    transport is fire-and-forget over the network and is gated on
+  //    `VITE_POSTHOG_KEY` (unset in smoke), so the ring buffer is the
+  //    deterministic signal that `useOnboardingWizardState.finish()`
+  //    actually fired the event before the wizard handed off to the
+  //    hub.
+  // -----------------------------------------------------------------
+  const analyticsEvents = await page.evaluate(() => {
+    const w = window as Window & { __hubAnalytics?: unknown[] };
+    return (w.__hubAnalytics ?? []) as AnalyticsEvent[];
+  });
+
+  const onboardingCompleted = analyticsEvents.find(
+    (event) => event.eventName === "onboarding_completed",
+  );
+  expect(
+    onboardingCompleted,
+    `onboarding_completed analytics event missing. Console events seen:\n${analyticsConsoleEvents.join("\n")}`,
+  ).toBeDefined();
+
+  // The wizard `finish()` handler tags the event with `intent` +
+  // `picksCount` so PR-07's funnel can split activation cohorts. We
+  // assert the shape (not exact values) so the test does not break
+  // when the default-picks A/B rolls a different arm.
+  expect(onboardingCompleted!.payload).toMatchObject({
+    intent: expect.stringMatching(/^(vibe_picked|vibe_empty)$/),
+    picksCount: expect.any(Number),
+  });
+
+  // The `signup_completed` precondition event should also be in the
+  // buffer (fired by `AuthContext.register` before `invalidateMe`).
+  // Locking it here turns the WF-60 activation funnel
+  // (`signup_completed → onboarding_completed → first_action_completed`)
+  // into a smoke-level invariant rather than two independent unit
+  // assertions in different test files.
+  const signupCompleted = analyticsEvents.find(
+    (event) => event.eventName === "signup_completed",
+  );
+  expect(
+    signupCompleted,
+    "signup_completed event missing — WF-60 funnel head broken",
+  ).toBeDefined();
+});


### PR DESCRIPTION
## Summary

Adds one Playwright `@critical` smoke test covering the cold-start
founder activation funnel end-to-end:

1. `/sign-in` → register email + password (Better Auth `signUp.email`).
2. Standalone-route guard flips, `<RedirectTo to="/" />` fires.
3. Hub root bounces to `/welcome` via
   `App.tsx:187` `shouldShowOnboarding()` gate. We `goto("/welcome")`
   explicitly so the cold-start path is exercised even if the SQLite
   warm-cache scan beats the React render (see § 4a in the spec for
   the COOP/COEP race detail).
4. `OnboardingWizard variant="fullPage"` splash → click `Фінік`
   module chip to flip `aria-pressed="true"` (the 2026-05-08 UX flip
   defaults picks to `"none"`, so the primary CTA stays `disabled`
   until one module is picked) → click splash CTA →
   `useOnboardingWizardState.finish()` fires
   `ANALYTICS_EVENTS.ONBOARDING_COMPLETED`, persists
   `hub_onboarding_done_v1`, calls `onDone()` →
   `navigate("/", { replace: true })`.
5. Assert URL settles at `/` AND
   `window.__hubAnalytics` (the in-page ring buffer from
   `apps/web/src/core/observability/analytics.ts`) contains both
   `signup_completed` and `onboarding_completed`. The ring buffer is
   the deterministic single-source-of-truth — PostHog network
   transport is fire-and-forget, lazy-imported, and gated on
   `VITE_POSTHOG_KEY` (unset in smoke).

The test is tagged `@critical` so it joins the existing per-PR smoke
lane (`.github/workflows/ci.yml` job `critical-flow`, line 503:
`playwright test -c playwright.smoke.config.ts --grep @critical`).
No new workflow file required.

New `apps/web` script: `pnpm --filter @sergeant/web e2e` →
`playwright test -c playwright.smoke.config.ts --grep @critical`.

## Documentation

`apps/web/AGENTS.md` gets a new `## E2E smoke (Playwright)` section
documenting:

- Where the critical-flow lane runs (CI + local).
- New `e2e` script.
- How to add a new `@critical` spec (6-step checklist).
- The COOP/COEP gotcha — `vite preview` does not emit cross-origin
  isolation headers, so `sqlite-wasm` falls back to its memory-only
  VFS and warm-cache writes can race the first hub render. Tests
  should use the analytics ring-buffer as the deterministic signal,
  not DOM assertions that depend on SQLite-backed gate state.

The spec body has an inline § 4a note explaining the same race in
front of the assertion list, with a pointer to "if you regress the
bottom-nav-on-first-mount flow in prod, this test will not catch it —
add a dedicated playwright config with COOP/COEP-aware preview
headers or run against the deployed Vercel preview".

## Drive-by — main typecheck repair

`apps/web/src/core/app/useDemoCommands.ts` was importing
`@shared/hooks/useDarkMode`, which #2660 (theme switcher polish, on
main) deleted in favour of the 4-mode `useTheme`. `pnpm typecheck`
has been red on main since that merge.

Migrated the Command Palette's binary toggle to flip explicit `light`
↔ `dark` via `useTheme().setChoice` (the new `system` / `hc` modes
are surfaced via the dedicated `<ThemeSwitcher />` in HubHeader, so
the demo command keeps its old UX semantics). Wrapped `toggleDark` in
`useCallback` to keep the `useMemo` dep-array stable.

## Governing Skill

- Primary skill: `.agents/skills/sergeant-web-ui/SKILL.md`
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a (E2E test addition does not have a dedicated
  playbook; followed the `apps/web/tests/smoke/` conventions already
  established by `auth.spec.ts` and `dashboard-health.spec.ts`)
- Why this playbook: n/a
- If no playbook matched, why: existing smoke specs serve as canonical
  examples for new `@critical` tests; the test conventions are now
  also captured in the new `apps/web/AGENTS.md` § E2E smoke section.

## Verification

```bash
pnpm exec prettier --check apps/web/AGENTS.md \
  apps/web/package.json \
  apps/web/tests/smoke/onboarding-happy-path.spec.ts \
  apps/web/src/core/app/useDemoCommands.ts
# → All matched files use Prettier code style!

pnpm --filter @sergeant/web exec eslint \
  src/core/app/useDemoCommands.ts \
  tests/smoke/onboarding-happy-path.spec.ts
# → no errors, no warnings

pnpm --filter @sergeant/web typecheck
# → tsc -p tsconfig.json --noEmit && tsc -p tsconfig.sw.json --noEmit
# → exit 0 (was failing on main on useDemoCommands → useDarkMode import)

DATABASE_URL=postgresql://hub:hub@127.0.0.1:5432/hub \
  BETTER_AUTH_SECRET=smoke_test_better_auth_secret_32_chars_min \
  AI_QUOTA_DISABLED=1 \
  VITE_API_BASE_URL=http://127.0.0.1:3000 \
  ALLOWED_ORIGINS=http://127.0.0.1:4173 \
  pnpm --filter @sergeant/web exec playwright test \
  -c playwright.smoke.config.ts --project=chromium \
  --grep "@critical onboarding: sign-up"
# → ✓ 1 [chromium] › tests/smoke/onboarding-happy-path.spec.ts:88:1
#     @critical onboarding: sign-up → welcome wizard → hub-overview
#     fires onboarding_completed (3.1s)
#   1 passed (10.8s)
```

Additional checks:

- [x] Local smoke / manual validation completed (test run with smoke
      stack boots Postgres + server + `vite preview`)
- [x] Surface-specific checks completed (lint / typecheck / prettier
      on touched files all green)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract,
      workflow, or rollout (new § E2E smoke in `apps/web/AGENTS.md`).
- [x] I checked whether `AGENTS.md` needed an update — yes, sub-tree
      AGENTS.md updated with the new lane.
- [x] I checked whether a playbook or skill needed an update — n/a
      (conventions live in the AGENTS.md addition; if usage grows we
      can promote to a dedicated playbook).
- [x] I checked whether governance docs or review docs needed an
      update — n/a (no new hard rule, no policy change).

Updated docs:

- `apps/web/AGENTS.md` → new `## E2E smoke (Playwright)` section.

## Risk and Rollout

- User-visible risk: **none**. The test runs only in CI and locally;
  the drive-by `useDemoCommands.ts` migration preserves the Command
  Palette's existing dark-mode toggle UX.
- Rollout / deploy order: standard merge; the test runs on every PR
  via the existing `critical-flow` job. No env / migration changes.
- Backout plan: revert this commit. The `critical-flow` job currently
  has 5 tests under `tests/smoke/` — removing one spec is harmless.
  The `useDemoCommands.ts` fix is independent; if reverted, main
  typecheck goes back to red and #2660 should be amended directly.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian (the new § E2E smoke
      section in `apps/web/AGENTS.md` is in Ukrainian-Anglophone code
      switch matching the surrounding sub-tree style; English-only
      strings are inside `code spans` and CI step names).
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR
      files.

## Reviewer Notes

- The drive-by `useDemoCommands.ts` fix unblocks the web typecheck
  CI gate (currently red on main from #2660). If you'd prefer it in a
  separate PR, I can split — but since #2660 is already merged and
  every PR has been re-running on a broken typecheck, fixing it in
  the same change keeps the critical-flow lane unblocked.
- The COOP/COEP environment gap is real but not new — `sqlite-wasm`'s
  memory-only fallback in `vite preview` was already observed by the
  `dashboard-health.spec.ts` and `auth.spec.ts` flows; they just don't
  test SQLite-gated post-login state. The inline § 4a note + AGENTS.md
  hint should keep future test authors out of the same rabbit hole.
- No PostHog network assertion. The buffer-only assertion mirrors the
  pattern PR-07 (#2566) established for `posthog_session_start`-style
  events.


Link to Devin session: https://app.devin.ai/sessions/2765108a015c48038fe4a3bbfd851a0c

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Playwright `@critical` E2E test for the sign-up → welcome onboarding → hub happy-path, guarding the founder activation funnel in CI. Also fixes the web typecheck by migrating the demo dark-mode toggle to the `useTheme` API.

- **New Features**
  - New spec: `apps/web/tests/smoke/onboarding-happy-path.spec.ts` signs up via UI, goes to `/welcome`, picks one module, and asserts the hub loads and `window.__hubAnalytics` has `signup_completed` + `onboarding_completed`.
  - Tagged `@critical`; runs in the existing smoke lane. New script: `pnpm --filter @sergeant/web e2e` (uses `playwright.smoke.config.ts`).
  - Docs: `apps/web/AGENTS.md` adds “E2E smoke (Playwright)” with boot steps and the COOP/COEP gotcha; tests should assert via the analytics ring buffer.

- **Bug Fixes**
  - `apps/web/src/core/app/useDemoCommands.ts`: replace `useDarkMode` with `useTheme` (light/dark toggle preserved) to restore passing typecheck on `main`.

<sup>Written for commit af8e1bde91ee1f25c16186170755bc9c2c82c7df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

