### PR TITLE
fix(web): aipill collapse listens on document capture-phase, not window

### DIFF
--- a/apps/web/src/shared/components/ui/AIPill.tsx
+++ b/apps/web/src/shared/components/ui/AIPill.tsx
@@ -91,21 +91,55 @@ const DEFAULT_PLACEHOLDER: Record<ModuleAccent | "hub", string> = {
  * affordance reachable but stops it from covering content while the
  * user is reading.
  *
+ * The Sergeant hub/module shells render content inside a flex column
+ * with `<div class="flex-1 overflow-y-auto min-h-0">` as the actual
+ * scroll container — `window` itself almost never scrolls. So a plain
+ * `window` listener never fires under real user gestures (confirmed in
+ * prod via DOM probe: 3 window-scrolls dispatched, hook never toggled).
+ *
+ * Fix: listen in **capture phase** on `document`. `scroll` events don't
+ * bubble, but capture-phase handlers on ancestors still fire for any
+ * descendant scroll source — window, `<html>`, or any inner overflow
+ * container. We then read the scroll position from `event.target`
+ * (or fall back to `window.scrollY` when the document itself scrolled).
+ *
  * Listener is `passive: true` + rAF-throttled so it never blocks the
  * scrolling thread. `lastY` tracks direction so a tiny jitter near the
- * threshold doesn't flicker.
+ * threshold doesn't flicker. `lastTarget` keeps the per-container
+ * baseline so a swap between two scroll hosts doesn't read a negative
+ * `dy` (which would incorrectly snap the pill back open).
  */
 function useCollapseOnScroll(threshold = 80) {
   const [collapsed, setCollapsed] = useState(false);
   const lastY = useRef(0);
+  const lastTarget = useRef<EventTarget | null>(null);
   const ticking = useRef(false);
   useEffect(() => {
     if (typeof window === "undefined") return;
-    const onScroll = () => {
+    const onScroll = (event: Event) => {
       if (ticking.current) return;
       ticking.current = true;
+      const target = event.target;
       window.requestAnimationFrame(() => {
-        const y = window.scrollY || window.pageYOffset || 0;
+        let y = 0;
+        if (target instanceof Element) {
+          y = target.scrollTop;
+        } else if (target === document || target === document.documentElement) {
+          y = window.scrollY || window.pageYOffset || 0;
+        } else {
+          y = window.scrollY || window.pageYOffset || 0;
+        }
+        // Reset baseline when the user starts scrolling a different
+        // container (e.g. switching between nested scroll hosts).
+        // Without this, switching from a deeply-scrolled host to a
+        // fresh one would emit a huge negative `dy` and snap the pill
+        // back open even though the user is actively scrolling down.
+        if (lastTarget.current !== target) {
+          lastTarget.current = target;
+          lastY.current = y;
+          ticking.current = false;
+          return;
+        }
         const dy = y - lastY.current;
         if (y > threshold && dy > 4) setCollapsed(true);
         else if (dy < -4 || y < threshold / 2) setCollapsed(false);
@@ -113,8 +147,16 @@ function useCollapseOnScroll(threshold = 80) {
         ticking.current = false;
       });
     };
-    window.addEventListener("scroll", onScroll, { passive: true });
-    return () => window.removeEventListener("scroll", onScroll);
+    // Capture phase: scroll events don't bubble, but ancestor capture
+    // handlers DO fire for descendant scroll sources.
+    document.addEventListener("scroll", onScroll, {
+      passive: true,
+      capture: true,
+    });
+    return () =>
+      document.removeEventListener("scroll", onScroll, {
+        capture: true,
+      } as EventListenerOptions);
   }, [threshold]);
   return collapsed;
 }


### PR DESCRIPTION
## Summary

Regression from #3043. The AIPill auto-collapse on scroll-down never triggered in prod.

**Live DOM probe on /nutrition confirmed**:
- pill class string contained the v2 transition classes (deploy verified)
- after dispatching 3 window-scrolls with scrollY=500, `data-collapsed` stayed null and width stayed 1439px (expanded)
- scroll-host inspection revealed the actual scroll container is `<div class="flex-1 overflow-y-auto min-h-0">` - the inner module shell, not window

## Root cause

The Sergeant module shell never lets window scroll. Content is wrapped in a flex column with `overflow-y-auto` on the inner container, so all user wheel/touch gestures scroll **that div**, not window. `window.scrollY` stays at 0 forever; `window`-attached scroll listener never fires.

## Fix

- Listener moved to **capture phase on `document`**. `scroll` events do not bubble, but capture-phase handlers on ancestors fire for descendant scroll sources. One listener catches window, `<html>`, and any inner overflow container.
- Position read from `event.target.scrollTop` for Element targets, falls back to `window.scrollY` when the document itself scrolled.
- New `lastTarget` ref: when user switches between scroll hosts (modal opens with its own scroller, etc.), reset the per-container baseline so a large `dy` does not incorrectly snap the pill back open on first scroll of the new container.

## Test plan

- [ ] Open /nutrition (or /routine, /finyk, /fizruk), scroll the inner content past 80px - pill collapses to a 44px pip
- [ ] Scroll back to top - pill expands again
- [ ] Open a habit dialog (its own scroller) - pill stays in last state without flicker
- [ ] Reduced-motion respected (transition-none class applied)

## Out of scope

Reports/Settings cold-tab slowness still exists - chunks download instantly (cached) but mounting 14 sections in one tab takes 10+ s of JS execution. Separate refactor needed (per-section lazy mount).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a regression where the AI Pill did not auto-collapse on scroll in production. It now listens to inner container scrolls and collapses correctly instead of staying expanded over content.

- **Bug Fixes**
  - Listen for `scroll` on `document` in capture phase (not `window`) to catch inner overflow containers.
  - Read position from `event.target.scrollTop`, falling back to `window.scrollY`.
  - Reset the baseline when the scroll host changes to avoid snap-open flicker (e.g., opening a modal).

<sup>Written for commit 90578c3e5736922f16cbc04b2187b26023ef183c. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3052?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

