### PR TITLE
fix(web): use full 'год' suffix for avg sleep on Fizruk Моє тіло header

### DIFF
--- a/apps/web/src/modules/fizruk/pages/Body.tsx
+++ b/apps/web/src/modules/fizruk/pages/Body.tsx
@@ -254,7 +254,7 @@ export function Body({ onOpenMeasurements, onOpenAtlas }: BodyProps) {
               <div className="text-xs text-subtle">Сон</div>
               <div className="text-base font-extrabold text-text tabular-nums">
                 {stats.avgSleep != null
-                  ? `${stats.avgSleep.toFixed(1)} г`
+                  ? `${stats.avgSleep.toFixed(1)} год`
                   : "—"}
               </div>
             </div>


### PR DESCRIPTION
## Summary

The Fizruk **Моє тіло** summary header rendered the avg-sleep stat as `Сон 7.5 г`. The Ukrainian one-letter `г` reads as *"гр(ам)"* (grams) — confusing on a row that already shows weight in **kg** right next to it. Every other surface in the module (the form label `Сон (год)` and `JournalEntryCard` summary) prints the full `год`, so this header is the only outlier.

Single-line fix in `apps/web/src/modules/fizruk/pages/Body.tsx:257`: change the template literal suffix `' г'` → `' год'`. No styling, no data shape, no behaviour change.

Caught during a Fizruk QA pass (Devin session [3b6d2aa3](https://app.devin.ai/sessions/3b6d2aa3f4b24dc59865474f7f459e0b)) after entering body metrics `вага=72.5kg, сон=7.5h`. The header rendered:

```
Вага 72.5 кг   Сон 7.5 г
```

instead of the expected `Сон 7.5 год`.

## Governing Skill

- Primary skill: `sergeant-web-ui` (Fizruk module, copy hygiene)
- Secondary skill (if truly needed): `sergeant-bugfix-and-regression`

## Playbook

- Primary playbook: n/a — single-character copy fix
- Why this playbook: n/a
- If no playbook matched, why: trivial isolated label fix; playbook scaffolding would be overkill

## Verification

```bash
cd apps/web && pnpm exec eslint src/modules/fizruk/pages/Body.tsx --no-warn-ignored   # → clean
cd apps/web && pnpm exec tsc -p . --noEmit                                            # → clean
```

Visual check (Chrome on dev-server): after entering body metrics in the form, the header now reads `Сон 7.5 год` instead of `Сон 7.5 г`. Matches the form label `Сон (год)` and the `JournalEntryCard` row `7.5 год`.

Additional checks:

- [x] Local smoke / manual validation completed (entered metrics 72.5 kg / 7.5 h in `/fizruk/body`, header now shows `Сон 7.5 год`)
- [x] Surface-specific checks completed (no other `\${...} г\` occurrences in the Fizruk module — the only other `г`-suffix is the legitimate `кг` weight unit)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a — pure UI copy fix, no documented contract or behaviour change

## Risk and Rollout

- User-visible risk: extremely low — single string suffix in one render path on the Fizruk Моє тіло summary header. No data, no API, no validation, no analytics events touched.
- Rollout / deploy order: ship with the next web deploy; no migration coordination needed.
- Backout plan: revert this PR. The previous string was wrong-but-rendering, not crashing — rollback is a pure cosmetic step.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

This is one of several findings from the Fizruk QA pass linked in the Summary. Sister PR for the journal-entry date-year regression (`26 р.` → `2026 р.`) lands separately to keep `1 bug = 1 PR`. Remaining findings (gear-button → /welcome misroute; Progress page requires F5 after workout completion) are documented for triage in the parent session's QA report; both are larger than a one-line copy fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the avg sleep unit in the Fizruk «Моє тіло» header by replacing the abbreviation "г" with "год" (e.g., "Сон 7.5 год").
Aligns with the form label and JournalEntryCard and avoids confusion with grams; no other changes.

<sup>Written for commit b7354e626f3d17c48ec83b8414b696303153c46e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

