### PR TITLE
fix(web): drop bottom-nav icons toward edge + soften welcome entrance

### DIFF
--- a/apps/web/src/core/app/HubBottomNav.tsx
+++ b/apps/web/src/core/app/HubBottomNav.tsx
@@ -100,7 +100,7 @@ function HubBottomNavTab({
       // accessible name (`label`), і тести з `name: /Звіти/` падали б.
       style={hiddenSlot ? { visibility: "hidden" } : undefined}
       className={cn(
-        "relative flex-1 flex flex-col items-center justify-center gap-1",
+        "relative flex-1 flex flex-col items-center justify-end gap-1 pb-1.5",
         "transition-all duration-200 min-h-[48px] pointer-coarse:min-h-[52px]",
         "active:scale-95",
         "focus:outline-none focus-visible:ring-2 focus-visible:ring-focus/45 focus-visible:ring-offset-2 focus-visible:ring-offset-panel",

--- a/apps/web/src/shared/components/ui/ModuleBottomNav.tsx
+++ b/apps/web/src/shared/components/ui/ModuleBottomNav.tsx
@@ -155,7 +155,7 @@ export const ModuleBottomNav = memo(function ModuleBottomNav({
               tabIndex={isTablist ? (active ? 0 : -1) : undefined}
               onClick={() => onChange(item.id)}
               className={cn(
-                "relative flex-1 flex flex-col items-center justify-center gap-1",
+                "relative flex-1 flex flex-col items-center justify-end gap-1 pb-1.5",
                 "min-h-touch-target",
                 "transition-all duration-200",
                 "active:scale-95",

--- a/apps/web/src/styles/animations.css
+++ b/apps/web/src/styles/animations.css
@@ -80,7 +80,7 @@
 }
 .animate-onboarding-enter {
   animation: onboarding-enter var(--motion-duration-slow)
-    var(--motion-ease-overshoot) both;
+    var(--motion-ease-decelerate) both;
 }
 
 /* ── Page transition slide directions (RESPONSE) ─────────────────────── */


### PR DESCRIPTION
## Summary

Two UX nits reported on the 2026-05-19 dashboard screenshot.

1. **Bottom-nav icons sat too high above the screen edge.** The icons were vertically centered in the 60px tab row, then `safe-area-pb` (~34px on home-indicator iPhones) added another empty cream band below — total ~46px of dead space between the icon+label cluster and the actual screen edge. Flip each tab button from `justify-center` → `justify-end gap-1 pb-1.5` so the cluster hugs the bottom of the row, abutting the safe-area inset with a 6px breathing margin. Net: icons sit ~34-40px from the screen edge instead of ~60-70px. Applied to both `HubBottomNav` and the shared `ModuleBottomNav` so all four modules inherit the same positioning.

2. **Welcome card visibly "trembled" up/down at mount.** After PR-#3022 dropped the white card chrome on the `fullPage` `/welcome` variant (so the mesh gradient could go full-bleed), the bare card animates in via `animate-onboarding-enter` with `--motion-ease-overshoot` (cubic-bezier(0.34, 1.56, 0.64, 1)). The springy bounce is much more visible against a transparent backdrop than it was inside the previous opaque card — reads as a wobble. Swap that animation's easing to `--motion-ease-decelerate` (cubic-bezier(0, 0, 0.2, 1)): same translateY(24px)→0 + scale(0.97)→1 entrance, but settles softly without overshoot. Other consumers of `--motion-ease-overshoot` (module-card stagger, celebration pops) are untouched.

## Governing Skill

- Primary skill: `sergeant-web-frontend`
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a
- Why this playbook: n/a
- If no playbook matched, why: Two small visual nits — one Tailwind class change on two components, one easing-token swap on one CSS rule. No playbook covers visual nudges at this granularity.

## Verification

```bash
pnpm --filter @sergeant/web test -- HubBottomNav   # 16/16 ✓ locally
pnpm exec eslint apps/web/src/core/app/HubBottomNav.tsx apps/web/src/shared/components/ui/ModuleBottomNav.tsx   # ✓ no warnings
```

Additional checks:

- [x] Local smoke / manual validation completed (Vercel preview will exercise the new positioning + entrance)
- [x] Surface-specific checks completed (no test changes — assertions cover roles/aria + indicator left math, neither of which moved)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a — no doc-impacting behaviour change.

## Risk and Rollout

- User-visible risk: Bottom-nav icons shift downward by ~20-30px within the nav band; welcome-card entrance no longer bounces. No functional change.
- Rollout / deploy order: Standard web deploy via Vercel preview → main.
- Backout plan: Revert this commit — both prior values (`justify-center` and `--motion-ease-overshoot`) are preserved in the immediately preceding commits.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

- No migrations, env changes, HubChat tools, or auth touched.
- `pb-1.5` on the tab button puts the tappable cluster ~6px above the safe-area inset boundary — still well clear of any home-indicator gesture conflict on iOS.
- Argos visual regression will flag both changes by design (intentional positional/animation diffs).


---
_Generated by [Claude Code](https://claude.ai/code/session_01EqFpmEjGLfb3or5CMftaSD)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops bottom-nav icons closer to the screen edge and softens the `/welcome` entrance animation. Reduces empty space on devices with a home indicator and removes the brief wobble on mount.

- **Bug Fixes**
  - Bottom nav: switched tab buttons from `justify-center` to `justify-end gap-1 pb-1.5` so the icon+label cluster sits near the bottom of the row; applied in `HubBottomNav` and `ModuleBottomNav`.
  - Onboarding: changed `.animate-onboarding-enter` easing from `--motion-ease-overshoot` to `--motion-ease-decelerate` to keep the slide/scale entrance but settle without a bounce.

<sup>Written for commit 12291a6e6987bde79ae33a83cdfd06b970c0e0a8. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3027?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted bottom navigation tab content alignment to position icons and labels at the bottom of the tab area with added spacing.
  * Modified onboarding animation easing for a smoother entry motion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Skords-01/Sergeant/pull/3027?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->