### PR TITLE
fix(server): disable strict tool use on TOOLS (Anthropic 20-tool cap)

### DIFF
--- a/apps/server/src/modules/chat/toolDefs/strict.test.ts
+++ b/apps/server/src/modules/chat/toolDefs/strict.test.ts
@@ -187,7 +187,14 @@ describe("applyStrictModeToAll (масив)", () => {
   });
 });
 
-describe("TOOLS (агрегований Anthropic-payload)", () => {
+// INCIDENT 2026-05-16: strict-mode на агрегованому TOOLS вимкнено, бо
+// Anthropic API має ліміт 20 strict tools на запит, а в нас 66 — щохвилини
+// падало 400 `Too many strict tools (66)`. Інваріанти strict-режиму на
+// TOOLS не виконуються до того моменту, як ми переробимо стратегію
+// (opt-in на ≤20 high-value tools). Сам декоратор `applyStrictMode` і
+// його одиничні тести вище лишилися активні — інфра готова до повторної
+// активації, але вже точково.
+describe.skip("TOOLS (агрегований Anthropic-payload)", () => {
   it("є непорожній", () => {
     expect(TOOLS.length).toBeGreaterThan(0);
   });
@@ -229,6 +236,30 @@ describe("TOOLS (агрегований Anthropic-payload)", () => {
   it("input_schema root `type` завжди `object`", () => {
     for (const tool of TOOLS) {
       expect(tool.input_schema["type"]).toBe("object");
+    }
+  });
+});
+
+describe("TOOLS (агрегований Anthropic-payload — post-incident invariants)", () => {
+  it("є непорожній", () => {
+    expect(TOOLS.length).toBeGreaterThan(0);
+  });
+
+  it("input_schema root `type` завжди `object`", () => {
+    for (const tool of TOOLS) {
+      expect(tool.input_schema["type"]).toBe("object");
+    }
+  });
+
+  // Strict mode тимчасово знятий — Anthropic ліміт 20 strict tools на запит,
+  // а в нас 66. Інваріант: жоден tool НЕ повинен мати strict, поки не буде
+  // селективної активації. Це guard від випадкового реверту інциденту.
+  it("жоден tool не має strict-режиму (Anthropic 20-tool cap)", () => {
+    for (const tool of TOOLS) {
+      expect(
+        tool.strict,
+        `tool "${tool.name}" не повинен мати strict до селективної активації`,
+      ).not.toBe(true);
     }
   });
 });

--- a/apps/server/src/modules/chat/tools.ts
+++ b/apps/server/src/modules/chat/tools.ts
@@ -9,11 +9,13 @@
  * блоки від моделі й отримує назад `tool_results` — тому змінювати сигнатури
  * tools треба синхронно з frontend-виконавцями (`src/core/lib/hubChatActions.ts`).
  *
- * `applyStrictModeToAll` обгортає весь масив у Anthropic Strict tool use —
- * grammar-constrained sampling гарантує, що `tool_use.input` від моделі завжди
- * матчить наш JSON Schema. Це усуває retry через invalid JSON (TR-2026-05 §9,
- * issue #261). Сирі domain-арeі залишаються без `strict`/`additionalProperties`,
- * щоб одна точка вмикала/вимикала режим (toggle тут, не в 8 файлах).
+ * INCIDENT 2026-05-16: `applyStrictModeToAll` (PR 830c1342) обгортав весь
+ * масив у Anthropic Strict tool use. Anthropic API має жорсткий ліміт
+ * **20 strict tools на запит**, а в нас 66 — тож кожен `/api/chat` падав
+ * із 400 `Too many strict tools (66)`. Unit-тести верифікували `strict: true`
+ * на кожному tool, але не били реальний Anthropic — регресія пройшла повз.
+ * Strict-режим знятий до того моменту, як ми переробимо стратегію
+ * (opt-in per-tool на ≤20 high-value tools, або waivers від Anthropic).
  */
 
 export type { AnthropicTool } from "./toolDefs/types.js";
@@ -25,11 +27,10 @@ import { NUTRITION_TOOLS } from "./toolDefs/nutrition.js";
 import { CROSS_MODULE_TOOLS } from "./toolDefs/crossModule.js";
 import { UTILITY_TOOLS } from "./toolDefs/utility.js";
 import { MEMORY_TOOLS } from "./toolDefs/memory.js";
-import { applyStrictModeToAll } from "./toolDefs/strict.js";
 
 import type { AnthropicTool } from "./toolDefs/types.js";
 
-export const TOOLS: AnthropicTool[] = applyStrictModeToAll([
+export const TOOLS: AnthropicTool[] = [
   ...FINYK_TOOLS,
   ...ROUTINE_TOOLS,
   ...FIZRUK_TOOLS,
@@ -37,7 +38,7 @@ export const TOOLS: AnthropicTool[] = applyStrictModeToAll([
   ...CROSS_MODULE_TOOLS,
   ...UTILITY_TOOLS,
   ...MEMORY_TOOLS,
-]);
+];
 
 export {
   SYSTEM_PREFIX,


### PR DESCRIPTION
INCIDENT 2026-05-16. Hub Chat і Inline AI Rail на проді повертали 400 на кожному запиті. Прямий тест /api/v1/chat показав, що Anthropic API відмовляє payload-у ще на pre-flight валідації:

  HTTP 400  code: EXTERNAL_SERVICE
  "Too many strict tools (66). The maximum number of strict tools
   supported is 20. Try reducing the number of tools marked as strict."

Регресія з PR 830c1342 (9 травня) — applyStrictModeToAll(TOOLS) обгортав всі 66 інструментів strict:true, не врахувавши документований Anthropic ліміт 20 strict tools на запит. Unit-тести верифікували інваріант "кожен tool має strict: true" і пройшли, але реального Anthropic не били — класичний випадок, де контрактний тест із моком api.anthropic.com зловив би проблему ще в PR.

Чому circuit breaker не спрацював: circuitBreakers.anthropic.state лишався closed, failures: 0 — 400 трактується як validation error, breaker його не лічить як execution failure. Тому Grafana-алерти мовчали з 9 травня по 16 травня.

Що змінено:
- apps/server/src/modules/chat/tools.ts — прибрав applyStrictModeToAll(...) обгортку. TOOLS повертається до raw aggregation без strict-режиму, як було до 9 травня. Сам декоратор applyStrictMode і його 13 unit-тестів лишилися — інфраструктура готова до селективної активації на ≤20 high-value tools через applyStrictMode(tool) точково.
- apps/server/src/modules/chat/toolDefs/strict.test.ts — describe.skip на блок "TOOLS (агрегований Anthropic-payload)" з incident-коментарем; додано новий блок "post-incident invariants", що активно перевіряє "жоден tool не має strict-режиму" — guard від випадкового реверту.

Impact map (підтверджено curl-пробою на prod):
- Hub Chat і Inline AI Rail (/api/chat) — фіксяться.
- Weekly digest, Coach insight, Nutrition photo, Day hint — не зачеплені (не використовують TOOLS, окремі Anthropic-flow-и).

Окремо (не в цьому PR): /healthz показав
redis: degraded, connected: false, reconnectAttempts: 11 — не блокує AI (rate-limit fallback на Postgres), але треба розслідувати окремо.

## Summary

<!-- What changed in one tight paragraph or a short flat list. -->

## Governing Skill

- Primary skill:
- Secondary skill (if truly needed):

## Playbook

- Primary playbook:
- Why this playbook:
- If no playbook matched, why:

## Verification

<!-- Paste the exact commands you ran and the key result.
     Before claiming "Done" — Iron Law gate: NO COMPLETION CLAIMS WITHOUT
     FRESH VERIFICATION EVIDENCE. See `sergeant-review-and-merge` SKILL.md
     § "Verification gate" (.agents/skills/sergeant-review-and-merge/SKILL.md). -->

```bash
pnpm lint
pnpm typecheck
```

Additional checks:

- [ ] Local smoke / manual validation completed
- [ ] Surface-specific checks completed

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [ ] I checked whether `AGENTS.md` needed an update.
- [ ] I checked whether a playbook or skill needed an update.
- [ ] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a

## Risk and Rollout

- User-visible risk:
- Rollout / deploy order:
- Backout plan:

## Hard Rule #15

- [ ] I read `AGENTS.md` before coding.
- [ ] Internal docs I touched are in Ukrainian.
- [ ] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

<!-- Per `docs/governance/audit-freeze-2026-05-05.md`. New files under
docs/audits/, docs/initiatives/, docs/playbooks/, docs/adr/ trigger a
non-blocking CI warning. If this PR adds such a file, add `[skip-freeze]`
or `[freeze-exception]` to the PR title and explain below. Otherwise leave
this section as-is or remove. -->

- [ ] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

<!-- Flag migrations, env changes, HubChat tools, auth, or anything else that deserves extra reviewer attention. -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable strict tool use for aggregated `TOOLS` to comply with Anthropic’s 20 strict-tools cap, fixing 400 errors on `/api/chat`. Restores pre-05/09 behavior; strict can be re-enabled later for ≤20 high-value tools.

- **Bug Fixes**
  - `apps/server/src/modules/chat/tools.ts`: removed `applyStrictModeToAll(...)`; export raw aggregated `TOOLS` without strict.
  - `apps/server/src/modules/chat/toolDefs/strict.test.ts`: skipped strict invariants for aggregated payload; added guard asserting no tool has `strict: true`.

<sup>Written for commit 07eb5b1182207c68df62625bd1c62ccc201d56dc. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/2930?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

