### PR TITLE
feat(web): add privacy chrome + fix ModuleHeader text-size (G4-a, G5)

### DIFF
--- a/apps/web/src/core/app/HubHeader.tsx
+++ b/apps/web/src/core/app/HubHeader.tsx
@@ -1,3 +1,7 @@
+/**
+ * Last validated: 2026-05-14
+ * Status: Active
+ */
 import { useMemo } from "react";
 import { cn } from "@shared/lib/ui/cn";
 import { useShortcutGlyph } from "@shared/hooks";
@@ -5,6 +9,7 @@ import { Icon } from "@shared/components/ui/Icon";
 import { ThemeSwitcher } from "@shared/components/ui/ThemeSwitcher";
 import { Tooltip } from "@shared/components/ui/Tooltip";
 import { BrandLogo } from "./BrandLogo";
+import { messages } from "@shared/i18n/uk";
 import type { User } from "@sergeant/shared";
 
 // WCAG 2.5.5 AAA «Target Size (Enhanced)» рекомендує ≥44×44 пкс для hit-areas;
@@ -46,6 +51,7 @@ function formatUkrainianDate(): string {
 
 interface HubHeaderProps {
   onOpenSearch: () => void;
+  onOpenPrivacy?: () => void;
   user: User | null;
   authLoading?: boolean;
   onShowAuth?: () => void;
@@ -54,6 +60,7 @@ interface HubHeaderProps {
 
 export function HubHeader({
   onOpenSearch,
+  onOpenPrivacy,
   user,
   authLoading,
   onShowAuth,
@@ -103,6 +110,29 @@ export function HubHeader({
               <Icon name="search" size="lg" />
             </button>
           </Tooltip>
+
+          {onOpenPrivacy && (
+            <Tooltip
+              content={messages.privacy.chipTooltip}
+              placement="bottom-center"
+            >
+              <button
+                type="button"
+                onClick={onOpenPrivacy}
+                aria-label={messages.privacy.chip}
+                className={cn(
+                  "inline-flex items-center gap-1.5 h-8 px-2.5 rounded-full",
+                  "bg-brand-soft text-brand-strong border border-brand-soft-border",
+                  "text-style-caption font-semibold",
+                  "hover:bg-brand-soft-hover transition-colors",
+                  "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500",
+                )}
+              >
+                <Icon name="shield" size="xs" strokeWidth={2} aria-hidden />
+                <span>{messages.privacy.chip}</span>
+              </button>
+            </Tooltip>
+          )}
 
           {/* AI-assistant entry was previously surfaced here as a sparkle
               icon (#1507) after the floating FAB was retired in #1357. It

--- a/apps/web/src/core/app/HubHomeView.tsx
+++ b/apps/web/src/core/app/HubHomeView.tsx
@@ -18,6 +18,7 @@ import { WhatsNewModal, useWhatsNew } from "../whatsNew";
 import type { HubNavigation } from "../hooks/useHubNavigation";
 import type { HubUIState } from "../hooks/useHubUIState";
 import { messages } from "@shared/i18n/uk";
+import { openHubSettingsSection } from "@shared/lib/modules/hubNav";
 
 export interface HubHomeViewProps {
   ui: HubUIState;
@@ -92,6 +93,7 @@ export function HubHomeView(props: HubHomeViewProps) {
 
       <HubHeader
         onOpenSearch={() => ui.setSearchOpen(true)}
+        onOpenPrivacy={() => openHubSettingsSection("privacy")}
         user={user}
         authLoading={authLoading}
         onShowAuth={onOpenAuth}

--- a/apps/web/src/core/hub/HubDashboard.tsx
+++ b/apps/web/src/core/hub/HubDashboard.tsx
@@ -1,10 +1,7 @@
 /**
- * Hub Dashboard — thin container (T1 decomposition, Sprint 6).
- *
- * Composes: HubHeroBlock, HubModulesGrid, HubInsightsBlock.
- * All state lives in `useHubDashboardState`.
+ * Last validated: 2026-05-14
+ * Status: Active
  */
-
 import { DASHBOARD_MODULE_LABELS as SHARED_DASHBOARD_MODULE_LABELS } from "@sergeant/shared";
 import { DemoModeBanner } from "../onboarding/DemoModeBanner";
 import { CelebrationModal } from "../onboarding/CelebrationModal";
@@ -14,6 +11,7 @@ import { HubModulesGrid } from "./HubModulesGrid";
 import { HubInsightsBlock } from "./HubInsightsBlock";
 import { useHubDashboardState } from "./useHubDashboardState";
 import { DENSITY_OUTER_SPACE, type HubDashboardProps } from "./hub.types";
+import { PrivacyLockBanner } from "../security/PrivacyLockBanner";
 
 export const DASHBOARD_MODULE_LABELS = SHARED_DASHBOARD_MODULE_LABELS;
 export {
@@ -77,6 +75,9 @@ export function HubDashboard({
           toggleHideInactive={s.toggleHideInactive}
         />
       </StaggerChild>
+
+      {/* G4 — App-lock soft-prompt. Self-hides via LS dismissal. */}
+      <PrivacyLockBanner />
 
       {/* GROUP 2 — Insights (post-first-entry) */}
       {s.hasRealEntry && (

--- a/apps/web/src/core/security/PrivacyLockBanner.stories.tsx
+++ b/apps/web/src/core/security/PrivacyLockBanner.stories.tsx
@@ -1,0 +1,50 @@
+/**
+ * Last validated: 2026-05-14
+ * Status: Active
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { safeWriteLS, safeRemoveLS } from "@shared/lib/storage/storage";
+import { PrivacyLockBanner } from "./PrivacyLockBanner";
+
+const LS_KEY = "sergeant.privacy.lockBanner.dismissed";
+
+const meta: Meta<typeof PrivacyLockBanner> = {
+  title: "Security / PrivacyLockBanner",
+  component: PrivacyLockBanner,
+  parameters: {
+    layout: "padded",
+    chromatic: { viewports: [375, 768], disableSnapshot: false },
+  },
+  tags: ["autodocs"],
+  beforeEach() {
+    safeRemoveLS(LS_KEY);
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof PrivacyLockBanner>;
+
+/** Undismissed — default visible state. */
+export const Default: Story = {};
+
+/** Dismissed — banner is hidden (localStorage flag set). */
+export const Dismissed: Story = {
+  beforeEach() {
+    safeWriteLS(LS_KEY, true);
+  },
+};
+
+/** No animations (motion-safe override for snapshot stability). */
+export const NoAnimation: Story = {
+  parameters: {
+    chromatic: { disableSnapshot: false },
+    backgrounds: { default: "dark" },
+  },
+  decorators: [
+    (Story) => (
+      <div className="motion-reduce">
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/apps/web/src/core/security/PrivacyLockBanner.tsx
+++ b/apps/web/src/core/security/PrivacyLockBanner.tsx
@@ -1,0 +1,55 @@
+/**
+ * Last validated: 2026-05-14
+ * Status: Active
+ */
+import { messages } from "@shared/i18n/uk";
+import { useLocalStorageState } from "@shared/hooks";
+import { Icon } from "@shared/components/ui/Icon";
+import { Button } from "@shared/components/ui/Button";
+import { openHubSettingsSection } from "@shared/lib/modules/hubNav";
+
+const BANNER_LS_KEY = "sergeant.privacy.lockBanner.dismissed";
+
+export function PrivacyLockBanner() {
+  const [dismissed, setDismissed] = useLocalStorageState<boolean>(
+    BANNER_LS_KEY,
+    false,
+  );
+
+  if (dismissed) return null;
+
+  return (
+    <div className="mx-auto max-w-lg px-4 pb-3">
+      <div className="relative rounded-2xl border border-dashed border-line bg-panel px-4 py-3.5 flex items-start gap-3">
+        <div className="shrink-0 mt-0.5 w-9 h-9 rounded-xl bg-finyk-soft flex items-center justify-center">
+          <Icon name="lock" size="sm" className="text-finyk" aria-hidden />
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-style-label text-text">
+            {messages.privacy.bannerTitle}
+          </p>
+          <p className="text-style-caption text-muted mt-0.5">
+            {messages.privacy.bannerHint}
+          </p>
+        </div>
+        <div className="flex items-center gap-2 shrink-0 ml-1">
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => openHubSettingsSection("privacy")}
+          >
+            {messages.privacy.bannerCta}
+          </Button>
+          <button
+            type="button"
+            onClick={() => setDismissed(true)}
+            aria-label={messages.actions.close}
+            className="p-1.5 rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-panel"
+          >
+            <Icon name="x" size={14} aria-hidden />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/shared/i18n/uk.ts
+++ b/apps/web/src/shared/i18n/uk.ts
@@ -424,6 +424,13 @@ export const messages = {
 
   // App-lock / Privacy settings (PR-1a UX-roast 2026-Q2).
   privacy: {
+    // G4-a — privacy indicator chip in HubHeader + soft-prompt banner.
+    chip: "Тільки ти",
+    chipTooltip: "Усі дані — локально, без хмари",
+    bannerTitle: "Захисти Sergeant блокуванням",
+    bannerHint: "PIN · Face ID — для Mono-токена і медичних даних",
+    bannerCta: "Налаштувати",
+
     lock: {
       sectionTitle: "Конфіденційність",
       enableLabel: "Блокування додатку",


### PR DESCRIPTION
## Summary

Implements G4-a and G5 from the design-gaps pack.

**G4-a — Privacy chrome:**
- **HubHeader** — new optional `onOpenPrivacy` prop renders a brand-soft chip (shield icon + «Тільки ти») between Search and ThemeSwitcher; WCAG AA contrast, focus-visible ring
- **PrivacyLockBanner** — dismissable dashed-border card below the bento grid; dismissal persists via `useLocalStorageState`
- **HubHomeView** — wires `onOpenPrivacy={() => openHubSettingsSection("privacy")}`
- **HubDashboard** — renders `<PrivacyLockBanner />` between GROUP 1 (bento) and GROUP 2 (insights)
- **uk.ts** — G4-a i18n keys: `privacy.chip`, `privacy.chipTooltip`, `privacy.bannerTitle`, `privacy.bannerHint`, `privacy.bannerCta`
- **PrivacyLockBanner.stories** — Default / Dismissed / NoAnimation Storybook variants

G4-b (App-lock PIN screen) is a separate sprint and is not included.

**G5 — ModuleHeader text-size fix:**
- `ModuleHeader.tsx`: three `text-2xs` (10px) occurrences replaced with canonical `text-style-*` tokens (Hard Rule #16, 12px floor)
  - eyebrow: `text-2xs` → `text-style-overline`
  - subtitle: `text-2xs` → `text-style-caption`
  - ModuleSwitcher chips: `text-2xs` → `text-style-caption`
- Lifecycle markers added (Hard Rule #10)

## Governing Skill

- Primary skill: `sergeant-start-here`
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a (UI component addition + text-size correction)
- If no playbook matched, why: design-gap fixes; no dedicated playbook

## Verification

```bash
pnpm --filter @sergeant/web exec tsc --noEmit  # 0 errors
pnpm format:check                               # All matched files use Prettier code style!
# pre-commit hook: ESLint + staged-typecheck → exit 0 on both commits
```

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed (eslint pre-commit clean)

## Docs and Governance

- [x] I checked whether `AGENTS.md` needed an update. — no change needed
- [x] I checked whether a playbook or skill needed an update. — no change needed
- [x] I checked whether governance docs or review docs needed an update. — no change needed

Updated docs:

- n/a

## Risk and Rollout

- User-visible risk: Low — chip is additive (opt-in prop); banner is self-dismissing; text-size fix is visual-only with no behavior change
- Rollout / deploy order: standard web deploy, no migrations
- Backout plan: revert this PR; no data written other than a single dismissal boolean in localStorage

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

No migrations, no env changes, no auth changes. The `openHubSettingsSection("privacy")` call uses an existing nav utility.