### PR TITLE
Claude/v2 polish redesign

### DIFF
--- a/apps/web/src/core/hub/HubSettingsPage.tsx
+++ b/apps/web/src/core/hub/HubSettingsPage.tsx
@@ -272,7 +272,7 @@ export function HubSettingsPage({ user }: HubSettingsPageProps) {
   return (
     <div className="flex flex-col gap-4 pt-3 pb-6">
       {/* Search and tabs header */}
-      <div className="flex flex-col gap-3 sticky top-0 z-10 bg-bg/95 backdrop-blur-sm -mx-4 px-4 py-2 -mt-3">
+      <div className="flex flex-col gap-3 sticky top-0 z-10 bg-surface-glass backdrop-blur-md border-b border-surface-line -mx-4 px-4 py-2 -mt-3" style={{ paddingTop: "calc(0.5rem + env(safe-area-inset-top, 0px))" }}>
         <label className="relative block">
           <span className="sr-only">Пошук по налаштуваннях</span>
           <span className="absolute left-4 top-1/2 -translate-y-1/2 text-muted pointer-events-none">
@@ -283,7 +283,7 @@ export function HubSettingsPage({ user }: HubSettingsPageProps) {
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Пошук налаштувань…"
-            className="input-focus w-full min-h-[48px] pl-11 pr-11 py-3 bg-panel border border-line rounded-2xl text-base md:text-sm text-text placeholder:text-muted shadow-soft"
+            className="input-focus w-full min-h-[48px] pl-11 pr-11 py-3 bg-surface-soft-glass border border-surface-line rounded-r-lg text-base md:text-sm text-ink placeholder:text-muted-v2"
           />
           {query && (
             <Button
@@ -308,7 +308,7 @@ export function HubSettingsPage({ user }: HubSettingsPageProps) {
             items={GROUPS.map((g) => ({ value: g.id, label: g.label }))}
             value={tab}
             onChange={(v) => setTab(v)}
-            className="overflow-x-auto border border-line shadow-soft"
+            className="overflow-x-auto border border-surface-line bg-surface-soft-glass rounded-r-lg"
           />
         )}
       </div>
@@ -317,7 +317,7 @@ export function HubSettingsPage({ user }: HubSettingsPageProps) {
       <div className="flex flex-col gap-4">
         {visible.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-12 gap-3">
-            <div className="w-12 h-12 rounded-full bg-panelHi flex items-center justify-center">
+            <div className="w-12 h-12 rounded-full bg-surface-soft-glass border border-surface-line flex items-center justify-center">
               <Icon name="search" size={24} className="text-muted" />
             </div>
             <p className="text-sm text-muted text-center">

--- a/apps/web/src/core/onboarding/WelcomeOneScreen.tsx
+++ b/apps/web/src/core/onboarding/WelcomeOneScreen.tsx
@@ -2,6 +2,7 @@ import type { RefObject } from "react";
 import { cn } from "@shared/lib/ui/cn";
 import { Button } from "@shared/components/ui/Button";
 import { Icon } from "@shared/components/ui/Icon";
+import { MeshBackground } from "@shared/components/layout/MeshBackground";
 import { BrandLogo } from "../app/BrandLogo";
 import { OnboardingProgress } from "./OnboardingProgress";
 import { ALL_MODULES } from "./vibePicks";
@@ -90,6 +91,7 @@ export function WelcomeOneScreen({
   ctaBusy?: boolean;
 }) {
   return (
+    <MeshBackground>
     <div className="flex flex-col items-center text-center space-y-5">
       <div className="space-y-2">
         <BrandLogo size="md" variant="inline" className="mx-auto" />
@@ -198,5 +200,6 @@ export function WelcomeOneScreen({
         {expanded ? "Згорнути" : "Що це за розділи?"}
       </button>
     </div>
+    </MeshBackground>
   );
 }

--- a/apps/web/src/core/settings/SettingsPrimitives.test.tsx
+++ b/apps/web/src/core/settings/SettingsPrimitives.test.tsx
@@ -1,0 +1,182 @@
+// @vitest-environment jsdom
+//
+// PR-A v2-polish-redesign — SettingsPrimitives icon prop + glass surface.
+// Covers: SettingsGroup renders <Icon> when `icon` is passed; falls back to
+// `emoji` when no `icon`; module badge applies correct bg class.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import { SettingsGroup, SettingsSubGroup, ToggleRow, ConfirmModal } from "./SettingsPrimitives";
+
+// Icon is a thin wrapper; stub it so tests don't need an SVG sprite.
+vi.mock("@shared/components/ui/Icon", () => ({
+  Icon: ({ name, size }: { name: string; size?: number }) => (
+    <span data-testid="icon" data-name={name} data-size={size} />
+  ),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("SettingsGroup — icon prop", () => {
+  it("renders an <Icon> when `icon` is provided", () => {
+    render(
+      <SettingsGroup title="Профіль" icon="user">
+        <div>child</div>
+      </SettingsGroup>,
+    );
+
+    const icons = screen.getAllByTestId("icon");
+    // First icon belongs to the icon badge; second is the ChevronIcon.
+    const badgeIcon = icons.find((el) => el.dataset["name"] === "user");
+    expect(badgeIcon).toBeTruthy();
+    expect(badgeIcon?.dataset["size"]).toBe("18");
+  });
+
+  it("does NOT render an emoji span when only `icon` is provided", () => {
+    render(
+      <SettingsGroup title="Профіль" icon="user" emoji="👤">
+        <div>child</div>
+      </SettingsGroup>,
+    );
+
+    // emoji span has text-lg class; should not appear when icon wins
+    const emojiSpan = document
+      .querySelector("span.text-lg");
+    expect(emojiSpan).toBeNull();
+  });
+
+  it("falls back to emoji span when no `icon` is set", () => {
+    render(
+      <SettingsGroup title="Профіль" emoji="👤">
+        <div>child</div>
+      </SettingsGroup>,
+    );
+
+    const emojiSpan = document.querySelector("span.text-lg");
+    expect(emojiSpan).toBeTruthy();
+    expect(emojiSpan?.textContent).toBe("👤");
+  });
+
+  it("applies module soft-surface class on the icon badge span", () => {
+    render(
+      <SettingsGroup title="Фінанси" icon="wallet" module="finyk">
+        <div>child</div>
+      </SettingsGroup>,
+    );
+
+    // The badge span wrapping the Icon should carry the finyk soft bg class.
+    const badge = document.querySelector("span.bg-finyk-soft");
+    expect(badge).toBeTruthy();
+  });
+
+  it("uses neutral surface class when no module is given", () => {
+    render(
+      <SettingsGroup title="Загальне" icon="settings">
+        <div>child</div>
+      </SettingsGroup>,
+    );
+
+    const badge = document.querySelector("span.bg-surface-soft-glass");
+    expect(badge).toBeTruthy();
+  });
+
+  it("expands children on button click", () => {
+    render(
+      <SettingsGroup title="Тест" icon="info">
+        <p>прихований контент</p>
+      </SettingsGroup>,
+    );
+
+    const btn = screen.getByRole("button", { name: /Тест/ });
+    expect(btn).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(btn);
+    expect(btn).toHaveAttribute("aria-expanded", "true");
+  });
+});
+
+describe("SettingsSubGroup", () => {
+  it("expands on click", () => {
+    render(
+      <SettingsSubGroup title="Деталі">
+        <p>вміст</p>
+      </SettingsSubGroup>,
+    );
+
+    const btn = screen.getByRole("button");
+    fireEvent.click(btn);
+    expect(screen.getByText("вміст")).toBeTruthy();
+  });
+});
+
+describe("ToggleRow", () => {
+  it("calls onChange when the label is clicked", () => {
+    const onChange = vi.fn();
+    render(
+      <ToggleRow label="Сповіщення" checked={false} onChange={onChange} />,
+    );
+
+    // Switch renders an input[type=checkbox] inside the label.
+    const input = document.querySelector('input[type="checkbox"]') as HTMLInputElement | null;
+    if (!input) throw new Error("Switch input not found");
+    fireEvent.click(input);
+    expect(onChange).toHaveBeenCalled();
+  });
+});
+
+describe("ConfirmModal", () => {
+  it("renders nothing when closed", () => {
+    render(
+      <ConfirmModal
+        open={false}
+        title="Видалити?"
+        confirmLabel="Так"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("renders dialog and calls onConfirm", () => {
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+    render(
+      <ConfirmModal
+        open={true}
+        title="Видалити акаунт?"
+        confirmLabel="Підтвердити"
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />,
+    );
+
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    fireEvent.click(screen.getByText("Підтвердити"));
+    expect(onConfirm).toHaveBeenCalled();
+  });
+
+  it("calls onCancel on backdrop click", () => {
+    const onCancel = vi.fn();
+    render(
+      <ConfirmModal
+        open={true}
+        title="Тест"
+        confirmLabel="ОК"
+        onConfirm={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+
+    // Backdrop button is the sibling of the dialog panel.
+    const backdrop = document.querySelector(
+      "button.absolute.inset-0",
+    ) as HTMLButtonElement | null;
+    if (!backdrop) throw new Error("backdrop button not found");
+    fireEvent.click(backdrop);
+    expect(onCancel).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/core/settings/SettingsPrimitives.tsx
+++ b/apps/web/src/core/settings/SettingsPrimitives.tsx
@@ -23,9 +23,34 @@ function ChevronIcon({ expanded }: ChevronIconProps) {
   );
 }
 
+/** Module names accepted by SettingsGroup (mirrors CardModule but decoupled). */
+type SettingsModule = "finyk" | "fizruk" | "routine" | "nutrition";
+
+/** Scoped bg-class for the icon badge — avoids global accent-rgb emission
+ *  (Hard Rule #12). Each module has a registered `-soft` / `-soft-border`
+ *  pair in the design token contract. */
+const MODULE_ICON_BG: Record<SettingsModule, string> = {
+  finyk: "bg-finyk-soft border-finyk-soft-border text-finyk",
+  fizruk: "bg-fizruk-soft border-fizruk-soft-border text-fizruk",
+  routine: "bg-routine-soft border-routine-soft-border text-routine",
+  nutrition: "bg-nutrition-soft border-nutrition-soft-border text-nutrition",
+};
+
 export interface SettingsGroupProps {
   title: string;
+  /**
+   * Optional icon name (Lucide icon string). Replaces the deprecated
+   * `emoji` prop. When combined with `module`, the icon badge uses the
+   * module's soft-surface palette.
+   */
+  icon?: string;
+  /**
+   * @deprecated Use `icon` instead. Kept for call-site back-compat;
+   * when both are provided `icon` wins.
+   */
   emoji?: string;
+  /** Module accent for the icon badge. Requires `icon` to be set. */
+  module?: SettingsModule;
   children: ReactNode;
   defaultOpen?: boolean;
   /**
@@ -46,7 +71,9 @@ function matchesHash(anchorId: string | undefined): boolean {
 
 export function SettingsGroup({
   title,
+  icon,
   emoji,
+  module,
   children,
   defaultOpen = false,
   anchorId,
@@ -62,22 +89,41 @@ export function SettingsGroup({
     window.addEventListener("hashchange", onHashChange);
     return () => window.removeEventListener("hashchange", onHashChange);
   }, [anchorId]);
+
+  // `icon` wins over the deprecated `emoji` prop.
+  const resolvedIcon = icon ?? undefined;
+  const resolvedEmoji = !resolvedIcon ? emoji : undefined;
+
+  // Scoped module bg class — uses registered token pair, never raw RGB
+  // (Hard Rule #12). Guard with ?. so noUncheckedIndexedAccess is satisfied.
+  const moduleBg = module != null ? (MODULE_ICON_BG[module] ?? "") : "";
+
   return (
-    <Card radius="lg" padding="none" className="overflow-hidden shadow-soft">
+    <Card prominence="glass" radius="r-lg" padding="none" className="overflow-hidden">
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}
         className={cn(
           "w-full px-4 py-4 flex items-center justify-between gap-3",
-          "hover:bg-panelHi/60 active:bg-panelHi transition-colors",
-          open && "bg-panelHi/30",
+          "hover:bg-surface-strong-glass active:bg-surface-soft-glass transition-colors",
+          open && "bg-surface-soft-glass",
         )}
       >
         <div className="flex items-center gap-3 min-w-0">
-          {emoji && (
+          {resolvedIcon && (
+            <span
+              className={cn(
+                "rounded-r-md p-1.5 border flex items-center justify-center shrink-0",
+                moduleBg || "bg-surface-soft-glass border-surface-line text-muted-v2",
+              )}
+            >
+              <Icon name={resolvedIcon} size={18} />
+            </span>
+          )}
+          {resolvedEmoji && (
             <span className="text-lg w-7 h-7 flex items-center justify-center rounded-xl bg-bg">
-              {emoji}
+              {resolvedEmoji}
             </span>
           )}
           <span className="text-base font-semibold text-text">{title}</span>
@@ -113,13 +159,13 @@ export function SettingsSubGroup({
 }: SettingsSubGroupProps) {
   const [open, setOpen] = useState<boolean>(defaultOpen);
   return (
-    <div className="rounded-xl bg-bg/50 border border-line/40 overflow-hidden">
+    <div className="rounded-xl bg-surface-soft-glass border border-surface-line overflow-hidden">
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
         className={cn(
-          "flex items-center gap-2 w-full text-left group px-3 py-2.5",
-          "hover:bg-panelHi/40 transition-colors",
+          "flex items-center gap-2 w-full text-left group px-3 py-3",
+          "hover:bg-surface-strong-glass transition-colors",
         )}
       >
         <ChevronIcon expanded={open} />
@@ -166,8 +212,8 @@ export function ToggleRow({
       // hover/active-стейтом, по всій ширині.
       className={cn(
         "flex items-center justify-between gap-4 cursor-pointer group min-h-[44px]",
-        "p-3 rounded-2xl border border-line/60 bg-panel/60 shadow-soft",
-        "hover:border-brand/40 hover:bg-panelHi/60 active:bg-panelHi",
+        "p-3 rounded-2xl border border-line/60 bg-surface-soft-glass shadow-soft",
+        "hover:border-brand/40 hover:bg-surface-strong-glass active:bg-surface-soft-glass",
         "transition-[background-color,border-color]",
       )}
     >
@@ -227,7 +273,14 @@ export function ConfirmModal({
         role="dialog"
         aria-modal="true"
         aria-labelledby="confirm-modal-title"
-        className="relative w-full max-w-sm bg-panel border border-line rounded-2xl shadow-float p-6 z-10 motion-safe:animate-scale-in"
+        className={cn(
+          "relative w-full max-w-sm p-6 z-10 motion-safe:animate-scale-in",
+          // v2 glass surface — auto-upgrades to opaque in HC (theme.css
+          // §HC v2 overrides: --surface-glass → rgba(255,255,255,1) /
+          // rgba(32,28,25,1) dark-HC). No separate `html.hc &` needed.
+          "bg-surface-glass backdrop-blur-xl border border-surface-line",
+          "rounded-r-2xl shadow-card-v2",
+        )}
       >
         <h2
           id="confirm-modal-title"
@@ -241,7 +294,7 @@ export function ConfirmModal({
         <div className="flex gap-3 mt-6">
           <button
             type="button"
-            className="text-style-label flex-1 py-3.5 rounded-xl border border-line text-muted hover:bg-panelHi hover:text-text transition-colors"
+            className="text-style-label flex-1 py-3.5 rounded-xl border border-line text-muted hover:bg-surface-strong-glass hover:text-text transition-colors"
             onClick={onCancel}
           >
             {messages.actions.cancel}
@@ -251,8 +304,8 @@ export function ConfirmModal({
             className={cn(
               "text-style-label flex-1 py-3.5 rounded-xl text-white transition-colors shadow-soft",
               danger
-                ? "bg-danger hover:bg-danger/90 active:bg-danger/80"
-                : "bg-brand hover:bg-brand/90 active:bg-brand/80",
+                ? "bg-danger-strong hover:bg-danger/90 active:bg-danger/80"
+                : "bg-brand-strong hover:bg-brand/90 active:bg-brand/80",
             )}
             onClick={onConfirm}
           >

--- a/apps/web/src/styles/theme.css
+++ b/apps/web/src/styles/theme.css
@@ -838,6 +838,13 @@
   background-attachment: fixed;
 }
 
+/* iOS WKWebView (Capacitor) ignores background-attachment:fixed on scrollable containers,
+ * causing mesh to stutter during scroll. Detect via -webkit-overflow-scrolling CSS feature
+ * (iOS-only, CSS-only — no JS runtime detection needed). */
+@supports (-webkit-overflow-scrolling: touch) {
+  .bg-mesh { background-attachment: scroll; }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .bg-mesh {
     background: rgb(var(--c-bg-base));

--- a/packages/design-tokens/tailwind-preset.js
+++ b/packages/design-tokens/tailwind-preset.js
@@ -572,6 +572,13 @@ const preset = {
         "card-routine-dark": "var(--gradient-card-routine-dark)",
         "card-nutrition-dark": "var(--gradient-card-nutrition-dark)",
 
+        // Module hero gradients — CSS vars defined in theme.css:705-708.
+        // Used by PR-E..PR-H module page headers (bg-hero-grad-* utility).
+        "hero-grad-finyk": "var(--hero-grad-finyk)",
+        "hero-grad-fizruk": "var(--hero-grad-fizruk)",
+        "hero-grad-routine": "var(--hero-grad-routine)",
+        "hero-grad-nutrition": "var(--hero-grad-nutrition)",
+
         hero: "linear-gradient(150deg, #fdf9f3 0%, #fefdfb 100%)",
         "hero-g": "linear-gradient(150deg, #f0fdfa 0%, #ffffff 100%)",
         "routine-hero":


### PR DESCRIPTION
## Summary

<!-- What changed in one tight paragraph or a short flat list. -->

## Governing Skill

- Primary skill:
- Secondary skill (if truly needed):

## Playbook

- Primary playbook:
- Why this playbook:
- If no playbook matched, why:

## Verification

<!-- Paste the exact commands you ran and the key result.
     Before claiming "Done" — Iron Law gate: NO COMPLETION CLAIMS WITHOUT
     FRESH VERIFICATION EVIDENCE. See `sergeant-review-and-merge` SKILL.md
     § "Verification gate" (.agents/skills/sergeant-review-and-merge/SKILL.md). -->

```bash
pnpm lint
pnpm typecheck
```

Additional checks:

- [ ] Local smoke / manual validation completed
- [ ] Surface-specific checks completed

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [ ] I checked whether `AGENTS.md` needed an update.
- [ ] I checked whether a playbook or skill needed an update.
- [ ] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a

## Risk and Rollout

- User-visible risk:
- Rollout / deploy order:
- Backout plan:

## Hard Rule #15

- [ ] I read `AGENTS.md` before coding.
- [ ] Internal docs I touched are in Ukrainian.
- [ ] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

<!-- Per `docs/governance/audit-freeze-2026-05-05.md`. New files under
docs/audits/, docs/initiatives/, docs/playbooks/, docs/adr/ trigger a
non-blocking CI warning. If this PR adds such a file, add `[skip-freeze]`
or `[freeze-exception]` to the PR title and explain below. Otherwise leave
this section as-is or remove. -->

- [ ] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

<!-- Flag migrations, env changes, HubChat tools, auth, or anything else that deserves extra reviewer attention. -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the v2 UI across settings and onboarding with glass surfaces, icon-based settings groups, and module-tinted badges. Fixed iOS mesh scroll stutter and added hero gradient utilities; tests cover the new settings primitives.

- **New Features**
  - Revamped settings primitives: v2 glass surfaces across `SettingsGroup`, `SettingsSubGroup`, `ToggleRow`, and `ConfirmModal`; new `icon` prop (supersedes `emoji`) with optional module-tinted badge; larger touch targets; stronger CTA tokens. Tests included.
  - Hub settings chrome: glass sticky header with safe-area padding, updated search input and tabs, and a consistent glass empty state.
  - Onboarding: wrapped the first screen in `MeshBackground` for consistent FTUX atmosphere.
  - Design tokens: added `bg-hero-grad-{finyk,fizruk,routine,nutrition}` utilities.

- **Bug Fixes**
  - iOS WKWebView: `.bg-mesh` switches to `background-attachment: scroll` under `@supports (-webkit-overflow-scrolling: touch)` to eliminate scroll stutter.

<sup>Written for commit eb7653329a810bd6356bbf50432d6049a62a40af. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/2931?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

