### PR TITLE
fix(web): expose routine weekday picker selection state to AT

### DIFF
--- a/apps/web/src/modules/routine/components/settings/WeekdayPicker.tsx
+++ b/apps/web/src/modules/routine/components/settings/WeekdayPicker.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import { memo, useId } from "react";
 import { cn } from "@shared/lib/ui/cn";
 import { ROUTINE_THEME as C, WEEKDAY_LABELS } from "../../lib/routineConstants";
 import { messages } from "@shared/i18n/uk";
@@ -13,16 +13,24 @@ export const WeekdayPicker = memo(function WeekdayPicker({
   onChange,
 }: WeekdayPickerProps) {
   const active = weekdays || [];
+  const labelId = useId();
   return (
     <div>
-      <p className="text-xs text-subtle mb-2">{messages.routine.weekdays}</p>
-      <div className="flex flex-wrap gap-2">
+      <p id={labelId} className="text-xs text-subtle mb-2">
+        {messages.routine.weekdays}
+      </p>
+      <div
+        className="flex flex-wrap gap-2"
+        role="group"
+        aria-labelledby={labelId}
+      >
         {WEEKDAY_LABELS.map((label, wd) => {
           const on = active.includes(wd);
           return (
             <button
               key={label}
               type="button"
+              aria-pressed={on}
               onClick={() => {
                 const cur = [...active];
                 const i = cur.indexOf(wd);


### PR DESCRIPTION
## Summary

The weekday picker in the routine habit form (`apps/web/src/modules/routine/components/settings/WeekdayPicker.tsx`) rendered each weekday chip as a bare `<button>` with no ARIA state. The "active" days only had a visual highlight (`C.chipOn`), so screen readers had no way to announce which days were selected for a weekly habit.

This PR:

- Wraps the chip row in `role="group"` with `aria-labelledby` pointing at the "Дні тижня" caption (uses `useId()` to scope the id, so multiple `WeekdayPicker` instances on the same page do not collide).
- Adds `aria-pressed={on}` to each chip — the toggle-button pattern, since multiple weekdays can be selected simultaneously (vs. the radio-group used for mutually-exclusive recurrence).
- No layout, behaviour, or test changes.

Found during routine-module QA (Devin child session). Repro: open `/routine` → tap the FAB ("+") → pick "По тижню" recurrence → inspect the "Дні тижня" chips → none of them expose `aria-pressed` / `aria-checked`. With this PR each chip announces "Пн, pressed/not pressed, toggle button" and the group is named "Дні тижня".

## Governing Skill

- Primary skill: sergeant-web-ui
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a — single-file ARIA polish, no playbook required
- Why this playbook: n/a
- If no playbook matched, why: small, focused a11y fix; mirrors the toggle-button convention already used elsewhere in the codebase (e.g. tag chips in `TagPickerInline`).

## Verification

```bash
pnpm --filter @sergeant/web typecheck   # exit 0
pnpm --filter @sergeant/web lint        # exit 0
```

Additional checks:

- [x] Local smoke: opened `/routine` → FAB → "По тижню" → confirmed `role="group"` + `aria-labelledby` on the chip container and `aria-pressed="true"` on the seven chips for default-all-days draft.
- [x] Surface-specific checks: no consumers other than `HabitForm.tsx` (per `grep -rn WeekdayPicker apps/web/src/`).

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. (No docs changes needed — ARIA polish only.)
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a

## Risk and Rollout

- User-visible risk: low. ARIA-only change; no visual, layout, or behavioural diff. AT users gain proper toggle-button + named-group semantics.
- Rollout / deploy order: standard, no migrations.
- Backout plan: revert the single-file diff.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian. (No docs touched.)
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

Single-file diff (`WeekdayPicker.tsx`). The `useId()` import is added so that the `aria-labelledby` id is unique per-instance — matches the pattern used elsewhere in `apps/web/src/modules/routine/components/settings/HabitForm.tsx` (`fieldIds = useId()`).

Spawned by parent: Devin session `devin-3441cf9e2252481da4b9aa0a5c47bd38`. Child session: https://app.devin.ai/sessions/1fb71b92d2cf49b08a2c52dc5da6bab3


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved the weekday picker’s accessibility by exposing selection state to screen readers. Adds proper toggle-button semantics and a labeled group with no visual or behavior changes.

- **Bug Fixes**
  - Wrapped the chip row with role="group" and aria-labelledby (caption id from useId()).
  - Added aria-pressed to each weekday chip to announce selected state.

<sup>Written for commit d132dee836b35dbdbf70d14cdd7282c9ab5d9403. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

