### PR TITLE
chore(root): add dedupe:check script alias (QW-1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "strict:coverage": "node scripts/strict-coverage.mjs",
     "dead-code:files": "node scripts/knip-respects-scaffolded.mjs",
     "knip": "knip",
+    "dedupe:check": "pnpm dedupe --check",
     "prepare": "husky",
     "gen": "plop",
     "gen:adr": "plop adr",


### PR DESCRIPTION
## Summary

Adds the `dedupe:check` npm-script alias to root `package.json` so contributors have a short, discoverable command for the lockfile-drift guard before the D-2 CI gate from the testing/devx plan lands. Pure devX ergonomics — no production code, no CI behavior changes.

```diff
   "dead-code:files": "node scripts/knip-respects-scaffolded.mjs",
   "knip": "knip",
+  "dedupe:check": "pnpm dedupe --check",
   "prepare": "husky",
```

This is the QW-1 quick-win card from [`docs/planning/pr-plan-testing-devx-2026-05.md`](./docs/planning/pr-plan-testing-devx-2026-05.md) (§ "Quick-wins — XS PR-и"). The card explicitly does **not** wire this into CI — that's still scoped to follow-up D-2.

## Governing Skill

- Primary skill: `sergeant-start-here` (root devX wiring, no surface-specialist applies)
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a (≤50 LoC quick-win per § "Quick-wins" in the plan; no existing playbook covers `package.json` script-alias additions)
- Why this playbook: see above
- If no playbook matched, why: matches the [pr-plan-testing-devx-2026-05.md § Quick-wins](./docs/planning/pr-plan-testing-devx-2026-05.md) explicit XS-card definition — alias-only, no CI/lint impact.

## Verification

```bash
pnpm lint:pnpm-overrides   # OK — all 11 override(s) validated. (alias does not touch overrides — matches the plan acceptance)
pnpm dedupe:check          # exits with list of duplicates (pre-existing drift on main, e.g. third-party-web 0.29.0 vs 0.29.2). The plan accepts "exit 0 або список дублікатів".
pnpm prettier --check package.json  # All matched files use Prettier code style!
```

Pre-commit Husky pipeline ran on commit (lint-staged ESLint+Prettier, no `--no-verify`).

Additional checks:

- [x] Local smoke / manual validation completed (manual `pnpm dedupe:check` invocation)
- [x] Surface-specific checks completed (`pnpm lint:pnpm-overrides` green, as plan demands)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. — n/a, the alias is documented in the plan card itself (QW-1).
- [x] I checked whether `AGENTS.md` needed an update. — No; AGENTS.md lists `pnpm` Quick commands but not every alias.
- [x] I checked whether a playbook or skill needed an update. — No; this is a tooling alias, not a workflow change.
- [x] I checked whether governance docs or review docs needed an update. — No.

Updated docs:

- n/a

## Risk and Rollout

- User-visible risk: none — pure additive npm-script alias, no behavior change.
- Rollout / deploy order: merges directly to `main`; no deploy.
- Backout plan: revert the one-line addition.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian. — n/a (no doc changes).
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

- The `pnpm dedupe:check` invocation on `main` currently reports a pre-existing duplicate of `third-party-web@0.29.0 / 0.29.2`. That drift is unrelated to this PR and is the exact reason the testing/devx plan scoped a CI gate (D-2) for it. The plan acceptance criterion explicitly allows "exit 0 або список дублікатів", so this PR ships the alias without forcing a lockfile bump.
- Companion XS cards QW-2 (`CONTRIBUTING.md` cross-ref) and QW-3 (`docs/testing/README.md` cross-ref) will land as separate PRs per the plan's per-card sequencing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `dedupe:check` script to the root `package.json` that runs `pnpm dedupe --check` so contributors can quickly spot lockfile duplicates. Implements QW-1 from the testing/devx plan; no production or CI changes.

<sup>Written for commit e04ba865958416100c345a19275b5e57542b1f6e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

