### PR TITLE
feat(web): category-tinted icon pill on finyk transaction rows (6.1)

### DIFF
--- a/apps/web/src/modules/finyk/components/TxRow.tsx
+++ b/apps/web/src/modules/finyk/components/TxRow.tsx
@@ -1,5 +1,5 @@
 /**
- * Last validated: 2026-05-14
+ * Last validated: 2026-05-19
  * Status: Active
  */
 import { memo, useCallback, useMemo, useState } from "react";
@@ -17,7 +17,7 @@ import type { MonoAccount } from "@sergeant/finyk-domain/lib/accounts";
 import type { TxSplit, TxSplitsMap } from "@sergeant/finyk-domain/domain/types";
 import { cn } from "@shared/lib/ui/cn";
 import { Button } from "@shared/components/ui/Button";
-import { Icon } from "@shared/components/ui/Icon";
+import { Icon, type IconName } from "@shared/components/ui/Icon";
 
 const splitInp =
   "input-focus-finyk flex-1 text-xs h-9 rounded-xl border border-line bg-panelHi px-2 text-text";
@@ -29,6 +29,35 @@ const INCOME_ICONS: Record<string, string> = {
   in_cashback: "🎁",
   in_pension: "🏛️",
   in_other: "📥",
+};
+
+/**
+ * Maps category IDs to Icon names for the tinted pill.
+ * Falls back to "tag" for any unknown or custom category.
+ * Phase 6.1 — Expensa-inspired category-tinted icon pill.
+ */
+const CATEGORY_ICON_MAP: Record<string, IconName> = {
+  food: "shopping-cart",
+  restaurant: "coffee",
+  transport: "truck",
+  subscriptions: "bell",
+  health: "droplet",
+  shopping: "tag",
+  entertainment: "play",
+  sport: "dumbbell",
+  beauty: "tag",
+  smoking: "tag",
+  education: "package",
+  travel: "trending-up",
+  debt: "credit-card",
+  charity: "hand-coins",
+  [INTERNAL_TRANSFER_ID]: "trending-down",
+  // income
+  in_salary: "briefcase",
+  in_freelance: "briefcase",
+  in_cashback: "tag",
+  in_pension: "briefcase",
+  in_other: "trending-up",
 };
 
 function getAccountShortName(acc: MonoAccount | undefined): string | null {
@@ -120,9 +149,6 @@ function TxRowImpl({
         overrideCatId,
         customCategories as readonly unknown[],
       );
-  const catIcon = isIncome
-    ? INCOME_ICONS[cat.id] || "📥"
-    : cat.label.split(" ")[0];
   const catName = isIncome
     ? cat.label
     : cat.label.slice(cat.label.indexOf(" ") + 1);
@@ -172,11 +198,33 @@ function TxRowImpl({
     setSplitEditor(false);
   }, [draftSplits, onSplitChange, tx.id]);
 
+  // Resolve the icon name for the category pill (Phase 6.1).
+  const pillIconName: IconName =
+    CATEGORY_ICON_MAP[cat.id] ?? "tag";
+
   const mainRowInner = (
     <>
-      <span className="text-xl shrink-0 leading-none">
-        {highlighted ? "✅" : catIcon}
-      </span>
+      {highlighted ? (
+        <span className="text-xl shrink-0 leading-none" aria-hidden="true">
+          ✅
+        </span>
+      ) : (
+        // 28px tinted circle — decorative, non-interactive (aria-hidden).
+        // bg-finyk/[0.08] gives a soft emerald wash; text-finyk-strong
+        // ensures ≥4.5:1 contrast on the bg-panel surface in light mode.
+        // dark:bg-finyk/[0.15] lifts the wash slightly for dark-surface parity.
+        <span
+          aria-hidden="true"
+          className={cn(
+            "shrink-0 inline-flex items-center justify-center rounded-full",
+            "w-7 h-7",
+            "bg-finyk/[0.08] dark:bg-finyk/[0.15]",
+            "text-finyk-strong dark:text-finyk",
+          )}
+        >
+          <Icon name={pillIconName} size={16} strokeWidth={1.75} />
+        </span>
+      )}
       <div className="min-w-0">
         <div
           className={cn(


### PR DESCRIPTION
## Summary

- Replaces the plain emoji span on every Finyk transaction row with a 28px circular icon pill tinted with the finyk module accent.
- Pill: `w-7 h-7` (28px) circle, `bg-finyk/[0.08] dark:bg-finyk/[0.15]`, `text-finyk-strong dark:text-finyk`, contains a 16px `<Icon>` with `strokeWidth={1.75}`.
- Icon name resolved via `CATEGORY_ICON_MAP` keyed by `cat.id` (food→`shopping-cart`, restaurant→`coffee`, transport→`truck`, subscriptions→`bell`, health→`droplet`, entertainment→`play`, sport→`dumbbell`, education→`package`, travel→`trending-up`, debt→`credit-card`, charity→`hand-coins`, income→`briefcase`/`trending-up`, internal transfer→`trending-down`, fallback→`tag`).
- Row file: `apps/web/src/modules/finyk/components/TxRow.tsx`
- Non-interactive, `aria-hidden="true"` on pill container; `<Icon>` auto-applies `aria-hidden` when no `title` is given.
- `highlighted` row keeps the ✅ emoji treatment unchanged.
- No data shape change. No new types. No new shared components.

## F5b conflict assessment

F5b (`feat/redesign-v2-phase-5b-manual-expense-emoji-migration`) edits `ManualExpenseSheet.tsx` (and possibly category constants for emoji migration). This PR touches only `TxRow.tsx`. No shared file overlap. However: if F5b changes the `label` format of `MCC_CATEGORIES` entries (emoji-strip migration), `catName` derivation (`cat.label.slice(cat.label.indexOf(" ") + 1)`) may need adjustment at rebase time. The `CATEGORY_ICON_MAP` keys use `cat.id` (stable slug strings), so the pill icon lookup is unaffected by any label-format change.

## Test plan

- [ ] Verify each category type renders the correct icon glyph inside the pill.
- [ ] Verify pill shows soft emerald wash in light mode, slightly stronger in dark mode.
- [ ] Verify `highlighted` rows still show ✅ (no regression).
- [ ] Verify swipe gestures and click handlers on TxListItem are unaffected.
- [ ] Verify category picker still shows emoji + label text as before.
- [ ] CI typecheck passes (no unused `catIcon` variable, `IconName` import is used).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the emoji on Finyk transaction rows with a 28px category-tinted icon pill for a clearer, consistent look. Highlighted rows still show ✅. No data or type changes.

- **New Features**
  - Added a circular 28px pill using finyk accent tint (`bg-finyk/[0.08]` light, `dark:bg-finyk/[0.15]`).
  - Renders a 16px `<Icon>` (`strokeWidth={1.75}`) with `aria-hidden` on the pill container.
  - Icons resolved via `CATEGORY_ICON_MAP` keyed by `cat.id` with a `tag` fallback; income and internal transfer mapped.
  - Non-interactive; gestures and click handlers unchanged.

<sup>Written for commit 04ac6a8ea8f4eca853efa74fc73ee1080b3ead26. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3048?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

