### PR TITLE
fix(web): raise touch targets to 44px in nutrition delete buttons (audit 08 F4-F5)

### DIFF
--- a/apps/web/src/modules/nutrition/components/MealRow.tsx
+++ b/apps/web/src/modules/nutrition/components/MealRow.tsx
@@ -1,6 +1,11 @@
+/**
+ * Last validated: 2026-05-14
+ * Status: Active
+ */
 import { useEffect, useState } from "react";
 import { cn } from "@shared/lib/ui/cn";
 import { Badge } from "@shared/components/ui/Badge";
+import { Button } from "@shared/components/ui/Button";
 import { type Meal } from "@sergeant/nutrition-domain";
 import { getMealThumbnailBlob } from "../lib/mealPhotoStorage";
 
@@ -110,14 +115,16 @@ export function MealRow({ meal, onRemove, onEdit }: MealRowProps) {
           )}
         </div>
       </button>
-      <button
-        type="button"
+      <Button
+        variant="ghost"
+        size="xs"
+        iconOnly
         onClick={onRemove}
-        className="w-8 h-8 flex items-center justify-center rounded-full text-muted hover:text-danger hover:bg-danger/10 transition-colors opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
         aria-label="Видалити запис"
+        className="text-muted hover:text-danger hover:bg-danger/10 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-focus/45"
       >
         ✕
-      </button>
+      </Button>
     </div>
   );
 }

--- a/apps/web/src/modules/nutrition/components/PantryCard.tsx
+++ b/apps/web/src/modules/nutrition/components/PantryCard.tsx
@@ -1,7 +1,12 @@
+/**
+ * Last validated: 2026-05-14
+ * Status: Active
+ */
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Card } from "@shared/components/ui/Card";
 import { Input } from "@shared/components/ui/Input";
 import { Icon } from "@shared/components/ui/Icon";
+import { Button } from "@shared/components/ui/Button";
 import { Tooltip } from "@shared/components/ui/Tooltip";
 import { cn } from "@shared/lib/ui/cn";
 import { groupItemsByCategory } from "../lib/foodCategories";
@@ -70,16 +75,18 @@ function ItemRow({
           </span>
         )}
       </button>
-      <button
-        type="button"
+      <Button
+        variant="ghost"
+        size="xs"
+        iconOnly
         onClick={() => removeItemAtOrByName(idx, item?.name)}
         disabled={busy}
-        className="w-6 h-6 rounded-xl flex items-center justify-center text-subtle/60 sm:opacity-0 sm:group-hover:opacity-100 sm:focus-visible:opacity-100 hover:text-danger hover:bg-danger/10 transition-[color,background-color,opacity] text-sm leading-none shrink-0"
         aria-label={`Прибрати ${item?.name || "продукт"}`}
         title="Прибрати"
+        className="shrink-0 text-subtle/60 sm:opacity-0 sm:group-hover:opacity-100 sm:focus-visible:ring-2 sm:focus-visible:ring-focus/45 sm:focus-visible:opacity-100 hover:text-danger hover:bg-danger/10 transition-[color,background-color,opacity]"
       >
         ×
-      </button>
+      </Button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Fixes audit 08 F4/F5 — two delete buttons in the Nutrition module with sub-44px hit areas and missing focus rings.

- **PantryCard** (F4): pantry item delete `w-6 h-6` (24px) → `<Button variant="ghost" size="xs" iconOnly>`; adds `focus-visible:ring` (F5 fix)
- **MealRow** (F4): meal delete `w-8 h-8` (32px) → `<Button variant="ghost" size="xs" iconOnly>`; adds `focus-visible:ring-2 focus-visible:ring-focus/45` (F5 fix)
- Lifecycle markers added to both files

## Test plan
- [ ] Pantry item delete button has ≥44×44px hit area; still works on tap
- [ ] Meal delete button has ≥44×44px hit area; still works
- [ ] Keyboard focus shows a visible ring on both delete buttons
- [ ] Hover-reveal behaviour (`opacity-0 group-hover:opacity-100`) still works on desktop

https://claude.ai/code/session_01TBfuYCbtj3ukhbK16PtBdr

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBfuYCbtj3ukhbK16PtBdr)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise delete button touch targets to 44×44px and add visible focus rings in the Nutrition module to satisfy audit 08 F4/F5. Improves touch and keyboard accessibility without changing behavior.

- **Bug Fixes**
  - PantryCard: replace 24px delete control with an icon-only ghost button sized to ≥44px; add focus-visible ring; keep hover-reveal.
  - MealRow: replace 32px delete control with an icon-only ghost button sized to ≥44px; add focus-visible ring.
  - Add lifecycle markers to both files.

<sup>Written for commit f108399f24b7a84e0ab918d3d15ec9b1307be8be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

