### PR TITLE
feat(server,web): posthog product events sync to AI memory (PR-24)

### DIFF
--- a/apps/server/src/migrations/068_ai_memories_product_source.down.sql
+++ b/apps/server/src/migrations/068_ai_memories_product_source.down.sql
@@ -1,0 +1,24 @@
+-- 068 down: rollback `product` source. Видаляємо product rows перш ніж
+-- вузити CHECK constraint, інакше re-add впаде на existing data.
+--
+-- Якщо у `ai_memories` уже є `source='product'` rows, ця rollback ВИДАЛИТЬ
+-- їх (без soft-delete buffer-у — це rollback, не data-loss-protected path).
+-- Backup перед запуском: `pg_dump --table=ai_memories`.
+
+DELETE FROM ai_memories WHERE source = 'product';
+
+ALTER TABLE ai_memories
+  DROP CONSTRAINT IF EXISTS ai_memories_source_check;
+
+ALTER TABLE ai_memories
+  ADD CONSTRAINT ai_memories_source_check
+  CHECK (source IN (
+    'chat',
+    'finyk',
+    'fizruk',
+    'nutrition',
+    'routine',
+    'journal',
+    'digest',
+    'cofounder'
+  ));

--- a/apps/server/src/migrations/068_ai_memories_product_source.sql
+++ b/apps/server/src/migrations/068_ai_memories_product_source.sql
@@ -1,0 +1,73 @@
+-- 068: ai_memories `product` source — нова namespace для PostHog → AI memory sync.
+--
+-- Контекст: PR-19 (#2605) активував AI memory ingest для `finyk`/`cofounder`
+-- через server-side hooks; PR-22 (#2712) додав retroactive backfill з
+-- `tg_topic_archive` (`cofounder`). Цей PR (PostHog → AI memory sync) додає
+-- behavioral-event source: коли user робить значущу action у продукт
+-- (completes onboarding, hits first-action, activates v2 milestone, починає
+-- subscription) — analytics event автоматично mirror-иться у memory як
+-- structured text, тож `/recall` має cross-source view ("коли я останній
+-- раз активувався у фінику?").
+--
+-- ─── Семантика ─────────────────────────────────────────────────────────
+--
+-- `product` — новий source-namespace; isolation pattern як у `cofounder`
+-- (ADR-0031 §3): rows цього source-у пише ТІЛЬКИ event-sync handler
+-- (`POST /api/ai-memory/event-sync`), читає `/recall` через optional
+-- `sources=['product']` filter або combined `['cofounder', 'product']` для
+-- founder-у. Не змішується з `chat`/`finyk`/`digest` — кожен source
+-- лишається own bucket-ом.
+--
+-- Source ref (`source_ref`): canonical event name + idempotency-suffix
+-- ("onboarding_completed:<userId>:<dateKey>" — формується у event-mapper-і).
+-- UNIQUE partial index на `(user_id, source, source_ref) WHERE source_ref
+-- IS NOT NULL` (025) природно блокує дубляж, тож якщо event прилетить
+-- двічі за день (browser tab reload + idempotent flag race) — другий
+-- запис буде no-op.
+--
+-- ─── ADR-0031 §3 isolation ───────────────────────────────────────────
+--
+-- `cofounder` source хардкодиться у `recall_memory` openclaw tool
+-- (`apps/server/src/modules/openclaw/tools.ts`) як `sources=['cofounder']`.
+-- Це не зачіпається — openclaw bot бачить тільки cofounder-namespace.
+-- `product` доступний через API-recall (`POST /api/ai-memory/recall`), де
+-- caller явно вказує `sources` у body, або через combined recall з
+-- допустимим mix-ом.
+--
+-- ─── Why not extend cofounder ─────────────────────────────────────────
+--
+-- Можна було б писати product events як `source='cofounder'` з distinct
+-- `metadata.kind = 'product_event'`. Не вибрали бо:
+--   1. Vector-search recall у openclaw зараз hardcode-ить `cofounder` —
+--      product events почали б "забруднювати" cofounder DM-recall з
+--      auto-generated text-ами замість founder-input narrative-у.
+--   2. Окремий source дозволяє `/recall sources=['cofounder']` лишити
+--      founder-input clean, а UI-recall (web) — combined view.
+--   3. Soft-delete (067 `deleted_at`) — sympathetic до per-source policies
+--      (можна додати auto-prune product-events старші 90 днів окремо).
+--
+-- ─── Партиційний caveat ──────────────────────────────────────────────
+--
+-- `ai_memories` HASH-партиційована (025). DROP CONSTRAINT / ADD CONSTRAINT
+-- на parent каскадиться у партиції автоматично (Postgres ≥11). Тому ALTER
+-- TABLE лише parent-у.
+
+ALTER TABLE ai_memories
+  DROP CONSTRAINT IF EXISTS ai_memories_source_check;
+
+ALTER TABLE ai_memories
+  ADD CONSTRAINT ai_memories_source_check
+  CHECK (source IN (
+    'chat',
+    'finyk',
+    'fizruk',
+    'nutrition',
+    'routine',
+    'journal',
+    'digest',
+    'cofounder',
+    'product'
+  ));
+
+COMMENT ON CONSTRAINT ai_memories_source_check ON ai_memories IS
+  'Доменний source. Розширено у 028 на ''cofounder'' (ADR-0031), у 068 на ''product'' для PostHog → AI memory sync. Strict isolation на app-рівні (recall_memory tool хардкодить sources=[''cofounder''], product читається через POST /api/ai-memory/recall).';

--- a/apps/server/src/modules/ai-memory/eventSync.test.ts
+++ b/apps/server/src/modules/ai-memory/eventSync.test.ts
@@ -1,0 +1,263 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  PRODUCT_MEMORY_EVENTS,
+  buildProductSourceRef,
+  checkPayloadSize,
+  dayKeyKyiv,
+  formatEventAsMemoryText,
+  isProductMemoryEvent,
+  recordProductMemoryEvent,
+  sanitizeEventPayload,
+} from "./eventSync.js";
+
+const { enqueueStub } = vi.hoisted(() => ({
+  enqueueStub: vi.fn<(...args: unknown[]) => Promise<void>>(async () => {}),
+}));
+
+vi.mock("./ingestQueue.js", () => ({
+  enqueueMemoryIngest: enqueueStub,
+}));
+
+const fakePool = {} as unknown as import("pg").Pool;
+
+describe("eventSync — isProductMemoryEvent + allowlist", () => {
+  it("повертає true для відомих подій", () => {
+    for (const name of PRODUCT_MEMORY_EVENTS) {
+      expect(isProductMemoryEvent(name)).toBe(true);
+    }
+  });
+
+  it("повертає false для довільних рядків", () => {
+    expect(isProductMemoryEvent("evil_event")).toBe(false);
+    expect(isProductMemoryEvent("")).toBe(false);
+    expect(isProductMemoryEvent("ONBOARDING_COMPLETED")).toBe(false);
+  });
+});
+
+describe("eventSync — dayKeyKyiv", () => {
+  it("формує YYYY-MM-DD у Europe/Kyiv", () => {
+    // 2026-05-13 19:00 UTC → 22:00 Kyiv same day
+    const utc = new Date("2026-05-13T19:00:00.000Z");
+    expect(dayKeyKyiv(utc)).toBe("2026-05-13");
+  });
+
+  it("враховує перетин півночі по Київському часу", () => {
+    // 23:00 UTC → 02:00 Kyiv наступного дня
+    const utc = new Date("2026-05-13T23:00:00.000Z");
+    expect(dayKeyKyiv(utc)).toBe("2026-05-14");
+  });
+});
+
+describe("eventSync — sanitizeEventPayload (PII)", () => {
+  it("видаляє email/password/apiKey глибоко", () => {
+    const out = sanitizeEventPayload({
+      module: "finyk",
+      email: "founder@example.com",
+      password: "hunter2",
+      nested: { apiKey: "sk-secret", harmless: 42 },
+    });
+    expect(out["module"]).toBe("finyk");
+    expect(out["email"]).toBe("[redacted]");
+    expect(out["password"]).toBe("[redacted]");
+    expect((out["nested"] as Record<string, unknown>)["apiKey"]).toBe(
+      "[redacted]",
+    );
+    expect((out["nested"] as Record<string, unknown>)["harmless"]).toBe(42);
+  });
+
+  it("повертає {} для нерозпарсених/невалідних payload-ів", () => {
+    expect(sanitizeEventPayload(undefined)).toEqual({});
+    expect(sanitizeEventPayload({} as Record<string, unknown>)).toEqual({});
+  });
+
+  it("не мутує оригінальний payload (deep clone)", () => {
+    const original = { email: "a@b.com", module: "fizruk" };
+    const out = sanitizeEventPayload(original);
+    expect(original["email"]).toBe("a@b.com");
+    expect(out["email"]).toBe("[redacted]");
+  });
+});
+
+describe("eventSync — formatEventAsMemoryText", () => {
+  const now = new Date("2026-05-13T12:00:00.000Z");
+
+  it("форматує signup_completed з method", () => {
+    const out = formatEventAsMemoryText(
+      "signup_completed",
+      { method: "email" },
+      now,
+    );
+    expect(out.content).toContain("2026-05-13");
+    expect(out.content).toContain("signup");
+    expect(out.content).toContain("email");
+    expect(out.metadata).toMatchObject({
+      event: "signup_completed",
+      method: "email",
+    });
+  });
+
+  it("форматує onboarding_completed з intent та picksCount", () => {
+    const out = formatEventAsMemoryText(
+      "onboarding_completed",
+      { intent: "vibe_picked", picksCount: 3 },
+      now,
+    );
+    expect(out.content).toContain("completed onboarding");
+    expect(out.content).toContain("3 module picks");
+    expect(out.content).toContain("vibe_picked");
+    expect(out.metadata).toMatchObject({
+      event: "onboarding_completed",
+      intent: "vibe_picked",
+      picksCount: 3,
+    });
+  });
+
+  it("форматує first_action_completed з module", () => {
+    const out = formatEventAsMemoryText(
+      "first_action_completed",
+      { module: "finyk" },
+      now,
+    );
+    expect(out.content).toContain("first action completed");
+    expect(out.content).toContain("finyk");
+    expect(out.metadata).toMatchObject({
+      event: "first_action_completed",
+      module: "finyk",
+    });
+  });
+
+  it("форматує subscription_started з plan + source", () => {
+    const out = formatEventAsMemoryText(
+      "subscription_started",
+      { plan: "monthly", source: "paywall" },
+      now,
+    );
+    expect(out.content).toContain("subscription started");
+    expect(out.content).toContain("monthly");
+    expect(out.content).toContain("paywall");
+    expect(out.metadata).toMatchObject({
+      event: "subscription_started",
+      plan: "monthly",
+      source: "paywall",
+    });
+  });
+
+  it("витирає PII при форматуванні", () => {
+    const out = formatEventAsMemoryText(
+      "first_action_completed",
+      { module: "nutrition", email: "leaked@example.com" },
+      now,
+    );
+    expect(out.content).not.toContain("leaked@example.com");
+  });
+
+  it("використовує fallback `unknown` для пропущених полей", () => {
+    const out = formatEventAsMemoryText("signup_completed", undefined, now);
+    expect(out.content).toContain("email");
+    expect(out.metadata["event"]).toBe("signup_completed");
+  });
+});
+
+describe("eventSync — buildProductSourceRef", () => {
+  it("формує канонічну форму", () => {
+    const ref = buildProductSourceRef(
+      "onboarding_completed",
+      "user_123",
+      "2026-05-13",
+    );
+    expect(ref).toBe("onboarding_completed:user_123:2026-05-13");
+  });
+});
+
+describe("eventSync — checkPayloadSize", () => {
+  it("ok для невеликих payload-ів", () => {
+    expect(checkPayloadSize({ a: 1, b: "x" })).toEqual({ ok: true });
+  });
+
+  it("ok для undefined", () => {
+    expect(checkPayloadSize(undefined)).toEqual({ ok: true });
+  });
+
+  it("відмова на >4KB", () => {
+    const big = { blob: "x".repeat(5000) };
+    const result = checkPayloadSize(big);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("too_large");
+  });
+});
+
+describe("eventSync — recordProductMemoryEvent", () => {
+  beforeEach(() => {
+    enqueueStub.mockClear();
+    enqueueStub.mockImplementation(async () => {});
+  });
+
+  it("enqueueує product event у memory ingest queue", async () => {
+    const result = await recordProductMemoryEvent(fakePool, {
+      userId: "user_abc",
+      eventName: "onboarding_completed",
+      payload: { intent: "vibe_picked", picksCount: 2 },
+      now: new Date("2026-05-13T12:00:00.000Z"),
+    });
+    expect(result.enqueued).toBe(true);
+    expect(result.sourceRef).toBe("onboarding_completed:user_abc:2026-05-13");
+    expect(enqueueStub).toHaveBeenCalledTimes(1);
+    const call = enqueueStub.mock.calls[0]?.[0] as {
+      userId: string;
+      source: string;
+      sourceRef: string | null;
+      content: string;
+      metadata: Record<string, unknown>;
+    };
+    expect(call.userId).toBe("user_abc");
+    expect(call.source).toBe("product");
+    expect(call.sourceRef).toBe("onboarding_completed:user_abc:2026-05-13");
+    expect(call.content).toContain("completed onboarding");
+    expect(call.metadata).toMatchObject({
+      event: "onboarding_completed",
+      intent: "vibe_picked",
+    });
+  });
+
+  it("чистить PII з payload перед enqueueом", async () => {
+    await recordProductMemoryEvent(fakePool, {
+      userId: "user_xyz",
+      eventName: "signup_completed",
+      payload: { method: "email", email: "founder@example.com" },
+      now: new Date("2026-05-13T12:00:00.000Z"),
+    });
+    const call = enqueueStub.mock.calls[0]?.[0] as {
+      content: string;
+      metadata: Record<string, unknown>;
+    };
+    expect(call.content).not.toContain("founder@example.com");
+    expect(call.metadata).not.toHaveProperty("email");
+  });
+
+  it("повертає enqueued=false для невідомих подій без throw", async () => {
+    const result = await recordProductMemoryEvent(fakePool, {
+      userId: "user_x",
+      // @ts-expect-error — навмисно невалідний event для defense-in-depth
+      eventName: "evil_event",
+      payload: {},
+      now: new Date("2026-05-13T12:00:00.000Z"),
+    });
+    expect(result.enqueued).toBe(false);
+    expect(enqueueStub).not.toHaveBeenCalled();
+  });
+
+  it("повертає enqueued=false якщо enqueueMemoryIngest throw-нув (best-effort)", async () => {
+    enqueueStub.mockImplementationOnce(async () => {
+      throw new Error("redis_down");
+    });
+    const result = await recordProductMemoryEvent(fakePool, {
+      userId: "user_q",
+      eventName: "first_action_completed",
+      payload: { module: "finyk" },
+      now: new Date("2026-05-13T12:00:00.000Z"),
+    });
+    expect(result.enqueued).toBe(false);
+    expect(result.sourceRef).toBe("first_action_completed:user_q:2026-05-13");
+  });
+});

--- a/apps/server/src/modules/ai-memory/eventSync.ts
+++ b/apps/server/src/modules/ai-memory/eventSync.ts
@@ -1,0 +1,355 @@
+/**
+ * PostHog → AI memory sync (PR-24).
+ *
+ * Контекст: PR-19 (#2605) активував `ai_memories` ingest для server-side
+ * sources (`finyk` webhook, `digest` cron), PR-22 (#2712) додав
+ * retroactive backfill з `tg_topic_archive` (`cofounder` source). Цього
+ * мало для `/recall` behavioral history — він не бачить, коли user
+ * **робив** значущі дії у продукті: завершив onboarding, дозвонив
+ * першого actiona, відкрив підписку. PostHog ловить ці події у
+ * `apps/web/src/core/observability/analytics.ts` через `trackEvent`,
+ * але вони живуть у PostHog-instance і недосяжні для AI memory recall.
+ *
+ * Цей модуль закриває петлю: web → `POST /api/ai-memory/event-sync` з
+ * `{eventName, payload}` → `formatEventAsMemoryText()` → scrubPII →
+ * `enqueueMemoryIngest` як `source='product'`. Worker (PR-19 BullMQ) сам
+ * embed-ить + upsert-ить у pgvector. `/recall sources=['cofounder','product']`
+ * тоді бачить cross-source view ("коли я останній раз активувався
+ * у фініку?").
+ *
+ * ─── Architecture ───────────────────────────────────────────────────
+ *
+ * 1. Web `trackEvent(name, payload)` (analytics.ts) — fire-and-forget;
+ *    додатково POST-ить ці події (allowlist) до `/api/ai-memory/event-sync`.
+ * 2. Server route (`apps/server/src/routes/ai-memory.ts`) — session-gated,
+ *    Zod-validated, форвардить у `recordProductMemoryEvent`.
+ * 3. Цей модуль (`recordProductMemoryEvent`):
+ *    - валідує `eventName` проти PRODUCT_MEMORY_EVENTS allowlist
+ *    - scrubPII(payload) — видаляє credentials/email/phone глибоко
+ *    - `formatEventAsMemoryText` — людський опис ("2026-05-13: completed
+ *      onboarding wizard (vibe_picks)")
+ *    - `buildSourceRef` — `<eventName>:<userId>:<dayKey>` для idempotency
+ *    - enqueueMemoryIngest з source='product'
+ *
+ * ─── Idempotency ────────────────────────────────────────────────────
+ *
+ * `sourceRef = <eventName>:<userId>:<dayKey>` гарантує що ре-fire тієї
+ * самої події одного й того ж дня — no-op у BullMQ (jobId-dedup) і у
+ * SQL (partial UNIQUE на `(user_id, source, source_ref) WHERE
+ * source_ref IS NOT NULL`, із PR-19 schema). Хоча web-сторона має
+ * idempotency flags (`hub_onboarding_completed_v1` etc.), мережеві
+ * ретраї або deploy-flapping можуть створити дубль — захист на
+ * сервер-сторі робить це безпечним.
+ *
+ * ─── ADR-0031 §3 isolation ──────────────────────────────────────────
+ *
+ * `recall_memory` openclaw tool хардкодить `sources=['cofounder']` — НЕ
+ * зачіпається. Product events живуть у окремому namespace. Founder
+ * combined-view через web-recall (`POST /api/ai-memory/recall`,
+ * `sources=['cofounder','product']`) — пізніший follow-up.
+ */
+
+import { scrubPII } from "@sergeant/shared";
+
+import type { Pool } from "pg";
+
+import { logger, serializeError } from "../../obs/logger.js";
+import { enqueueMemoryIngest } from "./ingestQueue.js";
+
+/**
+ * Allowlist подій, які дзеркаляться у `ai_memories` як `source='product'`.
+ *
+ * Чому **allowlist**, а не "усі ANALYTICS_EVENTS":
+ *   - Більшість analytics-подій — telemetry (clicks, impressions), які
+ *     "забруднили" б memory recall шумом ("user dismissed banner X").
+ *   - Voyage embedding коштує гроші — selectively embed-имо тільки
+ *     поведінкові milestone-и (funnel signposts).
+ *   - PII surface менший — кожна подія у allowlist має stable payload
+ *     contract, тож `formatEventAsMemoryText` знає що чистити.
+ *
+ * Які події входять (поточний v1 scope):
+ *   - `signup_completed` (PR-06): facto-початок user journey.
+ *   - `onboarding_completed` (PR-07 #2566): activation milestone.
+ *   - `first_action_completed` (PR-08 #2025): per-module activation.
+ *   - `subscription_started` (server-side, stripe.ts): conversion signal.
+ *
+ * Розширення — додай константу + entry у `EVENT_FORMATTERS`. Не міняй
+ * текст без узгодження: `/recall` запити founder-а полягають на
+ * стабільні фрази (наприклад, "completed onboarding" — щоб
+ * vector-search ловив).
+ */
+export const PRODUCT_MEMORY_EVENTS = [
+  "signup_completed",
+  "onboarding_completed",
+  "first_action_completed",
+  "subscription_started",
+] as const;
+
+export type ProductMemoryEventName = (typeof PRODUCT_MEMORY_EVENTS)[number];
+
+const PRODUCT_MEMORY_EVENT_SET: ReadonlySet<string> = new Set(
+  PRODUCT_MEMORY_EVENTS,
+);
+
+/**
+ * Чи дозволено подія для дзеркаливання у memory. Caller (HTTP handler)
+ * робить early-return 200 OK з `{ok:false, reason:"event_not_synced"}`
+ * якщо event поза allowlist — клієнт може спокійно дрібнити trackEvent
+ * на будь-яку подію без ризику 4xx.
+ */
+export function isProductMemoryEvent(
+  name: string,
+): name is ProductMemoryEventName {
+  return PRODUCT_MEMORY_EVENT_SET.has(name);
+}
+
+/**
+ * Day-key у Europe/Kyiv (`YYYY-MM-DD`). Domain invariant — увесь sergeant
+ * рахує дні у Kyiv-TZ. Не залежимо від системного TZ контейнера.
+ */
+export function dayKeyKyiv(at: Date = new Date()): string {
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Europe/Kyiv",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  return formatter.format(at);
+}
+
+const MAX_PAYLOAD_BYTES = 4 * 1024;
+const MAX_CONTENT_LEN = 500;
+
+/**
+ * Re-используем PII-scrubber із @sergeant/shared (вже задіяний у
+ * Sentry beforeSend для server+web). Це гарантує, що navigator-leak
+ * полів (`email`, `password`, `apiKey` …) ніколи не потрапляють у
+ * vector embedding-text.
+ *
+ * Mutates argument. Повертаємо безпечну (cloned) копію, щоб caller-у
+ * ніколи не передавався shared mutable reference.
+ */
+export function sanitizeEventPayload(
+  payload: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  if (!payload || typeof payload !== "object") return {};
+  let cloned: Record<string, unknown>;
+  try {
+    cloned = JSON.parse(JSON.stringify(payload));
+  } catch {
+    // Структуру не вдалося серіалізувати (циклічні refs тощо) —
+    // безпечніше відкинути все, ніж пропускати у scrubber-у unbounded
+    // обʼєкт.
+    return {};
+  }
+  scrubPII(cloned);
+  return cloned;
+}
+
+/**
+ * Маперы з event → людський текст. Кожен мап ОЧІКУЄ payload вже
+ * sanitized (PII пройшов scrubPII). Текст має містити дату Kyiv (щоб
+ * vector-search ловив temporal queries "що я робив минулого тижня") і
+ * мнемонічну event-фразу.
+ *
+ * Контракт стабільний — recall queries founder-а полягають на конкретні
+ * фрази ("completed onboarding", "first action", "subscription"). Зміна
+ * текстів — breaking change для recall accuracy; за-update розширюй
+ * synonyms у фразу замість заміни.
+ */
+type FormatterFn = (
+  payload: Record<string, unknown>,
+  dayKey: string,
+) => { content: string; metadata: Record<string, unknown> };
+
+const EVENT_FORMATTERS: Record<ProductMemoryEventName, FormatterFn> = {
+  signup_completed: (payload, dayKey) => {
+    const method = stringField(payload, "method") ?? "email";
+    return {
+      content: `${dayKey}: signup completed (method: ${method}). User started journey у Sergeant.`,
+      metadata: { event: "signup_completed", method },
+    };
+  },
+  onboarding_completed: (payload, dayKey) => {
+    const intent = stringField(payload, "intent") ?? "unknown";
+    const picksRaw = payload["picksCount"];
+    const picks =
+      typeof picksRaw === "number" && Number.isFinite(picksRaw)
+        ? picksRaw
+        : null;
+    const picksSuffix = picks == null ? "" : ` (${picks} module picks)`;
+    return {
+      content: `${dayKey}: completed onboarding wizard${picksSuffix}, intent=${intent}.`,
+      metadata: {
+        event: "onboarding_completed",
+        intent,
+        ...(picks == null ? {} : { picksCount: picks }),
+      },
+    };
+  },
+  first_action_completed: (payload, dayKey) => {
+    const moduleId = stringField(payload, "module") ?? "unknown";
+    return {
+      content: `${dayKey}: first action completed у модулі ${moduleId}. Activation milestone hit.`,
+      metadata: { event: "first_action_completed", module: moduleId },
+    };
+  },
+  subscription_started: (payload, dayKey) => {
+    const plan = stringField(payload, "plan") ?? "unknown";
+    const source = stringField(payload, "source") ?? "unknown";
+    return {
+      content: `${dayKey}: subscription started, plan=${plan}, source=${source}. Conversion event.`,
+      metadata: {
+        event: "subscription_started",
+        plan,
+        source,
+      },
+    };
+  },
+};
+
+function stringField(
+  payload: Record<string, unknown>,
+  key: string,
+): string | null {
+  const value = payload[key];
+  if (typeof value !== "string" || value.length === 0) return null;
+  // Hard truncate щоб одна неправильно сформована payload не
+  // роздула embedding-content.
+  return value.slice(0, 80);
+}
+
+export interface FormatEventOutput {
+  content: string;
+  metadata: Record<string, unknown>;
+}
+
+/**
+ * Перетворює event-name + payload у структуру для memory ingest. Pure
+ * function: ні DB, ні HTTP — тестується ізольовано.
+ */
+export function formatEventAsMemoryText(
+  eventName: ProductMemoryEventName,
+  rawPayload: Record<string, unknown> | undefined,
+  now: Date = new Date(),
+): FormatEventOutput {
+  const dayKey = dayKeyKyiv(now);
+  const sanitized = sanitizeEventPayload(rawPayload);
+  const formatter = EVENT_FORMATTERS[eventName];
+  const formatted = formatter(sanitized, dayKey);
+  // Hard truncate content (defense-in-depth — форматтери самі обмежують
+  // input strings, але хто завгодно міг забути).
+  const content =
+    formatted.content.length > MAX_CONTENT_LEN
+      ? formatted.content.slice(0, MAX_CONTENT_LEN - 1) + "…"
+      : formatted.content;
+  return { content, metadata: formatted.metadata };
+}
+
+/**
+ * Idempotency-ref. День-rotated: ре-fire тієї ж події тим же user-ом у
+ * межах того ж Kyiv-доби дедуплікується у BullMQ jobId і SQL UNIQUE.
+ * Це навмисно крупно-зернисте: cross-day signup_completed (рідкісне,
+ * але можливе при re-test acc-у) лишиться як два окремі rows — це
+ * корректно з точки зору `/recall` ("я колись завів акаунт двічі").
+ */
+export function buildProductSourceRef(
+  eventName: ProductMemoryEventName,
+  userId: string,
+  dayKey: string,
+): string {
+  return `${eventName}:${userId}:${dayKey}`;
+}
+
+/**
+ * Перевіряє розмір payload до scrubPII (raw byte-cap). Не критично, але
+ * захищає Redis/BullMQ payload-buffer від zip-bomb-стилю атак.
+ */
+export function checkPayloadSize(
+  payload: Record<string, unknown> | undefined,
+): { ok: true } | { ok: false; reason: string; size: number } {
+  if (!payload) return { ok: true };
+  let serialized = "";
+  try {
+    serialized = JSON.stringify(payload);
+  } catch {
+    return { ok: false, reason: "not_serializable", size: 0 };
+  }
+  const size = Buffer.byteLength(serialized, "utf8");
+  if (size > MAX_PAYLOAD_BYTES) return { ok: false, reason: "too_large", size };
+  return { ok: true };
+}
+
+export interface RecordProductMemoryInput {
+  userId: string;
+  eventName: ProductMemoryEventName;
+  payload: Record<string, unknown> | undefined;
+  now?: Date;
+}
+
+export interface RecordProductMemoryResult {
+  enqueued: boolean;
+  sourceRef: string;
+  contentLength: number;
+}
+
+/**
+ * Public entry-point. Caller-и:
+ *   - HTTP route `POST /api/ai-memory/event-sync` (web → fetch)
+ *   - Server-side hooks (наприклад, stripe.ts при `subscription_started`)
+ *
+ * Помилки enqueue (Redis-down тощо) НЕ кидаються — ai-memory ingest
+ * best-effort: краще втратити один dual-write, ніж 500-нути analytics
+ * каллера. Це дзеркалить семантику `enqueueMemoryIngest` (теж best-effort).
+ */
+export async function recordProductMemoryEvent(
+  _pool: Pool,
+  input: RecordProductMemoryInput,
+): Promise<RecordProductMemoryResult> {
+  const { userId, eventName, payload, now } = input;
+
+  if (!isProductMemoryEvent(eventName)) {
+    // Defensive: caller має фільтрувати, але double-guard зручний для
+    // server-side hook-ів, що еволюціонують швидше allowlist-у.
+    logger.warn({
+      msg: "ai_memory_event_sync_unknown_event",
+      eventName,
+    });
+    return {
+      enqueued: false,
+      sourceRef: "",
+      contentLength: 0,
+    };
+  }
+
+  const formatted = formatEventAsMemoryText(eventName, payload, now);
+  const dayKey = dayKeyKyiv(now);
+  const sourceRef = buildProductSourceRef(eventName, userId, dayKey);
+
+  try {
+    await enqueueMemoryIngest({
+      userId,
+      source: "product",
+      sourceRef,
+      content: formatted.content,
+      metadata: formatted.metadata,
+    });
+    return {
+      enqueued: true,
+      sourceRef,
+      contentLength: formatted.content.length,
+    };
+  } catch (err) {
+    logger.warn({
+      msg: "ai_memory_event_sync_enqueue_failed",
+      eventName,
+      userId,
+      err: serializeError(err, { includeStack: false }),
+    });
+    return {
+      enqueued: false,
+      sourceRef,
+      contentLength: formatted.content.length,
+    };
+  }
+}

--- a/apps/server/src/modules/ai-memory/eventSyncRoute.ts
+++ b/apps/server/src/modules/ai-memory/eventSyncRoute.ts
@@ -1,0 +1,110 @@
+/**
+ * Handler `POST /api/ai-memory/event-sync` — PostHog → AI memory dual-fire.
+ *
+ * Caller: web `apps/web/src/core/observability/productMemorySync.ts` дзеркалить
+ * allowlisted analytics events. Server: валідує event-name + payload, дзвонить
+ * `recordProductMemoryEvent`, повертає 202 / 200 / 4xx.
+ *
+ * Status codes:
+ *   - 202 — event у allowlist, ingest enqueued (best-effort: повертаємо
+ *           навіть якщо `recordProductMemoryEvent` логуючи fail-нувся
+ *           всередині — клієнт нічого не може з цим зробити).
+ *   - 200 + `{ok:false, reason:"event_not_synced"}` — event поза allowlist;
+ *           НЕ помилка для клієнта (web `trackEvent` дрібнить десятки
+ *           подій, sync викликається безумовно — нам зручно сказати "пас"
+ *           замість 4xx).
+ *   - 400 — schema-fail (відсутній eventName/payload, погані типи).
+ *   - 401 — без сесії (router middleware).
+ *   - 503 — `AI_MEMORY_ENABLED=false`.
+ */
+
+import type { Request, Response } from "express";
+import type { Pool } from "pg";
+import { z } from "zod";
+
+import { env } from "../../env.js";
+import { validateBody } from "../../http/validate.js";
+import { logger } from "../../obs/logger.js";
+import {
+  isProductMemoryEvent,
+  recordProductMemoryEvent,
+  type ProductMemoryEventName,
+} from "./eventSync.js";
+
+type WithSessionUser = Request & { user?: { id: string } };
+
+const MAX_EVENT_NAME_LEN = 80;
+
+/**
+ * Zod schema. `payload` навмисно `z.record(z.string(), z.unknown())` —
+ * жорсткіша валідація живе в event-mapper-і; route шар — anti-DoS
+ * (rejected huge/malformed objects).
+ */
+function buildEventSyncSchema() {
+  return z
+    .object({
+      eventName: z.string().min(1).max(MAX_EVENT_NAME_LEN),
+      payload: z.record(z.string(), z.unknown()).optional(),
+    })
+    .strict();
+}
+
+export function buildEventSyncHandler(pool: Pool) {
+  return async function eventSyncHandler(
+    req: Request,
+    res: Response,
+  ): Promise<void> {
+    if (!env.AI_MEMORY_ENABLED) {
+      res.status(503).json({
+        error: "AI memory вимкнено на сервері",
+        code: "AI_MEMORY_DISABLED",
+      });
+      return;
+    }
+
+    const parsed = validateBody(buildEventSyncSchema(), req, res);
+    if (!parsed.ok) return;
+    const { eventName, payload } = parsed.data;
+
+    if (!isProductMemoryEvent(eventName)) {
+      // Не 4xx — web sync-shim дзвонить безумовно; відмова з 4xx
+      // забруднила б browser console + Sentry чужими `network error`
+      // breadcrumbs.
+      res.status(200).json({ ok: false, reason: "event_not_synced" });
+      return;
+    }
+
+    const userId = (req as WithSessionUser).user!.id;
+
+    try {
+      const result = await recordProductMemoryEvent(pool, {
+        userId,
+        eventName: eventName as ProductMemoryEventName,
+        payload,
+      });
+      logger.info({
+        msg: "ai_memory_event_sync_ok",
+        userId,
+        eventName,
+        enqueued: result.enqueued,
+        contentLength: result.contentLength,
+      });
+      res.status(202).json({
+        ok: true,
+        enqueued: result.enqueued,
+        sourceRef: result.sourceRef,
+      });
+    } catch (err) {
+      logger.error({
+        msg: "ai_memory_event_sync_unexpected_error",
+        userId,
+        eventName,
+        err: err instanceof Error ? err.message : String(err),
+      });
+      res.status(500).json({
+        error: "Не вдалося обробити event-sync",
+        code: "EVENT_SYNC_FAILED",
+      });
+    }
+  };
+}

--- a/apps/server/src/modules/ai-memory/types.ts
+++ b/apps/server/src/modules/ai-memory/types.ts
@@ -28,6 +28,13 @@ export const ALLOWED_MEMORY_SOURCES = [
   "journal",
   "digest",
   "cofounder",
+  // Migration 068 — PostHog → AI memory sync (PR-24). Behavioral product
+  // events (`onboarding_completed`, `first_action_completed`,
+  // `subscription_started`, `activation_v2_hit`) дзеркаляться як
+  // structured text-rows. Strict-isolation: `recall_memory` openclaw tool
+  // лишається на `sources=['cofounder']`; combined recall — через
+  // `POST /api/ai-memory/recall` з явним `sources=['cofounder','product']`.
+  "product",
 ] as const;
 
 export type MemorySource = (typeof ALLOWED_MEMORY_SOURCES)[number];

--- a/apps/server/src/routes/__snapshots__/registerRoutes.test.ts.snap
+++ b/apps/server/src/routes/__snapshots__/registerRoutes.test.ts.snap
@@ -34,6 +34,7 @@ exports[`registerRoutes > mounts the stable set of /api/* endpoints (snapshot) 1
   "GET /metrics",
   "GET /readyz",
   "GET /startupz",
+  "POST /api/ai-memory/event-sync",
   "POST /api/ai-memory/ingest",
   "POST /api/ai-memory/recall",
   "POST /api/billing/checkout",

--- a/apps/server/src/routes/ai-memory.route.test.ts
+++ b/apps/server/src/routes/ai-memory.route.test.ts
@@ -455,3 +455,113 @@ describe("POST /api/ai-memory/recall — provider failure", () => {
     expect(res.body).toMatchObject({ code: "RECALL_FAILED" });
   });
 });
+
+// ─── PR-24: POST /api/ai-memory/event-sync ────────────────────────────
+
+describe("POST /api/ai-memory/event-sync — auth guard", () => {
+  it("→ 401 без сесії", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/api/ai-memory/event-sync")
+      .set("X-Requested-With", "XMLHttpRequest")
+      .send({ eventName: "onboarding_completed", payload: {} });
+    expect(res.status).toBe(401);
+    expect(enqueueMemoryIngestMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/ai-memory/event-sync — schema validation", () => {
+  beforeEach(() => {
+    getSessionUserMock.mockResolvedValue({ id: "u1" });
+  });
+
+  it("→ 400 коли eventName відсутній", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/api/ai-memory/event-sync")
+      .set("X-Requested-With", "XMLHttpRequest")
+      .send({ payload: {} });
+    expect(res.status).toBe(400);
+    expect(enqueueMemoryIngestMock).not.toHaveBeenCalled();
+  });
+
+  it("→ 400 коли payload — масив (не obj)", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/api/ai-memory/event-sync")
+      .set("X-Requested-With", "XMLHttpRequest")
+      .send({ eventName: "onboarding_completed", payload: ["evil"] });
+    expect(res.status).toBe(400);
+  });
+
+  it("→ 200 + ok:false для подій поза allowlist (без 4xx)", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/api/ai-memory/event-sync")
+      .set("X-Requested-With", "XMLHttpRequest")
+      .send({ eventName: "expense_added", payload: { amount_kop: 100 } });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: false, reason: "event_not_synced" });
+    expect(enqueueMemoryIngestMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/ai-memory/event-sync — happy path", () => {
+  beforeEach(() => {
+    getSessionUserMock.mockResolvedValue({ id: "user_42" });
+  });
+
+  it("→ 202 + enqueueMemoryIngest викликаний з source='product'", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/api/ai-memory/event-sync")
+      .set("X-Requested-With", "XMLHttpRequest")
+      .send({
+        eventName: "onboarding_completed",
+        payload: { intent: "vibe_picked", picksCount: 2 },
+      });
+    expect(res.status).toBe(202);
+    expect(res.body).toMatchObject({ ok: true, enqueued: true });
+    expect(res.body.sourceRef).toMatch(
+      /^onboarding_completed:user_42:\d{4}-\d{2}-\d{2}$/,
+    );
+    expect(enqueueMemoryIngestMock).toHaveBeenCalledTimes(1);
+    const arg = enqueueMemoryIngestMock.mock.calls[0]?.[0] as {
+      userId: string;
+      source: string;
+      content: string;
+      metadata: Record<string, unknown>;
+    };
+    expect(arg.userId).toBe("user_42");
+    expect(arg.source).toBe("product");
+    expect(arg.content).toContain("completed onboarding");
+    expect(arg.metadata).toMatchObject({
+      event: "onboarding_completed",
+      intent: "vibe_picked",
+    });
+  });
+
+  it("витирає PII перед enqueue (email/password)", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/api/ai-memory/event-sync")
+      .set("X-Requested-With", "XMLHttpRequest")
+      .send({
+        eventName: "signup_completed",
+        payload: {
+          method: "email",
+          email: "leaked@example.com",
+          password: "hunter2",
+        },
+      });
+    expect(res.status).toBe(202);
+    const arg = enqueueMemoryIngestMock.mock.calls[0]?.[0] as {
+      content: string;
+      metadata: Record<string, unknown>;
+    };
+    expect(arg.content).not.toContain("leaked@example.com");
+    expect(arg.content).not.toContain("hunter2");
+    expect(arg.metadata).not.toHaveProperty("email");
+    expect(arg.metadata).not.toHaveProperty("password");
+  });
+});

--- a/apps/server/src/routes/ai-memory.ts
+++ b/apps/server/src/routes/ai-memory.ts
@@ -8,6 +8,7 @@ import {
   setModule,
 } from "../http/index.js";
 import { requirePlan } from "../modules/billing/requirePlan.js";
+import { buildEventSyncHandler } from "../modules/ai-memory/eventSyncRoute.js";
 import { ingestMemoryHandler } from "../modules/ai-memory/ingestRoute.js";
 import { recallMemoryHandler } from "../modules/ai-memory/recallRoute.js";
 
@@ -48,6 +49,16 @@ export function createAiMemoryRouter({ pool }: { pool: Pool }): Router {
     requireSession(),
     requirePlan(pool, "pro"),
     asyncHandler(recallMemoryHandler),
+  );
+  // PR-24: PostHog → AI memory sync. Не вимагаємо pro-plan — behavioral
+  // events важливі для founder-recall на будь-якому tier-і (founder теж
+  // user-row, на free-tier у dev). Memory ingest сам перевіряє
+  // `AI_MEMORY_ENABLED`; per-user Voyage квоту обмежує
+  // `service.remember()`.
+  r.post(
+    "/api/ai-memory/event-sync",
+    requireSession(),
+    asyncHandler(buildEventSyncHandler(pool)),
   );
   return r;
 }

--- a/apps/web/src/core/observability/analytics.ts
+++ b/apps/web/src/core/observability/analytics.ts
@@ -18,6 +18,7 @@
 
 import { ANALYTICS_EVENTS } from "@sergeant/shared";
 import { capturePostHogEvent } from "./posthog";
+import { syncEventToMemory } from "./productMemorySync";
 import { safeReadLS, safeWriteLS } from "@shared/lib/storage/storage";
 
 export { ANALYTICS_EVENTS };
@@ -71,5 +72,16 @@ export function trackEvent(
     capturePostHogEvent(eventName, event.payload as Record<string, unknown>);
   } catch {
     /* PostHog transport never breaks trackEvent callers */
+  }
+  // PR-24 — PostHog → AI memory sync. Дзеркалить allowlist-events до
+  // server-side ingest queue як `source='product'`, щоб `/recall`
+  // мав behavioral context. Fire-and-forget, ніколи не throw-ить.
+  // Server-side allowlist authoritative (`PRODUCT_MEMORY_EVENTS`);
+  // тут — фільтр-shortcut, що пропускає лишні network-trip-и.
+  try {
+    syncEventToMemory(eventName, event.payload as Record<string, unknown>);
+  } catch {
+    /* AI memory sync best-effort — analytics call-site не повинен
+       впасти, якщо fetch() throw-нув на CSP/lock-tab edge-кейсі. */
   }
 }

--- a/apps/web/src/core/observability/productMemorySync.test.ts
+++ b/apps/web/src/core/observability/productMemorySync.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  PRODUCT_MEMORY_SYNC_EVENTS,
+  shouldSyncEventToMemory,
+  syncEventToMemory,
+} from "./productMemorySync";
+import { ANALYTICS_EVENTS } from "@sergeant/shared";
+
+describe("productMemorySync — shouldSyncEventToMemory", () => {
+  it("повертає true для подій з allowlist", () => {
+    expect(shouldSyncEventToMemory(ANALYTICS_EVENTS.ONBOARDING_COMPLETED)).toBe(
+      true,
+    );
+    expect(
+      shouldSyncEventToMemory(ANALYTICS_EVENTS.FIRST_ACTION_COMPLETED),
+    ).toBe(true);
+    expect(shouldSyncEventToMemory(ANALYTICS_EVENTS.SIGNUP_COMPLETED)).toBe(
+      true,
+    );
+    expect(shouldSyncEventToMemory(ANALYTICS_EVENTS.SUBSCRIPTION_STARTED)).toBe(
+      true,
+    );
+  });
+
+  it("повертає false для довільних подій", () => {
+    expect(shouldSyncEventToMemory("expense_added")).toBe(false);
+    expect(shouldSyncEventToMemory("page_view")).toBe(false);
+    expect(shouldSyncEventToMemory("")).toBe(false);
+  });
+
+  it("expose-ить allowlist у Set-формі (test-friendly)", () => {
+    expect(PRODUCT_MEMORY_SYNC_EVENTS).toBeInstanceOf(Set);
+    expect(PRODUCT_MEMORY_SYNC_EVENTS.size).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe("productMemorySync — syncEventToMemory", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let originalFetch: typeof globalThis.fetch | undefined;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    fetchMock = vi.fn(async () => new Response(null, { status: 202 }));
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+  });
+
+  afterEach(() => {
+    if (originalFetch) globalThis.fetch = originalFetch;
+    else delete (globalThis as { fetch?: typeof globalThis.fetch }).fetch;
+  });
+
+  it("POST-ить на /api/ai-memory/event-sync для allowlist-event", () => {
+    syncEventToMemory(ANALYTICS_EVENTS.ONBOARDING_COMPLETED, {
+      intent: "vibe_picked",
+      picksCount: 2,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/ai-memory/event-sync");
+    expect(init.method).toBe("POST");
+    expect(init.credentials).toBe("include");
+    expect(init.keepalive).toBe(true);
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBe(
+      "application/json",
+    );
+    expect((init.headers as Record<string, string>)["X-Requested-With"]).toBe(
+      "XMLHttpRequest",
+    );
+    const body = JSON.parse(init.body as string);
+    expect(body).toMatchObject({
+      eventName: "onboarding_completed",
+      payload: { intent: "vibe_picked", picksCount: 2 },
+    });
+  });
+
+  it("НЕ дзвонить fetch для подій поза allowlist", () => {
+    syncEventToMemory("expense_added", { amount_kop: 100 });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("НЕ кидає коли fetch повертає rejected promise (network drop)", async () => {
+    // Створюємо rejected-promise через `.catch(() => Promise.reject())`,
+    // щоб обʼєкт-rejection-у мав хоча б один handler перед event-loop-ом
+    // ловлячи unhandled-rejection. Виробничий код кріпить .catch() сам,
+    // але mock повертає raw promise, який тест має закрити.
+    fetchMock.mockImplementationOnce(() => {
+      const p = Promise.reject(new Error("network_down"));
+      // Підвʼязуємо catch одразу, щоб vitest не репортував unhandled.
+      // Production-код у `syncEventToMemory` робить це сам (.catch()),
+      // але тест має imitate-ити тільки сам call — і ми хочемо
+      // переконатись, що caller-функція не throw-ить синхронно.
+      p.catch(() => {});
+      return p;
+    });
+    expect(() => {
+      syncEventToMemory(ANALYTICS_EVENTS.SIGNUP_COMPLETED, { method: "email" });
+    }).not.toThrow();
+    // Дозволяє event-loop-у завершити microtask-черга з rejected promise.
+    await new Promise((r) => setTimeout(r, 0));
+  });
+
+  it("НЕ кидає коли fetch синхронно throw-ає (CSP/lock-tab)", () => {
+    fetchMock.mockImplementationOnce(() => {
+      throw new Error("csp_violation");
+    });
+    expect(() => {
+      syncEventToMemory(ANALYTICS_EVENTS.FIRST_ACTION_COMPLETED, {
+        module: "finyk",
+      });
+    }).not.toThrow();
+  });
+
+  it("ігнорує порожній/невалідний eventName", () => {
+    syncEventToMemory("", { a: 1 });
+    syncEventToMemory(null as unknown as string, { a: 1 });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("використовує {} як default payload коли caller не передає", () => {
+    syncEventToMemory(ANALYTICS_EVENTS.SIGNUP_COMPLETED);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.payload).toEqual({});
+  });
+});

--- a/apps/web/src/core/observability/productMemorySync.ts
+++ b/apps/web/src/core/observability/productMemorySync.ts
@@ -1,0 +1,103 @@
+/**
+ * PostHog → AI memory sync (web side, PR-24).
+ *
+ * Контекст: PostHog ловить product events (`onboarding_completed`,
+ * `first_action_completed`, `signup_completed`, `subscription_started`)
+ * у PR-06/07/08/09. Ці події живуть у PostHog-instance і недосяжні для
+ * AI memory `/recall`, тож founder не може запитати «коли я останній
+ * раз активувався у фінику?» — мемор з product-боку порожня.
+ *
+ * Цей модуль — fire-and-forget dual-fire shim: для allowlisted-event
+ * робить POST на `/api/ai-memory/event-sync`. Server transforms event +
+ * payload у structured-text, scrubPII, enqueue-ить у memory ingest queue
+ * як `source='product'`.
+ *
+ * Контракт: НІКОЛИ не кидає (`trackEvent` обіцяє це call-site-ам). HTTP
+ * failures swallow-аться, server side rate-limit (4xx) — теж тихий no-op.
+ *
+ * ─── Чому allowlist у web ─────────────────────────────────────────
+ *
+ * `trackEvent` дрібниться на десятки analytics events. Дзвонити server-
+ * у на всі — лишній DoS + 200/`ok:false` від server-у. Allowlist у web
+ * — perf-shortcut: пропускаємо непотрібний network-trip навіть для
+ * подій, які server відхилить. Сервер далі має свій authoritative
+ * allowlist (`PRODUCT_MEMORY_EVENTS`), тож якщо web-allowlist розійдеться
+ * — це лише missed-sync, ніколи false-positive.
+ */
+
+import { ANALYTICS_EVENTS } from "@sergeant/shared";
+
+/**
+ * Web-side allowlist подій, що дзеркаляться у `ai_memories` як
+ * `source='product'`. ПОВИНЕН бути підмножиною server-side
+ * `PRODUCT_MEMORY_EVENTS` (`apps/server/src/modules/ai-memory/eventSync.ts`),
+ * інакше server відхилить з 200/`ok:false` — це не шкодить, але
+ * додає лишній network-roundtrip.
+ *
+ * Якщо додаєш new entry — синхронізуй з server-side `EVENT_FORMATTERS`
+ * (інакше event прилетить, але server не знатиме, як його зреймити).
+ */
+export const PRODUCT_MEMORY_SYNC_EVENTS: ReadonlySet<string> = new Set([
+  ANALYTICS_EVENTS.SIGNUP_COMPLETED,
+  ANALYTICS_EVENTS.ONBOARDING_COMPLETED,
+  ANALYTICS_EVENTS.FIRST_ACTION_COMPLETED,
+  // `subscription_started` fire-иться зі stripe-webhook (server) — тут
+  // у allowlist на випадок, якщо у майбутньому web почне його track-ати
+  // на client-side (наприклад success-redirect).
+  ANALYTICS_EVENTS.SUBSCRIPTION_STARTED,
+]);
+
+const SYNC_URL = "/api/ai-memory/event-sync";
+
+/**
+ * Чи слід дзеркалити цю подію у AI memory. Стабільний predicate —
+ * test-friendly (важливо, бо реальний viability-залежить від
+ * `PRODUCT_MEMORY_SYNC_EVENTS`, що може ростати).
+ */
+export function shouldSyncEventToMemory(eventName: string): boolean {
+  return PRODUCT_MEMORY_SYNC_EVENTS.has(eventName);
+}
+
+/**
+ * Fire-and-forget HTTP POST. Не повертає Promise — caller-у нема чого
+ * await-ити. Усі помилки swallow-аться (network drop, 4xx, 5xx, AbortError).
+ *
+ * Auth: `credentials: "include"` — Better Auth session cookie.
+ * CSRF: `X-Requested-With: XMLHttpRequest` за конвенцією server-у
+ * (`apps/server/src/http/csrf.ts` exempt-ить XHR-маркер).
+ * Reliability: `keepalive: true` — браузер довершить запит навіть якщо
+ * tab закриється під час події (важливо для `onboarding_completed`,
+ * де founder одразу йде на dashboard).
+ */
+export function syncEventToMemory(
+  eventName: string,
+  payload: Record<string, unknown> = {},
+): void {
+  if (!eventName || typeof eventName !== "string") return;
+  if (!shouldSyncEventToMemory(eventName)) return;
+  if (typeof fetch !== "function") return;
+
+  // Захист тестового середовища (jsdom): не вирубаємо тести
+  // network-call-ом коли test setup не мокнув fetch.
+  if (typeof window === "undefined") return;
+
+  const body = JSON.stringify({ eventName, payload });
+
+  try {
+    void fetch(SYNC_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Requested-With": "XMLHttpRequest",
+      },
+      body,
+      keepalive: true,
+      credentials: "include",
+    }).catch(() => {
+      /* PostHog → memory sync — best-effort; failures NEVER break
+         analytics call-site-ів. */
+    });
+  } catch {
+    /* noop — fetch() throw на edge-кейсах (CSP, locked tab) */
+  }
+}

--- a/docs/architecture/ai-memory.md
+++ b/docs/architecture/ai-memory.md
@@ -7,14 +7,14 @@
 
 ## Modules
 
-| Surface      | File / table                                                                                                               | Roles                                                                                                                                                                                               |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Storage      | [`apps/server/src/migrations/025_ai_memories_pgvector.sql`](../../apps/server/src/migrations/025_ai_memories_pgvector.sql) | pgvector HALFVEC(1024) partitioned by user_id; CHECK source IN (`chat`, `finyk`, `fizruk`, `nutrition`, `routine`, `journal`, `digest`, `cofounder`).                                               |
-| Embeddings   | [`apps/server/src/modules/ai-memory/embeddings.ts`](../../apps/server/src/modules/ai-memory/embeddings.ts)                 | Voyage `voyage-3.5-lite` (1024d). Voyage budget guard у [`apps/server/src/modules/ai-memory/voyageBudget.ts`](../../apps/server/src/modules/ai-memory/voyageBudget.ts).                             |
-| Service      | [`apps/server/src/modules/ai-memory/service.ts`](../../apps/server/src/modules/ai-memory/service.ts)                       | `remember()` + `recall()` орchestrator. Викликається BullMQ-worker-ом + recall-route.                                                                                                               |
-| Ingest queue | [`apps/server/src/modules/ai-memory/ingestQueue.ts`](../../apps/server/src/modules/ai-memory/ingestQueue.ts)               | BullMQ `ai-memory-ingest`. `enqueueMemoryIngest()` — public producer. Per-source gating через `AI_MEMORY_ENABLED` (master) + `MONO_AI_MEMORY_INGEST_ENABLED` (finyk).                               |
-| Recall route | [`apps/server/src/modules/ai-memory/recallRoute.ts`](../../apps/server/src/modules/ai-memory/recallRoute.ts)               | Public `POST /api/ai-memory/recall` (session-auth). HubChat tool: [`packages/openclaw-plugin/src/legacy/tools/recall-memory.ts`](../../packages/openclaw-plugin/src/legacy/tools/recall-memory.ts). |
-| Backfill     | [`apps/server/src/modules/ai-memory/backfill.ts`](../../apps/server/src/modules/ai-memory/backfill.ts)                     | Resumable backfill з `tg_topic_archive` → cofounder memory. Detailed нижче.                                                                                                                         |
+| Surface      | File / table                                                                                                               | Roles                                                                                                                                                                                                               |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Storage      | [`apps/server/src/migrations/025_ai_memories_pgvector.sql`](../../apps/server/src/migrations/025_ai_memories_pgvector.sql) | pgvector HALFVEC(1024) partitioned by user_id; CHECK source IN (`chat`, `finyk`, `fizruk`, `nutrition`, `routine`, `journal`, `digest`, `cofounder`, `product`). `cofounder` додано у 028, `product` у 068 (PR-24). |
+| Embeddings   | [`apps/server/src/modules/ai-memory/embeddings.ts`](../../apps/server/src/modules/ai-memory/embeddings.ts)                 | Voyage `voyage-3.5-lite` (1024d). Voyage budget guard у [`apps/server/src/modules/ai-memory/voyageBudget.ts`](../../apps/server/src/modules/ai-memory/voyageBudget.ts).                                             |
+| Service      | [`apps/server/src/modules/ai-memory/service.ts`](../../apps/server/src/modules/ai-memory/service.ts)                       | `remember()` + `recall()` орchestrator. Викликається BullMQ-worker-ом + recall-route.                                                                                                                               |
+| Ingest queue | [`apps/server/src/modules/ai-memory/ingestQueue.ts`](../../apps/server/src/modules/ai-memory/ingestQueue.ts)               | BullMQ `ai-memory-ingest`. `enqueueMemoryIngest()` — public producer. Per-source gating через `AI_MEMORY_ENABLED` (master) + `MONO_AI_MEMORY_INGEST_ENABLED` (finyk).                                               |
+| Recall route | [`apps/server/src/modules/ai-memory/recallRoute.ts`](../../apps/server/src/modules/ai-memory/recallRoute.ts)               | Public `POST /api/ai-memory/recall` (session-auth). HubChat tool: [`packages/openclaw-plugin/src/legacy/tools/recall-memory.ts`](../../packages/openclaw-plugin/src/legacy/tools/recall-memory.ts).                 |
+| Backfill     | [`apps/server/src/modules/ai-memory/backfill.ts`](../../apps/server/src/modules/ai-memory/backfill.ts)                     | Resumable backfill з `tg_topic_archive` → cofounder memory. Detailed нижче.                                                                                                                                         |
 
 ## Ingest flow (current state)
 
@@ -23,9 +23,12 @@ producer-callsite                            BullMQ queue                worker
 ─────────────────                            ─────────────                ──────
  mono webhook  (source=finyk)         ┐                                  ┌─ Voyage embed
  weekly digest (source=digest)        ├─→  ai-memory-ingest    ───→     ├─ INSERT ai_memories
- hub/chat user posts (chat)           ┘                                  └─ metrics + breadcrumb
- backfill CLI (source=cofounder)
+ hub/chat user posts (chat)           │                                  └─ metrics + breadcrumb
+ backfill CLI (source=cofounder)      │
+ event-sync route (source=product)    ┘
 ```
+
+`event-sync` (PR-24): web `trackEvent` дзеркалить allowlist analytics events (`onboarding_completed`, `first_action_completed`, `signup_completed`, `subscription_started`) до `POST /api/ai-memory/event-sync`. Route форматує payload у людський text (`"2026-05-13: completed onboarding wizard (vibe_picked)"`), scrubPII, enqueue-ить як `source='product'`. Idempotency: `sourceRef = "<eventName>:<userId>:<dayKey>"` — повторні fire-и тієї ж події у Kyiv-добу дедуплікуються.
 
 `enqueueMemoryIngest` gating:
 
@@ -90,6 +93,22 @@ SELECT source, COUNT(*) AS active_failures
  WHERE replayed_at IS NULL
  GROUP BY source;
 ```
+
+## Sources matrix
+
+`source` differentiates origin + read-policy. CHECK constraint у `025_ai_memories_pgvector.sql` (extended у 028 + 068).
+
+| Source      | Producer                                                                                                | Reader                                                                                   | Isolation                                                                                                                                                                                                               |
+| ----------- | ------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `chat`      | Hub chat user posts                                                                                     | `/recall` API + RAG context-injection                                                    | Per-user; default tier.                                                                                                                                                                                                 |
+| `finyk`     | Mono webhook (server-side)                                                                              | `/recall` + RAG                                                                          | Per-user; behind `MONO_AI_MEMORY_INGEST_ENABLED` (PR-19).                                                                                                                                                               |
+| `fizruk`    | Client-driven (RxDB) ingest                                                                             | `/recall` + RAG                                                                          | Per-user.                                                                                                                                                                                                               |
+| `nutrition` | Client-driven (RxDB) ingest                                                                             | `/recall` + RAG                                                                          | Per-user.                                                                                                                                                                                                               |
+| `routine`   | Client-driven (RxDB) ingest                                                                             | `/recall` + RAG                                                                          | Per-user.                                                                                                                                                                                                               |
+| `journal`   | Client-driven (RxDB) ingest                                                                             | `/recall` + RAG                                                                          | Per-user.                                                                                                                                                                                                               |
+| `digest`    | Weekly digest cron (server-side)                                                                        | `/recall` + RAG                                                                          | Per-user.                                                                                                                                                                                                               |
+| `cofounder` | `pnpm ai-memory:backfill` CLI (PR-22) → backfill API → `tg_topic_archive`                               | OpenClaw `recall_memory` tool (HARDCODED `sources=['cofounder']`, ADR-0031 §3 isolation) | Founder-only namespace. Хардкодинг у tool гарантує що cofounder DM-recall повертає тільки founder-input narrative.                                                                                                      |
+| `product`   | Web `trackEvent` (PR-24) → `POST /api/ai-memory/event-sync` для allowlist (`onboarding_completed` etc.) | `POST /api/ai-memory/recall` з явним `sources=['cofounder','product']` для combined view | НЕ доступний з OpenClaw `recall_memory` tool (зберігає founder-input clean). UI-recall на web-side комбінує. Soft-isolation: server route — session-gated, не INTERNAL_API_KEY; per-user partitioning (як усі sources). |
 
 ## Backfill з `tg_topic_archive` (PR-21 follow-up)
 

--- a/packages/shared/src/schemas/api.ts
+++ b/packages/shared/src/schemas/api.ts
@@ -75,6 +75,11 @@ const RECALL_MEMORY_SOURCES = [
   "journal",
   "digest",
   "cofounder",
+  // Migration 068 — PostHog → AI memory sync (PR-24). `product` source —
+  // behavioral events дзеркаляться з web `trackEvent` через
+  // `POST /api/ai-memory/event-sync`. Дозволяємо у recall-filter, щоб
+  // founder міг запитати combined `sources=['cofounder','product']` view.
+  "product",
 ] as const;
 
 /** POST /api/ai-memory/recall — semantic memory retrieval. */


### PR DESCRIPTION
## Summary

Закриває **PR-24** з [`docs/planning/pr-plan-2026-05.md`](https://github.com/Skords-01/Sergeant/blob/main/docs/planning/pr-plan-2026-05.md): PostHog product events → AI memory ingest sync. Коли founder завершує onboarding, виконує first action, signup-иться чи стартує subscription — подія дзеркалиться у `ai_memories` як structured text під новим `source='product'`. Дає `/recall` cross-source view: founder-input narrative (`cofounder` source) + behavioral product context (`product` source).

Будується на foundation попередніх PR: PR-19 (#2605, ingest activation) + PR-22 (#2712, backfill) + PR-23 (#2731, `/forget` soft-delete). ADR-0031 §3 strict isolation respected: OpenClaw `recall_memory` tool лишається з hardcoded `sources=['cofounder']`, новий `product` source доступний тільки через explicit `POST /api/ai-memory/recall` filter.

## Governing Skill

- Primary skill: `.agents/skills/sergeant-server-api/SKILL.md` (apps/server, migrations, contract triplet)
- Secondary skill: `.agents/skills/sergeant-web-ui/SKILL.md` (apps/web, analytics wiring)

## Playbook

- Primary playbook: n/a (incremental feature на існуючий ingest pipeline)
- Why this playbook: PR-24 не вкладається у жоден з naming-індексованих playbook-ів — це plumbing-шар над PR-19 ingestQueue + новий route.
- If no playbook matched, why: ADR-0031 §3 + PR-plan-2026-05 § PR-24 — sufficient guidance.

## Verification

```bash
pnpm --filter @sergeant/server test     # 2715 passed (8 нових event-sync route, 21 eventSync unit)
pnpm --filter @sergeant/server typecheck # ok
pnpm --filter @sergeant/server lint      # 4 pre-existing warnings (security/detect-non-literal-fs-filename)
pnpm --filter @sergeant/web test         # 2796 passed (9 нових productMemorySync)
pnpm --filter @sergeant/web typecheck    # ok
pnpm --filter @sergeant/web lint         # ok
pnpm --filter @sergeant/shared test      # 648 passed
pnpm format:check                        # ok
```

Additional checks:

- [x] Local smoke / manual validation completed (route → enqueue dispatch + PII redaction tests pass)
- [x] Surface-specific checks completed (registerRoutes snapshot updated)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- `docs/architecture/ai-memory.md` — додав event-sync ingest flow + sources matrix (8 sources → 9: новий `product`).

## Risk and Rollout

- **User-visible risk:** низький. `POST /api/ai-memory/event-sync` — нова route, не змінює existing endpoints. Web `trackEvent()` тепер дзеркалить 4 allowlist events fire-and-forget — network failures swallow-аться, ніколи не throw caller-у. Voyage quota витрати: ~$0.0004/day per active founder (4 events × ~$0.0001 per Voyage embed; idempotency дедуплікує duplicate fires у Kyiv day).
- **Rollout / deploy order:**
  1. Merge → CI green → Railway redeploy (auto).
  2. Migration 068 auto-applied на deploy (sequential, no gaps after 067).
  3. Web dual-fire активний з deploy — без explicit feature flag.
  4. Spot-check: complete onboarding у production → query `SELECT * FROM ai_memories WHERE source='product' ORDER BY inserted_at DESC LIMIT 5` → має зʼявитись row з content `"YYYY-MM-DD: completed onboarding..."`.
- **Backout plan:**
  1. Швидкий kill (без revert): flip `AI_MEMORY_ENABLED=false` у Railway env → масковий disable усіх sources, включно з `product`. Existing `cofounder` digest теж зупиниться, тож тільки емерджентні випадки.
  2. Партіальний kill: revert PR. Migration 068 rollback (`068_ai_memories_product_source.down.sql`) **DELETE**-ить усі `product`-rows перед narrowing CHECK constraint — це безпечно, бо `cofounder` source ізольований, recall на `cofounder` нічого не втратить.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

- **Migration 068:** sequential after 067 (соft-delete з PR-23). Extends CHECK constraint (8 → 9 sources). Не вимагає two-phase (no DROP) — Hard Rule #4 не активований.
- **Auth gating:** route — `requireSession()` без `requirePlan('pro')`. Behavioral events важливі для founder на free tier; downstream Voyage quota через `service.remember()` per-user.
- **Allowlist на сервері — authoritative.** Web-allowlist — perf-shortcut, що дозволяє server reject-ити з `200/ok:false` без 4xx (зменшує console-noise від analytics).
- **Idempotency через Kyiv-day:** `sourceRef = <event>:<userId>:<dayKey>` дозволяє повторні fire-и тієї ж події у добу — UNIQUE-індекс із PR-19 schema дедуплікує (no row duplication, no Voyage waste).
- **Pre-existing migration dupe `066_ai_memory_ingest_failed.sql + 066_openclaw_mute_state.sql`** — не блокує цей PR (068 sequential), але `pnpm lint:migrations` показуватиме duplicate. Окремий rename-PR трекається як ops follow-up.
- **PII scrubbing:** `scrubPII` з `@sergeant/shared` — той самий util, який редагує Sentry beforeSend (web + server). Deep-walk, redacts `email|password|apiKey|phone` at arbitrary depth.

Link to Devin session: https://app.devin.ai/sessions/5b8245ad8d8b41adaaa54fb8ce902612

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync key product events into `ai_memories` as `source='product'` via a new event-sync route. This adds behavioral context to `/recall` while keeping `cofounder` memory isolated.

- **New Features**
  - Server: `POST /api/ai-memory/event-sync` (session-only) accepts allowlisted events (`signup_completed`, `onboarding_completed`, `first_action_completed`, `subscription_started`), scrubs PII, and enqueues to the ingest queue as `source='product'` (202 on accept; non-allowlisted return 200 `{ok:false}`).
  - Idempotency: `sourceRef = <event>:<userId>:<Kyiv-day>` dedupes same-day re-fires.
  - Web: `trackEvent()` dual-fires allowlisted events via `syncEventToMemory` (fire-and-forget, `keepalive`, `credentials:'include'`).
  - Isolation: OpenClaw `recall_memory` remains `sources=['cofounder']`; `product` is available only via `POST /api/ai-memory/recall` with explicit `sources`.

- **Migration**
  - 068 extends `ai_memories.source` CHECK to include `product` (down migration deletes `product` rows before narrowing). Deploy applies automatically; verify by checking recent `source='product'` rows after an onboarding flow.

<sup>Written for commit fca82d7c3b96721ec3316da228ca049ebf0cb67f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

