### PR TITLE
feat(web): manual expense big amount hero + inline AI suggestion (6.2+6.3)

### DIFF
--- a/apps/web/src/modules/finyk/components/ManualExpenseSheet.tsx
+++ b/apps/web/src/modules/finyk/components/ManualExpenseSheet.tsx
@@ -1,5 +1,5 @@
 /**
- * Last validated: 2026-05-19
+ * Last validated: 2026-05-20
  * Status: Active
  */
 import { useState, useEffect, useId, useMemo } from "react";
@@ -19,6 +19,7 @@ import { hapticSuccess } from "@shared/lib/adapters/haptic";
 import { formatMoney } from "@sergeant/shared";
 import { Icon } from "@shared/components/ui/Icon";
 import type { IconName } from "@shared/components/ui/Icon";
+import { Badge } from "@shared/components/ui/Badge";
 import {
   CANONICAL_TO_MANUAL_LABEL,
   type FrequentCategory,
@@ -334,7 +335,27 @@ export function ManualExpenseSheet({
   const description = watch("description");
   const category = watch("category");
   const date = watch("date");
+  const amount = watch("amount");
   const amountError = formState.errors.amount?.message;
+
+  // 6.2 hero preview — show big display-hero typography above the input
+  // once a value is set. Input stays editable below. Parsed defensively
+  // because react-hook-form stores `amount` as string while the schema
+  // validates it as a non-empty numeric string.
+  const amountNumeric = useMemo(() => {
+    if (!amount) return 0;
+    const n = parseFloat(amount);
+    return Number.isFinite(n) && n > 0 ? n : 0;
+  }, [amount]);
+  const amountHeroVisible = amountNumeric > 0;
+
+  // 6.3 inline AI suggestion — surfaces the silent merchant-driven
+  // category auto-application as a dismissible badge. Set when a
+  // merchant chip with `suggestedManualCategory` is clicked; cleared on
+  // dismiss OR when the user picks a different category manually OR on
+  // form reset.
+  const [aiAppliedCategory, setAiAppliedCategory] =
+    useState<CategorySlug | null>(null);
 
   // showDateField — UI-only, не частина zod-схеми. Раніше жило в
   // form-state, але то був лиш toggle для видимості поля — без валідації
@@ -390,6 +411,9 @@ export function ManualExpenseSheet({
       setCategoriesExpanded(false);
       setDescFocused(false);
       setShowDateField(false);
+      // 6.3: clear AI-applied state when the sheet reopens — stale
+      // suggestion from a previous session shouldn't carry over.
+      setAiAppliedCategory(null);
     }
     // frequentCategories/initialCategory/initialDescription лише задають
     // стартовий стан при відкритті — навмисно не реагуємо на їхні
@@ -530,6 +554,19 @@ export function ManualExpenseSheet({
                 ))}
               </div>
             )}
+            {/* 6.2: display-hero preview anchors the sheet on the single
+                "must-fill" field. Input stays editable below so users can
+                tap to correct without losing the visual emphasis. Hidden
+                from screen readers (aria-hidden) — the editable input
+                below carries the accessible label + value. */}
+            {amountHeroVisible ? (
+              <div
+                aria-hidden
+                className="text-style-display-hero font-mono tabular-nums text-finyk-strong dark:text-finyk leading-none mb-2 select-none"
+              >
+                {formatMoney(amountNumeric)}
+              </div>
+            ) : null}
             <Input
               id={amountId}
               type="number"
@@ -622,6 +659,10 @@ export function ManualExpenseSheet({
                         : null;
                     if (suggested) {
                       setValue("category", suggested, { shouldDirty: true });
+                      // 6.3: surface the auto-applied category via an AI
+                      // badge near the category section so users can see
+                      // why their category changed and dismiss if wrong.
+                      setAiAppliedCategory(suggested);
                     }
                   }}
                   className="px-2.5 py-1 rounded-full text-style-caption bg-panelHi text-muted border border-line hover:border-muted/50 transition-colors"
@@ -667,6 +708,37 @@ export function ManualExpenseSheet({
           >
             Категорія
           </div>
+          {/* 6.3: AI-applied badge surfaces the silent merchant→category
+              auto-application. Renders only when AI applied and current
+              category still matches the AI suggestion (so dismissal +
+              manual overrides hide it). Dismiss = clear local state only;
+              category stays applied (user can still change it via picker
+              below).
+              motion-safe wrappers — reduced-motion users see a static
+              badge without the fade-in. */}
+          {aiAppliedCategory && categorySlug === aiAppliedCategory ? (
+            <div className="motion-safe:animate-in motion-safe:fade-in motion-safe:duration-200 mb-2">
+              <Badge
+                variant="finyk"
+                tone="soft"
+                size="sm"
+                className="inline-flex items-center gap-1.5"
+              >
+                <Icon name="sparkles" size={12} aria-hidden />
+                AI ·{" "}
+                {CATEGORY_DISPLAY[aiAppliedCategory]?.label ??
+                  aiAppliedCategory}
+                <button
+                  type="button"
+                  onClick={() => setAiAppliedCategory(null)}
+                  aria-label="Сховати AI-підказку"
+                  className="ml-0.5 inline-flex h-4 w-4 items-center justify-center rounded-full hover:bg-finyk/20 transition-colors"
+                >
+                  <Icon name="close" size={10} aria-hidden />
+                </button>
+              </Badge>
+            </div>
+          ) : null}
           <div
             className="flex flex-wrap gap-2"
             role="group"
@@ -678,9 +750,15 @@ export function ManualExpenseSheet({
                 <button
                   key={slug}
                   type="button"
-                  onClick={() =>
-                    setValue("category", slug, { shouldDirty: true })
-                  }
+                  onClick={() => {
+                    setValue("category", slug, { shouldDirty: true });
+                    // Manual category pick supersedes any AI suggestion;
+                    // clear the badge so it doesn't linger after an
+                    // explicit user choice.
+                    if (slug !== aiAppliedCategory) {
+                      setAiAppliedCategory(null);
+                    }
+                  }}
                   className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-style-caption border transition-[background-color,border-color,color,opacity,transform] duration-150 ease-smooth active:scale-95 ${
                     categorySlug === slug
                       ? "bg-finyk-strong text-white border-finyk-strong shadow-sm"


### PR DESCRIPTION
## Summary

Phase 6 Expensa delights — bundled because both fixes touch `ManualExpenseSheet.tsx`.

### 6.2 — Big amount hero
- Amount renders in `text-style-display-hero` + `font-mono tabular-nums` above the input when a positive value is set
- Input stays editable below; hero is purely visual (`aria-hidden`)
- Color: `text-finyk-strong` light / `text-finyk` dark — matches Finyk hero accent on Overview

### 6.3 — Inline AI suggestion
- Surfaces the previously-silent merchant→category auto-application via `<Badge variant="finyk" tone="soft" size="sm">`
- Copy: `✨ AI · {category label}` (sparkles icon + slug → label lookup via `CATEGORY_DISPLAY`)
- Dismissible: X button clears badge (category stays applied)
- Auto-hides on manual category pick OR on sheet reopen
- `motion-safe:animate-in fade-in duration-200` — reduced-motion users see no fade

## F5b coordination

F5b ([#3049](https://github.com/Skords-01/Sergeant/pull/3049)) merged its category slug refactor before this PR. This work uses post-F5b shape:
- `CATEGORY_DISPLAY[slug]?.label` for badge text
- `aiAppliedCategory` typed as `CategorySlug | null`
- No overlap with F5b's `upgradeCategory()` / persistence logic

## Test plan

- [ ] CI: `pnpm check` passes (typecheck + lint + test + build)
- [ ] Open ManualExpenseSheet, type amount → see big hero typography
- [ ] Click merchant chip with cached category → AI badge appears with category label
- [ ] Click X on AI badge → badge disappears, category remains
- [ ] Click different category manually → AI badge auto-clears
- [ ] Close + reopen sheet → AI badge does not persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a big amount hero preview above the manual expense input and shows an inline category suggestion badge when a merchant chip applies a category. Improves clarity while keeping inputs fully editable and accessible.

- New Features
  - Big amount hero: shows formatted amount in display-hero mono above the input when > 0; aria-hidden; uses Finyk accent colors.
  - Inline category suggestion: when a merchant chip sets a category, show a small dismissible `Badge` with the category label; hides on manual category change or sheet reopen; motion-safe fade-in.
  - Compatible with the recent category slug shape (uses `CATEGORY_DISPLAY[slug]?.label`); no persistence changes.

<sup>Written for commit 2de36dc1c9b7a5c3fc0424d36551313035edb4a4. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3051?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a numeric preview display above the amount input when entering a valid positive amount
  * Introduced AI-suggested category feature that displays as a dismissible indicator, automatically suggested based on merchant information
  * AI suggestions reset when reopening the expense sheet and clear when manually selecting a different category

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Skords-01/Sergeant/pull/3051?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->