### PR TITLE
feat(agents): add sergeant-security-audit, sergeant-e2e-testing, sergeant-tech-debt skills

### DIFF
--- a/.agents/skills-lock.json
+++ b/.agents/skills-lock.json
@@ -54,7 +54,7 @@
     "sergeant-start-here": {
       "source": "local",
       "sourceType": "local",
-      "computedHash": "4a9ec9dc8b3fb06dd0c3028210725b48bec3f8646644a8f7c107320ad317b295"
+      "computedHash": "10e5f868b7c17998de63c782dab6a9e09811d258b43e8850d0798650050843d3"
     },
     "sergeant-web-ui": {
       "source": "local",
@@ -70,6 +70,21 @@
       "source": "local",
       "sourceType": "local",
       "computedHash": "3a585bc29ba2677659508b5cff7b4d3b337744f70224c3d3b8219f92437a4fcc"
+    },
+    "sergeant-security-audit": {
+      "source": "local",
+      "sourceType": "local",
+      "computedHash": "fa866ad140b5ea5293dcf8f526ca256562defbde9a289f7b2a6129849eb53dec"
+    },
+    "sergeant-e2e-testing": {
+      "source": "local",
+      "sourceType": "local",
+      "computedHash": "0fbebb860a243a2811895ab9f1ed065ec1a17977cc6a93f95591b11e4d76873a"
+    },
+    "sergeant-tech-debt": {
+      "source": "local",
+      "sourceType": "local",
+      "computedHash": "064447cafcb37da37f9cc82e09ef0e7c2925c7f69d7ee729b0b1b66b4df33202"
     }
   }
 }

--- a/.agents/skills/sergeant-e2e-testing/SKILL.md
+++ b/.agents/skills/sergeant-e2e-testing/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: sergeant-e2e-testing
+description: Use when writing, reviewing, or debugging Playwright E2E tests in apps/web; for auth fixtures, network mocking, trace debugging, or CI retry config; UA: Playwright, E2E тести, e2e, smoke test.
+lang: en
+lang-reason: Agent-runtime SKILL — body kept EN to maximize tool-calling stability across LLM providers (Anthropic, OpenAI, etc.) whose attention bias toward English persists in tool-routing decisions even when prompts are bilingual. The bilingual trigger phrase lives in `description:` so UA-only chat routing still resolves the right SKILL.
+---
+
+# E2E Testing (Playwright) у Sergeant
+
+Playwright tests in Sergeant run against a preview build (`vite build && vite preview`). The test suite lives in `apps/web/tests/` split into `tests/smoke/` (auth and critical path) and `tests/a11y/` (axe-core accessibility snapshots). Config: `apps/web/playwright.config.ts`.
+
+## 8 Golden Rules
+
+1. **Web-first assertions** — use `await expect(locator).toBeVisible()` not `await page.waitForSelector()`. Web-first assertions auto-retry; raw selectors block immediately.
+2. **No `waitForTimeout`** — replace any `page.waitForTimeout(N)` with a web-first assertion on the element that must appear. Timing-based waits are always wrong.
+3. **Role-based selectors first** — prefer `page.getByRole("button", { name: "..." })` over CSS or `nth-child`. Fallback to `data-testid` (`getByTestId`) only when ARIA role is insufficient.
+4. **State seeding via `seedFTUX`** — use `apps/web/tests/utils/seedFTUX.ts` (`"cold"`, `"pre-ftux"`, `"post-ftux"`, `"module-first-run"`) to seed `localStorage` state before navigation. Never drive the full UI sign-up/onboarding flow to reach steady state.
+5. **Trace retention** — active config uses `trace: "retain-on-failure"`. Do not change to `"on"` (bloats CI artifacts). For local debugging run with `--trace on`.
+6. **Screenshot on failure only** — `screenshot: "only-on-failure"` in config. Do not commit golden screenshots for non-visual-qa tests; `tests/a11y/ds-visual-qa.spec.ts` is the only allowed visual baseline.
+7. **Workers = 1** — config sets `workers: 1` because tests share a single preview server. Do not change to `fullyParallel: true` without making each spec spin up its own server.
+8. **Tag critical tests** — prefix test descriptions with `@critical` for auth and onboarding happy-path tests. CI can filter with `--grep @critical` for fast smoke runs.
+
+## Reference files
+
+For deeper guidance on specific scenarios:
+
+- [`references/selectors.md`](references/selectors.md) — selector hierarchy, when to use `data-testid`, common anti-patterns.
+- [`references/network-mocking.md`](references/network-mocking.md) — when to mock vs. use real API; MSW integration patterns.
+- [`references/auth-flow.md`](references/auth-flow.md) — Sergeant-specific auth fixture using `seedFTUX` and Better Auth cookie patterns.
+- [`references/traces-and-debugging.md`](references/traces-and-debugging.md) — trace flags, `--ui` mode, Playwright Inspector, CI artifact retrieval.
+
+## Running tests
+
+```bash
+cd apps/web
+pnpm build && pnpm preview &           # start preview server (required)
+pnpm playwright test tests/smoke/      # smoke suite
+pnpm playwright test tests/a11y/       # accessibility suite
+pnpm playwright test --ui              # interactive UI mode (local debug)
+pnpm playwright test --trace on        # force-enable traces locally
+```
+
+## What NOT to do
+
+- Do not use `page.waitForTimeout()` — ever.
+- Do not seed auth state by driving the login UI in `beforeEach` — use `seedFTUX`.
+- Do not use CSS class or nth-child selectors — they break on design-system refactors.
+- Do not commit snapshot updates without visual review.
+- Do not change `workers` or `fullyParallel` without understanding the shared-server constraint.
+- Do not run tests against the dev server (`vite dev`) — tests must run against `vite preview` to match CI.
+
+## Playbooks
+
+- `docs/playbooks/stabilize-flaky-test.md` — when a test becomes flaky in CI.
+- Skill catalog: `docs/agents/agent-skills-catalog.md`.

--- a/.agents/skills/sergeant-e2e-testing/references/auth-flow.md
+++ b/.agents/skills/sergeant-e2e-testing/references/auth-flow.md
@@ -1,0 +1,65 @@
+---
+title: Auth Flow Testing with seedFTUX
+impact: HIGH
+impactDescription: Driving the UI sign-up flow in every test creates slow, brittle tests. Sergeant provides seedFTUX for direct state seeding.
+tags: [playwright, auth, better-auth, cookies, fixtures, ftux, seedFTUX]
+---
+
+# Auth Flow Testing in Sergeant
+
+## Do not drive the UI login flow in beforeEach
+
+The full sign-up + onboarding flow takes 5–10 seconds per test. Driving it in `beforeEach` makes the suite slow and brittle. Seed application state directly instead.
+
+## seedFTUX helper
+
+`apps/web/tests/utils/seedFTUX.ts` seeds `localStorage` state before navigation via `page.addInitScript()`.
+
+```typescript
+import { seedFTUX } from "../utils/seedFTUX";
+
+test("hub dashboard shows modules", async ({ page }) => {
+  await seedFTUX(page, "post-ftux");  // fully onboarded, steady-state hub
+  await page.goto("/hub");
+  await expect(page.getByRole("main")).toBeVisible();
+});
+```
+
+### Available modes
+
+| Mode | State |
+|---|---|
+| `"cold"` | Theme only; welcome splash active |
+| `"pre-ftux"` | Onboarding done; FTUX hero banner pending |
+| `"post-ftux"` | Fully onboarded; all overlays dismissed (steady-state hub) |
+| `"module-first-run"` | post-ftux but a specific module first-run banner active |
+
+## Better Auth session cookies
+
+Better Auth uses HttpOnly cookies. Playwright cannot set HttpOnly cookies from test code — they must come from the server response.
+
+If a test requires a real authenticated session (not just localStorage state), the correct approach is a server-side seed script that calls Better Auth's internal session creator and returns the cookie for Playwright to inject via `storageState`. Do not bypass auth by mocking the session validation endpoint — this hides auth regressions.
+
+## Incorrect pattern
+
+**Incorrect — drives UI in beforeEach:**
+```typescript
+test.beforeEach(async ({ page }) => {
+  await page.goto("/auth/sign-in");
+  await page.getByLabel("Email").fill("test@example.com");
+  await page.getByLabel("Password").fill("password");
+  await page.getByRole("button", { name: "Sign in" }).click();
+  await page.waitForURL("/hub");
+});
+```
+
+**Correct — seeds state via seedFTUX:**
+```typescript
+test.beforeEach(async ({ page }) => {
+  await seedFTUX(page, "post-ftux");
+});
+```
+
+## Sergeant-specific note
+
+`apps/web/tests/smoke/auth.spec.ts` and `auth-webkit.spec.ts` are the canonical reference for testing the real sign-up/sign-in flow. These tests intentionally drive the UI because they are testing auth itself — not as a setup step for other tests.

--- a/.agents/skills/sergeant-e2e-testing/references/network-mocking.md
+++ b/.agents/skills/sergeant-e2e-testing/references/network-mocking.md
@@ -1,0 +1,57 @@
+---
+title: Network Mocking Strategy
+impact: MEDIUM
+impactDescription: Over-mocking hides integration bugs; under-mocking creates flaky tests dependent on external services.
+tags: [playwright, msw, network, mocking, api]
+---
+
+# Network Mocking in Sergeant E2E Tests
+
+## When to mock
+
+| Scenario | Decision |
+|---|---|
+| External third-party API (Stripe, Monobank webhook) | Always mock — never hit prod credentials in tests |
+| Better Auth session endpoints | Do not mock — use `seedFTUX` to pre-seed state instead |
+| Sergeant API (`/api/**`) | Mock for isolated smoke tests; use real preview server for integration tests |
+| Static assets / CDN | Do not mock — `vite preview` serves them locally |
+
+## Route interception (Playwright-native)
+
+For tests that stub a specific response without touching MSW:
+
+```typescript
+// Correct — intercept and mock a single endpoint
+await page.route("**/api/hubs", (route) =>
+  route.fulfill({ json: { hubs: [] } })
+);
+```
+
+**Incorrect — aborting all requests cascades failures:**
+```typescript
+await page.route("**/*", (route) => route.abort());
+```
+
+Abort only specific third-party domains (e.g. analytics) that are irrelevant to the test:
+
+```typescript
+await page.route("**/*.{png,jpg,gif,svg}", (route) => route.abort());
+```
+
+## MSW handlers
+
+The web app uses MSW for browser-level mocking. Handlers live in `apps/web/src/mocks/`. In Playwright, MSW runs inside the browser context started by the app. To override a handler for a single test:
+
+```typescript
+// Add a test-specific override before navigation
+await page.addInitScript(() => {
+  // access MSW worker through the app's global setup
+  window.__msw_override = { path: "/api/hubs", response: { hubs: [] } };
+});
+```
+
+Check `apps/web/src/mocks/` for the current handler setup before adding test-specific overrides.
+
+## Sergeant-specific note
+
+`apps/server` runs separately from the preview server. Integration tests that exercise the real API need both servers running simultaneously. The smoke suite mocks API responses to avoid this dependency. If you need real API calls in a test, document this in the test file and ensure a local server setup script exists.

--- a/.agents/skills/sergeant-e2e-testing/references/selectors.md
+++ b/.agents/skills/sergeant-e2e-testing/references/selectors.md
@@ -1,0 +1,44 @@
+---
+title: Selector Hierarchy and Anti-Patterns
+impact: HIGH
+impactDescription: Wrong selectors are the primary cause of flaky Playwright tests and post-refactor breakage in Sergeant.
+tags: [playwright, selectors, locators, e2e]
+---
+
+# Selector Hierarchy
+
+Playwright's built-in locators encode semantics and auto-retry. Prefer them over raw CSS.
+
+## Preferred order
+
+1. `page.getByRole("button", { name: "Sign in" })` — ARIA role + accessible name; survives DOM refactors.
+2. `page.getByLabel("Email")` — matches `<label>` association; good for form fields.
+3. `page.getByText("Continue", { exact: true })` — exact text match; use `exact: true` to avoid false positives.
+4. `page.getByTestId("auth-email")` — `data-testid` attribute for elements without a natural ARIA role.
+5. `page.locator("css selector")` — last resort; never use `nth-child`, `first-child`, or positional selectors.
+
+## Anti-patterns
+
+**Incorrect — positional selector breaks on design changes:**
+```typescript
+await page.locator(".auth-form button:nth-child(2)").click();
+```
+
+**Correct — role-based locator:**
+```typescript
+await page.getByRole("button", { name: "Sign in" }).click();
+```
+
+**Incorrect — CSS class tied to implementation detail:**
+```typescript
+await page.locator(".btn-primary").click();
+```
+
+**Correct — accessible name:**
+```typescript
+await page.getByRole("button", { name: "Continue" }).click();
+```
+
+## Sergeant-specific note
+
+`packages/design-tokens` Tailwind classes change during token refactors. Always prefer role or label locators over class-based ones. For components that genuinely lack an ARIA role (e.g. custom card grids), add a `data-testid` attribute in the component source rather than writing a fragile CSS path.

--- a/.agents/skills/sergeant-e2e-testing/references/traces-and-debugging.md
+++ b/.agents/skills/sergeant-e2e-testing/references/traces-and-debugging.md
@@ -1,0 +1,53 @@
+---
+title: Traces and Debugging
+impact: MEDIUM
+impactDescription: Without trace retention, flaky test failures in CI are impossible to diagnose. Without the right local flags, debugging is slow.
+tags: [playwright, traces, debugging, ci, inspector]
+---
+
+# Playwright Traces and Debugging in Sergeant
+
+## Active configuration
+
+`apps/web/playwright.config.ts` sets:
+
+```typescript
+trace: "retain-on-failure",   // attaches trace only when a test fails
+screenshot: "only-on-failure",
+```
+
+Do not change `trace` to `"on"` globally — it bloats CI artifacts on every passing run. `retain-on-failure` is the right balance for CI diagnostics.
+
+## Local debugging
+
+```bash
+# Interactive UI mode — full timeline, network tab, DOM snapshots
+pnpm playwright test --ui
+
+# Force trace on every test (local only — do not use in CI config)
+pnpm playwright test --trace on
+
+# Playwright Inspector — pauses on every step, shows selector suggestions
+PWDEBUG=1 pnpm playwright test tests/smoke/auth.spec.ts
+```
+
+## Viewing traces from CI
+
+When a CI run fails, download the `playwright-report` artifact from the workflow run. Open the trace locally:
+
+```bash
+pnpm playwright show-trace path/to/trace.zip
+```
+
+The trace shows: DOM snapshot at every action, network calls (request + response), action timeline. This is usually sufficient to diagnose a flaky failure without reproducing it locally.
+
+## Debugging a flaky test
+
+1. Run with `--trace on` locally 3–5 times.
+2. Compare traces between a passing and a failing run — look for timing differences in network calls or animations blocking interaction.
+3. Fix with a web-first assertion (`await expect(locator).toBeVisible()`), not `waitForTimeout`. See `references/selectors.md`.
+4. If still flaky after adding web-first assertions, consult `docs/playbooks/stabilize-flaky-test.md`.
+
+## Sergeant-specific note
+
+Tests run against `vite preview` (not the dev server). If a test passes locally in dev but fails in CI, the likely cause is a missing build step or a CSP/CORS header that `vite dev` ignores. Reproduce by running `pnpm build && pnpm preview` locally before concluding it is a flaky test.

--- a/.agents/skills/sergeant-security-audit/SKILL.md
+++ b/.agents/skills/sergeant-security-audit/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: sergeant-security-audit
+description: Use when running a security review of Sergeant code or API, auditing deps with pnpm audit, or checking PAT/credential safety; before any auth or user-data surface ships; UA: security review, перевірка безпеки, аудит.
+lang: en
+lang-reason: Agent-runtime SKILL — body kept EN to maximize tool-calling stability across LLM providers (Anthropic, OpenAI, etc.) whose attention bias toward English persists in tool-routing decisions even when prompts are bilingual. The bilingual trigger phrase lives in `description:` so UA-only chat routing still resolves the right SKILL.
+---
+
+# Security Audit у Sergeant
+
+Security review in Sergeant is not a generic OWASP checklist. Every surface has Sergeant-specific bindings that an agent without this skill systematically misses.
+
+## Non-negotiable commands (run before any security claim)
+
+```bash
+pnpm audit --audit-level=moderate     # CVEs across all pnpm workspaces
+pnpm lint                             # catches Pino redaction violations via ESLint rules
+pnpm typecheck                        # catches unsafe type coercions
+```
+
+## Hard Rules that govern security
+
+| Rule | What to verify |
+|---|---|
+| **Hard Rule #20 — No OpenClaw PATs in production** | Grep diff for any literal `OPENCLAW_PAT_*` not in env-var context; check `ops/openclaw/` config-as-code for hardcoded tokens |
+| **Hard Rule #21 — Pino redaction policy** | New logging path → verify key is covered by `REDACT_KEY_NAMES` in `packages/shared/src/lib/pii.ts`; check `apps/server/src/obs/logger.ts` redaction walker |
+| **Hard Rule #22 — Skill body security scan** | When reviewing `.agents/skills/**/SKILL.md` changes run `pnpm lint:skills` — 7-category threat scanner |
+
+## Server-side API security (`apps/server`)
+
+- **Auth:** Every route in `apps/server/src/modules/` must apply Better Auth session middleware. Confirm `requireSession` (or equivalent) is present — verify the error path, not just the happy path.
+- **Input validation:** Every request body must pass through a Zod schema. Raw `req.body` access without schema = flag immediately.
+- **SQL injection:** Sergeant uses Drizzle ORM. Risk vector is raw template literals with user input inside `sql\`...\``. Inspect all `sql` tagged template calls for user-controlled interpolation.
+- **Hard Rule #1 (bigint coercion):** Serializers that skip `Number()` cast on `bigint` DB fields can expose internal types to API consumers — flag as data-contract issue.
+
+## Pino redaction (`apps/server/src/obs/logger.ts`)
+
+The logger imports `REDACT_KEY_NAMES` from `@sergeant/shared/lib/pii.ts`. Redaction is key-name based (case-insensitive), recursive, non-mutating. Primitives redact to `"[redacted]"`, objects to `null`.
+
+When adding a surface that logs user data:
+
+1. Check whether the key name is already in `REDACT_KEY_NAMES`.
+2. If not, add it in `packages/shared/src/lib/pii.ts` — the shared package exports it to both server logger and browser Sentry SDK.
+3. Run `pnpm lint` — ESLint rules check redaction policy compliance.
+
+Do not mutate the log object before passing to Pino; redaction runs non-mutating on the value passed in.
+
+## Supply chain (`pnpm audit`)
+
+```bash
+# Flag high/critical CVEs across all workspaces
+pnpm audit --json | jq '.vulnerabilities | to_entries[]
+  | select(.value.severity == "high" or .value.severity == "critical")'
+```
+
+- Cross-reference CVEs with `renovate.json` — if Renovate already has a pending update PR, do not create a duplicate; comment on the existing one instead.
+- Check `THIRD_PARTY_LICENSES.md` for GPL transitive deps — compliance risk.
+- Run `pnpm outdated` to surface packages outside Renovate range constraints.
+- For safe dep bumps, follow `docs/playbooks/bump-dep-safely.md`.
+
+## Frontend security (`apps/web`)
+
+- `dangerouslySetInnerHTML` → always flag for XSS review; require sanitization proof.
+- LocalStorage access outside `apps/web/src/shared/lib/storage/` `TypedStore` wrappers → flag as unreviewed data leakage surface.
+- Auth tokens must travel only via HttpOnly cookies managed by Better Auth; tokens must never appear in `localStorage` or any JS-accessible storage.
+
+## Mobile security (`apps/mobile`)
+
+- MMKV keys holding sensitive data (tokens, PII) must not store plaintext; verify encryption configuration.
+- Deep links in `apps/mobile/src/core/navigation/`: ensure unknown scheme parameters are sanitized before use in routing.
+
+## Severity triage
+
+| Level | Action |
+|---|---|
+| Critical — CVE / hardcoded secret / auth bypass | Block PR; escalate via `docs/playbooks/respond-to-suspected-account-compromise.md` |
+| High — injection vector / missing auth check | Must-fix before merge |
+| Medium — logging exposure / outdated dep with known exploit | Fix in this PR or create tracked issue |
+| Low — best-practice gap / minor config drift | PR comment; not a blocker |
+
+## What NOT to do
+
+- Do not run `npm audit` — pnpm workspaces require `pnpm audit` to cover all packages.
+- Do not flag Drizzle's query builder as "raw SQL risk" without confirming user input reaches it.
+- Do not confuse OpenClaw PATs (Hard Rule #20) with Better Auth session tokens — different threat models, different remediation paths.
+- Do not audit redaction by searching log output for plaintext values — Sergeant's redaction is key-name based; verify the key is listed in `REDACT_KEY_NAMES`.
+
+## Playbooks
+
+- `docs/playbooks/security-pen-test-checklist.md` — full pentest workflow before launch.
+- `docs/playbooks/respond-to-suspected-account-compromise.md` — escalation when credential found in code or logs.
+- `docs/playbooks/rotate-secrets.md` — rotate when a credential is exposed.
+- `docs/playbooks/bump-dep-safely.md` — safe dependency updates after audit findings.
+- Skill catalog: `docs/agents/agent-skills-catalog.md`.

--- a/.agents/skills/sergeant-start-here/SKILL.md
+++ b/.agents/skills/sergeant-start-here/SKILL.md
@@ -40,6 +40,9 @@ lang-reason: Agent-runtime SKILL — body kept EN to maximize tool-calling stabi
 | Незрозуміло, де саме код має жити в монорепо                     | `sergeant-monorepo-boundaries`     |
 | Деплой, env-vars, health checks, Sentry, Railway/Vercel, n8n     | `sergeant-deploy-and-observability`|
 | Логін/сесія/кукі/account lifecycle                               | `better-auth-best-practices`       |
+| Playwright / E2E тести / smoke test / accessibility automation    | `sergeant-e2e-testing`             |
+| Security review, аудит вразливостей, pnpm audit, PAT safety       | `sergeant-security-audit`          |
+| Технічний борг, dead code, ESLint baseline, module-size refactor  | `sergeant-tech-debt`               |
 | Створення / редагування `.agents/skills/**/SKILL.md`             | `sergeant-writing-skills`          |
 
 ## Політика generic-skill-ів

--- a/.agents/skills/sergeant-tech-debt/SKILL.md
+++ b/.agents/skills/sergeant-tech-debt/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: sergeant-tech-debt
+description: Use when reducing technical debt, cleaning dead code with Knip, lowering ESLint baseline violations, or tackling Hard Rule #18 (module-size) refactor sprints in Sergeant; UA: технічний борг, dead code, рефакторинг.
+lang: en
+lang-reason: Agent-runtime SKILL — body kept EN to maximize tool-calling stability across LLM providers (Anthropic, OpenAI, etc.) whose attention bias toward English persists in tool-routing decisions even when prompts are bilingual. The bilingual trigger phrase lives in `description:` so UA-only chat routing still resolves the right SKILL.
+---
+
+# Technical Debt у Sergeant
+
+Technical debt in Sergeant has a taxonomy: the 26 hard rules define what "correct" looks like, and `eslint-baseline.js` + Knip + module-size metrics track how far current code deviates from that standard. Use these tools — not intuition — to prioritize debt work.
+
+## Debt inventory tools
+
+### 1. ESLint baseline (`eslint.baseline.js`)
+
+`eslint.baseline.js` tracks violations that existed before a rule was enabled. Reducing this count is the primary debt-reduction metric for lint-enforced rules.
+
+```bash
+pnpm lint          # run ESLint across all packages
+pnpm lint --fix    # auto-fix fixable violations
+```
+
+The baseline contains 25 rule entries: 6 enforced as errors, 9 disabled (legacy react-hooks v7 suppressions queued for cleanup), remainder as warnings.
+
+To close a baseline violation:
+
+1. Fix the violation in the source code.
+2. Remove the specific entry from `eslint.baseline.js`.
+3. Run `pnpm lint` — it must stay green.
+4. Do not remove baseline entries without fixing the underlying code — that silently re-enables the violation elsewhere.
+
+The 9 disabled react-hooks v7 rules (`set-state-in-effect`, `preserve-manual-memoization`, `purity`, etc.) represent an active cleanup initiative. When working in a file that triggers one, fix it as part of the change.
+
+### 2. Dead code (Knip)
+
+```bash
+pnpm knip          # find unused exports, files, and deps across all workspaces
+```
+
+Knip covers all 5 apps and `packages/`. Setting `ignoreExportsUsedInFile: true` suppresses same-file re-exports as false positives.
+
+Before deleting a Knip finding, apply lifecycle marker guards per `docs/playbooks/cleanup-dead-code.md`:
+
+| Marker | Action |
+|---|---|
+| `@scaffolded` | DO NOT delete — intentional infrastructure |
+| `@deprecated` + `@removeBy <date>`, date not yet reached | Defer until the date; do not delete early |
+| Added < 90 days ago, no marker | Add `@deprecated` + `@removeBy` marker; do not delete |
+| No marker, no consumers, untouched > 12 months | Safe to delete after full monorepo grep |
+
+Full monorepo verification before any deletion:
+
+```bash
+grep -rn "<symbol>" --include="*.{ts,tsx,js,jsx,mjs,cjs,json,md}" .
+```
+
+### 3. Module size (Hard Rule #18 — `active-initiative`)
+
+Hard Rule #18 sets `max-lines: 600` for `apps/web` TS/TSX files as an `active-initiative` ESLint rule.
+
+When a file exceeds 600 lines, decompose by extracting a focused concern — a custom hook, a utility function, or a sub-component — into a sibling file within the same feature folder. Do not move shared logic to `apps/web/src/shared/` unless it truly belongs there; verify boundary with `sergeant-monorepo-boundaries` first.
+
+Do not decompose files solely to pass the lint gate. Decompose when the extraction creates a coherent, independently named unit.
+
+### 4. TypeScript strictness (Hard Rule #19 — `active-initiative`)
+
+Hard Rule #19 requires `noUncheckedIndexedAccess: true` across the monorepo. Existing violations are tracked. When working in a file, fix unguarded index access:
+
+```typescript
+// Incorrect — may throw at runtime if items is empty
+const first = items[0].name;
+
+// Correct — handles undefined safely
+const first = items[0]?.name ?? "default";
+```
+
+## Prioritization
+
+| Type | Priority | Signal |
+|---|---|---|
+| `blocker-invariant` Hard Rule violations (#1–#7, #20, #21) | Highest | Data loss or outage risk |
+| `lint-enforced-convention` with active baseline entries | High | Tracked; clear fix path |
+| Module size violations in high-churn files | Medium | Files touched > 2× per sprint per `git log` |
+| Disabled react-hooks v7 rules | Medium | Enables real-time feedback once fixed |
+| `@deprecated` symbols past `@removeBy` date | Medium | Clean up during related feature work |
+| Low-churn files over 600 lines | Low | Decompose only when already editing the file |
+
+## Separate PRs for separate classes of debt
+
+Do not mix dead-code deletion, baseline reduction, and module decomposition in one PR. These are different risk profiles and different reviewers need to reason about them independently. Keep them as separate PRs.
+
+## What NOT to do
+
+- Do not refactor a file just because it is large — touch it when already changing behavior there.
+- Do not remove `eslint-baseline.js` entries without fixing the underlying code.
+- Do not delete Knip findings without verifying lifecycle markers (Hard Rule #10).
+- Do not move logic to `packages/shared/` without a `sergeant-monorepo-boundaries` check.
+- Do not create a single "cleanup PR" that mixes all three debt classes.
+
+## Playbooks
+
+- `docs/playbooks/cleanup-dead-code.md` — step-by-step dead code removal with lifecycle marker guards.
+- Skill catalog: `docs/agents/agent-skills-catalog.md`.

--- a/docs/agents/agent-skills-catalog.md
+++ b/docs/agents/agent-skills-catalog.md
@@ -33,6 +33,9 @@ pnpm skills:lock    # регенерує SHA-256 у .agents/skills-lock.json п�
 | [`sergeant-monorepo-boundaries`](../../.agents/skills/sergeant-monorepo-boundaries/SKILL.md)           | Unsure where code belongs                 | App vs package placement, shared logic boundaries              |
 | [`sergeant-deploy-and-observability`](../../.agents/skills/sergeant-deploy-and-observability/SKILL.md) | Deploys, env vars, health, Sentry, n8n    | Runtime verification, operator docs, release safety            |
 | [`better-auth-best-practices`](../../.agents/skills/better-auth-best-practices/SKILL.md)               | Login/session/cookie/account lifecycle    | Better Auth wiring, cross-site cookies, auth env safety        |
+| [`sergeant-e2e-testing`](../../.agents/skills/sergeant-e2e-testing/SKILL.md)                           | Playwright E2E tests, smoke tests, a11y   | 8 golden rules, seedFTUX, no waitForTimeout, role selectors    |
+| [`sergeant-security-audit`](../../.agents/skills/sergeant-security-audit/SKILL.md)                     | Security reviews, pnpm audit, PAT/cred safety | Hard Rules #20/#21/#22, Pino redaction, Drizzle SQL, supply chain |
+| [`sergeant-tech-debt`](../../.agents/skills/sergeant-tech-debt/SKILL.md)                               | Tech debt, dead code, ESLint baseline     | Knip, eslint-baseline.js, module-size #18, noUncheckedIndexedAccess #19 |
 | [`sergeant-writing-skills`](../../.agents/skills/sergeant-writing-skills/SKILL.md)                     | Creating or editing `.agents/skills/**`   | TDD-for-skills, frontmatter shape, lock SHA-256, security scan |
 
 ## Preferred Routing by Scenario
@@ -44,6 +47,9 @@ pnpm skills:lock    # регенерує SHA-256 у .agents/skills-lock.json п�
 | Add a DB column safely                   | `sergeant-feature-delivery` + `sergeant-data-and-migrations`                          |
 | Review PR touching server + `api-client` | `sergeant-review-and-merge` + `sergeant-server-api`                                   |
 | Add or change a HubChat tool             | `sergeant-feature-delivery` + `sergeant-hubchat`                                      |
+| Write or debug a Playwright E2E test     | `sergeant-e2e-testing`                                                                |
+| Run a security review or pnpm audit      | `sergeant-security-audit`                                                             |
+| Reduce tech debt, dead code, ESLint baseline | `sergeant-tech-debt`                                                              |
 | Port a screen from web to Expo           | `sergeant-feature-delivery` + `sergeant-mobile-expo` + `sergeant-monorepo-boundaries` |
 | Change auth or cookies                   | `better-auth-best-practices` and only then the touched surface skill                  |
 | Ship env or deploy changes               | `sergeant-deploy-and-observability`                                                   |

--- a/docs/agents/skills-evolution-roadmap.md
+++ b/docs/agents/skills-evolution-roadmap.md
@@ -146,7 +146,7 @@ PR проходить у roadmap, якщо він задовольняє всі 
 
 ---
 
-### PR 4 — `sergeant-e2e-testing` skill (≈2 дні, M)
+### PR 4 — `sergeant-e2e-testing` skill (≈2 дні, M) ✅ (in progress: claude/review-ai-agents-templates-JQOrZ, 2026-05-16)
 
 **Проблема.** Sergeant використовує Playwright для E2E (див. `apps/web` test-stack), але немає specialist-skill-у про Playwright-discipline. `sergeant-web-ui` згадує a11y і design tokens, але golden-rules для Playwright (web-first assertions, fixtures over globals, traces='on-first-retry', retries=2-in-CI/0-locally, ніколи `page.waitForTimeout()`) — розкидані по PR-описах і не enforce-ні.
 
@@ -342,6 +342,64 @@ PR проходить у roadmap, якщо він задовольняє всі 
 
 ---
 
+### PR 10 — `sergeant-security-audit` skill (≈1 день, M) 🔄 (in progress: claude/review-ai-agents-templates-JQOrZ, 2026-05-16)
+
+**Проблема.** Sergeant має Hard Rules #20 (PAT safety), #21 (Pino redaction), #22 (skill security scan) і playbook `security-pen-test-checklist.md`, але немає specialist-skill-у, що веде агента через security review. Агент без цього skill-у системно пропускає Sergeant-specific вектори: перевірку `REDACT_KEY_NAMES` у `@sergeant/shared/lib/pii.ts`, Drizzle `sql\`...\`` injection, `pnpm audit` (не `npm audit`) для workspace-монорепо.
+
+**Скоуп.**
+
+- Створити `.agents/skills/sergeant-security-audit/SKILL.md`.
+- Покрити: Hard Rules #20/#21/#22, Pino redaction walker у `apps/server/src/obs/logger.ts`, Drizzle ORM SQL injection vector, pnpm audit, Better Auth session enforcement, frontend TypedStore, mobile MMKV, severity triage.
+- Оновити `agent-skills-catalog.md` і routing у `sergeant-start-here`.
+
+**Acceptance criteria.**
+
+- `pnpm lint:skills` зелений (shape + SHA-256 + security scan).
+- Routing-рядок у `sergeant-start-here` для "Security review, pnpm audit, PAT safety".
+- Кожна секція посилається на конкретний шлях у репо або команду.
+
+**Files touched.**
+
+- `.agents/skills/sergeant-security-audit/SKILL.md`.
+- `.agents/skills/sergeant-start-here/SKILL.md` (routing-таблиця).
+- `.agents/skills-lock.json`.
+- `docs/agents/agent-skills-catalog.md`.
+
+**References.**
+
+- aitmpl.com: `security/security-auditor`, `security/api-security-audit`, `security/supply-chain-security` — натхнення для структури, адаптовано під Sergeant-specific hard rules.
+
+---
+
+### PR 11 — `sergeant-tech-debt` skill (≈1 день, M) 🔄 (in progress: claude/review-ai-agents-templates-JQOrZ, 2026-05-16)
+
+**Проблема.** 26 hard rules визначають taxonomy технічного боргу, але немає specialist-skill-у, що систематично веде агента через `eslint-baseline.js`, Knip, Hard Rule #18 (module-size), Hard Rule #19 (noUncheckedIndexedAccess). Агент без цього skill-у міксує різні класи боргу в один PR або видаляє код без перевірки lifecycle markers.
+
+**Скоуп.**
+
+- Створити `.agents/skills/sergeant-tech-debt/SKILL.md`.
+- Покрити: eslint-baseline.js (25 rules, 9 disabled react-hooks v7), Knip lifecycle marker guards, module-size decomposition strategy (Hard Rule #18), noUncheckedIndexedAccess guards (Hard Rule #19), prioritization matrix, "окремі PRs для різних класів боргу" правило.
+- Оновити `agent-skills-catalog.md` і routing у `sergeant-start-here`.
+
+**Acceptance criteria.**
+
+- `pnpm lint:skills` зелений.
+- Routing-рядок у `sergeant-start-here` для "Технічний борг, dead code, ESLint baseline".
+- Чітке правило: не змішувати dead-code deletion, baseline reduction і module decomposition в одному PR.
+
+**Files touched.**
+
+- `.agents/skills/sergeant-tech-debt/SKILL.md`.
+- `.agents/skills/sergeant-start-here/SKILL.md` (routing-таблиця).
+- `.agents/skills-lock.json`.
+- `docs/agents/agent-skills-catalog.md`.
+
+**References.**
+
+- aitmpl.com: `development-tools/technical-debt-manager` — натхнення для структури аудиту; адаптовано під Sergeant's eslint-baseline.js і Knip замість generic complexity-метрик.
+
+---
+
 ## Priority matrix
 
 | #   | PR                                | Effort | Value-per-hour | Dependencies        | Status   |
@@ -349,12 +407,14 @@ PR проходить у roadmap, якщо він задовольняє всі 
 | 1   | Pushy descriptions audit          | S      | High           | none                | ✅ #2374 |
 | 2   | Verification gate in review skill | S      | **Highest**    | none                | ✅ #2373 |
 | 3   | Postgres references               | M      | High           | (no hard dep)       |          |
-| 4   | E2E testing skill                 | M      | Medium         | (no hard dep)       |          |
+| 4   | E2E testing skill                 | M      | Medium         | (no hard dep)       | 🔄 in progress |
 | 5   | Security body-scan in lint:skills | M      | High           | none                | ✅ #2378 |
 | 6   | References folder convention      | S      | Medium         | depends on PR 3 / 4 |          |
 | 7   | Skill evals (substring)           | L      | Medium-High    | depends on PR 1     |          |
 | 8   | Real-LLM eval runner              | L      | Medium         | depends on PR 7     |          |
 | 9   | PR template cross-link            | S      | High           | depends on PR 2     | ✅ #2375 |
+| 10  | `sergeant-security-audit` skill   | M      | High           | none                | 🔄 in progress |
+| 11  | `sergeant-tech-debt` skill        | M      | High           | none                | 🔄 in progress |
 
 **Recommended starting order:** PR 2 → PR 1 → PR 5 → PR 9 → PR 3 → PR 6 → PR 4 → PR 7 → PR 8.
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Три нові Sergeant skills, натхнені aitmpl.com agent templates, але повністю адаптовані під Sergeant's hard rules, конкретні шляхи репо та pnpm toolchain. Жоден generic-темплейт не імпортовано as-is — це **import-of-patterns**, як описано в `docs/agents/skills-evolution-roadmap.md`.

### Новий skill: `sergeant-security-audit`

Натхнення: aitmpl `security/security-auditor` + `api-security-audit` + `supply-chain-security`.

Покриває те, що агент без цього skill-у системно пропускає в Sergeant:
- Hard Rules #20 (No OpenClaw PATs), #21 (Pino redaction), #22 (skill body scan)
- Pino redaction через `@sergeant/shared/lib/pii.ts` → `apps/server/src/obs/logger.ts`
- Drizzle ORM `sql\`...\`` injection vector (не generic "SQL injection")
- `pnpm audit` (не `npm audit`) для workspace-монорепо з jq-фільтром high/critical
- Better Auth session enforcement на кожному route в `apps/server/src/modules/`
- TypedStore boundary для `localStorage` в `apps/web`
- Severity triage з конкретними playbook-escalation paths

### Новий skill: `sergeant-e2e-testing`

Реалізує roadmap **PR 4** з `docs/agents/skills-evolution-roadmap.md`.

Натхнення: aitmpl Playwright agents + `testdino-hq/playwright-skill`.

8 golden rules адаптовані під **фактичний** `apps/web/playwright.config.ts`:
- `trace: "retain-on-failure"` (не `"on"` — bloats CI)
- `workers: 1` — shared preview server constraint
- `seedFTUX` (`apps/web/tests/utils/seedFTUX.ts`) замість UI-driven login в beforeEach
- `screenshot: "only-on-failure"` — тільки `ds-visual-qa.spec.ts` має baseline

4 reference files у `references/`:
- `selectors.md` — role > label > text > testid > CSS hierarchy
- `network-mocking.md` — коли MSW, коли `page.route()`, коли не мокати (Better Auth)
- `auth-flow.md` — seedFTUX modes + Better Auth HttpOnly cookie constraints
- `traces-and-debugging.md` — `--ui`, `PWDEBUG=1`, `show-trace`, CI artifact retrieval

### Новий skill: `sergeant-tech-debt`

Натхнення: aitmpl `development-tools/technical-debt-manager`.

Покриває Sergeant-specific debt taxonomy через наявні інструменти:
- `eslint-baseline.js` — 25 rules, 9 disabled react-hooks v7 (cleanup initiative)
- Knip + lifecycle markers (`@scaffolded`, `@deprecated` + `@removeBy`)
- Hard Rule #18 module-size decomposition strategy (≤600 lines, apps/web TS/TSX)
- Hard Rule #19 `noUncheckedIndexedAccess` guards при роботі з `arr[i]`
- Prioritization matrix: blocker-invariant > lint-enforced > churn-based
- Дисципліна: dead-code, baseline, module-size — **три окремих PRs**

### Оновлення інфраструктури

- `sergeant-start-here/SKILL.md` — 3 нових routing rows
- `docs/agents/agent-skills-catalog.md` — 3 нових рядки в Active Skills + routing scenarios
- `docs/agents/skills-evolution-roadmap.md` — PR 4 marked in progress; PR 10/11 додано з full spec
- `.agents/skills-lock.json` — SHA-256 для 17 skills (було 14)

## Verification

```
pnpm lint:skills
# [lint:skills] OK — 17 skill(s) pass shape contract (frontmatter + grounding + playbook link).
# [lint:skills] OK — 17 skill(s) match SHA-256 in skills-lock.json.
# [lint:skills:security] OK — 17 skill(s) pass body security scan (7 threat categories).
```

## Audit-freeze compliance

Жоден файл з frozen pathspec не зачеплений:
- ❌ `docs/audits/` — не торкались
- ❌ `docs/initiatives/` — не торкались
- ❌ `docs/playbooks/` — не торкались (тільки лінкуємо на існуючі)
- ❌ `docs/adr/` — не торкались
- ✅ `docs/agents/` — дозволено freeze-ом

https://claude.ai/code/session_01SssWcJ2DdLYah6toSt5fJ3
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SssWcJ2DdLYah6toSt5fJ3)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three agent skills tailored to our repo and hard rules: security audits, Playwright E2E testing, and technical debt management. This tightens test discipline, closes common security gaps, and standardizes debt workflows; routing and docs updated.

- **New Features**
  - `sergeant-security-audit`: Enforces Hard Rules #20/#21/#22, Pino redaction via `@sergeant/shared/lib/pii.ts`, checks Drizzle `sql\`...\`` risk, runs `pnpm audit`, verifies Better Auth on routes, guards TypedStore, and adds severity triage.
  - `sergeant-e2e-testing`: 8 Playwright rules aligned with `apps/web/playwright.config.ts` (web-first assertions, no `waitForTimeout`, role-first selectors, `trace: "retain-on-failure"`, `workers: 1`, `seedFTUX` state), plus references for selectors, network mocking, auth flow, and traces.
  - `sergeant-tech-debt`: Guides `eslint-baseline.js` cleanup, Knip with lifecycle markers, module-size decomposition (Hard Rule #18), `noUncheckedIndexedAccess` guards (Hard Rule #19), and “separate PRs per debt class”.

- **Dependencies**
  - Updated `.agents/skills-lock.json` with SHA-256 entries for 17 skills.

<sup>Written for commit f0581fa8e5b34ada54fb221ef214e86644099c33. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/2925?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

