### PR TITLE
fix(web): include manual expenses in Finyk Analytics aggregations

### DIFF
--- a/apps/web/src/modules/finyk/pages/Analytics.tsx
+++ b/apps/web/src/modules/finyk/pages/Analytics.tsx
@@ -18,6 +18,8 @@ import { CategoryPieChart } from "../components/charts/lazy";
 import { ChartFallback } from "../components/charts/ChartFallback";
 import { MerchantList } from "../components/analytics/MerchantList";
 import { getTrendComparison } from "@sergeant/finyk-domain/domain/selectors";
+import { manualExpenseToTransaction } from "@sergeant/finyk-domain/domain/transactions";
+import type { ManualExpense } from "@sergeant/finyk-domain/domain/personalization";
 import type {
   Transaction,
   TxSplitsMap,
@@ -55,6 +57,7 @@ export interface AnalyticsMonoAdapter {
 export interface AnalyticsStorageAdapter {
   excludedTxIds: Set<string> | Iterable<string>;
   txSplits: TxSplitsMap;
+  manualExpenses?: ManualExpense[];
 }
 
 interface AnalyticsProps {
@@ -259,15 +262,50 @@ export function Analytics({ mono, storage }: AnalyticsProps) {
     ensureMonth(prevYear, prevMonth, prevKey);
   }, [prevYear, prevMonth, prevKey, ensureMonth]);
 
-  const activeTx = useMemo(() => {
-    if (isCurrentMonth) return mono.realTx || [];
-    return monthCache[monthKey] || [];
-  }, [isCurrentMonth, mono.realTx, monthCache, monthKey]);
+  // Manual expenses for the currently selected month. These live in
+  // storage (localStorage-backed), not in the server tx stream, so they
+  // must be merged into `activeTx` explicitly — otherwise Analytics shows
+  // 0 ₴ even when Transactions clearly lists them. See useTransactionFilters
+  // for the source-of-truth merge pattern.
+  const manualExpenseTxs = useMemo(() => {
+    const list = storage.manualExpenses;
+    if (!list || list.length === 0) return [] as Transaction[];
+    const monthStart = new Date(year, month - 1, 1).getTime();
+    const monthEnd = new Date(year, month, 1).getTime();
+    return list
+      .filter((e) => {
+        const ts = new Date(e.date).getTime();
+        return ts >= monthStart && ts < monthEnd;
+      })
+      .map((e) => manualExpenseToTransaction(e));
+  }, [storage.manualExpenses, year, month]);
 
-  const prevTx = useMemo(
-    () => monthCache[prevKey] || [],
-    [monthCache, prevKey],
-  );
+  const prevManualExpenseTxs = useMemo(() => {
+    const list = storage.manualExpenses;
+    if (!list || list.length === 0) return [] as Transaction[];
+    const monthStart = new Date(prevYear, prevMonth - 1, 1).getTime();
+    const monthEnd = new Date(prevYear, prevMonth, 1).getTime();
+    return list
+      .filter((e) => {
+        const ts = new Date(e.date).getTime();
+        return ts >= monthStart && ts < monthEnd;
+      })
+      .map((e) => manualExpenseToTransaction(e));
+  }, [storage.manualExpenses, prevYear, prevMonth]);
+
+  const activeTx = useMemo(() => {
+    const bankTx = isCurrentMonth
+      ? mono.realTx || []
+      : monthCache[monthKey] || [];
+    if (manualExpenseTxs.length === 0) return bankTx;
+    return [...bankTx, ...manualExpenseTxs];
+  }, [isCurrentMonth, mono.realTx, monthCache, monthKey, manualExpenseTxs]);
+
+  const prevTx = useMemo(() => {
+    const bankTx = monthCache[prevKey] || [];
+    if (prevManualExpenseTxs.length === 0) return bankTx;
+    return [...bankTx, ...prevManualExpenseTxs];
+  }, [monthCache, prevKey, prevManualExpenseTxs]);
 
   const analyticsMono = useMemo(
     () => ({ ...mono, realTx: activeTx, loadingTx: mono.loadingTx || loading }),


### PR DESCRIPTION
## Summary

**Severity:** HIGH — silent data integrity bug. Users see meaningful totals on `Операції` but a misleading **0 ₴** + empty-state copy ("Поки немає витрат", "Поки немає мерчантів") on `Аналітика`.

The Analytics page only fed bank transactions (`mono.realTx`, or the cached
historical month) into `useAnalytics`. **Manual expenses** — which live in
storage and ARE merged into the Transactions list via `useTransactionFilters`
— were silently dropped from the monthly summary, category distribution and
top-merchants list.

Mirror the merge pattern from `useTransactionFilters`: precompute manual-expense → Transaction projections for both the active and previous month, then append them to the bank tx arrays before they flow into `useAnalytics` and `getTrendComparison`. Comparison stays correct because the previous-month bucket is now also augmented.

## Repro steps (before fix)

1. Open Finyk → Операції → manually add 4 demo expenses (or any expense via FAB +).
2. Switch to Аналітика → "Травень 2026 р."
3. Bug: Витрати=**0 ₴**, Дохід=0₴, Категорії="Поки немає витрат", Топ мерчанти="Поки немає мерчантів".

After this PR (verified in browser):
- Витрати=**500 ₴** ← matches sum of 4 manual demo expenses (45+75+120+260)
- Категорії: Інше 380₴ (76%) + Транспорт 120₴ (24%)
- Топ мерчанти: Квиток на концерт 260₴, Таксі додому 120₴, Бізнес-ланч 75₴, Кава на винос 45₴

## Files changed

- `apps/web/src/modules/finyk/pages/Analytics.tsx` — extend `AnalyticsStorageAdapter` with optional `manualExpenses`, derive `manualExpenseTxs` + `prevManualExpenseTxs` per selected month, merge into `activeTx` / `prevTx` before they reach `useAnalytics` / `getTrendComparison`.

No domain-package changes; reuses existing `manualExpenseToTransaction` selector.

## Verification

- `pnpm --filter @sergeant/web typecheck` → ok
- `pnpm --filter @sergeant/web lint` → ok
- Manual UI verification: hard refresh `/finyk/analytics` → all three sections now populated with manual-expense data (see PR description above).

## Recording

Annotated screen recording attached in the child session report (assertion **"It should reflect manual expenses in Analytics summary"** flips from FAIL → PASS).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Analytics to include manual expenses in all aggregations and comparisons. Totals, categories, and top merchants now match what users see in Operations.

- **Bug Fixes**
  - Merge manual expenses from storage into both active and previous month transactions before `useAnalytics` and `getTrendComparison`.
  - Extend `AnalyticsStorageAdapter` with `manualExpenses?: ManualExpense[]` and convert via `manualExpenseToTransaction` from `@sergeant/finyk-domain`.

<sup>Written for commit 413ffc446d49b7987ec8a2a679c993ddef117987. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

