### PR TITLE
feat(web): ai-source badge on finyk tx + nutrition meal rows (6.4)

### DIFF
--- a/apps/web/src/modules/finyk/components/TxRow.tsx
+++ b/apps/web/src/modules/finyk/components/TxRow.tsx
@@ -1,5 +1,5 @@
 /**
- * Last validated: 2026-05-19
+ * Last validated: 2026-05-20
  * Status: Active
  */
 import { memo, useCallback, useMemo, useState } from "react";
@@ -18,6 +18,7 @@ import type { TxSplit, TxSplitsMap } from "@sergeant/finyk-domain/domain/types";
 import { cn } from "@shared/lib/ui/cn";
 import { Button } from "@shared/components/ui/Button";
 import { Icon, type IconName } from "@shared/components/ui/Icon";
+import { Badge } from "@shared/components/ui/Badge";
 
 const splitInp =
   "input-focus-finyk flex-1 text-xs h-9 rounded-xl border border-line bg-panelHi px-2 text-text";
@@ -199,8 +200,7 @@ function TxRowImpl({
   }, [draftSplits, onSplitChange, tx.id]);
 
   // Resolve the icon name for the category pill (Phase 6.1).
-  const pillIconName: IconName =
-    CATEGORY_ICON_MAP[cat.id] ?? "tag";
+  const pillIconName: IconName = CATEGORY_ICON_MAP[cat.id] ?? "tag";
 
   const mainRowInner = (
     <>
@@ -236,6 +236,34 @@ function TxRowImpl({
         </div>
         <div className="flex items-center gap-1.5 mt-0.5 flex-wrap">
           <span className="text-xs text-subtle">{catName}</span>
+          {/* 6.4: AI-source tag — surfaces auto-categorized expense rows
+              so users can tell which categorizations are inferred (MCC +
+              description match) vs explicit (user override, manual entry,
+              splits, transfers, fallback "other"). Sparkles icon-only
+              keeps the row uncluttered — category label is right next to it.
+              Skipped on:
+                – manual expenses (`_manual`): user typed the category
+                – overridden rows: explicit user choice, shows "змін." instead
+                – internal transfers: special routing, not categorization
+                – income rows: handled by separate income flow above
+                – "other" fallback: no real inference happened
+          */}
+          {!tx._manual &&
+            !overrideCatId &&
+            !isIncome &&
+            cat.id !== INTERNAL_TRANSFER_ID &&
+            cat.id !== "other" && (
+              <Badge
+                variant="finyk"
+                tone="soft"
+                size="xs"
+                className="shrink-0 inline-flex items-center gap-1 rounded-full"
+                title="Категорію визначив AI на основі опису + MCC"
+              >
+                <Icon name="sparkles" size={10} aria-hidden />
+                <span>AI</span>
+              </Badge>
+            )}
           {cat.id === INTERNAL_TRANSFER_ID && (
             <span className="text-style-caption bg-muted/15 text-muted px-1.5 py-0.5 rounded-full font-semibold">
               не в статистиці

--- a/apps/web/src/modules/nutrition/components/MealRow.tsx
+++ b/apps/web/src/modules/nutrition/components/MealRow.tsx
@@ -1,11 +1,12 @@
 /**
- * Last validated: 2026-05-14
+ * Last validated: 2026-05-20
  * Status: Active
  */
 import { useEffect, useState } from "react";
 import { cn } from "@shared/lib/ui/cn";
 import { Badge } from "@shared/components/ui/Badge";
 import { Button } from "@shared/components/ui/Button";
+import { Icon } from "@shared/components/ui/Icon";
 import { type Meal } from "@sergeant/nutrition-domain";
 import { getMealThumbnailBlob } from "../lib/mealPhotoStorage";
 
@@ -60,6 +61,11 @@ export function MealRow({ meal, onRemove, onEdit }: MealRowProps) {
         : macroSource === "productDb"
           ? "DB"
           : "";
+  // 6.4: AI-sourced entries (photoAI / recipeAI) get the nutrition-tinted
+  // sparkles badge — same recipe as Finyk tx-rows (#3048 / 6.1). `productDb`
+  // is a deterministic lookup, not AI inference, so it keeps the neutral
+  // soft tone without the sparkles icon.
+  const isAiSourced = macroSource === "photoAI" || macroSource === "recipeAI";
   return (
     <div className="flex items-center gap-3 bg-panelHi rounded-2xl px-3 py-2.5 group">
       <MealThumb mealId={meal.id} />
@@ -82,13 +88,14 @@ export function MealRow({ meal, onRemove, onEdit }: MealRowProps) {
           )}
           {sourceLabel && (
             <Badge
-              variant="neutral"
+              variant={isAiSourced ? "nutrition" : "neutral"}
               tone="soft"
               size="xs"
-              className="shrink-0 rounded-full uppercase tracking-wider"
+              className="shrink-0 inline-flex items-center gap-1 rounded-full uppercase tracking-wider"
               title="Походження КБЖВ"
             >
-              {sourceLabel}
+              {isAiSourced && <Icon name="sparkles" size={10} aria-hidden />}
+              <span>{sourceLabel}</span>
             </Badge>
           )}
         </div>


### PR DESCRIPTION
## Summary

Phase 6 Expensa delights — Wave 3. Final piece of the Expensa-inspired AI transparency layer. Reuses the Badge recipe from [#3051](https://github.com/Skords-01/Sergeant/pull/3051) (Phase 6.3 inline AI suggestion).

### Finyk TxRow (`apps/web/src/modules/finyk/components/TxRow.tsx`)
- Tiny `<Badge variant="finyk" tone="soft" size="xs">` with sparkles icon shown next to the category name
- Condition: `!tx._manual && !overrideCatId && !isIncome && cat.id !== INTERNAL_TRANSFER_ID && cat.id !== "other"`
- Skipped on: manual expenses, user overrides (already badged "змін."), internal transfers, income rows, and the "other" fallback
- title="Категорію визначив AI на основі опису + MCC" for screen-reader context

### Nutrition MealRow (`apps/web/src/modules/nutrition/components/MealRow.tsx`)
- Existing `macroSource` badge upgraded:
  - AI sources (`photoAI`, `recipeAI`) → `variant="nutrition"` + sparkles icon
  - `productDb` (deterministic lookup) → stays `variant="neutral"` (no AI, no sparkles)
- Single conditional handles both label and icon via `isAiSourced` boolean

## Why icon-only "AI" instead of "AI · {category}"
Plan suggested `<Badge soft module>AI · {category}</Badge>`. In Finyk TxRow the category name is rendered immediately adjacent (`{catName}`), so repeating it would clutter the row. The sparkles + "AI" pair signals the source without duplication.

In MealRow, the existing badge already shows the source label ("AI", "AI-рецепт", "DB"), so we kept that and only added the sparkles icon for AI sources.

## Test plan

- [ ] CI: `pnpm check` passes
- [ ] Open Finyk transactions list — auto-categorized tx-rows show AI badge next to category name
- [ ] Manual expenses do NOT show AI badge
- [ ] Rows with user-overridden category show "змін." instead of AI badge
- [ ] Internal transfers + "other" fallback do NOT show AI badge
- [ ] Open Nutrition log — photoAI / recipeAI meals show nutrition-tinted badge with sparkles
- [ ] productDb meals show neutral badge without sparkles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a sparkles badge to show auto-categorized expense rows in Finyk and updates nutrition meal rows to highlight inferred macro sources. This makes auto decisions visible at a glance without clutter.

- **New Features**
  - Finyk TxRow: tiny soft badge next to the category when the category was inferred from description + MCC. Skips manual entries, user overrides, internal transfers, income, and the "other" fallback.
  - Nutrition MealRow: existing macro source badge now uses a nutrition-tinted style with sparkles for photo/recipe analysis; deterministic DB lookups stay neutral.

<sup>Written for commit 277db32d61de4f545589518b0cd22293689933e1. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3053?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

