### PR TITLE
feat(agents): add skill trigger eval harness

### DIFF
--- a/docs/agents/agent-skills-catalog.md
+++ b/docs/agents/agent-skills-catalog.md
@@ -1,6 +1,6 @@
 # Sergeant Agent Skills Catalog
 
-> **Last validated:** 2026-05-18 by @codex. **Next review:** 2026-08-16.
+> **Last validated:** 2026-05-19 by @codex. **Next review:** 2026-08-17.
 > **Status:** Active
 
 Канонічна карта repo-owned skills. Якщо ти агент у цьому репо, починай із `sergeant-start-here`, а потім переходь до одного specialist skill на основну поверхню змін.
@@ -13,6 +13,8 @@
 pnpm lint:skills    # перевіряє shape (frontmatter, посилання) + integrity (SHA-256 ↔ skills-lock.json)
 pnpm skills:lock    # регенерує SHA-256 у .agents/skills-lock.json після свідомої зміни вмісту
 ```
+
+Skill-trigger eval-и живуть у [`skill-trigger-evals.json`](./skill-trigger-evals.json). `pnpm eval:skills` перевіряє, що кожен repo-owned skill має 2 trigger, 1 anti-trigger і 1 workflow-compliance prompt; команда входить у `pnpm lint:skills`.
 
 Гейти введено initiative-ою [`0009-agent-os-hardening`](../initiatives/archive/_0009-agent-os-hardening.md) PR 1.1 ([#1659](https://github.com/Skords-01/Sergeant/pull/1659)). `skill-freshness.yml` тепер запускає той самий `pnpm lint:skills` як required-чек на PR. Без оновленого lock-у CI падає з посиланням на `pnpm skills:lock`.
 

--- a/docs/agents/skill-trigger-evals.json
+++ b/docs/agents/skill-trigger-evals.json
@@ -1,0 +1,726 @@
+{
+  "schemaVersion": 1,
+  "description": "Golden prompts for static Sergeant skill-trigger evaluation. Each repo-owned skill has two trigger prompts, one anti-trigger prompt, and one workflow-compliance prompt.",
+  "cases": [
+    {
+      "id": "better-auth-best-practices-trigger-cookie-session",
+      "skill": "better-auth-best-practices",
+      "kind": "trigger",
+      "prompt": "Fix a login session bug where Better Auth cookies work locally but fail after the Railway and Vercel split-origin deploy.",
+      "expectedSkills": ["sergeant-start-here", "better-auth-best-practices"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "better-auth-best-practices-trigger-account-lifecycle",
+      "skill": "better-auth-best-practices",
+      "kind": "trigger",
+      "prompt": "Review the account lifecycle flow for password reset, session expiry, and Better Auth rate-limit wiring.",
+      "expectedSkills": ["sergeant-start-here", "better-auth-best-practices"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "better-auth-best-practices-anti-web-layout",
+      "skill": "better-auth-best-practices",
+      "kind": "anti-trigger",
+      "prompt": "Polish the nutrition dashboard mobile layout and Tailwind spacing without touching login, cookies, or sessions.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-web-ui"],
+      "forbiddenSkills": ["better-auth-best-practices"]
+    },
+    {
+      "id": "better-auth-best-practices-workflow-start-here",
+      "skill": "better-auth-best-practices",
+      "kind": "workflow",
+      "prompt": "Before changing Better Auth cookie settings, load Sergeant startup rules and then exactly this auth specialist.",
+      "expectedSkills": ["sergeant-start-here", "better-auth-best-practices"],
+      "forbiddenSkills": [],
+      "complianceChecks": ["start-here-first", "exactly-one-specialist"]
+    },
+    {
+      "id": "sergeant-bugfix-and-regression-trigger-regression",
+      "skill": "sergeant-bugfix-and-regression",
+      "kind": "trigger",
+      "prompt": "A previously working sync endpoint now returns stale data after the latest PR; reproduce and fix the regression.",
+      "expectedSkills": [
+        "sergeant-start-here",
+        "sergeant-bugfix-and-regression"
+      ],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-bugfix-and-regression-trigger-flaky",
+      "skill": "sergeant-bugfix-and-regression",
+      "kind": "trigger",
+      "prompt": "Investigate a flaky Vitest that fails only in CI and create the smallest safe fix with a failing check first.",
+      "expectedSkills": [
+        "sergeant-start-here",
+        "sergeant-bugfix-and-regression"
+      ],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-bugfix-and-regression-anti-new-feature",
+      "skill": "sergeant-bugfix-and-regression",
+      "kind": "anti-trigger",
+      "prompt": "Add a brand new dashboard screen and route for a planned feature that has no existing broken behavior.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-feature-delivery"],
+      "forbiddenSkills": ["sergeant-bugfix-and-regression"]
+    },
+    {
+      "id": "sergeant-bugfix-and-regression-workflow-reproduce-first",
+      "skill": "sergeant-bugfix-and-regression",
+      "kind": "workflow",
+      "prompt": "For this production regression, start with repo rules, load only the bugfix skill, reproduce first, then patch.",
+      "expectedSkills": [
+        "sergeant-start-here",
+        "sergeant-bugfix-and-regression"
+      ],
+      "forbiddenSkills": [],
+      "complianceChecks": ["start-here-first", "exactly-one-specialist"]
+    },
+    {
+      "id": "sergeant-council-trigger-ambiguous-decision",
+      "skill": "sergeant-council",
+      "kind": "trigger",
+      "prompt": "I am torn between two valid product architecture paths; convene the Sergeant council and synthesize the tradeoffs.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-council"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-council-trigger-go-no-go",
+      "skill": "sergeant-council",
+      "kind": "trigger",
+      "prompt": "Run a structured go/no-go discussion for a risky OpenClaw rollout where product, UX, growth, and tech disagree.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-council"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-council-anti-simple-bug",
+      "skill": "sergeant-council",
+      "kind": "anti-trigger",
+      "prompt": "Fix a single null check bug in the server serializer with no strategic tradeoff or multi-view decision needed.",
+      "expectedSkills": [
+        "sergeant-start-here",
+        "sergeant-bugfix-and-regression"
+      ],
+      "forbiddenSkills": ["sergeant-council"]
+    },
+    {
+      "id": "sergeant-council-workflow-one-specialist",
+      "skill": "sergeant-council",
+      "kind": "workflow",
+      "prompt": "Use the repo startup skill first, then only the council specialist before deciding which advisors to consult.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-council"],
+      "forbiddenSkills": [],
+      "complianceChecks": ["start-here-first", "exactly-one-specialist"]
+    },
+    {
+      "id": "sergeant-data-and-migrations-trigger-new-column",
+      "skill": "sergeant-data-and-migrations",
+      "kind": "trigger",
+      "prompt": "Add a Postgres column with a sequential SQL migration and verify rollout safety for existing production rows.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-data-and-migrations"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-data-and-migrations-trigger-drop-column",
+      "skill": "sergeant-data-and-migrations",
+      "kind": "trigger",
+      "prompt": "Plan a two-phase DROP for an obsolete table and make sure the migration numbering has no gaps.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-data-and-migrations"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-data-and-migrations-anti-css",
+      "skill": "sergeant-data-and-migrations",
+      "kind": "anti-trigger",
+      "prompt": "Fix Tailwind focus-visible styling on an icon button without changing schema, SQL, or database rollout.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-web-ui"],
+      "forbiddenSkills": ["sergeant-data-and-migrations"]
+    },
+    {
+      "id": "sergeant-data-and-migrations-workflow-sequential",
+      "skill": "sergeant-data-and-migrations",
+      "kind": "workflow",
+      "prompt": "Before editing migrations, load start-here and then only the data-and-migrations specialist for numbering checks.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-data-and-migrations"],
+      "forbiddenSkills": [],
+      "complianceChecks": ["start-here-first", "exactly-one-specialist"]
+    },
+    {
+      "id": "sergeant-deliver-squad-trigger-cross-surface",
+      "skill": "sergeant-deliver-squad",
+      "kind": "trigger",
+      "prompt": "Ship a feature that needs DB migration, server serializer, api-client contract, web UI, and mobile updates.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-deliver-squad"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-deliver-squad-trigger-contract-chain",
+      "skill": "sergeant-deliver-squad",
+      "kind": "trigger",
+      "prompt": "Coordinate parallel implementation for a contract change that spans migrations, server, api-client, web, and mobile.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-deliver-squad"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-deliver-squad-anti-single-web",
+      "skill": "sergeant-deliver-squad",
+      "kind": "anti-trigger",
+      "prompt": "Change one isolated web component with no server contract, migration, mobile, or api-client dependency.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-web-ui"],
+      "forbiddenSkills": ["sergeant-deliver-squad"]
+    },
+    {
+      "id": "sergeant-deliver-squad-workflow-handoff",
+      "skill": "sergeant-deliver-squad",
+      "kind": "workflow",
+      "prompt": "Start with Sergeant rules, load only the deliver-squad coordinator, then sequence migration before server and clients.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-deliver-squad"],
+      "forbiddenSkills": [],
+      "complianceChecks": ["start-here-first", "exactly-one-specialist"]
+    },
+    {
+      "id": "sergeant-deploy-and-observability-trigger-env",
+      "skill": "sergeant-deploy-and-observability",
+      "kind": "trigger",
+      "prompt": "Add a Railway environment variable, update operator docs, and verify health checks after deploy.",
+      "expectedSkills": [
+        "sergeant-start-here",
+        "sergeant-deploy-and-observability"
+      ],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-deploy-and-observability-trigger-sentry",
+      "skill": "sergeant-deploy-and-observability",
+      "kind": "trigger",
+      "prompt": "Wire Sentry and Prometheus alerts for a background worker and document the rollout and rollback procedure.",
+      "expectedSkills": [
+        "sergeant-start-here",
+        "sergeant-deploy-and-observability"
+      ],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-deploy-and-observability-anti-local-test",
+      "skill": "sergeant-deploy-and-observability",
+      "kind": "anti-trigger",
+      "prompt": "Add a local Vitest unit for a pure utility with no deploy, runtime env, observability, or health-check change.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-feature-delivery"],
+      "forbiddenSkills": ["sergeant-deploy-and-observability"]
+    },
+    {
+      "id": "sergeant-deploy-and-observability-workflow-runtime",
+      "skill": "sergeant-deploy-and-observability",
+      "kind": "workflow",
+      "prompt": "For a deploy config change, load start-here and then only deploy-and-observability before touching env docs.",
+      "expectedSkills": [
+        "sergeant-start-here",
+        "sergeant-deploy-and-observability"
+      ],
+      "forbiddenSkills": [],
+      "complianceChecks": ["start-here-first", "exactly-one-specialist"]
+    },
+    {
+      "id": "sergeant-e2e-testing-trigger-playwright",
+      "skill": "sergeant-e2e-testing",
+      "kind": "trigger",
+      "prompt": "Write a Playwright smoke test for onboarding, using role selectors and no waitForTimeout calls.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-e2e-testing"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-e2e-testing-trigger-accessibility",
+      "skill": "sergeant-e2e-testing",
+      "kind": "trigger",
+      "prompt": "Debug a failing E2E accessibility check for the web app and update the golden test path.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-e2e-testing"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-e2e-testing-anti-unit-pure",
+      "skill": "sergeant-e2e-testing",
+      "kind": "anti-trigger",
+      "prompt": "Add a small unit test for a pure TypeScript money-formatting helper with no browser flow.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-feature-delivery"],
+      "forbiddenSkills": ["sergeant-e2e-testing"]
+    },
+    {
+      "id": "sergeant-e2e-testing-workflow-golden-rules",
+      "skill": "sergeant-e2e-testing",
+      "kind": "workflow",
+      "prompt": "Before editing Playwright tests, load start-here and then only the E2E specialist so the golden rules apply.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-e2e-testing"],
+      "forbiddenSkills": [],
+      "complianceChecks": ["start-here-first", "exactly-one-specialist"]
+    },
+    {
+      "id": "sergeant-feature-delivery-trigger-new-screen",
+      "skill": "sergeant-feature-delivery",
+      "kind": "trigger",
+      "prompt": "Build a new user-facing screen with behavior changes and focused verification for the coherent feature slice.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-feature-delivery"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-feature-delivery-trigger-new-api-action",
+      "skill": "sergeant-feature-delivery",
+      "kind": "trigger",
+      "prompt": "Add a new saved action flow from UI to API, using a small spec-first implementation plan.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-feature-delivery"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-feature-delivery-anti-regression",
+      "skill": "sergeant-feature-delivery",
+      "kind": "anti-trigger",
+      "prompt": "A shipped route broke yesterday and needs reproduce-first debugging rather than a new feature slice.",
+      "expectedSkills": [
+        "sergeant-start-here",
+        "sergeant-bugfix-and-regression"
+      ],
+      "forbiddenSkills": ["sergeant-feature-delivery"]
+    },
+    {
+      "id": "sergeant-feature-delivery-workflow-spec-first",
+      "skill": "sergeant-feature-delivery",
+      "kind": "workflow",
+      "prompt": "For this new feature, load the Sergeant entrypoint and then only feature-delivery before implementing.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-feature-delivery"],
+      "forbiddenSkills": [],
+      "complianceChecks": ["start-here-first", "exactly-one-specialist"]
+    },
+    {
+      "id": "sergeant-hubchat-trigger-tool-def",
+      "skill": "sergeant-hubchat",
+      "kind": "trigger",
+      "prompt": "Add a HubChat tool definition and executor for a new read action, including prompt-cache considerations.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-hubchat"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-hubchat-trigger-action-card",
+      "skill": "sergeant-hubchat",
+      "kind": "trigger",
+      "prompt": "Fix a HubChat action card so risky mutations require confirmation and executor output remains typed.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-hubchat"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-hubchat-anti-mobile-layout",
+      "skill": "sergeant-hubchat",
+      "kind": "anti-trigger",
+      "prompt": "Adjust Expo tab navigation and NativeWind spacing without touching chat tools, executors, or action cards.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-mobile-expo"],
+      "forbiddenSkills": ["sergeant-hubchat"]
+    },
+    {
+      "id": "sergeant-hubchat-workflow-tool-executor",
+      "skill": "sergeant-hubchat",
+      "kind": "workflow",
+      "prompt": "Before editing HubChat executors, load start-here and then only the HubChat specialist.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-hubchat"],
+      "forbiddenSkills": [],
+      "complianceChecks": ["start-here-first", "exactly-one-specialist"]
+    },
+    {
+      "id": "sergeant-mobile-expo-trigger-expo-router",
+      "skill": "sergeant-mobile-expo",
+      "kind": "trigger",
+      "prompt": "Implement an Expo Router screen with NativeWind styling and no DOM-only APIs leaking into mobile.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-mobile-expo"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-mobile-expo-trigger-mmkv",
+      "skill": "sergeant-mobile-expo",
+      "kind": "trigger",
+      "prompt": "Fix a mobile-shell MMKV persistence bug and verify deep-link behavior in the Expo app.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-mobile-expo"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-mobile-expo-anti-web-only",
+      "skill": "sergeant-mobile-expo",
+      "kind": "anti-trigger",
+      "prompt": "Change only a Vite web route and Tailwind class in apps/web, with no Expo or React Native surface.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-web-ui"],
+      "forbiddenSkills": ["sergeant-mobile-expo"]
+    },
+    {
+      "id": "sergeant-mobile-expo-workflow-native-boundaries",
+      "skill": "sergeant-mobile-expo",
+      "kind": "workflow",
+      "prompt": "For mobile work, load the Sergeant entrypoint first and then only the Expo specialist before editing apps/mobile.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-mobile-expo"],
+      "forbiddenSkills": [],
+      "complianceChecks": ["start-here-first", "exactly-one-specialist"]
+    },
+    {
+      "id": "sergeant-monorepo-boundaries-trigger-placement",
+      "skill": "sergeant-monorepo-boundaries",
+      "kind": "trigger",
+      "prompt": "Decide whether shared validation logic belongs in apps/server, apps/web, or a package boundary.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-monorepo-boundaries"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-monorepo-boundaries-trigger-shared-package",
+      "skill": "sergeant-monorepo-boundaries",
+      "kind": "trigger",
+      "prompt": "Review where to place cross-surface domain code before moving it into packages/shared.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-monorepo-boundaries"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-monorepo-boundaries-anti-known-web",
+      "skill": "sergeant-monorepo-boundaries",
+      "kind": "anti-trigger",
+      "prompt": "Update a clearly local web component inside an existing feature folder with no shared-code question.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-web-ui"],
+      "forbiddenSkills": ["sergeant-monorepo-boundaries"]
+    },
+    {
+      "id": "sergeant-monorepo-boundaries-workflow-placement-first",
+      "skill": "sergeant-monorepo-boundaries",
+      "kind": "workflow",
+      "prompt": "When code placement is unclear, load start-here and then only monorepo-boundaries before implementation.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-monorepo-boundaries"],
+      "forbiddenSkills": [],
+      "complianceChecks": ["start-here-first", "exactly-one-specialist"]
+    },
+    {
+      "id": "sergeant-openclaw-trigger-gateway",
+      "skill": "sergeant-openclaw",
+      "kind": "trigger",
+      "prompt": "Change the OpenClaw Gateway config-as-code and verify no production path uses a plain PAT.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-openclaw"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-openclaw-trigger-plugin",
+      "skill": "sergeant-openclaw",
+      "kind": "trigger",
+      "prompt": "Update the openclaw-plugin routing tests and persona skill allowlist for a new strategic mode.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-openclaw"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-openclaw-anti-plain-web",
+      "skill": "sergeant-openclaw",
+      "kind": "anti-trigger",
+      "prompt": "Fix a normal web dashboard display bug with no OpenClaw Gateway, plugin, PAT, or console-agent change.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-web-ui"],
+      "forbiddenSkills": ["sergeant-openclaw"]
+    },
+    {
+      "id": "sergeant-openclaw-workflow-pat-safety",
+      "skill": "sergeant-openclaw",
+      "kind": "workflow",
+      "prompt": "Before touching OpenClaw code, load start-here and then only the OpenClaw specialist for PAT safety.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-openclaw"],
+      "forbiddenSkills": [],
+      "complianceChecks": ["start-here-first", "exactly-one-specialist"]
+    },
+    {
+      "id": "sergeant-qa-squad-trigger-full-qa",
+      "skill": "sergeant-qa-squad",
+      "kind": "trigger",
+      "prompt": "Run full QA across web, server, mobile, and OpenClaw surfaces in parallel and synthesize the results.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-qa-squad"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-qa-squad-trigger-all-surfaces",
+      "skill": "sergeant-qa-squad",
+      "kind": "trigger",
+      "prompt": "Before merge, verify tests and typechecks for every Sergeant app surface with coordinated QA agents.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-qa-squad"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-qa-squad-anti-single-test",
+      "skill": "sergeant-qa-squad",
+      "kind": "anti-trigger",
+      "prompt": "Run one focused server unit test for a local bugfix, not a full multi-surface QA sweep.",
+      "expectedSkills": [
+        "sergeant-start-here",
+        "sergeant-bugfix-and-regression"
+      ],
+      "forbiddenSkills": ["sergeant-qa-squad"]
+    },
+    {
+      "id": "sergeant-qa-squad-workflow-coordinator",
+      "skill": "sergeant-qa-squad",
+      "kind": "workflow",
+      "prompt": "Load start-here first, then only qa-squad before coordinating parallel verification across surfaces.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-qa-squad"],
+      "forbiddenSkills": [],
+      "complianceChecks": ["start-here-first", "exactly-one-specialist"]
+    },
+    {
+      "id": "sergeant-review-and-merge-trigger-pr-review",
+      "skill": "sergeant-review-and-merge",
+      "kind": "trigger",
+      "prompt": "Review an open PR for merge readiness, focusing on regressions, tests, hard rules, and PR body quality.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-review-and-merge"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-review-and-merge-trigger-premerge",
+      "skill": "sergeant-review-and-merge",
+      "kind": "trigger",
+      "prompt": "Do a pre-merge safety pass on a branch, checking contracts, docs freshness, and verification evidence.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-review-and-merge"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-review-and-merge-anti-implement-feature",
+      "skill": "sergeant-review-and-merge",
+      "kind": "anti-trigger",
+      "prompt": "Implement a new feature from scratch rather than reviewing an existing PR or merge candidate.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-feature-delivery"],
+      "forbiddenSkills": ["sergeant-review-and-merge"]
+    },
+    {
+      "id": "sergeant-review-and-merge-workflow-findings-first",
+      "skill": "sergeant-review-and-merge",
+      "kind": "workflow",
+      "prompt": "For PR review, load start-here and then only review-and-merge so findings lead the response.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-review-and-merge"],
+      "forbiddenSkills": [],
+      "complianceChecks": ["start-here-first", "exactly-one-specialist"]
+    },
+    {
+      "id": "sergeant-review-squad-trigger-multi-surface-review",
+      "skill": "sergeant-review-squad",
+      "kind": "trigger",
+      "prompt": "Review a PR touching server contracts, web design, security, and docs using parallel specialist lenses.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-review-squad"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-review-squad-trigger-three-surfaces",
+      "skill": "sergeant-review-squad",
+      "kind": "trigger",
+      "prompt": "Coordinate a review for changes across three governed surfaces and synthesize contract, design, security, and docs risks.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-review-squad"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-review-squad-anti-single-file",
+      "skill": "sergeant-review-squad",
+      "kind": "anti-trigger",
+      "prompt": "Review a one-file typo fix in docs where a normal focused review is enough.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-review-and-merge"],
+      "forbiddenSkills": ["sergeant-review-squad"]
+    },
+    {
+      "id": "sergeant-review-squad-workflow-parallel-lenses",
+      "skill": "sergeant-review-squad",
+      "kind": "workflow",
+      "prompt": "Load start-here first, then only review-squad before deciding which reviewer lenses should run.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-review-squad"],
+      "forbiddenSkills": [],
+      "complianceChecks": ["start-here-first", "exactly-one-specialist"]
+    },
+    {
+      "id": "sergeant-security-audit-trigger-pat",
+      "skill": "sergeant-security-audit",
+      "kind": "trigger",
+      "prompt": "Audit the repo for OpenClaw PAT exposure, sensitive logging, and SKILL.md injection patterns.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-security-audit"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-security-audit-trigger-pnpm-audit",
+      "skill": "sergeant-security-audit",
+      "kind": "trigger",
+      "prompt": "Run a security review of dependency risk, Pino redaction, and secret handling before release.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-security-audit"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-security-audit-anti-visual-polish",
+      "skill": "sergeant-security-audit",
+      "kind": "anti-trigger",
+      "prompt": "Adjust button sizes and typography in a web component with no secrets, auth, logging, or dependency risk.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-web-ui"],
+      "forbiddenSkills": ["sergeant-security-audit"]
+    },
+    {
+      "id": "sergeant-security-audit-workflow-hard-rules",
+      "skill": "sergeant-security-audit",
+      "kind": "workflow",
+      "prompt": "Before a security audit, load start-here and then only security-audit so Hard Rules 20 through 22 apply.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-security-audit"],
+      "forbiddenSkills": [],
+      "complianceChecks": ["start-here-first", "exactly-one-specialist"]
+    },
+    {
+      "id": "sergeant-server-api-trigger-serializer",
+      "skill": "sergeant-server-api",
+      "kind": "trigger",
+      "prompt": "Change a server route serializer that returns Postgres bigint values and update the API client contract test.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-server-api"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-server-api-trigger-route",
+      "skill": "sergeant-server-api",
+      "kind": "trigger",
+      "prompt": "Add a backend API route with business logic, typed response shape, and contract coverage.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-server-api"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-server-api-anti-mobile-only",
+      "skill": "sergeant-server-api",
+      "kind": "anti-trigger",
+      "prompt": "Fix an Expo screen render bug that does not touch server routes, serializers, or api-client types.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-mobile-expo"],
+      "forbiddenSkills": ["sergeant-server-api"]
+    },
+    {
+      "id": "sergeant-server-api-workflow-contract-triplet",
+      "skill": "sergeant-server-api",
+      "kind": "workflow",
+      "prompt": "For server API work, load start-here and then only server-api before changing serializers or api-client types.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-server-api"],
+      "forbiddenSkills": [],
+      "complianceChecks": ["start-here-first", "exactly-one-specialist"]
+    },
+    {
+      "id": "sergeant-start-here-trigger-any-repo-task",
+      "skill": "sergeant-start-here",
+      "kind": "trigger",
+      "prompt": "Start any new coding task inside the Sergeant repo and orient on hard rules before touching files.",
+      "expectedSkills": ["sergeant-start-here"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-start-here-trigger-review-request",
+      "skill": "sergeant-start-here",
+      "kind": "trigger",
+      "prompt": "A user asks for a review of this Sergeant branch, so first load the mandatory repo entrypoint.",
+      "expectedSkills": ["sergeant-start-here"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-start-here-anti-non-repo-question",
+      "skill": "sergeant-start-here",
+      "kind": "anti-trigger",
+      "prompt": "Answer a general conceptual question about OAuth outside the Sergeant workspace without repo-specific action.",
+      "expectedSkills": [],
+      "forbiddenSkills": ["sergeant-start-here"]
+    },
+    {
+      "id": "sergeant-start-here-workflow-before-specialist",
+      "skill": "sergeant-start-here",
+      "kind": "workflow",
+      "prompt": "When a Sergeant task begins, run the entrypoint before selecting exactly one surface specialist.",
+      "expectedSkills": ["sergeant-start-here"],
+      "forbiddenSkills": [],
+      "complianceChecks": ["start-here-first", "exactly-one-specialist"]
+    },
+    {
+      "id": "sergeant-tech-debt-trigger-eslint-baseline",
+      "skill": "sergeant-tech-debt",
+      "kind": "trigger",
+      "prompt": "Reduce ESLint baseline debt by fixing the underlying violation and removing the matching baseline entry.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-tech-debt"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-tech-debt-trigger-dead-code",
+      "skill": "sergeant-tech-debt",
+      "kind": "trigger",
+      "prompt": "Clean a Knip dead-code finding with lifecycle marker checks and monorepo grep before deletion.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-tech-debt"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-tech-debt-anti-product-feature",
+      "skill": "sergeant-tech-debt",
+      "kind": "anti-trigger",
+      "prompt": "Build a new paid feature flow rather than reducing debt, dead code, lint baseline, or module size.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-feature-delivery"],
+      "forbiddenSkills": ["sergeant-tech-debt"]
+    },
+    {
+      "id": "sergeant-tech-debt-workflow-separate-prs",
+      "skill": "sergeant-tech-debt",
+      "kind": "workflow",
+      "prompt": "For a technical debt cleanup, load start-here and then only tech-debt before choosing one debt class.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-tech-debt"],
+      "forbiddenSkills": [],
+      "complianceChecks": ["start-here-first", "exactly-one-specialist"]
+    },
+    {
+      "id": "sergeant-web-ui-trigger-tailwind",
+      "skill": "sergeant-web-ui",
+      "kind": "trigger",
+      "prompt": "Update an apps/web component with Tailwind classes, accessible focus-visible states, and touch targets.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-web-ui"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-web-ui-trigger-query-keys",
+      "skill": "sergeant-web-ui",
+      "kind": "trigger",
+      "prompt": "Fix a React Query hook in the web app so it uses centralized query key factories.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-web-ui"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-web-ui-anti-sql-migration",
+      "skill": "sergeant-web-ui",
+      "kind": "anti-trigger",
+      "prompt": "Create a sequential SQL migration for a new Postgres index without any web UI changes.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-data-and-migrations"],
+      "forbiddenSkills": ["sergeant-web-ui"]
+    },
+    {
+      "id": "sergeant-web-ui-workflow-design-rules",
+      "skill": "sergeant-web-ui",
+      "kind": "workflow",
+      "prompt": "Before editing apps/web UI, load start-here and then only web-ui so design conventions apply.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-web-ui"],
+      "forbiddenSkills": [],
+      "complianceChecks": ["start-here-first", "exactly-one-specialist"]
+    },
+    {
+      "id": "sergeant-writing-skills-trigger-new-skill",
+      "skill": "sergeant-writing-skills",
+      "kind": "trigger",
+      "prompt": "Create a new repo-owned Sergeant skill with frontmatter shape, security scan, and skills-lock update.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-writing-skills"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-writing-skills-trigger-edit-skill",
+      "skill": "sergeant-writing-skills",
+      "kind": "trigger",
+      "prompt": "Edit an existing .agents/skills SKILL.md and regenerate the skill lock hash safely.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-writing-skills"],
+      "forbiddenSkills": []
+    },
+    {
+      "id": "sergeant-writing-skills-anti-normal-docs",
+      "skill": "sergeant-writing-skills",
+      "kind": "anti-trigger",
+      "prompt": "Update a planning roadmap without creating or editing any .agents/skills/SKILL.md file.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-tech-debt"],
+      "forbiddenSkills": ["sergeant-writing-skills"]
+    },
+    {
+      "id": "sergeant-writing-skills-workflow-lock",
+      "skill": "sergeant-writing-skills",
+      "kind": "workflow",
+      "prompt": "Before editing SKILL.md files, load start-here and then only writing-skills so lock and scan rules apply.",
+      "expectedSkills": ["sergeant-start-here", "sergeant-writing-skills"],
+      "forbiddenSkills": [],
+      "complianceChecks": ["start-here-first", "exactly-one-specialist"]
+    }
+  ]
+}

--- a/docs/planning/ai-coding-improvements.md
+++ b/docs/planning/ai-coding-improvements.md
@@ -1,6 +1,6 @@
 # Roadmap покращень AI-coding
 
-> **Last validated:** 2026-05-14 by Codex (перекладено українською та синхронізовано з planning index). **Next review:** 2026-08-12.
+> **Last validated:** 2026-05-19 by Codex (додано перший виконуваний skill-trigger eval harness). **Next review:** 2026-08-17.
 > **Status:** Active
 
 Roadmap для агентської інфраструктури Sergeant. Це не продуктовий roadmap; це план, як зробити AI-assisted development швидшим, безпечнішим і дисциплінованішим.
@@ -23,14 +23,14 @@ Roadmap для агентської інфраструктури Sergeant. Це 
 
 ## Наступні блоки
 
-| Блок                               | Статус | Нотатки                                                                                    |
-| ---------------------------------- | ------ | ------------------------------------------------------------------------------------------ |
-| Eval harness для skill trigger-ів  | next   | 2 trigger + 1 anti-trigger + 1 workflow-compliance prompt на кожен skill                   |
-| Eval harness для playbook routing  | next   | один очевидний playbook match для priority-сценаріїв                                       |
-| Discoverability tests              | next   | new contributor / new agent знаходить потрібний route менш ніж за два кліки                |
-| Sampling відповідності PR template | next   | dry-run quality gate для PR descriptions                                                   |
-| Автоматизація operator dashboards  | next   | saved searches / issue views для lead time, stale flags, postmortem actions                |
-| Privacy and data-rights operations | next   | перетворити launch/privacy draft на канонічні retention, consent, export, delete surface-и |
+| Блок                               | Статус | Нотатки                                                                                                                               |
+| ---------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Eval harness для skill trigger-ів  | active | `docs/agents/skill-trigger-evals.json` + `pnpm eval:skills`: 2 trigger + 1 anti-trigger + 1 workflow-compliance prompt на кожен skill |
+| Eval harness для playbook routing  | next   | один очевидний playbook match для priority-сценаріїв                                                                                  |
+| Discoverability tests              | next   | new contributor / new agent знаходить потрібний route менш ніж за два кліки                                                           |
+| Sampling відповідності PR template | next   | dry-run quality gate для PR descriptions                                                                                              |
+| Автоматизація operator dashboards  | next   | saved searches / issue views для lead time, stale flags, postmortem actions                                                           |
+| Privacy and data-rights operations | next   | перетворити launch/privacy draft на канонічні retention, consent, export, delete surface-и                                            |
 
 ## План оцінювання
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "api:check-openapi-types": "node scripts/api/check-openapi-types-fresh.mjs",
     "lint:plugins": "node --test packages/eslint-plugin-sergeant-design/__tests__/*.test.mjs",
     "lint:discoverability": "node scripts/check-discoverability.mjs",
-    "lint:skills": "node scripts/check-skill-shape.mjs && node scripts/check-skills-lock.mjs && node scripts/check-skill-body-security.mjs",
+    "lint:skills": "node scripts/check-skill-shape.mjs && node scripts/check-skills-lock.mjs && node scripts/check-skill-body-security.mjs && pnpm eval:skills",
     "lint:playbook-language": "node scripts/check-playbook-language.mjs",
     "skills:lock": "node scripts/check-skills-lock.mjs --write",
     "typecheck": "turbo run typecheck",
@@ -128,7 +128,9 @@
     "pre-commit:timings": "node scripts/pre-commit-timings-report.mjs",
     "eval:rag": "node scripts/eval-rag-recall.mjs",
     "eval:rag:weekly": "node scripts/rag-eval-weekly.mjs",
-    "eval:rag:test": "node --test scripts/__tests__/eval-rag-recall.test.mjs scripts/__tests__/rag-eval-weekly.test.mjs"
+    "eval:rag:test": "node --test scripts/__tests__/eval-rag-recall.test.mjs scripts/__tests__/rag-eval-weekly.test.mjs",
+    "eval:skills": "node scripts/eval-skill-triggers.mjs",
+    "eval:skills:test": "node --test scripts/__tests__/eval-skill-triggers.test.mjs"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.5.3",

--- a/scripts/__tests__/eval-skill-triggers.test.mjs
+++ b/scripts/__tests__/eval-skill-triggers.test.mjs
@@ -1,0 +1,175 @@
+// node --test scripts/__tests__/eval-skill-triggers.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, rmSync, writeFileSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+import {
+  collectSkillSlugs,
+  validateGoldenSet,
+} from "../eval-skill-triggers.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..", "..");
+const SCRIPT_PATH = resolve(__dirname, "..", "eval-skill-triggers.mjs");
+
+function makeRepoWithSkills(slugs) {
+  const root = mkdtempSync(join(tmpdir(), "skill-eval-test-"));
+  for (const slug of slugs) {
+    const dir = join(root, ".agents", "skills", slug);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "SKILL.md"),
+      `---\nname: ${slug}\n---\n# ${slug}\n`,
+    );
+  }
+  return root;
+}
+
+function validCasesFor(skill, expected = [skill]) {
+  const expectedSkills = expected.includes("sergeant-start-here")
+    ? expected
+    : ["sergeant-start-here", ...expected];
+  return [
+    {
+      id: `${skill}-trigger-one`,
+      skill,
+      kind: "trigger",
+      prompt: `Please handle the primary ${skill} scenario in this Sergeant repo.`,
+      expectedSkills,
+      forbiddenSkills: [],
+    },
+    {
+      id: `${skill}-trigger-two`,
+      skill,
+      kind: "trigger",
+      prompt: `Route this second realistic request to ${skill} after start-here.`,
+      expectedSkills,
+      forbiddenSkills: [],
+    },
+    {
+      id: `${skill}-anti-one`,
+      skill,
+      kind: "anti-trigger",
+      prompt: `This is intentionally about some other Sergeant surface, not ${skill}.`,
+      expectedSkills:
+        skill === "sergeant-start-here" ? [] : ["sergeant-start-here"],
+      forbiddenSkills: [skill],
+    },
+    {
+      id: `${skill}-workflow-one`,
+      skill,
+      kind: "workflow",
+      prompt: `Run the required Sergeant startup flow before using ${skill}.`,
+      expectedSkills,
+      forbiddenSkills: [],
+      complianceChecks: ["start-here-first", "exactly-one-specialist"],
+    },
+  ];
+}
+
+test("collectSkillSlugs returns directories with SKILL.md", () => {
+  const root = makeRepoWithSkills(["sergeant-start-here", "sergeant-web-ui"]);
+  try {
+    assert.deepEqual(collectSkillSlugs(root), [
+      "sergeant-start-here",
+      "sergeant-web-ui",
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("validateGoldenSet passes a complete minimal fixture", () => {
+  const skills = ["sergeant-start-here", "sergeant-web-ui"];
+  const golden = {
+    schemaVersion: 1,
+    cases: [
+      ...validCasesFor("sergeant-start-here", ["sergeant-start-here"]),
+      ...validCasesFor("sergeant-web-ui", ["sergeant-web-ui"]),
+    ],
+  };
+
+  const report = validateGoldenSet(golden, skills);
+  assert.equal(report.ok, true, report.errors.join("\n"));
+});
+
+test("validateGoldenSet fails when a skill has incomplete coverage", () => {
+  const report = validateGoldenSet(
+    {
+      schemaVersion: 1,
+      cases: validCasesFor("sergeant-start-here", ["sergeant-start-here"]),
+    },
+    ["sergeant-start-here", "sergeant-web-ui"],
+  );
+
+  assert.equal(report.ok, false);
+  assert.ok(
+    report.errors.some((error) =>
+      error.includes("sergeant-web-ui: missing all golden cases"),
+    ),
+  );
+});
+
+test("validateGoldenSet rejects anti-triggers that still expect the target skill", () => {
+  const cases = validCasesFor("sergeant-web-ui", ["sergeant-web-ui"]);
+  const anti = cases.find((item) => item.kind === "anti-trigger");
+  anti.expectedSkills = ["sergeant-start-here", "sergeant-web-ui"];
+
+  const report = validateGoldenSet(
+    {
+      schemaVersion: 1,
+      cases: [
+        ...validCasesFor("sergeant-start-here", ["sergeant-start-here"]),
+        ...cases,
+      ],
+    },
+    ["sergeant-start-here", "sergeant-web-ui"],
+  );
+
+  assert.equal(report.ok, false);
+  assert.ok(
+    report.errors.some((error) =>
+      error.includes("anti-trigger must not expect its target skill"),
+    ),
+  );
+});
+
+test("validateGoldenSet rejects workflow cases without required checks", () => {
+  const cases = validCasesFor("sergeant-web-ui", ["sergeant-web-ui"]);
+  const workflow = cases.find((item) => item.kind === "workflow");
+  workflow.complianceChecks = ["start-here-first"];
+
+  const report = validateGoldenSet(
+    {
+      schemaVersion: 1,
+      cases: [
+        ...validCasesFor("sergeant-start-here", ["sergeant-start-here"]),
+        ...cases,
+      ],
+    },
+    ["sergeant-start-here", "sergeant-web-ui"],
+  );
+
+  assert.equal(report.ok, false);
+  assert.ok(
+    report.errors.some((error) =>
+      error.includes("workflow case missing exactly-one-specialist"),
+    ),
+  );
+});
+
+test("CLI passes against the real repo golden set", () => {
+  const result = spawnSync(process.execPath, [SCRIPT_PATH, "--json"], {
+    cwd: REPO_ROOT,
+    encoding: "utf-8",
+  });
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(result.status, 0, JSON.stringify(parsed.errors, null, 2));
+  assert.equal(parsed.ok, true);
+  assert.ok(parsed.summary.cases >= parsed.summary.skills * 4);
+});

--- a/scripts/eval-skill-triggers.mjs
+++ b/scripts/eval-skill-triggers.mjs
@@ -1,0 +1,352 @@
+#!/usr/bin/env node
+// Static golden-set gate for Sergeant skill routing prompts.
+
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export const DEFAULT_ROOT = resolve(__dirname, "..");
+export const DEFAULT_GOLDEN_PATH = resolve(
+  DEFAULT_ROOT,
+  "docs/agents/skill-trigger-evals.json",
+);
+
+export const CASE_KINDS = new Set(["trigger", "anti-trigger", "workflow"]);
+export const REQUIRED_WORKFLOW_CHECKS = new Set([
+  "start-here-first",
+  "exactly-one-specialist",
+]);
+
+const MIN_PROMPT_LENGTH = 24;
+const MAX_PROMPT_LENGTH = 800;
+
+function parseArgs(argv) {
+  const out = {
+    goldenPath: DEFAULT_GOLDEN_PATH,
+    json: false,
+    root: DEFAULT_ROOT,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--json") {
+      out.json = true;
+    } else if (arg === "--root") {
+      out.root = resolve(argv[++i] ?? "");
+    } else if (arg.startsWith("--root=")) {
+      out.root = resolve(arg.slice("--root=".length));
+    } else if (arg === "--golden") {
+      out.goldenPath = resolve(argv[++i] ?? "");
+    } else if (arg.startsWith("--golden=")) {
+      out.goldenPath = resolve(arg.slice("--golden=".length));
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return out;
+}
+
+function asStringArray(value) {
+  return (
+    Array.isArray(value) && value.every((item) => typeof item === "string")
+  );
+}
+
+function unique(items) {
+  return Array.from(new Set(items));
+}
+
+export function collectSkillSlugs(repoRoot) {
+  const skillsDir = resolve(repoRoot, ".agents/skills");
+  if (!existsSync(skillsDir)) {
+    throw new Error(`Missing skills directory: ${skillsDir}`);
+  }
+
+  return readdirSync(skillsDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((slug) => {
+      const skillPath = resolve(skillsDir, slug, "SKILL.md");
+      try {
+        return statSync(skillPath).isFile();
+      } catch {
+        return false;
+      }
+    })
+    .sort();
+}
+
+export function readGoldenSet(goldenPath = DEFAULT_GOLDEN_PATH) {
+  return JSON.parse(readFileSync(goldenPath, "utf8"));
+}
+
+export function validateGoldenSet(golden, skillSlugs) {
+  const skillSet = new Set(skillSlugs);
+  const errors = [];
+  const warnings = [];
+  const counts = new Map();
+  const ids = new Set();
+
+  if (!golden || typeof golden !== "object") {
+    return {
+      ok: false,
+      errors: ["Golden set must be a JSON object."],
+      warnings,
+      summary: { skills: skillSlugs.length, cases: 0 },
+    };
+  }
+
+  if (golden.schemaVersion !== 1) {
+    errors.push("schemaVersion must be 1.");
+  }
+
+  if (!Array.isArray(golden.cases)) {
+    errors.push("cases must be an array.");
+    return {
+      ok: false,
+      errors,
+      warnings,
+      summary: { skills: skillSlugs.length, cases: 0 },
+    };
+  }
+
+  for (const slug of skillSlugs) {
+    counts.set(slug, { trigger: 0, "anti-trigger": 0, workflow: 0 });
+  }
+
+  for (const [index, item] of golden.cases.entries()) {
+    const label =
+      item && typeof item === "object" && typeof item.id === "string"
+        ? item.id
+        : `case[${index}]`;
+
+    if (!item || typeof item !== "object") {
+      errors.push(`${label}: case must be an object.`);
+      continue;
+    }
+
+    if (typeof item.id !== "string" || item.id.trim() === "") {
+      errors.push(`${label}: id is required.`);
+    } else if (ids.has(item.id)) {
+      errors.push(`${label}: duplicate id.`);
+    } else {
+      ids.add(item.id);
+    }
+
+    if (typeof item.skill !== "string" || !skillSet.has(item.skill)) {
+      errors.push(`${label}: skill must name an existing .agents/skills slug.`);
+    }
+
+    if (typeof item.kind !== "string" || !CASE_KINDS.has(item.kind)) {
+      errors.push(`${label}: kind must be trigger, anti-trigger, or workflow.`);
+    }
+
+    if (
+      typeof item.prompt !== "string" ||
+      item.prompt.trim().length < MIN_PROMPT_LENGTH ||
+      item.prompt.length > MAX_PROMPT_LENGTH
+    ) {
+      errors.push(
+        `${label}: prompt must be ${MIN_PROMPT_LENGTH}-${MAX_PROMPT_LENGTH} characters.`,
+      );
+    }
+
+    if (!asStringArray(item.expectedSkills)) {
+      errors.push(`${label}: expectedSkills must be an array of strings.`);
+    }
+
+    if (!asStringArray(item.forbiddenSkills ?? [])) {
+      errors.push(`${label}: forbiddenSkills must be an array of strings.`);
+    }
+
+    const expectedSkills = item.expectedSkills ?? [];
+    const forbiddenSkills = item.forbiddenSkills ?? [];
+    const unknownExpected = expectedSkills.filter(
+      (slug) => !skillSet.has(slug),
+    );
+    const unknownForbidden = forbiddenSkills.filter(
+      (slug) => !skillSet.has(slug),
+    );
+
+    for (const slug of unknownExpected) {
+      errors.push(`${label}: expectedSkills contains unknown skill ${slug}.`);
+    }
+    for (const slug of unknownForbidden) {
+      errors.push(`${label}: forbiddenSkills contains unknown skill ${slug}.`);
+    }
+
+    const overlap = expectedSkills.filter((slug) =>
+      forbiddenSkills.includes(slug),
+    );
+    if (overlap.length > 0) {
+      errors.push(
+        `${label}: expectedSkills and forbiddenSkills overlap: ${unique(overlap).join(", ")}.`,
+      );
+    }
+
+    if (item.skill && item.kind && counts.has(item.skill)) {
+      counts.get(item.skill)[item.kind] += 1;
+    }
+
+    if (item.kind === "trigger" || item.kind === "workflow") {
+      if (!expectedSkills.includes(item.skill)) {
+        errors.push(
+          `${label}: ${item.kind} case must expect its target skill.`,
+        );
+      }
+      if (!expectedSkills.includes("sergeant-start-here")) {
+        errors.push(
+          `${label}: ${item.kind} case must expect sergeant-start-here.`,
+        );
+      }
+    }
+
+    if (item.kind === "anti-trigger") {
+      if (expectedSkills.includes(item.skill)) {
+        errors.push(`${label}: anti-trigger must not expect its target skill.`);
+      }
+      if (!forbiddenSkills.includes(item.skill)) {
+        errors.push(`${label}: anti-trigger must forbid its target skill.`);
+      }
+    }
+
+    if (item.kind === "workflow") {
+      if (!asStringArray(item.complianceChecks)) {
+        errors.push(`${label}: workflow case needs complianceChecks array.`);
+      } else {
+        for (const check of REQUIRED_WORKFLOW_CHECKS) {
+          if (!item.complianceChecks.includes(check)) {
+            errors.push(`${label}: workflow case missing ${check}.`);
+          }
+        }
+      }
+    }
+
+    const specialists = expectedSkills.filter(
+      (slug) => slug !== "sergeant-start-here",
+    );
+    if (
+      (item.kind === "trigger" || item.kind === "workflow") &&
+      item.skill !== "sergeant-start-here" &&
+      specialists.length !== 1
+    ) {
+      errors.push(
+        `${label}: trigger/workflow cases must expect exactly one specialist skill.`,
+      );
+    }
+  }
+
+  const goldenSkills = new Set(golden.cases.map((item) => item.skill));
+  for (const slug of skillSlugs) {
+    const count = counts.get(slug);
+    if (!goldenSkills.has(slug)) {
+      errors.push(`${slug}: missing all golden cases.`);
+      continue;
+    }
+    if (count.trigger < 2) {
+      errors.push(
+        `${slug}: needs at least 2 trigger cases; found ${count.trigger}.`,
+      );
+    }
+    if (count["anti-trigger"] < 1) {
+      errors.push(
+        `${slug}: needs at least 1 anti-trigger case; found ${count["anti-trigger"]}.`,
+      );
+    }
+    if (count.workflow < 1) {
+      errors.push(
+        `${slug}: needs at least 1 workflow case; found ${count.workflow}.`,
+      );
+    }
+  }
+
+  for (const item of golden.cases) {
+    if (item?.skill && !skillSet.has(item.skill)) continue;
+    const expected = item?.expectedSkills ?? [];
+    if (
+      (item?.kind === "trigger" || item?.kind === "workflow") &&
+      item.skill !== "sergeant-start-here" &&
+      !expected.includes(item.skill)
+    ) {
+      warnings.push(`${item.id}: target skill is not in expectedSkills.`);
+    }
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    summary: {
+      skills: skillSlugs.length,
+      cases: golden.cases.length,
+      triggerCases: golden.cases.filter((item) => item.kind === "trigger")
+        .length,
+      antiTriggerCases: golden.cases.filter(
+        (item) => item.kind === "anti-trigger",
+      ).length,
+      workflowCases: golden.cases.filter((item) => item.kind === "workflow")
+        .length,
+    },
+  };
+}
+
+export function run({
+  repoRoot = DEFAULT_ROOT,
+  goldenPath = DEFAULT_GOLDEN_PATH,
+}) {
+  const skillSlugs = collectSkillSlugs(repoRoot);
+  const golden = readGoldenSet(goldenPath);
+  return validateGoldenSet(golden, skillSlugs);
+}
+
+function main() {
+  let args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+    const report = run({ repoRoot: args.root, goldenPath: args.goldenPath });
+
+    if (args.json) {
+      console.log(JSON.stringify(report, null, 2));
+      process.exit(report.ok ? 0 : 1);
+    }
+
+    if (report.ok) {
+      console.log(
+        `[eval:skills] OK — ${report.summary.cases} case(s) cover ${report.summary.skills} skill(s).`,
+      );
+      process.exit(0);
+    }
+
+    console.error("[eval:skills] skill trigger golden-set failed:");
+    for (const error of report.errors) {
+      console.error(`  ✘ ${error}`);
+    }
+    process.exit(1);
+  } catch (err) {
+    if (args?.json) {
+      console.log(
+        JSON.stringify(
+          {
+            ok: false,
+            errors: [err instanceof Error ? err.message : String(err)],
+          },
+          null,
+          2,
+        ),
+      );
+    } else {
+      console.error(
+        `[eval:skills] ${err instanceof Error ? err.message : err}`,
+      );
+    }
+    process.exit(1);
+  }
+}
+
+const isMain =
+  process.argv[1] && resolve(process.argv[1]) === resolve(__filename);
+if (isMain) {
+  main();
+}


### PR DESCRIPTION
## Summary

- Adds a static skill-trigger eval harness for repo-owned Sergeant skills.
- Adds `docs/agents/skill-trigger-evals.json` with 84 golden prompts across 21 skills: 2 trigger, 1 anti-trigger, and 1 workflow-compliance case per skill.
- Wires `pnpm eval:skills` into `pnpm lint:skills` and documents the active roadmap step.

## Governing Skill

- Primary skill: `sergeant-tech-debt`
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a
- Why this playbook: no existing playbook matched agent eval harness creation; followed existing scripts/docs lint-gate patterns.
- If no playbook matched, why: this is governance/tooling infrastructure for the AI-coding roadmap, not a product or deployment playbook.

## Verification

```bash
pnpm lint:skills
pnpm eval:skills:test
pnpm prettier --check scripts/eval-skill-triggers.mjs scripts/__tests__/eval-skill-triggers.test.mjs docs/agents/skill-trigger-evals.json docs/agents/agent-skills-catalog.md docs/planning/ai-coding-improvements.md package.json .agents/skills-lock.json
```

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- `docs/agents/agent-skills-catalog.md`
- `docs/planning/ai-coding-improvements.md`
- `docs/agents/skill-trigger-evals.json`

## Risk and Rollout

- User-visible risk: none; CI/tooling only.
- Rollout / deploy order: merge to `main`; new gate runs via `pnpm lint:skills`.
- Backout plan: revert this PR to remove the eval gate and fixture.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

No migrations, env changes, HubChat tools, auth, or runtime behavior changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a static eval harness for Sergeant skill-trigger routing and integrates it into `pnpm lint:skills`. It enforces golden prompts per skill and checks start-here and single-specialist workflow rules.

- **New Features**
  - Added `docs/agents/skill-trigger-evals.json` with 84 golden prompts (2 trigger, 1 anti-trigger, 1 workflow) across 21 repo-owned skills.
  - Added `scripts/eval-skill-triggers.mjs` (CLI with JSON output) and tests in `scripts/__tests__/eval-skill-triggers.test.mjs`.
  - Integrated `pnpm eval:skills` into `lint:skills`; added scripts: `eval:skills`, `eval:skills:test`.
  - Updated docs: `docs/agents/agent-skills-catalog.md` (evals location and command), `docs/planning/ai-coding-improvements.md` (block now active).

<sup>Written for commit bbe4af9d0aa6bd684ff25edc545695bb937353f3. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3030?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added skill-trigger evaluation harness to validate skill configurations against golden test cases.
  * New `pnpm eval:skills` command evaluates trigger, anti-trigger, and workflow compliance prompts.
  * Enhanced `pnpm lint:skills` command to include skill evaluation checks.

* **Documentation**
  * Updated skill catalog and planning documentation with evaluation harness details and specifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Skords-01/Sergeant/pull/3030?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->