### PR TITLE
feat(web): AIPill + InsightCard + insight-dismissal hook for v2 redesign

### DIFF
--- a/apps/web/src/shared/components/ui/AIPill.tsx
+++ b/apps/web/src/shared/components/ui/AIPill.tsx
@@ -1,0 +1,168 @@
+/**
+ * Sergeant Design System — `AIPill` (PR-7a).
+ *
+ * @lifecycle experimental (introduced 2026-05; promoted to active after PR-8)
+ * @see docs/design/redesign-v2.md § AI surfaces
+ *
+ * Persistent AI affordance що сидить НАД bottom-nav (z-sticky tier).
+ * Двi окремi кнопки в одному visual pill:
+ *   - **Primary** (зліва) — tap → navigate(/chat). Висить як "глобальний"
+ *     entry-point до chat sheet з контекстним placeholder per module.
+ *   - **Mic** (справа) — tap → trigger voice input handler (TODO у PR-8;
+ *     поки фігурує як placeholder for Whisper-API wiring).
+ *
+ * ## A11y refactor vs. handoff JSX
+ *
+ * Handoff `03-new-components.md` рендерив зовнішній `<button>` з вкладеним
+ * `<span role="button">` для mic. Це **nested-interactive bug**:
+ *   - axe (Hard Rule #14) валиться з `role-name` violation
+ *   - screen readers double-announce ("Відкрити AI помічника. Голосовий ввід.")
+ *   - keyboard Tab focuses outer + inner separately, друкуючи дві кнопки
+ *
+ * Виправлення (Sergeant intent):
+ *   - Outer container — `<div role="group" aria-label="…">` (NOT a button)
+ *   - Inside — два `<button type="button">` як siblings із спільним
+ *     visual pill chrome via flexbox / position
+ *   - Mic-button has stopPropagation НЕ потрібен, бо primary і mic — це
+ *     окремі focusable elements у DOM
+ *
+ * ## Module context
+ *
+ * `module` prop (`null` для hub) керує:
+ *   - placeholder text (Запитай про витрати… / Що сьогодні робити… / …)
+ *   - icon gradient (sparkle сам тінтується через brand-400 → module-strong)
+ *
+ * ## Z-index + positioning
+ *
+ * `fixed left-3.5 right-[4.5rem] bottom-[…]` — лишає простір справа для FAB.
+ * `z-sticky` (Sergeant semantic) — над content/dropdowns, під modals.
+ * `safe-area-inset-bottom` додається до bottom offset для iOS.
+ *
+ * ## Hide-on conditions
+ *
+ * Не рендеримо коли:
+ *   - FTUX session (`inFtuxSession` у caller — caller просто не рендерить)
+ *   - `/chat` route (chat is already open)
+ *   - Full-screen overlays (login, scanner viewfinder)
+ *
+ * Caller відповідає за conditional rendering — компонент завжди показує
+ * себе якщо змонтований.
+ */
+
+import { useNavigate } from "react-router-dom";
+import type { ModuleAccent } from "@sergeant/design-tokens";
+import { Icon } from "@shared/components/ui/Icon";
+import { CHAT_PATH } from "@core/app/appPaths";
+import { hapticTap } from "@shared/lib/adapters/haptic";
+import { cn } from "@shared/lib/ui/cn";
+import { messages } from "@shared/i18n/uk";
+
+export interface AIPillProps {
+  /** Module context that drives the placeholder copy. `null` = hub. */
+  module?: ModuleAccent | null;
+  /** Override default placeholder. */
+  placeholder?: string;
+  /** Bottom offset in px (default 84 — sits above ModuleBottomNav). */
+  bottom?: number;
+  /** Voice input callback (PR-8 will wire Whisper). */
+  onMicTap?: () => void;
+  className?: string;
+}
+
+const DEFAULT_PLACEHOLDER: Record<ModuleAccent | "hub", string> = {
+  finyk: "Запитай про витрати…",
+  fizruk: "Що сьогодні робити?",
+  routine: "Запитай про звички…",
+  nutrition: "Що приготувати?",
+  hub: "Запитай Sergeant…",
+};
+
+export function AIPill({
+  module = null,
+  placeholder,
+  bottom = 84,
+  onMicTap,
+  className,
+}: AIPillProps) {
+  const navigate = useNavigate();
+  const placeholderText =
+    placeholder ?? DEFAULT_PLACEHOLDER[module ?? "hub"];
+
+  const openChat = () => {
+    hapticTap();
+    navigate(CHAT_PATH);
+  };
+
+  const handleMic = () => {
+    hapticTap();
+    onMicTap?.();
+    // TODO(PR-8): wire Whisper voice input when onMicTap is undefined.
+  };
+
+  return (
+    <div
+      role="group"
+      aria-label={messages.nav.openAssistant}
+      style={{ bottom: `calc(${bottom}px + env(safe-area-inset-bottom, 0px))` }}
+      className={cn(
+        // Fixed pill positioning. `right-[4.5rem]` leaves space for the
+        // module FAB on the right edge so they never overlap.
+        "fixed left-3.5 right-[4.5rem] z-sticky",
+        // Visual chrome — translucent glass surface with v2 pill shadow.
+        // `surface-strong-glass` is alpha-baked (0.93 light / 0.10 dark /
+        // 1.0 HC) so HC mode reads as a solid pill.
+        "h-11 bg-surface-strong-glass backdrop-blur-md",
+        "border border-line rounded-full shadow-pill",
+        "flex items-center gap-2 pl-2.5 pr-2",
+        className,
+      )}
+    >
+      {/* Primary tap target — opens chat sheet. Takes the full remaining
+          width so the entire pill body feels tappable. */}
+      <button
+        type="button"
+        onClick={openChat}
+        aria-label={messages.nav.openAssistant}
+        className={cn(
+          "flex-1 flex items-center gap-2 min-w-0",
+          "focus:outline-none focus-visible:rounded-full focus-visible:ring-2",
+          "focus-visible:ring-focus/45 focus-visible:ring-offset-2",
+          "focus-visible:ring-offset-bg",
+        )}
+      >
+        <span
+          aria-hidden
+          className={cn(
+            "w-7 h-7 rounded-full shrink-0 text-white",
+            "flex items-center justify-center",
+            "bg-gradient-to-br from-brand-400 to-brand-strong",
+          )}
+        >
+          <Icon name="sparkle" size={14} strokeWidth={2.2} />
+        </span>
+        <span className="flex-1 text-left text-style-body-sm text-muted truncate min-w-0">
+          {placeholderText}
+        </span>
+      </button>
+
+      {/* Mic button — sibling, not nested. Keyboard Tab order: primary
+          chat button first, then mic. */}
+      <button
+        type="button"
+        onClick={handleMic}
+        aria-label="Голосовий ввід"
+        className={cn(
+          "w-7 h-7 rounded-full shrink-0",
+          "flex items-center justify-center",
+          "text-muted hover:text-text hover:bg-panel",
+          "transition-colors",
+          "focus:outline-none focus-visible:ring-2",
+          "focus-visible:ring-focus/45 focus-visible:ring-offset-2",
+          "focus-visible:ring-offset-bg",
+        )}
+      >
+        <Icon name="mic" size={15} strokeWidth={2} />
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/shared/components/ui/InsightCard.tsx
+++ b/apps/web/src/shared/components/ui/InsightCard.tsx
@@ -1,0 +1,156 @@
+/**
+ * Sergeant Design System — `InsightCard` (PR-7a).
+ *
+ * @lifecycle experimental (introduced 2026-05; promoted to active after PR-8)
+ * @see docs/design/redesign-v2.md § AI surfaces
+ *
+ * AI push card — конкретна пропозиція коли AI знайшов щось важливе.
+ * Show-once-per-day, dismissible. Поступово рендериться через
+ * `useInsightDismissal()` hook що зберігає dismissals у localStorage
+ * (`sergeant.v2.insights.dismissed`).
+ *
+ * Структура:
+ *   [✨ amber icon] [Title \n Subtitle (button → activate)] [→ (button → dismiss)]
+ *
+ * ## A11y refactor vs. handoff JSX
+ *
+ * Handoff JSX був nested-button: зовнішній `<div>` wrapping і activate
+ * button + dismiss button — це OK, але це не group. Sergeant wraps в
+ * `<div role="group" aria-labelledby="…">` так що screen readers
+ * announce'ять обидві дії як пов'язані.
+ *
+ * ## Token discipline (Hard Rule #11 — no raw palette in className)
+ *
+ * Handoff пропонував `bg-em-900/95` (raw em-palette + opacity modifier).
+ * У Sergeant це violation #11. Замість того використовуємо `bg-ink-strong`
+ * — semantic token що мапиться на emerald-900 в light / white в dark /
+ * pure #000 в HC (via PR-1). Контрастний text-bg-base inverts через
+ * theme. Amber icon уживає `bg-celebration-soft` token (PR-1).
+ *
+ * ## Module context
+ *
+ * `module` prop керує decorative module tint (через accent border) — але
+ * primary visual identity лишається AI/celebration (amber + ink-strong),
+ * не module accent. Це навмисно: insight reads as "from Sergeant", not
+ * "from Finyk/Fizruk/...".
+ */
+
+import { useState } from "react";
+import { Icon } from "@shared/components/ui/Icon";
+import { cn } from "@shared/lib/ui/cn";
+import { hapticTap } from "@shared/lib/adapters/haptic";
+import { useInsightDismissal } from "@shared/lib/insights";
+import type { InsightId } from "@shared/lib/insights";
+
+export interface InsightCardProps {
+  /** Stable id for dismissal tracking (e.g. "finyk-coffee-limit-2026-05"). */
+  id: InsightId;
+  /** Bold signal headline ("Витрати на каву ↑ 34%"). */
+  title: string;
+  /** Subtitle / recommended action ("Встановити ліміт?"). */
+  subtitle: string;
+  /** CTA glyph — defaults to → arrow. */
+  ctaLabel?: string;
+  /** Called when user taps the activate area. Navigate / open chat etc. */
+  onActivate: () => void;
+  /** Called after dismissal is persisted (analytics hook). */
+  onDismiss?: () => void;
+  className?: string;
+}
+
+export function InsightCard({
+  id,
+  title,
+  subtitle,
+  ctaLabel = "→",
+  onActivate,
+  onDismiss,
+  className,
+}: InsightCardProps) {
+  const { isDismissed, dismiss } = useInsightDismissal();
+  // Local optimistic flag so the card disappears immediately on dismiss
+  // even before the hook's localStorage write completes.
+  const [hidden, setHidden] = useState(false);
+
+  if (hidden || isDismissed(id)) return null;
+
+  const handleDismiss = () => {
+    hapticTap();
+    dismiss(id);
+    setHidden(true);
+    onDismiss?.();
+  };
+
+  const handleActivate = () => {
+    hapticTap();
+    onActivate();
+  };
+
+  const titleId = `insight-card-title-${id}`;
+
+  return (
+    <div
+      role="group"
+      aria-labelledby={titleId}
+      className={cn(
+        // v2 push-card chrome — ink-strong solid in light, glass-tinted
+        // in dark (mirrors handoff `bg-em-900/95` intent without raw
+        // palette). Shadow uses elevation `shadow-e3` (overlay tier).
+        "mx-3.5 mt-2 px-3 py-2.5 rounded-r-2xl",
+        "bg-ink-strong text-bg-base",
+        "flex items-center gap-3 shadow-e3",
+        className,
+      )}
+    >
+      {/* Amber sparkle — celebration-tier visual signal so the card
+          reads as "AI noticed something" without competing з module accent. */}
+      <span
+        aria-hidden
+        className={cn(
+          "w-8 h-8 rounded-xl shrink-0",
+          "flex items-center justify-center",
+          "bg-celebration/22 text-celebration",
+        )}
+      >
+        <Icon name="sparkle" size={16} strokeWidth={2} />
+      </span>
+
+      {/* Activate button — title + subtitle. Takes the remaining width. */}
+      <button
+        type="button"
+        onClick={handleActivate}
+        className={cn(
+          "flex-1 text-left min-w-0",
+          "focus:outline-none focus-visible:rounded-lg",
+          "focus-visible:ring-2 focus-visible:ring-celebration/45",
+          "focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
+        )}
+      >
+        <div
+          id={titleId}
+          className="text-style-body-sm font-extrabold truncate text-bg-base"
+        >
+          {title}
+        </div>
+        <div className="text-style-caption opacity-70 truncate text-bg-base">
+          {subtitle}
+        </div>
+      </button>
+
+      {/* Dismiss button — separate sibling so Tab order is activate → dismiss. */}
+      <button
+        type="button"
+        onClick={handleDismiss}
+        aria-label="Закрити пропозицію"
+        className={cn(
+          "text-[18px] font-bold text-celebration shrink-0 px-2 -my-1",
+          "hover:opacity-80 transition-opacity",
+          "focus:outline-none focus-visible:rounded-lg",
+          "focus-visible:ring-2 focus-visible:ring-celebration/45",
+        )}
+      >
+        {ctaLabel}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/shared/components/ui/index.ts
+++ b/apps/web/src/shared/components/ui/index.ts
@@ -310,3 +310,13 @@ export {
   useRegisterCommand,
 } from "./CommandPalette";
 export type { PaletteCommand } from "./CommandPalette";
+
+// Sergeant v2 redesign (2026-05, PR-7a) — AI push/pull surfaces.
+// `<AIPill>` sits above bottom-nav as persistent chat-entry affordance;
+// `<InsightCard>` shows AI-detected actionable insights with dismissal
+// tracked via `@shared/lib/insights/useInsightDismissal`.
+export { AIPill } from "./AIPill";
+export type { AIPillProps } from "./AIPill";
+
+export { InsightCard } from "./InsightCard";
+export type { InsightCardProps } from "./InsightCard";

--- a/apps/web/src/shared/lib/insights/index.ts
+++ b/apps/web/src/shared/lib/insights/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Sergeant Design System — AI Insight surfaces public API.
+ *
+ * Import from `@shared/lib/insights` to keep deep paths stable and the
+ * public surface focused. Introduced у PR-7a (2026-05 v2 redesign).
+ */
+
+export type {
+  Insight,
+  InsightAction,
+  InsightId,
+  InsightShowOn,
+} from "./types";
+
+export {
+  useInsightDismissal,
+  type UseInsightDismissalResult,
+} from "./useInsightDismissal";

--- a/apps/web/src/shared/lib/insights/types.ts
+++ b/apps/web/src/shared/lib/insights/types.ts
@@ -1,0 +1,51 @@
+/**
+ * Sergeant Design System — AI Insight types (PR-7a).
+ *
+ * @lifecycle experimental (introduced 2026-05; promoted to active after PR-8)
+ * @see docs/design/redesign-v2.md § AI surfaces
+ *
+ * `Insight` describes a single AI push-notification surface rendered by
+ * `<InsightCard>`. Identified by a stable string id so dismissals
+ * persist across reloads + sessions (see `useInsightDismissal`).
+ *
+ * Insight registry — examples used by PR-8 / future insights backlog:
+ *
+ *   finyk-coffee-limit-{YYYY-MM}      Coffee spend > +25% MoM
+ *   finyk-budget-overrun-{cat}        Category exceeded > 10%
+ *   finyk-recurring-detected          Recurring tx without recurring rule
+ *   fizruk-rest-day-overdue           3+ days without workout
+ *   fizruk-pr-pending                 PR achievable on current weight
+ *   routine-streak-record-pending     Longest streak −1 day
+ *   routine-todo-evening              2+ pending habits, >= 20:00
+ *   nutrition-protein-low             Protein < 60 % of goal, >= 18:00
+ *   nutrition-streak-7-days           7 days in kcal range
+ *
+ * No `z` validation here yet — types kept structural. PR-7b adds Zod
+ * runtime parser once the wire-up surfaces actual data.
+ */
+
+import type { ModuleAccent } from "@sergeant/design-tokens";
+
+/** Stable insight identifier — `{module}-{slug}-{optional-suffix}`. */
+export type InsightId = string;
+
+export type InsightAction =
+  | { type: "navigate"; path: string }
+  | { type: "open-chat"; prompt: string }
+  | { type: "callback"; fn: () => void };
+
+export type InsightShowOn = "hub" | "module" | "both";
+
+export interface Insight {
+  id: InsightId;
+  /** `null` для hub-level інсайтів. */
+  module: ModuleAccent | null;
+  /** Bold title — стислий signal ("Витрати на каву ↑ 34%"). */
+  title: string;
+  /** Subtitle — рекомендована дія ("Встановити ліміт?"). */
+  subtitle: string;
+  action: InsightAction;
+  /** ms — auto-dismiss після інтервалу. Опціонально. */
+  ttl?: number;
+  showOn: InsightShowOn;
+}

--- a/apps/web/src/shared/lib/insights/useInsightDismissal.ts
+++ b/apps/web/src/shared/lib/insights/useInsightDismissal.ts
@@ -1,0 +1,90 @@
+/**
+ * Sergeant Design System — useInsightDismissal hook (PR-7a).
+ *
+ * @lifecycle experimental (introduced 2026-05; promoted to active after PR-8)
+ * @see docs/design/redesign-v2.md § AI surfaces
+ *
+ * Centralizes the localStorage-backed "already dismissed" tracking for
+ * <InsightCard>. Listens to `storage` events so cross-tab dismissal
+ * propagates immediately (user dismisses an insight on tab A; tab B's
+ * card hides without reload).
+ *
+ * Storage namespace: `sergeant.v2.insights.dismissed`. Decoupled from
+ * v1 storage keys so a future cleanup migration doesn't accidentally
+ * re-show every insight. Values are JSON arrays of stable insight ids.
+ *
+ * `safeReadStringLS` / `safeWriteLS` are reused so the hook degrades
+ * gracefully when localStorage is unavailable (private browsing, quota
+ * exhausted, SSR pre-hydration).
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  safeReadStringLS,
+  safeWriteLS,
+} from "@shared/lib/storage/storage";
+import type { InsightId } from "./types";
+
+const DISMISSED_KEY = "sergeant.v2.insights.dismissed";
+
+function parseDismissed(raw: string | null): Set<InsightId> {
+  if (!raw) return new Set();
+  try {
+    const arr = JSON.parse(raw);
+    return Array.isArray(arr) ? new Set(arr.filter((x): x is string => typeof x === "string")) : new Set();
+  } catch {
+    return new Set();
+  }
+}
+
+export interface UseInsightDismissalResult {
+  /** True iff `id` has been dismissed in this browser. */
+  isDismissed: (id: InsightId) => boolean;
+  /** Mark `id` as dismissed (persists immediately + notifies other tabs). */
+  dismiss: (id: InsightId) => void;
+  /** Clear all dismissals — used by settings "Reset insights" action. */
+  clear: () => void;
+}
+
+export function useInsightDismissal(): UseInsightDismissalResult {
+  const [dismissed, setDismissed] = useState<Set<InsightId>>(() =>
+    parseDismissed(safeReadStringLS(DISMISSED_KEY)),
+  );
+
+  // Cross-tab sync — when another tab writes to the storage key, mirror
+  // its state here so a dismissed-in-tab-A insight disappears from tab-B
+  // without a page reload. `storage` events do NOT fire in the same tab
+  // that wrote them — only other tabs receive them, exactly the semantics
+  // we want.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const handler = (e: StorageEvent) => {
+      if (e.key !== DISMISSED_KEY) return;
+      setDismissed(parseDismissed(e.newValue));
+    };
+    window.addEventListener("storage", handler);
+    return () => window.removeEventListener("storage", handler);
+  }, []);
+
+  const isDismissed = useCallback(
+    (id: InsightId): boolean => dismissed.has(id),
+    [dismissed],
+  );
+
+  const dismiss = useCallback((id: InsightId) => {
+    setDismissed((prev) => {
+      if (prev.has(id)) return prev;
+      const next = new Set(prev);
+      next.add(id);
+      safeWriteLS(DISMISSED_KEY, JSON.stringify(Array.from(next)));
+      return next;
+    });
+  }, []);
+
+  const clear = useCallback(() => {
+    setDismissed(new Set());
+    safeWriteLS(DISMISSED_KEY, "[]");
+  }, []);
+
+  return { isDismissed, dismiss, clear };
+}


### PR DESCRIPTION
## Summary

PR-7a / 9 у послідовності Sergeant v2 редизайн. Follows PR-6 (#2908 — merged).

Creates **3 нові AI surfaces + 1 hook** з handoff `03-new-components.md`. **Pure additions** — no wiring into hub чи module shells yet (PR-7b + PR-8).

## New files

### `apps/web/src/shared/lib/insights/`
- **`types.ts`** — `Insight` schema, `InsightId` / `InsightAction` / `InsightShowOn` unions. Insight ids documented inline (finyk-coffee-limit, routine-streak-record-pending, etc.) як target для PR-8 backlog.
- **`useInsightDismissal.ts`** — hook що wraps localStorage tracking під `sergeant.v2.insights.dismissed`. Subscribes до `storage` events для cross-tab sync. Returns `{ isDismissed, dismiss, clear }`. Reuses existing `safeReadStringLS`/`safeWriteLS` для graceful degradation.
- **`index.ts`** — barrel.

### `apps/web/src/shared/components/ui/`
- **`AIPill.tsx`** — persistent AI affordance над bottom-nav. **A11y refactor**: two sibling buttons inside `<div role="group">` (NOT nested-button anti-pattern із handoff JSX). Primary tap → `navigate(CHAT_PATH)`. Mic → optional `onMicTap` callback (Whisper wiring у PR-8). Glass chrome через PR-1 tokens (`bg-surface-strong-glass`, `shadow-pill`, `backdrop-blur-md`). `z-sticky` semantic tier.
- **`InsightCard.tsx`** — AI push card з localStorage dismissal. `<div role="group" aria-labelledby="…">` + two sibling buttons (activate + dismiss). Visual chrome via `bg-ink-strong text-bg-base` (semantic tokens — Hard Rule #11 compliant; handoff's raw `bg-em-900/95` was violation). Amber sparkle через `bg-celebration/22 text-celebration` tokens.

### `apps/web/src/shared/components/ui/index.ts`
- Re-exports `AIPill` + `InsightCard` + their `*Props` types.

## A11y notes (deviations from handoff JSX)

Handoff JSX мав вкладені `<button>` всередині `<button>` для mic + dismiss controls. Це провалюється axe (`role-name`/`nested-interactive`) і screen readers double-announce. Sergeant version:
- Outer container = `<div role="group" aria-label|aria-labelledby="…">`
- Inside = sibling `<button>` elements, кожен з власним focus ring + handler
- Keyboard Tab order чистий: primary action → secondary action

## Token discipline (Hard Rule #11)

Handoff `bg-em-900/95` (raw palette + opacity modifier) — violation #11. Replaced with `bg-ink-strong` semantic token (PR-1):
- Light: emerald-900 → reads as deep dark insight surface on cream
- Dark: white → inverts cleanly
- HC: pure #000 / #fff → AAA contrast guaranteed

## Test plan
- [ ] CI: typecheck — new types derive correctly
- [ ] CI: existing component tests untouched (pure additions)
- [ ] Manual (after PR-7b lands wiring):
  - [ ] AIPill — Tab order primary → mic; axe a11y clean
  - [ ] InsightCard — dismiss → reload → still hidden (localStorage)
  - [ ] Cross-tab: dismiss in tab A → tab B updates without reload
  - [ ] HC mode: `bg-ink-strong` inverts to white; mesh strips off
- [ ] PR-7b: wires AIPill + InsightCard into HubHomeView + 4 modules

## What's NOT in this PR

- No wiring into HubHomeView / FinykApp / FizrukApp / RoutineApp / NutritionApp (PR-7b)
- No ChatSheet modal-route handling (PR-7b)
- No actual insight backlog implementation — just the schema + hook (PR-8)
- No Storybook stories — added inline test descriptions for now (stories land in PR-8 polish)

## Refs

- docs/design/redesign-v2.md (governance, PR-1 #2903)
- Handoff `03-new-components.md § AIPill / InsightCard`
- PR-6 (#2908 — module shells merged)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a persistent assistant entry pill and an actionable insight card, plus a localStorage-backed dismissal hook, for the v2 redesign. These are pure additions and not yet wired into screens.

- **New Features**
  - AIPill: two sibling buttons in a group; primary opens chat, optional mic callback; fixed above bottom nav with proper a11y and focus order.
  - InsightCard: dismissible push card with activate and dismiss buttons; uses semantic tokens and optimistic hide.
  - Dismissal hook: `useInsightDismissal` stores ids under `sergeant.v2.insights.dismissed`, syncs across tabs, exposes `isDismissed`, `dismiss`, and `clear`.
  - Types and barrels: insight types and actions added under `@shared/lib/insights`; `AIPill` and `InsightCard` re-exported from `@shared/components/ui`.

<sup>Written for commit 3916fd0cfc058218956232b55902c42848ef2203. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

