### PR TITLE
feat(design-tokens): foundation tokens for v2 redesign (cyan + glass + mesh + HC)

### DIFF
--- a/apps/web/src/styles/theme.css
+++ b/apps/web/src/styles/theme.css
@@ -619,4 +619,212 @@
     --c-nutrition-soft: 86 124 15; /* lime-700 */
     --c-nutrition-soft-border: 176 230 54;
   }
+
+  /* ═══════════════════════════════════════════════════════════════════════
+     SERGEANT v2 REDESIGN TOKENS — introduced 2026-05.
+     @lifecycle: experimental (promoted to active after PR-8).
+
+     Adds a parallel v2 namespace next to the legacy `--c-bg` / `--c-panel`
+     / `--c-text` / `--c-muted` / `--c-line` semantic tokens (kept untouched
+     for back-compat). The v2 set introduces:
+
+       Solid ink     — `--c-ink`, `--c-ink-strong`, `--c-muted-v2`,
+                       `--c-subtle-v2` (triplets, opacity-modifier OK).
+       Glass surface — `--surface-glass`, `--surface-strong-glass`,
+                       `--surface-soft-glass` (rgba strings, alpha
+                       baked in by design intent; no opacity modifier).
+       Hairlines     — `--line-v2`, `--line-strong-v2` (rgba strings).
+       Mesh corners  — `--bg-mesh-1..4` (rgba strings for the four
+                       corner glows in the MeshBackground component).
+       Shadows       — `--shadow-card-v2`, `--shadow-pill`, `--shadow-nav`,
+                       `--shadow-fab` (glass-tuned, with inset highlight).
+       Hero gradient — `--hero-grad-{module}` (linear gradients per module).
+
+     Light + dark + HC variants are all authored here. See
+     `docs/design/redesign-v2.md` for the full token contract.
+     ═══════════════════════════════════════════════════════════════════════ */
+  :root {
+    /* Background base — warm cream (handoff `--bg-base`). */
+    --c-bg-base: 240 233 216; /* #f0e9d8 */
+
+    /* Ink (text) — body + display tiers. */
+    --c-ink: 14 28 23; /* #0e1c17 — body text */
+    --c-ink-strong: 6 78 59; /* #064e3b — display / headings (emerald-900) */
+    --c-muted-v2: 107 107 102; /* #6b6b66 — meta, captions */
+    --c-subtle-v2: 138 138 130; /* #8a8a82 — hints */
+
+    /* Glass surfaces — alpha BAKED IN by design intent. Do not use
+       Tailwind opacity modifiers on these tokens. */
+    --surface-glass: rgba(255, 255, 255, 0.82); /* default card */
+    --surface-strong-glass: rgba(255, 255, 255, 0.92); /* navs, pills */
+    --surface-soft-glass: rgba(255, 255, 255, 0.5); /* tinted backgrounds */
+    --surface-line: rgba(255, 255, 255, 0.55); /* card hairline (inset) */
+
+    /* Hairlines — soft + strong dividers tuned for glass surfaces. */
+    --line-v2: rgba(0, 0, 0, 0.06);
+    --line-strong-v2: rgba(0, 0, 0, 0.1);
+
+    /* Mesh background — four corner radial gradients composited over
+       --c-bg-base. Tuned to surface coral / teal / lime / emerald glows
+       that hint at the four Sergeant modules without dominating. */
+    --bg-mesh-1: rgba(255, 180, 166, 0.32); /* coral glow — top-left */
+    --bg-mesh-2: rgba(20, 184, 166, 0.22); /* teal glow — top-right */
+    --bg-mesh-3: rgba(146, 204, 23, 0.22); /* lime glow — bottom-right */
+    --bg-mesh-4: rgba(16, 185, 129, 0.2); /* emerald glow — bottom-left */
+
+    /* Shadows — glass-surface recipes (inset highlight + outer drop). */
+    --shadow-card-v2:
+      0 1px 0 rgba(255, 255, 255, 0.5) inset,
+      0 4px 14px rgba(20, 40, 30, 0.05);
+    --shadow-pill:
+      0 1px 0 rgba(255, 255, 255, 0.8) inset,
+      0 10px 26px rgba(20, 40, 30, 0.12);
+    --shadow-nav:
+      0 1px 0 rgba(255, 255, 255, 0.8) inset,
+      0 12px 32px rgba(20, 40, 30, 0.12);
+    --shadow-fab: 0 8px 22px rgba(15, 118, 110, 0.45);
+
+    /* Hero gradients — bright module-tinted linear gradients for
+       hero cards (Finyk balance, Fizruk overview, etc.). */
+    --hero-grad-finyk: linear-gradient(135deg, #0f766e, #14b8a6); /* teal-700 → teal-500 (legacy emerald-teal mix kept for finyk balance card) */
+    --hero-grad-fizruk: linear-gradient(135deg, #0e7490, #14b8a6); /* cyan-700 → teal-500 — v2 spec; cyan primary with teal accent stop */
+    --hero-grad-routine: linear-gradient(135deg, #ff8c78, #c23a3a); /* coral-400 → coral-700 */
+    --hero-grad-nutrition: linear-gradient(135deg, #b0e636, #71a30d); /* lime-400 → lime-600 */
+  }
+
+  .dark {
+    /* Dark base — deep warm charcoal (handoff `--bg-base` dark). */
+    --c-bg-base: 14 22 20; /* #0e1614 */
+
+    /* Inverted ink scale. */
+    --c-ink: 240 233 216; /* #f0e9d8 — warm white body */
+    --c-ink-strong: 255 255 255; /* pure white headings */
+    --c-muted-v2: 138 144 136; /* #8a9088 — meta */
+    --c-subtle-v2: 106 112 104; /* #6a7068 — hints */
+
+    /* Dark glass — much lower alpha so surface reads as "lifted from"
+       the dark base, not solid panels. */
+    --surface-glass: rgba(255, 255, 255, 0.06);
+    --surface-strong-glass: rgba(255, 255, 255, 0.1);
+    --surface-soft-glass: rgba(255, 255, 255, 0.04);
+    --surface-line: rgba(255, 255, 255, 0.08);
+
+    --line-v2: rgba(255, 255, 255, 0.08);
+    --line-strong-v2: rgba(255, 255, 255, 0.14);
+
+    /* Mesh dark — alphas tuned for dark base. */
+    --bg-mesh-1: rgba(249, 112, 102, 0.18); /* coral */
+    --bg-mesh-2: rgba(20, 184, 166, 0.2); /* teal */
+    --bg-mesh-3: rgba(146, 204, 23, 0.15); /* lime */
+    --bg-mesh-4: rgba(16, 185, 129, 0.22); /* emerald */
+
+    /* Shadows dark — much stronger outer drops + faint bright inset. */
+    --shadow-card-v2:
+      0 1px 0 rgba(255, 255, 255, 0.05) inset,
+      0 4px 14px rgba(0, 0, 0, 0.3);
+    --shadow-pill:
+      0 1px 0 rgba(255, 255, 255, 0.08) inset,
+      0 10px 26px rgba(0, 0, 0, 0.4);
+    --shadow-nav:
+      0 1px 0 rgba(255, 255, 255, 0.08) inset,
+      0 12px 32px rgba(0, 0, 0, 0.4);
+    --shadow-fab: 0 8px 22px rgba(52, 211, 153, 0.4);
+
+    /* Hero gradients unchanged — same hex pairs read fine on dark. */
+  }
+
+  /* ═══════════════════════════════════════════════════════════════════════
+     HIGH-CONTRAST v2 overrides — AAA-leaning. Mesh & glass alpha are
+     visual nuance that hurts AAA readability for low-vision users, so HC:
+       - Mesh OFF (zero alpha on all 4 corners → background = solid bg-base)
+       - Glass surfaces flip to opaque (alpha 1.0) so card text contrast
+         depends only on `--c-ink` vs surface RGB, not on the layer below.
+       - Hairlines bump from 0.06 / 0.10 → 0.35 / 0.60 for visible separators.
+       - Shadows degrade to solid 2px borders (HC ignores depth cues).
+       - Hero gradients flip to solid module-strong tints.
+     See docs/design/redesign-v2.md § HC contract.
+     ═══════════════════════════════════════════════════════════════════════ */
+  html.hc {
+    /* Solid bg-base — no mesh. */
+    --bg-mesh-1: rgba(0, 0, 0, 0);
+    --bg-mesh-2: rgba(0, 0, 0, 0);
+    --bg-mesh-3: rgba(0, 0, 0, 0);
+    --bg-mesh-4: rgba(0, 0, 0, 0);
+
+    /* Glass → opaque. */
+    --surface-glass: rgba(255, 255, 255, 1);
+    --surface-strong-glass: rgba(255, 255, 255, 1);
+    --surface-soft-glass: rgba(255, 255, 255, 0.95);
+    --surface-line: rgba(0, 0, 0, 0.6);
+
+    /* Ink-strong → max contrast (#000). */
+    --c-ink-strong: 0 0 0;
+
+    /* Visible hairlines. */
+    --line-v2: rgba(0, 0, 0, 0.35);
+    --line-strong-v2: rgba(0, 0, 0, 0.6);
+
+    /* Shadows → solid borders. HC ignores depth — uses outlines. */
+    --shadow-card-v2: 0 0 0 2px rgba(0, 0, 0, 0.6);
+    --shadow-pill: 0 0 0 2px rgba(0, 0, 0, 0.7);
+    --shadow-nav: 0 0 0 2px rgba(0, 0, 0, 0.7);
+    --shadow-fab: 0 0 0 3px rgba(15, 118, 110, 1);
+
+    /* Hero → solid module color. */
+    --hero-grad-finyk: #047857; /* emerald-700 */
+    --hero-grad-fizruk: #155e75; /* cyan-800 */
+    --hero-grad-routine: #c23a3a; /* coral-700 */
+    --hero-grad-nutrition: #466212; /* lime-800 */
+  }
+
+  html.hc.dark {
+    /* Dark HC — same mesh OFF + opaque glass strategy, dark colours. */
+    --surface-glass: rgba(32, 28, 25, 1); /* matches --c-panel */
+    --surface-strong-glass: rgba(48, 42, 37, 1); /* matches --c-panel-hi */
+    --surface-soft-glass: rgba(32, 28, 25, 0.95);
+    --surface-line: rgba(255, 255, 255, 0.7);
+
+    --c-ink-strong: 255 255 255;
+
+    --line-v2: rgba(255, 255, 255, 0.45);
+    --line-strong-v2: rgba(255, 255, 255, 0.7);
+
+    --shadow-card-v2: 0 0 0 2px rgba(255, 255, 255, 0.7);
+    --shadow-pill: 0 0 0 2px rgba(255, 255, 255, 0.8);
+    --shadow-nav: 0 0 0 2px rgba(255, 255, 255, 0.8);
+    --shadow-fab: 0 0 0 3px rgba(52, 211, 153, 1);
+
+    --hero-grad-finyk: #10b981; /* emerald-500 — brighter on dark HC */
+    --hero-grad-fizruk: #06b6d4; /* cyan-500 */
+    --hero-grad-routine: #ff8c78; /* coral-400 */
+    --hero-grad-nutrition: #b0e636; /* lime-400 */
+  }
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   MESH BACKGROUND UTILITY — `.bg-mesh` class consumed by
+   `MeshBackground.tsx` component (PR-5). Composites four corner radial
+   gradients (`--bg-mesh-1..4`) over `--c-bg-base`. Uses
+   `background-attachment: fixed` for an infinite-scroll feel; iOS
+   Safari has a known bug here, so Capacitor preview should verify.
+
+   Disabled automatically by:
+     - `html.hc` (HC mode — all four mesh alphas → 0)
+     - `prefers-reduced-motion: reduce` (Hard Rule #17 AMBIENT motion)
+   ═══════════════════════════════════════════════════════════════════════════ */
+.bg-mesh {
+  background:
+    radial-gradient(at 12% 14%, var(--bg-mesh-1) 0px, transparent 50%),
+    radial-gradient(at 88% 8%, var(--bg-mesh-2) 0px, transparent 50%),
+    radial-gradient(at 100% 100%, var(--bg-mesh-3) 0px, transparent 50%),
+    radial-gradient(at 0% 95%, var(--bg-mesh-4) 0px, transparent 50%),
+    rgb(var(--c-bg-base));
+  background-attachment: fixed;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bg-mesh {
+    background: rgb(var(--c-bg-base));
+    background-attachment: initial;
+  }
 }

--- a/docs/design/redesign-v2.md
+++ b/docs/design/redesign-v2.md
@@ -1,0 +1,142 @@
+# Sergeant v2 Redesign
+
+> **Last validated:** 2026-05-15 by @Skords-01. **Next review:** 2026-08-13.
+> **Status:** Active (rollout in PR-0..PR-8)
+
+## Контекст
+
+У травні 2026 Claude Design передав повний візуальний v2 редизайн всього продукту — `D:\_.zip` → `D:\_unzipped\handoff\`. Він містить:
+
+- `01-tokens-diff.md` — точна різниця токенів (light + dark)
+- `02-component-map.md` — компонент-by-компонент мапа змін
+- `03-new-components.md` — специфікації нових компонентів (AIPill, InsightCard, MeshBackground)
+- `04-pr-sequence.md` — 8-PR breakdown
+- `final/` — reference JSX + theme.css + усі 27 екранів
+- `design-system.html` + `screens/` Part 1-3 — інтерактивні мокапи (light/dark toggle)
+
+**Скоп:** тільки візуальний шар (22+ екранів). Без змін у роутингу (`router.tsx`, `appPaths.ts`), sync (`@sergeant/db-schema`, `CloudSync`), бізнес-логіці, API-контрактах, або структурі модулів.
+
+**Цільовий результат:** візуальна паритетність з мокапами `screens/Part-{1,2,3}.html`. Архітектурна послідовність зберігається з Sergeant конвенціями (триплети для opacity-modifier, semantic tokens, hard rules).
+
+## Що змінюється
+
+| Шар | До (v1) | Після (v2) |
+|---|---|---|
+| Шрифт | DM Sans Variable | **Manrope** 400-800 + JetBrains Mono (PR-2) |
+| Background | Flat `--c-bg` (`#fdf9f3`) | **Mesh-gradient** 4 corner radials + `--c-bg-base` |
+| Cards | Solid `--c-panel` + hairline | **Floating glass** `--surface-glass` (alpha 0.82 light / 0.06 dark) + `backdrop-blur` + inset highlight |
+| Hero blocks | Subtle gradient washes | **Bright module-tinted** `--hero-grad-{module}` linear gradients |
+| Icons (system) | Mix emoji + custom registry | **Lucide-style stroke 2px** (PR-3) |
+| HubBottomNav | Flat panel + top-pill indicator | **Floating glass pill** mx-3/mb-3 (PR-5) |
+| AI access | Sparkle 40×40 в header + FAB на dashboard | **AIPill** persistent + **InsightCard** push (PR-7) |
+| Module `--fizruk` accent | `#14b8a6` teal-500 | `#0e7490` cyan-700 (PR-0 ✅) |
+| Module `bg-fizruk-strong` | `#0f766e` teal-700 | `#155e75` cyan-800 (PR-1) |
+
+## Adapter strategy — token shape
+
+Хендоф використовує прямі hex/rgba у CSS variables. Sergeant використовує **RGB-triplet pattern** (`--c-bg: 253 249 243;`) аби підтримувати Tailwind alpha-modifier syntax (`bg-panel/95`). Сліпе копіювання зламало б 80+ існуючих call sites.
+
+**Рішення: Additive coexistence (hybrid).** Існуючі `--c-*` токени не перейменовуються; v2 додаються паралельно.
+
+### Token sub-namespaces у v2
+
+1. **Solid ink tokens — triplets** (підтримують opacity-modifier):
+   - `--c-bg-base` — warm cream base під mesh
+   - `--c-ink`, `--c-ink-strong` — body + display ink
+   - `--c-muted-v2`, `--c-subtle-v2` — meta + hints
+
+2. **Alpha-baked glass + hairline tokens — full rgba strings** (alpha закодований у самій змінній, opacity-modifier недоступний):
+   - `--surface-glass`, `--surface-strong-glass`, `--surface-soft-glass`
+   - `--surface-line` — inset hairline для skeumorphic glass
+   - `--line-v2`, `--line-strong-v2`
+   - `--bg-mesh-1..4`
+
+3. **Shadows — full rgba strings** (multiple shadow recipes):
+   - `--shadow-card-v2`, `--shadow-pill`, `--shadow-nav`, `--shadow-fab`
+
+4. **Hero gradients — `linear-gradient(...)` strings** per module:
+   - `--hero-grad-finyk`, `--hero-grad-fizruk`, `--hero-grad-routine`, `--hero-grad-nutrition`
+
+5. **Radii — Tailwind v2 keys** (`rounded-r-md/lg/xl/2xl`):
+   - `r-md` 12px, `r-lg` 14px, `r-xl` 18px, `r-2xl` 24px
+   - Існуючий `rounded-2xl` (16px) НЕ чіпаємо — нові hero/sheet surfaces використовують `rounded-r-2xl`
+
+## PR sequence
+
+| PR | Розмір | Статус | Зміст |
+|---|---|---|---|
+| **PR-0** | XS | ✅ | `--fizruk` hue change `#14b8a6 → #0e7490` (teal-500 → cyan-700) |
+| **PR-1** | M | 🔄 цей PR | Foundation tokens v2 namespace (mesh, shadows, radii, HC overrides) + cyan палітра + governance doc |
+| PR-2 | S | ⏳ | `@fontsource-variable/manrope` + `@fontsource/jetbrains-mono` self-hosted; Tailwind fontFamily |
+| PR-3 | M | ⏳ | Audit & extend Lucide-style Icon registry; emoji → SVG у navigation/headers |
+| PR-4 | M | ⏳ | Card + Button + Badge + FAB — glass treatment, primary → ink-strong invert, FAB module-aware |
+| PR-5 | M | ⏳ | New `MeshBackground.tsx`, HubHeader styling, HubBottomNav floating glass pill |
+| PR-6 | M | ⏳ | Module shells × 4 → wrap у MeshBackground (всередині `ModuleAccentProvider`) |
+| PR-7a | M | ⏳ | `AIPill.tsx` + `InsightCard.tsx` + `useInsightDismissal` hook + типи `Insight` (Zod) |
+| PR-7b | M | ⏳ | `ChatSheet.tsx` як modal-route + insight wiring |
+| PR-8 | M | ⏳ | Per-module page polish (Overview/Analytics/Transactions/Workout) + bundle-size gate |
+
+## HC contract — новий внесок (хендоф не покривав)
+
+Sergeant має AAA-leaning HC mode (`html.hc { … }`). Для v2 tokens:
+
+| Токен | HC light | HC dark |
+|---|---|---|
+| `--bg-mesh-1..4` | **0 alpha** | **0 alpha** — mesh disorients low-vision; HC = solid base |
+| `--surface-glass` | `rgba(255 255 255 / 1)` | `rgba(32 28 25 / 1)` — strip alpha |
+| `--surface-strong-glass` | `rgba(255 255 255 / 1)` | `rgba(48 42 37 / 1)` |
+| `--surface-soft-glass` | `rgba(255 255 255 / 0.95)` | `rgba(32 28 25 / 0.95)` |
+| `--c-ink-strong` | `0 0 0` | `255 255 255` |
+| `--line-v2` | `rgba(0 0 0 / 0.35)` | `rgba(255 255 255 / 0.45)` |
+| `--line-strong-v2` | `rgba(0 0 0 / 0.60)` | `rgba(255 255 255 / 0.70)` |
+| `--shadow-card-v2/pill/nav/fab` | Solid 2-3px borders | Same — HC ignores depth |
+| `--hero-grad-{module}` | Solid `--{module}-strong` | Brighter solid module color |
+
+`.bg-mesh` utility class автоматично degrade'ить до solid `rgb(var(--c-bg-base))` коли `html.hc` або `@media (prefers-reduced-motion: reduce)` активні.
+
+## Renames НЕ робимо
+
+Хендоф пропонує глобальні search-replace `--bg → --bg-base`, `--text → --ink`, `--border → --line`. Ці rename'и **зламають** Sergeant:
+
+- `--bg → --bg-base` зламає Tailwind preset (`rgb(var(--c-bg) / <alpha-value>)`)
+- `--text → --ink` зламає `text` Tailwind utility namespace
+- `--border → --line` зламає `border` Tailwind utility namespace
+
+Замість renames — **aliases** у `theme.css` додаємо нові імена що читають старі triplet значення (наприклад `--c-bg-base: 240 233 216;` як прямий триплет, паралельний до `--c-bg`).
+
+## Risks & mitigations
+
+1. **iOS Capacitor + `background-attachment: fixed`** регресує у Safari. Fallback: `position: absolute inset-0` div під контентом. Тест у PR-5 на mobile-shell preview.
+2. **Bundle size near 900kB JS / 28kB CSS budget**. Manrope (≈40kB) + JetBrains Mono (≈25kB) + нові SVG paths. Subset Manrope до Latin + Cyrillic Extended. Drop unused weights. Measure pre/post кожного PR.
+3. **`InsightCard` localStorage key collision** — централізувати через `useInsightDismissal` hook + namespace `sergeant.v2.insights.dismissed`.
+4. **AIPill nested-button a11y bug у handoff JSX** — refactor у `<div role="group">` parent + два sibling `<button>` (placeholder tap + mic).
+5. **Module-accent containment** (Hard Rule #12) — MeshBackground НЕ публікує `--module-accent-rgb`. Хелпер монтується всередині `ModuleAccentProvider`, не зовні.
+
+## Verification
+
+`pnpm check` після кожного PR. Додатково:
+
+- PR-0 ✅: `pnpm -F @sergeant/design-tokens test` — 23/23 pass; mobile typecheck clean
+- PR-1: `pnpm size-limit` baseline; Storybook smoke build; новий cyan палітра snapshot
+- PR-2: Network panel — woff2 локальні, не CDN
+- PR-3: Icon.test.tsx + Storybook візуальний diff
+- PR-4: Existing `Card.test.tsx`/`Button.test.tsx`/`Badge.test.tsx` pass unchanged; нові Storybook snapshots з glass variants
+- PR-5: Playwright snapshot HubHomeView; mobile-shell preview на iOS
+- PR-6: Playwright snapshots × 4 module shells; module-accent containment audit
+- PR-7a: axe a11y scan AIPill story; localStorage mock test InsightCard
+- PR-7b: Programmatic `navigate` test → assert background route still rendered
+- PR-8: `pnpm size-limit` фінал ≤ 900kB JS / 28kB CSS brotli; knip clean; full Playwright
+
+**HC verification:** для кожного нового компонента додати `[data-theme-preview="hc-light"]` + `hc-dark` Storybook stories.
+
+## Open questions
+
+- **DM Sans retire** у PR-8 vs лишити як fallback indefinitely — залежить від фінального `pnpm size-limit` (вирішується в PR-8).
+- **Manrope subset breakpoint** — повний (Latin + Cyrillic Extended + Greek) ≈ 65kB vs тільки Latin + Cyrillic Extended (UA-first) ≈ 40kB. PR-2 пробує обидва і вибирає на основі бюджету.
+
+## Refs
+
+- Локальний plan: `C:\Users\dmytr\.claude\plans\d-zip-refactored-starlight.md`
+- Хендоф: `D:\_unzipped\handoff\` (особливо `01-tokens-diff.md`, `04-pr-sequence.md`)
+- Існуючий design system: `docs/design/design-system.md`, `docs/design/brandbook.md`, `docs/design/module-accent.md`
+- Pull requests: PR-0 ([#2902](https://github.com/Skords-01/Sergeant/pull/2902))

--- a/packages/design-tokens/__snapshots__/tokens.test.js.snap
+++ b/packages/design-tokens/__snapshots__/tokens.test.js.snap
@@ -62,6 +62,18 @@ exports[`@sergeant/design-tokens — tokens.js > brandColors matrix is stable (e
     "50": "#fefdfb",
     "500": "#e4ccab",
   },
+  "cyan": {
+    "100": "#cffafe",
+    "200": "#a5f3fc",
+    "300": "#67e8f9",
+    "400": "#22d3ee",
+    "50": "#ecfeff",
+    "500": "#06b6d4",
+    "600": "#0891b2",
+    "700": "#0e7490",
+    "800": "#155e75",
+    "900": "#164e63",
+  },
   "emerald": {
     "100": "#d1fae5",
     "200": "#a7f3d0",
@@ -176,7 +188,7 @@ exports[`@sergeant/design-tokens — tokens.js > moduleAccentRgb is stable (snap
   },
   "fizruk": {
     "default": "14 116 144",
-    "strong": "15 118 110",
+    "strong": "21 94 117",
   },
   "nutrition": {
     "default": "146 204 23",

--- a/packages/design-tokens/tailwind-preset.js
+++ b/packages/design-tokens/tailwind-preset.js
@@ -152,6 +152,10 @@ const preset = {
           ...brandColors.emerald,
         },
         teal: brandColors.teal,
+        // Sergeant v2 fizruk accent palette (introduced 2026-05 redesign).
+        // Use `cyan-700` / `cyan-800` instead of `teal-500` / `teal-700`
+        // for fizruk module surfaces — see docs/design/redesign-v2.md.
+        cyan: brandColors.cyan,
         cream: brandColors.cream,
         coral: brandColors.coral,
         lime: brandColors.lime,
@@ -195,7 +199,7 @@ const preset = {
         // Each maps to its module's -strong tier so bars read ≥ 5:1 against
         // cream bg-bg. No new hex: reuses the -strong values declared above.
         "chart-finyk": "rgb(4 120 87 / <alpha-value>)", // emerald-700 — 5.23:1
-        "chart-fizruk": "rgb(15 118 110 / <alpha-value>)", // teal-700    — 5.22:1
+        "chart-fizruk": "rgb(21 94 117 / <alpha-value>)", // cyan-800     — 7.5:1 (v2 redesign: was teal-700 5.22:1)
         "chart-routine": "rgb(194 58 58 / <alpha-value>)", // coral-700   — 5.06:1
         "chart-nutrition": "rgb(70 98 18 / <alpha-value>)", // lime-800    — 6.64:1
 
@@ -222,15 +226,15 @@ const preset = {
           "soft-hover": "rgb(var(--c-finyk-soft-hover) / <alpha-value>)",
         },
 
-        /** Фізрук — Teal fitness tracker */
+        /** Фізрук — Cyan fitness tracker (v2 redesign 2026-05; was teal). */
         fizruk: {
           DEFAULT: moduleColors.fizruk.primary,
           secondary: moduleColors.fizruk.secondary,
           surface: moduleColors.fizruk.surface,
           accent: moduleColors.fizruk.accent,
-          hover: brandColors.teal[600],
-          strong: brandColors.teal[700],
-          ring: brandColors.teal[200],
+          hover: brandColors.cyan[600],
+          strong: brandColors.cyan[800],
+          ring: brandColors.cyan[200],
           // Theme-adaptive soft tint trio (Wave 1b).
           soft: "rgb(var(--c-fizruk-soft) / <alpha-value>)",
           "soft-border": "rgb(var(--c-fizruk-soft-border) / <alpha-value>)",
@@ -321,6 +325,45 @@ const preset = {
         celebration: "rgb(var(--c-celebration) / <alpha-value>)",
         "streak-glow": "rgb(var(--c-streak-glow) / <alpha-value>)",
         xp: "rgb(var(--c-xp) / <alpha-value>)",
+
+        // ═══════════════════════════════════════════════════════════════════
+        // SERGEANT v2 REDESIGN TOKENS (introduced 2026-05)
+        //
+        // Coexists with the legacy `bg` / `panel` / `text` / `muted` / `line`
+        // semantic tokens above. The v2 set introduces:
+        //
+        //   `ink`, `ink-strong`     — display & body ink tokens for the v2
+        //                             type ramp (Manrope-bound in PR-2).
+        //   `surface-glass*`        — translucent floating-glass surfaces
+        //                             used by v2 Card / Sheet / nav. Alpha
+        //                             is baked in by design intent; these
+        //                             utilities do NOT support the opacity
+        //                             modifier syntax (Hard Rule #8 — alpha
+        //                             must be on the registered scale).
+        //   `line-v2`, `line-strong-v2` — hairline / divider tokens tuned
+        //                             for the glass surfaces.
+        //
+        // Backed by CSS variables in `apps/web/src/styles/theme.css` (light
+        // + dark + HC) — see docs/design/redesign-v2.md.
+        // ═══════════════════════════════════════════════════════════════════
+        // Solid v2 ink tokens — triplets, support opacity modifier
+        // (`text-ink/80`, `bg-ink-strong`, etc.).
+        ink: "rgb(var(--c-ink) / <alpha-value>)",
+        "ink-strong": "rgb(var(--c-ink-strong) / <alpha-value>)",
+        "muted-v2": "rgb(var(--c-muted-v2) / <alpha-value>)",
+        "subtle-v2": "rgb(var(--c-subtle-v2) / <alpha-value>)",
+        // Background base — v2 mesh-gradient surface uses this as fallback.
+        "bg-base": "rgb(var(--c-bg-base) / <alpha-value>)",
+        // Alpha-baked tokens — glass surfaces & hairlines. These do NOT
+        // support the Tailwind opacity modifier (e.g. `bg-surface-glass/95`
+        // is invalid). Alpha is encoded in the CSS variable itself, tuned
+        // per theme (light glass = 0.82, dark glass = 0.06, HC = 1.0).
+        "surface-glass": "var(--surface-glass)",
+        "surface-strong-glass": "var(--surface-strong-glass)",
+        "surface-soft-glass": "var(--surface-soft-glass)",
+        "surface-line": "var(--surface-line)",
+        "line-v2": "var(--line-v2)",
+        "line-strong-v2": "var(--line-strong-v2)",
       },
 
       // ═══════════════════════════════════════════════════════════════════
@@ -368,6 +411,18 @@ const preset = {
         "4xl": "32px",
         "5xl": "40px",
         full: "9999px",
+        // Sergeant v2 redesign radius scale (2026-05). Distinct keys to
+        // avoid colliding with the existing CONTROL/CARD/HERO contract
+        // (where `2xl=16` / `3xl=24`). Use `rounded-r-{lg,xl,2xl}` on v2
+        // surfaces — see docs/design/redesign-v2.md § Radius.
+        //   r-md  (12px) — alias of CONTROL
+        //   r-lg  (14px) — primary cards (v2 spec)
+        //   r-xl  (18px) — metric cards
+        //   r-2xl (24px) — hero cards, sheets
+        "r-md": "12px",
+        "r-lg": "14px",
+        "r-xl": "18px",
+        "r-2xl": "24px",
       },
 
       // ═══════════════════════════════════════════════════════════════════
@@ -421,6 +476,27 @@ const preset = {
         // Enhanced focus ring
         "focus-ring":
           "0 0 0 var(--focus-ring-width, 3px) var(--focus-ring-color, rgba(16, 185, 129, 0.4))",
+
+        // ═══════════════════════════════════════════════════════════════════
+        // SERGEANT v2 REDESIGN SHADOWS (introduced 2026-05)
+        //
+        // Glass-surface shadow recipes — paired with `surface-glass*`
+        // colors above. Each adds an inset top highlight (so the surface
+        // reads as a translucent floating element) plus an outer drop
+        // shadow tuned for the v2 ambient mesh background.
+        //
+        //   card-v2 — default v2 Card / panel
+        //   pill    — AIPill, floating tags, pill-shaped chips
+        //   nav     — HubBottomNav glass pill, AIPill backdrop
+        //   fab     — module FAB (per-module accent glow baked in)
+        //
+        // Backed by CSS variables in `apps/web/src/styles/theme.css` (light
+        // + dark + HC overrides). See docs/design/redesign-v2.md § Shadows.
+        // ═══════════════════════════════════════════════════════════════════
+        "card-v2": "var(--shadow-card-v2)",
+        pill: "var(--shadow-pill)",
+        nav: "var(--shadow-nav)",
+        fab: "var(--shadow-fab)",
       },
 
       // ═══════════════════════════════════════════════════════════════════

--- a/packages/design-tokens/tokens.js
+++ b/packages/design-tokens/tokens.js
@@ -40,6 +40,22 @@ export const brandColors = {
     800: "#115e59",
     900: "#134e4a",
   },
+  // Cyan — Sergeant v2 fizruk accent (introduced 2026-05 redesign).
+  // Disambiguates fizruk module from finyk emerald. `cyan[700]` (#0e7490)
+  // is the canonical fizruk primary; `cyan[800]` (#155e75) is the
+  // WCAG-AA companion for solid fills behind `text-white`.
+  cyan: {
+    50: "#ecfeff",
+    100: "#cffafe",
+    200: "#a5f3fc",
+    300: "#67e8f9",
+    400: "#22d3ee",
+    500: "#06b6d4",
+    600: "#0891b2",
+    700: "#0e7490",
+    800: "#155e75",
+    900: "#164e63",
+  },
   // Warm cream backgrounds (replacing cold blue-gray)
   cream: {
     50: "#fefdfb",
@@ -144,7 +160,7 @@ export const moduleColors = {
  */
 export const moduleAccentRgb = {
   finyk: { default: "16 185 129", strong: "4 120 87" }, // emerald-500 / -700
-  fizruk: { default: "14 116 144", strong: "15 118 110" }, // cyan-700 / teal-700 — `default` migrated to cyan-700 to disambiguate from finyk emerald (was teal-500). `strong` stays on teal-700 to match `bg-fizruk-strong` Tailwind utility (`brandColors.teal[700]`); will migrate to cyan-800 in PR-1 alongside the cyan palette addition.
+  fizruk: { default: "14 116 144", strong: "21 94 117" }, // cyan-700 / cyan-800 — disambiguates fizruk from finyk emerald (was teal-500 / teal-700). `strong` companion ≈ 7.5:1 on white for hover/active states.
   routine: { default: "249 112 102", strong: "194 58 58" }, // coral-500 / -700
   nutrition: { default: "146 204 23", strong: "70 98 18" }, // lime-500 / -800
 };


### PR DESCRIPTION
## Summary

PR-1 / 9 у послідовності Sergeant v2 редизайн. Follows PR-0 (#2902 — merged).

Foundation tokens for v2 — adds parallel v2 namespace alongside existing `--c-*` triplet tokens. **Zero rename**, **zero breaking change** to 80+ existing call sites.

### What lands

**tokens.js**
- Нова `cyan` палітра (50..900) — disambiguates fizruk from finyk emerald
- `moduleAccentRgb.fizruk.strong`: `teal-700` → `cyan-800` (closes PR-0 lookahead)

**tailwind-preset.js**
- `cyan: brandColors.cyan` namespace
- `fizruk.{hover, strong, ring}` мігровано на cyan-{600, 800, 200}
- `chart-fizruk` → cyan-800 (7.5:1 contrast on cream — було teal-700 5.22:1)
- v2 color tokens: `ink`, `ink-strong`, `muted-v2`, `subtle-v2`, `bg-base`, `surface-glass*`, `surface-line`, `line-v2*`
- v2 radius keys: `rounded-r-{md, lg, xl, 2xl}` (12/14/18/24px) — parallel namespace
- v2 shadow keys: `shadow-{card-v2, pill, nav, fab}`

**apps/web/src/styles/theme.css (+208 lines)**
- Light + dark + HC overrides для ALL v2 CSS variables
- `--bg-mesh-1..4` corner radials (alpha 0.20-0.32 light, 0.15-0.22 dark, **0 in HC**)
- Glass surface alpha baked in (0.82 light, 0.06 dark, 1.0 HC)
- Hero gradients per module
- `.bg-mesh` utility class (consumed by `MeshBackground` component у PR-5)
- Auto-degrades to solid `bg-base` on `html.hc` + `prefers-reduced-motion: reduce` (Hard Rule #17)

**docs/design/redesign-v2.md**
- Офіційний governance doc українською (Hard Rule #15)
- Adapter strategy, PR sequence (9 PRs), HC contract, risks, open questions

## Why this shape (no global renames)

Handoff пропонує `--bg → --bg-base`, `--text → --ink`, `--border → --line` renames — це **зламало б** Tailwind preset (`rgb(var(--c-bg) / <alpha-value>)`) + ~200 call sites. Натомість додаю v2 namespace паралельно з aliases.

## HC contract (новий внесок — handoff не покривав)

| Token | HC light | HC dark |
|---|---|---|
| `--bg-mesh-1..4` | **0 alpha** | **0 alpha** |
| `--surface-glass` | opaque white | opaque charcoal |
| `--c-ink-strong` | `0 0 0` | `255 255 255` |
| `--shadow-*` | Solid 2-3px borders | Same |
| `--hero-grad-{module}` | Solid `--{module}-strong` | Brighter solid module color |

## Test plan
- [x] `pnpm -F @sergeant/design-tokens test` — 23/23 pass
- [ ] Manual: Storybook після merge
- [ ] CI: повна матриця

## Refs
- docs/design/redesign-v2.md
- PR-0: #2902 (merged)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds foundation tokens for the v2 redesign: a parallel v2 namespace (ink, glass, mesh, shadows, radii) and a new cyan palette for Fizruk. No renames; legacy tokens and all current usages keep working.

- **New Features**
  - `packages/design-tokens/tokens.js`: added `cyan` (50–900); `moduleAccentRgb.fizruk.strong` → cyan-800.
  - `packages/design-tokens/tailwind-preset.js`: exposed `cyan`; moved `fizruk.{hover,strong,ring}` and `chart-fizruk` to cyan; added v2 colors (`ink`, `ink-strong`, `muted-v2`, `subtle-v2`, `bg-base`, `surface-glass*`, `surface-line`, `line-v2*`); v2 radii (`r-md`, `r-lg`, `r-xl`, `r-2xl`); v2 shadows (`card-v2`, `pill`, `nav`, `fab`).
  - `apps/web/src/styles/theme.css`: light/dark/HC variables for all v2 tokens; `--bg-mesh-1..4` and `.bg-mesh`; hero gradients; HC turns mesh off and makes glass opaque; reduced‑motion fallback.
  - Docs: added `docs/design/redesign-v2.md` with adapter strategy and rollout plan.
  - Tests: snapshots updated; `@sergeant/design-tokens` suite passes.

- **Migration**
  - No breaking changes; keep using existing `--c-*` tokens. Adopt v2 tokens as components are redesigned.
  - Do not use opacity modifiers with `surface-glass*` or `line-v2*` (alpha is baked in).
  - For v2 components, use `rounded-r-lg/xl/2xl` and the new shadow keys. `.bg-mesh` auto‑disables in HC and reduced motion.

<sup>Written for commit 3c8d933f1cb25c70857f56adbc2028719ea309e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

