### PR TITLE
test(web): lock bottom nav edge alignment

### DIFF
--- a/apps/web/src/core/app/HubBottomNav.test.tsx
+++ b/apps/web/src/core/app/HubBottomNav.test.tsx
@@ -95,6 +95,20 @@ describe("HubBottomNav", () => {
     expect(onChange).toHaveBeenCalledWith("settings");
   });
 
+  it("keeps the PWA nav edge-to-edge with bottom-aligned controls", () => {
+    renderNav({});
+    const nav = screen.getByRole("navigation");
+    const settingsTab = screen.getByRole("tab", { name: /Налаштування/ });
+
+    expect(nav.className).toContain("safe-area-pb");
+    expect(nav.className).not.toContain("mx-3");
+    expect(nav.className).not.toContain("mb-3");
+    expect(nav.className).not.toContain("rounded");
+    expect(nav.className).not.toContain("shadow-nav");
+    expect(settingsTab.className).toContain("justify-end");
+    expect(settingsTab.className).toContain("pb-1.5");
+  });
+
   it("tablist semantics: кожен таб має aria-controls", () => {
     renderNav({});
     const tabs = screen.getAllByRole("tab");

--- a/apps/web/src/shared/components/ui/ModuleBottomNav.test.tsx
+++ b/apps/web/src/shared/components/ui/ModuleBottomNav.test.tsx
@@ -1,0 +1,46 @@
+/** @vitest-environment jsdom */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { ModuleBottomNav } from "./ModuleBottomNav";
+
+const items = [
+  {
+    id: "overview",
+    label: "Overview",
+    icon: <span aria-hidden>O</span>,
+  },
+  {
+    id: "stats",
+    label: "Stats",
+    icon: <span aria-hidden>S</span>,
+  },
+] as const;
+
+describe("ModuleBottomNav", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("keeps the PWA nav edge-to-edge with bottom-aligned controls", () => {
+    render(
+      <ModuleBottomNav
+        items={items}
+        activeId="overview"
+        onChange={vi.fn()}
+        module="finyk"
+        ariaLabel="Module sections"
+      />,
+    );
+
+    const nav = screen.getByRole("navigation", { name: "Module sections" });
+    const statsTab = screen.getByRole("button", { name: "Stats" });
+
+    expect(nav.className).toContain("safe-area-pb");
+    expect(nav.className).not.toContain("mx-3");
+    expect(nav.className).not.toContain("mb-3");
+    expect(nav.className).not.toContain("rounded");
+    expect(nav.className).not.toContain("shadow-nav");
+    expect(statsTab.className).toContain("justify-end");
+    expect(statsTab.className).toContain("pb-1.5");
+  });
+});

--- a/apps/web/src/styles/theme.css
+++ b/apps/web/src/styles/theme.css
@@ -54,8 +54,8 @@
      needs safe-area now applies it at the COMPONENT level:
        - Hub shell  → `MeshBackground` className `safe-area-pt`
        - Module shells → `ModuleHeader` `safe-area-pt`
-       - HubBottomNav / ModuleBottomNav → own
-         `padding-bottom: calc(0.75rem + env(safe-area-inset-bottom))`
+       - HubBottomNav / ModuleBottomNav → own `safe-area-pb` on an
+         edge-to-edge bottom panel with bottom-aligned controls
        - Standalone routes (`WelcomeScreen`, `AuthPage`,
          `ResetPasswordPage`) → own inline `paddingTop: max(..., env(...))`
      The body-level rule was stacking on top of every one of those,


### PR DESCRIPTION
## Summary
- Add regression coverage for the hub bottom nav edge-to-edge PWA layout.
- Add shared ModuleBottomNav coverage for the same bottom-aligned controls contract.
- Refresh the safe-area comment in `theme.css` so it matches the current edge-to-edge bottom panel implementation.

## Governing Skill
- `sergeant-web-ui`

## Playbook
- N/A — narrow web UI regression lock.

## Verification
- PASS: `git diff --check HEAD~1 HEAD`
- BLOCKED locally: `pnpm --filter @sergeant/web exec vitest run src/core/app/HubBottomNav.test.tsx src/shared/components/ui/ModuleBottomNav.test.tsx`
  - Vitest startup fails before tests run because local install is missing `@rolldown/binding-win32-x64-msvc`.
  - Attempted `pnpm install --frozen-lockfile`, `pnpm install --frozen-lockfile --filter @sergeant/web...`, and `npm install --no-save --legacy-peer-deps @rolldown/binding-win32-x64-msvc@1.0.0-rc.17`; local bootstrap remained unreliable/timed out.

## Docs and Governance
- Updates only an implementation comment in `apps/web/src/styles/theme.css`; no canonical docs changed.
- Hard Rule #15 acknowledged.

## Risk and Rollout
- Low risk: test-only behavioral lock plus comment refresh.
- No runtime code paths changed in this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add regression tests to lock the PWA bottom navigation to an edge-to-edge, bottom-aligned layout in `HubBottomNav` and shared `ModuleBottomNav`, and refresh the `theme.css` comment to match the current `safe-area-pb` bottom panel implementation. No runtime code changed.

<sup>Written for commit 133146a9b7bedbbd473b36ed11f10da57071d7c6. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3031?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

