### PR TITLE
revert(web): bottom nav back to edge-to-edge line-indicator

### DIFF
--- a/apps/web/src/core/app/HubBottomNav.test.tsx
+++ b/apps/web/src/core/app/HubBottomNav.test.tsx
@@ -85,7 +85,7 @@ describe("HubBottomNav", () => {
       ),
     ).toHaveLength(1);
     expect(indicator).toHaveStyle({
-      left: "calc(2 * (100% / 3) + 0.25rem)",
+      left: "calc(2 * (100% / 3) + (100% / 3 - 2.5rem) / 2)",
     });
   });
 

--- a/apps/web/src/core/app/HubBottomNav.tsx
+++ b/apps/web/src/core/app/HubBottomNav.tsx
@@ -13,22 +13,26 @@ import { messages } from "@shared/i18n/uk";
 /**
  * Sergeant Design System — `HubBottomNav`
  *
- * Hub-level bottom navigation. Replaces the earlier top-positioned
- * `HubTabs` so the whole app lives under a single navigation pattern:
- * everything (hub + 4 modules) reads bottom-up, not bottom-down for
- * modules and top-down for the hub.
+ * Hub-level bottom navigation. Sits as an edge-to-edge `border-t`
+ * panel flush with the screen bottom — matches `ModuleBottomNav` so
+ * the whole app reads under one navigation pattern.
  *
- * Shape mirrors `ModuleBottomNav` for visual consistency:
+ * Canonical shape:
  * - 60 px height (64 px on coarse-pointer devices).
  * - `safe-area-pb` so iOS home-indicator clears.
- * - Active indicator pill (`w-10 h-1`) at the top, brand-colored
- *   instead of module-colored (the hub is module-agnostic).
+ * - `bg-panel/95 motion-safe:backdrop-blur-xl` translucent surface,
+ *   `border-t border-line` only — no horizontal margin, no rounded
+ *   corners, no shadow (no floating-card look).
+ * - Active indicator: thin 4 px sliding stripe (`top-0 h-1 w-10
+ *   rounded-full`) at the top of the active tab, `bg-ink-strong`
+ *   (brand) — module-agnostic by design.
+ * - Active label + icon: `text-ink-strong`; inactive: `text-muted`.
  * - `role="tablist"` + `aria-selected` for AT.
  *
  * Layout contract:
  * - Rendered at the bottom of the hub `<div h-dvh flex-col>` shell, so
  *   `ActiveWorkoutBanner` and other floating chrome must offset
- *   their `bottom:` by 76 px + safe-area-inset-bottom to sit above it.
+ *   their `bottom:` by 60 px + safe-area-inset-bottom to sit above it.
  *
  * The reports-tab reveal behavior (a single bounce-in animation when
  * the tab first appears) is preserved from the old `HubTabs` — see
@@ -94,16 +98,11 @@ function HubBottomNavTab({
       // accessible name (`label`), і тести з `name: /Звіти/` падали б.
       style={hiddenSlot ? { visibility: "hidden" } : undefined}
       className={cn(
-        // `z-10` ставить кнопку поверх absolutely-positioned active-tab
-        // background pill (added in PR-5 v2 redesign).
-        "relative z-10 flex-1 flex flex-col items-center justify-center gap-1",
+        "relative flex-1 flex flex-col items-center justify-center gap-1",
         "transition-all duration-200 min-h-[48px] pointer-coarse:min-h-[52px]",
         "active:scale-95",
         "focus:outline-none focus-visible:ring-2 focus-visible:ring-focus/45 focus-visible:ring-offset-2 focus-visible:ring-offset-panel",
-        // v2 redesign: active tab reads on the ink-strong background pill
-        // → text inverts to `bg-base` (warm cream in light, dark in dark);
-        // inactive stays muted on the glass surface.
-        active ? "text-bg-base" : "text-muted hover:text-text/70",
+        active ? "text-ink-strong" : "text-muted hover:text-text/70",
         hiddenSlot && "invisible pointer-events-none",
         className,
       )}
@@ -255,72 +254,48 @@ export function HubBottomNav({
   const activeIndex = tabs.findIndex((tab) => tab.active);
 
   return (
-    // Sergeant v2 redesign (2026-05, PR-5) — transformed from flat
-    // `border-t` panel to a floating glass pill (`mx-3 mb-3`,
-    // `rounded-r-2xl`, `shadow-nav`). The outer wrapper preserves
-    // `safe-area-pb` so iOS home-indicator clears; the inner `<nav>`
-    // becomes the visible pill. Active indicator changed from a top
-    // 1-px stripe to a full-cell `bg-ink-strong` background pill
-    // sitting BEHIND the active tab content.
-    //
-    // Phase 1 (M2) — bottom inset math moved from `mb-3` on the nav
-    // to the wrapper as `padding-bottom: calc(0.75rem +
-    // env(safe-area-inset-bottom))`. Putting `mb-3` on the nav while
-    // the wrapper also applied `safe-area-pb` stacked both margins on
-    // iPhone notch devices, pushing the pill into the home indicator.
-    // Phase 1 (M3) — `backdrop-blur-md` → `motion-safe:backdrop-blur-md`
-    // so `prefers-reduced-motion` users get the clearer translucent
-    // surface without the GPU-heavy blur (Android Chrome WebView jank).
-    <div
-      className="shrink-0 relative z-30"
-      aria-hidden={false}
+    <nav
+      aria-label={messages.nav.hubSections}
+      className={cn(
+        "shrink-0 relative z-30 safe-area-pb",
+        "bg-panel/95 motion-safe:backdrop-blur-xl",
+        "border-t border-line",
+      )}
     >
-      <nav
-        aria-label={messages.nav.hubSections}
-        className={cn(
-          "mx-3",
-          "bg-surface-strong-glass motion-safe:backdrop-blur-md",
-          "border border-line",
-          "rounded-r-2xl",
-          "shadow-nav",
-        )}
+      <div
+        role="tablist"
+        className="relative flex h-[60px] pointer-coarse:h-[64px]"
       >
-        <div
-          role="tablist"
-          className="relative flex h-[60px] pointer-coarse:h-[64px] p-1"
-        >
-          {activeIndex >= 0 && (
-            <span
-              data-testid="hub-bottom-nav-active-indicator"
-              className={cn(
-                "absolute inset-y-1 pointer-events-none",
-                "rounded-xl bg-ink-strong",
-                "transition-[left] duration-200 ease-out",
-              )}
-              style={{
-                left: `calc(${activeIndex} * (100% / ${tabs.length}) + 0.25rem)`,
-                width: `calc(100% / ${tabs.length} - 0.5rem)`,
-              }}
-              aria-hidden
-            />
-          )}
+        {activeIndex >= 0 && (
+          <span
+            data-testid="hub-bottom-nav-active-indicator"
+            className={cn(
+              "absolute top-0 h-1 w-10 rounded-full pointer-events-none",
+              "bg-ink-strong shadow-sm",
+              "transition-[left] duration-200 ease-out",
+            )}
+            style={{
+              left: `calc(${activeIndex} * (100% / ${tabs.length}) + (100% / ${tabs.length} - 2.5rem) / 2)`,
+            }}
+            aria-hidden
+          />
+        )}
 
-          {tabs.map((tab) => (
-            <HubBottomNavTab
-              key={tab.key}
-              id={tab.id}
-              panelId={tab.panelId}
-              active={tab.active}
-              onClick={tab.onClick}
-              iconName={tab.iconName}
-              label={tab.label}
-              className={tab.className}
-              prefetchPage={tab.prefetchPage}
-              hiddenSlot={tab.hiddenSlot}
-            />
-          ))}
-        </div>
-      </nav>
-    </div>
+        {tabs.map((tab) => (
+          <HubBottomNavTab
+            key={tab.key}
+            id={tab.id}
+            panelId={tab.panelId}
+            active={tab.active}
+            onClick={tab.onClick}
+            iconName={tab.iconName}
+            label={tab.label}
+            className={tab.className}
+            prefetchPage={tab.prefetchPage}
+            hiddenSlot={tab.hiddenSlot}
+          />
+        ))}
+      </div>
+    </nav>
   );
 }

--- a/apps/web/src/modules/fizruk/components/dashboard/StatusStrip.tsx
+++ b/apps/web/src/modules/fizruk/components/dashboard/StatusStrip.tsx
@@ -60,7 +60,6 @@ function Chip({ label, value, tone, onClick, ariaLabel }: ChipProps) {
       prominence="glass"
       radius="r-xl"
       padding="none"
-      type="button"
       onClick={onClick}
       aria-label={ariaLabel}
       className="flex-1 min-w-0 active:scale-[0.99] hover:opacity-90 px-3 py-2.5 text-left transition-[opacity,transform]"

--- a/apps/web/src/shared/components/ui/ModuleBottomNav.stories.tsx
+++ b/apps/web/src/shared/components/ui/ModuleBottomNav.stories.tsx
@@ -5,11 +5,12 @@ import { RoutineBottomNav } from "../../../modules/routine/components/RoutineBot
 
 /**
  * `ModuleBottomNav` — спільна bottom-navigation shell для Finyk /
- * Fizruk / Routine / Nutrition. v2 (PR-8) shape: floating glass pill
- * (`mx-3 rounded-r-2xl shadow-nav bg-surface-strong-glass`) з
- * module-tinted active background pill (`bg-{module}-strong`). Icon
- * glow та top-pill indicator з v1 прибрані — active background pill
- * сам несе module identity.
+ * Fizruk / Routine / Nutrition. Edge-to-edge `border-t` панель flush
+ * з низом екрану (`bg-panel/95`, `motion-safe:backdrop-blur-xl`).
+ * Активний таб маркується тонкою 4 px sliding-стрічкою зверху
+ * (`top-0 h-1 w-10 rounded-full`) з module-tinted градієнтом — це
+ * носій module identity. Активна іконка приймає `tokens.text`, label
+ * лишається `text-text`.
  */
 const meta: Meta<typeof ModuleBottomNav> = {
   title: "Shared / ModuleBottomNav",

--- a/apps/web/src/shared/components/ui/ModuleBottomNav.tsx
+++ b/apps/web/src/shared/components/ui/ModuleBottomNav.tsx
@@ -2,37 +2,30 @@ import { memo, type ReactNode } from "react";
 import { cn } from "../../lib/ui/cn";
 
 /**
- * Sergeant Design System — ModuleBottomNav (v2)
+ * Sergeant Design System — ModuleBottomNav
  *
  * Shared bottom-navigation shell for Фінік / Фізрук / Рутина /
- * Харчування. v2 (2026-05, PR-8) aligns the shape with `HubBottomNav`
- * — both navs are now floating glass pills (`mx-3`, `rounded-r-2xl`,
- * `shadow-nav`, `bg-surface-strong-glass`) so the whole app reads
- * under one navigation pattern. The only intentional divergence:
- * active-pill background is **module-tinted** (`bg-{module}-strong`)
- * instead of brand-agnostic `bg-ink-strong` — it carries module
- * identity now that the icon-glow + top-pill stripe are gone.
+ * Харчування. Sits edge-to-edge along the screen bottom (matches
+ * `HubBottomNav` shape) so the whole app reads under one navigation
+ * pattern.
  *
- * Migration notes:
- * - v1 flat `border-t bg-panel/95` shell removed.
- * - v1 4px sliding top-pill indicator removed (active background pill
- *   does the same job with less visual noise).
- * - v1 icon `drop-shadow` glow removed (redundant once the pill is
- *   color-tinted). Active state now reads on the pill via
- *   `text-bg-base` (warm cream in light, near-black in dark) like
- *   HubBottomNav. Inactive icons keep `text-muted`.
- * - Labels switched from `text-2xs` (10px) to `text-style-caption`
- *   (12px) to satisfy Hard Rule #16 (12px floor for tab labels).
- * - Layout contract: outer wrapper owns `safe-area-pb` via
- *   `padding-bottom: calc(0.75rem + env(safe-area-inset-bottom))`;
- *   the inner `<nav>` becomes the visible pill. Floating chrome
- *   (`AIPill`, `ActiveWorkoutBanner`, FABs) must clear ≈ 84 px above
- *   the bottom — same offset as HubBottomNav.
+ * Canonical shape:
+ * - Height 60 px (64 px on coarse-pointer devices).
+ * - `safe-area-pb` so iOS home-indicator clears.
+ * - `bg-panel/95 motion-safe:backdrop-blur-xl` translucent surface,
+ *   `border-t border-line` only — no horizontal margin, no rounded
+ *   corners, no shadow.
+ * - Active indicator: thin 4 px sliding stripe (`top-0 h-1 w-10
+ *   rounded-full`) at the top of the active tab, tinted with the
+ *   module's accent gradient. Carries module identity.
+ * - Active icon picks up `tokens.text` (module-colored); label
+ *   stays `text-text`. No drop-shadow glow.
+ * - Labels `text-style-caption` (12px) per Hard Rule #16.
  *
  * Routine special-case (FAB):
  * - Consumers may render an additional center FAB as a sibling of
  *   the nav (NOT nested inside it) at `z-40`, positioned over the
- *   pill's top edge. See `RoutineBottomNav`. The FAB sits in front
+ *   nav's top edge. See `RoutineBottomNav`. The FAB sits in front
  *   of the nav's stacking context and keeps its own coral gradient
  *   per Routine identity.
  *
@@ -70,7 +63,9 @@ export interface ModuleBottomNavProps {
 }
 
 type ColorTokens = {
-  /** Active-pill background. Module-tinted — identity carrier in v2. */
+  /** Active icon tint. Module-colored text token. */
+  text: string;
+  /** Top-stripe gradient — identity carrier. */
   pill: string;
   /** Tiny unread/attention dot color. */
   badge: string;
@@ -78,19 +73,23 @@ type ColorTokens = {
 
 const COLORS: Record<ModuleNavColor, ColorTokens> = {
   finyk: {
-    pill: "bg-finyk-strong",
+    text: "text-finyk",
+    pill: "bg-linear-to-r from-brand-400 to-brand-500",
     badge: "bg-finyk",
   },
   fizruk: {
-    pill: "bg-fizruk-strong",
+    text: "text-fizruk",
+    pill: "bg-linear-to-r from-teal-400 to-teal-500",
     badge: "bg-fizruk",
   },
   routine: {
-    pill: "bg-routine-strong",
+    text: "text-routine",
+    pill: "bg-linear-to-r from-coral-400 to-coral-500",
     badge: "bg-routine",
   },
   nutrition: {
-    pill: "bg-nutrition-strong",
+    text: "text-nutrition",
+    pill: "bg-linear-to-r from-lime-400 to-lime-500",
     badge: "bg-nutrition",
   },
 };
@@ -109,100 +108,84 @@ export const ModuleBottomNav = memo(function ModuleBottomNav({
   const activeIndex = items.findIndex((i) => i.id === activeId);
 
   return (
-    // Outer wrapper owns `safe-area-pb` so the floating pill clears
-    // the iOS home indicator without doubling padding inside `<nav>`
-    // (matches HubBottomNav Phase 1 / M2 fix).
-    <div className={cn("shrink-0 relative z-30", className)}>
-      <nav
-        aria-label={ariaLabel}
-        className={cn(
-          "mx-3",
-          // Phase 1 (M3) — `motion-safe:` guard so prefers-reduced-motion
-          // users get the translucent panel without GPU-heavy blur
-          // (Android Chrome WebView jank). Same treatment as
-          // HubBottomNav v2.
-          "bg-surface-strong-glass motion-safe:backdrop-blur-md",
-          "border border-line",
-          "rounded-r-2xl",
-          "shadow-nav",
-        )}
+    <nav
+      aria-label={ariaLabel}
+      className={cn(
+        "shrink-0 relative z-30 safe-area-pb",
+        "bg-panel/95 motion-safe:backdrop-blur-xl",
+        "border-t border-line",
+        className,
+      )}
+    >
+      <div
+        className="relative flex h-[60px] pointer-coarse:h-[64px]"
+        role={isTablist ? "tablist" : undefined}
       >
-        <div
-          className="relative flex h-[60px] pointer-coarse:h-[64px] p-1"
-          role={isTablist ? "tablist" : undefined}
-        >
-          {/* Active-tab background pill — module-tinted, sits BEHIND the
-           * button content (`z-10` on each button keeps icons + labels
-           * on top). Translates between tabs via `transition-[left]`. */}
-          {activeIndex >= 0 && (
-            <span
-              data-testid="module-bottom-nav-active-indicator"
-              className={cn(
-                "absolute inset-y-1 pointer-events-none",
-                "rounded-xl",
-                tokens.pill,
-                "transition-[left] duration-200 ease-out",
-              )}
-              style={{
-                left: `calc(${activeIndex} * (100% / ${items.length}) + 0.25rem)`,
-                width: `calc(100% / ${items.length} - 0.5rem)`,
-              }}
-              aria-hidden
-            />
-          )}
+        {activeIndex >= 0 && (
+          <span
+            data-testid="module-bottom-nav-active-indicator"
+            className={cn(
+              "absolute top-0 h-1 w-10 rounded-full pointer-events-none",
+              tokens.pill,
+              "shadow-sm",
+              "transition-[left] duration-200 ease-out",
+            )}
+            style={{
+              left: `calc(${activeIndex} * (100% / ${items.length}) + (100% / ${items.length} - 2.5rem) / 2)`,
+            }}
+            aria-hidden
+          />
+        )}
 
-          {items.map((item) => {
-            const active = activeId === item.id;
-            return (
-              <button
-                key={item.id}
-                type="button"
-                role={isTablist ? "tab" : undefined}
-                id={isTablist ? `${module}-tab-${item.id}` : undefined}
-                aria-selected={isTablist ? active : undefined}
-                aria-current={
-                  !isTablist ? (active ? "page" : undefined) : undefined
-                }
-                aria-controls={isTablist ? item.panelId : undefined}
-                tabIndex={isTablist ? (active ? 0 : -1) : undefined}
-                onClick={() => onChange(item.id)}
+        {items.map((item) => {
+          const active = activeId === item.id;
+          return (
+            <button
+              key={item.id}
+              type="button"
+              role={isTablist ? "tab" : undefined}
+              id={isTablist ? `${module}-tab-${item.id}` : undefined}
+              aria-selected={isTablist ? active : undefined}
+              aria-current={
+                !isTablist ? (active ? "page" : undefined) : undefined
+              }
+              aria-controls={isTablist ? item.panelId : undefined}
+              tabIndex={isTablist ? (active ? 0 : -1) : undefined}
+              onClick={() => onChange(item.id)}
+              className={cn(
+                "relative flex-1 flex flex-col items-center justify-center gap-1",
+                "min-h-touch-target",
+                "transition-all duration-200",
+                "active:scale-95",
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-focus/45 focus-visible:ring-offset-2 focus-visible:ring-offset-panel",
+                active ? "text-text" : "text-muted hover:text-text/70",
+              )}
+            >
+              <span
                 className={cn(
-                  // `z-10` lifts the button above the absolutely-positioned
-                  // active background pill so icons + labels stay on top.
-                  "relative z-10 flex-1 flex flex-col items-center justify-center gap-1",
-                  "min-h-touch-target",
-                  "transition-all duration-200",
-                  "active:scale-95",
-                  "focus:outline-none focus-visible:ring-2 focus-visible:ring-focus/45 focus-visible:ring-offset-2 focus-visible:ring-offset-panel",
-                  // v2: active label/icon read on the module-strong pill
-                  // background → invert to cream (`bg-base`). Inactive
-                  // stays muted on the glass surface.
-                  active ? "text-bg-base" : "text-muted hover:text-text/70",
+                  "relative transition-all duration-200",
+                  active && tokens.text,
                 )}
+                aria-hidden
               >
-                <span
-                  className="relative transition-all duration-200"
-                  aria-hidden
-                >
-                  {item.icon}
-                  {item.badge && !active && (
-                    <span
-                      className={cn(
-                        "absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full border border-panel",
-                        tokens.badge,
-                      )}
-                      aria-hidden
-                    />
-                  )}
-                </span>
-                <span className="text-style-caption font-semibold leading-none">
-                  {item.label}
-                </span>
-              </button>
-            );
-          })}
-        </div>
-      </nav>
-    </div>
+                {item.icon}
+                {item.badge && !active && (
+                  <span
+                    className={cn(
+                      "absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full border border-panel",
+                      tokens.badge,
+                    )}
+                    aria-hidden
+                  />
+                )}
+              </span>
+              <span className="text-style-caption font-semibold leading-none">
+                {item.label}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </nav>
   );
 });


### PR DESCRIPTION
## Summary

Reverts the v2 floating-glass-pill aesthetic on both `HubBottomNav` and the shared `ModuleBottomNav` (Finyk / Fizruk / Routine / Nutrition) to the v1 edge-to-edge line-indicator shape used before the 2026-05-17 redesign.

- Nav shell: `bg-panel/95 motion-safe:backdrop-blur-xl border-t border-line safe-area-pb` — flush with the screen, no `mx-3`, no rounded corners, no `shadow-nav`.
- Active indicator: thin 4 px sliding stripe at the top of the active tab (`top-0 h-1 w-10 rounded-full`). `bg-ink-strong` on the hub (brand-agnostic); module-tinted gradient on the modules.
- Active icon picks up `tokens.text` (module-coloured); label stays `text-text`. No drop-shadow glow (cleaner than v1).
- Routine centre FAB unaffected — still rendered as a sibling of `ModuleBottomNav`.

User reported (screenshots) that the v2 active pill plus the floating shell read as a separate white card pasted onto a dead band at the bottom — inconsistent with the rest of the surface across hub + modules.

Drive-by: dropped `type="button"` from `StatusStrip.Chip` — `Card<as="button">` does not surface button-specific attributes and `staged-typecheck` tripped on it whenever any `apps/web` file was committed.

## Governing Skill

- Primary skill: `sergeant-web-frontend`
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a (pure visual revert, no behavioural/contract change)
- Why this playbook: n/a
- If no playbook matched, why: This is a small UI revert of a recent design change. No playbook covers single-component design rollbacks; the change is scoped to two presentational components plus their test/Storybook companions.

## Verification

```bash
pnpm --filter @sergeant/web test -- HubBottomNav   # 16/16 ✓ locally
pnpm --filter @sergeant/web typecheck              # clean on changed files (pre-existing errors elsewhere on main)
pnpm exec eslint apps/web/src/core/app/HubBottomNav.tsx apps/web/src/shared/components/ui/ModuleBottomNav.tsx   # ✓ no warnings
```

Additional checks:

- [x] Local smoke / manual validation completed (Vercel preview deployment will exercise the new shell)
- [x] Surface-specific checks completed (HubBottomNav tests updated for v1 indicator-position formula)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- `HubBottomNav.tsx` JSDoc — refreshed to describe the reverted v1 edge-to-edge shape.
- `ModuleBottomNav.tsx` JSDoc — refreshed (drop v2 floating-glass-pill prose).
- `ModuleBottomNav.stories.tsx` JSDoc — refreshed for the Storybook autodoc.

## Risk and Rollout

- User-visible risk: Bottom nav visually changes for all signed-in + guest users on web. Functional behaviour (routing, prefetch, accessibility roles, focus management, reports-tab reveal animation, localStorage flags) is unchanged.
- Rollout / deploy order: Standard web deploy via Vercel preview → main.
- Backout plan: Revert this commit — the v2 floating-pill shape is preserved verbatim in commits `4c6835d` and `d4cae3c` for reference.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

- No migrations, env changes, HubChat tools, or auth touched.
- `StatusStrip.tsx` drive-by fix: dropped redundant `type="button"` so `staged-typecheck` stops tripping on `Card<as="button">` polymorphic prop forwarding (unrelated pre-existing bug; was blocking every `apps/web` commit on main).
