### PR TITLE
fix(web): raise touch targets and add aria-pressed to BodyAtlas toggles (audit 06 F2)

### DIFF
--- a/apps/web/src/modules/fizruk/components/BodyAtlas.tsx
+++ b/apps/web/src/modules/fizruk/components/BodyAtlas.tsx
@@ -1,3 +1,7 @@
+/**
+ * Last validated: 2026-05-14
+ * Status: Active
+ */
 import { useEffect, useMemo, useRef, useState } from "react";
 import createBodyHighlighter from "body-highlighter";
 import { cn } from "@shared/lib/ui/cn";
@@ -84,8 +88,11 @@ export function BodyAtlas({
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-2">
           <button
+            type="button"
+            aria-pressed={view === "anterior"}
             className={cn(
-              "text-xs px-3 py-2 rounded-full border transition-colors",
+              "text-xs px-3 min-h-[44px] rounded-full border transition-colors",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fizruk/50",
               view === "anterior"
                 ? "bg-text text-bg border-text"
                 : "border-line text-subtle hover:text-text",
@@ -95,8 +102,11 @@ export function BodyAtlas({
             Спереду
           </button>
           <button
+            type="button"
+            aria-pressed={view === "posterior"}
             className={cn(
-              "text-xs px-3 py-2 rounded-full border transition-colors",
+              "text-xs px-3 min-h-[44px] rounded-full border transition-colors",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fizruk/50",
               view === "posterior"
                 ? "bg-text text-bg border-text"
                 : "border-line text-subtle hover:text-text",


### PR DESCRIPTION
## Summary

Partial fix for audit 06 F2 — the anterior/posterior view toggle buttons on the Fizruk muscle atlas had sub-44px hit areas and no keyboard accessibility state.

- `py-2` → `min-h-[44px]` on both toggle buttons (WCAG 2.5.5)
- Add `type="button"` (was missing)
- Add `aria-pressed={view === "anterior/posterior"}` so screen readers announce toggle state (WCAG 4.1.2)
- Add `focus-visible:ring-2 focus-visible:ring-fizruk/50` for keyboard focus visibility (WCAG 2.4.7)
- Lifecycle marker added

## Test plan
- [ ] "Спереду" / "Ззаду" buttons are ≥44px tall and tappable
- [ ] Tab focus shows fizruk-coloured ring on both buttons
- [ ] Screen reader announces "Спереду, pressed" when anterior is active
- [ ] Toggle still switches the muscle map view correctly

https://claude.ai/code/session_01TBfuYCbtj3ukhbK16PtBdr

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBfuYCbtj3ukhbK16PtBdr)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves accessibility of the BodyAtlas anterior/posterior toggle buttons to address audit 06 F2. Touch targets meet 44px, keyboard focus is visible, and screen readers announce the pressed state.

- **Bug Fixes**
  - Set min height to 44px for both toggle buttons (WCAG 2.5.5).
  - Added aria-pressed to reflect active view (WCAG 4.1.2).
  - Added focus-visible ring for clear keyboard focus (WCAG 2.4.7).
  - Set type="button" to prevent unintended form submits.

<sup>Written for commit 8cfaff0c0d963f95fe5b259ddddd6bdc5091b4f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

