### PR TITLE
feat(web): Manrope + JetBrains Mono fonts for v2 redesign typography

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -43,6 +43,8 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@fontsource-variable/dm-sans": "^5.2.8",
+    "@fontsource-variable/jetbrains-mono": "^5.2.8",
+    "@fontsource-variable/manrope": "^5.2.8",
     "@hookform/resolvers": "^5.2.2",
     "@sentry/react": "^8.55.1",
     "@sergeant/api-client": "workspace:*",

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -20,14 +20,22 @@
    `@import` statements MUST precede all other rules (CSS spec). The
    `@config` directive is a Tailwind-only hook processed away by PostCSS.
    ═══════════════════════════════════════════════════════════════════════ */
-/* DM Sans Variable — self-hosted, `font-display: swap` is baked into the
+/* Self-hosted variable fonts — `font-display: swap` is baked into the
    fontsource `@font-face` blocks, so there is no FOIT. Fonts are bundled
    into the Vite build at hashed paths and served from same-origin: no
-   external preconnect required, and a `<link rel="preload">` in
-   `apps/web/index.html` would have to know the hashed URL, which Vite
-   resolves only at build time. Fallback metrics for DM Sans live in
-   `styles/theme.css` → `@font-face "DM Sans Fallback"` (size-adjust +
+   external preconnect required.
+
+   Sergeant v2 redesign (introduced 2026-05) — Manrope is the primary
+   sans + display family; JetBrains Mono Variable is used for technical
+   values (hero numbers, code, monospace stats). DM Sans Variable is
+   retained during PR-2..PR-8 rollout as the fallback; PR-8 polish
+   decides whether to retire it based on `pnpm size-limit` measurement.
+
+   Fallback metrics for both DM Sans and Manrope live in
+   `styles/theme.css` → `@font-face "*Fallback"` (size-adjust +
    ascent/descent overrides) to suppress CLS during the swap window. */
+@import "@fontsource-variable/manrope" layer(base);
+@import "@fontsource-variable/jetbrains-mono" layer(base);
 @import "@fontsource-variable/dm-sans" layer(base);
 @import "./styles/animations.css" layer(base);
 @import "./styles/background.css" layer(base);

--- a/apps/web/src/styles/theme.css
+++ b/apps/web/src/styles/theme.css
@@ -5,6 +5,8 @@
    ═══════════════════════════════════════════════════════════════════════ */
 
 @layer base {
+  /* DM Sans fallback — kept during v2 rollout. Retire decision in PR-8
+     once `pnpm size-limit` confirms Manrope alone fits the bundle budget. */
   @font-face {
     font-family: "DM Sans Fallback";
     src: local("Arial");
@@ -12,6 +14,20 @@
     descent-override: 26%;
     line-gap-override: 0%;
     size-adjust: 104%;
+  }
+
+  /* Manrope fallback — Sergeant v2 redesign (introduced 2026-05).
+     Metrics tuned via Capsize to match Manrope's x-height + cap-height
+     against `local("Arial")`, suppressing CLS during the font swap
+     window. `font-display: swap` is baked into the fontsource
+     `@font-face` blocks themselves. */
+  @font-face {
+    font-family: "Manrope Fallback";
+    src: local("Arial");
+    ascent-override: 99.42%;
+    descent-override: 31.31%;
+    line-gap-override: 0%;
+    size-adjust: 100.71%;
   }
 }
 

--- a/packages/design-tokens/tailwind-preset.js
+++ b/packages/design-tokens/tailwind-preset.js
@@ -25,7 +25,15 @@ const preset = {
   theme: {
     extend: {
       fontFamily: {
+        // Sergeant v2 redesign (2026-05) — Manrope as primary; DM Sans
+        // Variable retained as fallback during PR-2..PR-8 rollout. The
+        // PR-8 polish pass decides whether to retire DM Sans entirely
+        // based on `pnpm size-limit` measurement. Fallback metrics live
+        // in `apps/web/src/styles/theme.css` (Manrope Fallback @font-face).
         sans: [
+          '"Manrope Variable"',
+          '"Manrope"',
+          '"Manrope Fallback"',
           '"DM Sans Variable"',
           '"DM Sans"',
           "system-ui",
@@ -33,13 +41,31 @@ const preset = {
           '"Segoe UI"',
           "sans-serif",
         ],
+        // Display ramp — same family, semantically used for hero/H1/H2
+        // stacks (weight 800 in v2 type ramp).
         display: [
+          '"Manrope Variable"',
+          '"Manrope"',
+          '"Manrope Fallback"',
           '"DM Sans Variable"',
           '"DM Sans"',
           "system-ui",
           "-apple-system",
           '"Segoe UI"',
           "sans-serif",
+        ],
+        // Mono — JetBrains Mono Variable for technical values (large
+        // hero numbers, money, code blocks). Variable so a single woff2
+        // covers weight 100..800 without per-weight files.
+        mono: [
+          '"JetBrains Mono Variable"',
+          '"JetBrains Mono"',
+          "ui-monospace",
+          "SFMono-Regular",
+          '"SF Mono"',
+          "Menlo",
+          "Consolas",
+          "monospace",
         ],
       },
       colors: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -521,6 +521,12 @@ importers:
       '@fontsource-variable/dm-sans':
         specifier: ^5.2.8
         version: 5.2.8
+      '@fontsource-variable/jetbrains-mono':
+        specifier: ^5.2.8
+        version: 5.2.8
+      '@fontsource-variable/manrope':
+        specifier: ^5.2.8
+        version: 5.2.8
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.75.0(react@18.3.1))
@@ -2764,6 +2770,12 @@ packages:
 
   '@fontsource-variable/dm-sans@5.2.8':
     resolution: {integrity: sha512-AxkvMTvNWgfrmlyjiV05vlHYJa+nRQCf1EfvIrQAPBpFJW0O9VTz7oAFr9S3lvbWdmnFoBk7yFqQL86u64nl2g==}
+
+  '@fontsource-variable/jetbrains-mono@5.2.8':
+    resolution: {integrity: sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==}
+
+  '@fontsource-variable/manrope@5.2.8':
+    resolution: {integrity: sha512-nc9lOuCRz73UHnovDE2bwXUdghE2SEOc7Aii0qGe3CLyE03W1a7VnY5Z6euRiapiKbCkGS+eXbY3s/kvWeGeSw==}
 
   '@formatjs/ecma402-abstract@2.3.6':
     resolution: {integrity: sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==}
@@ -15479,6 +15491,10 @@ snapshots:
   '@flatten-js/interval-tree@1.1.4': {}
 
   '@fontsource-variable/dm-sans@5.2.8': {}
+
+  '@fontsource-variable/jetbrains-mono@5.2.8': {}
+
+  '@fontsource-variable/manrope@5.2.8': {}
 
   '@formatjs/ecma402-abstract@2.3.6':
     dependencies:


### PR DESCRIPTION
## Summary

PR-2 / 9 у послідовності Sergeant v2 редизайн. Follows PR-0 (#2902 — merged) + PR-1 (#2903).

## Adds two self-hosted variable fonts

- `@fontsource-variable/manrope@5.2.8` — primary sans + display family
- `@fontsource-variable/jetbrains-mono@5.2.8` — mono для technical numerics (hero stats, money, code)

## Wires

**apps/web/src/index.css** — `@import` blocks above existing DM Sans. Manrope first wins font resolution; DM Sans retained як fallback під час PR-2..PR-8 rollout.

**packages/design-tokens/tailwind-preset.js:**
- `fontFamily.sans`: `Manrope Variable → Manrope → Manrope Fallback → DM Sans Variable → DM Sans → system-ui …`
- `fontFamily.display`: same stack (hero/H1/H2 weight-800 slots)
- `fontFamily.mono` (NEW): `JetBrains Mono Variable → system mono fallbacks`

**apps/web/src/styles/theme.css** — `@font-face "Manrope Fallback"` із Capsize-style overrides (`ascent`, `descent`, `size-adjust`) щоб suppress CLS під час font-swap window. DM Sans Fallback retained.

## Self-hosted, no CDN

Усі три families bundled у Vite build at hashed paths, same-origin (matches existing DM Sans pattern). Не `fonts.googleapis.com` (handoff пропонував CDN — відхилено для privacy + bundle control).

## DM Sans retire

Deferred to PR-8 polish — залежить від фінального `pnpm size-limit` проти 900kB JS / 28kB CSS brotli budget.

## Test plan

- [ ] CI fresh install — node_modules materializes new packages
- [ ] CI bundle size — `pnpm size-limit` baseline (Manrope variable ≈ 40kB woff2 + JetBrains Mono variable ≈ 25kB)
- [ ] Manual: Storybook after merge, verify Manrope renders

## Refs

- docs/design/redesign-v2.md
- PR-1: #2903 (foundation tokens)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds self-hosted Manrope and JetBrains Mono variable fonts for the v2 typography redesign. Updates Tailwind stacks and adds metric fallbacks to reduce CLS; DM Sans stays as a temporary fallback.

- **New Features**
  - Import Manrope and JetBrains Mono in `apps/web/src/index.css` above DM Sans.
  - Update `packages/design-tokens/tailwind-preset.js`: `sans`/`display` prefer Manrope; new `mono` uses JetBrains Mono with system fallbacks.
  - Add `"Manrope Fallback"` in `apps/web/src/styles/theme.css` (size-adjust/ascent/descent) to minimize CLS; keep `"DM Sans Fallback"`.
  - Fonts are self-hosted via Vite build; no CDN.

- **Dependencies**
  - Add `@fontsource-variable/manrope@5.2.8`.
  - Add `@fontsource-variable/jetbrains-mono@5.2.8`.

<sup>Written for commit c5342cbe521e115dc3ca7a24c3e084515bda0b0a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

