### PR TITLE
test(server): add route-level e2e for POST /api/billing/stripe-webhook

### DIFF
--- a/apps/server/src/routes/billing.webhook.test.ts
+++ b/apps/server/src/routes/billing.webhook.test.ts
@@ -1,0 +1,221 @@
+import { createHmac } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createBillingRouter } from "./billing.js";
+
+/**
+ * Route-level e2e для `POST /api/billing/stripe-webhook`. Закриває gap D1
+ * з `docs/audits/2026-05-15-deep-audit-state-of-repo.md`: module-level
+ * `stripe.test.ts` покриває `verifyStripeSignature` + `processStripeWebhook`
+ * окремо (signature replay/tolerance/tampering + DB transaction + PostHog
+ * lifecycle), але end-to-end Express-flow через `createBillingRouter`
+ * (raw body capture → header parse → signature gate → JSON parse → event
+ * shape validation → DB call → JSON response) тестується тут.
+ */
+
+const SECRET = "whsec_test_e2e_1234567890abcdef";
+
+function signedHeader(timestampSeconds: number, rawBody: Buffer): string {
+  const v1 = createHmac("sha256", SECRET)
+    .update(`${timestampSeconds}.${rawBody.toString("utf8")}`)
+    .digest("hex");
+  return `t=${timestampSeconds},v1=${v1}`;
+}
+
+function makePool(rowCount: number) {
+  const query = vi.fn().mockResolvedValue({ rowCount, rows: [] });
+  const client = { query, release: vi.fn() };
+  return {
+    connect: vi.fn().mockResolvedValue(client),
+    query: vi.fn().mockResolvedValue({ rowCount: 0, rows: [] }),
+    __client: client,
+  };
+}
+
+function makeApp(pool: ReturnType<typeof makePool>) {
+  const app = express();
+  // Webhook endpoint потребує raw body для signature-verification —
+  // це той самий patern, що в `apps/server/src/app.ts` для billing route.
+  app.use(
+    "/api/billing/stripe-webhook",
+    express.raw({ type: "application/json" }),
+  );
+  app.use(createBillingRouter({ pool: pool as never }));
+  return app;
+}
+
+describe("POST /api/billing/stripe-webhook (route-level e2e)", () => {
+  beforeEach(() => {
+    process.env["STRIPE_WEBHOOK_SECRET"] = SECRET;
+  });
+
+  afterEach(() => {
+    delete process.env["STRIPE_WEBHOOK_SECRET"];
+    delete process.env["STRIPE_WEBHOOK_TOLERANCE_SECONDS"];
+  });
+
+  it("happy-path: signed payload → 200 з `{ ok, duplicate }` від processStripeWebhook", async () => {
+    const pool = makePool(1);
+    const payload = Buffer.from(
+      JSON.stringify({
+        id: "evt_e2e_happy",
+        type: "checkout.session.completed",
+        data: {
+          object: {
+            id: "cs_test_1",
+            client_reference_id: "user_e2e",
+            customer: "cus_e2e",
+            subscription: "sub_e2e",
+            metadata: { plan: "pro" },
+          },
+        },
+      }),
+    );
+    const nowSec = Math.floor(Date.now() / 1000);
+
+    const res = await request(makeApp(pool))
+      .post("/api/billing/stripe-webhook")
+      .set("Content-Type", "application/json")
+      .set("stripe-signature", signedHeader(nowSec, payload))
+      .send(payload);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, duplicate: false });
+    // DB transaction повністю проходить: BEGIN → INSERT idempotency
+    // → INSERT subscriptions → COMMIT.
+    expect(pool.__client.query).toHaveBeenCalledWith("BEGIN");
+    expect(pool.__client.query).toHaveBeenLastCalledWith("COMMIT");
+  });
+
+  it("duplicate event: rowCount=0 → 200 з `{ ok, duplicate: true }`, NO subscription INSERT", async () => {
+    const pool = makePool(0);
+    const payload = Buffer.from(
+      JSON.stringify({
+        id: "evt_e2e_dup",
+        type: "checkout.session.completed",
+        data: { object: { id: "cs_dup" } },
+      }),
+    );
+    const nowSec = Math.floor(Date.now() / 1000);
+
+    const res = await request(makeApp(pool))
+      .post("/api/billing/stripe-webhook")
+      .set("Content-Type", "application/json")
+      .set("stripe-signature", signedHeader(nowSec, payload))
+      .send(payload);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, duplicate: true });
+  });
+
+  it("invalid signature (tampered payload) → 400, NO DB call", async () => {
+    const pool = makePool(1);
+    const goodPayload = Buffer.from(
+      JSON.stringify({ id: "evt_x", type: "ping" }),
+    );
+    const tampered = Buffer.from(
+      JSON.stringify({ id: "evt_x", type: "evil" }),
+    );
+    const nowSec = Math.floor(Date.now() / 1000);
+
+    const res = await request(makeApp(pool))
+      .post("/api/billing/stripe-webhook")
+      .set("Content-Type", "application/json")
+      .set("stripe-signature", signedHeader(nowSec, goodPayload))
+      .send(tampered);
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "Invalid Stripe signature" });
+    expect(pool.connect).not.toHaveBeenCalled();
+  });
+
+  it("missing signature header → 400, NO DB call", async () => {
+    const pool = makePool(1);
+    const payload = Buffer.from(JSON.stringify({ id: "evt_x", type: "ping" }));
+
+    const res = await request(makeApp(pool))
+      .post("/api/billing/stripe-webhook")
+      .set("Content-Type", "application/json")
+      .send(payload);
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "Invalid Stripe signature" });
+    expect(pool.connect).not.toHaveBeenCalled();
+  });
+
+  it("replay outside tolerance (10 minutes old) → 400", async () => {
+    const pool = makePool(1);
+    const payload = Buffer.from(JSON.stringify({ id: "evt_x", type: "ping" }));
+    const tenMinutesAgo = Math.floor(Date.now() / 1000) - 600;
+
+    const res = await request(makeApp(pool))
+      .post("/api/billing/stripe-webhook")
+      .set("Content-Type", "application/json")
+      .set("stripe-signature", signedHeader(tenMinutesAgo, payload))
+      .send(payload);
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "Invalid Stripe signature" });
+    expect(pool.connect).not.toHaveBeenCalled();
+  });
+
+  it("missing event.id (after valid signature) → 400 'Invalid Stripe event'", async () => {
+    const pool = makePool(1);
+    const payload = Buffer.from(
+      JSON.stringify({ type: "checkout.session.completed", data: {} }),
+    );
+    const nowSec = Math.floor(Date.now() / 1000);
+
+    const res = await request(makeApp(pool))
+      .post("/api/billing/stripe-webhook")
+      .set("Content-Type", "application/json")
+      .set("stripe-signature", signedHeader(nowSec, payload))
+      .send(payload);
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "Invalid Stripe event" });
+    expect(pool.connect).not.toHaveBeenCalled();
+  });
+
+  it("missing event.type (after valid signature) → 400 'Invalid Stripe event'", async () => {
+    const pool = makePool(1);
+    const payload = Buffer.from(
+      JSON.stringify({ id: "evt_no_type", data: {} }),
+    );
+    const nowSec = Math.floor(Date.now() / 1000);
+
+    const res = await request(makeApp(pool))
+      .post("/api/billing/stripe-webhook")
+      .set("Content-Type", "application/json")
+      .set("stripe-signature", signedHeader(nowSec, payload))
+      .send(payload);
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "Invalid Stripe event" });
+    expect(pool.connect).not.toHaveBeenCalled();
+  });
+
+  it("event with `data` but без `data.object` → 200 (event shape без object — pass-through)", async () => {
+    const pool = makePool(1);
+    const payload = Buffer.from(
+      JSON.stringify({
+        id: "evt_no_object",
+        type: "ping",
+        data: { extra: "field" },
+      }),
+    );
+    const nowSec = Math.floor(Date.now() / 1000);
+
+    const res = await request(makeApp(pool))
+      .post("/api/billing/stripe-webhook")
+      .set("Content-Type", "application/json")
+      .set("stripe-signature", signedHeader(nowSec, payload))
+      .send(payload);
+
+    expect(res.status).toBe(200);
+    // Idempotency rows are still recorded, subscription branches skip.
+    expect(pool.connect).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Closes audit gap **D1** з [`docs/audits/2026-05-15-deep-audit-state-of-repo.md`](../blob/main/docs/audits/2026-05-15-deep-audit-state-of-repo.md).

Module-level [`apps/server/src/modules/billing/stripe.test.ts`](../blob/main/apps/server/src/modules/billing/stripe.test.ts) уже покриває `verifyStripeSignature` (replay, tolerance, tampering, missing secret — 9 cases) і `processStripeWebhook` (idempotency, lifecycle PostHog events, edge cases — 7 cases). Що бракує — route-level Express integration: raw body capture → header parse → signature gate → JSON parse → event shape validation → DB call → JSON response.

Новий [`apps/server/src/routes/billing.webhook.test.ts`](../blob/feat/2026-05-15-D1-stripe-webhook-e2e/apps/server/src/routes/billing.webhook.test.ts) (8 cases):
- happy-path: signed payload → 200 з \`processStripeWebhook\` result
- duplicate event: rowCount=0 → 200 \`{ ok, duplicate: true }\`
- invalid signature (tampered payload) → 400, NO DB call
- missing signature header → 400, NO DB call
- replay outside tolerance (10 min old) → 400
- missing event.id → 400 'Invalid Stripe event'
- missing event.type → 400 'Invalid Stripe event'
- event без \`data.object\` → 200 (graceful pass-through)

Pattern за [\`apps/server/src/routes/email-unsubscribe.test.ts\`](../blob/main/apps/server/src/routes/email-unsubscribe.test.ts): supertest + express + vi.fn-mocked pg pool. Mock-pool exposes \`__client\` для assertion-ів на BEGIN/COMMIT transaction calls.

## Governing Skill

- Primary skill: route-level integration testing (`apps/server`)
- Secondary skill: —

## Playbook

- Primary playbook: testing-devx (`docs/audits/2026-05-13-testing-devx-roast.md`)
- Why this playbook: closes revenue-critical path e2e coverage gap
- If no playbook matched, why: n/a

## Verification

\`\`\`bash
# Очікується на CI (Node 20 baseline). Локально pnpm install не завершився
# через disk-space у моєму dev-env, але pattern дзеркалить existing
# email-unsubscribe.test.ts, який зелений на main.
pnpm --filter @sergeant/server test src/routes/billing.webhook.test.ts
\`\`\`

Additional checks:

- [ ] Local smoke / manual validation completed (заблоковано dev-env)
- [x] Surface-specific checks completed (pattern reuse з email-unsubscribe.test.ts)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether \`AGENTS.md\` needed an update. (n/a — додання тесту)
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a (нові тести; coverage-приріст відобразиться у Implemented-counter \`docs/audits/2026-05-13-testing-devx-roast.md\` при наступному \`Last validated\` бампі)

## Risk and Rollout

- User-visible risk: none (test-only)
- Rollout / deploy order: будь-яке
- Backout plan: \`git revert\`

## Hard Rule #15

- [x] I read \`AGENTS.md\` before coding.
- [x] Internal docs I touched are in Ukrainian. (тестові коментарі — українською)
- [x] I did not use \`--no-verify\`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

Mock-pool створює \`{ connect: vi.fn().mockResolvedValue({ query, release }) }\`, експортує внутрішній client через \`__client\` поле — це той самий patern, що в \`stripe.test.ts\` (рядки 21–27). Якщо команда вважає, що краще ховати mock-internals — radi радо переписати.

Raw-body middleware (\`express.raw({ type: "application/json" })\`) монтується перед \`createBillingRouter\` — повторює production app.ts wiring для webhook endpoint.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds route-level e2e tests for POST /api/billing/stripe-webhook to verify the full Express flow (raw body, signature, JSON, event validation, DB, response). Closes audit gap D1 and increases confidence in webhook handling.

- **New Features**
  - Added `apps/server/src/routes/billing.webhook.test.ts` (8 cases): happy path, duplicate, invalid/missing signature, replay tolerance, missing `event.id`/`event.type`, and `data` without `data.object` (pass-through).
  - Tests mirror production wiring using `express` + `supertest` with `express.raw({ type: "application/json" })`, and a mocked `pg` pool (via `vitest`) to assert BEGIN/COMMIT and ensure no DB calls on signature failures.

<sup>Written for commit a97086f908233e5a8bcdd9df531b1a9ee10ae329. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

