### PR TITLE
chore(root): unblock knip dead-code scan and clear unmarked unused files

### DIFF
--- a/apps/web/src/core/billing/index.ts
+++ b/apps/web/src/core/billing/index.ts
@@ -1,3 +1,15 @@
+/**
+ * @scaffolded
+ * @owner @Skords-01
+ * @nextStep Migrate deep imports (`../billing/usePlan`, `../billing/PaywallModal`,
+ *           `../billing/TrialBanner`) in `HubMainContent`, `HubChat`,
+ *           `FinykSection`, `PlanSection`, and `useChatSend` to this barrel
+ *           (`@/core/billing`). Once consumers exist, drop this tag.
+ *
+ * Public entry point for the billing module — declared API surface kept for
+ * cross-module consumers. See AGENTS.md → Hard Rule #10.
+ */
+
 export { usePlan } from "./usePlan";
 export type { Plan, UsePlanResult } from "./usePlan";
 export { PaywallModal } from "./PaywallModal";

--- a/apps/web/src/core/errors/OfflinePage.tsx
+++ b/apps/web/src/core/errors/OfflinePage.tsx
@@ -1,11 +1,14 @@
 /**
- * @status Active
+ * @scaffolded
  * @owner @Skords-01
+ * @nextStep Register the `/offline` path in `StandaloneRoutes.tsx`
+ *           (`apps/web/src/core/app/StandaloneRoutes.tsx`) and add the
+ *           offline navigation-fallback to `apps/web/src/sw.ts` precache
+ *           strategy. Once mounted, drop the tag.
  *
- * Canonical `/offline` surface. Shown by the service worker when the
- * browser can't reach the network and no cached page is available (the
- * "offline navigation-fallback" in the `sw.ts` precache strategy). Also
- * mountable as a standalone route by `StandaloneRoutes`. Uses the
+ * Canonical `/offline` surface. Intended to be shown by the service worker
+ * when the browser can't reach the network and no cached page is available,
+ * and mountable as a standalone route by `StandaloneRoutes`. Uses the
  * `<EmptyState>` primitive + `OfflineIllustration` so the page inherits
  * the design system's a11y, motion, and dark-mode recolouring contracts.
  *

--- a/apps/web/src/core/errors/ServerErrorPage.tsx
+++ b/apps/web/src/core/errors/ServerErrorPage.tsx
@@ -1,10 +1,14 @@
 /**
- * @status Active
+ * @scaffolded
  * @owner @Skords-01
+ * @nextStep Mount inside the top-level error boundary
+ *           (`apps/web/src/core/App.tsx`) as the fallback for unrecoverable
+ *           render-time exceptions, and register `/500` in
+ *           `StandaloneRoutes.tsx`. Once a consumer renders it, drop the tag.
  *
  * Canonical `/500` (server-error) surface. Composed from the design-system
  * `<EmptyState>` primitive + `ServerErrorIllustration`, the same a11y and
- * motion guarantees ship here for free. Mounted by the top-level error
+ * motion guarantees ship here for free. Intended for the top-level error
  * boundary when an unrecoverable render-time exception happens inside the
  * app shell. The primary CTA reloads the current page instead of
  * navigating — a server 500 is often transient, and reloading is the

--- a/apps/web/src/core/errors/index.ts
+++ b/apps/web/src/core/errors/index.ts
@@ -1,6 +1,16 @@
 /**
- * @status Active
+ * @scaffolded
  * @owner @Skords-01
+ * @nextStep Wire `ServerErrorPage` into the top-level error boundary
+ *           (`apps/web/src/core/App.tsx`) and `OfflinePage` into
+ *           `StandaloneRoutes.tsx` / the SW offline navigation fallback
+ *           (`sw.ts`). Once consumers import through this barrel, drop the
+ *           tag. `NotFoundPage` is currently re-exported via the
+ *           `core/NotFoundPage.tsx` back-compat shim — migrate that callsite
+ *           to `@/core/errors` first.
+ *
+ * Public entry point for the canonical error/empty-state surfaces. See
+ * AGENTS.md → Hard Rule #10.
  */
 export { NotFoundPage } from "./NotFoundPage";
 export type { NotFoundPageProps } from "./NotFoundPage";

--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -4,7 +4,15 @@ import tailwindcss from "@tailwindcss/vite";
 import { VitePWA } from "vite-plugin-pwa";
 import { visualizer } from "rollup-plugin-visualizer";
 import { sentryVitePlugin } from "@sentry/vite-plugin";
-import { resolve } from "path";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+
+// `apps/web/package.json` has `"type": "module"`, so the CJS `__dirname`
+// global isn't available. Vite itself shims it at runtime, but static
+// loaders (knip, ts-morph, etc.) evaluate this file as plain ESM and
+// blow up. Derive the directory from `import.meta.url` so the config is
+// portable across both worlds.
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");

--- a/knip.json
+++ b/knip.json
@@ -16,6 +16,8 @@
     "apps/mobile": {
       "entry": ["app/**/*.{ts,tsx}", "src/**/*.{ts,tsx}"],
       "project": ["app/**/*.{ts,tsx}", "src/**/*.{ts,tsx}"],
+      "ignore": ["metro.config.js"],
+      "metro": false,
       "ignoreDependencies": [
         "sucrase",
         "@babel/preset-typescript",


### PR DESCRIPTION
## Summary

Closes the dead-code visibility gap flagged in point 5 of the critical-issues audit. After this PR, `pnpm knip` runs without ERROR-level loader failures and `pnpm dead-code:files` reports `No unmarked unused files. ✓`.

### What changed

- **Marked 4 unmarked unused files as `@scaffolded`** (Hard Rule #10), each with a concrete `@nextStep` wiring instruction:
  - `apps/web/src/core/billing/index.ts` — barrel; deep imports (`../billing/usePlan`, `PaywallModal`, `TrialBanner`) exist in `HubMainContent`, `HubChat`, `FinykSection`, `PlanSection`, `useChatSend` but no consumer goes through the barrel yet.
  - `apps/web/src/core/errors/index.ts` — barrel; `NotFoundPage` is re-exported via the `core/NotFoundPage.tsx` back-compat shim, the other two aren't mounted.
  - `apps/web/src/core/errors/OfflinePage.tsx` — implementation ready; needs registration in `StandaloneRoutes.tsx` and the SW offline navigation-fallback (`apps/web/src/sw.ts`).
  - `apps/web/src/core/errors/ServerErrorPage.tsx` — implementation ready; needs mounting inside the top-level error boundary (`apps/web/src/core/App.tsx`).

- **`apps/web/vite.config.js`** — derive `__dirname` from `import.meta.url` (`apps/web/package.json` has `"type": "module"`). Vite shims `__dirname` at runtime, but static loaders (knip, ts-morph) evaluate the file as plain ESM and crashed with `__dirname is not defined`.

- **`knip.json`** — disable knip's `metro` plugin for `apps/mobile` (`"metro": false`). It loaded `apps/mobile/metro.config.js`, which transitively requires `nativewind/metro`; NativeWind 4.2.3 hard-rejects Tailwind v4 at import time. The mobile workspace already lists explicit entry globs, so coverage is unchanged.

### Knip findings now visible (separate follow-up)

With the loader unblocked, the report surfaces real cleanup candidates worth tracking:
- 4 truly unused dependencies (`@capacitor/ios`, 3× `@fontsource-variable/*`).
- 12 unused devDependencies — most interestingly `@stryker-mutator/core`, `@stryker-mutator/vitest-runner` (mutation testing not running), `tsc-files`, `lint-staged`, `typescript-eslint`, `openapi-typescript`, `drizzle-kit`.
- 97 unused exports, 15 unused types, 58 duplicate exports (mostly `Component|default` pairs in `apps/mobile/**`).

### Out of scope — tech-debt callouts

- **NativeWind 4.x ↔ Tailwind v4** in `apps/mobile`: `nativewind@4.2.3` (peer `tailwindcss>3.3.0`) installed alongside `tailwindcss@4.2.4`, which NativeWind explicitly rejects. Mobile Metro bundling likely fails for the same reason knip did. Needs a dedicated fix (downgrade Tailwind in mobile workspace, or upgrade NativeWind to a v4-compatible release once available).
- **Hard Rule #19** gap (`noUncheckedIndexedAccess`) — still missing in `apps/web`, `apps/server`, `apps/mobile-shell`.
- **react-hooks v7 baseline** — 7 disabled rules in `eslint.baseline.js`.

## Test plan

- [x] `pnpm dead-code:files` exits 0 with `No unmarked unused files. ✓`
- [x] `pnpm knip` runs without `ERROR:` lines (only finding output)
- [x] `node --input-type=module` import of `apps/web/vite.config.js` resolves to a `function` (config factory works under plain ESM)
- [ ] CI green on PR (lint / typecheck / format / build)
- [ ] Manual review of the 4 `@nextStep` instructions for accuracy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrVDaFw4y33dWk9C22cL2G)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks the `knip` dead-code scan and makes `pnpm dead-code:files` pass cleanly. Addresses the audit gap (critical issues, point 5) by marking planned surfaces and fixing ESM loader issues.

- **Refactors**
  - Marked four planned-but-unreferenced files as `@scaffolded` with `@nextStep` wiring notes: `apps/web/src/core/billing/index.ts`, `apps/web/src/core/errors/index.ts`, `apps/web/src/core/errors/OfflinePage.tsx`, `apps/web/src/core/errors/ServerErrorPage.tsx`.
  - `apps/web/vite.config.js`: derive `__dirname` from `import.meta.url` to work under ESM so static loaders (e.g., `knip`, `ts-morph`) don't crash.
  - `knip.json` (mobile): disabled `metro` plugin and ignored `metro.config.js` to avoid `nativewind/metro` rejecting `tailwindcss@4`; coverage is unchanged due to explicit entry globs.
  - Outcome: `pnpm knip` runs without loader errors; `pnpm dead-code:files` reports “No unmarked unused files.”

<sup>Written for commit 06ad8a443273a4f9ff11f7509134b35ded5661d8. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/2933?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced module documentation for billing, offline handling, and error pages with clearer integration guidance.

* **Chores**
  * Resolved module system compatibility issue in the build configuration to support modern JavaScript standards.
  * Updated build analysis tool settings to exclude mobile-specific configuration files from analysis.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Skords-01/Sergeant/pull/2933?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->