### PR TITLE
feat(web): extend Icon registry with 22 Lucide-style icons for v2 redesign

### DIFF
--- a/apps/web/src/shared/components/ui/Icon.paths.content.tsx
+++ b/apps/web/src/shared/components/ui/Icon.paths.content.tsx
@@ -108,4 +108,17 @@ export const CONTENT_PATHS: Record<string, ReactNode> = {
       <path d="M21 13v2a4 4 0 0 1-4 4H3" />
     </>
   ),
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // SERGEANT v2 REDESIGN ICONS (2026-05, PR-3).
+  // ═══════════════════════════════════════════════════════════════════════
+
+  // `book` — generic publication / journal / docs glyph. Used by Routine
+  // module (habit tracking) and educational content tiles.
+  book: (
+    <>
+      <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+      <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
+    </>
+  ),
 };

--- a/apps/web/src/shared/components/ui/Icon.paths.domain.tsx
+++ b/apps/web/src/shared/components/ui/Icon.paths.domain.tsx
@@ -151,4 +151,65 @@ export const DOMAIN_PATHS: Record<string, ReactNode> = {
       <polyline points="14 17 21 17 21 10" />
     </>
   ),
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // SERGEANT v2 REDESIGN ICONS (2026-05, PR-3).
+  // Domain glyphs for transaction categories (briefcase/truck/coffee),
+  // fitness actions (run, play/pause), nutrition (egg), tools (pen, scanner).
+  // ═══════════════════════════════════════════════════════════════════════
+
+  // `briefcase` — work / business transaction category.
+  briefcase: (
+    <>
+      <rect x="2" y="7" width="20" height="14" rx="2" ry="2" />
+      <path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16" />
+    </>
+  ),
+  // `truck` — delivery / shipping category.
+  truck: (
+    <>
+      <path d="M8 6v6M15 6v6M2 12h19.6M18 18h3s.5-1.7.8-2.8.2-.8.2-1.2-.1-.8-.2-1.2l-1.4-5C20.1 6.8 19.1 6 18 6H4a2 2 0 0 0-2 2v10h3" />
+      <circle cx="7" cy="18" r="2" />
+      <path d="M9 18h5" />
+      <circle cx="16" cy="18" r="2" />
+    </>
+  ),
+  // `coffee` — coffee/cafe transaction category. Insights flag heavy
+  // coffee spend with this glyph.
+  coffee: (
+    <>
+      <path d="M17 8h1a4 4 0 0 1 0 8h-1M3 8h14v9a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4z" />
+      <line x1="6" y1="1" x2="6" y2="4" />
+      <line x1="10" y1="1" x2="10" y2="4" />
+      <line x1="14" y1="1" x2="14" y2="4" />
+    </>
+  ),
+  // `run` — fitness / running activity (Fizruk module).
+  run: (
+    <>
+      <circle cx="14" cy="5" r="2" />
+      <path d="M6 20l3-5 4 1 2-4 4 3M9 9l2-2 3 1 2 3" />
+    </>
+  ),
+  // `pen` — edit / annotate (alternative to Lucide `edit-2`).
+  pen: <path d="M12 19l7-7 3 3-7 7-3-3zM18 13l-1.5-7.5L2 2l3.5 14.5L13 18l5-5z" />,
+  // `egg` — nutrition: dairy/protein category.
+  egg: <path d="M12 3c-4 0-7 6-7 11a7 7 0 0 0 14 0c0-5-3-11-7-11z" />,
+  // `scanner` — barcode / photo scanner trigger (Nutrition module).
+  scanner: (
+    <>
+      <rect x="2" y="6" width="20" height="14" rx="3" />
+      <circle cx="12" cy="13" r="4" />
+      <path d="M9 6V3h6v3" />
+    </>
+  ),
+  // `play` — start workout / playback action (Fizruk module).
+  play: <polygon points="5 3 19 12 5 21 5 3" />,
+  // `pause` — pause workout / playback action (Fizruk module).
+  pause: (
+    <>
+      <rect x="6" y="4" width="4" height="16" rx="1" />
+      <rect x="14" y="4" width="4" height="16" rx="1" />
+    </>
+  ),
 };

--- a/apps/web/src/shared/components/ui/Icon.paths.status.tsx
+++ b/apps/web/src/shared/components/ui/Icon.paths.status.tsx
@@ -177,4 +177,28 @@ export const STATUS_PATHS: Record<string, ReactNode> = {
       <line x1="12" y1="2" x2="12" y2="22" />
     </>
   ),
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // SERGEANT v2 REDESIGN ICONS (2026-05, PR-3).
+  // Status glyphs for streaks, nature, achievements. Lucide-style.
+  // ═══════════════════════════════════════════════════════════════════════
+
+  // `flame` — fire/streak glyph. Used by streak counters, hot deals.
+  flame: (
+    <path d="M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 1-3a2.5 2.5 0 0 0 2.5 2.5z" />
+  ),
+  // `leaf` — nutrition / nature / organic glyph.
+  leaf: (
+    <>
+      <path d="M11 20A7 7 0 0 1 9.8 6.1C15.5 5 17 4.48 19 2c1 2 2 4.18 2 8 0 5.5-4.78 10-10 10z" />
+      <path d="M2 21c0-3 1.85-5.36 5.08-6" />
+    </>
+  ),
+  // `award` — achievement medal / trophy. Used by Profile screen.
+  award: (
+    <>
+      <circle cx="12" cy="8" r="7" />
+      <polyline points="8.21 13.89 7 23 12 20 17 23 15.79 13.88" />
+    </>
+  ),
 };

--- a/apps/web/src/shared/components/ui/Icon.paths.system.tsx
+++ b/apps/web/src/shared/components/ui/Icon.paths.system.tsx
@@ -171,4 +171,70 @@ export const SYSTEM_PATHS: Record<string, ReactNode> = {
       <polygon points="16.24 7.76 14.12 14.12 7.76 16.24 9.88 9.88 16.24 7.76" />
     </>
   ),
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // SERGEANT v2 REDESIGN ICONS (2026-05, PR-3).
+  // Lucide-style strokes 2px, rounded line caps. Added to support the v2
+  // navigation, AIPill, FTUX, and module-header chrome — see
+  // docs/design/redesign-v2.md § Icons.
+  // ═══════════════════════════════════════════════════════════════════════
+
+  // `x` — close glyph, alias of `close`. Handoff uses bare `x`; keep both
+  // names to avoid breaking existing call sites.
+  x: (
+    <>
+      <line x1="18" y1="6" x2="6" y2="18" />
+      <line x1="6" y1="6" x2="18" y2="18" />
+    </>
+  ),
+  // `more` — three horizontal dots, alias of `more-horizontal`. Handoff
+  // canonical name is `more`.
+  more: (
+    <>
+      <circle cx="5" cy="12" r="1.5" />
+      <circle cx="12" cy="12" r="1.5" />
+      <circle cx="19" cy="12" r="1.5" />
+    </>
+  ),
+  // `arrow-up` / `arrow-down` — vertical pointers for trending / numeric
+  // change indicators. Lucide spec.
+  "arrow-up": (
+    <>
+      <line x1="12" y1="19" x2="12" y2="5" />
+      <polyline points="5 12 12 5 19 12" />
+    </>
+  ),
+  "arrow-down": (
+    <>
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <polyline points="19 12 12 19 5 12" />
+    </>
+  ),
+  // `shield` — privacy / safety indicator (Sergeant HubHeader).
+  shield: <path d="M12 2l8 4v6c0 5-3.5 9-8 10-4.5-1-8-5-8-10V6l8-4z" />,
+  // `mic` — voice-input glyph inside AIPill.
+  mic: (
+    <>
+      <rect x="9" y="3" width="6" height="12" rx="3" />
+      <path d="M5 11a7 7 0 0 0 14 0" />
+      <line x1="12" y1="18" x2="12" y2="21" />
+    </>
+  ),
+  // `filter` — filter chip / sort affordance in lists.
+  filter: <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />,
+  // `link` — generic hyperlink / connection glyph.
+  link: (
+    <>
+      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+    </>
+  ),
+  // `log-in` — counterpart to existing `log-out`, used on auth screens.
+  "log-in": (
+    <>
+      <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4" />
+      <polyline points="10 17 15 12 10 7" />
+      <line x1="15" y1="12" x2="3" y2="12" />
+    </>
+  ),
 };


### PR DESCRIPTION
## Summary

PR-3 / 9 у послідовності Sergeant v2 редизайн. Follows PR-2 (#2904).

Audit поточного Icon.paths.{system,status,domain,content}.tsx registry проти canonical v2 handoff list (60 icons у `docs/design/redesign-v2.md § Icons`) знайшов:

- **20 missing icons** — додано inline
- **1 naming discrepancy** (current `more-horizontal` vs handoff `more`) — додано `more` як паралельний entry (не rename), щоб existing call sites не зламалися

## What lands

| File | Added |
|---|---|
| `Icon.paths.system.tsx` | `x` (alias of `close`), `more` (alias of `more-horizontal`), `arrow-up`, `arrow-down`, `shield`, `mic`, `filter`, `link`, `log-in` (9) |
| `Icon.paths.status.tsx` | `flame`, `leaf`, `award` (3) |
| `Icon.paths.domain.tsx` | `briefcase`, `truck`, `coffee`, `run`, `pen`, `egg`, `scanner`, `play`, `pause` (9) |
| `Icon.paths.content.tsx` | `book` (1) |

Total: **22 entries** across 4 files, 164 lines added.

## Why inline SVG paths (not `lucide-react`)

Existing Sergeant pattern — registry of inline SVG paths — keeps bundle tight (no extra dep, no tree-shaking concerns). All paths verbatim from handoff `final/icons.jsx` to preserve visual fidelity з мокапами.

## Aliases

`x` references same SVG as `close` (handoff uses bare `x` syntax). `more` references same SVG as `more-horizontal` (handoff uses bare `more`). Both kept so v2 mockups copy-paste cleanly AND existing code continues to compile.

## Test plan

- [ ] CI: `Icon.test.tsx` compiles + passes (auto-derived `IconName` union picks up new entries)
- [ ] CI: typecheck — `Record<string, ReactNode>` happy
- [ ] Manual: відкрити Storybook `Icon.stories.tsx` після merge, verify 22 new glyphs render
- [ ] PR-5/6/7: AIPill, MeshBackground hub chrome, ModuleHeader can now reference `mic`, `sparkle`, `shield`, etc.

## Refs

- docs/design/redesign-v2.md (PR-1 #2903)
- Handoff: `D:\_unzipped\handoff\final\icons.jsx`
- Audit: `02-component-map.md § Icon`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 22 Lucide-style icons to the icon registry to meet the v2 redesign handoff and unblock new UI. Adds v2 names without breaking existing calls.

- **New Features**
  - System (9) in `Icon.paths.system.tsx`: x (alias of close), more (alias of more-horizontal), arrow-up, arrow-down, shield, mic, filter, link, log-in
  - Status (3) in `Icon.paths.status.tsx`: flame, leaf, award
  - Domain (9) in `Icon.paths.domain.tsx`: briefcase, truck, coffee, run, pen, egg, scanner, play, pause
  - Content (1) in `Icon.paths.content.tsx`: book

- **Dependencies**
  - Kept inline SVG path registry; no `lucide-react` added.

<sup>Written for commit eeb4f08b73e665e82fddc009cf4a978495e5672f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 22 new icons to enhance the UI library, including domain icons (briefcase, truck, coffee, run, pen, egg, scanner, play, pause), status indicator icons (flame, leaf, award), system navigation icons (arrow-up, arrow-down, shield, mic, filter, link, log-in, x, more), and a content icon (book).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Skords-01/Sergeant/pull/2905)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->