### PR TITLE
fix(server): match Better Auth /request-password-reset in auth middleware

### DIFF
--- a/apps/server/src/http/authMiddleware.ts
+++ b/apps/server/src/http/authMiddleware.ts
@@ -28,6 +28,7 @@ export function authSensitiveRateLimit(
     (url.includes("/sign-in") ||
       url.includes("/sign-up") ||
       url.includes("forget-password") ||
+      url.includes("request-password-reset") ||
       url.includes("reset-password"));
   if (!sensitive) {
     next();
@@ -86,7 +87,12 @@ export function authMetricsMiddleware(
   const op: AuthOp | null =
     (url.includes("/sign-in") && "sign_in") ||
     (url.includes("/sign-up") && "sign_up") ||
+    // Better Auth v1.6 renamed `/forget-password` to
+    // `/request-password-reset`; keep both spellings so the audit-log /
+    // `authAttemptsTotal{op="forget_password"}` counter survives the
+    // rename and stays compatible with older clients.
     (url.includes("forget-password") && "forget_password") ||
+    (url.includes("request-password-reset") && "forget_password") ||
     (url.includes("reset-password") && "reset_password") ||
     (url.includes("/sign-out") && "signout") ||
     null;


### PR DESCRIPTION
## Summary

Better Auth v1.6 renamed the email/password endpoint from `/forget-password` to `/request-password-reset`, but `apps/server/src/http/authMiddleware.ts` still only matched the legacy URL substring. That had two silent consequences on every successful upgrade:

1. **Sensitive rate-limit bypass** — `authSensitiveRateLimit` only POSTs that include `forget-password` / `reset-password` / `sign-in` / `sign-up` in their URL are counted against the `api:auth:sensitive` 5/60s OWASP ASVS V11.1.3 budget. After the rename, password-reset traffic via `/api/auth/request-password-reset` is **not rate-limited** at all — enabling unmitigated enumeration / email-pumping against the `sendResetPassword` callback in `apps/server/src/auth.ts:172`.
2. **Audit / metrics gap** — `authMetricsMiddleware` classifies sensitive POSTs into `authAttemptsTotal{op,outcome}` and emits a structured `auth_event` log with email-fingerprint + IP. After the rename, the new path no longer matched any branch → no counter sample, no audit-log entry. Brute-force triage dashboards on the `forget_password` op silently flatlined.

Both classifiers now also match `request-password-reset`. For the metrics path we deliberately re-use the existing `forget_password` op label so historical dashboards / alerts continue to fire unchanged.

This PR is the **server-side companion** to https://github.com/Skords-01/Sergeant/pull/2788 (which fixes the client-side wire path).

## Governing Skill

- Primary skill: `better-auth-best-practices` (verify auth binding on **both** server and client in the same upgrade — see SKILL.md § "Wire-path drift")
- Secondary skill (if truly needed): n/a (server-only)

## Playbook

- Primary playbook: generic "auth wire-path mismatch after upstream rename" — companion to PR #2788
- Why this playbook: identical class of bug (Better Auth v1.6 endpoint rename) on the server's observation layer; same minimal-blast-radius fix.
- If no playbook matched, why: contained to a single file; no migration / config / data shape changes.

## Verification

```bash
pnpm --filter @sergeant/server lint        # passed (4 pre-existing warnings, unrelated)
pnpm --filter @sergeant/server typecheck   # passed
pnpm --filter @sergeant/server exec vitest run \
  src/http/authMiddleware.test.ts          # 4/4 passed
```

Additional checks:

- [x] Local smoke / manual validation completed — `curl /api/auth/request-password-reset` now triggers `api:auth:sensitive` rate-limiter (5/60s) and emits `authAttemptsTotal{op="forget_password"}` on the metrics endpoint.
- [x] Surface-specific checks completed — only `apps/server/src/http/authMiddleware.ts` changed; no route changes, no config changes, no schema/migration changes.

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. — inline rationale comment explains the v1.6 rename + dual-spelling matcher.
- [x] I checked whether `AGENTS.md` needed an update. — no, no policy change.
- [x] I checked whether a playbook or skill needed an update. — `better-auth-best-practices` SKILL.md already enforces "verify both server and client in the same change"; this PR is the application of it.
- [x] I checked whether governance docs or review docs needed an update. — none.

Updated docs:

- n/a (inline rationale comment in `authMiddleware.ts`)

## Risk and Rollout

- User-visible risk: low — security-positive change (closes a rate-limit gap; restores audit-log coverage). The legacy `forget-password` spelling stays accepted so any in-flight clients on the older path keep working.
- Rollout / deploy order: standard merge → server build → Fly.io deploy. No DB migration. No env change. No client coordination required.
- Backout plan: revert this commit. Rate-limit gap and audit-log gap return but no data is at risk; the rest of the auth observability surface is unaffected.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian. — n/a (only an English code comment changed in a file whose existing rationale comments are in Ukrainian; followed local file convention).
- [x] I did not use `--no-verify`. — pre-commit Husky + commitlint + lint-staged ran clean.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

- Server-side companion to PR #2788. Together they restore the full password-reset flow (client reach → server rate-limit → server audit-log).
- Reusing the existing `forget_password` op label is intentional — splitting it into a new `request_password_reset` series would invalidate `docs/security/better-auth-audit-2026-05.md` baselines and existing alerting rules. Op-label renames should be a separate, dashboard-coordinated change.
- `apps/server/src/config/rateLimit.ts` and `apps/server/src/env/env.ts` still reference `forget-password` in **comments only** (`// Better-Auth POST /sign-in|/sign-up|/forget-password|/reset-password ...`) — these are descriptive doc strings, not URL matchers, so they don't affect runtime. Left as-is to keep the diff focused; a separate docs-only sweep can refresh them.

---

Devin session: https://app.devin.ai/sessions/305fbbd3cd844f4fa56f870ef4d8e5ae


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update auth middleware to recognize Better Auth v1.6 `/request-password-reset`. This restores sensitive rate limiting and audit/metrics for password-reset requests.

- **Bug Fixes**
  - Extend URL checks in `authSensitiveRateLimit` and `authMetricsMiddleware` to match both `forget-password` and `request-password-reset`.
  - Map `request-password-reset` to the existing `forget_password` op label to keep dashboards and alerts unchanged.

<sup>Written for commit 1e2d1704c6fb6196899c4c31a2bfdca58a7befea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

