### PR TITLE
fix(routine-domain): dedupe tags/categories with case-insensitive trim guard

### DIFF
--- a/apps/web/src/modules/routine/components/settings/CategoriesSection.tsx
+++ b/apps/web/src/modules/routine/components/settings/CategoriesSection.tsx
@@ -6,6 +6,7 @@ import { Card } from "@shared/components/ui/Card";
 import { IconButton } from "@shared/components/ui/IconButton";
 import { Input } from "@shared/components/ui/Input";
 import { useToast } from "@shared/hooks/useToast";
+import { messages } from "@shared/i18n/uk";
 import { showUndoToast } from "@shared/lib/ui/undoToast";
 import {
   createCategory,
@@ -60,6 +61,26 @@ export function CategoriesSection({
                 variant="secondary"
                 className="min-h-[44px] min-w-0 sm:min-w-28"
                 onClick={() => {
+                  // PR-058 (web): пара до reducer-level dedupe в
+                  // `applyUpdateCategory`. Перевіряємо conflict в UI
+                  // (свіжий `routine`), дженжимо edit-mode активним
+                  // і показуємо toast — без цього save був би silent
+                  // no-op з побічним рефрешем входу.
+                  const trimmed = catDraft.name.trim();
+                  if (trimmed) {
+                    const conflict = routine.categories.some(
+                      (c) =>
+                        c.id !== editingCatId &&
+                        c.name.trim().toLocaleLowerCase() ===
+                          trimmed.toLocaleLowerCase(),
+                    );
+                    if (conflict) {
+                      // tone=warning per docs/ui/toast-policy.md
+                      // (validation-style soft-fail, no recovery action).
+                      toast.warning(messages.validation.categoryNameDuplicate);
+                      return;
+                    }
+                  }
                   setRoutine((s) =>
                     updateCategory(s, editingCatId, {
                       name: catDraft.name,
@@ -90,9 +111,22 @@ export function CategoriesSection({
               variant="secondary"
               className="min-h-[44px] w-full min-w-0 sm:w-auto sm:min-w-28"
               onClick={() => {
-                setRoutine((s) =>
-                  createCategory(s, catDraft.name, catDraft.emoji),
+                // PR-058 (web): дзеркало TagsSection. Reducer-level dedupe
+                // у `applyCreateCategory` повертає same state при
+                // дублікаті — ловимо це в UI і показуємо toast,
+                // щоб користувач розумів, чому «Додати» не працює.
+                const trimmed = catDraft.name.trim();
+                if (!trimmed) return;
+                const isDuplicate = routine.categories.some(
+                  (c) =>
+                    c.name.trim().toLocaleLowerCase() ===
+                    trimmed.toLocaleLowerCase(),
                 );
+                if (isDuplicate) {
+                  toast.warning(messages.validation.categoryNameDuplicate);
+                  return;
+                }
+                setRoutine((s) => createCategory(s, trimmed, catDraft.emoji));
                 setCatDraft({ name: "", emoji: "" });
               }}
             >

--- a/apps/web/src/modules/routine/components/settings/TagsSection.tsx
+++ b/apps/web/src/modules/routine/components/settings/TagsSection.tsx
@@ -57,7 +57,25 @@ export function TagsSection({
     defaultValues: { tagName: "" },
     onSubmit: async (values) => {
       if (!editingTagId) return;
-      setRoutine((s) => updateTag(s, editingTagId, values.tagName));
+      const trimmed = values.tagName.trim();
+      // PR-058 (web): дзеркало create-flow. Reducer-level `applyUpdateTag`
+      // тепер returns same state при conflict (інший тег уже носить таку
+      // назву) — без цього guard'у `onSuccess` би прогнав reset, edit-mode
+      // зник, а тег у списку лишився б зі старим імʼям без жодного UI
+      // signal. Throw тримає edit-mode активним, toast показує copy.
+      const conflict = routine.tags.some(
+        (t) =>
+          t.id !== editingTagId &&
+          t.name.trim().toLocaleLowerCase() === trimmed.toLocaleLowerCase(),
+      );
+      if (conflict) {
+        // Validation-feedback tone-table (docs/ui/toast-policy.md):
+        // «duplicate» — не fail-stop, а soft-fail в автовиправляємому
+        // стані (user перепринтує інше імʼя) — tone=warning без action.
+        toast.warning(messages.validation.tagNameDuplicate);
+        throw new Error(messages.validation.tagNameDuplicate);
+      }
+      setRoutine((s) => updateTag(s, editingTagId, trimmed));
     },
     onSuccess: () => {
       setEditingTagId(null);
@@ -95,7 +113,26 @@ export function TagsSection({
           variant="secondary"
           className="min-h-[44px] shrink-0 px-4"
           onClick={() => {
-            setRoutine((s) => createTag(s, tagDraft));
+            // PR-058 (web): пара з reducer-level dedupe у `applyCreateTag`.
+            // Якщо запис із такою trim-назвою (case-insensitive) уже існує,
+            // reducer повертає той самий state — раніше `setRoutine` тихо
+            // запускався без жодного UI feedback, тож натиск «+» вдруге
+            // підряд виглядав так, ніби нічого не відбулось (хоча в
+            // деяких попередніх версіях він навпаки створював дублікат).
+            // Тепер ми перехоплюємо обидва no-op кейси (порожнє + дублікат)
+            // в UI і показуємо точний copy у toast.
+            const trimmed = tagDraft.trim();
+            if (!trimmed) return;
+            const isDuplicate = routine.tags.some(
+              (t) =>
+                t.name.trim().toLocaleLowerCase() ===
+                trimmed.toLocaleLowerCase(),
+            );
+            if (isDuplicate) {
+              toast.warning(messages.validation.tagNameDuplicate);
+              return;
+            }
+            setRoutine((s) => createTag(s, trimmed));
             setTagDraft("");
           }}
         >

--- a/apps/web/src/shared/i18n/uk.ts
+++ b/apps/web/src/shared/i18n/uk.ts
@@ -108,6 +108,11 @@ export const messages = {
     // — «Обери …». Snapshot-и `AddBudgetForm.test.tsx` оновлюються
     // разом з цим (тести закривають user-facing copy contract).
     tagNameRequired: "Введи назву тега",
+    // PR-058 (web): Reducer-level dedupe в `applyCreateTag` /
+    // `applyCreateCategory` (case-insensitive trim) — UI ловить
+    // `next === state` після `setRoutine` і показує цей copy у toast.
+    tagNameDuplicate: "Тег з такою назвою вже існує",
+    categoryNameDuplicate: "Категорія з такою назвою вже існує",
     goalNameRequired: "Введи назву цілі",
     goalAmountRequired: "Введи суму цілі більше 0",
     goalSavedNonNegative: "Відкладена сума не може бути від'ємною",

--- a/packages/routine-domain/src/reducers.test.ts
+++ b/packages/routine-domain/src/reducers.test.ts
@@ -86,6 +86,15 @@ describe("routine-domain/reducers — теги і категорії", () => {
       expect(second.tags.map((t) => t.name)).toEqual(["A", "B"]);
       expect(first.tags).toHaveLength(1);
     });
+
+    it("відхиляє дублікати за case-insensitive trim-порівнянням", () => {
+      // Reducer-level fix: «+» двічі підряд в routine-settings більше
+      // не створює дві однакові теги; UI ловить `next === state` для toast.
+      const a = applyCreateTag(baseState(), "Здоровʼя");
+      const dup = applyCreateTag(a, "  здоровʼя  ");
+      expect(dup).toBe(a);
+      expect(dup.tags.map((t) => t.name)).toEqual(["Здоровʼя"]);
+    });
   });
 
   describe("applyCreateCategory", () => {
@@ -114,6 +123,16 @@ describe("routine-domain/reducers — теги і категорії", () => {
       const next = applyCreateCategory(baseState(), "Спорт", "");
       expect(next.categories[0]!.emoji).toBeUndefined();
     });
+
+    it("відхиляє дублікати за case-insensitive trim-порівнянням (emoji не враховується)", () => {
+      // emoji-prefix знаходиться окремою властивістю (тип малюнка)
+      // — дублікат визначається лише по текстовій назві (вона є ключем
+      // для користувача при виборі у фільтрах).
+      const a = applyCreateCategory(baseState(), "Спорт", "🏋");
+      const dup = applyCreateCategory(a, "  спорт  ", "🏃");
+      expect(dup).toBe(a);
+      expect(dup.categories.map((c) => c.name)).toEqual(["Спорт"]);
+    });
   });
 
   describe("applyUpdateTag", () => {
@@ -137,6 +156,23 @@ describe("routine-domain/reducers — теги і категорії", () => {
       const s = applyCreateTag(baseState(), "A");
       const next = applyUpdateTag(s, "unknown", "B");
       expect(next.tags.map((t) => t.name)).toEqual(["A"]);
+    });
+
+    it("відхиляє rename якщо інший тег вже носить таку назву (case-insensitive)", () => {
+      const a = applyCreateTag(baseState(), "A");
+      const b = applyCreateTag(a, "B");
+      const idA = b.tags[0]!.id;
+      const next = applyUpdateTag(b, idA, "  b  ");
+      expect(next).toBe(b);
+      expect(next.tags.map((t) => t.name)).toEqual(["A", "B"]);
+    });
+
+    it("дозволяє self-rename (casing-only change того ж тега)", () => {
+      const s = applyCreateTag(baseState(), "Робота");
+      const id = s.tags[0]!.id;
+      const next = applyUpdateTag(s, id, "РОБОТА");
+      expect(next).not.toBe(s);
+      expect(next.tags[0]!.name).toBe("РОБОТА");
     });
   });
 
@@ -167,6 +203,21 @@ describe("routine-domain/reducers — теги і категорії", () => {
       const s = applyCreateCategory(baseState(), "X", "❓");
       const next = applyUpdateCategory(s, "unknown", { name: "Y" });
       expect(next.categories[0]!.name).toBe("X");
+    });
+
+    it("відхиляє rename якщо інша категорія вже носить таку назву (case-insensitive)", () => {
+      const a = applyCreateCategory(baseState(), "Спорт");
+      const b = applyCreateCategory(a, "Навчання");
+      const idSport = b.categories[0]!.id;
+      const next = applyUpdateCategory(b, idSport, { name: "  навчання  " });
+      expect(next).toBe(b);
+    });
+
+    it("emoji-only patch не блокується дуплікат-перевіркою", () => {
+      const s = applyCreateCategory(baseState(), "Спорт", "🏃");
+      const id = s.categories[0]!.id;
+      const next = applyUpdateCategory(s, id, { emoji: "🏋" });
+      expect(next.categories[0]!.emoji).toBe("🏋");
     });
   });
 

--- a/packages/routine-domain/src/reducers.ts
+++ b/packages/routine-domain/src/reducers.ts
@@ -28,17 +28,34 @@ import type {
   Tag,
 } from "./types.js";
 
-/** Додає новий тег. Ігнорує порожнє імʼя. */
+/**
+ * Додає новий тег. Ігнорує порожнє імʼя. Також ігнорує дублікат
+ * (case-insensitive trim-порівняння з вже існуючими тегами) — раніше
+ * `applyCreateTag` сліпо пушив новий запис із новим `id`, через що у
+ * routine-settings можна було натиснути «+» двічі підряд й отримати
+ * двох однакових з виду тегів. Reducer тепер є джерелом істини для
+ * інваріанта «унікальна назва у scope='routine'»; UI-шари показують
+ * toast, щоб користувач розумів, що submit не пройшов.
+ */
 export function applyCreateTag(
   state: RoutineState,
   name: string,
 ): RoutineState {
   const n = (name || "").trim();
   if (!n) return state;
+  const key = n.toLocaleLowerCase();
+  if (state.tags.some((t) => t.name.trim().toLocaleLowerCase() === key)) {
+    return state;
+  }
   const t: Tag = { id: routineUid("tag"), name: n, scope: "routine" };
   return { ...state, tags: [...state.tags, t] };
 }
 
+/**
+ * Додає нову категорію. Окрім ignore порожнього імені, відсіює
+ * дублікати (case-insensitive trim-порівняння). Параллель до
+ * `applyCreateTag` — див. коментар вище.
+ */
 export function applyCreateCategory(
   state: RoutineState,
   name: string,
@@ -46,6 +63,10 @@ export function applyCreateCategory(
 ): RoutineState {
   const n = (name || "").trim();
   if (!n) return state;
+  const key = n.toLocaleLowerCase();
+  if (state.categories.some((c) => c.name.trim().toLocaleLowerCase() === key)) {
+    return state;
+  }
   const c: Category = {
     id: routineUid("cat"),
     name: n,
@@ -366,6 +387,16 @@ export function applyUpdateTag(
 ): RoutineState {
   const n = (newName || "").trim();
   if (!n) return state;
+  const key = n.toLocaleLowerCase();
+  // Reject rename, якщо інший тег вже носить таку назву — інакше у
+  // списку зʼявляться два візуально однакових теги. Тег зберігає
+  // власну назву (включно з оригінальним casing-ом) — це матчить
+  // поведінку `applyUpdateHabit`, де `normalizeHabit` повертає той
+  // самий `Habit` при no-op-патчі.
+  const conflict = state.tags.some(
+    (t) => t.id !== id && t.name.trim().toLocaleLowerCase() === key,
+  );
+  if (conflict) return state;
   return {
     ...state,
     tags: state.tags.map((t) => (t.id === id ? { ...t, name: n } : t)),
@@ -377,6 +408,17 @@ export function applyUpdateCategory(
   id: string,
   patch: { name?: string; emoji?: string },
 ): RoutineState {
+  // Дзеркало `applyUpdateTag`: відсіюємо conflict з іншою категорією за
+  // case-insensitive trim-назвою. Patch без `name` (наприклад, тільки
+  // emoji) обробляється як раніше — `nextName` лишається `null`.
+  const nextName = patch.name !== undefined ? (patch.name || "").trim() : null;
+  if (nextName) {
+    const key = nextName.toLocaleLowerCase();
+    const conflict = state.categories.some(
+      (c) => c.id !== id && c.name.trim().toLocaleLowerCase() === key,
+    );
+    if (conflict) return state;
+  }
   return {
     ...state,
     categories: state.categories.map((c) =>


### PR DESCRIPTION
## Summary

Manual cross-module QA на routine settings виявило, що кнопка «+» біля поля «Новий тег» дозволяла натиснути її двічі підряд (або з різним casing-ом) і отримати **дві однакові з виду теги** у списку — без жодного UI signal-у. Той же баг повторювався у:

- inline rename тегів (`applyUpdateTag`)
- створенні категорій (`applyCreateCategory`)
- редагуванні категорій (`applyUpdateCategory`)

Root cause — `applyCreateTag` / `applyCreateCategory` / `applyUpdateTag` / `applyUpdateCategory` у `packages/routine-domain/src/reducers.ts` пушили / переписували `name` без перевірки існуючих записів. Через те, що `id` генерується щоразу, два tag-и з ідентичним trim-name отримували різні `id`-и, тож persist-шар їх не дедуплював.

Зміни:

- `packages/routine-domain/src/reducers.ts` — додано case-insensitive trim-порівняння у всі 4 reducer-и; conflict повертає той самий state (тож `routineStorage.ts` short-circuit `if (next === state) return state` не пише в storage).
- `packages/routine-domain/src/reducers.test.ts` — 5 нових тестів на нові інваріанти + self-rename casing-only case.
- `apps/web/src/modules/routine/components/settings/TagsSection.tsx` / `CategoriesSection.tsx` — UI ловить duplicate у `routine.tags` / `routine.categories` ДО `setRoutine` і показує `toast.warning` з copy-string. Rename-flow тримає edit-mode активним (throw з `onSubmit` блокує `onSuccess`), щоб user міг виправити назву замість silent no-op.
- `apps/web/src/shared/i18n/uk.ts` — два нові copy-string-и `tagNameDuplicate` / `categoryNameDuplicate` під існуючою конвенцією «1-а особа, наказова форма».

Toast tone — `warning` per [`docs/ui/toast-policy.md`](docs/ui/toast-policy.md) (validation-style soft-fail, без recovery action).

## Governing Skill

- Primary skill: `sergeant-web-ui`
- Secondary skill: `sergeant-bugfix-and-regression`

## Playbook

- Primary playbook: n/a (manual-QA finding)
- Why this playbook: невеликий focused fix; основний паттерн — bugfix-and-regression.
- If no playbook matched, why: discovered під час cross-module manual QA, не з incident/follow-up roadmap-у.

## Verification

```bash
pnpm --filter @sergeant/routine-domain test
# Test Files 10 passed (10) / Tests 183 passed (183)

pnpm --filter @sergeant/web typecheck
# Exit code 0

pnpm --filter @sergeant/web lint
# Exit code 0 (0 errors, 0 warnings)

pnpm --filter @sergeant/web test src/modules/routine
# Test Files 13 passed (13) / Tests 153 passed (153)

pnpm --filter @sergeant/web test src/core/settings
# Test Files 2 passed (2) / Tests 7 passed (7)
```

Additional checks:

- [x] Local smoke / manual validation completed (`http://localhost:5173/?tab=settings&group=modules#settings-routine` — підтверджено: повторне натискання «+» більше не додає дублікат, toast.warning зʼявляється на 5 с).
- [x] Surface-specific checks completed (routine-domain + apps/web).

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. — n/a, internal invariant.
- [x] I checked whether `AGENTS.md` needed an update. — n/a.
- [x] I checked whether a playbook or skill needed an update. — n/a.
- [x] I checked whether governance docs or review docs needed an update. — n/a.

Updated docs:

- n/a

## Risk and Rollout

- User-visible risk: low. Existing duplicate tags / categories у production-storage не trimmed-ються — reducer лише блокує нові duplicates. Якщо у користувача вже є два теги «Здоров’я», вони залишаться (можна видалити вручну).
- Rollout / deploy order: web only, no migrations.
- Backout plan: revert PR.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit / initiative / playbook / ADR files.

## Reviewer Notes

- Reducer-level fix — джерело істини для інваріанта «унікальна назва у scope='routine'». UI ловить `setRoutine` no-op для feedback.
- Rename-conflict у `TagsSection` працює через `throw` з `onSubmit` (тримає edit-mode); у `CategoriesSection` — early return (edit-mode уже у explicit-button-flow, не on-blur). Обидва surface-и показують той самий `toast.warning`.
- Reducer normalization — `name.trim().toLocaleLowerCase()` ↔ зі збереженням оригінального casing-у в `Tag.name` / `Category.name`, що матчить `applyUpdateHabit`-стилістику.

---
Devin run: https://app.devin.ai/sessions/8226c89fbc51498db5151972ac59fc30 · Requested by Андрій (andrijvigrav@gmail.com)