### PR TITLE
fix(web): make bottom navs lie flush on screen edge in PWA

### DIFF
--- a/apps/web/src/styles/utilities.css
+++ b/apps/web/src/styles/utilities.css
@@ -363,8 +363,20 @@
    * `ui-layout-styling-fixes`). The calc keeps a ~16px clearance above the
    * home indicator on iPhone while letting the nav sit flush against the
    * bottom on Android / desktop where `env(safe-area-inset-bottom)` is 0.
+   *
+   * In a browser tab that ~16px reads fine (Safari's bottom toolbar sits
+   * below it), but installed as a PWA the gap still showed as page-coloured
+   * dead space and the nav looked detached from the bottom edge instead of
+   * lying on it (user report 2026-05-28 / `navbar-dead-space`). In
+   * `display-mode: standalone` we therefore drop the inset to 0 so the nav
+   * sits flush on the screen edge; the per-tab `pb-1.5` (6px) still keeps the
+   * labels off the very edge / home indicator.
    */
   padding-bottom: max(6px, calc(env(safe-area-inset-bottom, 0px) - 18px));
+
+  @media (display-mode: standalone) {
+    padding-bottom: 0;
+  }
 }
 
 @utility safe-area-pt-pb {


### PR DESCRIPTION
## Summary

Під нижніми навбарами (`HubBottomNav` + `ModuleBottomNav`) у PWA на iPhone лишався page-coloured «мертвий простір» під підписами — навбар виглядав відірваним від краю екрана, а не лежав на ньому. Це `env(safe-area-inset-bottom)` (кліренс під home-indicator), який утиліта `safe-area-pb-tight` тримала на ~16px. Зміна: у `@media (display-mode: standalone)` опускаємо нижній інсет до `0`, тож у встановленій PWA навбар лежить впритул до краю. Браузерна поведінка не змінюється (там кліренс лишається; під ним сидить тулбар Safari). Per-tab `pb-1.5` (6px) лишає підписи трохи над самим краєм / home-indicator. Зачеплено лише `apps/web/src/styles/utilities.css` (1 декларація + оновлений коментар).

## Governing Skill

- Primary skill: `sergeant-web` (зміна стилів у `apps/web`)
- Secondary skill (if truly needed): —

## Playbook

- Primary playbook: —
- Why this playbook: —
- If no playbook matched, why: точкова CSS-правка safe-area інсету для одного утиліта; під неї нема окремого playbook-рецепта, governing skill достатній.

## Verification

```bash
pnpm install --frozen-lockfile
pnpm --filter @sergeant/web exec vitest run src/core/app/HubBottomNav.test.tsx
# → HubBottomNav.test.tsx: 1 passed
```

`ModuleBottomNav.test.tsx` локально не зміг зтрансформуватися через непобудований workspace-пакет `@sergeant/db-schema` (середовище без `dist/`), що не пов'язано з цією CSS-зміною. `pnpm build` локально заблокований slow-hardware policy (Husky guard) — повна матриця проганяється в CI. className навбарів не змінювався, тож снапшот-перевірки класів у обох тестах лишаються валідними.

Additional checks:

- [ ] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- Оновлено inline-коментар утиліти `safe-area-pb-tight` у `apps/web/src/styles/utilities.css` (опис нового standalone-оверайду + посилання на `navbar-dead-space`, 2026-05-28). Окремі docs/ не інвалідовано.

## Risk and Rollout

- User-visible risk: у PWA на iPhone підписи навбару стануть ближче до зони home-indicator (свідомий вибір — навбар має лежати на краї). На Android/десктопі та в браузері поведінка не змінюється.
- Rollout / deploy order: звичайний фронтенд-деплой (Vercel), без міграцій/беку.
- Backout plan: revert одного коміту — утиліта повертається до попередньої формули.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

CSS-only. Ключовий нюанс — `@media (display-mode: standalone)` спрацьовує лише у встановленій PWA, не в браузерній вкладці. Утиліта спільна для хабового і модульного навбарів, тож обидва стають консистентними на нижньому краї.

https://claude.ai/code/session_01Tcv5QHkL9TSnuskvKdYSSm