### PR TITLE
feat(web): wire StreakFlame on routine hero (6.5 / W6)

### DIFF
--- a/apps/web/src/modules/routine/components/RoutineCalendarHero.tsx
+++ b/apps/web/src/modules/routine/components/RoutineCalendarHero.tsx
@@ -1,12 +1,14 @@
 /**
- * Last validated: 2026-05-18
+ * Last validated: 2026-05-19
  * Status: Active
  */
 import { Card } from "@shared/components/ui/Card";
 import { HeroValueLine } from "@shared/components/ui/HeroValueLine";
 import { KpiRowCompact } from "@shared/components/ui/KpiRowCompact";
 import { CounterReveal } from "@shared/components/ui/CounterReveal";
+import { StreakFlame } from "@shared/components/ui/StreakFlame";
 import { DayProgressRing } from "./DayProgressRing";
+import { useStreakFlame } from "../hooks/useStreakFlame";
 
 export interface RoutineCalendarHeroProps {
   rangeLabel: string;
@@ -42,6 +44,7 @@ export function RoutineCalendarHero({
   onOpenDayReport,
 }: RoutineCalendarHeroProps) {
   const narrative = `${headlineDate} · ${dayProgress.completed} з ${dayProgress.scheduled} звичок · Серія ${currentStreak} днів`;
+  const flame = useStreakFlame(currentStreak);
 
   return (
     <Card
@@ -50,7 +53,16 @@ export function RoutineCalendarHero({
       module="routine"
       radius="r-2xl"
       aria-label={rangeLabel}
+      className="relative"
     >
+      {flame.visible && (
+        <span
+          className="absolute top-3 right-3 min-h-[44px] min-w-[44px] flex items-center justify-center"
+          aria-hidden="true"
+        >
+          <StreakFlame streak={flame.count} size="sm" />
+        </span>
+      )}
       <HeroValueLine
         narrative={narrative}
         metric={

--- a/apps/web/src/modules/routine/hooks/useStreakFlame.ts
+++ b/apps/web/src/modules/routine/hooks/useStreakFlame.ts
@@ -1,0 +1,57 @@
+/**
+ * useStreakFlame — Routine hero streak flame hook.
+ *
+ * Derives display properties for the `StreakFlame` XS adornment placed in
+ * the top-right corner of `RoutineCalendarHero`. Hides the flame for cold
+ * streaks (0 days) and strips the glow animation when the user prefers
+ * reduced motion (Hard Rule #17 — one AMBIENT slot; motion-safe wrapper
+ * moves glow to CSS, this hook gates render-level decisions).
+ *
+ * Intensity tiers:
+ *   - 0          → not visible (no cold flame shown)
+ *   - 1–6        → low    (dim yellow; static icon-only for reduced-motion)
+ *   - 7–29       → medium (amber/orange; glow animation enabled)
+ *   - 30–99      → strong (red; larger glow radius)
+ *   - 100+       → max    (violet; full celebration glow)
+ */
+
+import { useReducedMotion } from "@shared/hooks/useReducedMotion";
+
+export type StreakFlameIntensity = "low" | "medium" | "strong" | "max";
+
+export interface UseStreakFlameResult {
+  /** Whether the flame adornment should be rendered at all. */
+  visible: boolean;
+  /** Colour/glow intensity tier passed to `<StreakFlame>`. */
+  intensity: StreakFlameIntensity;
+  /** Raw streak count (pass-through for `<StreakFlame streak={…}>`) */
+  count: number;
+  /**
+   * When `true` the user prefers reduced motion. Components should omit
+   * animation wrappers — `StreakFlame` already uses `motion-safe:` CSS,
+   * so this is mainly useful if a wrapper needs to suppress JS-driven
+   * effects (e.g. a burst particle).
+   */
+  reducedMotion: boolean;
+}
+
+function resolveIntensity(streakDays: number): StreakFlameIntensity {
+  if (streakDays >= 100) return "max";
+  if (streakDays >= 30) return "strong";
+  if (streakDays >= 7) return "medium";
+  return "low";
+}
+
+/**
+ * @param streakDays - Current consecutive-day streak. 0 hides the flame.
+ */
+export function useStreakFlame(streakDays: number): UseStreakFlameResult {
+  const reducedMotion = useReducedMotion();
+
+  return {
+    visible: streakDays > 0,
+    intensity: resolveIntensity(streakDays),
+    count: streakDays,
+    reducedMotion,
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `useStreakFlame(streakDays)` hook in `apps/web/src/modules/routine/hooks/useStreakFlame.ts` that derives `{ visible, intensity, count, reducedMotion }` from a raw streak count
- Wires the existing `StreakFlame` primitive (XS / `size="sm"`) into `RoutineCalendarHero` as an absolute-positioned adornment in the top-right corner
- Motion budget: MeshBackground lives at `RoutineApp` shell level (not inside the hero card), so no AMBIENT slot conflict. The hero's only AMBIENT is the flame glow itself (`motion-safe:animate-streak-glow` inside the primitive)

## Hook intensity tiers

| Range | Tier | Colour (primitive) | Animation |
|-------|------|--------------------|-----------|
| 0 | hidden | — | — |
| 1–6 | `low` | yellow-500 | none (static icon) |
| 7–29 | `medium` | amber-500 / orange-500 | `motion-safe:animate-streak-glow` |
| 30–99 | `strong` | red-500 | `motion-safe:animate-streak-glow` (larger shadow) |
| 100+ | `max` | violet-500 | `motion-safe:animate-streak-glow` + `animate-celebration-pop` at milestones |

## Primitive props used

`<StreakFlame streak={count} size="sm" />` — the primitive's own `getFlameIntensity()` function drives colour and glow class; the hook's `intensity` field is informational for callers that need to gate JS-side effects (e.g. burst particles).

## Placement in hero

Absolute corner via a `<span className="absolute top-3 right-3 min-h-[44px] min-w-[44px] flex items-center justify-center">` wrapper inside the Card (which receives `className="relative"`). `aria-hidden="true"` — screen reader coverage already comes from the existing "Серія N днів" narrative in `HeroValueLine` and the KpiRowCompact "Серія" item.

## Reduced-motion fallback

The primitive uses `motion-safe:` CSS guards — no JS branching needed for the glow itself. `useReducedMotion()` is surfaced on the return value for any future burst/particle layer.

## Test plan

- [ ] Streak > 0: flame visible top-right of Routine hero
- [ ] Streak = 0: flame absent, no layout shift
- [ ] Streak = 7: amber glow animates (motion-safe)
- [ ] Streak = 30: red glow, larger shadow
- [ ] Streak = 100: violet, milestone pop
- [ ] OS "Reduce Motion" on: static icon only, no pulse

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a streak flame to the Routine hero to visualize the current streak and celebrate milestones. Introduces a hook to control visibility and intensity, with motion-safe behavior and no layout shift at 0.

- **New Features**
  - Added `useStreakFlame(streakDays)` returning `{ visible, intensity, count, reducedMotion }`.
  - Wired `StreakFlame` (`size="sm"`) into `RoutineCalendarHero` top-right; hidden when streak is 0.
  - Intensity tiers: 1–6 low, 7–29 medium, 30–99 strong, 100+ max; glow animates only under `motion-safe`.

<sup>Written for commit 82484f5e23d5d3b28d7a04dd3cd6a5e0e8dfb97f. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3047?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

