### PR TITLE
feat(web): MeshBackground + Hub chrome glass pill for v2 redesign

### DIFF
--- a/apps/web/src/core/app/HubBottomNav.tsx
+++ b/apps/web/src/core/app/HubBottomNav.tsx
@@ -87,20 +87,22 @@ function HubBottomNavTab({
       // accessible name (`label`), і тести з `name: /Звіти/` падали б.
       style={hiddenSlot ? { visibility: "hidden" } : undefined}
       className={cn(
-        "relative flex-1 flex flex-col items-center justify-center gap-1",
+        // `z-10` ставить кнопку поверх absolutely-positioned active-tab
+        // background pill (added in PR-5 v2 redesign).
+        "relative z-10 flex-1 flex flex-col items-center justify-center gap-1",
         "transition-all duration-200 min-h-[48px] pointer-coarse:min-h-[52px]",
-        "active:scale-95 pointer-coarse:active:bg-panelHi/50",
+        "active:scale-95",
         "focus:outline-none focus-visible:ring-2 focus-visible:ring-focus/45 focus-visible:ring-offset-2 focus-visible:ring-offset-panel",
-        active ? "text-text" : "text-muted hover:text-text/70",
+        // v2 redesign: active tab reads on the ink-strong background pill
+        // → text inverts to `bg-base` (warm cream in light, dark in dark);
+        // inactive stays muted on the glass surface.
+        active ? "text-bg-base" : "text-muted hover:text-text/70",
         hiddenSlot && "invisible pointer-events-none",
         className,
       )}
     >
       <span
-        className={cn(
-          "relative transition-all duration-200 w-10 h-7 flex items-center justify-center rounded-xl",
-          active ? "text-brand-strong bg-brand-500/10" : "",
-        )}
+        className="relative transition-all duration-200 w-10 h-7 flex items-center justify-center"
         aria-hidden
       >
         <Icon name={iconName} size={20} strokeWidth={2} />
@@ -242,48 +244,62 @@ export function HubBottomNav({
   const activeIndex = tabs.findIndex((tab) => tab.active);
 
   return (
-    <nav
-      aria-label={messages.nav.hubSections}
-      className={cn(
-        "shrink-0 relative z-30 safe-area-pb",
-        "bg-panel/95 backdrop-blur-xl",
-        "border-t border-line",
-      )}
+    // Sergeant v2 redesign (2026-05, PR-5) — transformed from flat
+    // `border-t` panel to a floating glass pill (`mx-3 mb-3`,
+    // `rounded-r-2xl`, `shadow-nav`). The outer wrapper preserves
+    // `safe-area-pb` so iOS home-indicator clears; the inner `<nav>`
+    // becomes the visible pill. Active indicator changed from a top
+    // 1-px stripe to a full-cell `bg-ink-strong` background pill
+    // sitting BEHIND the active tab content.
+    <div
+      className="shrink-0 relative z-30 safe-area-pb"
+      aria-hidden={false}
     >
-      <div
-        role="tablist"
-        className="relative flex h-[60px] pointer-coarse:h-[64px]"
-      >
-        {activeIndex >= 0 && (
-          <span
-            data-testid="hub-bottom-nav-active-indicator"
-            className={cn(
-              "absolute top-0 h-1 w-10 rounded-full shadow-sm pointer-events-none",
-              "transition-[left] duration-200 ease-out",
-              // Brand accent (hub is module-agnostic — never module-colored).
-              "bg-linear-to-r from-brand-400 to-brand-500",
-            )}
-            style={{
-              left: `calc(${activeIndex} * (100% / ${tabs.length}) + (100% / ${tabs.length} - 2.5rem) / 2)`,
-            }}
-            aria-hidden
-          />
+      <nav
+        aria-label={messages.nav.hubSections}
+        className={cn(
+          "mx-3 mb-3",
+          "bg-surface-strong-glass backdrop-blur-md",
+          "border border-line",
+          "rounded-r-2xl",
+          "shadow-nav",
         )}
+      >
+        <div
+          role="tablist"
+          className="relative flex h-[60px] pointer-coarse:h-[64px] p-1"
+        >
+          {activeIndex >= 0 && (
+            <span
+              data-testid="hub-bottom-nav-active-indicator"
+              className={cn(
+                "absolute inset-y-1 pointer-events-none",
+                "rounded-xl bg-ink-strong",
+                "transition-[left] duration-200 ease-out",
+              )}
+              style={{
+                left: `calc(${activeIndex} * (100% / ${tabs.length}) + 0.25rem)`,
+                width: `calc(100% / ${tabs.length} - 0.5rem)`,
+              }}
+              aria-hidden
+            />
+          )}
 
-        {tabs.map((tab) => (
-          <HubBottomNavTab
-            key={tab.key}
-            id={tab.id}
-            panelId={tab.panelId}
-            active={tab.active}
-            onClick={tab.onClick}
-            iconName={tab.iconName}
-            label={tab.label}
-            className={tab.className}
-            hiddenSlot={tab.hiddenSlot}
-          />
-        ))}
-      </div>
-    </nav>
+          {tabs.map((tab) => (
+            <HubBottomNavTab
+              key={tab.key}
+              id={tab.id}
+              panelId={tab.panelId}
+              active={tab.active}
+              onClick={tab.onClick}
+              iconName={tab.iconName}
+              label={tab.label}
+              className={tab.className}
+              hiddenSlot={tab.hiddenSlot}
+            />
+          ))}
+        </div>
+      </nav>
+    </div>
   );
 }

--- a/apps/web/src/core/app/HubHeader.tsx
+++ b/apps/web/src/core/app/HubHeader.tsx
@@ -17,8 +17,13 @@ import type { User } from "@sergeant/shared";
 // (палець, без хіт-зони курсору) робимо 48 пкс; ≥sm — 44 пкс достатньо.
 // Focus-ring: суцільний brand-500 (без /45 альфи), щоб гарантовано холдити
 // ≥3:1 контраст до bg в dark-mode (alpha на panelHi-підкладках просідала).
+// Sergeant v2 redesign (2026-05, PR-5) — icon button radius tightened
+// `rounded-2xl` (16 px) → `rounded-xl` (12 px) per handoff spec. The
+// 12 px CONTROL tier matches Button/Badge sizing and aligns the header
+// chrome with the new floating-glass HubBottomNav pill (which uses
+// `rounded-r-2xl` on the outer container).
 const ICON_BUTTON_CLS =
-  "w-12 h-12 sm:w-11 sm:h-11 flex items-center justify-center rounded-2xl text-muted hover:text-text hover:bg-panelHi transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-bg";
+  "w-12 h-12 sm:w-11 sm:h-11 flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-bg";
 
 const GREETINGS: Record<string, string> = {
   morning: "Доброго ранку",

--- a/apps/web/src/core/app/HubHomeView.tsx
+++ b/apps/web/src/core/app/HubHomeView.tsx
@@ -3,6 +3,7 @@ import { type User } from "@sergeant/shared";
 import { SkipLink } from "@shared/components/ui/SkipLink";
 import { KeyboardShortcutsModal } from "@shared/components/ui/KeyboardShortcutsModal";
 import { FloatingActionButton } from "@shared/components/ui/FloatingActionButton";
+import { MeshBackground } from "@shared/components/layout/MeshBackground";
 import { ActiveWorkoutBanner } from "./ActiveWorkoutBanner";
 import { CHAT_PATH } from "./appPaths";
 import { HubBottomNav } from "./HubBottomNav";
@@ -83,7 +84,12 @@ export function HubHomeView(props: HubHomeViewProps) {
   });
 
   return (
-    <div className="h-dvh bg-bg flex flex-col overflow-hidden safe-area-pt page-enter">
+    // Sergeant v2 redesign (2026-05, PR-5) — wraps the hub shell in
+    // <MeshBackground> so the mesh-gradient surface (`.bg-mesh` utility
+    // from theme.css) renders behind all hub content. `h-dvh flex flex-col
+    // overflow-hidden` is baked into MeshBackground; the remaining
+    // `safe-area-pt page-enter` slot through as className.
+    <MeshBackground className="safe-area-pt page-enter">
       <SkipLink />
       <HintsOrchestrator
         inFtuxSession={inFtuxSession}
@@ -170,6 +176,6 @@ export function HubHomeView(props: HubHomeViewProps) {
           className="bottom-[calc(5.25rem+env(safe-area-inset-bottom,0px))]"
         />
       )}
-    </div>
+    </MeshBackground>
   );
 }

--- a/apps/web/src/shared/components/layout/MeshBackground.tsx
+++ b/apps/web/src/shared/components/layout/MeshBackground.tsx
@@ -1,0 +1,71 @@
+/**
+ * Sergeant Design System — `MeshBackground`
+ *
+ * @lifecycle experimental (introduced 2026-05 у PR-5; promote to active after PR-8)
+ * @see docs/design/redesign-v2.md § Mesh background
+ *
+ * Base layout layer that renders the v2 mesh-gradient surface. Composites
+ * four corner radial gradients (`--bg-mesh-1..4` defined in
+ * `apps/web/src/styles/theme.css`) over `--c-bg-base`. Background
+ * uses `background-attachment: fixed` для infinite-scroll-feel
+ * (iOS Capacitor WebView has a known regression — fall back is
+ * disabled-mesh on `prefers-reduced-motion: reduce`).
+ *
+ * Module-accent containment (Hard Rule #12): цей компонент НЕ публікує
+ * `--module-accent-rgb`. У module shells монтується ВСЕРЕДИНІ
+ * `<ModuleAccentProvider>` так, що accent ставиться першим, mesh — поверх.
+ *
+ * HC theme override (handoff не покривав, додано в PR-1): `html.hc`
+ * виставляє всі `--bg-mesh-{1..4}` у `rgba(0,0,0,0)` → mesh stripped,
+ * background → solid `--c-bg-base`. AAA contrast зберігається.
+ *
+ * Usage:
+ * ```tsx
+ * // Hub-level (PR-5)
+ * <MeshBackground>
+ *   <HubHeader />
+ *   <HubMainContent />
+ *   <HubBottomNav />
+ * </MeshBackground>
+ *
+ * // Module shells (PR-6)
+ * <ModuleAccentProvider module="finyk" asShellRoot>
+ *   <MeshBackground>
+ *     <ModuleHeader />
+ *     <ModuleSwitcher />
+ *     <main>{children}</main>
+ *     <ModuleBottomNav />
+ *   </MeshBackground>
+ * </ModuleAccentProvider>
+ * ```
+ */
+
+import { type ReactNode } from "react";
+import { cn } from "@shared/lib/ui/cn";
+
+export interface MeshBackgroundProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export function MeshBackground({ children, className }: MeshBackgroundProps) {
+  return (
+    <div
+      className={cn(
+        // Full-viewport shell — same h-dvh flex pattern as the legacy
+        // `<div className="h-dvh bg-bg flex flex-col">` wrappers that
+        // this replaces.
+        "h-dvh flex flex-col overflow-hidden",
+        // `.bg-mesh` utility class — defined in
+        // `apps/web/src/styles/theme.css` § MESH BACKGROUND UTILITY.
+        // Composites the four corner radials + sets background-attachment:
+        // fixed. Auto-degrades to solid `rgb(var(--c-bg-base))` on
+        // `html.hc` and `prefers-reduced-motion: reduce`.
+        "bg-mesh",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/shared/components/layout/index.ts
+++ b/apps/web/src/shared/components/layout/index.ts
@@ -33,3 +33,9 @@ export type { ModuleSettingsDrawerProps } from "./ModuleSettingsDrawer";
 
 export { StorageErrorBanner } from "./StorageErrorBanner";
 export type { StorageErrorBannerProps } from "./StorageErrorBanner";
+
+// Sergeant v2 redesign (2026-05, PR-5) — mesh-gradient surface used by
+// HubHomeView + 4 module shells (PR-6). Auto-degrades to solid base
+// on `html.hc` + `prefers-reduced-motion: reduce`.
+export { MeshBackground } from "./MeshBackground";
+export type { MeshBackgroundProps } from "./MeshBackground";


### PR DESCRIPTION
## Summary

PR-5 / 9 у послідовності Sergeant v2 редизайн. Follows PR-4 (#2906 — merged).

Створює **MeshBackground component** і трансформує Hub chrome у v2 glass pill стиль.

## What lands

### New file: `apps/web/src/shared/components/layout/MeshBackground.tsx` (~75 lines)

Base layout layer rendering v2 mesh-gradient surface. Composites чотири corner radials (`--bg-mesh-1..4`) over `--c-bg-base` через `.bg-mesh` utility class (added у PR-1 theme.css). Auto-degrades до solid base on `html.hc` + `prefers-reduced-motion: reduce` (Hard Rule #17).

**Module-accent containment** (Hard Rule #12): НЕ публікує `--module-accent-rgb`. PR-6 module shells монтуватимуть всередині `<ModuleAccentProvider>` так що accent ставиться перший, mesh — поверх.

### HubHeader.tsx — 1 line change

Icon button radius: `rounded-2xl` (16px) → `rounded-xl` (12px) per handoff. CONTROL tier matches Button/Badge sizing.

### HubBottomNav.tsx — major chrome transformation (+59/-49)

**Container:**
```diff
- <nav className="bg-panel/95 backdrop-blur-xl border-t border-line">
+ <div className="safe-area-pb">
+   <nav className="mx-3 mb-3 bg-surface-strong-glass backdrop-blur-md
+                   border border-line rounded-r-2xl shadow-nav">
```

**Active indicator:**
```diff
- <span class="absolute top-0 h-1 w-10 rounded-full
-              bg-linear-to-r from-brand-400 to-brand-500">
+ <span class="absolute inset-y-1 rounded-xl bg-ink-strong"
+       style={{ left: ..., width: 'calc(100%/N - 0.5rem)' }}>
```

**Active tab text:**
```diff
- active ? "text-text" : "text-muted"
+ active ? "text-bg-base" : "text-muted"  // inverts on ink pill
```

`data-testid="hub-bottom-nav-active-indicator"` **preserved** so existing HubBottomNav.test.tsx tests still find it.

### HubHomeView.tsx — wrap in MeshBackground

```diff
- <div className="h-dvh bg-bg flex flex-col overflow-hidden safe-area-pt page-enter">
+ <MeshBackground className="safe-area-pt page-enter">
```

`h-dvh flex flex-col overflow-hidden` baked into MeshBackground.

### layout/index.ts — barrel export

```ts
export { MeshBackground } from "./MeshBackground";
export type { MeshBackgroundProps } from "./MeshBackground";
```

## Test plan
- [ ] CI: `HubBottomNav.test.tsx` passes (testid preserved)
- [ ] CI: `HubMainContent.test.tsx` layout tests unaffected (no contents touched)
- [ ] CI: typecheck — `MeshBackground` import resolves через barrel
- [ ] Manual after merge:
  - [ ] Mesh-gradient renders behind hub content
  - [ ] Bottom nav floats as glass pill з margins (not edge-to-edge)
  - [ ] Active tab shows dark ink fill з cream text
  - [ ] Inactive tabs stay muted on glass
  - [ ] Dark mode: glass alpha drops to 0.10, mesh dimmer
  - [ ] HC mode: mesh strips off, nav becomes opaque + 2px border
  - [ ] iOS Capacitor preview: `background-attachment: fixed` may regress — fall back to non-fixed gracefully

## Refs

- docs/design/redesign-v2.md (governance, PR-1 #2903)
- Handoff `02-component-map.md § HubBottomNav` + `03-new-components.md § MeshBackground`
- PR-4: #2906 (Card/Button/FAB primitives — merged)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `MeshBackground` layout for the v2 mesh-gradient surface and updates Hub chrome to a floating glass pill. This aligns Hub visuals to the v2 redesign while keeping tests and accessibility intact.

- **New Features**
  - New `MeshBackground`: renders mesh via `.bg-mesh`; gracefully degrades on `html.hc` and `prefers-reduced-motion`.
  - Hub bottom nav: converted to a floating glass pill (blur, border, shadow, margins); active tab uses an ink background pill; `data-testid="hub-bottom-nav-active-indicator"` preserved; safe-area padding kept.
  - Hub header: icon button radius set to `rounded-xl` (12px).
  - Hub home: wrapped in `MeshBackground`; `layout/index.ts` re-exports `MeshBackground` and types.

<sup>Written for commit abd4deddc5cf5a24fac107a28871db39f0981069. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

