### PR TITLE
refactor(design-tokens): migrate fizruk accent from teal-500 to cyan-700

### DIFF
--- a/apps/mobile/global.css
+++ b/apps/mobile/global.css
@@ -106,8 +106,8 @@
        ─────────────────────────────────────────────────────────────────── */
     --c-finyk-surface-dark: 16 185 129; /* emerald-500 */
     --c-finyk-border-dark: 16 185 129; /* emerald-500 */
-    --c-fizruk-surface-dark: 20 184 166; /* teal-500 */
-    --c-fizruk-border-dark: 20 184 166; /* teal-500 */
+    --c-fizruk-surface-dark: 14 116 144; /* cyan-700 — mirrors moduleColors.fizruk.primary (was teal-500) */
+    --c-fizruk-border-dark: 14 116 144; /* cyan-700 — mirrors moduleColors.fizruk.primary (was teal-500) */
     --c-routine-surface-dark: 249 112 102; /* coral-500 */
     --c-routine-border-dark: 249 112 102; /* coral-500 */
     --c-nutrition-surface-dark: 146 204 23; /* lime-500 */

--- a/apps/mobile/src/components/ui/ProgressRing.tsx
+++ b/apps/mobile/src/components/ui/ProgressRing.tsx
@@ -53,7 +53,7 @@ const variantColors: Record<ProgressRingVariant, string> = {
   danger: "#ef4444", // red-500
   info: "#0ea5e9", // sky-500
   finyk: "#10b981", // emerald-500
-  fizruk: "#14b8a6", // teal-500
+  fizruk: "#0e7490", // cyan-700 — mirrors moduleColors.fizruk.primary
   routine: "#f97066", // coral-500
   nutrition: "#92cc17", // lime-500
   kcal: "#f97316", // orange-500

--- a/apps/mobile/src/components/ui/PullToRefresh.tsx
+++ b/apps/mobile/src/components/ui/PullToRefresh.tsx
@@ -44,7 +44,7 @@ export interface PullToRefreshProps {
 const variantColors: Record<RefreshVariant, string> = {
   default: "#10b981",
   finyk: "#10b981",
-  fizruk: "#14b8a6",
+  fizruk: "#0e7490", // cyan-700 — mirrors moduleColors.fizruk.primary
   routine: "#f97066",
   nutrition: "#84cc16",
 };

--- a/apps/web/src/styles/theme.css
+++ b/apps/web/src/styles/theme.css
@@ -449,8 +449,8 @@
        ─────────────────────────────────────────────────────────────────── */
     --c-finyk-surface-dark: 16 185 129; /* emerald-500 */
     --c-finyk-border-dark: 16 185 129; /* emerald-500 */
-    --c-fizruk-surface-dark: 20 184 166; /* teal-500 */
-    --c-fizruk-border-dark: 20 184 166; /* teal-500 */
+    --c-fizruk-surface-dark: 14 116 144; /* cyan-700 — mirrors moduleColors.fizruk.primary (was teal-500) */
+    --c-fizruk-border-dark: 14 116 144; /* cyan-700 — mirrors moduleColors.fizruk.primary (was teal-500) */
     --c-routine-surface-dark: 249 112 102; /* coral-500 */
     --c-routine-border-dark: 249 112 102; /* coral-500 */
     --c-nutrition-surface-dark: 176 230 54; /* lime-400 — WCAG AA ≥4.5:1 on dark panel */

--- a/packages/design-tokens/__snapshots__/tokens.test.js.snap
+++ b/packages/design-tokens/__snapshots__/tokens.test.js.snap
@@ -175,7 +175,7 @@ exports[`@sergeant/design-tokens — tokens.js > moduleAccentRgb is stable (snap
     "strong": "4 120 87",
   },
   "fizruk": {
-    "default": "20 184 166",
+    "default": "14 116 144",
     "strong": "15 118 110",
   },
   "nutrition": {
@@ -199,7 +199,7 @@ exports[`@sergeant/design-tokens — tokens.js > moduleColors define canonical f
   },
   "fizruk": {
     "accent": "#c8f264",
-    "primary": "#14b8a6",
+    "primary": "#0e7490",
     "secondary": "#0d9488",
     "surface": "#f0fdfa",
   },

--- a/packages/design-tokens/tokens.js
+++ b/packages/design-tokens/tokens.js
@@ -105,8 +105,8 @@ export const moduleColors = {
     surfaceAlt: "#f0fdfa", // teal-50
   },
   fizruk: {
-    primary: "#14b8a6", // teal-500
-    secondary: "#0d9488", // teal-600
+    primary: "#0e7490", // cyan-700 — disambiguates from finyk emerald (was teal-500 #14b8a6)
+    secondary: "#0d9488", // teal-600 — retained as accent for hero gradients
     surface: "#f0fdfa", // teal-50
     accent: "#c8f264", // lime-300 (CTA highlight)
   },
@@ -144,7 +144,7 @@ export const moduleColors = {
  */
 export const moduleAccentRgb = {
   finyk: { default: "16 185 129", strong: "4 120 87" }, // emerald-500 / -700
-  fizruk: { default: "20 184 166", strong: "15 118 110" }, // teal-500 / -700
+  fizruk: { default: "14 116 144", strong: "15 118 110" }, // cyan-700 / teal-700 — `default` migrated to cyan-700 to disambiguate from finyk emerald (was teal-500). `strong` stays on teal-700 to match `bg-fizruk-strong` Tailwind utility (`brandColors.teal[700]`); will migrate to cyan-800 in PR-1 alongside the cyan palette addition.
   routine: { default: "249 112 102", strong: "194 58 58" }, // coral-500 / -700
   nutrition: { default: "146 204 23", strong: "70 98 18" }, // lime-500 / -800
 };


### PR DESCRIPTION
## Summary

PR-0 / 9 у послідовності Sergeant v2 редизайн (per design handoff, May 2026).

- `moduleColors.fizruk.primary`: `#14b8a6` (teal-500) → `#0e7490` (cyan-700) — disambiguates fizruk from finyk emerald palette per v2 design intent.
- `moduleAccentRgb.fizruk.default`: triplet `20 184 166` → `14 116 144` (cyan-700 RGB).
- `--c-fizruk-surface-dark` / `--c-fizruk-border-dark` у `apps/web/src/styles/theme.css` + `apps/mobile/global.css` — оновлені mirrors primary.
- Mobile raw-hex літерали у `PullToRefresh.tsx` та `ProgressRing.tsx` — оновлені до нового hex.
- Snapshot test регенерований; design-tokens 23/23 pass.

`moduleAccentRgb.fizruk.strong` ЛИШАЄТЬСЯ на teal-700 у цьому PR для парітету з `bg-fizruk-strong` Tailwind utility (`brandColors.teal[700]`). Обидва мігрують на cyan-800 у PR-1 разом з cyan палітрою.

## Why standalone PR

Hue change має ширший blast radius (snapshot tests, contrast verifiers, mobile components, dark-mode surface-dark variables) — окрема XS-PR ізолює зміну й полегшує bisect, якщо щось регресує.

## Test plan

- [x] `pnpm -F @sergeant/design-tokens test` — 23/23 pass (snapshots оновлено)
- [x] `pnpm -F @sergeant/mobile typecheck` — clean
- [ ] Manual: відкрити fizruk модуль локально, перевірити що hero gradient + ModuleHeader + bottom-nav active state виглядають OK (cyan-700 замість teal-500)
- [ ] CI: повна `pnpm check` матриця у Vercel preview

## Refs

- Local plan: `C:\Users\dmytr\.claude\plans\d-zip-refactored-starlight.md`
- Design handoff: `D:\_.zip` → `D:\_unzipped\handoff\01-tokens-diff.md` (line `--fizruk: #0e7490`)
- Наступний PR-1: foundation tokens (v2 namespace, mesh, shadows v2, radii v2, HC overrides) + cyan palette → закрить лишок `fizruk.strong`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches fizruk from teal-500 to cyan-700 to align with the v2 redesign and clearly separate it from finyk’s emerald. Updates tokens, dark-mode surfaces, and mobile UI colors for consistency.

- **Refactors**
  - Set `moduleColors.fizruk.primary` to `#0e7490` and `moduleAccentRgb.fizruk.default` to `14 116 144` (cyan-700); updated `@sergeant/design-tokens` snapshots (tests pass).
  - Updated `--c-fizruk-surface-dark` and `--c-fizruk-border-dark` in web and mobile CSS; replaced mobile hex literals in `PullToRefresh.tsx` and `ProgressRing.tsx`.
  - Kept `moduleAccentRgb.fizruk.strong` on teal-700 for now to match the existing Tailwind utility.

<sup>Written for commit 9d6e7214eb066b94ec2651bafc6124577855395f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the fizruk theme's primary accent and border colors in dark mode for improved visual cohesion across mobile and web applications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Skords-01/Sergeant/pull/2902)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->