### PR TITLE
fix(web): match canvas backdrop to mesh base so no strip shows below nav

### DIFF
--- a/apps/web/src/styles/base.css
+++ b/apps/web/src/styles/base.css
@@ -36,6 +36,13 @@
      where we explicitly reset).
      ═══════════════════════════════════════════════════════════════════════ */
   html {
+    /* Canvas backdrop — propagates to the window canvas, including the
+       iOS PWA home-indicator strip that sits *below* the `h-dvh` content.
+       Match the mesh base (`--c-bg-base`, what `.bg-mesh` composites its
+       glows over) rather than `--c-bg`, so that bottom strip continues the
+       gradient surface instead of showing a lighter `bg-bg` band under it
+       (navbar-dead-space, 2026-05-29). */
+    background-color: rgb(var(--c-bg-base));
     text-rendering: optimizeLegibility;
     -webkit-font-feature-settings:
       "kern" 1,


### PR DESCRIPTION
## Summary

Прибираю світлу смужку в самому низу (під градієнтом). На iOS PWA canvas вікна, що визирає в зоні home-indicator **нижче** `h-dvh`-контенту, успадковував пропагований фон `body` (`bg-bg` — світліша смуга), а mesh-градієнт сидить на темнішій базі `--c-bg-base`. Ставлю фон кореня `<html>` = `--c-bg-base` (та сама база, поверх якої `.bg-mesh` накладає сяйва), тож нижня смужка продовжує градієнтну поверхню, а не читається як окрема світліша смуга під floating-навбаром.

Завершальний фікс серії `navbar-dead-space`.

## Governing Skill

- Primary skill: `sergeant-web`

## Playbook

- Primary playbook: —
- If no playbook matched, why: однорядкова правка фону кореня в global base.css.

## Verification

```bash
SERGEANT_HEAVY_OK=1 pnpm --filter @sergeant/web build   # ✓ built (CSS компілюється, --c-bg-base валідний у всіх темах)
```

CSS-only; жоден тест не асертить фон `body`/`html`. Передіснуюча typecheck-помилка `src/core/lib/hubChatContext/sections.ts` — поза діфом.

Additional checks:

- [ ] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- Додано пояснювальний коментар у `apps/web/src/styles/base.css` (чому canvas = `--c-bg-base`). Окремі docs/ не інвалідовано.

## Risk and Rollout

- User-visible risk: фон кореневого canvas стає `--c-bg-base` замість пропагованого `bg-bg`. На сторінках без власного фону це ледь помітно тепліший відтінок у зоні поза контентом; mesh-поверхні не змінюються. Visual regression (Argos) може флагнути дифф у нижній зоні.
- Rollout / deploy order: звичайний фронтенд-деплой (Vercel).
- Backout plan: revert одного коміту.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

`body` лишається `bg-bg` (фон його боксу не змінено) — правка лише на `<html>`, бо саме корінь пропагується на canvas вікна (і заповнює safe-area-смужку нижче `100dvh`). `--c-bg-base` визначений у світлій/темній/HC темах (його вже споживає `.bg-mesh`).

https://claude.ai/code/session_01Tcv5QHkL9TSnuskvKdYSSm

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tcv5QHkL9TSnuskvKdYSSm)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Match the window canvas backdrop to the mesh base to remove the lighter strip under the nav on iOS PWA. The `html` background now uses `--c-bg-base` so the safe-area below `100dvh` continues the mesh gradient. Addresses `navbar-dead-space-1eFrG`.

- **Bug Fixes**
  - Set `html` background-color to `rgb(var(--c-bg-base))` in `apps/web/src/styles/base.css`; keep `body` as `bg-bg`.

<sup>Written for commit 2996bd432856352d1f7c9bbf3fe7d44649d3e697. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3137?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Fixed background color rendering to ensure consistent visual appearance across all platforms, including iOS PWA environments, preventing unintended lighter color bands from appearing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Skords-01/Sergeant/pull/3137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->