### PR TITLE
docs(agents): note external agency-agents subagents in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Claude in Sergeant
 
-> **Last validated:** 2026-05-18 by @codex. **Next review:** 2026-08-16.
+> **Last validated:** 2026-05-19 by @Skords-01. **Next review:** 2026-08-17.
 > **Status:** Active
 
 > **Single source of truth -> [AGENTS.md](./AGENTS.md).** Цей файл — тонкий Claude-specific wrapper. Політика репо, hard rules, skills, playbooks і workflow-дерева живуть в `AGENTS.md` та `docs/`.
@@ -20,3 +20,4 @@
 - Для OpenClaw/Gateway задач використовуй `sergeant-openclaw`, не `sergeant-hubchat`.
 - Для SKILL.md змін спочатку відкрий `sergeant-writing-skills`, потім запускай `pnpm lint:skills && pnpm skills:lock`.
 - Heavy local commands запускай лише коли вони потрібні задачі або користувач прямо попросив.
+- Глобальні subagent-и з [msitarzewski/agency-agents](https://github.com/msitarzewski/agency-agents) (~169 шт.) встановлюються в `~/.claude/agents/` і доступні через `Agent` tool. Repo-owned `sergeant-*` skills мають пріоритет для роботи в монорепо; external subagent-и запускай для self-contained задач (ad copy, generic code review, market research, brand voice), коли під задачу немає specialist skill-у в [`docs/agents/agent-skills-catalog.md`](./docs/agents/agent-skills-catalog.md).


### PR DESCRIPTION
## Summary

- Add a one-line pointer in `CLAUDE.md` describing the ~169 global subagents installed from [msitarzewski/agency-agents](https://github.com/msitarzewski/agency-agents) under `~/.claude/agents/`.
- Clarify routing: repo-owned `sergeant-*` skills take priority; external subagents are for self-contained tasks (ad copy, generic code review, market research, brand voice) when no specialist skill in [`docs/agents/agent-skills-catalog.md`](./docs/agents/agent-skills-catalog.md) covers the surface.
- `AGENTS.md` stays untouched — it remains the single source of truth for repo policy.

## Why

External subagents are now installed on the maintainer's workstation and accessible across every Claude Code session. Without a pointer in the Claude-specific notes, agents (and humans) discovering the agency-agents folder might assume they conflict with or replace `sergeant-*` skills. One bullet makes the boundary explicit.

## Test plan

- [x] `git diff main..docs/claude-md-external-agents -- CLAUDE.md` — only the bullet is added (plus auto-bumped "Last validated" date from the lint hook).
- [x] `pnpm exec commitlint` accepts the commit message.
- [x] Pre-commit hook passes locally (lint-staged + gitleaks skipped — already gated in CI).
- [ ] CI green on PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a note in CLAUDE.md about the ~169 global subagents from `msitarzewski/agency-agents` installed in `~/.claude/agents/`. Clarifies routing: prefer repo-owned `sergeant-*` skills for monorepo work; use external subagents for self‑contained tasks when no specialist skill exists.

<sup>Written for commit 7001089cb197189e95980910be13e179ab2ade0a. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3033?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

