### PR TITLE
feat(web): migrate manual expense category to typed icon slug (F5b)

### DIFF
--- a/apps/web/src/modules/finyk/components/ManualExpenseSheet.test.tsx
+++ b/apps/web/src/modules/finyk/components/ManualExpenseSheet.test.tsx
@@ -7,7 +7,7 @@ import {
   waitFor,
   cleanup,
 } from "@testing-library/react";
-import { ManualExpenseSheet } from "./ManualExpenseSheet";
+import { ManualExpenseSheet, upgradeCategory } from "./ManualExpenseSheet";
 
 // Web Speech API check inside `VoiceMicButton` short-circuits to null when
 // SpeechRecognition isn't on `window`, which is exactly what jsdom gives
@@ -28,6 +28,41 @@ beforeAll(() => {
 
 afterEach(() => {
   cleanup();
+});
+
+// ─── upgradeCategory unit tests — all 3 storage eras ─────────────────────────
+describe("upgradeCategory — era detection", () => {
+  it("Era 3: known slug passes through unchanged", () => {
+    expect(upgradeCategory("food")).toBe("food");
+    expect(upgradeCategory("transport")).toBe("transport");
+    expect(upgradeCategory("other")).toBe("other");
+  });
+
+  it("Era 2: emoji-prefixed strings upgrade to slug", () => {
+    expect(upgradeCategory("🍴 їжа")).toBe("food");
+    expect(upgradeCategory("🚗 транспорт")).toBe("transport");
+    expect(upgradeCategory("🏷 інше")).toBe("other");
+    expect(upgradeCategory("🍔 кафе та ресторани")).toBe("cafe");
+    expect(upgradeCategory("💊 здоров'я")).toBe("health");
+  });
+
+  it("Era 1: bare UA labels upgrade to slug", () => {
+    expect(upgradeCategory("їжа")).toBe("food");
+    expect(upgradeCategory("транспорт")).toBe("transport");
+    expect(upgradeCategory("розваги")).toBe("entertainment");
+    expect(upgradeCategory("здоров'я")).toBe("health");
+    expect(upgradeCategory("одяг")).toBe("shopping");
+    expect(upgradeCategory("комунальні")).toBe("utilities");
+    expect(upgradeCategory("техніка")).toBe("tech");
+    expect(upgradeCategory("інше")).toBe("other");
+  });
+
+  it("null / undefined / unknown value falls back to 'other'", () => {
+    expect(upgradeCategory(null)).toBe("other");
+    expect(upgradeCategory(undefined)).toBe("other");
+    expect(upgradeCategory("")).toBe("other");
+    expect(upgradeCategory("🤷 невідоме")).toBe("other");
+  });
 });
 
 describe("ManualExpenseSheet — useApiForm + zod (Item #8 round-13)", () => {
@@ -74,20 +109,21 @@ describe("ManualExpenseSheet — useApiForm + zod (Item #8 round-13)", () => {
     };
     expect(call.amount).toBe(120.5);
     expect(call.description).toBe("Кава");
-    // Default category is "🏷 інше" — matches DEFAULT_CATEGORY у компоненті.
-    expect(call.category).toBe("🏷 інше");
+    // Default category is now slug "other" (F5b — was "🏷 інше").
+    expect(call.category).toBe("other");
     // ISO-8601 date string ('YYYY-MM-DDTHH:mm:ss.sssZ').
     expect(call.date).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
     expect(onClose).toHaveBeenCalled();
   });
 
-  it("falls back to category-derived description when name is empty", async () => {
+  it("falls back to category display label when name is empty (Era 2 initialCategory)", async () => {
     const onSave = vi.fn();
     render(
       <ManualExpenseSheet
         open
         onClose={() => {}}
         onSave={onSave}
+        // Era 2 emoji string — upgraded to slug "food" at read-time.
         initialCategory="🍴 їжа"
       />,
     );
@@ -100,8 +136,41 @@ describe("ManualExpenseSheet — useApiForm + zod (Item #8 round-13)", () => {
     await waitFor(() => {
       expect(onSave).toHaveBeenCalledTimes(1);
     });
-    const call = onSave.mock.calls[0]![0] as { description: string };
-    // stripEmoji("🍴 їжа") → "їжа".
-    expect(call.description).toBe("їжа");
+    const call = onSave.mock.calls[0]![0] as {
+      description: string;
+      category: string;
+    };
+    // CATEGORY_DISPLAY["food"].label = "Їжа" (capitalised, no emoji).
+    expect(call.description).toBe("Їжа");
+    // Write path always emits slug.
+    expect(call.category).toBe("food");
+  });
+
+  it("falls back to category display label when name is empty (Era 1 initialCategory)", async () => {
+    const onSave = vi.fn();
+    render(
+      <ManualExpenseSheet
+        open
+        onClose={() => {}}
+        onSave={onSave}
+        // Era 1 bare UA label — upgraded to slug "transport" at read-time.
+        initialCategory="транспорт"
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Сума ₴"), {
+      target: { value: "50" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Додати" }));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledTimes(1);
+    });
+    const call = onSave.mock.calls[0]![0] as {
+      description: string;
+      category: string;
+    };
+    expect(call.description).toBe("Транспорт");
+    expect(call.category).toBe("transport");
   });
 });

--- a/apps/web/src/modules/finyk/components/ManualExpenseSheet.tsx
+++ b/apps/web/src/modules/finyk/components/ManualExpenseSheet.tsx
@@ -1,5 +1,5 @@
 /**
- * Last validated: 2026-05-14
+ * Last validated: 2026-05-19
  * Status: Active
  */
 import { useState, useEffect, useId, useMemo } from "react";
@@ -17,68 +17,172 @@ import {
 } from "@sergeant/shared";
 import { hapticSuccess } from "@shared/lib/adapters/haptic";
 import { formatMoney } from "@sergeant/shared";
+import { Icon } from "@shared/components/ui/Icon";
+import type { IconName } from "@shared/components/ui/Icon";
 import {
   CANONICAL_TO_MANUAL_LABEL,
   type FrequentCategory,
   type FrequentMerchant,
 } from "@sergeant/finyk-domain/domain/personalization";
 
-// Manual-expense categories. Labels map to the MCC canonical ids used
-// across the rest of Finyk (see `MANUAL_CATEGORY_ID_MAP`), so manual
-// entries and bank transactions share one taxonomy for analytics and
-// budgets. Emojis mirror the MCC labels for visual consistency.
-const CATEGORIES = [
-  "🍴 їжа",
-  "🛍 продукти",
-  "🍔 кафе та ресторани",
-  "🚗 транспорт",
-  "🎮 розваги",
-  "💊 здоров'я",
-  "🛍️ покупки",
-  "🏠 комунальні",
-  "📱 техніка",
-  "🎵 підписки",
-  "📚 навчання",
-  "✈️ подорожі",
-  "🏷 інше",
-];
-const DEFAULT_CATEGORY = "🏷 інше";
+// ─── Category slug system (F5b, 2026-05) ────────────────────────────────────
+//
+// Era 1 — pre-emoji (legacy): category stored as bare UA label, e.g. "їжа",
+//   "транспорт". Upgraded at read-time via LEGACY_RAW_TO_SLUG.
+//
+// Era 2 — emoji-prefixed (legacy): "🍴 їжа", "🚗 транспорт". Upgraded at
+//   read-time by stripping leading emoji, then mapping the UA label to slug
+//   via UA_LABEL_TO_SLUG.
+//
+// Era 3 — slug (current): "food", "transport", "groceries", etc. Used
+//   directly. Write path always emits a slug.
+//
+// Historical records in localStorage are NOT batch-migrated. upgradeCategory()
+// normalises them on every read, then the result (always a slug) is stored
+// on submit.
 
-// Legacy labels (pre-emoji). Old manual expenses stored category as e.g.
-// "їжа". When loaded for edit, we upgrade the string to its emoji
-// counterpart so the picker highlights it; saved value still round-trips
-// through `MANUAL_CATEGORY_ID_MAP` for personalization/analytics.
-const LEGACY_CATEGORY_UPGRADE: Record<string, string> = {
-  їжа: "🍴 їжа",
-  транспорт: "🚗 транспорт",
-  розваги: "🎮 розваги",
-  "здоров'я": "💊 здоров'я",
-  одяг: "🛍️ покупки",
-  комунальні: "🏠 комунальні",
-  техніка: "📱 техніка",
-  інше: "🏷 інше",
-};
+/** Typed category slugs. */
+export type CategorySlug =
+  | "food"
+  | "groceries"
+  | "cafe"
+  | "transport"
+  | "entertainment"
+  | "health"
+  | "shopping"
+  | "utilities"
+  | "tech"
+  | "subscriptions"
+  | "education"
+  | "travel"
+  | "other";
 
-function upgradeCategory(raw: string | null | undefined) {
-  if (!raw) return DEFAULT_CATEGORY;
-  if (CATEGORIES.includes(raw)) return raw;
-  const up = LEGACY_CATEGORY_UPGRADE[raw];
-  return up || raw;
+interface CategoryDisplay {
+  iconName: IconName;
+  /** Human-readable Ukrainian label shown in the chip. */
+  label: string;
 }
 
-// Strips leading emoji + space so "🍴 їжа" → "їжа", used as a human-readable
-// fallback description when the user leaves the name empty. We accept any
-// run of non-letter / non-digit grapheme chunks so compound emoji (zwj
-// sequences, variation selectors) all get peeled off.
-function stripEmoji(label: string) {
-  const str = String(label || "");
+/**
+ * Canonical display map: slug → { iconName, label }.
+ * Single source of truth for rendering. No emoji — icons only.
+ */
+export const CATEGORY_DISPLAY: Record<CategorySlug, CategoryDisplay> = {
+  food: { iconName: "utensils", label: "Їжа" },
+  groceries: { iconName: "shopping-cart", label: "Продукти" },
+  cafe: { iconName: "coffee", label: "Кафе та ресторани" },
+  transport: { iconName: "truck", label: "Транспорт" },
+  entertainment: { iconName: "sparkles", label: "Розваги" },
+  health: { iconName: "heart", label: "Здоров'я" },
+  shopping: { iconName: "tag", label: "Покупки" },
+  utilities: { iconName: "home", label: "Комунальні" },
+  tech: { iconName: "monitor", label: "Техніка" },
+  subscriptions: { iconName: "repeat", label: "Підписки" },
+  education: { iconName: "book", label: "Навчання" },
+  travel: { iconName: "compass", label: "Подорожі" },
+  other: { iconName: "tag", label: "Інше" },
+};
+
+/**
+ * The ordered list of slugs used for the category picker.
+ * Matches the former CATEGORIES array in display order.
+ */
+const CATEGORY_SLUGS: CategorySlug[] = [
+  "food",
+  "groceries",
+  "cafe",
+  "transport",
+  "entertainment",
+  "health",
+  "shopping",
+  "utilities",
+  "tech",
+  "subscriptions",
+  "education",
+  "travel",
+  "other",
+];
+
+const DEFAULT_CATEGORY: CategorySlug = "other";
+
+// Era 1 upgrade map: bare UA label (lower-case) → slug.
+// Covers all the pre-emoji strings that were stored before the emoji era.
+const LEGACY_RAW_TO_SLUG: Record<string, CategorySlug> = {
+  їжа: "food",
+  продукти: "groceries",
+  "кафе та ресторани": "cafe",
+  кафе: "cafe",
+  транспорт: "transport",
+  розваги: "entertainment",
+  "здоров'я": "health",
+  здоров: "health",
+  одяг: "shopping",
+  покупки: "shopping",
+  комунальні: "utilities",
+  техніка: "tech",
+  підписки: "subscriptions",
+  навчання: "education",
+  подорожі: "travel",
+  інше: "other",
+};
+
+// Era 2 upgrade map: stripped UA label from emoji string → slug.
+// Keys are the labels that appear AFTER the emoji prefix (lower-case).
+// Identical to LEGACY_RAW_TO_SLUG — the strip makes them equivalent,
+// so we reuse the same map for both eras.
+const UA_LABEL_TO_SLUG = LEGACY_RAW_TO_SLUG;
+
+/** Returns true if the value is a known slug. */
+function isCategorySlug(value: string): value is CategorySlug {
+  return Object.prototype.hasOwnProperty.call(CATEGORY_DISPLAY, value);
+}
+
+/**
+ * Strips leading emoji + space so "🍴 їжа" → "їжа".
+ * Accepts any run of non-letter / non-digit grapheme chunks so compound
+ * emoji (ZWJ sequences, variation selectors) are all peeled off.
+ */
+function stripLeadingEmoji(str: string): string {
+  const s = String(str || "");
   let i = 0;
-  while (i < str.length && !/[\p{L}\p{N}]/u.test(str[i]!)) i++;
-  return str.slice(i).trim();
+  while (i < s.length && !/[\p{L}\p{N}]/u.test(s[i]!)) i++;
+  return s.slice(i).trim();
+}
+
+/**
+ * Normalises any stored category value to a CategorySlug.
+ *
+ * Era 3 (slug): returned directly if recognised.
+ * Era 2 (emoji-prefixed): emoji stripped, UA label looked up in UA_LABEL_TO_SLUG.
+ * Era 1 (bare UA label): looked up directly in LEGACY_RAW_TO_SLUG.
+ * Unknown: falls back to "other".
+ *
+ * @example
+ * upgradeCategory("food")      // Era 3 → "food"
+ * upgradeCategory("🍴 їжа")   // Era 2 → "food"
+ * upgradeCategory("їжа")       // Era 1 → "food"
+ * upgradeCategory(null)         // → "other"
+ */
+export function upgradeCategory(raw: string | null | undefined): CategorySlug {
+  if (!raw) return DEFAULT_CATEGORY;
+
+  const trimmed = raw.trim();
+
+  // Era 3: known slug — use directly.
+  if (isCategorySlug(trimmed)) return trimmed;
+
+  // Era 2: emoji-prefixed string — strip emoji then map the UA label.
+  // Era 1: bare UA label — also matched by the stripped path (no-op strip).
+  const stripped = stripLeadingEmoji(trimmed).toLocaleLowerCase("uk-UA");
+  const fromLabel = UA_LABEL_TO_SLUG[stripped];
+  if (fromLabel) return fromLabel;
+
+  // Unknown legacy value — graceful fallback.
+  return DEFAULT_CATEGORY;
 }
 
 // Amount suggestion pills. Defaults give a first-run user sane round
-// values; personalised «часті» amounts (from top merchants’ average
+// values; personalised «часті» amounts (from top merchants' average
 // spend) are merged into the same row and rendered first, marked with
 // a small dot so the user can still tell which suggestion is based on
 // their own history. One row instead of two separately-labelled rows
@@ -124,31 +228,34 @@ type ExpenseFormValues = z.infer<typeof expenseFormSchema>;
 
 function sortCategoriesByFrequency(
   frequentCategories: FrequentCategory[] = [],
-) {
-  if (!frequentCategories.length) return CATEGORIES;
-  // Перетворюємо частотну статистику на індекс manual-label → rank.
-  // Для canonical id беремо відповідний manual-label; для custom / невідомих —
-  // використовуємо original manualLabel, якщо він є у списку кнопок.
-  const rank = new Map<string, number>();
+): CategorySlug[] {
+  if (!frequentCategories.length) return CATEGORY_SLUGS;
+  // Перетворюємо частотну статистику на індекс slug → rank.
+  // manualLabel може зберігати будь-яку з 3 ер — upgradeCategory нормалізує.
+  // CANONICAL_TO_MANUAL_LABEL повертає slug (F5b), тож подвійне upgradeCategory
+  // — no-op для Era 3; безпечно для Era 2/1.
+  const rank = new Map<CategorySlug, number>();
   frequentCategories.forEach((cat, idx) => {
-    const label =
-      cat.manualLabel && CATEGORIES.includes(cat.manualLabel)
-        ? cat.manualLabel
-        : CANONICAL_TO_MANUAL_LABEL[cat.id];
-    if (label && CATEGORIES.includes(label) && !rank.has(label)) {
-      rank.set(label, idx);
+    const rawLabel = cat.manualLabel
+      ? upgradeCategory(cat.manualLabel)
+      : cat.id
+        ? upgradeCategory(CANONICAL_TO_MANUAL_LABEL[cat.id] ?? null)
+        : null;
+    const slug = rawLabel && isCategorySlug(rawLabel) ? rawLabel : null;
+    if (slug && CATEGORY_SLUGS.includes(slug) && !rank.has(slug)) {
+      rank.set(slug, idx);
     }
   });
-  const withRank = CATEGORIES.map((c, originalIdx) => ({
-    label: c,
-    rank: rank.has(c) ? (rank.get(c) ?? Infinity) : Infinity,
+  const withRank = CATEGORY_SLUGS.map((slug, originalIdx) => ({
+    slug,
+    rank: rank.has(slug) ? (rank.get(slug) ?? Infinity) : Infinity,
     originalIdx,
   }));
   withRank.sort((a, b) => {
     if (a.rank !== b.rank) return a.rank - b.rank;
     return a.originalIdx - b.originalIdx;
   });
-  return withRank.map((x) => x.label);
+  return withRank.map((x) => x.slug);
 }
 
 interface ManualExpenseSheetProps {
@@ -202,14 +309,18 @@ export function ManualExpenseSheet({
         date: toLocalISODate(),
       },
       onSubmit: async (values) => {
+        const slug = upgradeCategory(values.category);
         const trimmedDesc = values.description.trim();
-        const description = trimmedDesc || stripEmoji(values.category);
+        // Fallback description uses the UA label from the display map.
+        const description =
+          trimmedDesc || (CATEGORY_DISPLAY[slug]?.label ?? slug);
         hapticSuccess();
         onSave?.({
           ...(initialExpense?.id ? { id: String(initialExpense.id) } : {}),
           description,
           amount: parseFloat(values.amount),
-          category: values.category,
+          // Write path: always emit slug (Era 3).
+          category: slug,
           // "YYYY-MM-DD" як local date може з'їхати при toISOString() в UTC.
           // Ставимо полудень, щоб стабільно зберігати правильний день.
           date: values.date
@@ -241,26 +352,27 @@ export function ManualExpenseSheet({
           description: String(initialExpense.description || ""),
           amount:
             initialExpense.amount != null ? String(initialExpense.amount) : "",
+          // upgradeCategory handles Era 1/2/3 stored values.
           category: upgradeCategory(initialExpense.category),
           date: toLocalISODate(d),
         });
       } else {
         // Пріоритет: явна initialCategory (клік з дашборду) > найчастіша
-        // категорія з статистики > дефолт ("інше"). Будь-яка legacy
-        // мітка ("їжа", "транспорт") оновлюється до emoji-версії.
-        let startCategory = DEFAULT_CATEGORY;
+        // категорія з статистики > дефолт ("other"). Будь-яка legacy
+        // мітка (Era 1/2) оновлюється до slug (Era 3).
+        let startCategory: CategorySlug = DEFAULT_CATEGORY;
         if (initialCategory) {
           startCategory = upgradeCategory(initialCategory);
         } else if (frequentCategories.length > 0) {
           const top = frequentCategories[0];
-          const topLabel =
-            top!.manualLabel! && typeof top!.manualLabel! === "string"
-              ? upgradeCategory(top!.manualLabel!)
+          const topSlug =
+            top!.manualLabel && typeof top!.manualLabel === "string"
+              ? upgradeCategory(top!.manualLabel)
               : CANONICAL_TO_MANUAL_LABEL[top!.id!]
                 ? upgradeCategory(CANONICAL_TO_MANUAL_LABEL[top!.id!])
                 : null;
-          if (topLabel && CATEGORIES.includes(topLabel)) {
-            startCategory = topLabel;
+          if (topSlug && CATEGORY_SLUGS.includes(topSlug)) {
+            startCategory = topSlug;
           }
         }
         reset({
@@ -295,14 +407,19 @@ export function ManualExpenseSheet({
   // залишався видимим і не плутав користувача при відкритті аркуша.
   const CATEGORY_COLLAPSED_COUNT = 6;
   const [categoriesExpanded, setCategoriesExpanded] = useState(false);
+
+  // Normalise the watched category value so comparison against slug list is
+  // stable even if a legacy value slips through.
+  const categorySlug = upgradeCategory(category);
+
   const visibleCategories = useMemo(() => {
     if (categoriesExpanded) return sortedCategories;
     const base = sortedCategories.slice(0, CATEGORY_COLLAPSED_COUNT);
-    if (category && !base.includes(category)) {
-      return [category, ...base].slice(0, CATEGORY_COLLAPSED_COUNT);
+    if (categorySlug && !base.includes(categorySlug)) {
+      return [categorySlug, ...base].slice(0, CATEGORY_COLLAPSED_COUNT);
     }
     return base;
-  }, [sortedCategories, categoriesExpanded, category]);
+  }, [sortedCategories, categoriesExpanded, categorySlug]);
   const hasHiddenCategories =
     sortedCategories.length > CATEGORY_COLLAPSED_COUNT;
 
@@ -495,10 +612,13 @@ export function ManualExpenseSheet({
                     setValue("description", m.name, { shouldDirty: true });
                     // Якщо є впевнений підпис manual-категорії для цього
                     // мерчанта — підставляємо його, щоб економити тапи.
+                    // suggestedManualCategory може бути Era 1/2/3 — upgradeCategory
+                    // нормалізує до slug.
+                    const suggestedRaw = m.suggestedManualCategory;
                     const suggested =
-                      m.suggestedManualCategory &&
-                      CATEGORIES.includes(m.suggestedManualCategory)
-                        ? m.suggestedManualCategory
+                      suggestedRaw &&
+                      CATEGORY_SLUGS.includes(upgradeCategory(suggestedRaw))
+                        ? upgradeCategory(suggestedRaw)
                         : null;
                     if (suggested) {
                       setValue("category", suggested, { shouldDirty: true });
@@ -552,20 +672,30 @@ export function ManualExpenseSheet({
             role="group"
             aria-labelledby={catLabelId}
           >
-            {visibleCategories.map((cat) => (
-              <button
-                key={cat}
-                type="button"
-                onClick={() => setValue("category", cat, { shouldDirty: true })}
-                className={`px-3 py-1.5 rounded-full text-style-caption border transition-[background-color,border-color,color,opacity,transform] duration-150 ease-smooth active:scale-95 ${
-                  category === cat
-                    ? "bg-finyk-strong text-white border-finyk-strong shadow-sm"
-                    : "bg-panelHi text-muted border-line hover:border-muted/50 hover:bg-panelHi/80"
-                }`}
-              >
-                {cat}
-              </button>
-            ))}
+            {visibleCategories.map((slug) => {
+              const display = CATEGORY_DISPLAY[slug];
+              return (
+                <button
+                  key={slug}
+                  type="button"
+                  onClick={() =>
+                    setValue("category", slug, { shouldDirty: true })
+                  }
+                  className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-style-caption border transition-[background-color,border-color,color,opacity,transform] duration-150 ease-smooth active:scale-95 ${
+                    categorySlug === slug
+                      ? "bg-finyk-strong text-white border-finyk-strong shadow-sm"
+                      : "bg-panelHi text-muted border-line hover:border-muted/50 hover:bg-panelHi/80"
+                  }`}
+                >
+                  <Icon
+                    name={display?.iconName ?? "tag"}
+                    size="xs"
+                    aria-hidden
+                  />
+                  {display?.label ?? slug}
+                </button>
+              );
+            })}
             {hasHiddenCategories && (
               <button
                 type="button"

--- a/packages/finyk-domain/src/domain/personalization.ts
+++ b/packages/finyk-domain/src/domain/personalization.ts
@@ -92,30 +92,29 @@ const MANUAL_CATEGORY_ID_MAP: Record<string, string> = {
   інше: "other",
 };
 
-// Зворотний пошук: canonical id → відповідний manual-label, який є серед
-// кнопок у ManualExpenseSheet (щоб при кліку по картці у dashboard виставляти
-// коректний вибір у списку). Повертаємо нові emoji-labels — `ManualExpenseSheet`
-// also runs them through `upgradeCategory` to stay tolerant of legacy strings.
+// Зворотний пошук: canonical id → category slug used by ManualExpenseSheet.
+// Values are Era 3 slugs (F5b, 2026-05). ManualExpenseSheet's upgradeCategory()
+// accepts any era, so old callers that already pass the result through
+// upgradeCategory() are unaffected.
 export const CANONICAL_TO_MANUAL_LABEL: Record<string, string> = {
-  food: "🍴 їжа",
-  restaurant: "🍔 кафе та ресторани",
-  transport: "🚗 транспорт",
-  entertainment: "🎮 розваги",
-  health: "💊 здоров'я",
-  shopping: "🛍️ покупки",
-  utilities: "🏠 комунальні",
-  subscriptions: "🎵 підписки",
-  sport: "🎮 розваги",
-  beauty: "🛍️ покупки",
-  travel: "✈️ подорожі",
-  education: "📚 навчання",
-  other: "🏷 інше",
+  food: "food",
+  restaurant: "cafe",
+  transport: "transport",
+  entertainment: "entertainment",
+  health: "health",
+  shopping: "shopping",
+  utilities: "utilities",
+  subscriptions: "subscriptions",
+  sport: "entertainment",
+  beauty: "shopping",
+  travel: "travel",
+  education: "education",
+  other: "other",
 };
 
-// Labels in `ManualExpenseSheet` are now emoji-prefixed (e.g. "🍴 їжа").
-// Strip leading non-letter / non-digit runs (emoji, ZWJ sequences,
-// variation selectors, whitespace) before lookup so map keys stay
-// stable across legacy and new entries.
+// manualLabel stored in FrequentCategory may be Era 1 (bare UA), Era 2
+// (emoji-prefixed), or Era 3 (slug). Strip leading non-letter / non-digit
+// runs before lookup so map keys stay stable across all eras.
 function stripLeadingSymbols(str: string): string {
   let i = 0;
   // `str[i]` під strict noUncheckedIndexedAccess — `string | undefined`,


### PR DESCRIPTION
## Summary

Closes the emoji eradication on `ManualExpenseSheet` category labels (F5b — follow-up to #3015 F5a).

**Chosen option: Option A (slug-based)** — compact, stable, no JSON overhead.

## Category slug map

| Slug | Icon | UA label |
|------|------|----------|
| `food` | `utensils` | Їжа |
| `groceries` | `shopping-cart` | Продукти |
| `cafe` | `coffee` | Кафе та ресторани |
| `transport` | `truck` | Транспорт |
| `entertainment` | `sparkles` | Розваги |
| `health` | `heart` | Здоров'я |
| `shopping` | `tag` | Покупки |
| `utilities` | `home` | Комунальні |
| `tech` | `monitor` | Техніка |
| `subscriptions` | `repeat` | Підписки |
| `education` | `book` | Навчання |
| `travel` | `compass` | Подорожі |
| `other` | `tag` | Інше |

## Era detection logic (upgradeCategory)

- **Era 3 (slug):** value is a known key in `CATEGORY_DISPLAY` — used directly.
- **Era 2 (emoji-prefixed):** leading non-letter/digit chars stripped, remaining UA label looked up in `UA_LABEL_TO_SLUG`.
- **Era 1 (bare UA label):** no stripping needed (same map lookup handles both eras 1 and 2 after stripping).
- **Unknown:** falls back to `"other"`.

Historical localStorage records are not touched. `upgradeCategory()` normalises on every read; submit always writes the slug.

## Files changed

- `apps/web/src/modules/finyk/components/ManualExpenseSheet.tsx` — full rewrite of category system
- `apps/web/src/modules/finyk/components/ManualExpenseSheet.test.tsx` — new `upgradeCategory` unit tests (all 3 eras) + updated submit expectations
- `packages/finyk-domain/src/domain/personalization.ts` — `CANONICAL_TO_MANUAL_LABEL` updated to return slugs

## Divergence notes

- `FinykApp.tsx` line ~588 compares `cat === "restaurant"` for a cross-module nudge. That comparison was already broken pre-F5b (the stored value was never the canonical id `"restaurant"` — it was `"🍔 кафе та ресторани"`). Now the slug is `"cafe"`, not `"restaurant"`. The `cat === "food"` branch works correctly. The restaurant nudge was silently dead before; it remains so. Filed as separate cleanup.
- `shopping` and `other` both use `tag` icon — closest available glyph. `shopping` could use `shopping-cart` but that icon is already taken by `groceries`; `tag` reads as "labelled item" which fits general shopping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates manual expense categories from emoji-prefixed labels to typed slugs with icon rendering, while auto-upgrading legacy values on read. This stabilizes storage, simplifies UI, and keeps old data working.

- **New Features**
  - Switched `ManualExpenseSheet` to slug-based categories rendered as `Icon` + UA label via `CATEGORY_DISPLAY`.
  - Added `upgradeCategory()` to normalize Era 1/2/3 inputs to a slug; write path always stores a slug.
  - Category sorting and suggestions now use slugs; `CANONICAL_TO_MANUAL_LABEL` returns slugs.
  - Fallback description uses the category’s display label when the name is empty.

- **Migration**
  - No batch migration; legacy values upgrade on read (Era 1 bare UA, Era 2 emoji, Era 3 slug). Unknown → `"other"`.
  - Updated tests to cover all eras and new submit expectations.

<sup>Written for commit f2c9f272cae03b69aa63f55ec77ce60aec0a3c40. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3049?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized category system architecture for improved data handling and consistency.
  * Enhanced category initialization and normalization logic with better legacy data support.

* **Tests**
  * Expanded test coverage for category system behavior across multiple data scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Skords-01/Sergeant/pull/3049?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->