### PR TITLE
feat(web): outcome framing on module empty states (V4)

### DIFF
--- a/apps/web/src/modules/finyk/pages/transactions/TransactionList.test.tsx
+++ b/apps/web/src/modules/finyk/pages/transactions/TransactionList.test.tsx
@@ -132,7 +132,7 @@ describe("TransactionList — DataState routing", () => {
 
     // Title comes from the curated finyk config inside
     // `ModuleEmptyState` (MODULE_EMPTY_CONFIG.finyk.title).
-    expect(screen.getByText("Почни вести фінанси")).toBeInTheDocument();
+    expect(screen.getByText("Куди йдуть твої гроші?")).toBeInTheDocument();
     // The filter-empty copy must NOT also render at the same time.
     expect(screen.queryByText("Немає транзакцій")).not.toBeInTheDocument();
     expect(screen.queryByTestId("grouped-virtuoso")).not.toBeInTheDocument();

--- a/apps/web/src/modules/finyk/pages/transactions/TransactionList.tsx
+++ b/apps/web/src/modules/finyk/pages/transactions/TransactionList.tsx
@@ -1,8 +1,8 @@
 /**
- * Last validated: 2026-05-14
+ * Last validated: 2026-05-19
  * Status: Active
  */
-import { useState, type ReactNode } from "react";
+import { useState, useMemo, type ReactNode } from "react";
 import { GroupedVirtuoso } from "react-virtuoso";
 import { TxListItem } from "../../components/TxListItem";
 import type { TxRowTx } from "../../components/TxRow";
@@ -18,6 +18,8 @@ import { useCloudPullPending } from "@shared/hooks/useCloudPullPending";
 import { cn } from "@shared/lib/ui/cn";
 import { TransactionDayHeader } from "./TransactionDayHeader";
 import type { computeDaySummary } from "./transactionsLib";
+import { getOnboardingGoals } from "@sergeant/shared";
+import { webKVStore } from "@shared/lib/storage/storage";
 import type {
   Transaction,
   TxCategoriesMap,
@@ -117,6 +119,8 @@ export function TransactionList({
 }: TransactionListProps) {
   const [scrollParent, setScrollParent] = useState<HTMLDivElement | null>(null);
   const cloudPullPending = useCloudPullPending();
+  // Read onboarding goals once per render — stable across the session.
+  const onboardingGoals = useMemo(() => getOnboardingGoals(webKVStore), []);
 
   // DataState contract:
   //   - `data === undefined` triggers the skeleton slot. We mark the
@@ -170,7 +174,7 @@ export function TransactionList({
   //     the surface still feels owned by the module.
   const emptyFallback =
     activeTx.length === 0 ? (
-      <ModuleEmptyState module="finyk" />
+      <ModuleEmptyState module="finyk" goalContext={onboardingGoals} />
     ) : (
       <div className="rounded-2xl border border-dashed border-line bg-panelHi/40">
         <EmptyState

--- a/apps/web/src/shared/components/ui/EmptyState.stories.tsx
+++ b/apps/web/src/shared/components/ui/EmptyState.stories.tsx
@@ -167,8 +167,8 @@ export const ModuleFinyk: Story = {
 export const ModuleFizruk: Story = {
   args: {
     illustration: <ModuleEmptyIllustration module="fizruk" size={120} />,
-    title: "Час тренуватись",
-    description: "Запиши перше тренування або обери готову програму.",
+    title: "Як прогресують мої тренування?",
+    description: "Запиши перше тренування — і побачиш ріст у цифрах.",
     action: (
       <Button variant="fizruk" size="md">
         Почати тренування
@@ -184,8 +184,8 @@ export const ModuleFizruk: Story = {
 export const ModuleRoutine: Story = {
   args: {
     illustration: <ModuleEmptyIllustration module="routine" size={120} />,
-    title: "Створи першу звичку",
-    description: "Маленькі кроки щодня ведуть до великих змін.",
+    title: "Що насправді стало звичкою?",
+    description: "Відстежуй щоденні дії — серія днів покаже правду.",
     action: (
       <Button variant="routine" size="md">
         Створити звичку
@@ -202,8 +202,8 @@ export const ModuleRoutine: Story = {
 export const ModuleNutrition: Story = {
   args: {
     illustration: <ModuleEmptyIllustration module="nutrition" size={120} />,
-    title: "Залогай перший прийом їжі",
-    description: "Відстежуй що їси і отримай персональні поради.",
+    title: "Що ти їси насправді?",
+    description: "Залогай перший прийом їжі й отримай чесну картину.",
     action: (
       <Button variant="nutrition" size="md">
         Додати їжу

--- a/apps/web/src/shared/components/ui/EmptyState.tsx
+++ b/apps/web/src/shared/components/ui/EmptyState.tsx
@@ -1,5 +1,5 @@
 /**
- * Last validated: 2026-05-14
+ * Last validated: 2026-05-19
  * Status: Active
  */
 /**
@@ -52,6 +52,7 @@
  */
 import type { ReactNode } from "react";
 import type { ModuleAccent } from "@sergeant/design-tokens";
+import type { OnboardingGoals } from "@sergeant/shared";
 import { cn } from "@shared/lib/ui/cn";
 import { Icon } from "./Icon";
 import { Button } from "./Button";
@@ -400,6 +401,14 @@ export interface ModuleEmptyStateProps {
   dismissible?: boolean;
   onDismiss?: () => void;
   description?: string;
+  /**
+   * Onboarding goals snapshot from `getOnboardingGoals(webKVStore)`.
+   * When provided, the description adapts to the user's saved goal
+   * (e.g. budget amount, weekly training target) so the copy feels
+   * personal rather than generic. Callers should pass this whenever
+   * the module goal state is already available in their render scope.
+   */
+  goalContext?: OnboardingGoals;
   className?: string;
 }
 
@@ -420,8 +429,8 @@ const MODULE_EMPTY_CONFIG: Record<
 > = {
   finyk: {
     icon: "credit-card",
-    title: "Почни вести фінанси",
-    description: "Додай першу витрату і побач куди йдуть гроші.",
+    title: "Куди йдуть твої гроші?",
+    description: "Додай першу витрату і побач реальну картину бюджету.",
     hint: "Порада: Підключи Monobank для автоматичного імпорту",
     actionLabel: "Додати витрату",
     accent: "text-finyk bg-finyk-soft dark:bg-finyk/10",
@@ -430,8 +439,8 @@ const MODULE_EMPTY_CONFIG: Record<
   },
   fizruk: {
     icon: "dumbbell",
-    title: "Час тренуватись",
-    description: "Запиши першу тренування або обери готову програму.",
+    title: "Як прогресують мої тренування?",
+    description: "Запиши перше тренування — і побачиш ріст у цифрах.",
     hint: "Порада: Почни з 10-хвилинної розминки",
     actionLabel: "Почати тренування",
     accent: "text-fizruk bg-fizruk-soft dark:bg-fizruk/10",
@@ -440,8 +449,8 @@ const MODULE_EMPTY_CONFIG: Record<
   },
   routine: {
     icon: "check-circle",
-    title: "Створи першу звичку",
-    description: "Маленькі кроки щодня ведуть до великих змін.",
+    title: "Що насправді стало звичкою?",
+    description: "Відстежуй щоденні дії — серія днів покаже правду.",
     hint: "Порада: Почни з однієї звички, яку точно виконаєш",
     actionLabel: "Створити звичку",
     accent: "text-routine bg-routine-surface dark:bg-routine/10",
@@ -450,8 +459,8 @@ const MODULE_EMPTY_CONFIG: Record<
   },
   nutrition: {
     icon: "utensils",
-    title: "Залогай перший прийом їжі",
-    description: "Відстежуй що їси і отримай персональні поради.",
+    title: "Що ти їси насправді?",
+    description: "Залогай перший прийом їжі й отримай чесну картину.",
     hint: "Порада: Сфоткай страву — AI порахує калорії",
     actionLabel: "Додати їжу",
     accent: "text-nutrition bg-nutrition-soft dark:bg-nutrition/10",
@@ -459,6 +468,45 @@ const MODULE_EMPTY_CONFIG: Record<
     exampleLine2: "420 ккал · Б: 15г | Ж: 12г | В: 58г",
   },
 };
+
+/**
+ * Derives a goal-personalised description for the module's empty state.
+ * Mirrors the `getGoalAwareDesc` logic in `FirstActionSheet` — when the
+ * user set a concrete goal during onboarding, the copy anchors on that
+ * goal; when no goal is recorded, the generic outcome description is
+ * returned unchanged.
+ */
+function resolveGoalAwareDesc(
+  moduleId: ModuleEmptyStateProps["module"],
+  fallback: string,
+  goals: OnboardingGoals,
+): string {
+  if (moduleId === "finyk" && goals.finykBudget) {
+    return `Встанови бюджет ${goals.finykBudget.toLocaleString("uk-UA")}₴ — додай першу витрату.`;
+  }
+  if (moduleId === "fizruk" && goals.fizrukWeeklyGoal) {
+    return `${goals.fizrukWeeklyGoal}× на тиждень — починай із першого тренування.`;
+  }
+  if (moduleId === "routine" && goals.routineFirstHabit) {
+    const habitLabels: Record<string, string> = {
+      water: "«Пити воду»",
+      exercise: "«Зарядка»",
+      reading: "«Читання»",
+    };
+    const label = habitLabels[goals.routineFirstHabit] ?? "свою звичку";
+    return `Відстеж ${label} — серія днів покаже правду.`;
+  }
+  if (moduleId === "nutrition" && goals.nutritionGoal) {
+    const goalLabels: Record<string, string> = {
+      lose: "схуднути",
+      gain: "набрати масу",
+      maintain: "підтримувати вагу",
+    };
+    const goalLabel = goalLabels[goals.nutritionGoal] ?? goals.nutritionGoal;
+    return `Ціль «${goalLabel}» — залогай перший прийом їжі.`;
+  }
+  return fallback;
+}
 
 export function ModuleEmptyState({
   module,
@@ -468,10 +516,19 @@ export function ModuleEmptyState({
   dismissible = false,
   onDismiss,
   description: descriptionOverride,
+  goalContext,
   className,
 }: ModuleEmptyStateProps) {
   const config = MODULE_EMPTY_CONFIG[module];
   const compact = variant === "compact";
+
+  // Explicit `description` override wins; otherwise use goal-aware copy
+  // when caller provided `goalContext`, falling back to config default.
+  const resolvedDescription =
+    descriptionOverride ??
+    (goalContext
+      ? resolveGoalAwareDesc(module, config.description, goalContext)
+      : config.description);
 
   const examplePreview = (
     <div className="flex items-center gap-3 text-left">
@@ -532,7 +589,7 @@ export function ModuleEmptyState({
           )
         }
         title={config.title}
-        description={descriptionOverride ?? config.description}
+        description={resolvedDescription}
         hint={config.hint}
         examplePreview={!compact ? examplePreview : undefined}
         size={compact ? "sm" : "md"}


### PR DESCRIPTION
## Summary

Implements V4 of redesign-v2 execution plan (§ 4.2): switches 4 module empty states from **feature framing** to **outcome framing** that answers the user's actual question.

**Before → After copy:**

| Module | Before | After |
|---|---|---|
| Finyk | "Почни вести фінанси" | "Куди йдуть твої гроші?" |
| Fizruk | "Час тренуватись" | "Як прогресують мої тренування?" |
| Routine | "Створи першу звичку" | "Що насправді стало звичкою?" |
| Nutrition | "Залогай перший прийом їжі" | "Що ти їси насправді?" |

## Changes

- `ModuleEmptyState` gets a new optional `goalContext?: OnboardingGoals` prop
- When `goalContext` is provided and the user has a saved goal, the description personalises to that goal (e.g. "Встанови бюджет 5 000₴ — додай першу витрату.")
- `resolveGoalAwareDesc` helper inlined in `EmptyState.tsx` — mirrors `getGoalAwareDesc` from `FirstActionSheet` but scoped to the shared component (avoids core→shared import violation)
- `TransactionList.tsx` (finyk) updated to pass `goalContext={getOnboardingGoals(webKVStore)}`
- `EmptyState.stories.tsx` updated to match new copy
- Test assertion updated to expect new outcome-framing title

## Plan ref

`docs/design/redesign-v2/execution-plan.md` § V4 / § 4.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches four module empty states from feature framing to outcome framing and adds goal-aware personalization so the copy answers the user’s real question. Updates copy in Finyk, Fizruk, Routine, and Nutrition; `ModuleEmptyState` now adapts its description when onboarding goals exist.

- **New Features**
  - Updated titles: Finyk — "Куди йдуть твої гроші?", Fizruk — "Як прогресують мої тренування?", Routine — "Що насправді стало звичкою?", Nutrition — "Що ти їси насправді?"
  - `ModuleEmptyState` adds `goalContext?: OnboardingGoals` to personalize the description when goals are set.
  - Finyk `TransactionList` uses `getOnboardingGoals(webKVStore)` from `@sergeant/shared` and passes it to `ModuleEmptyState`.
  - Storybook examples and a Finyk test updated to reflect the new outcome-focused copy.

<sup>Written for commit e7547f021d12dd41b72e8a94c5abf2517e1513fc. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3035?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

