### PR TITLE
feat(server): /ai_cost &lt;days&gt; trending з sparkline (Anthropic per-day)

### DIFF
--- a/apps/server/src/modules/openclaw/aiCostSummary.test.ts
+++ b/apps/server/src/modules/openclaw/aiCostSummary.test.ts
@@ -13,13 +13,16 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   buildAiCostSummary,
   fetchAnthropicCostsForRange,
+  fetchAnthropicDailyTrend,
   fetchTopEndpointsFromProm,
   fetchVoyageCumulativeFromProm,
   kyivDayKey,
+  kyivDayMinus,
   kyivDaysInMonth,
   kyivMonthEnd,
   kyivMonthStart,
   kyivWeekStart,
+  MAX_TREND_DAYS,
 } from "./aiCostSummary.js";
 
 function makePool(rows: unknown[] | (() => unknown[])) {
@@ -336,5 +339,256 @@ describe("buildAiCostSummary — end-to-end", () => {
     });
     expect(result.topEndpoints).toHaveLength(2);
     expect(result.topEndpoints[0]?.endpoint).toBe("chat");
+  });
+});
+
+describe("kyivDayMinus", () => {
+  it("вираховує (today − 6) → день тижня-тому", () => {
+    expect(kyivDayMinus("2026-05-13", 6)).toBe("2026-05-07");
+  });
+
+  it("(today − 0) повертає той самий день", () => {
+    expect(kyivDayMinus("2026-05-13", 0)).toBe("2026-05-13");
+  });
+
+  it("перехід через місячну границю (1-ше → попередній місяць)", () => {
+    expect(kyivDayMinus("2026-05-01", 1)).toBe("2026-04-30");
+    expect(kyivDayMinus("2026-03-01", 1)).toBe("2026-02-28");
+    expect(kyivDayMinus("2024-03-01", 1)).toBe("2024-02-29"); // високосний
+  });
+
+  it("(today − 29) → 30-day window start", () => {
+    expect(kyivDayMinus("2026-05-13", 29)).toBe("2026-04-14");
+  });
+
+  it("MAX_TREND_DAYS = 30 (sanity)", () => {
+    expect(MAX_TREND_DAYS).toBe(30);
+  });
+});
+
+describe("fetchAnthropicDailyTrend — SQL shape + zero-fill", () => {
+  it("формує per-day GROUP BY usage_day + ORDER ASC", async () => {
+    const { pool, queryMock } = makePool([
+      {
+        usage_day: "2026-05-11",
+        request_count: "5",
+        input_tokens: "10000",
+        output_tokens: "3000",
+        total_tokens: "13000",
+        est_cost_usd: "0.105",
+      },
+      {
+        usage_day: "2026-05-13",
+        request_count: "12",
+        input_tokens: "30000",
+        output_tokens: "10000",
+        total_tokens: "40000",
+        est_cost_usd: "0.32",
+      },
+    ]);
+
+    const result = await fetchAnthropicDailyTrend(
+      pool,
+      "2026-05-11",
+      "2026-05-13",
+    );
+    expect(queryMock).toHaveBeenCalledTimes(1);
+    const call = queryMock.mock.calls[0] as unknown as [string, unknown[]];
+    const sql = call[0];
+    const params = call[1];
+    expect(sql).toMatch(/SUM\(est_cost_usd\)/);
+    expect(sql).toMatch(/subject_key = 'provider:anthropic'/);
+    expect(sql).toMatch(/bucket LIKE 'anthropic:%'/);
+    expect(sql).toMatch(/GROUP BY usage_day/);
+    expect(sql).toMatch(/ORDER BY usage_day ASC/);
+    expect(params).toEqual(["2026-05-11", "2026-05-13"]);
+
+    expect(result).toHaveLength(3);
+    expect(result[0]?.day).toBe("2026-05-11");
+    expect(result[0]?.totalCostUsd).toBeCloseTo(0.105, 6);
+    // 2026-05-12 — gap, заповнюється нулями.
+    expect(result[1]?.day).toBe("2026-05-12");
+    expect(result[1]?.totalCostUsd).toBe(0);
+    expect(result[1]?.requestCount).toBe(0);
+    expect(result[1]?.totalTokens).toBe(0);
+    expect(result[2]?.day).toBe("2026-05-13");
+    expect(result[2]?.totalCostUsd).toBeCloseTo(0.32, 6);
+  });
+
+  it("парсить usage_day у вигляді Date-об'єкта (pg DATE driver)", async () => {
+    const { pool } = makePool([
+      {
+        usage_day: new Date(Date.parse("2026-05-13T00:00:00Z")),
+        request_count: "1",
+        input_tokens: "100",
+        output_tokens: "50",
+        total_tokens: "150",
+        est_cost_usd: "0.01",
+      },
+    ]);
+    const result = await fetchAnthropicDailyTrend(
+      pool,
+      "2026-05-13",
+      "2026-05-13",
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]?.day).toBe("2026-05-13");
+    expect(result[0]?.totalCostUsd).toBeCloseTo(0.01, 6);
+  });
+
+  it("пустий range → всі дні нульові (zero-fill, no rows)", async () => {
+    const { pool } = makePool([]);
+    const result = await fetchAnthropicDailyTrend(
+      pool,
+      "2026-05-07",
+      "2026-05-13",
+    );
+    expect(result).toHaveLength(7);
+    expect(result.every((p) => p.totalCostUsd === 0)).toBe(true);
+    expect(result[0]?.day).toBe("2026-05-07");
+    expect(result[6]?.day).toBe("2026-05-13");
+  });
+});
+
+describe("buildAiCostSummary — trend block", () => {
+  beforeEach(async () => {
+    const { register } = await import("../../obs/metrics.js");
+    register.resetMetrics();
+  });
+
+  it("без trendDays → trend property відсутня", async () => {
+    const queryMock = vi.fn(async () => ({ rows: [], rowCount: 0 }));
+    const now = new Date(Date.parse("2026-05-13T06:00:00Z"));
+    const result = await buildAiCostSummary({
+      pool: { query: queryMock } as never,
+      now,
+      budget: { anthropicMonthlyBudgetUsd: 0, voyageMonthlyBudgetUsd: 0 },
+    });
+    expect(result.trend).toBeUndefined();
+  });
+
+  it("trendDays=7 → fetch 4-й query (per-day trend), повертає points за range", async () => {
+    // Послідовність queryMock: today, week, monthSoFar, trend.
+    const todayRows: unknown[] = [];
+    const weekRows: unknown[] = [];
+    const monthRows: unknown[] = [];
+    const trendRows = [
+      {
+        usage_day: "2026-05-09",
+        request_count: "2",
+        input_tokens: "5000",
+        output_tokens: "1000",
+        total_tokens: "6000",
+        est_cost_usd: "0.04",
+      },
+      {
+        usage_day: "2026-05-13",
+        request_count: "10",
+        input_tokens: "20000",
+        output_tokens: "8000",
+        total_tokens: "28000",
+        est_cost_usd: "0.21",
+      },
+    ];
+    let callCount = 0;
+    const queryMock = vi.fn(async (sql: string) => {
+      callCount += 1;
+      // 4-та query — той що містить "GROUP BY usage_day".
+      if (sql.includes("GROUP BY usage_day")) {
+        return { rows: trendRows, rowCount: trendRows.length };
+      }
+      // інакше — за порядком: today, week, month
+      const periodRows = [todayRows, weekRows, monthRows][callCount - 1] ?? [];
+      return { rows: periodRows, rowCount: periodRows.length };
+    });
+    const now = new Date(Date.parse("2026-05-13T06:00:00Z"));
+    const result = await buildAiCostSummary({
+      pool: { query: queryMock } as never,
+      now,
+      budget: { anthropicMonthlyBudgetUsd: 50, voyageMonthlyBudgetUsd: 10 },
+      trendDays: 7,
+    });
+    expect(queryMock).toHaveBeenCalledTimes(4);
+    expect(result.trend).toBeDefined();
+    expect(result.trend?.days).toBe(7);
+    expect(result.trend?.startDay).toBe("2026-05-07");
+    expect(result.trend?.endDay).toBe("2026-05-13");
+    expect(result.trend?.points).toHaveLength(7);
+    expect(result.trend?.totalCostUsd).toBeCloseTo(0.25, 6);
+    expect(result.trend?.totalTokens).toBe(34_000);
+    // 2026-05-09 — точка з DB; 2026-05-08 — zero-filled gap
+    const may09 = result.trend?.points.find((p) => p.day === "2026-05-09");
+    expect(may09?.totalCostUsd).toBeCloseTo(0.04, 6);
+    const may08 = result.trend?.points.find((p) => p.day === "2026-05-08");
+    expect(may08?.totalCostUsd).toBe(0);
+  });
+
+  it("trendDays > MAX_TREND_DAYS → clamp до MAX_TREND_DAYS", async () => {
+    const queryMock = vi.fn(async () => ({ rows: [], rowCount: 0 }));
+    const now = new Date(Date.parse("2026-05-13T06:00:00Z"));
+    const result = await buildAiCostSummary({
+      pool: { query: queryMock } as never,
+      now,
+      budget: { anthropicMonthlyBudgetUsd: 0, voyageMonthlyBudgetUsd: 0 },
+      trendDays: 999,
+    });
+    expect(result.trend?.days).toBe(MAX_TREND_DAYS);
+    expect(result.trend?.startDay).toBe("2026-04-14"); // 2026-05-13 − 29
+    expect(result.trend?.endDay).toBe("2026-05-13");
+    expect(result.trend?.points).toHaveLength(MAX_TREND_DAYS);
+  });
+
+  it("trendDays=0/негативний → clamp до 1 (single-day)", async () => {
+    const queryMock = vi.fn(async () => ({ rows: [], rowCount: 0 }));
+    const now = new Date(Date.parse("2026-05-13T06:00:00Z"));
+    const result = await buildAiCostSummary({
+      pool: { query: queryMock } as never,
+      now,
+      budget: { anthropicMonthlyBudgetUsd: 0, voyageMonthlyBudgetUsd: 0 },
+      trendDays: 0,
+    });
+    expect(result.trend?.days).toBe(1);
+    expect(result.trend?.startDay).toBe("2026-05-13");
+    expect(result.trend?.endDay).toBe("2026-05-13");
+    expect(result.trend?.points).toHaveLength(1);
+  });
+
+  it("fail-soft: trend query кидає → trend block з усіма нулями (не зриває весь reply)", async () => {
+    const queryMock = vi.fn(async (sql: string) => {
+      if (sql.includes("GROUP BY usage_day")) {
+        throw new Error("connection refused");
+      }
+      return { rows: [], rowCount: 0 };
+    });
+    const now = new Date(Date.parse("2026-05-13T06:00:00Z"));
+    const result = await buildAiCostSummary({
+      pool: { query: queryMock } as never,
+      now,
+      budget: { anthropicMonthlyBudgetUsd: 0, voyageMonthlyBudgetUsd: 0 },
+      trendDays: 7,
+    });
+    expect(result.trend).toBeDefined();
+    expect(result.trend?.points).toHaveLength(7);
+    expect(result.trend?.totalCostUsd).toBe(0);
+    expect(result.trend?.points.every((p) => p.totalCostUsd === 0)).toBe(true);
+  });
+
+  it("trendDays=NaN/Infinity → trend property відсутня (skip)", async () => {
+    const queryMock = vi.fn(async () => ({ rows: [], rowCount: 0 }));
+    const now = new Date(Date.parse("2026-05-13T06:00:00Z"));
+    const resultNaN = await buildAiCostSummary({
+      pool: { query: queryMock } as never,
+      now,
+      budget: { anthropicMonthlyBudgetUsd: 0, voyageMonthlyBudgetUsd: 0 },
+      trendDays: Number.NaN,
+    });
+    expect(resultNaN.trend).toBeUndefined();
+    const resultInf = await buildAiCostSummary({
+      pool: { query: queryMock } as never,
+      now,
+      budget: { anthropicMonthlyBudgetUsd: 0, voyageMonthlyBudgetUsd: 0 },
+      trendDays: Number.POSITIVE_INFINITY,
+    });
+    expect(resultInf.trend).toBeUndefined();
   });
 });

--- a/apps/server/src/modules/openclaw/aiCostSummary.ts
+++ b/apps/server/src/modules/openclaw/aiCostSummary.ts
@@ -74,6 +74,35 @@ export interface VoyageSnapshot {
   cumulativeSinceRestartUsd: number;
 }
 
+/**
+ * Один день у trend-серії — Anthropic-only (Voyage не пишеться у
+ * `ai_usage_daily`; для Voyage показуємо лише cumulative since restart).
+ */
+export interface DailyCostPoint {
+  /** Kyiv-day `YYYY-MM-DD`. */
+  day: string;
+  totalCostUsd: number;
+  totalTokens: number;
+  requestCount: number;
+}
+
+export interface AnthropicTrendBlock {
+  /** Скільки днів запросили (1..MAX_TREND_DAYS). */
+  days: number;
+  /** Inclusive [startDay, endDay] Kyiv-day window. */
+  startDay: string;
+  endDay: string;
+  /**
+   * Per-day Anthropic-rollup, відсортований ASCENDING by day. Дні, у яких
+   * нічого не витрачали, заповнені нулями (zero-fill) — щоб sparkline
+   * мав стабільну ширину = days.
+   */
+  points: ReadonlyArray<DailyCostPoint>;
+  /** Сума всіх `points[i].totalCostUsd`. */
+  totalCostUsd: number;
+  totalTokens: number;
+}
+
 export interface AiCostSummary {
   /** Момент генерації (UTC ISO). */
   generatedAt: string;
@@ -91,6 +120,12 @@ export interface AiCostSummary {
   voyage: VoyageSnapshot;
   /** Бюджет із env-конфігу. */
   budget: BudgetSnapshot;
+  /**
+   * Anthropic per-day trend — populated тільки коли caller передав
+   * `trendDays >= 1`. Voyage у trend-і не присутній — він не пишеться
+   * у `ai_usage_daily` (PR-12), тому historical breakdown недоступний.
+   */
+  trend?: AnthropicTrendBlock;
   /**
    * Run-rate (today_spent / day_of_month_so_far × days_in_month). 0 коли
    * day_of_month=1 і spent=0 — щоб projection не показував Infinity.
@@ -213,6 +248,43 @@ function modelFromBucket(bucket: string): string {
   return bucket;
 }
 
+/** Max-cap для `<days>` arg у `/ai_cost`. 30 = 1 month rolling window. */
+export const MAX_TREND_DAYS = 30;
+
+/**
+ * Zero-fill helper для trend-points: будує безперервний day-range між
+ * `startDay`..`endDay` (inclusive, Kyiv).
+ */
+function enumerateKyivDayRange(
+  startDay: string,
+  endDay: string,
+): ReadonlyArray<string> {
+  const out: string[] = [];
+  const start = parseKyivDay(startDay);
+  const end = parseKyivDay(endDay);
+  // Через UTC-noon (як kyivDayToUtcDate) — стабільно для DST-edge-кейсів.
+  let cursor = new Date(
+    Date.UTC(start.year, start.month - 1, start.day, 12, 0, 0),
+  );
+  const last = new Date(Date.UTC(end.year, end.month - 1, end.day, 12, 0, 0));
+  // Hard-cap на 366 ітерацій (один рік) — захист від caller-bug-у.
+  for (let i = 0; i < 366 && cursor.getTime() <= last.getTime(); i++) {
+    out.push(kyivDayKey(cursor));
+    cursor = new Date(cursor.getTime() + 86_400_000);
+  }
+  return out;
+}
+
+/**
+ * Повертає Kyiv-день за (todayKyiv − N днів). `N=0` ⇒ той самий день.
+ */
+export function kyivDayMinus(todayKyiv: string, n: number): string {
+  const { year, month, day } = parseKyivDay(todayKyiv);
+  const base = new Date(Date.UTC(year, month - 1, day, 12, 0, 0));
+  base.setUTCDate(base.getUTCDate() - n);
+  return kyivDayKey(base);
+}
+
 /**
  * Зчитує per-model aggregate за inclusive Kyiv-day range. Підсумовує
  * `ai_usage_daily` рядки із `subject_key='provider:anthropic'` і
@@ -250,6 +322,72 @@ export async function fetchAnthropicCostsForRange(
   const totalCostUsd = models.reduce((acc, m) => acc + m.estCostUsd, 0);
   const totalTokens = models.reduce((acc, m) => acc + m.totalTokens, 0);
   return { startDay, endDay, models, totalCostUsd, totalTokens };
+}
+
+interface AnthropicDailyTrendRow {
+  usage_day: string | Date;
+  request_count: string | number;
+  input_tokens: string | number;
+  output_tokens: string | number;
+  total_tokens: string | number;
+  est_cost_usd: string | number;
+}
+
+function kyivDayFromUsageDay(value: string | Date): string {
+  if (value instanceof Date) {
+    // pg повертає DATE як Date у local-time-zone; беремо лише ISO date part.
+    return kyivDayKey(value);
+  }
+  // DATE-як-string («2026-05-13») — beraемо як є.
+  return String(value).slice(0, 10);
+}
+
+/**
+ * Per-day Anthropic rollup для trend-series. Zero-fill: дні без рядків
+ * у `ai_usage_daily` додаються з нулями (потрібно для sparkline-ширини).
+ * Single SQL query через `GROUP BY usage_day`, JS заповнює gap-и.
+ */
+export async function fetchAnthropicDailyTrend(
+  pool: Pool,
+  startDay: string,
+  endDay: string,
+): Promise<ReadonlyArray<DailyCostPoint>> {
+  const result = await pool.query<AnthropicDailyTrendRow>(
+    `SELECT usage_day,
+            SUM(request_count)::bigint AS request_count,
+            SUM(input_tokens)::bigint  AS input_tokens,
+            SUM(output_tokens)::bigint AS output_tokens,
+            SUM(total_tokens)::bigint  AS total_tokens,
+            SUM(est_cost_usd)::numeric AS est_cost_usd
+       FROM ai_usage_daily
+      WHERE subject_key = 'provider:anthropic'
+        AND bucket LIKE 'anthropic:%'
+        AND usage_day >= $1::date
+        AND usage_day <= $2::date
+      GROUP BY usage_day
+      ORDER BY usage_day ASC`,
+    [startDay, endDay],
+  );
+  const byDay = new Map<string, DailyCostPoint>();
+  for (const row of result.rows) {
+    const day = kyivDayFromUsageDay(row.usage_day);
+    byDay.set(day, {
+      day,
+      requestCount: toNumber(row.request_count),
+      totalCostUsd: toNumber(row.est_cost_usd),
+      totalTokens: toNumber(row.total_tokens),
+    });
+  }
+  const allDays = enumerateKyivDayRange(startDay, endDay);
+  return allDays.map(
+    (day) =>
+      byDay.get(day) ?? {
+        day,
+        totalCostUsd: 0,
+        totalTokens: 0,
+        requestCount: 0,
+      },
+  );
 }
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -339,6 +477,13 @@ export interface BuildAiCostSummaryInput {
   /** Inject-имо щоб тести могли заморозити час. */
   now?: Date;
   budget: BudgetSnapshot;
+  /**
+   * Опційний trend window для `/ai_cost <days>`. `undefined` (default) — без
+   * trend-блоку (legacy behaviour). 1..30 — Anthropic-only per-day series.
+   * Caller відповідає за валідацію boundary; за value-том більш-30 буде
+   * `Math.min(days, MAX_TREND_DAYS)`.
+   */
+  trendDays?: number;
 }
 
 /**
@@ -349,6 +494,7 @@ export async function buildAiCostSummary({
   pool,
   now = new Date(),
   budget,
+  trendDays,
 }: BuildAiCostSummaryInput): Promise<AiCostSummary> {
   const todayKyiv = kyivDayKey(now);
   const weekStart = kyivWeekStart(todayKyiv);
@@ -374,13 +520,58 @@ export async function buildAiCostSummary({
     }
   }
 
-  const [today, week, monthSoFar, topEndpoints, voyage] = await Promise.all([
-    safeFetch(todayKyiv, todayKyiv),
-    safeFetch(weekStart, todayKyiv),
-    safeFetch(monthStart, todayKyiv),
-    fetchTopEndpointsFromProm(3),
-    fetchVoyageCumulativeFromProm(),
-  ]);
+  const trendDaysClamped =
+    typeof trendDays === "number" && Number.isFinite(trendDays)
+      ? Math.max(1, Math.min(MAX_TREND_DAYS, Math.floor(trendDays)))
+      : null;
+
+  async function safeFetchTrend(
+    days: number,
+  ): Promise<AnthropicTrendBlock | undefined> {
+    const startDay = kyivDayMinus(todayKyiv, days - 1);
+    try {
+      const points = await fetchAnthropicDailyTrend(pool, startDay, todayKyiv);
+      const totalCostUsd = points.reduce((acc, p) => acc + p.totalCostUsd, 0);
+      const totalTokens = points.reduce((acc, p) => acc + p.totalTokens, 0);
+      return {
+        days,
+        startDay,
+        endDay: todayKyiv,
+        points,
+        totalCostUsd,
+        totalTokens,
+      };
+    } catch {
+      // Partial-failure: повертаємо порожній trend-block (zero-fill за range)
+      // — UI відрендерить «no data» line замість зривати весь reply.
+      const points = enumerateKyivDayRange(startDay, todayKyiv).map((day) => ({
+        day,
+        totalCostUsd: 0,
+        totalTokens: 0,
+        requestCount: 0,
+      }));
+      return {
+        days,
+        startDay,
+        endDay: todayKyiv,
+        points,
+        totalCostUsd: 0,
+        totalTokens: 0,
+      };
+    }
+  }
+
+  const [today, week, monthSoFar, topEndpoints, voyage, trend] =
+    await Promise.all([
+      safeFetch(todayKyiv, todayKyiv),
+      safeFetch(weekStart, todayKyiv),
+      safeFetch(monthStart, todayKyiv),
+      fetchTopEndpointsFromProm(3),
+      fetchVoyageCumulativeFromProm(),
+      trendDaysClamped !== null
+        ? safeFetchTrend(trendDaysClamped)
+        : Promise.resolve(undefined),
+    ]);
 
   const { day: domToday } = parseKyivDay(todayKyiv);
   const daysInMonth = kyivDaysInMonth(todayKyiv);
@@ -404,6 +595,7 @@ export async function buildAiCostSummary({
       daysElapsedInMonth,
       daysInMonth,
     },
+    ...(trend ? { trend } : {}),
   };
 }
 

--- a/apps/server/src/modules/openclaw/index.ts
+++ b/apps/server/src/modules/openclaw/index.ts
@@ -24,18 +24,23 @@ export { checkDailyBudget, estimateClaudeSonnetCostUsd } from "./budget.js";
 export {
   buildAiCostSummary,
   fetchAnthropicCostsForRange,
+  fetchAnthropicDailyTrend,
   fetchTopEndpointsFromProm,
   fetchVoyageCumulativeFromProm,
   kyivDayKey,
+  kyivDayMinus,
   kyivWeekStart,
   kyivMonthStart,
   kyivMonthEnd,
   kyivDaysInMonth,
+  MAX_TREND_DAYS,
 } from "./aiCostSummary.js";
 export type {
   AiCostSummary,
+  AnthropicTrendBlock,
   BudgetSnapshot,
   BuildAiCostSummaryInput,
+  DailyCostPoint,
   EndpointCostRow,
   ModelCostBreakdown,
   PeriodCostSummary,

--- a/apps/server/src/routes/internal/openclaw.ts
+++ b/apps/server/src/routes/internal/openclaw.ts
@@ -43,6 +43,7 @@ import {
 } from "../../modules/ai-memory/forget.js";
 import {
   buildAiCostSummary,
+  MAX_TREND_DAYS,
   checkDailyBudget,
   finalizeInvocation,
   listRecentDecisions,
@@ -211,6 +212,16 @@ const ForgetCancelBody = z
 const StrategyBody = z.object({
   path: z.string().min(1).max(500),
 });
+
+// `/ai_cost <days>` — optional trend-window. Порожнє body беремо як
+// legacy `/ai_cost` (без trend); `trendDays: 1..30` — включає
+// Anthropic per-day series. Object loose-mode — forward-compat для
+// майбутніх параметрів (e.g. provider filter).
+const AiCostSummaryBody = z
+  .object({
+    trendDays: z.number().int().min(1).max(MAX_TREND_DAYS).optional(),
+  })
+  .strict();
 
 const QueryBody = z.object({
   sql: z.string().min(1).max(8000),
@@ -956,17 +967,24 @@ export function createOpenClawInternalRouter({ pool }: { pool: Pool }): Router {
   //     `ai_cost_estimate_usd_total` (since process restart).
   //   - Budget envelopes — `ANTHROPIC_MONTHLY_BUDGET_USD` /
   //     `VOYAGE_MONTHLY_BUDGET_USD` env-vars (PR-13 #2590).
-  // Body порожній — endpoint без аргументів, founder-bound по
-  // internal-API-bearer guard.
+  //
+  // Body: optional `{ trendDays?: 1..30 }` — включає per-day Anthropic
+  // trend-block (для `/ai_cost <N>` UI). Без trendDays — legacy shape
+  // (today/week/month).
   r.post(
     "/api/internal/openclaw/ai-cost-summary",
-    asyncHandler(async (_req, res) => {
+    asyncHandler(async (req, res) => {
+      const parsed = validateBody(AiCostSummaryBody, req, res);
+      if (!parsed.ok) return;
       const summary = await buildAiCostSummary({
         pool,
         budget: {
           anthropicMonthlyBudgetUsd: env.ANTHROPIC_MONTHLY_BUDGET_USD,
           voyageMonthlyBudgetUsd: env.VOYAGE_MONTHLY_BUDGET_USD,
         },
+        ...(parsed.data.trendDays !== undefined
+          ? { trendDays: parsed.data.trendDays }
+          : {}),
       });
       res.json(summary);
     }),

--- a/tools/openclaw/src/openclaw/aiCostFormat.test.ts
+++ b/tools/openclaw/src/openclaw/aiCostFormat.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect } from "vitest";
 import {
   formatAiCostMarkdown,
+  sparkline,
   type AiCostSummaryResponse,
 } from "./aiCostFormat.js";
 
@@ -226,5 +227,148 @@ describe("formatAiCostMarkdown — edge cases", () => {
     const out = formatAiCostMarkdown(summary);
     expect(out).toContain("<b>Сьогодні:</b> $0.00");
     expect(out).not.toContain("tokens, 0 requests");
+  });
+});
+
+describe("sparkline", () => {
+  it("порожній array → порожній рядок", () => {
+    expect(sparkline([])).toBe("");
+  });
+
+  it("всі нулі → N×▁", () => {
+    expect(sparkline([0, 0, 0, 0])).toBe("▁▁▁▁");
+  });
+
+  it("одне ненульове значення → █ у тій позиції, ▁ — у решті", () => {
+    expect(sparkline([0, 0, 5, 0])).toBe("▁▁█▁");
+  });
+
+  it("monotonically ascending → останній символ █", () => {
+    const out = sparkline([1, 2, 3, 4, 5, 6, 7, 8]);
+    expect(out).toHaveLength(8);
+    expect(out.endsWith("█")).toBe(true);
+    expect(out.startsWith("▁")).toBe(true);
+  });
+
+  it("монотонно descending → перший символ █", () => {
+    const out = sparkline([10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+    expect(out.startsWith("█")).toBe(true);
+  });
+
+  it("negative/NaN values clamp до 0", () => {
+    expect(sparkline([-1, NaN, 0, 4])).toBe("▁▁▁█");
+  });
+
+  it("два рівних max-и обидва рендеряться як █", () => {
+    expect(sparkline([1, 5, 5, 1])).toBe("▁██▁");
+  });
+});
+
+describe("formatAiCostMarkdown — trend block", () => {
+  it("без trend property → reply не містить trend-section", () => {
+    const out = formatAiCostMarkdown(makeSummary());
+    expect(out).not.toContain("<b>Trend");
+    expect(out).not.toContain("trend = Anthropic-only");
+  });
+
+  it("з trend (7 днів) → містить header + sparkline + per-day rows", () => {
+    const points = [
+      {
+        day: "2026-05-07",
+        totalCostUsd: 0.2,
+        totalTokens: 50_000,
+        requestCount: 3,
+      },
+      { day: "2026-05-08", totalCostUsd: 0.0, totalTokens: 0, requestCount: 0 },
+      {
+        day: "2026-05-09",
+        totalCostUsd: 0.45,
+        totalTokens: 110_000,
+        requestCount: 7,
+      },
+      {
+        day: "2026-05-10",
+        totalCostUsd: 0.8,
+        totalTokens: 180_000,
+        requestCount: 12,
+      },
+      {
+        day: "2026-05-11",
+        totalCostUsd: 1.2,
+        totalTokens: 250_000,
+        requestCount: 18,
+      },
+      {
+        day: "2026-05-12",
+        totalCostUsd: 0.6,
+        totalTokens: 130_000,
+        requestCount: 9,
+      },
+      {
+        day: "2026-05-13",
+        totalCostUsd: 0.75,
+        totalTokens: 130_000,
+        requestCount: 12,
+      },
+    ];
+    const total = points.reduce((acc, p) => acc + p.totalCostUsd, 0);
+    const tokens = points.reduce((acc, p) => acc + p.totalTokens, 0);
+    const out = formatAiCostMarkdown(
+      makeSummary({
+        trend: {
+          days: 7,
+          startDay: "2026-05-07",
+          endDay: "2026-05-13",
+          points,
+          totalCostUsd: total,
+          totalTokens: tokens,
+        },
+      }),
+    );
+    expect(out).toContain("<b>Trend (7d, 2026-05-07 → 2026-05-13):</b>");
+    expect(out).toMatch(/<code>[▁▂▃▄▅▆▇█]{7}<\/code>/u);
+    expect(out).toContain("05-09: $0.45 (110.0k tokens, 7 req)");
+    expect(out).toContain("05-11: $1.20 (250.0k tokens, 18 req)");
+    expect(out).toContain("trend = Anthropic-only");
+  });
+
+  it("trend з усіма нулями → sparkline = N×▁, total $0.00", () => {
+    const points = Array.from({ length: 7 }, (_, i) => ({
+      day: `2026-05-${String(7 + i).padStart(2, "0")}`,
+      totalCostUsd: 0,
+      totalTokens: 0,
+      requestCount: 0,
+    }));
+    const out = formatAiCostMarkdown(
+      makeSummary({
+        trend: {
+          days: 7,
+          startDay: "2026-05-07",
+          endDay: "2026-05-13",
+          points,
+          totalCostUsd: 0,
+          totalTokens: 0,
+        },
+      }),
+    );
+    expect(out).toContain("<b>Trend (7d, 2026-05-07 → 2026-05-13):</b> $0.00");
+    expect(out).toContain("<code>▁▁▁▁▁▁▁</code>");
+  });
+
+  it("trend з порожнім points[] → fallback 'даних немає'", () => {
+    const out = formatAiCostMarkdown(
+      makeSummary({
+        trend: {
+          days: 7,
+          startDay: "2026-05-07",
+          endDay: "2026-05-13",
+          points: [],
+          totalCostUsd: 0,
+          totalTokens: 0,
+        },
+      }),
+    );
+    expect(out).toContain("даних немає");
+    expect(out).not.toContain("<code>");
   });
 });

--- a/tools/openclaw/src/openclaw/aiCostFormat.ts
+++ b/tools/openclaw/src/openclaw/aiCostFormat.ts
@@ -40,6 +40,22 @@ export interface EndpointCostRowItem {
   estCostUsd: number;
 }
 
+export interface DailyCostPointItem {
+  day: string;
+  totalCostUsd: number;
+  totalTokens: number;
+  requestCount: number;
+}
+
+export interface AnthropicTrendBlockItem {
+  days: number;
+  startDay: string;
+  endDay: string;
+  points: ReadonlyArray<DailyCostPointItem>;
+  totalCostUsd: number;
+  totalTokens: number;
+}
+
 export interface AiCostSummaryResponse {
   generatedAt: string;
   todayKyiv: string;
@@ -58,6 +74,7 @@ export interface AiCostSummaryResponse {
     daysElapsedInMonth: number;
     daysInMonth: number;
   };
+  trend?: AnthropicTrendBlockItem;
 }
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -86,6 +103,81 @@ function fmtTokens(n: number): string {
   if (n < 1_000) return String(Math.round(n));
   if (n < 1_000_000) return `${(n / 1_000).toFixed(1)}k`;
   return `${(n / 1_000_000).toFixed(2)}M`;
+}
+
+// ASCII-render `MM-DD` з ISO `YYYY-MM-DD` (для trend-рядків у reply).
+function fmtMonthDay(day: string): string {
+  if (typeof day !== "string" || day.length < 10) return day;
+  return day.slice(5, 10);
+}
+
+// 8-level Unicode block chars. Пустий cell-space беремо як `▁`
+// (мінімальний, але видимий) — щоб sparkline не "схлопував" візуальну
+// ширину на zero-fill днях.
+const SPARK_GLYPHS = ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"] as const;
+
+/**
+ * Pure-fn sparkline renderer. Нормалізує values→[0..7] за (min..max)
+ * range і мапить на SPARK_GLYPHS. Range-based (а не tylko-max),
+ * щоб усі 8 рівнів задіювалися рівномірно. Edge cases:
+ *   - empty array → "" (caller відповідає за fallback-line).
+ *   - всі однакові (включно з нулями) → рядок з N «▁» (візуально "flat").
+ *   - одне max + інші нулі → max-точка = █, решта = ▁.
+ *   - negative / NaN входи clamp-аться до 0 (в `ai_usage_daily` CHECK
+ *     вже відсікає негативні values, але defensive).
+ */
+export function sparkline(values: ReadonlyArray<number>): string {
+  if (values.length === 0) return "";
+  const clamped = values.map((v) => (Number.isFinite(v) && v > 0 ? v : 0));
+  let min = Infinity;
+  let max = -Infinity;
+  for (const v of clamped) {
+    if (v < min) min = v;
+    if (v > max) max = v;
+  }
+  const range = max - min;
+  if (range === 0) {
+    // Всі значення рівні (включно з усіма нулями) — render flat baseline.
+    return SPARK_GLYPHS[0]!.repeat(clamped.length);
+  }
+  const last = SPARK_GLYPHS.length - 1;
+  return clamped
+    .map((v) => {
+      const idx = Math.min(
+        last,
+        Math.max(0, Math.round(((v - min) / range) * last)),
+      );
+      return SPARK_GLYPHS[idx]!;
+    })
+    .join("");
+}
+
+/**
+ * Render trend-section для Telegram HTML reply. Format:
+ *
+ *   <b>Trend (Nd, AAAA-AA-AA → AAAA-AA-AA):</b> $X.XX
+ *   <code>▁▃▅█▅▃▁</code>
+ *     MM-DD $X.XX (Yk tokens, Z req)
+ *     ...
+ */
+function trendSection(trend: AnthropicTrendBlockItem): string[] {
+  const lines: string[] = [];
+  lines.push(
+    `<b>Trend (${trend.days}d, ${trend.startDay} → ${trend.endDay}):</b> ${fmtUsd(trend.totalCostUsd)}`,
+  );
+  if (trend.points.length === 0) {
+    lines.push(`  └ даних немає`);
+    return lines;
+  }
+  const spark = sparkline(trend.points.map((p) => p.totalCostUsd));
+  // `<code>` забезпечує monospace у Telegram — вирівнювання sparkline.
+  lines.push(`<code>${spark}</code>`);
+  for (const p of trend.points) {
+    lines.push(
+      `  ${fmtMonthDay(p.day)}: ${fmtUsd(p.totalCostUsd)} (${fmtTokens(p.totalTokens)} tokens, ${p.requestCount} req)`,
+    );
+  }
+  return lines;
 }
 
 function topModelsLine(period: PeriodCostSummaryItem, max: number = 3): string {
@@ -174,6 +266,18 @@ export function formatAiCostMarkdown(summary: AiCostSummaryResponse): string {
     );
   } else {
     lines.push(`<b>Voyage embeddings:</b> 0 (з моменту рестарту інстансу)`);
+  }
+
+  // Trend (якщо founder викликав `/ai_cost <N>`). Voyage у trend-секцію не
+  // входить — ledger не пишеться (PR-12 покрив тільки Anthropic).
+  if (summary.trend) {
+    lines.push("");
+    for (const line of trendSection(summary.trend)) {
+      lines.push(line);
+    }
+    lines.push(
+      `  <i>ℹ trend = Anthropic-only (Voyage не пишеться у ai_usage_daily ledger)</i>`,
+    );
   }
 
   return lines.join("\n");

--- a/tools/openclaw/src/openclaw/aiCostParse.test.ts
+++ b/tools/openclaw/src/openclaw/aiCostParse.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { MAX_TREND_DAYS, parseAiCostArgument } from "./aiCostParse.js";
+
+describe("parseAiCostArgument", () => {
+  it("порожній arg → ok без trendDays (legacy)", () => {
+    expect(parseAiCostArgument("")).toEqual({ ok: true });
+    expect(parseAiCostArgument("   ")).toEqual({ ok: true });
+  });
+
+  it("'7' → trendDays=7", () => {
+    expect(parseAiCostArgument("7")).toEqual({ ok: true, trendDays: 7 });
+    expect(parseAiCostArgument(" 7 ")).toEqual({ ok: true, trendDays: 7 });
+  });
+
+  it("'30' (boundary) → trendDays=30", () => {
+    expect(parseAiCostArgument("30")).toEqual({
+      ok: true,
+      trendDays: MAX_TREND_DAYS,
+    });
+  });
+
+  it("'1' (boundary) → trendDays=1", () => {
+    expect(parseAiCostArgument("1")).toEqual({ ok: true, trendDays: 1 });
+  });
+
+  it("'0' → invalid (мін. 1)", () => {
+    const out = parseAiCostArgument("0");
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.error).toContain("1..30");
+  });
+
+  it("'31' → invalid (max — 30)", () => {
+    const out = parseAiCostArgument("31");
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.error).toContain("1..30");
+  });
+
+  it("'abc' → invalid (NaN)", () => {
+    const out = parseAiCostArgument("abc");
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.error).toContain("цілим числом");
+  });
+
+  it("'7d' → invalid (suffix не приймається)", () => {
+    const out = parseAiCostArgument("7d");
+    expect(out.ok).toBe(false);
+  });
+
+  it("'-3' → invalid (мінус не приймається)", () => {
+    const out = parseAiCostArgument("-3");
+    expect(out.ok).toBe(false);
+  });
+
+  it("'7 foo' → invalid (extra tokens)", () => {
+    const out = parseAiCostArgument("7 foo");
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.error).toContain("один аргумент");
+  });
+
+  it("'3.5' → invalid (десятковий)", () => {
+    const out = parseAiCostArgument("3.5");
+    expect(out.ok).toBe(false);
+  });
+});

--- a/tools/openclaw/src/openclaw/aiCostParse.ts
+++ b/tools/openclaw/src/openclaw/aiCostParse.ts
@@ -1,0 +1,52 @@
+/**
+ * `/ai_cost [<days>]` argument parser. Pure-fn so unit-tests не залежать
+ * від grammy-context-у.
+ *
+ * Grammar:
+ *   `/ai_cost`         → no args, no trend block (legacy).
+ *   `/ai_cost 7`       → trendDays=7.
+ *   `/ai_cost 30`      → trendDays=30.
+ *   `/ai_cost 0`       → "invalid" (мін. 1).
+ *   `/ai_cost 31`      → "invalid" (max — MAX_TREND_DAYS).
+ *   `/ai_cost abc`     → "invalid".
+ *   `/ai_cost 7 foo`   → "invalid" (extra tokens).
+ */
+
+/** Mirror server-side `MAX_TREND_DAYS` — окрема константа щоб `tools/openclaw`
+ *  не залежав від `apps/server`. CI-snapshot тест зловить drift. */
+export const MAX_TREND_DAYS = 30;
+
+export type AiCostArgParse =
+  | { ok: true; trendDays?: number }
+  | { ok: false; error: string };
+
+/**
+ * Парсить argument-частину після `/ai_cost` (тобто `c.match`). Очікує
+ * або порожній рядок (legacy), або один цифровий токен 1..MAX_TREND_DAYS.
+ */
+export function parseAiCostArgument(rawArgument: string): AiCostArgParse {
+  const trimmed = (rawArgument ?? "").trim();
+  if (trimmed === "") return { ok: true };
+  const tokens = trimmed.split(/\s+/);
+  if (tokens.length !== 1) {
+    return {
+      ok: false,
+      error: `Очікую один аргумент: /ai_cost [1..${MAX_TREND_DAYS}].`,
+    };
+  }
+  const token = tokens[0]!;
+  if (!/^\d+$/.test(token)) {
+    return {
+      ok: false,
+      error: `Аргумент має бути цілим числом 1..${MAX_TREND_DAYS}. Отримав: «${token}».`,
+    };
+  }
+  const days = Number(token);
+  if (!Number.isFinite(days) || days < 1 || days > MAX_TREND_DAYS) {
+    return {
+      ok: false,
+      error: `Аргумент має бути 1..${MAX_TREND_DAYS}. Отримав: ${days}.`,
+    };
+  }
+  return { ok: true, trendDays: days };
+}

--- a/tools/openclaw/src/openclaw/commands.ts
+++ b/tools/openclaw/src/openclaw/commands.ts
@@ -106,7 +106,7 @@ export const OPENCLAW_BOT_COMMANDS: ReadonlyArray<BotCommandSpec> = [
   },
   {
     command: "ai_cost",
-    description: "AI spend rollup: today/week/month + budget + top endpoints",
+    description: "AI spend rollup; /ai_cost <N> — N-day trend (1..30)",
   },
   {
     command: "openclaw",

--- a/tools/openclaw/src/openclaw/handler-info-commands.ts
+++ b/tools/openclaw/src/openclaw/handler-info-commands.ts
@@ -16,6 +16,7 @@ import {
   formatAiCostMarkdown,
   type AiCostSummaryResponse,
 } from "./aiCostFormat.js";
+import { parseAiCostArgument } from "./aiCostParse.js";
 import { buildAuditCsvFilename, renderWriteAuditCsv } from "./audit-csv.js";
 import { parseDuration } from "./duration.js";
 import { parseFounderTgUserId } from "./security.js";
@@ -90,20 +91,36 @@ export function registerInfoCommands(ctx: HandlerContext): void {
     );
   });
 
-  // `/ai_cost` — realtime AI-spend rollup for founder DM.
+  // `/ai_cost [<days>]` — realtime AI-spend rollup for founder DM.
   // Backend: `/api/internal/openclaw/ai-cost-summary` (PR-26 continuation
-  // of PR-12 #2567 + PR-13 #2590). Body не передаємо — endpoint
-  // ferments out-of-the-box з env-конфігу та DB.
+  // of PR-12 #2567 + PR-13 #2590).
+  //
+  // Аргумент `<days>` — опційний 1..30 (default — без trend-блоку).
+  // При наявності — backend додає `trend` з Anthropic per-day series і
+  // sparkline. Voyage у trend-і відсутній (ledger не пишеться у
+  // ai_usage_daily; відповідь пояснює це кавеатом).
   //
   // Telegram allows `^[a-z0-9_]{1,32}$` only — `/ai-cost` (з дефісом)
   // мовчки відкидається на стороні Telegram, тому реальна команда —
   // `/ai_cost` (з underscore).
   bot.command("ai_cost", async (c) => {
     if (!isAllowedDmContext(c)) return;
+    if (!rateLimiter.allow(String(c.from?.id))) {
+      await c.reply("Rate limit exceeded. Спробуй за хвилину.");
+      return;
+    }
+    const argument = (c.match ?? "").toString();
+    const parsed = parseAiCostArgument(argument);
+    if (!parsed.ok) {
+      await c.reply(parsed.error);
+      return;
+    }
+    const body: { trendDays?: number } = {};
+    if (parsed.trendDays !== undefined) body.trendDays = parsed.trendDays;
     const r = await postJson<AiCostSummaryResponse>(
       `${serverUrl}/api/internal/openclaw/ai-cost-summary`,
       internalApiKey,
-      {},
+      body,
     );
     if (!r.ok || !r.data) {
       await c.reply(`Не зміг прочитати ai-cost (HTTP ${r.status}).`);


### PR DESCRIPTION
## Summary

Розширює `/ai_cost` slash-команду (PR-26 #2706) історичним trending-блоком:

- `/ai_cost` — як раніше: today/week/month + budget + projection.
- `/ai_cost 7` → 7-day trend з ASCII sparkline (▁..█, 8 рівнів) + per-day rows.
- `/ai_cost 30` → 30-day trend (cap = MAX_TREND_DAYS).

Trend — **Anthropic-only**, бо PR-12 (#2567) не ledger-ить Voyage у `ai_usage_daily` (in-process Prom counter only). Reply містить кавеат-рядок, щоб founder не плутав.

**Що нового:**

- **Server**:
  - `fetchAnthropicDailyTrend(pool, startDay, endDay)` — `SUM ... GROUP BY usage_day` over inclusive Kyiv-day range з zero-fill для пропущених днів (sparkline-ширина стабільна).
  - `kyivDayMinus(today, n)` helper.
  - `buildAiCostSummary({trendDays})` — clamp 1..30, паралельний fetch разом із today/week/month, fail-soft на DB-помилці (повертає zero-filled block замість зривати reply).
- **Route**: `POST /api/internal/openclaw/ai-cost-summary` приймає optional `trendDays: 1..30` (Zod `.strict()`).
- **Formatter** (`tools/openclaw`):
  - `sparkline(values[])` — pure-fn range-normalised (min..max), 8 рівнів Unicode-блоків. Edge cases: empty / all-zero / negative+NaN / equal-values.
  - `trendSection()` рендерить header + sparkline + per-day rows (MM-DD: $X.XX (Yk tokens, Z req)).
- **Handler**: `/ai_cost [<N>]` arg-parser (`aiCostParse.ts`); empty arg → legacy behaviour, '1'..'30' → trend. Rate-limit зберігається (per-founder limiter з handler-context).

## Governing Skill

- Primary skill: `sergeant-server-api` (apps/server, Pino, Kyiv timezone, Zod body validation, pg bigint → number coercion)
- Secondary skill: `sergeant-data-and-migrations` — для query-shape перевірки. **Жодної міграції не додано**: trend читає існуючу `ai_usage_daily` (PR-12 #2567 schema).

## Playbook

- Primary playbook: power-user feature extension (slash-command arg parsing + read-only DB rollup).
- Why this playbook: minimal, single-PR feature extension без міграцій, без зміни існуючої контрактної поведінки (back-compat).
- If no playbook matched, why: n/a.

## Verification

```bash
pnpm --filter @sergeant/server test -- --run aiCostSummary
# Test Files 1 passed, Tests 30 passed (новий trend coverage додано)

pnpm --filter @sergeant/openclaw test
# Test Files 34 passed, Tests 562 passed (sparkline + trend + parser + commands-len)

pnpm --filter @sergeant/server test
# Test Files 197 passed, Tests 2702 passed | 2 todo (full suite)

pnpm --filter @sergeant/server typecheck   # ok
pnpm --filter @sergeant/openclaw typecheck # ok
pnpm --filter @sergeant/server lint        # 4 pre-existing warnings, no errors
pnpm --filter @sergeant/openclaw lint      # ok
pnpm format:check                          # ok
```

Additional checks:

- [x] Local smoke / manual validation completed — `aiCostFormat.test.ts` рендер показав очікувані Telegram-HTML lines з `<code>▁..█</code>` sparkline-ом і per-day rows.
- [x] Surface-specific checks completed — pg bigint→number coercion (`toNumber`) у `fetchAnthropicDailyTrend`; Kyiv-day boundary у range-helper-ах; Zod `.strict()` body validation на route.

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
  → Жодних public-facing docs не змінено. Команда лишилась `/ai_cost`; новий `<days>` arg відображено у command-description (≤64 char Telegram limit).
- [x] I checked whether `AGENTS.md` needed an update — ні, hard rules лишаються (bigint coercion дотримано, contract-triplet — internal endpoint, не публікується через api-client).
- [x] I checked whether a playbook or skill needed an update — ні.
- [x] I checked whether governance docs or review docs needed an update — ні.

Updated docs:

- n/a

## Risk and Rollout

- **User-visible risk**: Низький. Команда back-compat — без args reply ідентичний поточному. New trend-блок з'являється тільки коли founder ввів N. Voyage у trend відсутній → передбачено caveat-рядком у reply.
- **Rollout / deploy order**: Стандартний — server deploy → restart openclaw bot. Жодних DB-міграцій, env, або зовнішніх сервісів.
- **Backout plan**: revert PR. Жоден persistent state не змінюється.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian (PR body, code comments).
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

- **Per-day SQL shape**: див. `fetchAnthropicDailyTrend` — той самий predicate-set, що `fetchAnthropicCostsForRange` (`subject_key='provider:anthropic' AND bucket LIKE 'anthropic:%'`), але `GROUP BY usage_day` + `ORDER BY usage_day ASC`.
- **Sparkline normalisation**: range-based (min..max) — щоб усі 8 рівнів використовувалися рівномірно, а не concentrated в нижніх через outlier-max. Один peak + 6 нулів → `▁▁█▁▁▁▁`.
- **Voyage exclusion**: явно зазначено у trend-section caveat-рядку. Якщо PR-12.5 додасть Voyage у `ai_usage_daily`, цей PR розширюється тривіально (другий fetch + рядок).
- **Fail-soft trend**: на DB-помилці повертаємо zero-filled block (не throw), щоб user-facing reply не зривався — сам trend-блок все одно рендериться, тільки з усіма нулями.


Link to Devin session: https://app.devin.ai/sessions/786735c5c5ef4ec9aeb500119784eeb8

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional N-day trend to the founder-only `/ai_cost` command with a Unicode sparkline and per-day breakdown. Aggregates Anthropic spend per day from `ai_usage_daily`, clamps to 1..30 days, and fails soft on DB errors; Voyage is excluded and noted in the reply.

- **New Features**
  - Server: `fetchAnthropicDailyTrend()` with zero-fill; `kyivDayMinus()`; `buildAiCostSummary({ trendDays })` and `MAX_TREND_DAYS=30`.
  - Route: `POST /api/internal/openclaw/ai-cost-summary` accepts optional `trendDays: 1..30` (Zod `.strict()`).
  - Formatter (`tools/openclaw`): `sparkline(values[])` and `trendSection()` render header, sparkline, and per-day rows.
  - Bot: `/ai_cost [<N>]` arg parsing (1..30) with existing per-founder rate limit; no arg keeps legacy output.
  - Tests: parser edge cases, sparkline, SQL grouping + zero-fill, clamps, fail-soft, and formatter render.

- **Migration**
  - No schema or env changes. Deploy server, then restart `openclaw` bot.

<sup>Written for commit 2f8135ed3c5869eb2823a85e12ef835b0b9f37b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

