### PR TITLE
feat(web): hub-level insight aggregator (Phase 5e)

### DIFF
--- a/apps/web/src/core/hub/HubDashboard.test.tsx
+++ b/apps/web/src/core/hub/HubDashboard.test.tsx
@@ -2,6 +2,7 @@
 import type { ReactNode } from "react";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
 import {
   DASHBOARD_MODULE_LABELS,
   FIRST_REAL_ENTRY_KEY,
@@ -291,13 +292,15 @@ function renderDashboard({
   onShowAuth?: () => void;
 } = {}) {
   render(
-    <ToastProvider>
-      <HubDashboard
-        user={null}
-        onOpenModule={onOpenModule}
-        onShowAuth={onShowAuth}
-      />
-    </ToastProvider>,
+    <MemoryRouter>
+      <ToastProvider>
+        <HubDashboard
+          user={null}
+          onOpenModule={onOpenModule}
+          onShowAuth={onShowAuth}
+        />
+      </ToastProvider>
+    </MemoryRouter>,
   );
   return { onOpenModule, onShowAuth };
 }

--- a/apps/web/src/core/hub/HubInsightsBlock.tsx
+++ b/apps/web/src/core/hub/HubInsightsBlock.tsx
@@ -6,14 +6,23 @@
  *
  * Merged «Підказки + Аналітика» under one wrapper per UX audit
  * «Dashboard card avalanche». Only renders post-first-entry.
+ *
+ * Phase 5e: renders top 3 module insights (surface="hub") above the
+ * AssistantAdviceCard via useAllInsights. Module surfaces continue
+ * rendering their own insights locally via per-trigger hooks.
  */
 
+import { useNavigate } from "react-router-dom";
 import { CollapsibleSection } from "@shared/components/ui/CollapsibleSection";
 import { AssistantAdviceCard } from "../insights/AssistantAdviceCard";
 import { DailyNudge } from "../onboarding/DailyNudge";
 import { HubInsightsPanel } from "./HubInsightsPanel";
 import { WeeklyDigestCard } from "../insights/WeeklyDigestCard";
 import { WeeklyDigestFooter } from "./dashboard/dashboardCards";
+import { InsightCard } from "@shared/components/ui/InsightCard";
+import { useAllInsights } from "@shared/lib/insights/useAllInsights";
+import { emitHubBus } from "@shared/lib/modules/hubBus";
+import type { Insight } from "@shared/lib/insights/types";
 import type { Rec, NudgeDefinition } from "@sergeant/shared";
 
 export interface HubInsightsBlockProps {
@@ -53,6 +62,19 @@ export function HubInsightsBlock({
   setDigestExpanded,
   showDigestFooter,
 }: HubInsightsBlockProps) {
+  const navigate = useNavigate();
+  const moduleInsights = useAllInsights({ surface: "hub", cap: 3 });
+
+  function handleInsightActivate(insight: Insight) {
+    if (insight.action.type === "navigate") {
+      navigate(insight.action.path);
+    } else if (insight.action.type === "open-chat") {
+      emitHubBus("openChat", { message: insight.action.prompt, autoSend: false });
+    } else if (insight.action.type === "callback") {
+      insight.action.fn();
+    }
+  }
+
   return (
     <CollapsibleSection
       storageKey="sergeant:hub.insights.open"
@@ -75,6 +97,19 @@ export function HubInsightsBlock({
                   : "AI-порада на день"
       }
     >
+      {moduleInsights.length > 0 && (
+        <div className="space-y-1.5">
+          {moduleInsights.map((insight) => (
+            <InsightCard
+              key={insight.id}
+              id={insight.id}
+              title={insight.title}
+              subtitle={insight.subtitle}
+              onActivate={() => handleInsightActivate(insight)}
+            />
+          ))}
+        </div>
+      )}
       <AssistantAdviceCard
         insight={coachInsightText}
         loading={coachLoading}

--- a/apps/web/src/modules/finyk/hooks/useFinykInsights.ts
+++ b/apps/web/src/modules/finyk/hooks/useFinykInsights.ts
@@ -1,0 +1,85 @@
+/**
+ * Last validated: 2026-05-19
+ * Status: Active
+ *
+ * Per-module insight wrapper for Finyk.
+ *
+ * Fetches its own data independently — safe to call from any surface,
+ * including the Hub which has no Finyk network providers in scope.
+ *
+ * Transaction data is sourced from the SQLite Mono mirror cache
+ * (`getCachedFinykMonoMirrorState`), which is populated at boot by
+ * `useFinykMonoMirrorBoot`. The cache is reactive via
+ * `useFinykMonoMirrorTick` so the hook re-evaluates after each
+ * mirror refresh.
+ *
+ * Storage slots (budgets, txCategories, txSplits, customCategories,
+ * subscriptions, dismissedRecurring) come from `useFinykStorageSlots`,
+ * which reads from LS (first-paint) then overlays SQLite once warm —
+ * the same source used by `FinykInsightsBlock`.
+ *
+ * Returns up to 3 Insight objects in priority order:
+ *   1. budget-overrun  — actionable today
+ *   2. coffee-limit    — MoM trend
+ *   3. recurring       — discovery
+ */
+
+import { useMemo } from "react";
+import { getCachedFinykMonoMirrorState } from "../lib/monoMirrorReader";
+import { useFinykMonoMirrorTick } from "../lib/monoMirrorGate";
+import { useFinykStorageSlots } from "./useFinykStorageSlots";
+import { useCoffeeLimitInsight } from "./useCoffeeLimitInsight";
+import { useBudgetOverrunInsight } from "./useBudgetOverrunInsight";
+import { useRecurringDetectedInsight } from "./useRecurringDetectedInsight";
+import type { Insight } from "@shared/lib/insights/types";
+
+/** Max insights this wrapper surfaces. */
+const MAX_VISIBLE = 3;
+
+export function useFinykInsights(): Insight[] {
+  // Reactive tick — re-renders when the Mono mirror cache is refreshed.
+  const mirrorTick = useFinykMonoMirrorTick();
+
+  const transactions = useMemo(() => {
+    return getCachedFinykMonoMirrorState().transactions;
+    // mirrorTick is the intentional dep — re-read the cache on each tick.
+    // getCachedFinykMonoMirrorState is a stable module-level fn; omitting
+    // it from the dep array is intentional and mirrors the pattern in useWorkouts.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mirrorTick]);
+
+  const slots = useFinykStorageSlots();
+
+  const overrunInsight = useBudgetOverrunInsight({
+    budgets: slots.budgets,
+    transactions,
+    txCategories: slots.txCategories,
+    txSplits: slots.txSplits,
+    customCategories: slots.customCategories,
+  });
+
+  const coffeeInsight = useCoffeeLimitInsight({
+    transactions,
+    txCategories: slots.txCategories,
+    txSplits: slots.txSplits,
+    customCategories: slots.customCategories,
+  });
+
+  const recurringInsight = useRecurringDetectedInsight({
+    transactions,
+    subscriptions: slots.subscriptions,
+    dismissedRecurring: slots.dismissedRecurring,
+    excludedTxIds: undefined,
+  });
+
+  return useMemo((): Insight[] => {
+    const candidates: Array<Insight | null> = [
+      overrunInsight,
+      coffeeInsight,
+      recurringInsight,
+    ];
+    return candidates
+      .filter((i): i is Insight => i !== null)
+      .slice(0, MAX_VISIBLE);
+  }, [overrunInsight, coffeeInsight, recurringInsight]);
+}

--- a/apps/web/src/modules/fizruk/hooks/useFizrukInsights.ts
+++ b/apps/web/src/modules/fizruk/hooks/useFizrukInsights.ts
@@ -1,0 +1,45 @@
+/**
+ * Last validated: 2026-05-19
+ * Status: Active
+ *
+ * Per-module insight wrapper for Fizruk.
+ *
+ * Calls `useWorkouts` and `useActiveFizrukWorkout` internally — both are
+ * safe to call from any surface because they read from the SQLite
+ * warm-cache + localStorage respectively, with no network providers
+ * required.
+ *
+ * Returns up to 2 Insight objects in priority order:
+ *   1. pr-pending       — actionable (active/recent workout close to PR)
+ *   2. rest-day-overdue — informational (3+ days without training)
+ */
+
+import { useMemo } from "react";
+import { useWorkouts } from "./useWorkouts";
+import { useActiveFizrukWorkout } from "@shared/hooks/useActiveFizrukWorkout";
+import { usePrPendingInsight } from "./usePrPendingInsight";
+import { useRestDayOverdueInsight } from "./useRestDayOverdueInsight";
+import type { Insight } from "@shared/lib/insights/types";
+
+/** Max insights this wrapper surfaces. */
+const MAX_VISIBLE = 2;
+
+export function useFizrukInsights(): Insight[] {
+  const { workouts, loaded } = useWorkouts();
+  const activeWorkoutId = useActiveFizrukWorkout();
+
+  const prPendingInsight = usePrPendingInsight({
+    workouts,
+    loaded,
+    activeWorkoutId,
+  });
+
+  const restDayInsight = useRestDayOverdueInsight(workouts, loaded);
+
+  return useMemo((): Insight[] => {
+    const candidates: Array<Insight | null> = [prPendingInsight, restDayInsight];
+    return candidates
+      .filter((i): i is Insight => i !== null)
+      .slice(0, MAX_VISIBLE);
+  }, [prPendingInsight, restDayInsight]);
+}

--- a/apps/web/src/modules/nutrition/hooks/useNutritionInsights.ts
+++ b/apps/web/src/modules/nutrition/hooks/useNutritionInsights.ts
@@ -1,0 +1,60 @@
+/**
+ * Last validated: 2026-05-19
+ * Status: Active
+ *
+ * Per-module insight wrapper for Nutrition.
+ *
+ * Reads `NutritionLog` and `NutritionPrefs` from the SQLite warm-cache
+ * (`getCachedNutritionSqliteState`) with reactivity via
+ * `useNutritionSqliteReadTick`. Falls back to empty log / default prefs
+ * before the boot cache warms (consistent with `useNutritionLog` and
+ * `useNutritionPrefsState` behaviour).
+ *
+ * Safe to call from any surface — no network providers required.
+ *
+ * Returns up to 2 Insight objects in priority order:
+ *   1. protein-low        — actionable, time-gated (>= 18:00 Kyiv)
+ *   2. streak-7-days      — celebration, fires when 7-day kcal streak
+ */
+
+import { useMemo } from "react";
+import { getCachedNutritionSqliteState } from "../lib/sqliteReader";
+import { useNutritionSqliteReadTick } from "../lib/sqliteReadGate";
+import { defaultNutritionPrefs } from "@sergeant/nutrition-domain";
+import { useProteinLowInsight } from "./useProteinLowInsight";
+import { useStreakSevenDaysInsight } from "./useStreakSevenDaysInsight";
+import type { Insight } from "@shared/lib/insights/types";
+
+/** Max insights this wrapper surfaces. */
+const MAX_VISIBLE = 2;
+
+export function useNutritionInsights(): Insight[] {
+  // Reactive tick — re-renders when the Nutrition SQLite cache refreshes.
+  const sqliteCacheTick = useNutritionSqliteReadTick();
+
+  // Read log + prefs from the warm SQLite cache.
+  // Before the cache warms, log is `{}` and prefs fall back to defaults —
+  // both detection hooks return null for empty/zero input, so no false
+  // positives during the boot window.
+  const { log, prefs } = useMemo(() => {
+    const cached = getCachedNutritionSqliteState();
+    return {
+      log: cached.log,
+      prefs: cached.prefs ?? defaultNutritionPrefs(),
+    };
+    // sqliteCacheTick is the intentional dep — re-evaluate on cache tick.
+    // getCachedNutritionSqliteState is a stable module-level fn; omitting it
+    // from the dep array is intentional and mirrors the pattern in useWorkouts.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sqliteCacheTick]);
+
+  const proteinInsight = useProteinLowInsight(log, prefs);
+  const streakInsight = useStreakSevenDaysInsight(log, prefs);
+
+  return useMemo((): Insight[] => {
+    const candidates: Array<Insight | null> = [proteinInsight, streakInsight];
+    return candidates
+      .filter((i): i is Insight => i !== null)
+      .slice(0, MAX_VISIBLE);
+  }, [proteinInsight, streakInsight]);
+}

--- a/apps/web/src/modules/routine/hooks/useRoutineInsights.ts
+++ b/apps/web/src/modules/routine/hooks/useRoutineInsights.ts
@@ -1,0 +1,37 @@
+/**
+ * Last validated: 2026-05-19
+ * Status: Active
+ *
+ * Per-module insight wrapper for Routine.
+ *
+ * Calls `useRoutineState` internally — safe to call from any surface
+ * because it reads from localStorage with cross-tab sync and has no
+ * network dependencies.
+ *
+ * Returns up to 2 Insight objects in priority order:
+ *   1. todo-evening            — actionable, time-gated (>= 20:00 Kyiv)
+ *   2. streak-record-pending   — motivational, fires when 1 day from record
+ */
+
+import { useMemo } from "react";
+import { useRoutineState } from "./useRoutineState";
+import { useTodoEveningInsight } from "./useTodoEveningInsight";
+import { useStreakRecordPendingInsight } from "./useStreakRecordPendingInsight";
+import type { Insight } from "@shared/lib/insights/types";
+
+/** Max insights this wrapper surfaces. */
+const MAX_VISIBLE = 2;
+
+export function useRoutineInsights(): Insight[] {
+  const { routine } = useRoutineState();
+
+  const todoInsight = useTodoEveningInsight(routine);
+  const streakInsight = useStreakRecordPendingInsight(routine);
+
+  return useMemo((): Insight[] => {
+    const candidates: Array<Insight | null> = [todoInsight, streakInsight];
+    return candidates
+      .filter((i): i is Insight => i !== null)
+      .slice(0, MAX_VISIBLE);
+  }, [todoInsight, streakInsight]);
+}

--- a/apps/web/src/shared/lib/insights/index.ts
+++ b/apps/web/src/shared/lib/insights/index.ts
@@ -16,3 +16,8 @@ export {
   useInsightDismissal,
   type UseInsightDismissalResult,
 } from "./useInsightDismissal";
+
+export {
+  useAllInsights,
+  type UseAllInsightsOptions,
+} from "./useAllInsights";

--- a/apps/web/src/shared/lib/insights/useAllInsights.ts
+++ b/apps/web/src/shared/lib/insights/useAllInsights.ts
@@ -1,0 +1,104 @@
+/**
+ * Last validated: 2026-05-19
+ * Status: Active
+ *
+ * Top-level insight aggregator — collects Insight[] from all 4 modules,
+ * filters by display surface, sorts by priority, and caps the result.
+ *
+ * Safe to call from ANY surface (Hub, module, widget). Each module
+ * wrapper hook fetches its own data independently — no prop drilling,
+ * no cross-module context required.
+ *
+ * ## Priority rank (highest → lowest)
+ *
+ * 1. `fizruk-pr-pending`              — actionable, time-sensitive (active workout)
+ * 2. `nutrition-protein-low`          — actionable, time-sensitive (evening gate)
+ * 3. `routine-todo-evening`           — actionable, time-sensitive (evening gate)
+ * 4. `finyk-budget-overrun-*`         — actionable, fiscal urgency
+ * 5. `routine-streak-record-pending`  — motivational, immediate opportunity
+ * 6. `nutrition-streak-7-days-*`      — celebration, can wait
+ * 7. `finyk-coffee-limit-*`           — informational, MoM trend
+ * 8. `finyk-recurring-detected`       — informational, discovery
+ * 9. `fizruk-rest-day-overdue`        — informational, low urgency
+ *
+ * Unknown insight ids fall below rank 9 (stable sort preserves
+ * declaration order within the unknown bucket).
+ */
+
+import { useMemo } from "react";
+import { useFinykInsights } from "@finyk/hooks/useFinykInsights";
+import { useFizrukInsights } from "@fizruk/hooks/useFizrukInsights";
+import { useRoutineInsights } from "@routine/hooks/useRoutineInsights";
+import { useNutritionInsights } from "@nutrition/hooks/useNutritionInsights";
+import type { Insight } from "./types";
+
+/** Default cap for simultaneous insights rendered at the Hub. */
+const DEFAULT_CAP = 3;
+
+/**
+ * Priority rank for known insight id prefixes (lower number = higher priority).
+ * The map is keyed by the stable id prefix so parametric ids such as
+ * `finyk-budget-overrun-food` and `finyk-coffee-limit-2026-05` both match.
+ */
+const PRIORITY_RANK: ReadonlyArray<[prefix: string, rank: number]> = [
+  ["fizruk-pr-pending", 1],
+  ["nutrition-protein-low", 2],
+  ["routine-todo-evening", 3],
+  ["finyk-budget-overrun-", 4],
+  ["routine-streak-record-pending", 5],
+  ["nutrition-streak-7-days-", 6],
+  ["finyk-coffee-limit-", 7],
+  ["finyk-recurring-detected", 8],
+  ["fizruk-rest-day-overdue", 9],
+];
+
+function priorityOf(id: string): number {
+  for (const [prefix, rank] of PRIORITY_RANK) {
+    if (id === prefix || id.startsWith(prefix)) return rank;
+  }
+  return 99;
+}
+
+export interface UseAllInsightsOptions {
+  /**
+   * Which surface is requesting insights.
+   * - `"hub"`    → only insights with `showOn === "hub" | "both"`
+   * - `"module"` → only insights with `showOn === "module" | "both"`
+   */
+  surface: "hub" | "module";
+  /**
+   * Maximum number of insights to return. Defaults to 3.
+   */
+  cap?: number;
+}
+
+/**
+ * Aggregates insights from all 4 modules, filters by surface, sorts by
+ * priority, and caps the result. Use `surface: "hub"` in HubInsightsBlock.
+ *
+ * ⚠️ Must be called at the top level of a component — hook rules apply.
+ * All four module hooks run unconditionally (Rules of Hooks).
+ */
+export function useAllInsights(opts: UseAllInsightsOptions): Insight[] {
+  const { surface, cap = DEFAULT_CAP } = opts;
+
+  const finyk = useFinykInsights();
+  const fizruk = useFizrukInsights();
+  const routine = useRoutineInsights();
+  const nutrition = useNutritionInsights();
+
+  return useMemo((): Insight[] => {
+    const all = [...finyk, ...fizruk, ...routine, ...nutrition];
+
+    const filtered = all.filter((i) =>
+      surface === "hub" ? i.showOn !== "module" : i.showOn !== "hub",
+    );
+
+    // Stable sort by priority rank — equal-rank items retain declaration order.
+    const sorted = [...filtered].sort(
+      (a, b) => priorityOf(a.id) - priorityOf(b.id),
+    );
+
+    return sorted.slice(0, cap);
+  }, [finyk, fizruk, routine, nutrition, surface, cap]);
+}


### PR DESCRIPTION
## Summary

- Adds 4 per-module wrapper hooks that each fetch their own data internally and return `Insight[]`
- Adds `useAllInsights()` top-level aggregator that merges all 4 modules, filters by `showOn` surface, sorts by priority, and caps at N
- `HubInsightsBlock` calls `useAllInsights({ surface: "hub", cap: 3 })` and renders InsightCards above `AssistantAdviceCard`

## Architecture decisions

### Wrapper hook data sources

Each wrapper is fully self-contained — no prop drilling from Hub:

| Module | Transactions/data source |
|---|---|
| Finyk | `getCachedFinykMonoMirrorState()` (SQLite Mono mirror) + `useFinykStorageSlots()` for budgets/cats |
| Fizruk | `useWorkouts()` + `useActiveFizrukWorkout()` (both read from SQLite warm-cache / LS) |
| Routine | `useRoutineState()` (LS + cross-tab sync, no network) |
| Nutrition | `getCachedNutritionSqliteState()` (SQLite warm-cache, reactive via tick) |

Finyk uses the Mono mirror cache rather than the full `useMonobank` hook
because the Hub has no Mono network providers in scope. The mirror is
populated at boot by `useFinykMonoMirrorBoot` (wired in `useStorage`).
Before boot, `transactions = []` so all three Finyk triggers return `null`
— no false positives during the boot window.

### showOn filtering

- `surface: "hub"` → keeps insights with `showOn === "hub" | "both"`
- `surface: "module"` → keeps insights with `showOn === "module" | "both"`

Insights shipped in Phase 5 a-d are all marked `showOn: "module"`. This
means the Hub currently renders 0 insight cards unless a future PR changes
a trigger's `showOn` to `"hub"` or `"both"`. The aggregator is wired and
ready; the gate is intentionally at the trigger level.

**Exception:** `routine-streak-record-pending` and `routine-todo-evening`
are already marked `showOn: "both"` and will surface at Hub immediately.

### Priority order (1 = highest)

1. `fizruk-pr-pending` — actionable, active workout
2. `nutrition-protein-low` — actionable, evening gate
3. `routine-todo-evening` — actionable, evening gate
4. `finyk-budget-overrun-*` — actionable, fiscal
5. `routine-streak-record-pending` — motivational, immediate
6. `nutrition-streak-7-days-*` — celebration
7. `finyk-coffee-limit-*` — informational
8. `finyk-recurring-detected` — informational
9. `fizruk-rest-day-overdue` — informational

### Module surfaces

Left unchanged — module surfaces (FinykInsightsBlock, Fizruk Dashboard,
RoutineCalendarPanel, NutritionDashboard) continue calling individual
trigger hooks directly. Refactoring them to use the wrapper hooks is a
separate cleanup PR (no user-visible diff, smaller risk surface).

### Infinite-loop risks mitigated

- `useFinykInsights` and `useNutritionInsights` use `useMemo` keyed on the
  SQLite cache tick — a stable integer counter, not an object reference.
  No risk of tick-on-every-render.
- `useWorkouts` already memoizes the sorted workout array; wrapping it in
  `useFizrukInsights` adds no extra re-renders.
- `useAllInsights` memoizes on the 4 insight arrays from wrappers — all of
  which are themselves memoized. Stable deps chain throughout.

### Test wiring

`HubDashboard.test.tsx` now wraps `renderDashboard` in `<MemoryRouter>` to
satisfy `useNavigate` (added to `HubInsightsBlock` for insight navigation).
No other test files were touched.

## Test plan

- [ ] Hub renders 0 insight cards when no module data exists (empty boot)
- [ ] Hub renders `routine-streak-record-pending` and `routine-todo-evening`
      (both `showOn: "both"`) when conditions are met
- [ ] Dismiss on an InsightCard at Hub does not reappear (dismissal keyed by id)
- [ ] `navigate` action from an insight card navigates correctly in the app
- [ ] Module surfaces (Finyk Overview, Fizruk Dashboard, etc.) still render
      their own insights unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a hub-level insight aggregator and four module wrapper hooks to show the top 3 priority insights on the Hub. This delivers consistent, self-contained insights without cross-module wiring.

- New Features
  - Added `useFinykInsights`, `useFizrukInsights`, `useRoutineInsights`, `useNutritionInsights` — each reads its own cached state (SQLite/LS) and returns `Insight[]`.
  - Added `useAllInsights({ surface, cap })` — merges all modules, filters by `showOn`, sorts by priority, caps results (default 3).
    - Priority: `fizruk-pr-pending` > `nutrition-protein-low` > `routine-todo-evening` > `finyk-budget-overrun-*` > `routine-streak-record-pending` > `nutrition-streak-7-days-*` > `finyk-coffee-limit-*` > `finyk-recurring-detected` > `fizruk-rest-day-overdue`.
  - Updated `HubInsightsBlock` to call `useAllInsights({ surface: "hub", cap: 3 })` and render `InsightCard`s above AssistantAdviceCard. Supports actions: navigate, open-chat, callback.
  - Test update: wrapped `HubDashboard.test.tsx` in `MemoryRouter` from `react-router-dom` to support navigation.

<sup>Written for commit f37246061cc3f0943956d47650b1e5976c19b0c0. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3045?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

