### PR TITLE
feat(web): bottom navs as a distinct surface with outlined active tab

### DIFF
--- a/apps/web/src/core/app/HubBottomNav.test.tsx
+++ b/apps/web/src/core/app/HubBottomNav.test.tsx
@@ -75,18 +75,15 @@ describe("HubBottomNav", () => {
     expect(dashboard).toHaveAttribute("aria-selected", "false");
   });
 
-  it("рендерить один sliding pill для активного таба", () => {
-    const { container } = renderNav({ hubView: "settings" });
+  it("позначає активний таб контуром (border), решту — без нього", () => {
+    renderNav({ hubView: "settings" });
 
-    const indicator = screen.getByTestId("hub-bottom-nav-active-indicator");
-    expect(
-      container.querySelectorAll(
-        '[data-testid="hub-bottom-nav-active-indicator"]',
-      ),
-    ).toHaveLength(1);
-    expect(indicator).toHaveStyle({
-      left: "calc(2 * (100% / 3) + (100% / 3 - 2.5rem) / 2)",
-    });
+    const settings = screen.getByRole("tab", { name: /Налаштування/ });
+    expect(settings.className).toContain("border-ink-strong/25");
+
+    const home = screen.getByRole("tab", { name: /Головна/ });
+    expect(home.className).toContain("border-transparent");
+    expect(home.className).not.toContain("border-ink-strong/25");
   });
 
   it("виклик onChange при кліку на таб", () => {

--- a/apps/web/src/core/app/HubBottomNav.tsx
+++ b/apps/web/src/core/app/HubBottomNav.tsx
@@ -20,14 +20,16 @@ import { messages } from "@shared/i18n/uk";
  * Canonical shape:
  * - 60 px height (64 px on coarse-pointer devices).
  * - `safe-area-pb` so iOS home-indicator clears.
- * - `bg-bg/95 motion-safe:backdrop-blur-xl` translucent surface
- *   tinted to match the page background (so the nav reads as part
- *   of the surface, not a separate panel). `border-t border-line`
- *   provides a subtle delineation; no horizontal margin, no rounded
- *   corners, no shadow (no floating-card look).
- * - Active indicator: thin 4 px sliding stripe (`top-0 h-1 w-10
- *   rounded-full`) at the top of the active tab, `bg-ink-strong`
- *   (brand) — module-agnostic by design.
+ * - `bg-panel/95 motion-safe:backdrop-blur-xl` elevated surface a
+ *   step lighter than the page so the bar reads as its own surface
+ *   "lying" on the bottom edge — esp. in dark mode, where `bg-bg`
+ *   matched the page and the bottom strip read as empty space
+ *   (navbar-dead-space, 2026-05-28). `border-t border-line`; still
+ *   edge-to-edge — no horizontal margin, no rounded corners, no
+ *   shadow (no floating-card look).
+ * - Active indicator: a rounded outline (`rounded-2xl border
+ *   border-ink-strong/25`) framing the active tab — outline only, no
+ *   fill. Module-agnostic by design.
  * - Active label + icon: `text-ink-strong`; inactive: `text-muted`.
  * - `role="tablist"` + `aria-selected` for AT.
  *
@@ -101,10 +103,12 @@ function HubBottomNavTab({
       style={hiddenSlot ? { visibility: "hidden" } : undefined}
       className={cn(
         "relative flex-1 flex flex-col items-center justify-end gap-1 pb-1.5",
-        "transition-all duration-200 min-h-[48px] pointer-coarse:min-h-[52px]",
+        "my-1.5 rounded-2xl border transition-all duration-200 min-h-[48px] pointer-coarse:min-h-[52px]",
         "active:scale-95",
         "focus:outline-none focus-visible:ring-2 focus-visible:ring-focus/45 focus-visible:ring-offset-2 focus-visible:ring-offset-panel",
-        active ? "text-ink-strong" : "text-muted hover:text-text/70",
+        active
+          ? "text-ink-strong border-ink-strong/25"
+          : "text-muted border-transparent hover:text-text/70",
         hiddenSlot && "invisible pointer-events-none",
         className,
       )}
@@ -253,36 +257,19 @@ export function HubBottomNav({
     label: "Налаштування",
   });
 
-  const activeIndex = tabs.findIndex((tab) => tab.active);
-
   return (
     <nav
       aria-label={messages.nav.hubSections}
       className={cn(
         "shrink-0 relative z-30 safe-area-pb-tight",
-        "bg-bg/95 motion-safe:backdrop-blur-xl",
+        "bg-panel/95 motion-safe:backdrop-blur-xl",
         "border-t border-line",
       )}
     >
       <div
         role="tablist"
-        className="relative flex h-[60px] pointer-coarse:h-[64px]"
+        className="relative flex h-[60px] pointer-coarse:h-[64px] gap-1 px-1"
       >
-        {activeIndex >= 0 && (
-          <span
-            data-testid="hub-bottom-nav-active-indicator"
-            className={cn(
-              "absolute top-0 h-1 w-10 rounded-full pointer-events-none",
-              "bg-ink-strong shadow-sm",
-              "transition-[left] duration-200 ease-out",
-            )}
-            style={{
-              left: `calc(${activeIndex} * (100% / ${tabs.length}) + (100% / ${tabs.length} - 2.5rem) / 2)`,
-            }}
-            aria-hidden
-          />
-        )}
-
         {tabs.map((tab) => (
           <HubBottomNavTab
             key={tab.key}

--- a/apps/web/src/shared/components/ui/ModuleBottomNav.tsx
+++ b/apps/web/src/shared/components/ui/ModuleBottomNav.tsx
@@ -12,14 +12,16 @@ import { cn } from "../../lib/ui/cn";
  * Canonical shape:
  * - Height 60 px (64 px on coarse-pointer devices).
  * - `safe-area-pb` so iOS home-indicator clears.
- * - `bg-bg/95 motion-safe:backdrop-blur-xl` translucent surface
- *   tinted to match the page background (so the nav reads as part
- *   of the surface, not a separate panel). `border-t border-line`
- *   provides a subtle delineation; no horizontal margin, no rounded
- *   corners, no shadow.
- * - Active indicator: thin 4 px sliding stripe (`top-0 h-1 w-10
- *   rounded-full`) at the top of the active tab, tinted with the
- *   module's accent gradient. Carries module identity.
+ * - `bg-panel/95 motion-safe:backdrop-blur-xl` elevated surface a
+ *   step lighter than the page so the bar reads as its own surface
+ *   on the bottom edge (esp. dark mode, where `bg-bg` matched the
+ *   page and the bottom strip read as empty space — navbar-dead-space,
+ *   2026-05-28). `border-t border-line`; still edge-to-edge — no
+ *   horizontal margin, no rounded corners, no shadow.
+ * - Active indicator: a rounded outline (`rounded-2xl border`)
+ *   framing the active tab, tinted with the module accent
+ *   (`tokens.outline`) — outline only, no fill. Carries module
+ *   identity.
  * - Active icon picks up `tokens.text` (module-colored); label
  *   stays `text-text`. No drop-shadow glow.
  * - Labels `text-style-caption` (12px) per Hard Rule #16.
@@ -67,8 +69,8 @@ export interface ModuleBottomNavProps {
 type ColorTokens = {
   /** Active icon tint. Module-colored text token. */
   text: string;
-  /** Top-stripe gradient — identity carrier. */
-  pill: string;
+  /** Active-tab outline border — module accent at low opacity. */
+  outline: string;
   /** Tiny unread/attention dot color. */
   badge: string;
 };
@@ -76,22 +78,22 @@ type ColorTokens = {
 const COLORS: Record<ModuleNavColor, ColorTokens> = {
   finyk: {
     text: "text-finyk",
-    pill: "bg-linear-to-r from-brand-400 to-brand-500",
+    outline: "border-finyk/40",
     badge: "bg-finyk",
   },
   fizruk: {
     text: "text-fizruk",
-    pill: "bg-linear-to-r from-teal-400 to-teal-500",
+    outline: "border-fizruk/40",
     badge: "bg-fizruk",
   },
   routine: {
     text: "text-routine",
-    pill: "bg-linear-to-r from-coral-400 to-coral-500",
+    outline: "border-routine/40",
     badge: "bg-routine",
   },
   nutrition: {
     text: "text-nutrition",
-    pill: "bg-linear-to-r from-lime-400 to-lime-500",
+    outline: "border-nutrition/40",
     badge: "bg-nutrition",
   },
 };
@@ -107,38 +109,21 @@ export const ModuleBottomNav = memo(function ModuleBottomNav({
 }: ModuleBottomNavProps) {
   const tokens = COLORS[module];
   const isTablist = role === "tablist";
-  const activeIndex = items.findIndex((i) => i.id === activeId);
 
   return (
     <nav
       aria-label={ariaLabel}
       className={cn(
         "shrink-0 relative z-30 safe-area-pb-tight",
-        "bg-bg/95 motion-safe:backdrop-blur-xl",
+        "bg-panel/95 motion-safe:backdrop-blur-xl",
         "border-t border-line",
         className,
       )}
     >
       <div
-        className="relative flex h-[60px] pointer-coarse:h-[64px]"
+        className="relative flex h-[60px] pointer-coarse:h-[64px] gap-1 px-1"
         role={isTablist ? "tablist" : undefined}
       >
-        {activeIndex >= 0 && (
-          <span
-            data-testid="module-bottom-nav-active-indicator"
-            className={cn(
-              "absolute top-0 h-1 w-10 rounded-full pointer-events-none",
-              tokens.pill,
-              "shadow-sm",
-              "transition-[left] duration-200 ease-out",
-            )}
-            style={{
-              left: `calc(${activeIndex} * (100% / ${items.length}) + (100% / ${items.length} - 2.5rem) / 2)`,
-            }}
-            aria-hidden
-          />
-        )}
-
         {items.map((item) => {
           const active = activeId === item.id;
           return (
@@ -156,11 +141,13 @@ export const ModuleBottomNav = memo(function ModuleBottomNav({
               onClick={() => onChange(item.id)}
               className={cn(
                 "relative flex-1 flex flex-col items-center justify-end gap-1 pb-1.5",
-                "min-h-touch-target",
+                "my-1.5 rounded-2xl border min-h-touch-target",
                 "transition-all duration-200",
                 "active:scale-95",
                 "focus:outline-none focus-visible:ring-2 focus-visible:ring-focus/45 focus-visible:ring-offset-2 focus-visible:ring-offset-panel",
-                active ? "text-text" : "text-muted hover:text-text/70",
+                active
+                  ? cn("text-text", tokens.outline)
+                  : "text-muted border-transparent hover:text-text/70",
               )}
             >
               <span

--- a/apps/web/src/styles/utilities.css
+++ b/apps/web/src/styles/utilities.css
@@ -363,8 +363,20 @@
    * `ui-layout-styling-fixes`). The calc keeps a ~16px clearance above the
    * home indicator on iPhone while letting the nav sit flush against the
    * bottom on Android / desktop where `env(safe-area-inset-bottom)` is 0.
+   *
+   * In a browser tab that ~16px reads fine (Safari's bottom toolbar sits
+   * below it), but installed as a PWA the gap still showed as page-coloured
+   * dead space and the nav looked detached from the bottom edge instead of
+   * lying on it (user report 2026-05-28 / `navbar-dead-space`). In
+   * `display-mode: standalone` we therefore drop the inset to 0 so the nav
+   * sits flush on the screen edge; the per-tab `pb-1.5` (6px) still keeps the
+   * labels off the very edge / home indicator.
    */
   padding-bottom: max(6px, calc(env(safe-area-inset-bottom, 0px) - 18px));
+
+  @media (display-mode: standalone) {
+    padding-bottom: 0;
+  }
 }
 
 @utility safe-area-pt-pb {


### PR DESCRIPTION
## Summary

У темній темі нижні навбари (`HubBottomNav` + `ModuleBottomNav`) мали `bg-bg/95` — той самий колір, що й сторінка, тож смуга під підписами читалась як порожня сторінка навіть коли навбар притиснутий до краю. Зміни:

- Обидва навбари → `bg-panel/95` — навбар читається як **окрема поверхня**, що лежить на нижньому краї (особливо помітно в dark mode).
- Активний таб → **заокруглений контур** (`rounded-2xl border`, лише обведення, без заливки) замість верхньої sliding-смужки. Хаб: `border-ink-strong/25`; модулі: акцент модуля `border-<module>/40`.
- `gap-1 px-1` між табами, щоб контури не торкались; навбар лишається edge-to-edge (без rounded/shadow/margin на самому `<nav>`).

Це продовження роботи з `navbar-dead-space` (попередній PR #3132 прибрав safe-area інсет у PWA; цей робить навбар візуально окремою поверхнею за запитом користувача).

## Governing Skill

- Primary skill: `sergeant-web`

## Playbook

- Primary playbook: —
- If no playbook matched, why: точкова UI/стильова правка двох nav-компонентів; окремого playbook-рецепта під неї немає.

## Verification

```bash
pnpm --filter @sergeant/web exec eslint src/core/app/HubBottomNav.tsx src/shared/components/ui/ModuleBottomNav.tsx   # exit 0
pnpm --filter @sergeant/web exec vitest run src/core/app/HubBottomNav.test.tsx                                       # 1 passed
SERGEANT_HEAVY_OK=1 pnpm --filter @sergeant/web build                                                                # ✓ built
```

`ModuleBottomNav.test.tsx` локально не запускається через непобудований workspace-пакет `@sergeant/db-schema` (env, не пов'язано зі зміною); логічно проходить — таб лишає `justify-end`+`pb-1.5`, `<nav>` без `rounded/shadow-nav/mx/mb`. Передіснуюча typecheck-помилка в `src/core/lib/hubChatContext/sections.ts` (файл поза цим діфом) — не від цієї зміни. Pre-commit `staged-typecheck` на змінених файлах — exit 0.

Additional checks:

- [ ] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- Оновлено design-system доккоментарі в обох nav-компонентах (поверхня `bg-panel`, активний контур). Окремі docs/ не інвалідовано.

## Risk and Rollout

- User-visible risk: помітна візуальна зміна нижніх навбарів (інший фон + інший активний індикатор). Visual regression (Argos) очікувано флагне дифф — потребує апруву снапшотів.
- Rollout / deploy order: звичайний фронтенд-деплой (Vercel), без міграцій/беку.
- Backout plan: revert одного коміту.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

Прибрано верхню sliding-смужку-індикатор (`*-bottom-nav-active-indicator`) — її роль перебрав контур активного таба; хабовий тест оновлено відповідно (модульний тест на смужку не посилався). Opacity-кроки `/25` і `/40` — на зареєстрованій шкалі (Hard Rule #8). `ModuleBottomNav` у `shared/` — крос-модульна оболонка, тож усі 4 акценти дозволені (Rule #12).

https://claude.ai/code/session_01Tcv5QHkL9TSnuskvKdYSSm

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tcv5QHkL9TSnuskvKdYSSm)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make bottom navs read as their own surface and outline the active tab for clearer hierarchy, especially in dark mode. Also make the nav sit flush on the bottom edge in the PWA.

- **New Features**
  - Switched `HubBottomNav` and `ModuleBottomNav` to `bg-panel/95` with `border-t`, keeping them edge-to-edge.
  - Replaced the top sliding stripe with a rounded outline for the active tab (Hub: `border-ink-strong/25`; Modules: `border-<module>/40`) and added small gaps (`gap-1 px-1`) so outlines don’t touch.

- **Bug Fixes**
  - In PWA (`display-mode: standalone`), dropped the bottom inset in `safe-area-pb-tight` so the nav sits flush on the screen edge; labels retain `pb-1.5` clearance.

<sup>Written for commit ebd0eb0a1059ede0a12a783e61fc22078aa797ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3133?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned bottom navigation active tab indicator from sliding stripe to rounded border outline.
  * Updated bottom navigation background to elevated panel styling.
  * Adjusted safe-area padding behavior for standalone/PWA display mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Skords-01/Sergeant/pull/3133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->