### PR TITLE
docs(docs): add testing/devx surface verification bullet to CONTRIBUTING.md (QW-2)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,7 @@ pnpm dedupe --check   # P2-1: lockfile-drift guard (див. нижче)
 - `mobile`: `pnpm --filter @sergeant/mobile test`
 - `console`: `pnpm --filter @sergeant/openclaw exec vitest run`
 - `governance/docs`: `pnpm docs:check-links`, `pnpm docs:check-playbook-schema`, `pnpm docs:check-playbook-index`, `pnpm lint:governance-sync --strict`
+- `testing/devx`: звіряйся з [`docs/planning/pr-plan-testing-devx-2026-05.md`](./docs/planning/pr-plan-testing-devx-2026-05.md) і починай із [`.agents/skills/sergeant-start-here/SKILL.md`](./.agents/skills/sergeant-start-here/SKILL.md). Базові verification-команди — `pnpm lint`, `pnpm typecheck`, `pnpm test` + relevant filter (`pnpm --filter @sergeant/<workspace> test`); E2E / Detox / VRT — лише якщо змінюються відповідні spec-файли.
 
 Якщо сценарій має окремий playbook, секція `Verification` у playbook має пріоритет над загальним списком вище.
 


### PR DESCRIPTION
## Summary

Adds a `testing/devx` row to `CONTRIBUTING.md § "Verification за типом зміни"` pointing contributors who touch testing or devX infrastructure at the dedicated 2026-05 plan and the `sergeant-start-here` SKILL, with the minimum verification commands they should run. One-line addition; no behavior changes.

```diff
 - `governance/docs`: `pnpm docs:check-links`, `pnpm docs:check-playbook-schema`, ...
+- `testing/devx`: звіряйся з [`docs/planning/pr-plan-testing-devx-2026-05.md`](./docs/planning/pr-plan-testing-devx-2026-05.md) і починай із [`.agents/skills/sergeant-start-here/SKILL.md`](./.agents/skills/sergeant-start-here/SKILL.md). Базові verification-команди — `pnpm lint`, `pnpm typecheck`, `pnpm test` + relevant filter (`pnpm --filter @sergeant/<workspace> test`); E2E / Detox / VRT — лише якщо змінюються відповідні spec-файли.
```

This is the QW-2 quick-win card from [`docs/planning/pr-plan-testing-devx-2026-05.md`](./docs/planning/pr-plan-testing-devx-2026-05.md) (§ "Quick-wins — XS PR-и"). Cross-ref to `sergeant-start-here` ensures testing/devx-surface agents route through the mandatory entrypoint before touching shared CI infra.

## Governing Skill

- Primary skill: `sergeant-writing-skills` (governance/docs surface; updating contributor guide)
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a (≤2 LoC XS quick-win per § "Quick-wins" in the plan; no playbook governs single-line contributor-guide additions)
- Why this playbook: see above
- If no playbook matched, why: the addition matches the QW-2 card spec exactly — one bullet, relative path within the repo, scope per plan.

## Verification

```bash
pnpm docs:check-links              # +2 new internal links resolved (4849 vs 4847 baseline);
                                    # the single broken-link finding (docs/governance/hard-rules-matrix.md → 2026-04-28-ux-ui-audit.md)
                                    # is pre-existing on main — independent from this change.
pnpm lint:tech-debt-freshness      # OK: all 3 tech-debt freshness markers (frontend/backend/mobile) within window.
pnpm prettier --check CONTRIBUTING.md  # All matched files use Prettier code style!
```

Pre-commit Husky pipeline ran on commit (lint-staged ESLint+Prettier + `bump-last-validated.mjs`, no `--no-verify`).

Additional checks:

- [x] Local smoke / manual validation completed (manual link-target verification: both `pr-plan-testing-devx-2026-05.md` and `sergeant-start-here/SKILL.md` exist on `main`).
- [x] Surface-specific checks completed: `pnpm docs:check-links` net-new errors = 0; `pnpm lint:tech-debt-freshness` green.

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. — Yes; this PR _is_ the docs change.
- [x] I checked whether `AGENTS.md` needed an update. — No; CONTRIBUTING.md is the canonical "Verification per change type" surface (per AGENTS.md → CONTRIBUTING.md routing). AGENTS.md links into CONTRIBUTING.md, no duplication needed.
- [x] I checked whether a playbook or skill needed an update. — No; QW-2 only adds a contributor pointer.
- [x] I checked whether governance docs or review docs needed an update. — No.

Updated docs:

- `CONTRIBUTING.md` (1 line, § "Verification за типом зміни").

## Risk and Rollout

- User-visible risk: none — single doc bullet, no code change.
- Rollout / deploy order: merges directly to `main`; no deploy.
- Backout plan: revert the one-line addition.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

- Sibling QW-1 (`dedupe:check` alias) is in flight as a separate PR; QW-3 (`docs/testing/README.md` cross-ref) lands next.
- The plan card says "Deps: цей PR (план має бути merged перед QW-2)" — the plan was merged in [#2659](https://github.com/Skords-01/Sergeant/pull/2659)/equivalent commit, and lives on `main` today; dependency is satisfied.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `testing/devx` row to CONTRIBUTING.md that points to `docs/planning/pr-plan-testing-devx-2026-05.md` and `.agents/skills/sergeant-start-here/SKILL.md`, with baseline checks: `pnpm lint`, `pnpm typecheck`, `pnpm test` (or `pnpm --filter @sergeant/<workspace> test`). Fulfills QW-2 and clarifies E2E/Detox/VRT run only when their spec files change.

<sup>Written for commit d491c30c24a59f587bbd515724f5ca48ccaaa06e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

