### PR TITLE
chore(ci): post-deploy smoke tests (status + latency + shape per endpoint)

### DIFF
--- a/docs/testing/smoke-tests.md
+++ b/docs/testing/smoke-tests.md
@@ -1,0 +1,393 @@
+# Post-deploy smoke tests — runbook
+
+> **Last validated:** 2026-05-13 by @Skords-01 / Devin. **Next review:** 2026-08-08.
+> **Status:** Active
+
+Цей runbook описує, як працюють **post-deploy smoke tests** для Sergeant API — і що робити, коли cron / deploy-hook каже, що щось зламалось.
+
+Sister-сторінки:
+
+- [`docs/testing/pact-drift-runbook.md`](./pact-drift-runbook.md) — daily check, чи **wire shape** staging-у відповідає Pact-контрактам (schema regression).
+- [`docs/architecture/api-contracts.md`](../architecture/api-contracts.md) — як працює Pact pipeline загалом.
+- `.github/workflows/post-deploy-smoke.yml` — workflow (потрібно створити вручну — див. § Workflow YAML).
+- [`scripts/post-deploy-smoke.mjs`](../../scripts/post-deploy-smoke.mjs) — CLI runner.
+- [`scripts/smoke-tests.json`](../../scripts/smoke-tests.json) — конфіг із списком endpoint-ів.
+
+> **Why the YAML lives in docs and not under `.github/workflows/`:** PR-42 (#2675), #2737 і ця PR використовують OAuth App без `workflow` scope, тож автоматизований push нового workflow-файла remote rejected-иться. До отримання scope-а — скопіюй YAML із § Workflow YAML у `.github/workflows/post-deploy-smoke.yml` вручну через GH UI.
+
+## TL;DR
+
+| Що бачу                                                                                      | Що це означає                                                                                                             | Перший крок                                                                             |
+| -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| GitHub-issue `[Smoke] Post-deploy smoke failed — <env> YYYY-MM-DD` (label `smoke-test-fail`) | `post-deploy-smoke` workflow знайшов ≥1 endpoint з verdict `fail` (status / latency / shape mismatch).                    | Відкрий issue → `smoke-report` artifact → класифікуй failures.                          |
+| `post-deploy-smoke` job `failure` на `deployment_status` trigger                             | Deploy завершився, але smoke завалився — кандидат на **rollback**.                                                        | Перевір `GITHUB_STEP_SUMMARY` цього run-у; якщо user-facing → пуш rollback або hotfix.  |
+| `post-deploy-smoke` job `failure` на schedule                                                | Drift після deploy, який раніше пройшов smoke (e.g. dep-провайдер outage Mono/Anthropic, або running-handler regression). | Перевір зовнішні dep-status (Mono, Anthropic), Sentry на runtime-помилки, Railway logs. |
+| Issue reopen-ається > 2x за тиждень                                                          | Flaky endpoint **або** real regression, який ще не закомічили.                                                            | Eskalate: pair з owner → patch або тимчасово понизь tier на `extended`.                 |
+
+## Як працює workflow
+
+- Файл (потрібно створити вручну — див. § Workflow YAML): `.github/workflows/post-deploy-smoke.yml`.
+- Тригери:
+  - `workflow_dispatch` з `base_url` / `tier` / `strict` inputs (ad-hoc прогон з UI Actions).
+  - `deployment_status` — стартує одразу після успішного GitHub deployment-у (e.g. Vercel preview / Railway prod). `if: deployment_status.state == 'success'`.
+  - `schedule: "30 6 * * *"` — 06:30 UTC щодня, на 30 хв пізніше за `pact-drift` (06:00 UTC), щоб триaге-лейн не coalesce-ився.
+- Скрипт: [`scripts/post-deploy-smoke.mjs`](../../scripts/post-deploy-smoke.mjs) — параметри: `--base-url`, `--report`, `--json`, `--config`, `--tier`, `--only`, `--skip`, `--strict`, `--dry-run`, `--concurrency`.
+- Конфіг: [`scripts/smoke-tests.json`](../../scripts/smoke-tests.json) — JSON-список тестів.
+- Idempotent issue: один open issue з label `smoke-test-fail` (Mirrors `pact-drift.yml` + `db-backup-verify.yml`).
+
+### Як читається verdict
+
+Скрипт для кожного endpoint-а заміряє **status / latency / shape**, потім reducer вирішує verdict.
+
+| Verdict   | Коли                                                                                                                                                                            | Деталі                                                                                                                                       |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| ✅ `pass` | HTTP-status == `expectedStatus`, latency ≤ `latencyBudgetMs`, response-shape (якщо описана) збігається.                                                                         | —                                                                                                                                            |
+| ⚠️ `warn` | Status + shape OK, але latency `budget < latency ≤ 2×budget`.                                                                                                                   | Не блокує merge (без `--strict`). Сигнал «backend deps повільні». Часто dep-driven (Mono Open API throttle, Anthropic queue).                |
+| ❌ `fail` | Status mismatch **або** latency > 2×budget **або** shape mismatch (missing field, type mismatch, null замість string) **або** fetch-error (connection refused / DNS / timeout). | Real liveness regression. Створюється issue `smoke-test-fail`. На `deployment_status` тригері — кандидат на rollback (якщо `critical` tier). |
+| ⏭️ `skip` | Зарезервовано (наразі не використовується — конфіг включає всі тести; `--skip` flag-ом можна виключити named tests).                                                            | —                                                                                                                                            |
+
+## Setup
+
+### Required secrets
+
+| Secret                   | Where                                 | Why                                                                                                                                                    |
+| ------------------------ | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `STAGING_BASE_URL`       | GitHub → Settings → Secrets → Actions | Default target для cron-у. Override-иться `workflow_dispatch.base_url`.                                                                                |
+| `STAGING_SESSION_COOKIE` | GitHub → Settings → Secrets → Actions | Better Auth session cookie (формат `session=...`) для тестів із `"auth": "session"`. Без нього вони ранять анонімно (часто → 401, що теж valid smoke). |
+
+Для PR / preview deployment-ів `TARGET_BASE_URL` беруть із `deployment_status.environment_url` (Vercel populates це). Якщо deploy провайдер не сетить `environment_url` — упади fallback на `STAGING_BASE_URL`.
+
+### Як отримати `STAGING_SESSION_COOKIE`
+
+1. Відкрий staging app у браузері, залогінься як **smoke-test user** (рекомендую окремий dedicated account, не персональний).
+2. DevTools → Application → Cookies → знайди `better-auth.session_token` (або тaнк назву ключа, який віддає Better Auth).
+3. Скопіюй у форматі `better-auth.session_token=<value>` (з усіма `;`-separated cookie-attributes якщо треба передати кілька). Один-рядковий формат, бо ми кидаємо це у HTTP-header `cookie:`.
+4. У GH Secrets збережи як `STAGING_SESSION_COOKIE`.
+5. Cookie прострочується раз на ~30 днів — постав reminder продовжити, або налаштуй cron, що поновлює його через scripted login (далеко за межами цієї PR).
+
+## Як прогнати локально
+
+### Dry-run (без HTTP)
+
+```bash
+node scripts/post-deploy-smoke.mjs --dry-run
+node scripts/post-deploy-smoke.mjs --dry-run --tier critical
+```
+
+Друкує список тестів із бюджетами і auth-mode-ами, без жодного HTTP-виклику.
+
+### Проти локального dev-сервера
+
+```bash
+pnpm dev:server &  # http://localhost:3000
+
+node scripts/post-deploy-smoke.mjs \
+  --base-url http://localhost:3000 \
+  --tier critical \
+  --report /tmp/smoke-report.md
+```
+
+Anonymous-критичні endpoints (`/livez`, `/readyz`, `/healthz`, `/api/status`, `/api/push/vapid-public`) мають бути зеленими одразу. `auth:me-session` буде або skip-нутий, або 401 без cookie — це нормально для dry-перевірки скрипту.
+
+### Проти staging (як CI)
+
+```bash
+export STAGING_BASE_URL=https://staging.sergeant.example.com
+export STAGING_SESSION_COOKIE="better-auth.session_token=..."
+
+node scripts/post-deploy-smoke.mjs --tier all --strict
+```
+
+`--strict` робить warn → fail (для жорсткої перевірки SLO).
+
+## Як додати новий тест
+
+1. Відкрий [`scripts/smoke-tests.json`](../../scripts/smoke-tests.json).
+2. Додай новий запис у `tests`. Мінімум потрібно `name` і `path`. Решта береться з `defaults`.
+3. Поля:
+   - `name` — унікальний ID (e.g. `"finyk:transactions-list"`). Використовується у `--only` / `--skip`.
+   - `method` — `GET` / `POST` / `PUT` / `PATCH` / `DELETE`. Default: `GET`.
+   - `path` — relative-path від `base_url`, можна включати query-string (e.g. `"/api/v1/barcode?barcode=4820010840443"`).
+   - `expectedStatus` — number. Default: `200`.
+   - `latencyBudgetMs` — SLO. Default: `2500` ms.
+   - `timeoutMs` — hard cutoff. Default: `8000` ms.
+   - `auth` — `"none"` або `"session"` (передасть `cookie:` header).
+   - `tier` — `"critical"` (rollback-candidate) або `"extended"` (informational).
+   - `shape` — recursive type-skeleton, e.g. `{ "user": { "id": "string", "email": "string" } }`. Підтримує `"<type>?"` для optional / nullable полів.
+   - `expectedBodyContains` — substring для non-JSON endpoints (e.g. `/metrics` має містити `# HELP`).
+   - `headers` — додаткові headers.
+   - `body` — request body (для POST/PUT/PATCH).
+4. Прогон `node scripts/post-deploy-smoke.mjs --dry-run --only <new-name>` для перевірки, що config parse-иться.
+5. Прогон проти dev-сервера: `node scripts/post-deploy-smoke.mjs --base-url http://localhost:3000 --only <new-name>`.
+6. Open PR. CI прогонить unit-tests на pure-logic частину; новий тест автоматично включається у наступний staging-deploy + 06:30 UTC cron.
+
+## Triage playbook
+
+Якщо `[Smoke] Post-deploy smoke failed` issue з'явився:
+
+1. **Класифікуй failures** з `smoke-report` artifact:
+   - `fetch_error` (DNS / connection refused / timeout) — deploy не доступний з GH runner-а: перевір DNS staging-домену, статус деплоя на Railway/Vercel, чи WAF не блочить GH-IPS.
+   - `status_mismatch` (5xx) — runtime crash; перевір Sentry → grouped by `route:<path>`.
+   - `status_mismatch` (401 на endpoint, що раніше повертав 200) — `STAGING_SESSION_COOKIE` прострочився; поновіть.
+   - `shape_mismatch` — handler змінив response shape; одна з: a) PR-42 contract update забутий, b) infra додала middleware, що нормалізує/обрізає тіло, c) handler bug.
+   - `latency_severe_overrun` — DB connection pool exhausted? зовнішній API провайдер повільний? Перевір Railway → Database → Active queries, Anthropic / Voyage / Mono dashboards.
+2. **Якщо `deployment_status` тригер + `critical` tier завалився:**
+   - **Rollback first, fix second.** GitHub → Deployments → revert.
+   - Опен hotfix-PR, recreate smoke вручну через `workflow_dispatch` після hotfix-merge.
+3. **Якщо schedule-тригер (06:30 UTC) завалився, але дeplоy 8h тому пройшов smoke:**
+   - Зовнішній dep outage (Mono Open API частий suspect).
+   - Anthropic queue / RAG endpoint timeout — перевір `pact-drift` (06:00 UTC) — якщо там теж warn-и, це не handler regression, це provider degradation.
+4. **Persistent flaky:**
+   - Опуст tier на `extended` (інформаційний). Issue має ремаінути open, поки root cause не виправлений.
+   - Додай Sentry alert на той endpoint (через `apps/server/src/obs/anthropicBudgetGuard.ts` pattern) — тоді smoke на ньому стане **дублюючим сигналом**, а не primary.
+
+## Як це доповнює pact-drift
+
+| Аспект                  | `pact-drift.yml` (06:00 UTC)                               | `post-deploy-smoke.yml` (deployment + 06:30 UTC)                            |
+| ----------------------- | ---------------------------------------------------------- | --------------------------------------------------------------------------- |
+| Що ловить               | **Schema** drift (missing/typeswap/extra field).           | **Liveness** drift (5xx, timeout, latency SLO).                             |
+| Джерело очікувань       | `packages/api-client/pacts/*.json` (consumer-driven Pact). | `scripts/smoke-tests.json` (curated list of critical endpoints).            |
+| Виконується             | Тільки cron + manual.                                      | Cron + manual + **deployment_status** (запускається після кожного deploy).  |
+| Critical/optional split | Один tier (всі mutations skipped by default).              | Two tiers: `critical` (rollback-кандидат) + `extended` (информаційний).     |
+| Action on fail          | Issue `contract-drift` + tech-debt.                        | Issue `smoke-test-fail` + tech-debt. Можна rollback-нути у deploy provider. |
+
+Обидва running side-by-side — schema drift не блокує deploy (бо ловиться щодня), liveness drift блокує deploy (бо ловить regression миттєво після rollout).
+
+## Майбутні розширення
+
+- **Rollback automation:** на `critical`-tier fail після `deployment_status` — автоматичний revert у Railway / Vercel API.
+- **Latency histograms:** замість єдиного `latencyBudgetMs`, мати p50/p95/p99 budgets, заміряти кілька runs.
+- **Sentry route**: окремий alert-route `smoke-test-fail` через існуючий n8n WF-98 alert-bot pipeline (#2535).
+- **Mutation tests opt-in:** `--include-mutations` для `POST /api/auth/sign-in` із dedicated test-user-ом — щоб ловити Better Auth regression. Зараз skipped, бо мутації забруднюють staging state.
+
+## Workflow YAML
+
+Закомить як `.github/workflows/post-deploy-smoke.yml`:
+
+```yaml
+name: Post-deploy smoke
+
+# Owner: @Skords-01 (solo maintainer per .github/CODEOWNERS).
+# Triage: if this job fails, an issue tagged `smoke-test-fail` is auto-opened
+#         (idempotent — same pattern as pact-drift / db-backup-verify). Runbook:
+#         `docs/testing/smoke-tests.md`.
+# Why this workflow exists: complements `pact-drift.yml` (schema regression)
+#         with **liveness** regression. Pact-drift catches "wire shape
+#         changed"; this catches "endpoint stopped responding / SLO
+#         regressed". Triggered after deploys (manual + deployment_status).
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "Target base URL override (default: $TARGET_BASE_URL / $STAGING_BASE_URL)"
+        required: false
+        type: string
+      tier:
+        description: "Test tier filter"
+        required: false
+        type: choice
+        options:
+          - critical
+          - extended
+          - all
+        default: all
+      strict:
+        description: "Treat latency-over-budget warnings as failures"
+        required: false
+        type: boolean
+        default: false
+  deployment_status:
+  schedule:
+    # 06:30 UTC daily — 30 min after pact-drift so the same issue triage lane
+    # is staggered. Pact-drift is the canary for schema regression; this is
+    # the canary for liveness regression on staging.
+    - cron: "30 6 * * *"
+
+permissions:
+  contents: read
+  issues: write
+  deployments: read
+
+concurrency:
+  group: post-deploy-smoke-${{ github.event.deployment_status.environment || github.event.inputs.base_url || 'default' }}
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    name: Run post-deploy smoke tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Only run on successful deployments or manual triggers / scheduled runs.
+    if: |
+      github.event_name != 'deployment_status' ||
+      github.event.deployment_status.state == 'success'
+    env:
+      TARGET_BASE_URL: >-
+        ${{ github.event.inputs.base_url
+            || github.event.deployment_status.environment_url
+            || secrets.STAGING_BASE_URL }}
+      STAGING_SESSION_COOKIE: ${{ secrets.STAGING_SESSION_COOKIE }}
+
+    steps:
+      # actions/checkout v6.0.2 (SHA-pinned for supply-chain hardening)
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      # actions/setup-node v6.4.0 (SHA-pinned for supply-chain hardening)
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "20"
+
+      - name: Run smoke checker
+        id: smoke
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+
+          if [ -z "${TARGET_BASE_URL:-}" ]; then
+            echo "::error::TARGET_BASE_URL is not set. Configure STAGING_BASE_URL secret or pass base_url input. See docs/testing/smoke-tests.md § Setup."
+            exit 2
+          fi
+
+          mkdir -p dist
+          ARGS=(
+            --base-url "$TARGET_BASE_URL"
+            --report dist/smoke-report.md
+            --json dist/smoke-report.json
+            --tier "${{ inputs.tier || 'all' }}"
+          )
+          if [ "${{ inputs.strict }}" = "true" ]; then
+            ARGS+=(--strict)
+          fi
+
+          set +e
+          node scripts/post-deploy-smoke.mjs "${ARGS[@]}"
+          SMOKE_EXIT=$?
+          set -e
+
+          echo "smoke_exit=$SMOKE_EXIT" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Post-deploy smoke"
+            echo ""
+            echo "- **Base URL:** \`$TARGET_BASE_URL\`"
+            echo "- **Tier:** \`${{ inputs.tier || 'all' }}\`"
+            echo "- **Exit code:** \`$SMOKE_EXIT\` (0=clean, 1=failures, 2=script error)"
+            echo ""
+            echo "<details><summary>Full report</summary>"
+            echo ""
+            cat dist/smoke-report.md
+            echo ""
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          exit "$SMOKE_EXIT"
+
+      - name: Upload smoke report
+        if: always()
+        # actions/upload-artifact v4.4.3 (SHA-pinned for supply-chain hardening)
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: smoke-report
+          path: dist/smoke-report.*
+          retention-days: 14
+
+      - name: Create / refresh smoke-test-fail issue
+        if: steps.smoke.outcome == 'failure' && github.event_name != 'workflow_dispatch'
+        # actions/github-script v8.0.0 (SHA-pinned for supply-chain hardening)
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('node:fs');
+            const date = new Date().toISOString().slice(0, 10);
+
+            let report = '';
+            try {
+              report = fs.readFileSync('dist/smoke-report.md', 'utf-8');
+            } catch (err) {
+              report = `_No report artifact: ${err.message}_`;
+            }
+
+            const trigger = context.eventName;
+            const env =
+              context.payload?.deployment_status?.environment ?? 'staging';
+            const title = `[Smoke] Post-deploy smoke failed — ${env} ${date}`;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              '## Post-deploy smoke failed',
+              '',
+              `**Run:** ${runUrl}`,
+              `**Date:** ${new Date().toISOString()}`,
+              `**Environment:** \`${env}\``,
+              `**Triggered by:** \`${trigger}\``,
+              '',
+              'One or more critical endpoints returned an unexpected status,',
+              'latency above SLO budget, or shape mismatch right after deploy.',
+              'This is a **liveness regression** signal — the deployed copy is',
+              'not serving the expected contract.',
+              '',
+              'Follow [`docs/testing/smoke-tests.md`](../blob/main/docs/testing/smoke-tests.md)',
+              'for triage. TL;DR:',
+              '',
+              '1. Open the run above → `smoke-report` artifact for the full table.',
+              '2. Classify: dep outage (Anthropic/Mono/Voyage) vs handler regression vs config.',
+              '3. If regression — block next deploy + rollback if user-facing.',
+              '',
+              '---',
+              '',
+              '<details><summary>Latest report (markdown)</summary>',
+              '',
+              report,
+              '',
+              '</details>',
+              '',
+              'cc @Skords-01',
+            ].join('\n');
+
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'smoke-test-fail',
+              per_page: 5,
+            });
+            const existing = issues.find((i) =>
+              i.title.startsWith('[Smoke]'),
+            );
+
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body: [
+                  `### Re-detected on ${date} (${env})`,
+                  '',
+                  `**Run:** ${runUrl}`,
+                  '',
+                  '<details><summary>Latest report (markdown)</summary>',
+                  '',
+                  report,
+                  '',
+                  '</details>',
+                ].join('\n'),
+              });
+              core.info(`Updated existing issue #${existing.number}.`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['smoke-test-fail', 'tech-debt'],
+              });
+              core.info(`Created new issue #${created.data.number}.`);
+            }
+
+      - name: Fail the job on smoke failure
+        if: steps.smoke.outcome == 'failure'
+        run: |
+          echo "::error::Post-deploy smoke detected ≥1 failure. See dist/smoke-report.md."
+          exit 1
+```

--- a/scripts/__tests__/post-deploy-smoke.test.mjs
+++ b/scripts/__tests__/post-deploy-smoke.test.mjs
@@ -1,0 +1,324 @@
+// AI-NOTE: Unit tests for the pure logic in scripts/post-deploy-smoke.mjs:
+// shape-matcher, verdict reducer, test filtering. The HTTP runner itself is
+// covered by the live cron — locking it down with mocks would lock down
+// implementation details (AbortSignal.timeout, hrtime, etc.) without adding
+// regression coverage. The script's CI value comes from running against
+// deployed staging/prod.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  matchShape,
+  decideVerdict,
+  normaliseTests,
+  filterTests,
+  renderMarkdown,
+} from "../post-deploy-smoke.mjs";
+
+// ---------- matchShape ----------
+
+test("matchShape — primitive types match exactly", () => {
+  assert.deepEqual(matchShape("string", "hello"), []);
+  assert.deepEqual(matchShape("number", 42), []);
+  assert.deepEqual(matchShape("boolean", true), []);
+  assert.deepEqual(matchShape("object", { a: 1 }), []);
+  assert.deepEqual(matchShape("array", [1, 2]), []);
+});
+
+test("matchShape — primitive type mismatch is reported", () => {
+  const diff = matchShape("number", "42");
+  assert.equal(diff.length, 1);
+  assert.equal(diff[0].kind, "type_mismatch");
+  assert.equal(diff[0].expected, "number");
+  assert.equal(diff[0].actual, "string");
+});
+
+test("matchShape — null is reported as missing_or_null for required field", () => {
+  const diff = matchShape("string", null);
+  assert.equal(diff.length, 1);
+  assert.equal(diff[0].kind, "missing_or_null");
+});
+
+test("matchShape — undefined satisfies optional field", () => {
+  assert.deepEqual(matchShape("string?", undefined), []);
+  assert.deepEqual(matchShape("string?", null), []);
+});
+
+test("matchShape — optional field still type-checks when present", () => {
+  const diff = matchShape("string?", 42);
+  assert.equal(diff.length, 1);
+  assert.equal(diff[0].kind, "type_mismatch");
+});
+
+test("matchShape — nested object: missing field is reported", () => {
+  const diff = matchShape(
+    { user: { id: "string", email: "string" } },
+    { user: { id: "u1" } },
+  );
+  assert.equal(diff.length, 1);
+  assert.equal(diff[0].path, "$.user.email");
+  assert.equal(diff[0].kind, "missing_or_null");
+});
+
+test("matchShape — nested object: present + correct shape passes", () => {
+  const diff = matchShape(
+    { user: { id: "string", email: "string" } },
+    { user: { id: "u1", email: "a@b.c" } },
+  );
+  assert.deepEqual(diff, []);
+});
+
+test("matchShape — array element shape divergence is reported per index", () => {
+  const diff = matchShape(
+    [{ id: "string", n: "number" }],
+    [
+      { id: "a", n: 1 },
+      { id: "b", n: "not-a-number" },
+    ],
+  );
+  assert.equal(diff.length, 1);
+  assert.equal(diff[0].path, "$[1].n");
+  assert.equal(diff[0].kind, "type_mismatch");
+});
+
+test("matchShape — array expected but object received is type_mismatch", () => {
+  const diff = matchShape(["string"], { 0: "a" });
+  assert.equal(diff.length, 1);
+  assert.equal(diff[0].kind, "type_mismatch");
+  assert.equal(diff[0].expected, "array");
+  assert.equal(diff[0].actual, "object");
+});
+
+test("matchShape — object expected but null received", () => {
+  const diff = matchShape({ a: "string" }, null);
+  assert.equal(diff.length, 1);
+  assert.equal(diff[0].kind, "type_mismatch");
+  assert.equal(diff[0].actual, "null");
+});
+
+test("matchShape — object expected but array received is type_mismatch", () => {
+  const diff = matchShape({ a: "string" }, [1, 2, 3]);
+  assert.equal(diff.length, 1);
+  assert.equal(diff[0].kind, "type_mismatch");
+  assert.equal(diff[0].expected, "object");
+  assert.equal(diff[0].actual, "array");
+});
+
+test("matchShape — empty expected array does not enforce element shape", () => {
+  assert.deepEqual(matchShape([], [{ id: 1 }, "anything"]), []);
+});
+
+// ---------- decideVerdict ----------
+
+test("decideVerdict — fetch error is fail", () => {
+  const v = decideVerdict({
+    statusOK: false,
+    latencyMs: 0,
+    latencyBudgetMs: 1000,
+    fetchError: "ECONNREFUSED",
+  });
+  assert.equal(v.verdict, "fail");
+  assert.equal(v.reason, "fetch_error");
+});
+
+test("decideVerdict — status mismatch is fail", () => {
+  const v = decideVerdict({
+    statusOK: false,
+    latencyMs: 50,
+    latencyBudgetMs: 1000,
+  });
+  assert.equal(v.verdict, "fail");
+  assert.equal(v.reason, "status_mismatch");
+});
+
+test("decideVerdict — body-contains miss is fail", () => {
+  const v = decideVerdict({
+    statusOK: true,
+    latencyMs: 50,
+    latencyBudgetMs: 1000,
+    bodyContainsOK: false,
+  });
+  assert.equal(v.verdict, "fail");
+  assert.equal(v.reason, "body_contains_mismatch");
+});
+
+test("decideVerdict — shape diff non-empty is fail", () => {
+  const v = decideVerdict({
+    statusOK: true,
+    latencyMs: 50,
+    latencyBudgetMs: 1000,
+    shapeDiff: [{ path: "$.a", kind: "type_mismatch" }],
+  });
+  assert.equal(v.verdict, "fail");
+  assert.equal(v.reason, "shape_mismatch");
+});
+
+test("decideVerdict — latency above budget but below 2x is warn (non-strict)", () => {
+  const v = decideVerdict({
+    statusOK: true,
+    latencyMs: 1500,
+    latencyBudgetMs: 1000,
+  });
+  assert.equal(v.verdict, "warn");
+  assert.equal(v.reason, "latency_over_budget");
+});
+
+test("decideVerdict — latency above budget under strict mode is fail", () => {
+  const v = decideVerdict({
+    statusOK: true,
+    latencyMs: 1500,
+    latencyBudgetMs: 1000,
+    strict: true,
+  });
+  assert.equal(v.verdict, "fail");
+  assert.equal(v.reason, "latency_over_budget");
+});
+
+test("decideVerdict — latency above 2x budget is fail even in non-strict", () => {
+  const v = decideVerdict({
+    statusOK: true,
+    latencyMs: 5000,
+    latencyBudgetMs: 1000,
+  });
+  assert.equal(v.verdict, "fail");
+  assert.equal(v.reason, "latency_severe_overrun");
+});
+
+test("decideVerdict — all clean returns pass", () => {
+  const v = decideVerdict({
+    statusOK: true,
+    latencyMs: 100,
+    latencyBudgetMs: 1000,
+  });
+  assert.equal(v.verdict, "pass");
+  assert.equal(v.reason, "ok");
+});
+
+// ---------- normaliseTests ----------
+
+test("normaliseTests — applies defaults", () => {
+  const ts = normaliseTests({
+    defaults: { timeoutMs: 5000, latencyBudgetMs: 1000 },
+    tests: [{ name: "a", path: "/x" }],
+  });
+  assert.equal(ts.length, 1);
+  assert.equal(ts[0].method, "GET");
+  assert.equal(ts[0].expectedStatus, 200);
+  assert.equal(ts[0].timeoutMs, 5000);
+  assert.equal(ts[0].latencyBudgetMs, 1000);
+  assert.equal(ts[0].tier, "extended");
+});
+
+test("normaliseTests — explicit fields override defaults", () => {
+  const ts = normaliseTests({
+    defaults: { latencyBudgetMs: 1000 },
+    tests: [
+      {
+        name: "a",
+        path: "/x",
+        method: "post",
+        expectedStatus: 201,
+        latencyBudgetMs: 500,
+        tier: "critical",
+      },
+    ],
+  });
+  assert.equal(ts[0].method, "POST");
+  assert.equal(ts[0].expectedStatus, 201);
+  assert.equal(ts[0].latencyBudgetMs, 500);
+  assert.equal(ts[0].tier, "critical");
+});
+
+test("normaliseTests — rejects config without tests array", () => {
+  assert.throws(
+    () => normaliseTests({ defaults: {} }),
+    /missing "tests" array/,
+  );
+});
+
+test("normaliseTests — rejects test without name", () => {
+  assert.throws(
+    () => normaliseTests({ tests: [{ path: "/x" }] }),
+    /missing or invalid "name"/,
+  );
+});
+
+test("normaliseTests — rejects test without path", () => {
+  assert.throws(
+    () => normaliseTests({ tests: [{ name: "a" }] }),
+    /missing or invalid "path"/,
+  );
+});
+
+// ---------- filterTests ----------
+
+test("filterTests — tier=critical drops extended", () => {
+  const ts = [
+    { name: "a", tier: "critical" },
+    { name: "b", tier: "extended" },
+  ];
+  assert.deepEqual(
+    filterTests(ts, { tier: "critical" }).map((t) => t.name),
+    ["a"],
+  );
+});
+
+test("filterTests — tier=all returns everything", () => {
+  const ts = [
+    { name: "a", tier: "critical" },
+    { name: "b", tier: "extended" },
+  ];
+  assert.equal(filterTests(ts, { tier: "all" }).length, 2);
+});
+
+test("filterTests — only-list keeps only named tests", () => {
+  const ts = [{ name: "a" }, { name: "b" }, { name: "c" }];
+  assert.deepEqual(
+    filterTests(ts, { only: ["a", "c"] }).map((t) => t.name),
+    ["a", "c"],
+  );
+});
+
+test("filterTests — skip-list drops named tests", () => {
+  const ts = [{ name: "a" }, { name: "b" }, { name: "c" }];
+  assert.deepEqual(
+    filterTests(ts, { skip: ["b"] }).map((t) => t.name),
+    ["a", "c"],
+  );
+});
+
+// ---------- renderMarkdown ----------
+
+test("renderMarkdown — header includes counts and base URL", () => {
+  const md = renderMarkdown(
+    [
+      {
+        name: "ok",
+        verdict: "pass",
+        reason: "ok",
+        url: "http://x.test/livez",
+        method: "GET",
+        actualStatus: 200,
+        expectedStatus: 200,
+        latencyMs: 50,
+        latencyBudgetMs: 800,
+      },
+      {
+        name: "broken",
+        verdict: "fail",
+        reason: "status_mismatch",
+        url: "http://x.test/api/me",
+        method: "GET",
+        actualStatus: 500,
+        expectedStatus: 200,
+        latencyMs: 80,
+        latencyBudgetMs: 2500,
+      },
+    ],
+    { baseUrl: "http://x.test", generatedAt: "2026-05-13T19:30:00Z" },
+  );
+  assert.match(md, /Post-deploy smoke report/);
+  assert.match(md, /1 pass \/ 0 warn \/ 1 fail/);
+  assert.match(md, /❌ `fail` \| `broken`/);
+  assert.match(md, /Failures \(1\)/);
+});

--- a/scripts/post-deploy-smoke.mjs
+++ b/scripts/post-deploy-smoke.mjs
@@ -1,0 +1,659 @@
+#!/usr/bin/env node
+// AI-NOTE: Post-deploy smoke-test runner. Reads scripts/smoke-tests.json,
+// hits every endpoint against $TARGET_BASE_URL (parallel), checks status +
+// latency budget + response-shape skeleton, and emits a markdown + JSON
+// report. Sister script to scripts/pact-drift-check.mjs: drift = schema
+// regression vs canned pact; smoke = liveness regression vs deploy. Pure
+// shape-matcher logic + report renderer are exported for unit-testing
+// (scripts/__tests__/post-deploy-smoke.test.mjs).
+//
+// Usage:
+//   node scripts/post-deploy-smoke.mjs \
+//     --base-url https://staging.example.com \
+//     --report dist/smoke-report.md \
+//     --json dist/smoke-report.json
+//
+// Flags:
+//   --base-url <url>        Target server (defaults to $TARGET_BASE_URL /
+//                           $STAGING_BASE_URL — picked in that order).
+//   --report <path>         Write markdown report. Default: stdout.
+//   --json <path>           Write structured JSON report.
+//   --config <path>         Smoke-tests config. Default: scripts/smoke-tests.json.
+//   --tier critical|extended|all    Which tiers to run. Default: all.
+//   --only <comma,names>    Run only the named tests.
+//   --skip <comma,names>    Skip these named tests.
+//   --strict                Treat warnings (e.g. latency above budget but
+//                           below 2x budget) as failures.
+//   --dry-run               Parse config, print plan, do NOT make HTTP calls.
+//   --concurrency <n>       Max parallel requests (default: 8).
+//
+// Exit codes:
+//   0  All checks pass.
+//   1  ≥1 failure detected (status / latency / shape mismatch).
+//   2  Script error (config missing, base URL missing, parse error).
+
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import path from "node:path";
+
+const DEFAULT_CONFIG_PATH = path.resolve(
+  path.dirname(new URL(import.meta.url).pathname),
+  "smoke-tests.json",
+);
+
+// ---------- Shape matcher ----------
+
+/**
+ * Compares an actual JSON value against a declared shape descriptor.
+ *
+ * Shape grammar:
+ *   - "string" | "number" | "boolean" | "object" | "array" | "null" — primitive type assertion.
+ *   - "<type>?" — the field may be missing OR null (e.g. "string?").
+ *   - { key: shape } — recursive object descriptor; missing keys = fail unless declared as "<type>?".
+ *   - [shape] — array where every element must satisfy `shape`.
+ *
+ * Returns an array of diagnostics; empty array means PASS.
+ */
+export function matchShape(expected, actual, basePath = "$") {
+  const out = [];
+  matchShapeAt(expected, actual, basePath, out);
+  return out;
+}
+
+function matchShapeAt(expected, actual, p, out) {
+  if (expected === undefined || expected === null) return;
+
+  if (typeof expected === "string") {
+    const optional = expected.endsWith("?");
+    const baseType = optional ? expected.slice(0, -1) : expected;
+    if (actual === null || actual === undefined) {
+      if (!optional) {
+        out.push({
+          path: p,
+          kind: "missing_or_null",
+          expected: baseType,
+          actual: actual === undefined ? "undefined" : "null",
+        });
+      }
+      return;
+    }
+    const actualType = Array.isArray(actual) ? "array" : typeof actual;
+    if (actualType !== baseType) {
+      out.push({
+        path: p,
+        kind: "type_mismatch",
+        expected: baseType,
+        actual: actualType,
+      });
+    }
+    return;
+  }
+
+  if (Array.isArray(expected)) {
+    if (!Array.isArray(actual)) {
+      out.push({
+        path: p,
+        kind: "type_mismatch",
+        expected: "array",
+        actual: actual === null ? "null" : typeof actual,
+      });
+      return;
+    }
+    if (expected.length === 0) return;
+    const elementShape = expected[0];
+    actual.forEach((el, idx) => {
+      matchShapeAt(elementShape, el, `${p}[${idx}]`, out);
+    });
+    return;
+  }
+
+  if (typeof expected === "object") {
+    if (
+      actual === null ||
+      typeof actual !== "object" ||
+      Array.isArray(actual)
+    ) {
+      out.push({
+        path: p,
+        kind: "type_mismatch",
+        expected: "object",
+        actual:
+          actual === null
+            ? "null"
+            : Array.isArray(actual)
+              ? "array"
+              : typeof actual,
+      });
+      return;
+    }
+    for (const [k, sub] of Object.entries(expected)) {
+      matchShapeAt(sub, actual[k], `${p}.${k}`, out);
+    }
+  }
+}
+
+// ---------- Config loader ----------
+
+export function normaliseTests(config) {
+  const defaults = config.defaults ?? {};
+  if (!Array.isArray(config.tests)) {
+    throw new Error(
+      `smoke-tests config invalid: missing "tests" array (got ${typeof config.tests})`,
+    );
+  }
+  return config.tests.map((t, idx) => {
+    if (!t.name || typeof t.name !== "string") {
+      throw new Error(`smoke-tests[${idx}]: missing or invalid "name"`);
+    }
+    if (!t.path || typeof t.path !== "string") {
+      throw new Error(`smoke-tests[${t.name}]: missing or invalid "path"`);
+    }
+    return {
+      name: t.name,
+      method: (t.method ?? defaults.method ?? "GET").toUpperCase(),
+      path: t.path,
+      expectedStatus: t.expectedStatus ?? defaults.expectedStatus ?? 200,
+      latencyBudgetMs: t.latencyBudgetMs ?? defaults.latencyBudgetMs ?? 2500,
+      timeoutMs: t.timeoutMs ?? defaults.timeoutMs ?? 8000,
+      auth: t.auth ?? "none",
+      tier: t.tier ?? "extended",
+      shape: t.shape,
+      expectedBodyContains: t.expectedBodyContains,
+      body: t.body,
+      headers: t.headers ?? {},
+      comment: t.comment,
+    };
+  });
+}
+
+export async function loadConfig(configPath) {
+  const raw = await readFile(configPath, "utf-8");
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`smoke-tests config invalid JSON: ${err.message}`);
+  }
+  return { config: parsed, tests: normaliseTests(parsed) };
+}
+
+// ---------- Filtering ----------
+
+export function filterTests(tests, { tier, only, skip }) {
+  let out = tests;
+  if (tier && tier !== "all") {
+    out = out.filter((t) => t.tier === tier);
+  }
+  if (only && only.length > 0) {
+    const allow = new Set(only);
+    out = out.filter((t) => allow.has(t.name));
+  }
+  if (skip && skip.length > 0) {
+    const deny = new Set(skip);
+    out = out.filter((t) => !deny.has(t.name));
+  }
+  return out;
+}
+
+// ---------- Verdict reducer ----------
+
+/**
+ * Reduces (statusOK, latencyMs, latencyBudgetMs, shapeDiff[], bodyContainsOK,
+ * fetchError, strict) → verdict ∈ {pass, warn, fail}.
+ *
+ *   - fetchError → fail
+ *   - statusOK=false → fail
+ *   - shapeDiff.length > 0 → fail
+ *   - expectedBodyContains miss → fail
+ *   - latency > budget * 2 → fail (severe overrun, even in non-strict mode)
+ *   - latency > budget → warn (under non-strict) / fail (under strict)
+ *   - else → pass
+ */
+export function decideVerdict({
+  statusOK,
+  latencyMs,
+  latencyBudgetMs,
+  shapeDiff = [],
+  bodyContainsOK = true,
+  fetchError = null,
+  strict = false,
+}) {
+  if (fetchError) return { verdict: "fail", reason: "fetch_error" };
+  if (!statusOK) return { verdict: "fail", reason: "status_mismatch" };
+  if (!bodyContainsOK)
+    return { verdict: "fail", reason: "body_contains_mismatch" };
+  if (shapeDiff.length > 0)
+    return { verdict: "fail", reason: "shape_mismatch" };
+  if (latencyMs > latencyBudgetMs * 2)
+    return { verdict: "fail", reason: "latency_severe_overrun" };
+  if (latencyMs > latencyBudgetMs)
+    return {
+      verdict: strict ? "fail" : "warn",
+      reason: "latency_over_budget",
+    };
+  return { verdict: "pass", reason: "ok" };
+}
+
+// ---------- HTTP runner ----------
+
+async function executeTest(test, { baseUrl, sessionCookie, strict }) {
+  const url = new URL(test.path, baseUrl).toString();
+  const headers = {
+    accept: "application/json",
+    "user-agent": "sergeant-post-deploy-smoke/1.0",
+    ...test.headers,
+  };
+  if (test.auth === "session" && sessionCookie) {
+    headers.cookie = sessionCookie;
+  }
+
+  const init = {
+    method: test.method,
+    headers,
+    signal: AbortSignal.timeout(test.timeoutMs),
+  };
+  if (test.body !== undefined && test.method !== "GET") {
+    init.body =
+      typeof test.body === "string" ? test.body : JSON.stringify(test.body);
+    headers["content-type"] = "application/json";
+  }
+
+  const startedAt = process.hrtime.bigint();
+  let res, text, fetchError;
+  try {
+    res = await fetch(url, init);
+    text = await res.text();
+  } catch (err) {
+    fetchError = err.message || String(err);
+  }
+  const latencyMs = Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+
+  if (fetchError) {
+    const verdict = decideVerdict({
+      statusOK: false,
+      latencyMs,
+      latencyBudgetMs: test.latencyBudgetMs,
+      fetchError,
+      strict,
+    });
+    return {
+      name: test.name,
+      url,
+      method: test.method,
+      expectedStatus: test.expectedStatus,
+      actualStatus: null,
+      latencyMs,
+      latencyBudgetMs: test.latencyBudgetMs,
+      bodyContainsOK: true,
+      ...verdict,
+      fetchError,
+    };
+  }
+
+  const statusOK = res.status === test.expectedStatus;
+  let shapeDiff = [];
+  let bodyContainsOK = true;
+  let parsedBody = null;
+  let bodySnippet = text.length > 200 ? text.slice(0, 197) + "…" : text;
+
+  if (test.expectedBodyContains) {
+    bodyContainsOK = text.includes(test.expectedBodyContains);
+  }
+
+  if (test.shape && statusOK) {
+    try {
+      parsedBody = JSON.parse(text);
+      shapeDiff = matchShape(test.shape, parsedBody);
+    } catch (err) {
+      shapeDiff = [
+        {
+          path: "$",
+          kind: "json_parse_error",
+          expected: "json",
+          actual: err.message,
+        },
+      ];
+    }
+  }
+
+  const verdict = decideVerdict({
+    statusOK,
+    latencyMs,
+    latencyBudgetMs: test.latencyBudgetMs,
+    shapeDiff,
+    bodyContainsOK,
+    strict,
+  });
+
+  return {
+    name: test.name,
+    url,
+    method: test.method,
+    expectedStatus: test.expectedStatus,
+    actualStatus: res.status,
+    latencyMs,
+    latencyBudgetMs: test.latencyBudgetMs,
+    shapeDiff,
+    bodyContainsOK,
+    bodySnippet,
+    ...verdict,
+  };
+}
+
+// ---------- Parallel orchestration ----------
+
+async function runWithConcurrency(items, concurrency, worker) {
+  const results = [];
+  let cursor = 0;
+  async function next() {
+    while (cursor < items.length) {
+      const idx = cursor++;
+      results[idx] = await worker(items[idx], idx);
+    }
+  }
+  const workers = Array.from(
+    { length: Math.min(concurrency, items.length) },
+    () => next(),
+  );
+  await Promise.all(workers);
+  return results;
+}
+
+// ---------- Reporters ----------
+
+const VERDICT_BADGE = {
+  pass: "✅",
+  warn: "⚠️",
+  fail: "❌",
+  skip: "⏭️",
+};
+
+export function renderMarkdown(results, { baseUrl, generatedAt }) {
+  const counts = { pass: 0, warn: 0, fail: 0, skip: 0 };
+  for (const r of results) counts[r.verdict] = (counts[r.verdict] ?? 0) + 1;
+  const lines = [];
+  lines.push(`# Post-deploy smoke report`);
+  lines.push("");
+  lines.push(`- **Base URL:** \`${baseUrl}\``);
+  lines.push(`- **Generated:** \`${generatedAt}\``);
+  lines.push(
+    `- **Summary:** ${counts.pass} pass / ${counts.warn} warn / ${counts.fail} fail / ${counts.skip} skip (total ${results.length})`,
+  );
+  lines.push("");
+  lines.push(`| Verdict | Test | Method | Path | Status | Latency | Reason |`);
+  lines.push(`| ------- | ---- | ------ | ---- | ------ | ------- | ------ |`);
+  for (const r of results) {
+    const badge = VERDICT_BADGE[r.verdict] ?? "?";
+    const status =
+      r.actualStatus != null
+        ? `${r.actualStatus}${r.expectedStatus != null && r.actualStatus !== r.expectedStatus ? ` (≠ ${r.expectedStatus})` : ""}`
+        : "—";
+    const latency =
+      r.latencyMs != null
+        ? `${r.latencyMs.toFixed(0)} ms${r.latencyBudgetMs ? ` (budget ${r.latencyBudgetMs})` : ""}`
+        : "—";
+    const pathOnly = (() => {
+      try {
+        return new URL(r.url).pathname + (new URL(r.url).search ?? "");
+      } catch {
+        return r.url;
+      }
+    })();
+    lines.push(
+      `| ${badge} \`${r.verdict}\` | \`${r.name}\` | \`${r.method ?? "?"}\` | \`${pathOnly}\` | ${status} | ${latency} | ${r.reason} |`,
+    );
+  }
+  const failures = results.filter((r) => r.verdict === "fail");
+  if (failures.length > 0) {
+    lines.push("");
+    lines.push(`## Failures (${failures.length})`);
+    lines.push("");
+    for (const f of failures) {
+      lines.push(`### ❌ \`${f.name}\` — ${f.reason}`);
+      lines.push("");
+      lines.push(`- URL: \`${f.url}\``);
+      if (f.fetchError) {
+        lines.push(`- Fetch error: \`${f.fetchError}\``);
+      }
+      if (f.expectedStatus != null) {
+        lines.push(
+          `- Expected status: \`${f.expectedStatus}\`, actual: \`${f.actualStatus ?? "—"}\``,
+        );
+      }
+      if (f.latencyMs != null) {
+        lines.push(
+          `- Latency: \`${f.latencyMs.toFixed(0)} ms\` (budget \`${f.latencyBudgetMs} ms\`)`,
+        );
+      }
+      if (f.shapeDiff && f.shapeDiff.length > 0) {
+        lines.push(`- Shape diffs:`);
+        for (const d of f.shapeDiff) {
+          lines.push(
+            `  - \`${d.path}\`: ${d.kind} (expected \`${d.expected}\`, actual \`${d.actual}\`)`,
+          );
+        }
+      }
+      if (f.bodyContainsOK === false) {
+        lines.push(`- Body did not contain the expected substring.`);
+      }
+      if (f.bodySnippet) {
+        lines.push("");
+        lines.push("```");
+        lines.push(f.bodySnippet);
+        lines.push("```");
+      }
+      lines.push("");
+    }
+  }
+  const warns = results.filter((r) => r.verdict === "warn");
+  if (warns.length > 0) {
+    lines.push("");
+    lines.push(`## Warnings (${warns.length})`);
+    lines.push("");
+    for (const w of warns) {
+      lines.push(
+        `- \`${w.name}\`: ${w.reason} — latency \`${w.latencyMs.toFixed(0)} ms\` exceeds budget \`${w.latencyBudgetMs} ms\` (≤2x; not fail-stop).`,
+      );
+    }
+  }
+  return lines.join("\n") + "\n";
+}
+
+export function renderJson(results, { baseUrl, generatedAt }) {
+  const counts = { pass: 0, warn: 0, fail: 0, skip: 0 };
+  for (const r of results) counts[r.verdict] = (counts[r.verdict] ?? 0) + 1;
+  return JSON.stringify(
+    {
+      baseUrl,
+      generatedAt,
+      counts,
+      total: results.length,
+      results,
+    },
+    null,
+    2,
+  );
+}
+
+// ---------- CLI entry ----------
+
+function parseArgs(argv) {
+  const out = {
+    baseUrl: null,
+    report: null,
+    json: null,
+    configPath: DEFAULT_CONFIG_PATH,
+    tier: "all",
+    only: [],
+    skip: [],
+    strict: false,
+    dryRun: false,
+    concurrency: 8,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    switch (a) {
+      case "--base-url":
+        out.baseUrl = argv[++i];
+        break;
+      case "--report":
+        out.report = argv[++i];
+        break;
+      case "--json":
+        out.json = argv[++i];
+        break;
+      case "--config":
+        out.configPath = argv[++i];
+        break;
+      case "--tier":
+        out.tier = argv[++i];
+        break;
+      case "--only":
+        out.only = (argv[++i] ?? "").split(",").filter(Boolean);
+        break;
+      case "--skip":
+        out.skip = (argv[++i] ?? "").split(",").filter(Boolean);
+        break;
+      case "--strict":
+        out.strict = true;
+        break;
+      case "--dry-run":
+        out.dryRun = true;
+        break;
+      case "--concurrency":
+        out.concurrency = Math.max(1, parseInt(argv[++i], 10) || 8);
+        break;
+      case "--help":
+      case "-h":
+        out.help = true;
+        break;
+      default:
+        if (a.startsWith("--")) {
+          throw new Error(`Unknown flag: ${a}`);
+        }
+    }
+  }
+  return out;
+}
+
+const HELP = `post-deploy-smoke — daily smoke checks against a deployed Sergeant server.
+
+Usage:
+  node scripts/post-deploy-smoke.mjs --base-url <url> [options]
+
+Required:
+  --base-url <url>     Target base URL (or $TARGET_BASE_URL / $STAGING_BASE_URL).
+
+Options:
+  --report <path>      Write markdown report (default: stdout).
+  --json <path>        Write JSON report.
+  --config <path>      Config file (default: scripts/smoke-tests.json).
+  --tier critical|extended|all   Filter by tier (default: all).
+  --only a,b,c         Run only these test names.
+  --skip a,b,c         Skip these test names.
+  --strict             Treat latency-over-budget warnings as failures.
+  --dry-run            Print plan, do not make HTTP calls.
+  --concurrency <n>    Max parallel requests (default: 8).
+`;
+
+export async function runMain(argv = process.argv.slice(2)) {
+  let args;
+  try {
+    args = parseArgs(argv);
+  } catch (err) {
+    process.stderr.write(`${err.message}\n${HELP}`);
+    return 2;
+  }
+  if (args.help) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+
+  const baseUrl =
+    args.baseUrl || process.env.TARGET_BASE_URL || process.env.STAGING_BASE_URL;
+  if (!baseUrl && !args.dryRun) {
+    process.stderr.write(
+      "Error: --base-url is required (or set TARGET_BASE_URL / STAGING_BASE_URL).\n",
+    );
+    return 2;
+  }
+
+  let loaded;
+  try {
+    loaded = await loadConfig(args.configPath);
+  } catch (err) {
+    process.stderr.write(`Config error: ${err.message}\n`);
+    return 2;
+  }
+
+  const tests = filterTests(loaded.tests, {
+    tier: args.tier,
+    only: args.only,
+    skip: args.skip,
+  });
+  if (tests.length === 0) {
+    process.stderr.write(
+      "No tests selected. Check --tier/--only/--skip flags.\n",
+    );
+    return 2;
+  }
+
+  const generatedAt = new Date().toISOString();
+  const sessionCookie = process.env.STAGING_SESSION_COOKIE || "";
+
+  if (args.dryRun) {
+    process.stdout.write(`Dry-run — ${tests.length} test(s) planned:\n`);
+    for (const t of tests) {
+      const authNote =
+        t.auth === "session"
+          ? sessionCookie
+            ? "auth=session(set)"
+            : "auth=session(MISSING — will run anonymously)"
+          : "auth=none";
+      process.stdout.write(
+        `  - ${t.name} [${t.tier}] ${t.method} ${t.path} expect=${t.expectedStatus} budget=${t.latencyBudgetMs}ms ${authNote}\n`,
+      );
+    }
+    return 0;
+  }
+
+  const results = await runWithConcurrency(tests, args.concurrency, (t) =>
+    executeTest(t, {
+      baseUrl,
+      sessionCookie,
+      strict: args.strict,
+    }),
+  );
+
+  const markdown = renderMarkdown(results, { baseUrl, generatedAt });
+  if (args.report) {
+    await mkdir(path.dirname(args.report), { recursive: true });
+    await writeFile(args.report, markdown, "utf-8");
+  }
+  process.stdout.write(markdown);
+  if (args.json) {
+    await mkdir(path.dirname(args.json), { recursive: true });
+    await writeFile(
+      args.json,
+      renderJson(results, { baseUrl, generatedAt }),
+      "utf-8",
+    );
+  }
+
+  const hasFail = results.some((r) => r.verdict === "fail");
+  return hasFail ? 1 : 0;
+}
+
+const isDirectInvocation =
+  import.meta.url === `file://${process.argv[1]}` ||
+  process.argv[1]?.endsWith("post-deploy-smoke.mjs");
+
+if (isDirectInvocation) {
+  runMain()
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      process.stderr.write(
+        `Unhandled error: ${err.stack ?? err.message ?? String(err)}\n`,
+      );
+      process.exit(2);
+    });
+}

--- a/scripts/smoke-tests.json
+++ b/scripts/smoke-tests.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "./smoke-tests.schema.md",
+  "description": "Post-deploy smoke-test config. Список critical-endpoint-ів, які запускає scripts/post-deploy-smoke.mjs після кожного deploy на staging/prod. Не редагуй цей файл руками без оновлення docs/testing/smoke-tests.md.",
+  "defaults": {
+    "timeoutMs": 8000,
+    "latencyBudgetMs": 2500,
+    "expectedStatus": 200,
+    "method": "GET"
+  },
+  "tests": [
+    {
+      "name": "liveness:livez",
+      "method": "GET",
+      "path": "/livez",
+      "expectedStatus": 200,
+      "latencyBudgetMs": 800,
+      "auth": "none",
+      "tier": "critical",
+      "shape": { "ok": "boolean" }
+    },
+    {
+      "name": "liveness:health-liveness-nested",
+      "method": "GET",
+      "path": "/health/liveness",
+      "expectedStatus": 200,
+      "latencyBudgetMs": 800,
+      "auth": "none",
+      "tier": "critical",
+      "shape": { "ok": "boolean" }
+    },
+    {
+      "name": "readiness:readyz",
+      "method": "GET",
+      "path": "/readyz",
+      "expectedStatus": 200,
+      "latencyBudgetMs": 1500,
+      "auth": "none",
+      "tier": "critical",
+      "shape": { "ok": "boolean" }
+    },
+    {
+      "name": "readiness:health-alias",
+      "method": "GET",
+      "path": "/health",
+      "expectedStatus": 200,
+      "latencyBudgetMs": 1500,
+      "auth": "none",
+      "tier": "critical",
+      "shape": { "ok": "boolean" }
+    },
+    {
+      "name": "startup:startupz",
+      "method": "GET",
+      "path": "/startupz",
+      "expectedStatus": 200,
+      "latencyBudgetMs": 800,
+      "auth": "none",
+      "tier": "critical",
+      "shape": { "ok": "boolean" }
+    },
+    {
+      "name": "diag:healthz",
+      "method": "GET",
+      "path": "/healthz",
+      "expectedStatus": 200,
+      "latencyBudgetMs": 2500,
+      "auth": "none",
+      "tier": "critical",
+      "shape": { "ok": "boolean", "db": "object" }
+    },
+    {
+      "name": "diag:health-workers",
+      "method": "GET",
+      "path": "/health/workers",
+      "expectedStatus": 200,
+      "latencyBudgetMs": 2500,
+      "auth": "none",
+      "tier": "extended",
+      "shape": { "ok": "boolean" }
+    },
+    {
+      "name": "diag:api-status",
+      "method": "GET",
+      "path": "/api/status",
+      "expectedStatus": 200,
+      "latencyBudgetMs": 2500,
+      "auth": "none",
+      "tier": "critical",
+      "shape": { "ok": "boolean" }
+    },
+    {
+      "name": "push:vapid-public",
+      "method": "GET",
+      "path": "/api/push/vapid-public",
+      "expectedStatus": 200,
+      "latencyBudgetMs": 1500,
+      "auth": "none",
+      "tier": "critical",
+      "shape": { "publicKey": "string" }
+    },
+    {
+      "name": "push:vapid-public-v1",
+      "method": "GET",
+      "path": "/api/v1/push/vapid-public",
+      "expectedStatus": 200,
+      "latencyBudgetMs": 1500,
+      "auth": "none",
+      "tier": "extended",
+      "shape": { "publicKey": "string" }
+    },
+    {
+      "name": "obs:metrics",
+      "method": "GET",
+      "path": "/metrics",
+      "expectedStatus": 200,
+      "latencyBudgetMs": 3000,
+      "auth": "none",
+      "tier": "extended",
+      "expectedBodyContains": "# HELP"
+    },
+    {
+      "name": "auth:me-anonymous-401",
+      "method": "GET",
+      "path": "/api/v1/me",
+      "expectedStatus": 401,
+      "latencyBudgetMs": 1500,
+      "auth": "none",
+      "tier": "critical",
+      "comment": "Запит без cookie має повертати 401 — це smoke-test самого auth-middleware-а. Зеленим smoke цей тест означає, що requireSession() не зламано і не пускає неавтентифіковані запити."
+    },
+    {
+      "name": "auth:me-session",
+      "method": "GET",
+      "path": "/api/v1/me",
+      "expectedStatus": 200,
+      "latencyBudgetMs": 2500,
+      "auth": "session",
+      "tier": "critical",
+      "shape": { "user": { "id": "string", "email": "string" } }
+    },
+    {
+      "name": "barcode:public-lookup",
+      "method": "GET",
+      "path": "/api/v1/barcode?barcode=4820010840443",
+      "expectedStatus": 200,
+      "latencyBudgetMs": 4000,
+      "auth": "session",
+      "tier": "extended",
+      "shape": { "product": "object" }
+    },
+    {
+      "name": "coach:memory-empty",
+      "method": "GET",
+      "path": "/api/v1/coach/memory",
+      "expectedStatus": 200,
+      "latencyBudgetMs": 2500,
+      "auth": "session",
+      "tier": "extended",
+      "shape": { "facts": "array" }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Post-deploy liveness checks. Complement to `pact-drift.yml` (#2737) — that catches **schema** regression; this catches **liveness** regression (5xx, timeout, latency SLO miss).

- `scripts/post-deploy-smoke.mjs` reads `scripts/smoke-tests.json` (15 critical endpoints across liveness / readiness / startup / push / metrics / auth / coach / barcode), fetches each against `$TARGET_BASE_URL` in parallel (concurrency=8), and emits a verdict per test:
  - **pass** — status + latency + shape all match.
  - **warn** — status + shape OK, latency between budget and 2×budget (informational; `--strict` flips to fail).
  - **fail** — status mismatch / latency > 2× budget / shape mismatch / fetch error. Real liveness regression.
- Two tiers in the config: **critical** (rollback-candidate on `deployment_status` trigger) + **extended** (informational).
- Workflow YAML inlined in `docs/testing/smoke-tests.md § Workflow YAML` (same OAuth-scope blocker as PR-42 #2675 and pact-drift #2737). Triggers: `workflow_dispatch` + `deployment_status` (success only) + `schedule: "30 6 * * *"` (06:30 UTC, 30 min after pact-drift so the issue lane is staggered). On failure → idempotent issue with label `smoke-test-fail` (mirrors `pact-drift.yml` / `db-backup-verify.yml`).

The shape-matcher uses a simple JSON-DSL (`"string"`, `"number?"`, `{key: shape}`, `[shape]`) so the config stays declarative — no Zod imports, no workspace-package coupling. Body-contains is supported for non-JSON endpoints (`/metrics`).

### Why the workflow YAML is inlined in the runbook

Same OAuth-scope blocker as PR-42 (#2675) and pact-drift (#2737). The git-manager rejects new files under `.github/workflows/` (`refusing to allow an OAuth App to create or update workflow … without 'workflow' scope`). The YAML lives verbatim in `docs/testing/smoke-tests.md § Workflow YAML` and can be pasted via the GitHub UI as a one-line follow-up.

## Governing Skill

- Primary skill: `.agents/skills/sergeant-server-api/SKILL.md` (endpoints + auth model live in `apps/server`).
- Secondary skill (if truly needed): none — this is a standalone CLI + workflow, no app source touched.

## Playbook

- Primary playbook: none — pattern is the established `db-backup-verify.yml` / `pact-drift.yml` (#2737) shape (idempotent issue + artifact upload + workflow_dispatch inputs).
- Why this playbook: structural mirror of an existing daily-cron + post-trigger workflow.
- If no playbook matched, why: this is a one-off CI surface. The runbook itself acts as the operational playbook for downstream triage.

## Verification

```bash
$ node --test scripts/__tests__/post-deploy-smoke.test.mjs
# 30 tests / 30 pass

$ node scripts/post-deploy-smoke.mjs --dry-run --tier critical
# prints planned 10 critical tests with budgets + auth mode, exit 0

$ node scripts/post-deploy-smoke.mjs --base-url http://127.0.0.1:1 --tier critical --concurrency 4
# all 10 tests fail with fetch_error (connection refused), exit 1
# proves the fetch-failure path correctly fails the run

$ pnpm prettier --check scripts/post-deploy-smoke.mjs scripts/__tests__/post-deploy-smoke.test.mjs scripts/smoke-tests.json docs/testing/smoke-tests.md
# All matched files use Prettier code style!

$ pnpm eslint scripts/post-deploy-smoke.mjs scripts/__tests__/post-deploy-smoke.test.mjs
# 0 problems
```

Additional checks:

- [x] Local smoke / manual validation completed (dry-run + fetch-failure scenarios above)
- [x] Surface-specific checks completed (30 unit tests cover `matchShape` primitives/objects/arrays/optional fields/null-vs-string/object-vs-array, `decideVerdict` reducer with all 7 verdict branches, `normaliseTests` defaults + rejection paths, `filterTests` tier/only/skip selection, `renderMarkdown` counts header)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update — no (root AGENTS.md does not enumerate per-cron workflows; the runbook is the right home).
- [x] I checked whether a playbook or skill needed an update — runbook itself is the operational playbook for this surface.
- [x] I checked whether governance docs or review docs needed an update — no.

Updated docs:

- `docs/testing/smoke-tests.md` — new file. TL;DR table, verdict semantics, workflow walkthrough, secret setup (`STAGING_BASE_URL`, `STAGING_SESSION_COOKIE`), local dry-run, triage playbook, comparison with pact-drift, workflow-YAML appendix.

## Risk and Rollout

- **User-visible risk:** none — this is a CI-only addition. The cron does not gate per-PR merges.
- **Rollout / deploy order:**
  1. Merge this PR (script + config + runbook land; workflow does NOT auto-deploy due to OAuth-scope blocker).
  2. Owner (`@Skords-01`) pastes the YAML from `docs/testing/smoke-tests.md § Workflow YAML` into `.github/workflows/post-deploy-smoke.yml` via GH UI (≤2 min task).
  3. Owner adds GH secrets `STAGING_BASE_URL` (required) and `STAGING_SESSION_COOKIE` (optional — without it, `auth: session` tests run anonymously, which is still a valid 401-smoke).
  4. First scheduled run at next 06:30 UTC; or trigger immediately via `workflow_dispatch`. After this, every successful `deployment_status` event will also run the smoke.
- **Backout plan:** disable the workflow from the GH Actions UI; delete the workflow file. No DB / runtime side-effects to undo — the script is read-only against the target (default config has zero mutation endpoints).

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian (`docs/testing/smoke-tests.md`).
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files. `docs/testing/smoke-tests.md` lives under `docs/testing/` (sibling of `docs/testing/pact-drift-runbook.md` from #2737, `docs/testing/README.md`, `2026-05-05-tests-pr-plan.md`, `2026-05-05-tests-review.md`) — that path is not in the freeze allowlist.

## Reviewer Notes

- The workflow YAML in the runbook is the **canonical source of truth** until the OAuth-scope blocker is resolved. Once `.github/workflows/post-deploy-smoke.yml` is committed, please keep them in sync (or delete the inline copy and link to the file path).
- The HTTP runner is deliberately NOT unit-tested. Mocking `fetch` + `AbortSignal.timeout` + `process.hrtime.bigint` would lock down implementation details without adding regression coverage; the script's CI value comes from running against live deployments. If you'd prefer test coverage, I can add a `node:test` `mock`-based suite — flag if needed.
- The config currently covers 15 endpoints (10 critical + 5 extended). Easy to extend — see `docs/testing/smoke-tests.md § Як додати новий тест`. To rollback-gate on a new endpoint, add it with `"tier": "critical"`.
- Mutation endpoints (POST/PUT/PATCH/DELETE) are intentionally absent. Adding `POST /api/auth/sign-in` smoke would require a dedicated test-user with rotated password — flagged as a future extension in the runbook.
- Verdict ordering inside `decideVerdict` is significant: fetch_error → status → body-contains → shape → latency. Tests lock this ordering in.


Link to Devin session: https://app.devin.ai/sessions/2765108a015c48038fe4a3bbfd851a0c

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add post-deploy smoke tests to catch liveness regressions right after deploys (status, latency SLOs, and response shape). Includes a CLI runner, config for 15 endpoints, unit tests, and a runbook with the workflow YAML.

- **New Features**
  - `scripts/post-deploy-smoke.mjs` reads `scripts/smoke-tests.json`, hits endpoints in parallel (concurrency=8), and checks status + latency budgets + JSON shape/body-contains.
  - Verdicts: pass, warn (1–2× budget; `--strict` => fail), fail (>2× budget, status/shape mismatch, or fetch error).
  - Two tiers: `critical` (rollback candidate on `deployment_status`) and `extended` (informational). Creates/refreshes an idempotent `smoke-test-fail` issue and uploads a markdown/JSON report.
  - Triggers covered in the runbook: `workflow_dispatch`, `deployment_status` (success-only), and daily `06:30 UTC` cron. 30 unit tests cover shape matching, verdicts, filtering, and rendering.

- **Migration**
  - Paste the YAML from `docs/testing/smoke-tests.md` (§ Workflow YAML) into `.github/workflows/post-deploy-smoke.yml`.
  - Add GitHub secrets: `STAGING_BASE_URL` (required) and `STAGING_SESSION_COOKIE` (optional).
  - Run via Actions (`workflow_dispatch`), on successful `deployment_status`, or wait for the 06:30 UTC scheduled run.

<sup>Written for commit 07c6eb66463fb4d5a6ce10ddcda5ec56eb5237a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

