### PR TITLE
fix(web): clamp Finyk subscription billing day to 1-31 on save

### DIFF
--- a/apps/web/src/modules/finyk/components/SubCard.tsx
+++ b/apps/web/src/modules/finyk/components/SubCard.tsx
@@ -84,11 +84,19 @@ function SubCardComponent({
 
   const saveEdit = () => {
     if (!form.name || !form.billingDay) return;
+    // The day-of-month input is a free <input type="number">, so the
+    // min/max attributes are only browser hints — keyboard/paste/programmatic
+    // entry bypasses them. Clamp to the calendar range here so we never
+    // persist `0`, `99`, or `NaN` and render nonsense like "Через 18 днів · 0-го".
+    const parsedDay = Math.trunc(Number(form.billingDay));
+    if (!Number.isFinite(parsedDay) || parsedDay < 1 || parsedDay > 31) {
+      return;
+    }
     onEdit?.({
       name: form.name,
       emoji: form.emoji,
       keyword: form.keyword,
-      billingDay: Number(form.billingDay),
+      billingDay: parsedDay,
       currency: form.currency,
     });
     setEditing(false);

--- a/apps/web/src/modules/finyk/pages/AssetsForm.test.tsx
+++ b/apps/web/src/modules/finyk/pages/AssetsForm.test.tsx
@@ -37,6 +37,68 @@ describe("SubscriptionForm", () => {
     expect(buttonLabels).toContain("Скасувати");
   });
 
+  it("rejects out-of-range billing days (0, 99) and saves a valid one", () => {
+    const setSubscriptions = vi.fn();
+    const setShowSubForm = vi.fn();
+    const baseSub = {
+      name: "Netflix",
+      emoji: "\u{1F3AC}",
+      keyword: "",
+      currency: "UAH" as const,
+    };
+
+    // 0 — must NOT call setSubscriptions
+    const { container: c0, unmount: u0 } = render(
+      <SubscriptionForm
+        newSub={{ ...baseSub, billingDay: 0 }}
+        setNewSub={vi.fn()}
+        setSubscriptions={setSubscriptions}
+        setShowSubForm={setShowSubForm}
+      />,
+    );
+    fireEvent.click(
+      within(c0)
+        .getAllByRole("button")
+        .find((b) => b.textContent?.trim() === "Додати")!,
+    );
+    expect(setSubscriptions).not.toHaveBeenCalled();
+    u0();
+
+    // 99 — must NOT call setSubscriptions
+    const { container: c99, unmount: u99 } = render(
+      <SubscriptionForm
+        newSub={{ ...baseSub, billingDay: 99 }}
+        setNewSub={vi.fn()}
+        setSubscriptions={setSubscriptions}
+        setShowSubForm={setShowSubForm}
+      />,
+    );
+    fireEvent.click(
+      within(c99)
+        .getAllByRole("button")
+        .find((b) => b.textContent?.trim() === "Додати")!,
+    );
+    expect(setSubscriptions).not.toHaveBeenCalled();
+    u99();
+
+    // 15 — valid, must commit and close the form
+    const { container: c15 } = render(
+      <SubscriptionForm
+        newSub={{ ...baseSub, billingDay: 15 }}
+        setNewSub={vi.fn()}
+        setSubscriptions={setSubscriptions}
+        setShowSubForm={setShowSubForm}
+      />,
+    );
+    fireEvent.click(
+      within(c15)
+        .getAllByRole("button")
+        .find((b) => b.textContent?.trim() === "Додати")!,
+    );
+    expect(setSubscriptions).toHaveBeenCalledTimes(1);
+    expect(setShowSubForm).toHaveBeenCalledWith(false);
+  });
+
   it("calls setShowSubForm(false) on cancel", () => {
     const onCancel = vi.fn();
     const { container } = render(

--- a/apps/web/src/modules/finyk/pages/AssetsForm.tsx
+++ b/apps/web/src/modules/finyk/pages/AssetsForm.tsx
@@ -60,25 +60,36 @@ export function SubscriptionForm({
           className="flex-1"
           size="sm"
           onClick={() => {
-            if (newSub.name && newSub.billingDay) {
-              setSubscriptions((ss) => [
-                ...ss,
-                {
-                  ...newSub,
-                  id: Date.now().toString(),
-                  billingDay: Number(newSub.billingDay) || 0,
-                } as Subscription,
-              ]);
-              notifyFinykRoutineCalendarSync();
-              setNewSub({
-                name: "",
-                emoji: "\u{1F4F1}",
-                keyword: "",
-                billingDay: "",
-                currency: "UAH",
-              });
-              setShowSubForm(false);
+            if (!newSub.name || !newSub.billingDay) return;
+            // The day-of-month <input type="number"> exposes min/max only as
+            // browser hints — keyboard/paste/programmatic entry bypasses them.
+            // Clamp to the calendar range so we never persist 0/99/NaN and
+            // render nonsense like "Через 18 днів · 0-го".
+            const parsedDay = Math.trunc(Number(newSub.billingDay));
+            if (
+              !Number.isFinite(parsedDay) ||
+              parsedDay < 1 ||
+              parsedDay > 31
+            ) {
+              return;
             }
+            setSubscriptions((ss) => [
+              ...ss,
+              {
+                ...newSub,
+                id: Date.now().toString(),
+                billingDay: parsedDay,
+              } as Subscription,
+            ]);
+            notifyFinykRoutineCalendarSync();
+            setNewSub({
+              name: "",
+              emoji: "\u{1F4F1}",
+              keyword: "",
+              billingDay: "",
+              currency: "UAH",
+            });
+            setShowSubForm(false);
           }}
         >
           Додати


### PR DESCRIPTION
## Summary

**Severity:** MEDIUM — form-validation hole that lets users save nonsense data.

The "День (1-31)" / "День списання (1-31)" number input on the Finyk subscription **Add** form (`AssetsForm.tsx → SubscriptionForm`) and **Edit** form (`SubCard.tsx → saveEdit`) used `min="1" max="31"` as HTML hints only. The click handler ran `Number(value)` (with `|| 0` in the Add path) and persisted whatever the user typed, pasted, or set programmatically.

User-facing impact: typing `0` or `99` then Save was accepted and the card then rendered:

- `Через 18 днів · 0-го`  (0th of month)
- `Через 85 днів · 99-го` (99th of month)

The day-of-month suffix is rendered verbatim from the persisted value, so a single bad save permanently breaks that card until the user re-edits it.

## Fix

Validate inside the save handler:

```ts
const parsedDay = Math.trunc(Number(form.billingDay));
if (!Number.isFinite(parsedDay) || parsedDay < 1 || parsedDay > 31) return;
```

No noisy error UI: the form simply stays open, matching the existing "empty name" early-return branch.

## Repro

1. Finyk → Активи → expand `Підписки` → ✏️ on any subscription.
2. Set `День (1-31)` to `99`. Click **Зберегти**.
3. Before: form closes and card now reads `99-го` — saved.
   After: form stays open; nothing is persisted.
4. Repeat with `0`, `-5`, empty/`NaN`. Same result.
5. Set `15` → form closes, card reads `15-го` (happy path).

## Files changed

- `apps/web/src/modules/finyk/pages/AssetsForm.tsx` — clamp in `SubscriptionForm` `Додати` handler; drop `|| 0` fallback.
- `apps/web/src/modules/finyk/components/SubCard.tsx` — clamp in `saveEdit`.
- `apps/web/src/modules/finyk/pages/AssetsForm.test.tsx` — new Vitest case exercising `0` (rejected), `99` (rejected), `15` (accepted + closes form).

## Verification

- `pnpm --filter @sergeant/web typecheck` → ok
- `pnpm --filter @sergeant/web lint` → ok
- `pnpm --filter @sergeant/web test -- src/modules/finyk/pages/AssetsForm.test.tsx` → **7/7 pass** (was 6/6 before).
- Manual UI verification: typing 99 → Save keeps form open; typing 19 → Save closes form and `19-го` is rendered.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clamp the Finyk subscription billing day to 1–31 on save in both Add and Edit forms to stop invalid values from being persisted. On invalid input, the form stays open; valid values save as before.

- **Bug Fixes**
  - Validate in save handlers: use Math.trunc(Number(...)) and require a finite value in the 1–31 range.
  - Remove the `|| 0` fallback to avoid persisting 0.
  - Add a test: rejects 0 and 99; accepts 15 and closes the form.

<sup>Written for commit 57a01a9faf4d59f2dc2a2fc653da7859f787b670. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

