### PR TITLE
fix(server): bake busybox /bin/sh into distroless runtime for Railway…

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -27,6 +27,17 @@
 # виконати `wget`/`curl`. Railway моніторить через external HTTP-probe
 # на `/health` (service-level config), тому Dockerfile HEALTHCHECK
 # опущено — Railway автоматично рестартить unhealthy container незалежно.
+#
+# Railway Pre-Deploy винятки: Railway виконує `preDeployCommand`
+# (`node dist-server/migrate.js`) через `/bin/sh -c "<cmd>"` всередині
+# того ж runtime-образу. Distroless шела не має, тому pre-deploy
+# мовчки фейлиться (deploy-логи порожні, контейнер не встигає нічого
+# написати). Щоб не ламати release-stage міграцій, у runtime-стейдж
+# нижче запікаємо `busybox` (~1 MB) з alpine-білдера й симлінкуємо
+# його як `/bin/sh`. Це мінімальна додача поверх distroless: жодного
+# package manager-а / coreutils-у не з'являється, а Trivy attack
+# surface зростає тільки на один статичний binary, який і так
+# поставляється з alpine-base-у.
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Stage 1: builder — full dev deps + pnpm build
@@ -115,10 +126,22 @@ RUN find node_modules -maxdepth 3 -type d \
       -prune -exec rm -rf {} +
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Stage 3: runtime — distroless. Жодного shell-у, жодного package manager-у,
-# жодного `corepack` / `npm` / `pnpm` / `yarn`. Entrypoint = `/nodejs/bin/node`.
+# Stage 3: runtime — distroless. Жодного package manager-у, жодного
+# `corepack` / `npm` / `pnpm` / `yarn`. Entrypoint = `/nodejs/bin/node`.
+#
+# Єдиний shell-binary — busybox (див. коментар на початку файлу). Потрібен
+# виключно тому, що Railway виконує `preDeployCommand` через
+# `/bin/sh -c "..."`; без нього release-stage міграцій падає мовчки ще до
+# того, як `node dist-server/migrate.js` встигне щось вивести.
 FROM --platform=linux/amd64 gcr.io/distroless/nodejs20-debian12:nonroot AS runtime
 WORKDIR /app
+
+# Запікаємо busybox як `/bin/sh`. У alpine `/bin/sh` — це симлінк на
+# `/bin/busybox`, але `COPY` Docker-а резолвить симлінки і копіює сам
+# binary, тому файл вийде самодостатній (~1 MB, статично злінкований).
+# Власник `root:root`, права `0755` — наш runtime user `nonroot` (uid
+# 65532) виконує його через PATH-lookup, write-доступ йому не потрібен.
+COPY --from=builder /bin/busybox /bin/sh
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
… pre-deploy

Railway виконує preDeployCommand (`node dist-server/migrate.js`) через /bin/sh -c у тому ж runtime-образі. Distroless шела не має — pre-deploy крашиться мовчки до того, як міграційний runner встигне щось вивести у логи. Усі 7 деплоїв з 12:40 16.05 — FAILED з цієї ж причини.

Копіюємо busybox (~1 MB) з alpine-білдера як /bin/sh. Жодного package manager-а / coreutils-у не з'являється, Trivy attack surface зростає тільки на один статичний binary з alpine-base-у.

Fix-orientation: deployment ID 7433b0b4-9591-406b-9fb2-fc4210d9dc07 (Sergeant prod), Railway diagnosis 4c80a822-d79c-47d5-88c3-2050b9d7061b.

## Summary

<!-- What changed in one tight paragraph or a short flat list. -->

## Governing Skill

- Primary skill:
- Secondary skill (if truly needed):

## Playbook

- Primary playbook:
- Why this playbook:
- If no playbook matched, why:

## Verification

<!-- Paste the exact commands you ran and the key result.
     Before claiming "Done" — Iron Law gate: NO COMPLETION CLAIMS WITHOUT
     FRESH VERIFICATION EVIDENCE. See `sergeant-review-and-merge` SKILL.md
     § "Verification gate" (.agents/skills/sergeant-review-and-merge/SKILL.md). -->

```bash
pnpm lint
pnpm typecheck
```

Additional checks:

- [ ] Local smoke / manual validation completed
- [ ] Surface-specific checks completed

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [ ] I checked whether `AGENTS.md` needed an update.
- [ ] I checked whether a playbook or skill needed an update.
- [ ] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a

## Risk and Rollout

- User-visible risk:
- Rollout / deploy order:
- Backout plan:

## Hard Rule #15

- [ ] I read `AGENTS.md` before coding.
- [ ] Internal docs I touched are in Ukrainian.
- [ ] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

<!-- Per `docs/governance/audit-freeze-2026-05-05.md`. New files under
docs/audits/, docs/initiatives/, docs/playbooks/, docs/adr/ trigger a
non-blocking CI warning. If this PR adds such a file, add `[skip-freeze]`
or `[freeze-exception]` to the PR title and explain below. Otherwise leave
this section as-is or remove. -->

- [ ] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

<!-- Flag migrations, env changes, HubChat tools, auth, or anything else that deserves extra reviewer attention. -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Embed `busybox` as `/bin/sh` in the distroless runtime so Railway can run `preDeployCommand` via `/bin/sh -c`. This fixes the silent pre-deploy crashes and restores migrations during deploy.

- **Bug Fixes**
  - Copy `busybox` (~1 MB, static) from the Alpine builder into the runtime image as `/bin/sh`.
  - Keeps distroless minimal: no package managers or coreutils; Node remains the entrypoint; executable perms allow the `nonroot` user to run it.

<sup>Written for commit 4609e51b5a0ecee927e8e8bf574431e93f09548e. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/2934?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

