### PR TITLE
feat(web): v2 redesign opt-in variants for Card, Button, FAB primitives

### DIFF
--- a/apps/web/src/shared/components/ui/Button.tsx
+++ b/apps/web/src/shared/components/ui/Button.tsx
@@ -37,7 +37,13 @@ export type ButtonVariant =
   | "finyk-soft"
   | "fizruk-soft"
   | "routine-soft"
-  | "nutrition-soft";
+  | "nutrition-soft"
+  // Sergeant v2 redesign (2026-05, PR-4). Inverted primary: `--ink-strong`
+  // fill (emerald-900 in light, white in dark) with `--c-bg-base` text.
+  // The v2 design intent — primary CTAs read as "pen ink on paper" rather
+  // than the saturated emerald that competes with module accents. Opt-in;
+  // existing `primary` callers unchanged.
+  | "primary-ink";
 
 export type ButtonSize = "xs" | "sm" | "md" | "lg" | "xl";
 
@@ -78,6 +84,13 @@ const variants: Record<ButtonVariant, string> = {
     "bg-routine-surface text-routine-strong dark:bg-routine/15 dark:text-routine border border-routine-ring/50 dark:border-routine/30 hover:bg-coral-100 dark:hover:bg-routine/25 active:scale-[0.98]",
   "nutrition-soft":
     "bg-nutrition-soft text-nutrition-strong dark:bg-nutrition/15 dark:text-nutrition border border-nutrition-ring/50 dark:border-nutrition/30 hover:bg-lime-100 dark:hover:bg-nutrition/25 active:scale-[0.98]",
+
+  // Sergeant v2 inverted primary — see `ButtonVariant` JSDoc above.
+  // `bg-ink-strong` is emerald-900 in light + white in dark (HC: pure
+  // #000 / #fff). `text-bg-base` is the corresponding warm-cream / dark
+  // base, so the contrast inverts cleanly with the theme.
+  "primary-ink":
+    "bg-ink-strong text-bg-base shadow-sm hover:opacity-90 hover:shadow-glow active:opacity-80 active:scale-[0.98]",
 };
 
 // RADIUS — every Button size lives in the CONTROL tier (12 px, rounded-xl)

--- a/apps/web/src/shared/components/ui/Card.tsx
+++ b/apps/web/src/shared/components/ui/Card.tsx
@@ -64,7 +64,14 @@ export type CardProminence =
   | "ghost"
   | "hero"
   | "soft"
-  | "tinted";
+  | "tinted"
+  // Sergeant v2 redesign (2026-05, PR-4) — translucent floating-glass
+  // surface. Uses `--surface-glass` + `backdrop-blur(12px)` + inset
+  // highlight + module-untinted hairline. Opt-in; existing
+  // `default`/`interactive`/`flat`/`elevated` surfaces unchanged so
+  // 80+ existing call sites keep their look. New v2 module shells +
+  // AIPill + InsightCard pick this up explicitly.
+  | "glass";
 
 /**
  * @deprecated Prefer the orthogonal `module` + `prominence` props.
@@ -82,12 +89,17 @@ export type CardVariant =
 
 export type CardPadding = "none" | "sm" | "md" | "lg" | "xl";
 
-export type CardRadius = "md" | "lg" | "xl";
+export type CardRadius = "md" | "lg" | "xl" | "r-lg" | "r-xl" | "r-2xl";
 
 const radii: Record<CardRadius, string> = {
-  md: "rounded-xl",
-  lg: "rounded-2xl",
-  xl: "rounded-3xl",
+  md: "rounded-xl", // 12px — CONTROL tier (legacy)
+  lg: "rounded-2xl", // 16px — CARD tier (legacy)
+  xl: "rounded-3xl", // 24px — HERO tier (legacy)
+  // Sergeant v2 redesign radii (parallel namespace introduced in PR-1).
+  // Use these on v2 glass surfaces — see docs/design/redesign-v2.md.
+  "r-lg": "rounded-r-lg", // 14px — primary v2 card
+  "r-xl": "rounded-r-xl", // 18px — metric / sub-hero card
+  "r-2xl": "rounded-r-2xl", // 24px — hero / sheet
 };
 
 const paddings: Record<CardPadding, string> = {
@@ -118,6 +130,13 @@ const NON_MODULE_PROMINENCE: Record<
   flat: "bg-panel border border-line",
   elevated: "bg-panel border border-line shadow-e3",
   ghost: "bg-transparent border border-transparent",
+  // Sergeant v2 glass — translucent floating surface. `bg-surface-glass`
+  // is alpha-baked (0.82 light / 0.06 dark / 1.0 HC); `surface-line` is
+  // the inset hairline. `shadow-card-v2` includes an inset top-highlight
+  // recipe tuned for the glass look. Auto-degrades when `html.hc` strips
+  // mesh + alpha (see theme.css § High-Contrast v2 overrides).
+  glass:
+    "bg-surface-glass backdrop-blur-md border border-surface-line shadow-card-v2",
 };
 
 // ─── Module-branded surfaces ───────────────────────────────────────────
@@ -257,7 +276,13 @@ export interface CardProps extends HTMLAttributes<HTMLElement> {
  * `prominence`) always honour the `radius` prop with the standard
  * `xl` default.
  */
-function defaultRadius(variant: CardVariant | undefined): CardRadius {
+function defaultRadius(
+  variant: CardVariant | undefined,
+  prominence: CardProminence | undefined,
+): CardRadius {
+  // v2 glass surfaces default to the v2 `r-lg` (14px) radius — matches
+  // the handoff spec for primary cards.
+  if (prominence === "glass") return "r-lg";
   if (variant && SOFT_VARIANT_RE.test(variant)) return "lg";
   return "xl";
 }
@@ -277,7 +302,7 @@ export const Card = forwardRef<HTMLElement, CardProps>(function Card(
   ref,
 ) {
   const resolved = resolveVariant(variant, module, prominence);
-  const effectiveRadius = radius ?? defaultRadius(variant);
+  const effectiveRadius = radius ?? defaultRadius(variant, resolved.prominence);
   return (
     <Component
       ref={ref}

--- a/apps/web/src/shared/components/ui/FloatingActionButton.tsx
+++ b/apps/web/src/shared/components/ui/FloatingActionButton.tsx
@@ -45,7 +45,19 @@ export type FABVariant =
   | "finyk"
   | "fizruk"
   | "routine"
-  | "nutrition";
+  | "nutrition"
+  // Sergeant v2 redesign (2026-05, PR-4) — module-aware FAB gradients.
+  // Each v2 variant uses a bright top-left → darker bottom-right gradient
+  // tuned per module (handoff `02-component-map.md § FAB`):
+  //   v2-finyk     emerald-400 → teal-700  (cross-family green-teal)
+  //   v2-fizruk    cyan-400    → cyan-700
+  //   v2-routine   coral-400   → coral-700
+  //   v2-nutrition lime-400    → lime-600
+  // Paired with `shadow-fab` (teal-tinted glow from theme.css).
+  | "v2-finyk"
+  | "v2-fizruk"
+  | "v2-routine"
+  | "v2-nutrition";
 export type FABSize = "md" | "lg";
 
 export interface FABAction {
@@ -64,6 +76,16 @@ const variantStyles: Record<FABVariant, string> = {
     "bg-routine-strong text-white shadow-routine/30 hover:brightness-110",
   nutrition:
     "bg-nutrition-strong text-white shadow-nutrition/30 hover:brightness-110",
+  // v2 redesign — gradient backgrounds with `shadow-fab` glow (v2 token).
+  // Hover bumps brightness so motion feels alive without changing hue.
+  "v2-finyk":
+    "bg-gradient-to-br from-brand-400 to-teal-700 text-white shadow-fab hover:brightness-110",
+  "v2-fizruk":
+    "bg-gradient-to-br from-cyan-400 to-cyan-700 text-white shadow-fab hover:brightness-110",
+  "v2-routine":
+    "bg-gradient-to-br from-coral-400 to-coral-700 text-white shadow-fab hover:brightness-110",
+  "v2-nutrition":
+    "bg-gradient-to-br from-lime-400 to-lime-600 text-white shadow-fab hover:brightness-110",
 };
 
 const sizeStyles: Record<FABSize, { button: string; icon: number }> = {


### PR DESCRIPTION
## Summary

PR-4 / 9 у послідовності Sergeant v2 редизайн.

Усі зміни **additive** — existing call sites (80+ для Card, ~120 для Button, ~30 для FAB) keep their look. Нові компоненти у PR-5..PR-8 opt'інуть у v2 variants явно.

## Card.tsx (+39/-9)

- New `prominence="glass"` value → `bg-surface-glass backdrop-blur-md border-surface-line shadow-card-v2` (v2 tokens from PR-1)
- New radius values `r-lg` / `r-xl` / `r-2xl` (parallel namespace, 14/18/24px)
- Default radius для glass — `r-lg` (14px) per handoff spec
- Existing `default` / `interactive` / `flat` / `elevated` prominences та `md` / `lg` / `xl` radii **не зачеплені**

## Button.tsx (+15/-1)

- New variant `"primary-ink"` → `bg-ink-strong text-bg-base` (inverted: dark ink fill в light, white в dark, pure #000/#fff в HC)
- Existing `primary` (emerald) і module variants **не зачеплені**

## FloatingActionButton.tsx (+24/-1)

- 4 нові gradient variants `v2-finyk` / `v2-fizruk` / `v2-routine` / `v2-nutrition`:
  - v2-finyk: `from-brand-400 to-teal-700` (cross-family emerald → teal)
  - v2-fizruk: `from-cyan-400 to-cyan-700`
  - v2-routine: `from-coral-400 to-coral-700`
  - v2-nutrition: `from-lime-400 to-lime-600`
- Усі paired з `shadow-fab` (v2 token from PR-1)
- Existing solid `finyk`/`fizruk`/`routine`/`nutrition` variants **не зачеплені**

## Badge.tsx — **no change** ✅

Audit found existing `whitespace-nowrap` уже в base classes (line 128) + module-tinted variants (`finyk`/`fizruk`/`routine`/`nutrition` across soft/solid/outline tones) уже покривають handoff "module-tinted background" вимогу. Skipped, як надлишок.

## Why incremental opt-in (not breaking)

Усі call sites поточних variants (`bg-panel`, `bg-brand-strong`, solid module FAB) — це 200+ продовжуючих compoнентів. Сама заміна `primary → primary-ink` зробила б весь Hub layout інакшим візуально без preview. Хочемо контрольований rollout: PR-5 (hub) opts into ink-strong primary; PR-6 (modules) opts into glass cards; PR-7 (AIPill) opts into v2 FAB.

## Test plan
- [x] `pnpm -F @sergeant/design-tokens test` — 23/23 pass
- [ ] CI fresh install + `Button.test.tsx` / `Card.test.tsx` / `Badge.test.tsx`
- [ ] CI typecheck — нові variant strings derive correctly
- [ ] Manual: Storybook after merge — glass Card, primary-ink Button, v2 FAB render
- [ ] PR-5/6/7 будуть посилатися на ці variants

## Refs

- docs/design/redesign-v2.md (governance, PR-1 #2903)
- Handoff `02-component-map.md § Card/Button/FAB`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add opt-in v2 redesign variants for Card, Button, and FAB to enable a gradual rollout. Existing UIs keep their current look; new screens can adopt v2 explicitly.

- **New Features**
  - Card: added `prominence="glass"` and new radii `r-lg`/`r-xl`/`r-2xl`; glass defaults to `r-lg` (14px).
  - Button: added `variant="primary-ink"` (`bg-ink-strong text-bg-base`) as an inverted primary.
  - FAB: added gradient variants `v2-finyk`/`v2-fizruk`/`v2-routine`/`v2-nutrition` with `shadow-fab`.

- **Migration**
  - No breaking changes.
  - Opt in per use: `Card` with `prominence="glass"`, `Button` with `variant="primary-ink"`, `FAB` with `variant="v2-*"`.

<sup>Written for commit 2c8e26fb09befd4a26549b2f176f78cb22929a2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

