### PR TITLE
fix(web): throw ChunkLoadError on undefined module instead of hanging Suspense

### DIFF
--- a/apps/web/src/core/lib/lazyImport.test.ts
+++ b/apps/web/src/core/lib/lazyImport.test.ts
@@ -1,8 +1,9 @@
 /** @vitest-environment jsdom */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createElement, type ComponentType } from "react";
 
-import { lazyImport } from "./lazyImport";
+import { lazyImport, lazyDefault } from "./lazyImport";
+import { isChunkLoadError } from "./chunkReload";
 
 function Hello() {
   return createElement("span", null, "hello");
@@ -15,13 +16,10 @@ function Hello() {
  * assert the loader's eventual settlement, not React's render pipeline.
  */
 function getLoaderPromise(
-  Lazy: ReturnType<typeof lazyImport>,
+  Lazy: ReturnType<typeof lazyImport> | ReturnType<typeof lazyDefault>,
 ): Promise<unknown> {
   const payload = (Lazy as unknown as { _payload: { _result: unknown } })
     ._payload;
-  // React.lazy stores either the thenable (status === uninitialized) or
-  // a settled value. The thenable triggers the underlying loader on first
-  // read; calling it manually is enough.
   const result = payload._result;
   if (typeof result === "function") {
     return Promise.resolve((result as () => Promise<unknown>)());
@@ -33,6 +31,32 @@ function getLoaderPromise(
 }
 
 describe("lazyImport", () => {
+  // `recoverFromStaleChunk` calls `window.location.reload()` through
+  // `reloadOnceForChunkError`. JSDOM throws "Not implemented" on real
+  // reloads, so we stub the whole `location` to a no-op double for the
+  // undefined-module cases. Other tests don't need this — they never
+  // hit the recovery path.
+  let originalLocation: Location;
+  beforeEach(() => {
+    originalLocation = window.location;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: { ...originalLocation, reload: vi.fn() },
+    });
+    // Reset chunkReload session-storage counters between tests so the
+    // cooldown / MAX_RELOADS guards don't carry over and prevent reload
+    // (which would change the observable side-effect under test).
+    window.sessionStorage.clear();
+  });
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: originalLocation,
+    });
+  });
+
   it("returns the named export wrapped as a default-export module", async () => {
     const Lazy = lazyImport(async () => ({ Hello }), "Hello");
     const resolved = (await getLoaderPromise(Lazy)) as {
@@ -41,37 +65,88 @@ describe("lazyImport", () => {
     expect(resolved.default).toBe(Hello);
   });
 
-  it("hangs forever when the module resolves to undefined (vite preload-error suppression)", async () => {
+  it("throws ChunkLoadError when module resolves to undefined (vite preload-error suppression)", async () => {
     // Reproduces the real failure mode: `chunkReload.ts` preventDefault'd
     // the `vite:preloadError`, so Vite's preload helper resolves the
-    // dynamic import with `undefined`. A naive `m.X` would throw with
-    // `TypeError: undefined is not an object (evaluating 'm.X')` and
-    // pollute Sentry while `window.location.reload()` is in flight.
+    // dynamic import with `undefined`. The previous strategy was to
+    // hang Suspense forever; that left the user permanently stuck when
+    // the chunkReload reload-guard suppressed the recovery reload (real
+    // incident 2026-05-16). The new contract: throw a ChunkLoadError so
+    // ErrorBoundary surfaces a visible fallback and the global
+    // unhandledrejection handler counts it toward Sentry telemetry.
     const Lazy = lazyImport(
       async () => undefined as unknown as { Hello: typeof Hello },
       "Hello",
     );
-    const loader = getLoaderPromise(Lazy);
 
-    const settled = await Promise.race([
-      loader.then(
-        (v) => ["resolved", v] as const,
-        (e) => ["rejected", e] as const,
-      ),
-      new Promise<["timeout"]>((resolve) =>
-        setTimeout(() => resolve(["timeout"]), 50),
-      ),
-    ]);
-    expect(settled[0]).toBe("timeout");
+    await expect(getLoaderPromise(Lazy)).rejects.toSatisfy(
+      (err: unknown) => isChunkLoadError(err),
+    );
   });
 
-  it("propagates loader rejections to React.lazy", async () => {
+  it("triggers a single location.reload() when the module resolves to undefined", async () => {
+    const reload = window.location.reload as ReturnType<typeof vi.fn>;
+    const Lazy = lazyImport(
+      async () => undefined as unknown as { Hello: typeof Hello },
+      "Hello",
+    );
+    await getLoaderPromise(Lazy).catch(() => {
+      /* expected — see assertion below */
+    });
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates real loader rejections to React.lazy unchanged", async () => {
     const boom = new Error("real chunk load failure");
     const Lazy = lazyImport<{ Hello: typeof Hello }, "Hello">(
       () => Promise.reject(boom),
       "Hello",
     );
 
+    await expect(getLoaderPromise(Lazy)).rejects.toBe(boom);
+  });
+});
+
+describe("lazyDefault", () => {
+  let originalLocation: Location;
+  beforeEach(() => {
+    originalLocation = window.location;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: { ...originalLocation, reload: vi.fn() },
+    });
+    window.sessionStorage.clear();
+  });
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: originalLocation,
+    });
+  });
+
+  it("passes through a real { default: Component } payload", async () => {
+    const Lazy = lazyDefault(async () => ({ default: Hello }));
+    const resolved = (await getLoaderPromise(Lazy)) as {
+      default: ComponentType<unknown>;
+    };
+    expect(resolved.default).toBe(Hello);
+  });
+
+  it("throws ChunkLoadError when the module resolves to undefined", async () => {
+    const Lazy = lazyDefault(
+      async () => undefined as unknown as { default: typeof Hello },
+    );
+
+    await expect(getLoaderPromise(Lazy)).rejects.toSatisfy(
+      (err: unknown) => isChunkLoadError(err),
+    );
+  });
+
+  it("propagates real loader rejections unchanged", async () => {
+    const boom = new Error("real chunk load failure");
+    const Lazy = lazyDefault<typeof Hello>(() => Promise.reject(boom));
     await expect(getLoaderPromise(Lazy)).rejects.toBe(boom);
   });
 });

--- a/apps/web/src/core/lib/lazyImport.ts
+++ b/apps/web/src/core/lib/lazyImport.ts
@@ -1,4 +1,5 @@
 import { lazy, type ComponentType, type LazyExoticComponent } from "react";
+import { reloadOnceForChunkError } from "./chunkReload";
 
 /**
  * `React.lazy()` wrappers that survive Vite preload-error suppression.
@@ -19,15 +20,41 @@ import { lazy, type ComponentType, type LazyExoticComponent } from "react";
  * 'm.X')` (real Sentry noise from iOS Safari sessions hitting stale
  * Vercel chunk URLs — `e.AuthPage`, etc.). A bare
  * `lazy(() => import("./X"))` for a default export hits the same shape
- * (`m.default` of undefined). The error is harmless
- * (`window.location.reload()` is already in flight), but it crashes
- * Suspense's loader and reports to Sentry every time a deploy lands
- * while users have the app open.
+ * (`m.default` of undefined).
  *
- * Both helpers detect the undefined-module case and return a
- * never-resolving promise, so Suspense keeps showing the existing
- * fallback while navigation completes — no Sentry spam, no flash of
- * a broken screen.
+ * ## Recovery contract (two-layer)
+ *
+ * When the helper detects the undefined-module case (Vite preload was
+ * preventDefault'd OR a Service Worker resolved the preload with empty
+ * content), it does TWO things:
+ *
+ * 1. **Trigger `reloadOnceForChunkError()`** — same recovery path that
+ *    `vite:preloadError` and `unhandledrejection` listeners use. If
+ *    chunkReload's `COOLDOWN_MS` / `MAX_RELOADS` guards allow it, the
+ *    page reloads onto the fresh bundle.
+ *
+ * 2. **Throw a `ChunkLoadError`** — React's `lazy()` surfaces the
+ *    rejection to the nearest `<ErrorBoundary>`, which renders the
+ *    section-fallback (with retry button) instead of a frozen Suspense
+ *    skeleton. The error name matches `isChunkLoadError()` so the
+ *    existing global `unhandledrejection` / `error` listeners also
+ *    catch it as a chunk-load failure for telemetry purposes.
+ *
+ * **Why this replaces the previous `neverResolves()` strategy** — that
+ * helper kept Suspense in fallback indefinitely on the assumption that
+ * `chunkReload.ts` would always reload the page "in flight". Two real
+ * paths violated that assumption: (a) `reloadOnceForChunkError()`
+ * returns `false` after `MAX_RELOADS=3` reloads in a 5-min window or
+ * during the 10-second cooldown → no reload happens, helper hangs
+ * forever; (b) a Service Worker can resolve the `__vitePreload` fetch
+ * with `undefined` WITHOUT a `vite:preloadError` event being fired at
+ * all, so `chunkReload` never gets the chance to schedule a reload.
+ * In both cases the user was permanently stuck on a frozen skeleton
+ * (reported 2026-05-16: dashboard nav targets, module pages, sign-in,
+ * reports tab all permanently suspended on a SW-warm session). Throwing
+ * a `ChunkLoadError` keeps the original Sentry-suppression intent
+ * (single named error class, easy to filter) while guaranteeing the
+ * user always reaches either the new bundle or a visible error UI.
  */
 
 // `ComponentType<any>` (rather than `<unknown>`) keeps callers' specific
@@ -44,7 +71,7 @@ export function lazyImport<
 >(loader: () => Promise<M>, key: K): LazyExoticComponent<M[K]> {
   return lazy(() =>
     loader().then((m) =>
-      m ? { default: m[key] } : neverResolves<{ default: M[K] }>(),
+      m ? { default: m[key] } : recoverFromStaleChunk<{ default: M[K] }>(),
     ),
   );
 }
@@ -54,16 +81,35 @@ export function lazyDefault<T extends AnyComponent>(
   loader: () => Promise<{ default: T }>,
 ): LazyExoticComponent<T> {
   return lazy(() =>
-    loader().then((m) => (m ? m : neverResolves<{ default: T }>())),
+    loader().then((m) => (m ? m : recoverFromStaleChunk<{ default: T }>())),
   );
 }
 
-// Vite preload helper resolved with `undefined` because `chunkReload.ts`
-// preventDefault'd the `vite:preloadError` and triggered
-// `window.location.reload()`. Hang Suspense until navigation completes —
-// neither rendering a broken tree nor reporting a phantom error to Sentry.
-// The promise type is a phantom — at runtime this never settles, so the
-// `T` is just there to flow through `.then`'s resolved-value generic.
-function neverResolves<T>(): Promise<T> {
-  return new Promise<T>(() => {});
+/**
+ * Called when `__vitePreload` resolved the dynamic import with
+ * `undefined` (preload-error preventDefault'd, or a Service Worker
+ * answered the preload fetch with an empty/HTML body that Vite couldn't
+ * evaluate as a module). Triggers the canonical chunk-reload escape
+ * hatch and then throws a `ChunkLoadError` so callers can't accidentally
+ * use a "successful" undefined module.
+ *
+ * Returning `never` (via `throw`) lets the call-site type-check
+ * `m ? {default: m[key]} : recoverFromStaleChunk<...>()` without
+ * forcing an explicit `as never` cast at every helper.
+ */
+function recoverFromStaleChunk<T>(): T {
+  // Best-effort reload. Returns `false` if the cooldown / counter
+  // guards in chunkReload block it; in that case the throw below still
+  // takes the user to a visible ErrorBoundary fallback (with retry)
+  // instead of a frozen Suspense skeleton.
+  reloadOnceForChunkError();
+  // Match `isChunkLoadError()` patterns so the existing global
+  // `unhandledrejection` and `error` listeners count this toward the
+  // chunk-failure budget and surface it in Sentry under the same key
+  // as native `Failed to fetch dynamically imported module` errors.
+  const err = new Error(
+    "Vite preload resolved with undefined module — likely a stale chunk after deploy or a Service Worker intercept",
+  );
+  err.name = "ChunkLoadError";
+  throw err;
 }


### PR DESCRIPTION
## Summary

- Замінює `neverResolves()` у [lazyImport.ts](apps/web/src/core/lib/lazyImport.ts) на throw `ChunkLoadError` + best-effort `reloadOnceForChunkError()` — щоб користувач більше ніколи не залишався на замороженому Suspense fallback.
- Закриває **усі 20+ симптомів** одного інциденту (Звіти, sign-in, всі модулі, всі inner-сторінки модулів) одною точковою правкою.

## Background — інцидент 2026-05-16

Користувач на `sergeant.vercel.app` повідомив: «модулі не відкриваються, Звіти показують безкінечні скелетони, Профіль/Увійти не відкриває». При живому debug-у через DevTools MCP підтвердив:

- Всі JS chunks завантажуються 200 (без 404 / chunk-load errors)
- Console чистий (тільки OPFS warning + analytics)
- React.lazy на `HubReports`/`AuthPage`/`FinykApp` etc. **застряглі в pending forever** — Suspense fallback (`PageLoader` skeleton) тримається безкінечно
- DOM показує fallback, але React fiber tree повідомляє Suspense in primary mode → невідповідність вказує що `lazy()` loader повернув never-resolving promise
- Перевірив: пряма `import('/assets/HubReports-...js')` resolve-иться за 27 мс з валідним module — тобто chunk доступний, тільки в`React.lazy` payload він заморожений
- Після `unregister SW + clear caches + hard reload` — все працює (підтверджено: відкрив усі модулі + інні сторінки + sign-in)

## Root cause (точне)

PR [a236505b](https://github.com/Skords-01/Sergeant/commit/a236505b) (May 2 2026) додав `neverResolves()` для приховування `TypeError: undefined is not an object (evaluating 'm.AuthPage')` з iOS Safari під час stale-deploy. Логіка: коли `chunkReload.ts` робить `event.preventDefault()` на `vite:preloadError`, Vite resolve-ить import з `undefined`, помічник тримає Suspense поки `location.reload()` «в польоті».

Два припущення, які зламались:

1. **`reloadOnceForChunkError()` може повернути `false`** через `COOLDOWN_MS=10s` (Layer 1) або `MAX_RELOADS=3/5min` (Layer 2) у [chunkReload.ts](apps/web/src/core/lib/chunkReload.ts). Тоді reload не виконується → Suspense висить навіки.
2. **`vite:preloadError` може не випуститись** якщо Service Worker (workbox-precache) intercept-ить preload-fetch і повертає 200 + порожнє/HTML тіло. `__vitePreload` resolve-ить з `undefined` тихо, chunkReload не знає що треба reload → reload не плануєтся взагалі.

В обох випадках — frozen Suspense per-lazy. Це сталось у warm SW-сесії користувача.

## Fix

Заміна `neverResolves()` на `recoverFromStaleChunk<T>()`:

```ts
function recoverFromStaleChunk<T>(): T {
  reloadOnceForChunkError();              // best-effort canonical reload
  const err = new Error("Vite preload resolved with undefined module — ...");
  err.name = \"ChunkLoadError\";          // matches isChunkLoadError()
  throw err;
}
```

Два рівні захисту:
1. **Reload запускається** через канонічний шлях chunkReload (idempotent з cooldown/counter)
2. **Якщо reload заблокований** — throw → React.lazy реджект → ErrorBoundary в [HubMainContent](apps/web/src/core/app/HubMainContent.tsx:54) показує `HubSectionFallback` з кнопкою «Спробувати ще раз». Глобальні `unhandledrejection` / `error` listeners теж зловлять (через `isChunkLoadError` name-branch) і додадуть до chunk-failure budget / Sentry telemetry.

Original Sentry-suppression intent зберігається — це одна named error class яку легко фільтрувати.

## Поверхні, які закриває цей фікс

- `HubReports`, `HubSettingsPage`, `ProfilePage` (через HubMainContent)
- `AuthPage`, `WelcomeScreen`, `ResetPasswordPage`, `DesignShowcase`, `AssistantCataloguePage`, `PricingPage`, `LandingPage`, `StatusPage`, `HubChatPage`, `NotFoundPage` (через StandaloneRoutes)
- `FinykApp`, `FizrukApp`, `NutritionApp`, `RoutineApp` (через ActiveModuleView)
- `Transactions`, `Budgets`, `Assets`, `Analytics` (Finyk inner pages)
- `ReactQueryDevtools` (main.tsx, dev-only)

Всі через `lazyImport`/`lazyDefault` → всі отримують нову поведінку без жодних змін у call-site-ах.

## Out of scope

- `chunkReload.ts` reload-guards (`COOLDOWN_MS`, `MAX_RELOADS`, `RESET_AFTER_MS`) залишаються як є.
- Окремий Redis-side ETIMEDOUT інцидент на `sergeant-api` (`auth-mail-worker` / `ftux-drip-worker` / `ai-memory-ingest-worker`) — не пов'язаний з цим фіксом, відстежується окремо.
- CSP Report-Only warnings для `feedback-live` + Sentry Spotlight — окремий PR.
- OPFS sqlite3_vfs Cross-Origin Isolation headers — окремий PR.

## Test plan

- [ ] CI: \`pnpm lint\` пройшов на змінених файлах
- [ ] CI: \`pnpm typecheck\` — нова \`recoverFromStaleChunk<T>(): T\` через throw компілюється
- [ ] CI: \`pnpm test\` — нові юніти у [lazyImport.test.ts](apps/web/src/core/lib/lazyImport.test.ts):
  - happy path (lazyImport + lazyDefault)
  - undefined → throws ChunkLoadError (для обох)
  - undefined → triggers single \`location.reload()\`
  - real loader rejection propagates unchanged
- [ ] CI: [chunkReload.test.ts](apps/web/src/core/lib/chunkReload.test.ts) regression — інтеграція з \`isChunkLoadError(name === 'ChunkLoadError')\`
- [ ] Manual after merge — Vercel preview:
  - відкрити preview з активним SW з попередньої сесії → перевірити що жодна lazy-сторінка не залишається з frozen skeleton
  - якщо все resolve-нулось — fix підтверджено
  - якщо frozen — перевірити Sentry на новий ChunkLoadError event (signal що reload-guard заблокував)
- [ ] (Опційно після merge) `/ultrareview` — це системно-критичний шлях через всі lazy-chunks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents frozen Suspense skeletons when a dynamic import resolves to undefined by throwing a `ChunkLoadError` and triggering a best‑effort reload. Lazy routes now either recover via reload or show an error state, instead of hanging (affecting modules, reports, and sign‑in).

- **Bug Fixes**
  - Replace `neverResolves()` with `recoverFromStaleChunk()` that calls `reloadOnceForChunkError()` and throws `ChunkLoadError`.
  - Errors surface to ErrorBoundaries; global handlers still match via `isChunkLoadError` for telemetry.
  - Applies to all `lazyImport`/`lazyDefault` call sites automatically.
  - Tests update: assert `ChunkLoadError` on undefined, single `location.reload()`, and unchanged propagation of real loader rejections.

<sup>Written for commit 95f30983c594153e12c459836142aab655a782ea. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/2928?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for failed lazy module loading. The app now attempts recovery through page reload and displays errors to users instead of causing the UI to hang indefinitely.

* **Tests**
  * Expanded test coverage for lazy module loading and error recovery scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Skords-01/Sergeant/pull/2928?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->