### PR TITLE
fix(web): collapse AIPill on scroll + sticky habit submit + emoji picker polish

### DIFF
--- a/apps/web/src/core/app/useAppEffects.ts
+++ b/apps/web/src/core/app/useAppEffects.ts
@@ -60,13 +60,15 @@ export function useAppEffects(deps: AppEffectsDeps): void {
   // Safari ≤ 16 has no `requestIdleCallback`, so we keep the original
   // 2 s fallback for it.
   useEffect(() => {
+    // Hub navigation pages (Reports + Settings) are primary tabs. Kick
+    // their chunks off immediately so a tap on the bottom-nav lands on
+    // a hydrated component instead of the Suspense skeleton. The inner
+    // `prefetchHubNavigationPages` still wraps each import in
+    // `requestIdleCallback` (with its own 3 s timeout), so this stays
+    // non-blocking — we just drop the outer idle wrap that was stacking
+    // on top and pushing first-touch latency past the user's tap.
+    prefetchHubNavigationPages();
     if ("requestIdleCallback" in window) {
-      const pageId = requestIdleCallback(
-        () => {
-          prefetchHubNavigationPages();
-        },
-        { timeout: 4000 },
-      );
       const moduleId = requestIdleCallback(
         () => {
           prefetchCriticalModules();
@@ -74,18 +76,13 @@ export function useAppEffects(deps: AppEffectsDeps): void {
         { timeout: 6000 },
       );
       return () => {
-        cancelIdleCallback(pageId);
         cancelIdleCallback(moduleId);
       };
     }
-    const pageTimer = setTimeout(() => {
-      prefetchHubNavigationPages();
-    }, 2000);
     const moduleTimer = setTimeout(() => {
       prefetchCriticalModules();
     }, 3000);
     return () => {
-      clearTimeout(pageTimer);
       clearTimeout(moduleTimer);
     };
   }, []);

--- a/apps/web/src/modules/routine/components/HabitQuickCreateDialog.tsx
+++ b/apps/web/src/modules/routine/components/HabitQuickCreateDialog.tsx
@@ -12,6 +12,8 @@ import {
   routineTodayDate,
 } from "../lib/routineDraftUtils";
 import { dateKeyFromDate } from "../lib/hubCalendarAggregate";
+import { Button } from "@shared/components/ui/Button";
+import { ROUTINE_THEME as C } from "../lib/routineConstants";
 import { HabitForm, type HabitFormErrors } from "./settings/HabitForm";
 import type { Habit, HabitDraft, RoutineState } from "../lib/types";
 import type { Dispatch, SetStateAction } from "react";
@@ -206,7 +208,7 @@ export function HabitQuickCreateDialog({
             </svg>
           </button>
         </div>
-        <div className="flex-1 overflow-y-auto px-5 pb-5">
+        <div className="flex-1 overflow-y-auto px-5 pb-3">
           {firstRunHint && !editingId && (
             <FirstRunHintBanner
               variant="routine"
@@ -225,8 +227,36 @@ export function HabitQuickCreateDialog({
             onCancel={onClose}
             focusTick={internalFocusTick}
             hideHeading
+            hideActions
             errors={errors}
           />
+        </div>
+        {/* Sticky footer: keeps the primary CTA in the viewport regardless
+            of how long the form scrolls. Without this, a habit with the
+            advanced disclosure open pushes "Додати звичку" below the fold
+            and forces a scroll-hunt on every save. */}
+        <div className="border-t border-line bg-bg px-5 pt-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]">
+          <div
+            className={cn("flex gap-2", editingId ? "flex-row" : "flex-col")}
+          >
+            {editingId && (
+              <Button
+                type="button"
+                variant="secondary"
+                className="flex-1"
+                onClick={onClose}
+              >
+                {messages.actions.cancel}
+              </Button>
+            )}
+            <Button
+              type="button"
+              className={cn("w-full", C.primary)}
+              onClick={handleSave}
+            >
+              {editingId ? "Зберегти зміни" : "Додати звичку"}
+            </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/web/src/modules/routine/components/settings/HabitForm.tsx
+++ b/apps/web/src/modules/routine/components/settings/HabitForm.tsx
@@ -53,6 +53,13 @@ export interface HabitFormProps {
    * back up.
    */
   errors?: HabitFormErrors;
+  /**
+   * When the form is embedded inside a dialog host that renders its
+   * own action buttons in a sticky footer, suppress the in-flow
+   * "Скасувати / Додати звичку" row so the user always sees the CTA
+   * without scrolling to the end of the form.
+   */
+  hideActions?: boolean;
 }
 
 const EMOJI_SUGGESTIONS: readonly string[] = [
@@ -84,6 +91,7 @@ export function HabitForm({
   focusTick,
   hideHeading = false,
   errors,
+  hideActions = false,
 }: HabitFormProps) {
   const fieldIds = useId();
   const startId = `${fieldIds}-start`;
@@ -172,7 +180,7 @@ export function HabitForm({
               aria-expanded={showEmojiPicker}
               className={cn(
                 "routine-touch-field w-12 shrink-0 flex items-center justify-center",
-                "rounded-2xl border border-line bg-panelHi text-xl",
+                "rounded-2xl border border-line bg-panelHi text-2xl leading-none font-['Apple_Color_Emoji','Segoe_UI_Emoji','Noto_Color_Emoji','Segoe_UI_Symbol',sans-serif]",
                 "hover:bg-panel transition-colors",
               )}
             >
@@ -183,30 +191,30 @@ export function HabitForm({
                 role="dialog"
                 aria-label="Обрати емодзі"
                 className={cn(
-                  "absolute z-30 mt-2 left-0",
+                  "absolute z-30 mt-2 left-0 w-[17rem]",
                   "rounded-2xl border border-line bg-panel shadow-float p-2",
-                  "grid grid-cols-4 gap-1",
+                  "grid grid-cols-6 gap-1",
                 )}
               >
                 {EMOJI_SUGGESTIONS.map((e) => (
-                  <Button
+                  <button
                     key={e}
-                    iconOnly
-                    size="sm"
-                    variant="ghost"
                     type="button"
                     onClick={() => {
                       setHabitDraft((d) => ({ ...d, emoji: e }));
                       setShowEmojiPicker(false);
                     }}
+                    aria-label={`Емодзі ${e}`}
                     className={cn(
-                      "rounded-xl text-lg!",
+                      "w-10 h-10 flex items-center justify-center rounded-xl",
+                      "leading-none text-2xl font-['Apple_Color_Emoji','Segoe_UI_Emoji','Noto_Color_Emoji','Segoe_UI_Symbol',sans-serif]",
+                      "transition-colors hover:bg-panelHi",
+                      "focus:outline-none focus-visible:ring-2 focus-visible:ring-focus/45",
                       habitDraft.emoji === e && "bg-panelHi ring-1 ring-line",
                     )}
-                    aria-label={`Емодзі ${e}`}
                   >
                     <span aria-hidden>{e}</span>
-                  </Button>
+                  </button>
                 ))}
               </div>
             )}
@@ -422,33 +430,35 @@ export function HabitForm({
         </div>
       )}
 
-      <div
-        className={cn(
-          "flex gap-2",
-          // Inside the quick-create dialog the sheet already has an "X"
-          // close in the top-right, so the Cancel button would be
-          // redundant. Stretch the primary save button to fill the row.
-          editingId ? "flex-row" : "flex-col",
-        )}
-      >
-        {editingId && (
+      {!hideActions && (
+        <div
+          className={cn(
+            "flex gap-2",
+            // Inside the quick-create dialog the sheet already has an "X"
+            // close in the top-right, so the Cancel button would be
+            // redundant. Stretch the primary save button to fill the row.
+            editingId ? "flex-row" : "flex-col",
+          )}
+        >
+          {editingId && (
+            <Button
+              type="button"
+              variant="secondary"
+              className="flex-1"
+              onClick={onCancel}
+            >
+              Скасувати
+            </Button>
+          )}
           <Button
             type="button"
-            variant="secondary"
-            className="flex-1"
-            onClick={onCancel}
+            className={cn("w-full", C.primary)}
+            onClick={onSave}
           >
-            Скасувати
+            {editingId ? "Зберегти зміни" : "Додати звичку"}
           </Button>
-        )}
-        <Button
-          type="button"
-          className={cn("flex-1", C.primary)}
-          onClick={onSave}
-        >
-          {editingId ? "Зберегти зміни" : "Додати звичку"}
-        </Button>
-      </div>
+        </div>
+      )}
     </>
   );
 

--- a/apps/web/src/shared/components/ui/AIPill.tsx
+++ b/apps/web/src/shared/components/ui/AIPill.tsx
@@ -49,6 +49,7 @@
  * себе якщо змонтований.
  */
 
+import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import type { ModuleAccent } from "@sergeant/design-tokens";
 import { Icon } from "@shared/components/ui/Icon";
@@ -83,6 +84,41 @@ const DEFAULT_PLACEHOLDER: Record<ModuleAccent | "hub", string> = {
   hub: "Запитай Sergeant…",
 };
 
+/**
+ * Auto-hide hook: collapses the pill into a compact pip when the user
+ * scrolls down past `threshold`, restores it when they scroll back up.
+ * Pattern matches Material's bottom-bar shrink-on-scroll — keeps the
+ * affordance reachable but stops it from covering content while the
+ * user is reading.
+ *
+ * Listener is `passive: true` + rAF-throttled so it never blocks the
+ * scrolling thread. `lastY` tracks direction so a tiny jitter near the
+ * threshold doesn't flicker.
+ */
+function useCollapseOnScroll(threshold = 80) {
+  const [collapsed, setCollapsed] = useState(false);
+  const lastY = useRef(0);
+  const ticking = useRef(false);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onScroll = () => {
+      if (ticking.current) return;
+      ticking.current = true;
+      window.requestAnimationFrame(() => {
+        const y = window.scrollY || window.pageYOffset || 0;
+        const dy = y - lastY.current;
+        if (y > threshold && dy > 4) setCollapsed(true);
+        else if (dy < -4 || y < threshold / 2) setCollapsed(false);
+        lastY.current = y;
+        ticking.current = false;
+      });
+    };
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, [threshold]);
+  return collapsed;
+}
+
 export function AIPill({
   module = null,
   placeholder,
@@ -92,6 +128,7 @@ export function AIPill({
 }: AIPillProps) {
   const navigate = useNavigate();
   const placeholderText = placeholder ?? DEFAULT_PLACEHOLDER[module ?? "hub"];
+  const collapsed = useCollapseOnScroll();
 
   const openChat = () => {
     hapticTap();
@@ -108,17 +145,24 @@ export function AIPill({
     <div
       role="group"
       aria-label={messages.nav.openAssistant}
+      data-collapsed={collapsed ? "true" : undefined}
       style={{ bottom: `calc(${bottom}px + env(safe-area-inset-bottom, 0px))` }}
       className={cn(
-        // Fixed pill positioning. `right-[4.5rem]` leaves space for the
-        // module FAB on the right edge so they never overlap.
-        "fixed left-3.5 right-[4.5rem] z-sticky",
+        // Fixed pill positioning. Collapsed state shrinks to a circular
+        // pip on the right edge so the content underneath stays
+        // readable; expanded state spans `left-3.5 right-[4.5rem]` and
+        // leaves space for the module FAB.
+        "fixed z-sticky",
+        "transition-[left,width,padding,box-shadow] duration-200 ease-out motion-reduce:transition-none",
+        collapsed
+          ? "left-auto right-[4.5rem] w-11 pl-1 pr-1"
+          : "left-3.5 right-[4.5rem] pl-2.5 pr-2",
         // Visual chrome — translucent glass surface with v2 pill shadow.
         // `surface-strong-glass` is alpha-baked (0.93 light / 0.10 dark /
         // 1.0 HC) so HC mode reads as a solid pill.
         "h-11 bg-surface-strong-glass backdrop-blur-md",
         "border border-line rounded-full shadow-pill",
-        "flex items-center gap-2 pl-2.5 pr-2",
+        "flex items-center gap-2",
         className,
       )}
     >
@@ -129,7 +173,8 @@ export function AIPill({
         onClick={openChat}
         aria-label={messages.nav.openAssistant}
         className={cn(
-          "flex-1 flex items-center gap-2 min-w-0",
+          "flex items-center gap-2 min-w-0",
+          collapsed ? "flex-none" : "flex-1",
           "focus:outline-none focus-visible:rounded-full focus-visible:ring-2",
           "focus-visible:ring-focus/45 focus-visible:ring-offset-2",
           "focus-visible:ring-offset-bg",
@@ -145,29 +190,34 @@ export function AIPill({
         >
           <Icon name="sparkle" size={14} strokeWidth={2.2} />
         </span>
-        <span className="flex-1 text-left text-style-body-sm text-muted truncate min-w-0">
-          {placeholderText}
-        </span>
+        {!collapsed && (
+          <span className="flex-1 text-left text-style-body-sm text-muted truncate min-w-0">
+            {placeholderText}
+          </span>
+        )}
       </button>
 
       {/* Mic button — sibling, not nested. Keyboard Tab order: primary
-          chat button first, then mic. */}
-      <button
-        type="button"
-        onClick={handleMic}
-        aria-label={messages.nav.voiceInput}
-        className={cn(
-          "w-7 h-7 rounded-full shrink-0",
-          "flex items-center justify-center",
-          "text-muted hover:text-text hover:bg-panel",
-          "transition-colors",
-          "focus:outline-none focus-visible:ring-2",
-          "focus-visible:ring-focus/45 focus-visible:ring-offset-2",
-          "focus-visible:ring-offset-bg",
-        )}
-      >
-        <Icon name="mic" size={15} strokeWidth={2} />
-      </button>
+          chat button first, then mic. Hidden in collapsed mode so the
+          pip stays tap-target-clean and unambiguous. */}
+      {!collapsed && (
+        <button
+          type="button"
+          onClick={handleMic}
+          aria-label={messages.nav.voiceInput}
+          className={cn(
+            "w-7 h-7 rounded-full shrink-0",
+            "flex items-center justify-center",
+            "text-muted hover:text-text hover:bg-panel",
+            "transition-colors",
+            "focus:outline-none focus-visible:ring-2",
+            "focus-visible:ring-focus/45 focus-visible:ring-offset-2",
+            "focus-visible:ring-offset-bg",
+          )}
+        >
+          <Icon name="mic" size={15} strokeWidth={2} />
+        </button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Чотири UX-фікси з реального юзер-сесії скріншоту:

- **AIPill** автоматично стискається в круглу pip-кнопку при скролі вниз і повертає повний пілюль-вигляд при скролі вгору. Раніше fixed-пілюль постійно перекривав контент на Nutrition/Routine/Finyk.
- **HabitQuickCreateDialog** виносить кнопки "Скасувати / Додати звичку" у sticky footer з `border-t` і safe-area padding. До цього "Додати звичку" жила в кінці прокручуваного списку і губилась під fold при відкритому "Більше опцій". `HabitForm` отримав `hideActions` prop, щоб Settings-сторінка лишала свій in-flow ряд кнопок.
- **Emoji picker** у формі звички: `grid-cols-4` → `grid-cols-6`, фіксована ширина `17rem`, 40×40 tap-targets, `text-2xl` + явний emoji-font stack (`Apple Color Emoji`, `Segoe UI Emoji`, `Noto Color Emoji`). Windows Chrome тепер гарантовано рендерить кольорові емодзі замість дрібних монохромних gliph-ів.
- **Префетч Reports/Settings**: прибрав зовнішню `requestIdleCallback({timeout: 4000})` обгортку в `useAppEffects`. Внутрішня per-page idle-обгортка (3 s timeout) лишається — без блокування main thread, але без додаткових 4 s до старту імпорту. Раніше на повільних пристроях chunk не встигав завантажитись до першого тапа.

## Test plan

- [ ] Manual: scroll-down на Nutrition → AIPill стискається в pip справа; scroll-up → розгортається назад
- [ ] Manual: відкрити "Додати звичку", розгорнути "Більше опцій" → кнопка "Додати звичку" завжди видима у footer
- [ ] Manual: натиснути emoji-picker у формі звички → 6 колонок × ~3 рядки, емодзі повнокольорові на Windows
- [ ] Manual: cold load → tap Settings/Reports у hub-nav: switch має бути ≤ 100 ms на 4G
- [ ] `pnpm --filter @sergeant/web typecheck && pnpm --filter @sergeant/web test`
- [ ] axe не валиться на AIPill (role=group, два sibling buttons) і на habit dialog (focus trap, sticky footer)

## Risk

- Низький. Усі зміни локальні до 4 файлів, нічого не торкається API/storage/auth/billing.
- `useCollapseOnScroll` слухає `window scroll` з passive + rAF — на reduced-motion `transition-none`.
- `hideActions` опційний, default = false → Settings-сторінка не змінює поведінки.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves reading and form flows: the AI pill auto-collapses while scrolling, the habit submit stays visible in a sticky footer, the emoji picker is easier to tap, and Reports/Settings prefetch starts sooner for faster first taps.

- **Bug Fixes**
  - AIPill collapses to a small pip on scroll down and expands on scroll up to avoid covering content.
  - Habit quick-create moves actions to a sticky footer with safe-area padding; adds `hideActions` prop to the form host.
  - Emoji picker widens to 6 columns (17rem) with 40×40 targets, larger glyphs, and a color emoji font stack for consistent Windows rendering.
  - Removes outer `requestIdleCallback` around hub page prefetch so chunks load immediately; inner per-page idle wrapper remains non-blocking.

<sup>Written for commit 3b5587ebb3b66452e6a4df0b284e7d6c3d27f55f. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3043?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

