### PR TITLE
feat(web): wrap 4 module shells in MeshBackground for v2 redesign

### DIFF
--- a/apps/web/src/modules/finyk/FinykApp.tsx
+++ b/apps/web/src/modules/finyk/FinykApp.tsx
@@ -8,6 +8,7 @@ import { readRaw } from "./lib/finykStorage";
 import { FINYK_MANUAL_ONLY_KEY, enableFinykManualOnly } from "./lib/demoData";
 import { ModuleBottomNav } from "@shared/components/ui/ModuleBottomNav";
 import {
+  MeshBackground,
   ModuleAccentProvider,
   ModuleHeader,
   ModuleHeaderAssistantButton,
@@ -252,8 +253,16 @@ export default function App({
 
   // ── Main app ──────────────────────────────────────────────────────────
   return (
-    <ModuleAccentProvider module="finyk" asShellRoot>
-      <ModuleHeader
+    // Sergeant v2 redesign (2026-05, PR-6) — module shell wraps content
+    // in <MeshBackground> so the mesh-gradient surface (`.bg-mesh`)
+    // renders behind the entire Finyk view. ModuleAccentProvider drops
+    // `asShellRoot` so MeshBackground takes the shell role
+    // (`h-dvh flex flex-col overflow-hidden` is baked in); Provider
+    // stays as a transparent context provider (Hard Rule #12 — accent
+    // published BEFORE mesh overlay, but mesh DOM element is inside).
+    <ModuleAccentProvider module="finyk">
+      <MeshBackground>
+        <ModuleHeader
         module="finyk"
         left={
           typeof onBackToHub === "function" ? (
@@ -635,6 +644,7 @@ export default function App({
           />
         </div>
       )}
+      </MeshBackground>
     </ModuleAccentProvider>
   );
 }

--- a/apps/web/src/modules/nutrition/NutritionApp.tsx
+++ b/apps/web/src/modules/nutrition/NutritionApp.tsx
@@ -16,7 +16,10 @@ import { NutritionPantryPage } from "./pages/NutritionPantryPage";
 import { NutritionLogPage } from "./pages/NutritionLogPage";
 import { NutritionMenuPage } from "./pages/NutritionMenuPage";
 import { Banner } from "@shared/components/ui/Banner";
-import { ModuleAccentProvider } from "@shared/components/layout";
+import {
+  MeshBackground,
+  ModuleAccentProvider,
+} from "@shared/components/layout";
 import { PullToRefresh } from "@shared/components/ui/PullToRefresh";
 import { requestCloudPull } from "@shared/lib/modules/cloudPullRequest";
 import { useCloudPullPending } from "@shared/hooks/useCloudPullPending";
@@ -400,12 +403,17 @@ export default function NutritionApp({
   );
 
   return (
-    <ModuleAccentProvider module="nutrition" asShellRoot>
-      <NutritionHeader
-        busy={busy}
-        onBackToHub={onBackToHub}
-        onOpenSettings={onOpenSettings}
-      />
+    // Sergeant v2 redesign (2026-05, PR-6) — Nutrition shell wraps content
+    // in MeshBackground. ModuleAccentProvider drops asShellRoot; shell-root
+    // role moves to MeshBackground (Hard Rule #12 — accent published
+    // first, mesh DOM element inside).
+    <ModuleAccentProvider module="nutrition">
+      <MeshBackground>
+        <NutritionHeader
+          busy={busy}
+          onBackToHub={onBackToHub}
+          onOpenSettings={onOpenSettings}
+        />
 
       <PullToRefresh
         onRefresh={handlePullRefresh}
@@ -535,6 +543,7 @@ export default function NutritionApp({
         applyRestorePayload={applyRestorePayload}
         onRequestMealPhoto={handleRequestMealPhoto}
       />
+      </MeshBackground>
     </ModuleAccentProvider>
   );
 }

--- a/apps/web/src/modules/routine/RoutineApp.tsx
+++ b/apps/web/src/modules/routine/RoutineApp.tsx
@@ -17,7 +17,10 @@
  * adding a new behaviour means editing the matching shard above.
  */
 
-import { ModuleAccentProvider } from "@shared/components/layout";
+import {
+  MeshBackground,
+  ModuleAccentProvider,
+} from "@shared/components/layout";
 import { RoutineActions } from "./RoutineActions";
 import { RoutineHeader } from "./RoutineHeader";
 import { RoutineTimeline } from "./RoutineTimeline";
@@ -60,37 +63,43 @@ export default function RoutineApp({
   } = useRoutineAppState({ pwaAction, onPwaActionConsumed, onOpenModule });
 
   return (
-    <ModuleAccentProvider module="routine" asShellRoot>
-      <RoutineHeader
-        onBackToHub={onBackToHub}
-        onOpenSettings={onOpenSettings}
-      />
+    // Sergeant v2 redesign (2026-05, PR-6) — Routine shell wraps content
+    // in MeshBackground (shell-root role). ModuleAccentProvider drops
+    // asShellRoot so MeshBackground owns h-dvh + bg-mesh; Provider stays
+    // as transparent accent context (Hard Rule #12).
+    <ModuleAccentProvider module="routine">
+      <MeshBackground>
+        <RoutineHeader
+          onBackToHub={onBackToHub}
+          onOpenSettings={onOpenSettings}
+        />
 
-      <RoutineTimeline
-        storageErrorMsg={storageErrorMsg}
-        onDismissStorageError={() => setStorageErrorMsg(null)}
-        calendarData={calendarData}
-        calendarActions={calendarActions}
-        isHabitPending={isHabitPending}
-        mainTab={mainTab}
-        routine={routine}
-        streakMax={streakMax}
-        onPullRefresh={handlePullRefresh}
-        onPullRefreshError={handlePullRefreshError}
-      />
+        <RoutineTimeline
+          storageErrorMsg={storageErrorMsg}
+          onDismissStorageError={() => setStorageErrorMsg(null)}
+          calendarData={calendarData}
+          calendarActions={calendarActions}
+          isHabitPending={isHabitPending}
+          mainTab={mainTab}
+          routine={routine}
+          streakMax={streakMax}
+          onPullRefresh={handlePullRefresh}
+          onPullRefreshError={handlePullRefreshError}
+        />
 
-      <RoutineActions
-        mainTab={mainTab}
-        setMainTab={setMainTab}
-        routine={routine}
-        setRoutine={setRoutine}
-        quickAddHabitOpen={quickAddHabitOpen}
-        quickAddFocusTick={quickAddFocusTick}
-        quickAddFirstRunHint={quickAddFirstRunHint}
-        onDismissQuickAddFirstRunHint={dismissQuickAddFirstRunHint}
-        onOpenQuickAddHabit={openQuickAddHabit}
-        onCloseQuickAddHabit={closeQuickAddHabit}
-      />
+        <RoutineActions
+          mainTab={mainTab}
+          setMainTab={setMainTab}
+          routine={routine}
+          setRoutine={setRoutine}
+          quickAddHabitOpen={quickAddHabitOpen}
+          quickAddFocusTick={quickAddFocusTick}
+          quickAddFirstRunHint={quickAddFirstRunHint}
+          onDismissQuickAddFirstRunHint={dismissQuickAddFirstRunHint}
+          onOpenQuickAddHabit={openQuickAddHabit}
+          onCloseQuickAddHabit={closeQuickAddHabit}
+        />
+      </MeshBackground>
     </ModuleAccentProvider>
   );
 }

--- a/apps/web/src/shared/components/layout/MeshBackground.tsx
+++ b/apps/web/src/shared/components/layout/MeshBackground.tsx
@@ -40,17 +40,26 @@
  * ```
  */
 
-import { type ReactNode } from "react";
+import { type CSSProperties, type ReactNode } from "react";
 import { cn } from "@shared/lib/ui/cn";
 
 export interface MeshBackgroundProps {
   children: ReactNode;
   className?: string;
+  /** Inline style — used by ModuleShell to expose `--bottom-nav-height`
+   *  CSS var to descendants so sheets can lift themselves above the nav.
+   *  PR-6 added this; HubHomeView consumer leaves it undefined. */
+  style?: CSSProperties;
 }
 
-export function MeshBackground({ children, className }: MeshBackgroundProps) {
+export function MeshBackground({
+  children,
+  className,
+  style,
+}: MeshBackgroundProps) {
   return (
     <div
+      style={style}
       className={cn(
         // Full-viewport shell — same h-dvh flex pattern as the legacy
         // `<div className="h-dvh bg-bg flex flex-col">` wrappers that

--- a/apps/web/src/shared/components/layout/ModuleShell.tsx
+++ b/apps/web/src/shared/components/layout/ModuleShell.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties, ReactNode } from "react";
 import type { ModuleAccent } from "@sergeant/design-tokens";
 import { cn } from "@shared/lib/ui/cn";
+import { MeshBackground } from "./MeshBackground";
 import { ModuleAccentProvider } from "./ModuleAccentProvider";
 
 /**
@@ -62,13 +63,17 @@ export function ModuleShell({
     "--bottom-nav-height": nav ? "60px" : "0px",
   } as CSSProperties;
 
+  // Sergeant v2 redesign (2026-05, PR-6) — module shell wraps content in
+  // <MeshBackground> so the mesh-gradient surface renders behind every
+  // module screen. MeshBackground bakes `h-dvh flex flex-col overflow-hidden`
+  // + the `.bg-mesh` utility; remaining shell-level classes (`text-text`,
+  // `module-bg`) slot through via className. Inline `shellStyle` (the
+  // `--bottom-nav-height` CSS var) passes through MeshBackground's `style`
+  // prop so descendants still see it.
   const inner = (
-    <div
+    <MeshBackground
       style={shellStyle}
-      className={cn(
-        "h-dvh flex flex-col bg-bg text-text overflow-hidden module-bg",
-        className,
-      )}
+      className={cn("text-text module-bg", className)}
     >
       {header}
       {overlays}
@@ -82,7 +87,7 @@ export function ModuleShell({
         {children}
       </div>
       {nav}
-    </div>
+    </MeshBackground>
   );
 
   if (module) {


### PR DESCRIPTION
## Summary

PR-6 / 9 у послідовності Sergeant v2 редизайн. Follows PR-5 (#2907 — merged).

Module shells (Фінік / Фізрук / Рутина / Харчування) тепер рендерять v2 mesh-gradient surface за контентом. **Hard Rule #12** (module-accent containment) збережено — `ModuleAccentProvider` публікує `--module-accent-rgb` ПЕРЕД тим, як mesh DOM рендериться всередині. Mesh corner glows композуються поверх module-accent-aware shell, без leak accent сусідам.

## Changes

### `apps/web/src/shared/components/layout/MeshBackground.tsx` (+12/-1)

- Додав `style?: CSSProperties` prop so ModuleShell може forward'ити свій `--bottom-nav-height` CSS var до descendants (sheets lift above nav).

### `apps/web/src/shared/components/layout/ModuleShell.tsx` (+13/-4)

- Inner shell `<div>` заміщено на `<MeshBackground>`. `h-dvh flex flex-col overflow-hidden + bg-mesh` baked в MeshBackground; remaining `text-text module-bg` через className; `shellStyle` (з CSS var) через новий `style` prop.
- Coverage: **FizrukApp** автоматично (це ModuleShell consumer).

### `FinykApp.tsx`, `RoutineApp.tsx`, `NutritionApp.tsx` (3 files)

```diff
- <ModuleAccentProvider module="{name}" asShellRoot>
+ <ModuleAccentProvider module="{name}">
+   <MeshBackground>
    {content}
+   </MeshBackground>
  </ModuleAccentProvider>
```

- Drop `asShellRoot` prop (MeshBackground заміщає shell-root role)
- Add MeshBackground до existing `@shared/components/layout` barrel import

## Why this shape

Provider's `asShellRoot=true` додавав `h-dvh flex flex-col bg-bg overflow-hidden` — це конфліктує з MeshBackground's bg-mesh (double full-viewport sizing + solid `bg-bg` під mesh). Чистіше: Provider стає transparent accent-context, MeshBackground owns shell-root + mesh layer. Hard Rule #12 satisfied — Provider's CSS context for `--module-accent-rgb` встановлюється ДО mesh DOM рендериться.

## Test plan

- [ ] CI: існуючі module tests untouched (жоден test не імпортує MeshBackground)
- [ ] CI: typecheck — `MeshBackground style` prop derives correctly
- [ ] Manual after merge:
  - [ ] 4 модулі показують mesh-gradient behind content
  - [ ] Module accents (finyk emerald / fizruk cyan / routine coral / nutrition lime) досі tint heroes + bottom-nav indicators
  - [ ] iOS Capacitor preview: confirm `background-attachment: fixed` renders correctly (fallback на reduced-motion-only path)
  - [ ] HC mode: mesh strips off, solid `bg-base` лишається

## Refs

- docs/design/redesign-v2.md (governance, PR-1 #2903)
- PR-5 (#2907 — MeshBackground component, merged)
- Handoff `02-component-map.md § FinykApp/FizrukApp/RoutineApp/NutritionApp`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wrap Finyk, Fizruk, Routine, and Nutrition module shells in `MeshBackground` to show the v2 mesh gradient behind content while keeping module-accent isolation intact. `MeshBackground` now owns the shell layout; `ModuleAccentProvider` no longer acts as the shell root.

- **Refactors**
  - Replaced inner shell `<div>` in `ModuleShell` with `MeshBackground`; forwards `--bottom-nav-height` via a new `style` prop.
  - Added `style?: CSSProperties` to `MeshBackground` for CSS var forwarding.
  - Updated `FinykApp`, `RoutineApp`, `NutritionApp` to wrap content in `MeshBackground` under `ModuleAccentProvider`; removed `asShellRoot`.
  - Preserved Hard Rule #12: accent context is published before the mesh; no accent leakage. 
  - `FizrukApp` picks up the mesh via `ModuleShell` automatically.

<sup>Written for commit 0830c5ae91b338eaed1f771087b87615cceeaf05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

