### PR TITLE
fix(web): normalize password placeholder in DeleteAccountDialog

### DIFF
--- a/apps/web/src/core/profile/DeleteAccountDialog.tsx
+++ b/apps/web/src/core/profile/DeleteAccountDialog.tsx
@@ -72,7 +72,7 @@ export function DeleteAccountDialog({
             type="password"
             value={password}
             onChange={(e) => onPasswordChange(e.target.value)}
-            placeholder="Ваш пароль"
+            placeholder="Пароль"
             autoComplete="current-password"
           />
         </div>


### PR DESCRIPTION
## Summary

`DeleteAccountDialog` mixed registers inside the same overlay: the body uses informal «ти» («Введи пароль для підтвердження. Цю дію неможливо скасувати.»), the label is the neutral «Пароль», and the password input placeholder was `"Ваш пароль"` — the only password placeholder in `apps/web/src/` that uses the formal «Ви» form (verified by `rg 'placeholder=.*[Пп]ароль' apps/web/src`). Login / register / reset-password / nutrition-overlay placeholders are all the neutral `"Пароль"` (or no «Ви/ти» person marker), so the dialog stood out.

Change one user-visible string:

- `placeholder="Ваш пароль"` → `placeholder="Пароль"` in `apps/web/src/core/profile/DeleteAccountDialog.tsx:75`.

That aligns the placeholder with the dialog label («Пароль») and with the rest of the auth surface, without touching the destructive-confirm body copy or the «Введи пароль для підтвердження» description.

## Governing Skill

- Primary skill: sergeant-web-ui
- Secondary skill (if truly needed): sergeant-bugfix-and-regression

## Playbook

- Primary playbook: none — this is a single-line copy fix, not a multi-step recipe.
- Why this playbook: n/a
- If no playbook matched, why: 1-line, single-file, no infra / migration / API contract impact.

## Verification

```bash
pnpm --filter @sergeant/web test "DeleteAccountDialog" "ProfilePage"
# Test Files  1 passed (1)
# Tests       28 passed (28)

pnpm --filter @sergeant/web lint        # exit 0
pnpm --filter @sergeant/web typecheck   # exit 0
```

Additional checks:

- [x] Local smoke / manual validation completed — `DeleteAccountDialog` tests locate the password input via `getByLabelText("Пароль")`, so the label-based locators continue to match.
- [x] Surface-specific checks completed — searched `apps/web/src/` for `Ваш пароль`; only `DeleteAccountDialog.tsx` matched.

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a — pure UI copy normalisation.

## Risk and Rollout

- User-visible risk: extremely low — single placeholder text change inside an existing confirmation dialog.
- Rollout / deploy order: standard web rollout.
- Backout plan: revert this one-line commit.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

Found during a manual Settings/Profile testing pass (Devin child session: https://app.devin.ai/sessions/a5cc15e5ead5499bb3a435ebb85f6ed6). The dialog UI itself could not be exercised live because Settings/Profile tabs in `/?tab=settings` and `/?tab=profile` are stuck on `Завантаження…` due to an upstream `Maximum update depth exceeded` infinite render loop in `AppInner` (Suspense never settles, so the lazy chunks for `HubSettingsPage` / `ProfilePage` / `HubReports` never mount). That regression is documented in the child session's final report and is out of scope for this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize the password placeholder in DeleteAccountDialog for consistent copy across the app. Changed placeholder from "Ваш пароль" to "Пароль" to match the label and other auth screens.

<sup>Written for commit c40acfebd03b98ebc5b3cbbe32995a359607b737. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

