### PR TITLE
feat(mobile): RN parity — Nutrition DailyPlan, Onboarding wizard, HubReports

### DIFF
--- a/apps/mobile/app/(auth)/onboarding.tsx
+++ b/apps/mobile/app/(auth)/onboarding.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from "expo-router";
-import { useState } from "react";
-import { View, Text, Pressable } from "react-native";
+import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
+import { View, Text, Pressable, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import {
   Wallet,
@@ -10,7 +10,37 @@ import {
 } from "lucide-react-native";
 import type { LucideIcon } from "lucide-react-native";
 
+import {
+  ALL_MODULES,
+  buildFinalPicks,
+  EMPTY_GOALS,
+  saveVibePicks,
+  saveOnboardingGoals,
+  markFirstActionPending,
+  markFirstActionStartedAt,
+  markOnboardingDone,
+  assignVariant,
+  getOnboardingHeroCopy,
+  isOnboardingDefaultPicksVariant,
+  ONBOARDING_HERO_COPY_EXPERIMENT,
+  ONBOARDING_DEFAULT_PICKS_EXPERIMENT,
+  type DashboardModuleId,
+  type OnboardingGoals,
+  type OnboardingDefaultPicksVariant,
+  type OnboardingHeroCopyVariant,
+} from "@sergeant/shared";
+
 import { colors, radius } from "@/theme";
+import { mobileKVStore } from "@/lib/storage";
+import { ANALYTICS_EVENTS, trackEvent } from "@/lib/analytics";
+
+import { ModulesStep } from "@/core/onboarding/ModulesStep";
+import { GoalsStep } from "@/core/onboarding/GoalsStep";
+import {
+  PermissionsStep,
+  type PermissionPromptResult,
+} from "@/core/onboarding/PermissionsStep";
+import { StepIndicator } from "@/core/onboarding/StepIndicator";
 
 interface Slide {
   Icon: LucideIcon;
@@ -40,71 +70,397 @@ const SLIDES: Slide[] = [
   },
 ];
 
+/**
+ * Wizard phases rendered after the intro slides. Mirrors the web
+ * OnboardingWizard data structure (module grid → goals → JIT
+ * permissions), adapted to a native multi-step flow rather than a web
+ * modal. Intro slides stay mobile-only marketing chrome ahead of the
+ * shared funnel.
+ */
+type WizardStep = "modules" | "goals" | "permissions";
+const WIZARD_STEPS: readonly WizardStep[] = ["modules", "goals", "permissions"];
+
+interface WizardState {
+  step: WizardStep;
+  picks: DashboardModuleId[];
+  goals: OnboardingGoals;
+}
+
+type WizardAction =
+  | { type: "NEXT" }
+  | { type: "BACK" }
+  | { type: "TOGGLE_PICK"; id: DashboardModuleId }
+  | { type: "SET_GOAL"; key: keyof OnboardingGoals; value: unknown };
+
+// Local 3-step reducer ("permissions" extends the shared 3-step
+// taxonomy, so we cannot reuse `@/core/onboarding/wizardState`, which is
+// pinned to the shared `welcome → modules → goals` sequence).
+function wizardReducer(state: WizardState, action: WizardAction): WizardState {
+  switch (action.type) {
+    case "NEXT": {
+      const idx = WIZARD_STEPS.indexOf(state.step);
+      const next = WIZARD_STEPS[idx + 1];
+      return next ? { ...state, step: next } : state;
+    }
+    case "BACK": {
+      const idx = WIZARD_STEPS.indexOf(state.step);
+      const prev = WIZARD_STEPS[idx - 1];
+      return prev ? { ...state, step: prev } : state;
+    }
+    case "TOGGLE_PICK": {
+      const picks = state.picks.includes(action.id)
+        ? state.picks.filter((p) => p !== action.id)
+        : [...state.picks, action.id];
+      return { ...state, picks };
+    }
+    case "SET_GOAL":
+      return {
+        ...state,
+        goals: { ...state.goals, [action.key]: action.value },
+      };
+    default:
+      return state;
+  }
+}
+
 export default function OnboardingScreen() {
   const router = useRouter();
-  const [step, setStep] = useState(0);
-  const slide = SLIDES[step]!;
-  const isLast = step === SLIDES.length - 1;
 
-  const goNext = () => {
-    if (isLast) router.replace("/(auth)/sign-up");
-    else setStep((s) => s + 1);
-  };
+  // Default-picks A/B (S6.1) — same deterministic per-device assignment
+  // the web wizard uses so a single user sees the same arm on both
+  // surfaces. `none` starts the grid empty and disables «Далі» until a
+  // pick is made; `all` pre-checks every module.
+  const defaultPicksVariant = useMemo<OnboardingDefaultPicksVariant>(() => {
+    const raw = assignVariant(
+      mobileKVStore,
+      ONBOARDING_DEFAULT_PICKS_EXPERIMENT,
+    );
+    return isOnboardingDefaultPicksVariant(raw) ? raw : "all";
+  }, []);
 
+  // Hero copy A/B (S1.1 + S1.2). Used for the final intro slide CTA so
+  // the experiment arm controls the "start" wording, matching web.
+  const heroVariant = useMemo<OnboardingHeroCopyVariant>(
+    () =>
+      assignVariant(
+        mobileKVStore,
+        ONBOARDING_HERO_COPY_EXPERIMENT,
+      ) as OnboardingHeroCopyVariant,
+    [],
+  );
+  const heroCopy = useMemo(
+    () => getOnboardingHeroCopy(heroVariant),
+    [heroVariant],
+  );
+
+  // Wizard state survives intro-slide navigation: `inWizardRef` gates
+  // whether the carousel or the step machine renders, so the reducer
+  // never resets when the user pages through the intro slides.
+  const [state, dispatch] = useReducer(
+    wizardReducer,
+    undefined,
+    (): WizardState => ({
+      step: "modules",
+      picks: defaultPicksVariant === "none" ? [] : [...ALL_MODULES],
+      goals: { ...EMPTY_GOALS },
+    }),
+  );
+  const introIndexRef = useRef(0);
+  const inWizardRef = useRef(false);
+  // Re-render trigger for the ref-backed intro index / phase flag.
+  const [, forceRender] = useReducer((n: number) => n + 1, 0);
+
+  const startedAtRef = useRef<number | null>(null);
+  const stepEnteredAtRef = useRef<number>(Date.now());
+  const submittingRef = useRef(false);
+
+  // Mount: fire `onboarding_started` + the welcome step view +
+  // experiment exposures, matching web's single-screen mount effect.
+  useEffect(() => {
+    startedAtRef.current = Date.now();
+    stepEnteredAtRef.current = startedAtRef.current;
+    trackEvent(ANALYTICS_EVENTS.ONBOARDING_STARTED);
+    trackEvent(ANALYTICS_EVENTS.ONBOARDING_STEP_VIEWED, { step: "welcome" });
+    trackEvent(ANALYTICS_EVENTS.EXPERIMENT_EXPOSED, {
+      experiment_id: ONBOARDING_HERO_COPY_EXPERIMENT.id,
+      variant: heroVariant,
+    });
+    trackEvent(ANALYTICS_EVENTS.EXPERIMENT_EXPOSED, {
+      experiment_id: ONBOARDING_DEFAULT_PICKS_EXPERIMENT.id,
+      variant: defaultPicksVariant,
+    });
+  }, [heroVariant, defaultPicksVariant]);
+
+  // Persist picks on every change so a backgrounded / killed app
+  // resumes the in-progress selection (web persists picks on each
+  // state change too).
+  useEffect(() => {
+    saveVibePicks(mobileKVStore, state.picks);
+  }, [state.picks]);
+
+  const togglePick = useCallback((id: DashboardModuleId) => {
+    dispatch({ type: "TOGGLE_PICK", id });
+  }, []);
+
+  const setGoal = useCallback(
+    (key: keyof OnboardingGoals, value: unknown) => {
+      dispatch({ type: "SET_GOAL", key, value });
+      const goalToModule: Record<keyof OnboardingGoals, DashboardModuleId> = {
+        finykBudget: "finyk",
+        fizrukWeeklyGoal: "fizruk",
+        routineFirstHabit: "routine",
+        nutritionGoal: "nutrition",
+      };
+      trackEvent(ANALYTICS_EVENTS.ONBOARDING_GOAL_SET, {
+        module: goalToModule[key],
+        goalType: key,
+        value,
+      });
+    },
+    [],
+  );
+
+  const goToSignUp = useCallback(() => {
+    router.replace("/(auth)/sign-up");
+  }, [router]);
+
+  const skipAll = useCallback(() => {
+    trackEvent(ANALYTICS_EVENTS.ONBOARDING_SKIPPED, {
+      step: inWizardRef.current ? state.step : "welcome",
+      durationMs: Math.max(0, Date.now() - (startedAtRef.current ?? Date.now())),
+    });
+    goToSignUp();
+  }, [state.step, goToSignUp]);
+
+  // Intro carousel navigation. The last slide hands off to the wizard.
+  const advanceIntro = useCallback(() => {
+    if (introIndexRef.current < SLIDES.length - 1) {
+      introIndexRef.current += 1;
+      forceRender();
+      return;
+    }
+    inWizardRef.current = true;
+    stepEnteredAtRef.current = Date.now();
+    forceRender();
+  }, []);
+
+  const handleNext = useCallback(() => {
+    // S6.1 / B-1: `none` arm never advances modules step with no picks.
+    if (
+      state.step === "modules" &&
+      state.picks.length === 0 &&
+      defaultPicksVariant === "none"
+    ) {
+      return;
+    }
+    const leaving = state.step;
+    const durationMs = Math.max(0, Date.now() - stepEnteredAtRef.current);
+    trackEvent(ANALYTICS_EVENTS.ONBOARDING_STEP_COMPLETED, {
+      step: leaving,
+      durationMs,
+    });
+    if (leaving === "modules") {
+      const chosen = buildFinalPicks(state.picks, ALL_MODULES);
+      trackEvent(ANALYTICS_EVENTS.ONBOARDING_VIBE_PICKED, {
+        picks: chosen,
+        picksCount: chosen.length,
+      });
+    }
+    stepEnteredAtRef.current = Date.now();
+    dispatch({ type: "NEXT" });
+    trackEvent(ANALYTICS_EVENTS.ONBOARDING_STEP_VIEWED, {
+      step: nextStep(leaving),
+    });
+  }, [state.step, state.picks, defaultPicksVariant]);
+
+  const handleBack = useCallback(() => {
+    stepEnteredAtRef.current = Date.now();
+    dispatch({ type: "BACK" });
+  }, []);
+
+  const reportPermission = useCallback(
+    (permission: "notifications" | "camera", result: PermissionPromptResult) => {
+      trackEvent(ANALYTICS_EVENTS.PERMISSION_REQUESTED, {
+        type: permission,
+        context: "onboarding",
+      });
+      if (result === "granted") {
+        trackEvent(ANALYTICS_EVENTS.PERMISSION_GRANTED, {
+          type: permission,
+          context: "onboarding",
+        });
+      } else if (result === "denied") {
+        trackEvent(ANALYTICS_EVENTS.PERMISSION_DENIED, {
+          type: permission,
+          context: "onboarding",
+        });
+      }
+    },
+    [],
+  );
+
+  const handlePushResult = useCallback(
+    (result: PermissionPromptResult) => reportPermission("notifications", result),
+    [reportPermission],
+  );
+
+  const handleCameraResult = useCallback(
+    (result: PermissionPromptResult) => reportPermission("camera", result),
+    [reportPermission],
+  );
+
+  const finish = useCallback(() => {
+    if (submittingRef.current) return;
+    const hadEmptyPicks = state.picks.length === 0;
+    // S6.1: `none` arm never silently writes ALL_MODULES.
+    if (hadEmptyPicks && defaultPicksVariant === "none") return;
+
+    submittingRef.current = true;
+    const chosen = buildFinalPicks(state.picks, ALL_MODULES);
+    saveVibePicks(mobileKVStore, chosen);
+    saveOnboardingGoals(mobileKVStore, state.goals);
+    markFirstActionStartedAt(mobileKVStore);
+    markFirstActionPending(mobileKVStore);
+    markOnboardingDone(mobileKVStore);
+
+    trackEvent(ANALYTICS_EVENTS.ONBOARDING_STEP_COMPLETED, {
+      step: state.step,
+      durationMs: Math.max(0, Date.now() - stepEnteredAtRef.current),
+    });
+    trackEvent(ANALYTICS_EVENTS.ONBOARDING_COMPLETED, {
+      intent: hadEmptyPicks ? "vibe_empty" : "vibe_picked",
+      picksCount: chosen.length,
+    });
+    goToSignUp();
+  }, [state.picks, state.goals, state.step, defaultPicksVariant, goToSignUp]);
+
+  // -- Intro carousel -------------------------------------------------------
+  if (!inWizardRef.current) {
+    const slide = SLIDES[introIndexRef.current]!;
+    const isLast = introIndexRef.current === SLIDES.length - 1;
+    return (
+      <SafeAreaView className="flex-1 bg-bg px-6">
+        <Pressable
+          className="self-end pt-4 pb-6 active:opacity-70"
+          onPress={skipAll}
+          accessibilityRole="button"
+          accessibilityLabel="Пропустити"
+        >
+          <Text className="text-muted text-sm">Пропустити</Text>
+        </Pressable>
+
+        <View className="flex-1 items-center justify-center gap-6">
+          <View
+            className="w-28 h-28 rounded-3xl items-center justify-center"
+            style={{
+              backgroundColor: slide.color + "22",
+              borderWidth: 1.5,
+              borderColor: slide.color + "44",
+            }}
+          >
+            <slide.Icon size={48} color={slide.color} strokeWidth={1.5} />
+          </View>
+          <Text className="text-text text-2xl font-extrabold text-center">
+            {slide.title}
+          </Text>
+          <Text className="text-muted text-base text-center leading-6">
+            {slide.desc}
+          </Text>
+        </View>
+
+        <View className="flex-row justify-center gap-2 mb-4">
+          {SLIDES.map((_, i) => (
+            <Pressable
+              key={i}
+              onPress={() => {
+                introIndexRef.current = i;
+                forceRender();
+              }}
+            >
+              <View
+                className="h-2 rounded"
+                style={{
+                  width: i === introIndexRef.current ? 24 : 8,
+                  backgroundColor:
+                    i === introIndexRef.current ? slide.color : colors.textMuted,
+                }}
+              />
+            </Pressable>
+          ))}
+        </View>
+
+        <View className="pb-6">
+          <Pressable
+            className="flex-row items-center justify-center gap-2 py-4 active:opacity-80"
+            style={{ backgroundColor: slide.color, borderRadius: radius.md }}
+            onPress={advanceIntro}
+            accessibilityRole="button"
+          >
+            <Text className="text-white text-base font-bold">
+              {isLast ? heroCopy.primaryCta : "Далі"}
+            </Text>
+            <ArrowRight size={18} color="#fff" strokeWidth={2.5} />
+          </Pressable>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  // -- Wizard ---------------------------------------------------------------
+  const stepIdx = WIZARD_STEPS.indexOf(state.step);
   return (
-    <SafeAreaView className="flex-1 bg-bg px-6">
+    <SafeAreaView className="flex-1 bg-bg" testID="onboarding-wizard">
       <Pressable
-        className="self-end pt-4 pb-6 active:opacity-70"
-        onPress={() => router.replace("/(auth)/sign-up")}
+        className="self-end px-6 pt-4 pb-2 active:opacity-70"
+        onPress={skipAll}
+        accessibilityRole="button"
+        accessibilityLabel="Пропустити"
       >
         <Text className="text-muted text-sm">Пропустити</Text>
       </Pressable>
-
-      <View className="flex-1 items-center justify-center gap-6">
-        <View
-          className="w-28 h-28 rounded-3xl items-center justify-center"
-          style={{
-            backgroundColor: slide.color + "22",
-            borderWidth: 1.5,
-            borderColor: slide.color + "44",
-          }}
-        >
-          <slide.Icon size={48} color={slide.color} strokeWidth={1.5} />
-        </View>
-        <Text className="text-text text-2xl font-extrabold text-center">
-          {slide.title}
-        </Text>
-        <Text className="text-muted text-base text-center leading-6">
-          {slide.desc}
-        </Text>
-      </View>
-
-      <View className="flex-row justify-center gap-2 mb-4">
-        {SLIDES.map((_, i) => (
-          <Pressable key={i} onPress={() => setStep(i)}>
-            <View
-              className="h-2 rounded"
-              style={{
-                width: i === step ? 24 : 8,
-                backgroundColor: i === step ? slide.color : colors.textMuted,
+      <ScrollView
+        contentContainerClassName="grow justify-center px-6 pb-8"
+        keyboardShouldPersistTaps="handled"
+      >
+        <View className="gap-5">
+          <StepIndicator current={stepIdx} total={WIZARD_STEPS.length} />
+          {state.step === "modules" && (
+            <ModulesStep
+              picks={state.picks}
+              togglePick={togglePick}
+              onContinue={handleNext}
+              onBack={() => {
+                inWizardRef.current = false;
+                forceRender();
               }}
+              defaultPicksVariant={defaultPicksVariant}
             />
-          </Pressable>
-        ))}
-      </View>
-
-      <View className="pb-6">
-        <Pressable
-          className="flex-row items-center justify-center gap-2 py-4 active:opacity-80"
-          style={{ backgroundColor: slide.color, borderRadius: radius.md }}
-          onPress={goNext}
-        >
-          <Text className="text-white text-base font-bold">
-            {isLast ? "Розпочати" : "Далі"}
-          </Text>
-          <ArrowRight size={18} color="#fff" strokeWidth={2.5} />
-        </Pressable>
-      </View>
+          )}
+          {state.step === "goals" && (
+            <GoalsStep
+              picks={state.picks}
+              goals={state.goals}
+              onSetGoal={setGoal}
+              onFinish={handleNext}
+              onBack={handleBack}
+            />
+          )}
+          {state.step === "permissions" && (
+            <PermissionsStep
+              picks={state.picks}
+              onPushResult={handlePushResult}
+              onCameraResult={handleCameraResult}
+              onFinish={finish}
+              onBack={handleBack}
+            />
+          )}
+        </View>
+      </ScrollView>
     </SafeAreaView>
   );
+}
+
+function nextStep(current: WizardStep): WizardStep {
+  const idx = WIZARD_STEPS.indexOf(current);
+  return WIZARD_STEPS[Math.min(idx + 1, WIZARD_STEPS.length - 1)]!;
 }

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -104,6 +104,10 @@ function RootShell() {
           name="hub-search"
           options={{ presentation: "modal", animation: "slide_from_bottom" }}
         />
+        <Stack.Screen
+          name="hub-reports"
+          options={{ presentation: "modal", animation: "slide_from_bottom" }}
+        />
         <Stack.Screen name="auth/callback" options={{ headerShown: false }} />
         <Stack.Screen name="+not-found" />
       </Stack>

--- a/apps/mobile/app/hub-reports.tsx
+++ b/apps/mobile/app/hub-reports.tsx
@@ -1,0 +1,26 @@
+/**
+ * HubReports route — renders the cross-module reports surface.
+ *
+ * Lives outside `(tabs)` so it can be pushed/presented as a full-screen
+ * stack screen from the Hub dashboard, mirroring `hub-search` / `hub-chat`.
+ * Registered in `app/_layout.tsx` as a modal presentation.
+ *
+ * See `apps/mobile/src/core/hub/HubReports.tsx` for the shell and
+ * `apps/web/src/core/hub/HubReports.tsx` for the canonical web behaviour.
+ */
+
+import { router } from "expo-router";
+
+import { HubReports } from "@/core/hub/HubReports";
+
+export default function HubReportsRoute() {
+  const onClose = () => {
+    if (router.canGoBack()) {
+      router.back();
+    } else {
+      router.replace("/(tabs)");
+    }
+  };
+
+  return <HubReports onClose={onClose} />;
+}

--- a/apps/mobile/src/core/hub/HubReports.tsx
+++ b/apps/mobile/src/core/hub/HubReports.tsx
@@ -1,0 +1,304 @@
+/**
+ * Sergeant Hub — cross-module reports (mobile).
+ *
+ * Mobile mirror of `apps/web/src/core/hub/HubReports.tsx`. Composes:
+ *   - a week/month period selector with prev/next offset navigation
+ *   - a weekly-digest slot (placeholder until H4 lands the real card)
+ *   - four lazy per-domain report cards (Fitness / Expenses / Routine /
+ *     Nutrition), each a self-contained chunk that reads its own MMKV
+ *     shard and renders a skeleton while loading
+ *   - a cross-module insights list
+ *   - a Premium-gated PDF/HTML export action
+ *
+ * Day boundaries follow Europe/Kyiv semantics via `getPeriodRange`
+ * (week = пн–нд). Money is kopiykas in storage, converted to hryvnia for
+ * display inside the spending card.
+ */
+
+import { lazy, Suspense, useCallback, useMemo, useState } from "react";
+import { ActivityIndicator, Pressable, ScrollView, Text, View } from "react-native";
+import { ChevronLeft, ChevronRight, Download } from "lucide-react-native";
+import { useRouter } from "expo-router";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import { SectionHeading } from "@/components/ui/SectionHeading";
+import { Button } from "@/components/ui/Button";
+import { useFlag } from "@/core/lib/featureFlags";
+
+import { getPeriodRange, type Period } from "./reports/hubReports.aggregation";
+import { generateInsights } from "./reports/insightsEngine";
+import { exportReport } from "./reports/exportReport";
+
+const FitnessCard = lazy(() => import("./reports/FitnessCard"));
+const ExpensesCard = lazy(() => import("./reports/ExpensesCard"));
+const RoutineCard = lazy(() => import("./reports/RoutineCard"));
+const NutritionCard = lazy(() => import("./reports/NutritionCard"));
+
+// PDF export is a Premium feature on web (`useFeatureGate`). Mobile has no
+// billing surface yet, so we gate behind the existing feature-flag
+// mechanism. TODO(billing): swap `useFlag` for the real entitlement gate
+// (mirror of web `useFeatureGate("analytics-export-pdf")`) once mobile
+// billing lands.
+const EXPORT_FLAG_ID = "analytics-export-pdf";
+
+function CardSkeleton() {
+  return (
+    <View
+      className="h-14 items-center justify-center rounded-2xl border border-line bg-panel"
+      accessibilityLabel="Завантаження секції"
+    >
+      <ActivityIndicator size="small" color="#78716c" />
+    </View>
+  );
+}
+
+const MONTHS_UK = [
+  "січня",
+  "лютого",
+  "березня",
+  "квітня",
+  "травня",
+  "червня",
+  "липня",
+  "серпня",
+  "вересня",
+  "жовтня",
+  "листопада",
+  "грудня",
+] as const;
+
+const MONTHS_NOM = [
+  "Січень",
+  "Лютий",
+  "Березень",
+  "Квітень",
+  "Травень",
+  "Червень",
+  "Липень",
+  "Серпень",
+  "Вересень",
+  "Жовтень",
+  "Листопад",
+  "Грудень",
+] as const;
+
+function formatPeriodLabel(period: Period, offset: number): string {
+  const { start, end } = getPeriodRange(period, offset);
+  if (period === "week") {
+    const s = `${start.getDate()} ${MONTHS_UK[start.getMonth()] ?? ""}`;
+    const e = `${end.getDate()} ${MONTHS_UK[end.getMonth()] ?? ""}`;
+    return `${s} – ${e}`;
+  }
+  return `${MONTHS_NOM[start.getMonth()] ?? ""} ${start.getFullYear()}`;
+}
+
+interface InsightCardProps {
+  title: string;
+  stat: string;
+  detail?: string;
+}
+
+function InsightCard({ title, stat, detail }: InsightCardProps) {
+  return (
+    <View className="rounded-2xl border border-line bg-panel p-4">
+      <Text className="text-sm leading-snug text-text">{title}</Text>
+      <View className="mt-1 flex-row flex-wrap items-baseline gap-2">
+        <Text className="text-lg font-extrabold text-brand-strong">{stat}</Text>
+        {detail ? <Text className="text-xs text-muted">{detail}</Text> : null}
+      </View>
+    </View>
+  );
+}
+
+/**
+ * Local weekly-digest placeholder. The real week-shaped digest card for
+ * the Reports surface is built in parallel under H4.
+ *
+ * TODO(H4): swap for WeeklyDigestCard once it lands.
+ */
+function WeeklyDigestPlaceholder() {
+  return (
+    <View className="rounded-2xl border border-line bg-panel p-4">
+      <SectionHeading size="xs" variant="muted">
+        Звіт тижня
+      </SectionHeading>
+      <Text className="mt-1 text-xs leading-relaxed text-muted">
+        AI-дайджест тижня зʼявиться тут найближчим часом.
+      </Text>
+    </View>
+  );
+}
+
+export interface HubReportsProps {
+  onClose?: () => void;
+}
+
+export function HubReports({ onClose }: HubReportsProps) {
+  const router = useRouter();
+  const [period, setPeriod] = useState<Period>("week");
+  const [offset, setOffset] = useState(0);
+  const [exporting, setExporting] = useState(false);
+
+  const exportEnabled = useFlag(EXPORT_FLAG_ID);
+
+  const label = formatPeriodLabel(period, offset);
+  const isCurrentPeriod = offset === 0;
+
+  const insights = useMemo(() => generateInsights(), []);
+
+  const handleClose = useCallback(() => {
+    if (onClose) onClose();
+    else if (router.canGoBack()) router.back();
+    else router.replace("/(tabs)");
+  }, [onClose, router]);
+
+  const handleExport = useCallback(() => {
+    if (!exportEnabled) {
+      // TODO(billing): open the Premium paywall instead of a no-op once
+      // the mobile entitlement surface exists (web opens PaywallModal here).
+      return;
+    }
+    setExporting(true);
+    void exportReport({ title: "Sergeant — звіт", subtitle: label }).finally(
+      () => setExporting(false),
+    );
+  }, [exportEnabled, label]);
+
+  return (
+    <SafeAreaView
+      edges={["top", "bottom"]}
+      className="flex-1 bg-bg"
+      testID="hub-reports-screen"
+    >
+      <View className="flex-row items-center justify-between px-4 pb-2 pt-3">
+        <SectionHeading size="lg" variant="text">
+          Звіти
+        </SectionHeading>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Закрити"
+          onPress={handleClose}
+          hitSlop={8}
+          className="h-9 w-9 items-center justify-center rounded-xl"
+        >
+          <Text className="text-base text-muted">Готово</Text>
+        </Pressable>
+      </View>
+
+      <ScrollView
+        className="flex-1"
+        contentContainerClassName="gap-4 px-4 pb-10"
+        keyboardShouldPersistTaps="handled"
+      >
+        <View className="flex-row items-center justify-between gap-2">
+          <View className="flex-row overflow-hidden rounded-xl border border-line">
+            {(["week", "month"] as const).map((p) => {
+              const active = period === p;
+              return (
+                <Pressable
+                  key={p}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: active }}
+                  onPress={() => {
+                    setPeriod(p);
+                    setOffset(0);
+                  }}
+                  className={`px-3 py-1.5 ${active ? "bg-brand-strong" : ""}`}
+                >
+                  <Text
+                    className={`text-xs font-semibold ${
+                      active ? "text-white" : "text-muted"
+                    }`}
+                  >
+                    {p === "week" ? "Тиждень" : "Місяць"}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+
+          <View className="flex-row items-center gap-1">
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Попередній"
+              onPress={() => setOffset((o) => o - 1)}
+              hitSlop={8}
+              className="h-8 w-8 items-center justify-center rounded-xl"
+            >
+              <ChevronLeft size={16} color="#78716c" />
+            </Pressable>
+            <Text className="min-w-[110px] text-center text-xs text-muted">
+              {label}
+            </Text>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Наступний"
+              accessibilityState={{ disabled: isCurrentPeriod }}
+              disabled={isCurrentPeriod}
+              onPress={() => setOffset((o) => Math.min(0, o + 1))}
+              hitSlop={8}
+              className={`h-8 w-8 items-center justify-center rounded-xl ${
+                isCurrentPeriod ? "opacity-30" : ""
+              }`}
+            >
+              <ChevronRight size={16} color="#78716c" />
+            </Pressable>
+          </View>
+        </View>
+
+        {/* The weekly digest is week-shaped, so it only renders in the
+            «Тиждень» view — mirroring web. */}
+        {period === "week" ? <WeeklyDigestPlaceholder /> : null}
+
+        <View className="gap-3">
+          <Suspense fallback={<CardSkeleton />}>
+            <FitnessCard period={period} offset={offset} />
+          </Suspense>
+          <Suspense fallback={<CardSkeleton />}>
+            <ExpensesCard period={period} offset={offset} />
+          </Suspense>
+          <Suspense fallback={<CardSkeleton />}>
+            <RoutineCard period={period} offset={offset} />
+          </Suspense>
+          <Suspense fallback={<CardSkeleton />}>
+            <NutritionCard period={period} offset={offset} />
+          </Suspense>
+        </View>
+
+        {insights.length >= 1 ? (
+          <View className="gap-3">
+            <SectionHeading size="sm" variant="muted">
+              Інсайти
+            </SectionHeading>
+            {insights.map((ins) => (
+              <InsightCard
+                key={ins.id}
+                title={ins.title}
+                stat={ins.stat}
+                detail={ins.detail}
+              />
+            ))}
+          </View>
+        ) : (
+          <View className="rounded-2xl border border-line bg-panel p-4">
+            <Text className="text-center text-xs text-muted">
+              Збери більше даних для інсайтів
+            </Text>
+          </View>
+        )}
+
+        <Button
+          variant="secondary"
+          onPress={handleExport}
+          loading={exporting}
+          leftIcon={<Download size={16} color="#1c1917" />}
+          accessibilityLabel="Експортувати звіт"
+        >
+          Експортувати PDF
+        </Button>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+export default HubReports;

--- a/apps/mobile/src/core/hub/reports/ExpensesCard.tsx
+++ b/apps/mobile/src/core/hub/reports/ExpensesCard.tsx
@@ -1,0 +1,125 @@
+/**
+ * Lazy-loaded finyk/expense report card for the mobile Hub-Reports
+ * surface. Mirrors `apps/web/src/core/hub/ExpensesCard.tsx`: reads the
+ * `finyk_tx_cache` MMKV shard plus the hidden-tx / transfer-category
+ * shards and aggregates spending per day independently.
+ *
+ * Amounts in the cache are kopiykas (minor units). They are converted to
+ * hryvnia before aggregation so the rendered total matches the web card,
+ * which delegates to the shared finyk aggregation that reports whole
+ * hryvnia. Display uses `toLocaleString("uk-UA")` on the hryvnia value.
+ */
+
+import { useMemo } from "react";
+import { Text, View } from "react-native";
+
+import { safeReadLS } from "@/lib/storage";
+import { STORAGE_KEYS } from "@sergeant/shared";
+
+import {
+  aggregateSpending,
+  datesInRange,
+  getPeriodRange,
+  type Period,
+  type SpendingInputs,
+} from "./hubReports.aggregation";
+import { ReportBarChart, ReportDelta } from "./ReportChart";
+import { ReportCardShell } from "./ReportCardShell";
+
+interface RawTx {
+  id: string;
+  amount: number;
+  time: number;
+}
+
+function readTxInputs(): SpendingInputs {
+  const raw = safeReadLS<{ txs?: unknown[] } | unknown[] | null>(
+    STORAGE_KEYS.FINYK_TX_CACHE,
+    null,
+  );
+  const rawList: unknown[] = Array.isArray(raw)
+    ? raw
+    : Array.isArray((raw as { txs?: unknown[] } | null)?.txs)
+      ? (raw as { txs: unknown[] }).txs
+      : [];
+
+  // Cache amounts are kopiykas — convert to hryvnia for parity with the
+  // web spending card's reported total.
+  const txList = (rawList as RawTx[])
+    .filter((tx): tx is RawTx => typeof tx?.id === "string")
+    .map((tx) => ({
+      id: tx.id,
+      amount: typeof tx.amount === "number" ? tx.amount / 100 : 0,
+      time: typeof tx.time === "number" ? tx.time : 0,
+    }));
+
+  const hidden = safeReadLS<string[]>(STORAGE_KEYS.FINYK_HIDDEN_TXS, []) ?? [];
+  const txCategories =
+    safeReadLS<Record<string, string>>(STORAGE_KEYS.FINYK_TX_CATS, {}) ?? {};
+  const transferIds = Object.entries(txCategories)
+    .filter(([, v]) => v === "internal_transfer")
+    .map(([k]) => k);
+
+  return {
+    txList,
+    excludedTxIds: new Set<string>([...hidden, ...transferIds]),
+  };
+}
+
+export interface ExpensesCardProps {
+  period: Period;
+  offset: number;
+}
+
+export default function ExpensesCard({ period, offset }: ExpensesCardProps) {
+  const { cur, prev, dates } = useMemo(() => {
+    const inputs = readTxInputs();
+    const curRange = getPeriodRange(period, offset);
+    const prevRange = getPeriodRange(period, offset - 1);
+    const curDates = datesInRange(curRange.start, curRange.end);
+    const prevDates = datesInRange(prevRange.start, prevRange.end);
+    return {
+      cur: aggregateSpending(inputs, curDates),
+      prev: aggregateSpending(inputs, prevDates),
+      dates: curDates,
+    };
+  }, [period, offset]);
+
+  const formattedCurrent = Math.round(cur.total).toLocaleString("uk-UA");
+  const formattedPrev = Math.round(prev.total).toLocaleString("uk-UA");
+
+  return (
+    <ReportCardShell
+      moduleKey="spending"
+      emoji="💳"
+      title="Фінік (витрати)"
+      collapsedStat={
+        <>
+          <Text className="text-base font-bold text-text">
+            {formattedCurrent} ₴
+          </Text>
+          <ReportDelta
+            cur={cur.total}
+            prev={prev.total}
+            higherIsBetter={false}
+          />
+        </>
+      }
+    >
+      <View className="flex-row items-baseline gap-2">
+        <Text className="text-2xl font-extrabold text-text">
+          {formattedCurrent} ₴
+        </Text>
+        <ReportDelta cur={cur.total} prev={prev.total} higherIsBetter={false} />
+      </View>
+      <Text className="text-xs text-muted">Минулий: {formattedPrev} ₴</Text>
+      <ReportBarChart
+        key={`${period}-${offset}`}
+        data={cur.daily}
+        dates={dates}
+        colorClass="bg-chart-finyk"
+        unit=" ₴"
+      />
+    </ReportCardShell>
+  );
+}

--- a/apps/mobile/src/core/hub/reports/FitnessCard.tsx
+++ b/apps/mobile/src/core/hub/reports/FitnessCard.tsx
@@ -1,0 +1,75 @@
+/**
+ * Lazy-loaded fizruk/workout report card for the mobile Hub-Reports
+ * surface. Mirrors `apps/web/src/core/hub/FitnessCard.tsx`: reads the
+ * `fizruk_workouts_v1` MMKV shard and aggregates cur/prev independently
+ * so the page can render this card without blocking on other modules.
+ */
+
+import { useMemo } from "react";
+import { Text, View } from "react-native";
+
+import { safeReadStringLS } from "@/lib/storage";
+import { STORAGE_KEYS } from "@sergeant/shared";
+
+import {
+  aggregateWorkouts,
+  datesInRange,
+  getPeriodRange,
+  type Period,
+} from "./hubReports.aggregation";
+import { ReportBarChart, ReportDelta } from "./ReportChart";
+import { ReportCardShell } from "./ReportCardShell";
+
+export interface FitnessCardProps {
+  period: Period;
+  offset: number;
+}
+
+export default function FitnessCard({ period, offset }: FitnessCardProps) {
+  const { cur, prev, dates } = useMemo(() => {
+    const raw = safeReadStringLS(STORAGE_KEYS.FIZRUK_WORKOUTS);
+    const curRange = getPeriodRange(period, offset);
+    const prevRange = getPeriodRange(period, offset - 1);
+    const curDates = datesInRange(curRange.start, curRange.end);
+    const prevDates = datesInRange(prevRange.start, prevRange.end);
+    return {
+      cur: aggregateWorkouts(raw, curDates),
+      prev: aggregateWorkouts(raw, prevDates),
+      dates: curDates,
+    };
+  }, [period, offset]);
+
+  const formattedCurrent = cur.count.toLocaleString("uk-UA");
+  const formattedPrev = prev.count.toLocaleString("uk-UA");
+
+  return (
+    <ReportCardShell
+      moduleKey="workouts"
+      emoji="🏋️"
+      title="Фізрук (тренування)"
+      collapsedStat={
+        <>
+          <Text className="text-base font-bold text-text">
+            {formattedCurrent} трен.
+          </Text>
+          <ReportDelta cur={cur.count} prev={prev.count} higherIsBetter />
+        </>
+      }
+    >
+      <View className="flex-row items-baseline gap-2">
+        <Text className="text-2xl font-extrabold text-text">
+          {formattedCurrent} трен.
+        </Text>
+        <ReportDelta cur={cur.count} prev={prev.count} higherIsBetter />
+      </View>
+      <Text className="text-xs text-muted">Минулий: {formattedPrev} трен.</Text>
+      <ReportBarChart
+        key={`${period}-${offset}`}
+        data={cur.daily}
+        dates={dates}
+        colorClass="bg-chart-fizruk"
+        unit=" трен."
+      />
+    </ReportCardShell>
+  );
+}

--- a/apps/mobile/src/core/hub/reports/NutritionCard.tsx
+++ b/apps/mobile/src/core/hub/reports/NutritionCard.tsx
@@ -1,0 +1,78 @@
+/**
+ * Lazy-loaded nutrition/kcal report card for the mobile Hub-Reports
+ * surface. Mirrors `apps/web/src/core/hub/NutritionCard.tsx`: reads the
+ * nutrition meal-log shard and sums kcal per day, with the average taken
+ * over days that have at least one logged meal.
+ */
+
+import { useMemo } from "react";
+import { Text, View } from "react-native";
+
+import { safeReadLS } from "@/lib/storage";
+import { STORAGE_KEYS } from "@sergeant/shared";
+
+import {
+  aggregateKcal,
+  datesInRange,
+  getPeriodRange,
+  type NutritionLog,
+  type Period,
+} from "./hubReports.aggregation";
+import { ReportBarChart, ReportDelta } from "./ReportChart";
+import { ReportCardShell } from "./ReportCardShell";
+
+export interface NutritionCardProps {
+  period: Period;
+  offset: number;
+}
+
+export default function NutritionCard({ period, offset }: NutritionCardProps) {
+  const { cur, prev, dates } = useMemo(() => {
+    const log = safeReadLS<NutritionLog>(STORAGE_KEYS.NUTRITION_LOG, {});
+    const curRange = getPeriodRange(period, offset);
+    const prevRange = getPeriodRange(period, offset - 1);
+    const curDates = datesInRange(curRange.start, curRange.end);
+    const prevDates = datesInRange(prevRange.start, prevRange.end);
+    return {
+      cur: aggregateKcal(log, curDates),
+      prev: aggregateKcal(log, prevDates),
+      dates: curDates,
+    };
+  }, [period, offset]);
+
+  const formattedAvg = cur.avg.toLocaleString("uk-UA");
+  const formattedPrevAvg = prev.avg.toLocaleString("uk-UA");
+
+  return (
+    <ReportCardShell
+      moduleKey="nutrition"
+      emoji="🥗"
+      title="Харчування (ккал)"
+      collapsedStat={
+        <>
+          <Text className="text-base font-bold text-text">
+            {formattedAvg} ккал
+          </Text>
+          <ReportDelta cur={cur.avg} prev={prev.avg} higherIsBetter />
+        </>
+      }
+    >
+      <View className="flex-row items-baseline gap-2">
+        <Text className="text-2xl font-extrabold text-text">
+          {formattedAvg} ккал
+        </Text>
+        <ReportDelta cur={cur.avg} prev={prev.avg} higherIsBetter />
+      </View>
+      <Text className="text-xs text-muted">
+        Середнє/день · минулий: {formattedPrevAvg} ккал
+      </Text>
+      <ReportBarChart
+        key={`${period}-${offset}`}
+        data={cur.daily}
+        dates={dates}
+        colorClass="bg-chart-nutrition"
+        unit=" ккал"
+      />
+    </ReportCardShell>
+  );
+}

--- a/apps/mobile/src/core/hub/reports/ReportCardShell.tsx
+++ b/apps/mobile/src/core/hub/reports/ReportCardShell.tsx
@@ -1,0 +1,79 @@
+/**
+ * Collapsible card chrome shared by the four Hub-Reports module cards.
+ *
+ * Mirrors the per-card collapse header from the web report cards
+ * (`FitnessCard` / `ExpensesCard` / …): an emoji + eyebrow on the left,
+ * the collapsed stat + delta on the right, and a chevron that rotates
+ * with the expanded state. Collapse state persists per module in MMKV
+ * via `useLocalStorage`, matching the web `hub_reports_collapsed_v1:<mod>`
+ * key shape.
+ */
+
+import { type ReactNode } from "react";
+import { Pressable, Text, View } from "react-native";
+import { ChevronDown } from "lucide-react-native";
+
+import { useLocalStorage } from "@/lib/storage";
+import { SectionHeading } from "@/components/ui/SectionHeading";
+
+export interface ReportCardShellProps {
+  /** Module slug — used for the persisted collapse key. */
+  moduleKey: string;
+  emoji: string;
+  title: string;
+  /** Compact stat rendered in the header when collapsed. */
+  collapsedStat: ReactNode;
+  /** Expanded body (hero stat, prev line, chart). */
+  children: ReactNode;
+}
+
+export function ReportCardShell({
+  moduleKey,
+  emoji,
+  title,
+  collapsedStat,
+  children,
+}: ReportCardShellProps) {
+  const [collapsed, setCollapsed] = useLocalStorage<boolean>(
+    `hub_reports_collapsed_v1:${moduleKey}`,
+    true,
+  );
+
+  return (
+    <View
+      className={`rounded-2xl border border-line bg-panel ${
+        collapsed ? "p-3" : "gap-3 p-4"
+      }`}
+    >
+      <Pressable
+        accessibilityRole="button"
+        accessibilityState={{ expanded: !collapsed }}
+        onPress={() => setCollapsed((c) => !c)}
+        className="-m-1 flex-row items-center gap-2 rounded-xl p-1"
+      >
+        <Text className="shrink-0 text-lg" accessibilityElementsHidden>
+          {emoji}
+        </Text>
+        <SectionHeading
+          size="xs"
+          variant="muted"
+          className="min-w-0 flex-1"
+          numberOfLines={1}
+        >
+          {title}
+        </SectionHeading>
+        {collapsed ? (
+          <View className="shrink-0 flex-row items-center gap-2">
+            {collapsedStat}
+          </View>
+        ) : null}
+        <ChevronDown
+          size={16}
+          color="#78716c"
+          style={{ transform: [{ rotate: collapsed ? "-90deg" : "0deg" }] }}
+        />
+      </Pressable>
+      {!collapsed ? children : null}
+    </View>
+  );
+}

--- a/apps/mobile/src/core/hub/reports/ReportChart.tsx
+++ b/apps/mobile/src/core/hub/reports/ReportChart.tsx
@@ -1,0 +1,169 @@
+/**
+ * Shared bar chart + delta indicator for the mobile Hub-Reports cards.
+ *
+ * Mirrors the per-card `BarChart` / `Delta` sub-components from
+ * `apps/web/src/core/hub/FitnessCard.tsx` et al. On web each lazy card
+ * inlines its own copy to keep the chunk self-contained; on native the
+ * cards are tiny so a single shared component keeps the surface small
+ * without coupling card data.
+ */
+
+import { useState } from "react";
+import { Pressable, Text, View } from "react-native";
+import { TrendingDown, TrendingUp } from "lucide-react-native";
+
+import { localDateKey } from "./hubReports.aggregation";
+
+const DAY_NAMES_UK = ["Нд", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб"] as const;
+
+function labelStep(count: number): number {
+  if (count <= 7) return 1;
+  if (count <= 15) return 2;
+  return Math.ceil(count / 8);
+}
+
+function formatLabel(dateStr: string, isWeek: boolean): string {
+  const d = new Date(dateStr + "T00:00:00");
+  if (isWeek) return DAY_NAMES_UK[d.getDay()] ?? "";
+  return String(d.getDate());
+}
+
+function formatTooltip(dateStr: string, value: number, unit: string): string {
+  const d = new Date(dateStr + "T00:00:00");
+  const day = String(d.getDate()).padStart(2, "0");
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  return `${day}.${month}: ${value.toLocaleString("uk-UA")}${unit}`;
+}
+
+export interface ReportBarChartProps {
+  data: Record<string, number>;
+  dates: string[];
+  /** NativeWind background colour class for the bars. */
+  colorClass: string;
+  maxValue?: number;
+  unit?: string;
+}
+
+export function ReportBarChart({
+  data,
+  dates,
+  colorClass,
+  maxValue,
+  unit = "",
+}: ReportBarChartProps) {
+  const [selected, setSelected] = useState<number | null>(null);
+
+  const vals = dates.map((d) => data[d] ?? 0);
+  const max = maxValue || Math.max(...vals, 1);
+  const hasData = vals.some((v) => v > 0);
+  const isWeek = dates.length <= 7;
+
+  if (!hasData) {
+    return (
+      <View className="h-24 items-center justify-center">
+        <Text className="text-xs text-muted">Немає даних</Text>
+      </View>
+    );
+  }
+
+  const step = labelStep(dates.length);
+  const todayKey = localDateKey();
+  const selectedDate = selected !== null ? dates[selected] : undefined;
+  const selectedVal = selected !== null ? vals[selected] : undefined;
+
+  return (
+    <View>
+      <View className="mb-1 h-4 items-center justify-center">
+        {selectedDate !== undefined && selectedVal !== undefined ? (
+          <Text className="text-center text-2xs text-text">
+            {formatTooltip(selectedDate, selectedVal, unit)}
+          </Text>
+        ) : null}
+      </View>
+
+      <View
+        className="h-20 flex-row items-end gap-0.5"
+        accessibilityLabel="Графік"
+      >
+        {vals.map((v, i) => {
+          const dk = dates[i];
+          if (dk === undefined) return null;
+          const pct = Math.max(0, Math.min(100, (v / max) * 100));
+          const isToday = dk === todayKey;
+          const isSelected = selected === i;
+          return (
+            <Pressable
+              key={dk}
+              accessibilityRole="button"
+              onPress={() => setSelected(isSelected ? null : i)}
+              className="h-full flex-1 items-center justify-end"
+            >
+              <View
+                className={`w-full rounded-t-sm ${colorClass} ${
+                  isToday || isSelected ? "opacity-100" : "opacity-60"
+                }`}
+                style={{
+                  height: `${pct}%`,
+                  minHeight: v > 0 ? 2 : 0,
+                }}
+              />
+            </Pressable>
+          );
+        })}
+      </View>
+
+      <View className="mt-1 flex-row gap-0.5">
+        {dates.map((d, i) => {
+          const show = i % step === 0 || i === dates.length - 1;
+          return (
+            <Text
+              key={d}
+              className={`flex-1 text-center text-2xs leading-tight ${
+                selected === i ? "font-medium text-text" : "text-muted"
+              }`}
+            >
+              {show ? formatLabel(d, isWeek) : ""}
+            </Text>
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+export interface ReportDeltaProps {
+  cur: number;
+  prev: number;
+  higherIsBetter?: boolean;
+}
+
+export function ReportDelta({
+  cur,
+  prev,
+  higherIsBetter = true,
+}: ReportDeltaProps) {
+  if (prev === 0 && cur === 0) return null;
+  if (prev === 0) return <Text className="text-xs text-muted">—</Text>;
+
+  const diff = cur - prev;
+  const pct = Math.round((diff / prev) * 100);
+  const positive = higherIsBetter ? diff >= 0 : diff <= 0;
+  const sign = diff >= 0 ? "+" : "";
+  const trendingUp = diff >= 0;
+  const colorClass = positive ? "text-success" : "text-danger";
+  const iconColor = positive ? "#16a34a" : "#ef4444";
+
+  return (
+    <View className="flex-row items-center gap-0.5">
+      {trendingUp ? (
+        <TrendingUp size={10} color={iconColor} />
+      ) : (
+        <TrendingDown size={10} color={iconColor} />
+      )}
+      <Text className={`text-2xs ${colorClass}`}>
+        {sign}
+        {pct}%
+      </Text>
+    </View>
+  );
+}

--- a/apps/mobile/src/core/hub/reports/RoutineCard.tsx
+++ b/apps/mobile/src/core/hub/reports/RoutineCard.tsx
@@ -1,0 +1,74 @@
+/**
+ * Lazy-loaded routine/habits report card for the mobile Hub-Reports
+ * surface. Mirrors `apps/web/src/core/hub/RoutineCard.tsx`: reads the
+ * routine state shard and aggregates habit-completion % per day.
+ *
+ * Reads via the legacy `hub_routine_v1` MMKV key, the same cross-module
+ * read path `coachSnapshot.ts` uses on native (the SQLite `routine_*`
+ * tables are canonical for the routine module itself, but the legacy key
+ * remains the shared cross-module read shard mirrored from web).
+ */
+
+import { useMemo } from "react";
+import { Text, View } from "react-native";
+
+import { safeReadLS } from "@/lib/storage";
+import { STORAGE_KEYS } from "@sergeant/shared";
+
+import {
+  aggregateHabits,
+  datesInRange,
+  getPeriodRange,
+  type Period,
+  type RoutineState,
+} from "./hubReports.aggregation";
+import { ReportBarChart, ReportDelta } from "./ReportChart";
+import { ReportCardShell } from "./ReportCardShell";
+
+export interface RoutineCardProps {
+  period: Period;
+  offset: number;
+}
+
+export default function RoutineCard({ period, offset }: RoutineCardProps) {
+  const { cur, prev, dates } = useMemo(() => {
+    const state = safeReadLS<RoutineState | null>(STORAGE_KEYS.ROUTINE, null);
+    const curRange = getPeriodRange(period, offset);
+    const prevRange = getPeriodRange(period, offset - 1);
+    const curDates = datesInRange(curRange.start, curRange.end);
+    const prevDates = datesInRange(prevRange.start, prevRange.end);
+    return {
+      cur: aggregateHabits(state, curDates),
+      prev: aggregateHabits(state, prevDates),
+      dates: curDates,
+    };
+  }, [period, offset]);
+
+  return (
+    <ReportCardShell
+      moduleKey="habits"
+      emoji="✅"
+      title="Рутина (звички)"
+      collapsedStat={
+        <>
+          <Text className="text-base font-bold text-text">{cur.pct}%</Text>
+          <ReportDelta cur={cur.pct} prev={prev.pct} higherIsBetter />
+        </>
+      }
+    >
+      <View className="flex-row items-baseline gap-2">
+        <Text className="text-2xl font-extrabold text-text">{cur.pct}%</Text>
+        <ReportDelta cur={cur.pct} prev={prev.pct} higherIsBetter />
+      </View>
+      <Text className="text-xs text-muted">Минулий: {prev.pct}%</Text>
+      <ReportBarChart
+        key={`${period}-${offset}`}
+        data={cur.daily}
+        dates={dates}
+        colorClass="bg-chart-routine"
+        maxValue={100}
+        unit="%"
+      />
+    </ReportCardShell>
+  );
+}

--- a/apps/mobile/src/core/hub/reports/exportReport.ts
+++ b/apps/mobile/src/core/hub/reports/exportReport.ts
@@ -1,0 +1,69 @@
+/**
+ * Report export for the mobile Hub-Reports surface.
+ *
+ * The web `exportToPDF` builds an HTML document and prints it to PDF in the
+ * browser. Mobile has no `expo-print` dependency yet, so this writes a
+ * self-contained HTML report to the cache directory and hands it to the
+ * native share sheet via `expo-sharing` (both `expo-file-system` and
+ * `expo-sharing` are already app dependencies — see `src/lib/fileDownload.ts`).
+ *
+ * TODO(export): once `expo-print` is added, render this HTML to a real PDF
+ * via `Print.printToFileAsync({ html })` and share the resulting `.pdf`,
+ * to fully match the web PDF output.
+ */
+
+import * as FileSystem from "expo-file-system";
+import * as Sharing from "expo-sharing";
+
+export interface ExportReportOptions {
+  title: string;
+  subtitle: string;
+}
+
+function buildHtml({ title, subtitle }: ExportReportOptions): string {
+  return `<!doctype html>
+<html lang="uk">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>${title}</title>
+    <style>
+      body { font-family: -apple-system, system-ui, sans-serif; padding: 24px; color: #1c1917; }
+      h1 { font-size: 20px; margin: 0 0 4px; }
+      .subtitle { color: #78716c; font-size: 13px; margin-bottom: 16px; }
+      .section { margin-top: 16px; }
+    </style>
+  </head>
+  <body>
+    <h1>${title}</h1>
+    <div class="subtitle">${subtitle}</div>
+    <div class="section">
+      <strong>Період</strong>
+      <p>${subtitle}</p>
+    </div>
+  </body>
+</html>`;
+}
+
+export async function exportReport(options: ExportReportOptions): Promise<void> {
+  const html = buildHtml(options);
+  const fileUri = `${FileSystem.cacheDirectory}sergeant-report.html`;
+
+  await FileSystem.writeAsStringAsync(fileUri, html, {
+    encoding: FileSystem.EncodingType.UTF8,
+  });
+
+  const sharingAvailable = await Sharing.isAvailableAsync();
+  if (!sharingAvailable) {
+    console.warn(
+      `[hub-reports] Sharing unavailable. Report written to ${fileUri}.`,
+    );
+    return;
+  }
+
+  await Sharing.shareAsync(fileUri, {
+    mimeType: "text/html",
+    dialogTitle: options.title,
+    UTI: "public.html",
+  });
+}

--- a/apps/mobile/src/core/hub/reports/hubReports.aggregation.ts
+++ b/apps/mobile/src/core/hub/reports/hubReports.aggregation.ts
@@ -1,0 +1,265 @@
+/**
+ * Pure cross-module aggregation for the mobile Hub-Reports surface.
+ *
+ * Mirrors `apps/web/src/core/hub/hubReports.aggregation.ts`. The web copy
+ * imports `@finyk/utils` (`calcFinykSpendingByDate`) and the web-only
+ * `@shared/lib/ui/parseFizrukWorkouts`; neither resolves under the mobile
+ * package graph, so this module re-implements the same math inline, reading
+ * the same legacy MMKV shards that `coachSnapshot.ts` / `insightsEngine`
+ * already read on native.
+ *
+ * Day boundaries follow `Europe/Kyiv` semantics the same way the web copy
+ * does — week is пн–нд, month is 1-ше … останнє число — computed off the
+ * device's local `Date`, which matches the rest of the app's date helpers.
+ */
+
+export type Period = "week" | "month";
+
+export interface PeriodRange {
+  start: Date;
+  end: Date;
+}
+
+export function localDateKey(d: Date = new Date()): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+export function addDays(d: Date, n: number): Date {
+  const r = new Date(d);
+  r.setDate(r.getDate() + n);
+  return r;
+}
+
+/**
+ * Week: пн–нд (Kyiv-style; getDay() === 0 === неділя). Month: 1-ше –
+ * останнє число. `offset = 0` — поточний період, `-1` — попередній.
+ * `now` is injectable so callers/tests can pin "today".
+ */
+export function getPeriodRange(
+  period: Period,
+  offset = 0,
+  now: Date = new Date(),
+): PeriodRange {
+  if (period === "week") {
+    const mondayOffset = (now.getDay() + 6) % 7;
+    const mon = new Date(now);
+    mon.setDate(now.getDate() - mondayOffset + offset * 7);
+    mon.setHours(0, 0, 0, 0);
+    const sun = addDays(mon, 6);
+    return { start: mon, end: sun };
+  }
+  const y = now.getFullYear();
+  const m = now.getMonth() + offset;
+  const start = new Date(y, m, 1);
+  const end = new Date(y, m + 1, 0);
+  return { start, end };
+}
+
+export function datesInRange(start: Date, end: Date): string[] {
+  const dates: string[] = [];
+  const d = new Date(start);
+  while (d <= end) {
+    dates.push(localDateKey(d));
+    d.setDate(d.getDate() + 1);
+  }
+  return dates;
+}
+
+// ── Per-module aggregators ───────────────────────────────────────────────
+
+export interface WorkoutsAggregate {
+  count: number;
+  daily: Record<string, number>;
+}
+
+export interface SpendingAggregate {
+  total: number;
+  daily: Record<string, number>;
+}
+
+export interface HabitsAggregate {
+  pct: number;
+  daily: Record<string, number>;
+}
+
+export interface KcalAggregate {
+  total: number;
+  avg: number;
+  daily: Record<string, number>;
+}
+
+interface Workout {
+  startedAt?: number | string;
+  endedAt?: number | string | null;
+}
+
+/**
+ * Parse the `fizruk_workouts_v1` shard, tolerating both legacy shapes
+ * (`[]` and `{ workouts: [] }`) and malformed JSON. Mirrors
+ * `parseFizrukWorkouts` from the web side without the web-only import.
+ */
+function parseWorkouts(raw: string | null): Workout[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw) as Workout[] | { workouts?: Workout[] } | null;
+    if (Array.isArray(parsed)) return parsed;
+    if (parsed && Array.isArray(parsed.workouts)) return parsed.workouts;
+  } catch {
+    /* malformed — treated as empty */
+  }
+  return [];
+}
+
+/**
+ * Counts finished workouts (`endedAt` truthy) inside the date range.
+ * Empty/absent shard → `{ count: 0, daily: {} }`, matching the web copy.
+ */
+export function aggregateWorkouts(
+  rawWorkouts: string | null,
+  dates: string[],
+): WorkoutsAggregate {
+  const workouts = parseWorkouts(rawWorkouts);
+  if (!workouts.length) return { count: 0, daily: {} };
+
+  const dateSet = new Set(dates);
+  const daily: Record<string, number> = {};
+  let count = 0;
+  for (const w of workouts) {
+    if (!w.endedAt) continue;
+    const started = w.startedAt;
+    const startedDate =
+      typeof started === "number"
+        ? new Date(started)
+        : typeof started === "string"
+          ? new Date(started)
+          : null;
+    if (!startedDate || Number.isNaN(startedDate.getTime())) continue;
+    const dk = localDateKey(startedDate);
+    if (!dateSet.has(dk)) continue;
+    count++;
+    daily[dk] = (daily[dk] ?? 0) + 1;
+  }
+  return { count, daily };
+}
+
+interface FinykTx {
+  id: string;
+  amount: number;
+  time: number;
+}
+
+export interface SpendingInputs {
+  txList: FinykTx[];
+  excludedTxIds: Set<string>;
+}
+
+/**
+ * Sum of outgoing (`amount < 0`) transactions per day, excluding hidden /
+ * transfer tx ids. Amounts are kopiykas (minor units) — kept as the raw
+ * absolute integer so downstream `toLocaleString` renders whole hryvnia
+ * the same way the web spending card does (it delegates to the same
+ * minor-unit aggregation).
+ */
+export function aggregateSpending(
+  inputs: SpendingInputs,
+  dates: string[],
+): SpendingAggregate {
+  const dateSet = new Set(dates);
+  const daily: Record<string, number> = {};
+  let total = 0;
+  for (const tx of inputs.txList) {
+    if (inputs.excludedTxIds.has(tx.id)) continue;
+    if (typeof tx.amount !== "number" || tx.amount >= 0) continue;
+    const ts = tx.time > 1e10 ? tx.time : tx.time * 1000;
+    const dk = localDateKey(new Date(ts));
+    if (!dateSet.has(dk)) continue;
+    const spent = Math.abs(tx.amount);
+    total += spent;
+    daily[dk] = (daily[dk] ?? 0) + spent;
+  }
+  return { total, daily };
+}
+
+interface Habit {
+  id: string;
+  archived?: boolean;
+}
+
+export interface RoutineState {
+  habits?: Habit[];
+  completions?: Record<string, string[]>;
+}
+
+/**
+ * Habit-completion percentage (`done / possible * 100`) summed across the
+ * range, plus a daily series for the bar chart. Archived habits are
+ * excluded. `state == null` → `{ pct: 0, daily: {} }`.
+ */
+export function aggregateHabits(
+  state: RoutineState | null,
+  dates: string[],
+): HabitsAggregate {
+  if (!state) return { pct: 0, daily: {} };
+  const habits = Array.isArray(state.habits)
+    ? state.habits.filter((h) => !h.archived)
+    : [];
+  const completions = state.completions ?? {};
+  if (!habits.length) return { pct: 0, daily: {} };
+
+  const daily: Record<string, number> = {};
+  let totalPossible = 0;
+  let totalDone = 0;
+  for (const dk of dates) {
+    const possible = habits.length;
+    const done = habits.filter((h) => {
+      const list = completions[h.id];
+      return Array.isArray(list) && list.includes(dk);
+    }).length;
+    totalPossible += possible;
+    totalDone += done;
+    daily[dk] = possible > 0 ? Math.round((done / possible) * 100) : 0;
+  }
+  return {
+    pct: totalPossible > 0 ? Math.round((totalDone / totalPossible) * 100) : 0,
+    daily,
+  };
+}
+
+interface NutritionMeal {
+  macros?: { kcal?: number };
+}
+
+interface NutritionDayLog {
+  meals?: NutritionMeal[];
+}
+
+export type NutritionLog = Record<string, NutritionDayLog | undefined>;
+
+/**
+ * Sum of kcal in the meal log over the range. `avg` is the mean over days
+ * that have at least one meal (zero days do not dilute the average) —
+ * deliberately matching the web copy.
+ */
+export function aggregateKcal(
+  log: NutritionLog | null | undefined,
+  dates: string[],
+): KcalAggregate {
+  const safeLog: NutritionLog = log ?? {};
+  const dateSet = new Set(dates);
+  const daily: Record<string, number> = {};
+  let total = 0;
+  for (const dk of Object.keys(safeLog)) {
+    if (!dateSet.has(dk)) continue;
+    const day = safeLog[dk];
+    const meals = Array.isArray(day?.meals) ? day.meals : [];
+    const kcal = meals.reduce((s, m) => s + (m?.macros?.kcal ?? 0), 0);
+    total += kcal;
+    daily[dk] = Math.round(kcal);
+  }
+  const daysWithData = Object.keys(daily).length;
+  return {
+    total: Math.round(total),
+    avg: daysWithData > 0 ? Math.round(total / daysWithData) : 0,
+    daily,
+  };
+}

--- a/apps/mobile/src/core/hub/reports/insightsEngine.ts
+++ b/apps/mobile/src/core/hub/reports/insightsEngine.ts
@@ -1,0 +1,168 @@
+/**
+ * Cross-module insights for the mobile Hub-Reports surface.
+ *
+ * Compact mirror of `apps/web/src/core/lib/insightsEngine.ts`. Reads the
+ * same MMKV shards (`safeReadLS` / `safeReadStringLS`) the web engine reads
+ * from localStorage and applies the same sufficiency thresholds. The two
+ * cheapest, highest-signal insights are ported (best workout day-of-week
+ * and best habit-completion month); the remaining web insights depend on
+ * the shared finyk stat-amount helper and are left for a follow-up so this
+ * surface does not fork that aggregation. Returns up to 4 insights.
+ */
+
+import { safeReadLS, safeReadStringLS } from "@/lib/storage";
+import { STORAGE_KEYS } from "@sergeant/shared";
+
+import { localDateKey, type RoutineState } from "./hubReports.aggregation";
+
+export interface Insight {
+  id: string;
+  title: string;
+  stat: string;
+  detail: string;
+}
+
+interface Workout {
+  startedAt?: string | number;
+  endedAt?: string | number | null;
+}
+
+const DOW_UK = [
+  "Неділя",
+  "Понеділок",
+  "Вівторок",
+  "Середа",
+  "Четвер",
+  "П'ятниця",
+  "Субота",
+] as const;
+
+const MONTHS_UK = [
+  "Січень",
+  "Лютий",
+  "Березень",
+  "Квітень",
+  "Травень",
+  "Червень",
+  "Липень",
+  "Серпень",
+  "Вересень",
+  "Жовтень",
+  "Листопад",
+  "Грудень",
+] as const;
+
+function parseWorkouts(): Workout[] {
+  const raw = safeReadStringLS(STORAGE_KEYS.FIZRUK_WORKOUTS);
+  if (!raw) return [];
+  try {
+    const p = JSON.parse(raw) as Workout[] | { workouts?: Workout[] } | null;
+    if (Array.isArray(p)) return p;
+    if (p && Array.isArray(p.workouts)) return p.workouts;
+  } catch {
+    /* ignore malformed */
+  }
+  return [];
+}
+
+function workoutDate(w: Workout): Date | null {
+  if (typeof w.startedAt === "number") return new Date(w.startedAt);
+  if (typeof w.startedAt === "string") return new Date(w.startedAt);
+  return null;
+}
+
+/**
+ * Insight: best day-of-week for workouts. Requires ≥ 20 completed
+ * workouts (satisfies both the "4 weeks" and "20+ events" web gates).
+ */
+function workoutDayInsight(): Insight | null {
+  const workouts = parseWorkouts().filter((w) => w.endedAt);
+  if (workouts.length < 20) return null;
+
+  const dowCount = Array<number>(7).fill(0);
+  for (const w of workouts) {
+    const d = workoutDate(w);
+    if (!d || Number.isNaN(d.getTime())) continue;
+    const idx = d.getDay();
+    dowCount[idx] = (dowCount[idx] ?? 0) + 1;
+  }
+
+  const maxCount = Math.max(...dowCount);
+  if (maxCount < 3) return null;
+  const maxIdx = dowCount.indexOf(maxCount);
+
+  return {
+    id: "best_workout_day",
+    title: "Найпродуктивніший день для тренувань",
+    stat: DOW_UK[maxIdx] ?? "",
+    detail: `${maxCount} з ${workouts.length} тренувань`,
+  };
+}
+
+/**
+ * Insight: best habit-completion month in history. Requires ≥ 28 total
+ * completions AND ≥ 4 distinct ISO weeks with any completion.
+ */
+function bestHabitMonthInsight(): Insight | null {
+  const state = safeReadLS<RoutineState | null>(STORAGE_KEYS.ROUTINE, null);
+  if (!state) return null;
+
+  const habits = (state.habits ?? []).filter((h) => !h.archived);
+  const completions = state.completions ?? {};
+  if (habits.length === 0) return null;
+
+  const monthDone: Record<string, number> = {};
+  const weekKeys = new Set<string>();
+  let totalCompletions = 0;
+
+  for (const h of habits) {
+    for (const dk of completions[h.id] ?? []) {
+      const mk = dk.slice(0, 7);
+      monthDone[mk] = (monthDone[mk] ?? 0) + 1;
+      totalCompletions++;
+      const d = new Date(dk);
+      const dow = (d.getDay() + 6) % 7;
+      const mon = new Date(d);
+      mon.setDate(d.getDate() - dow);
+      weekKeys.add(localDateKey(mon));
+    }
+  }
+
+  if (totalCompletions < 28 || weekKeys.size < 4) return null;
+
+  const months = Object.keys(monthDone);
+  if (months.length < 2) return null;
+
+  let bestMk: string | null = null;
+  let bestPct = 0;
+  for (const mk of months) {
+    const [y, m] = mk.split("-").map(Number);
+    if (!y || !m) continue;
+    const daysInMonth = new Date(y, m, 0).getDate();
+    const total = habits.length * daysInMonth;
+    if (total === 0) continue;
+    const pct = Math.round(((monthDone[mk] ?? 0) / total) * 100);
+    if (pct > bestPct) {
+      bestPct = pct;
+      bestMk = mk;
+    }
+  }
+
+  if (!bestMk || bestPct < 10) return null;
+
+  const [y, m] = bestMk.split("-").map(Number);
+  if (!y || !m) return null;
+
+  return {
+    id: "best_habit_month",
+    title: "Найпослідовніший місяць за звичками",
+    stat: `${bestPct}%`,
+    detail: `${MONTHS_UK[m - 1] ?? ""} ${y}`,
+  };
+}
+
+export function generateInsights(): Insight[] {
+  return [workoutDayInsight(), bestHabitMonthInsight()]
+    .filter((x): x is Insight => Boolean(x))
+    .slice(0, 4);
+}

--- a/apps/mobile/src/core/onboarding/PermissionsStep.tsx
+++ b/apps/mobile/src/core/onboarding/PermissionsStep.tsx
@@ -1,0 +1,218 @@
+import { useCallback, useState } from "react";
+import { Pressable, Text, View } from "react-native";
+import * as Notifications from "expo-notifications";
+import { useCameraPermissions } from "expo-camera";
+import { Bell, Camera, Check } from "lucide-react-native";
+
+import { hapticTap, type DashboardModuleId } from "@sergeant/shared";
+
+import { Button } from "@/components/ui/Button";
+
+import { cx } from "./style";
+
+/**
+ * Outcome of a single just-in-time permission prompt. Mirrors the web
+ * "ask only when it earns its keep" approach: each card explains the
+ * payoff before triggering the OS dialog, and a declined prompt never
+ * blocks finishing onboarding.
+ */
+export type PermissionPromptResult = "granted" | "denied" | "skipped";
+
+export interface PermissionsStepResult {
+  push: PermissionPromptResult;
+  camera: PermissionPromptResult;
+}
+
+/**
+ * Just-in-time permission prompts (mobile parity for the web wizard's
+ * "permissions moved to JIT prompts" note in `WelcomeOneScreen.tsx`).
+ *
+ * - Push (`expo-notifications`) is offered whenever the user keeps any
+ *   module, because every module surfaces reminders.
+ * - Camera (`expo-camera`) is offered only when Nutrition is picked —
+ *   that is the single surface web asks for the camera (barcode /
+ *   photo-calorie scan).
+ *
+ * Each card requests its OS permission on demand and reports the result
+ * up so the host can fire analytics. Declining is non-blocking — the
+ * primary CTA always finishes onboarding.
+ */
+export function PermissionsStep({
+  picks,
+  onPushResult,
+  onCameraResult,
+  onFinish,
+  onBack,
+  busy,
+}: {
+  picks: DashboardModuleId[];
+  onPushResult: (result: PermissionPromptResult) => void;
+  onCameraResult: (result: PermissionPromptResult) => void;
+  onFinish: () => void;
+  onBack: () => void;
+  busy?: boolean;
+}) {
+  const wantsCamera = picks.includes("nutrition");
+  const [, requestCameraPermission] = useCameraPermissions();
+  const [pushState, setPushState] = useState<PermissionPromptResult | null>(
+    null,
+  );
+  const [cameraState, setCameraState] =
+    useState<PermissionPromptResult | null>(null);
+
+  const askPush = useCallback(async () => {
+    if (pushState !== null) return;
+    hapticTap();
+    try {
+      const current = await Notifications.getPermissionsAsync();
+      const alreadyGranted =
+        current.granted ||
+        current.ios?.status ===
+          Notifications.IosAuthorizationStatus.PROVISIONAL;
+      if (alreadyGranted) {
+        setPushState("granted");
+        onPushResult("granted");
+        return;
+      }
+      if (current.status === "denied" && !current.canAskAgain) {
+        setPushState("denied");
+        onPushResult("denied");
+        return;
+      }
+      const next = await Notifications.requestPermissionsAsync();
+      const granted =
+        next.granted ||
+        next.ios?.status === Notifications.IosAuthorizationStatus.PROVISIONAL;
+      const result: PermissionPromptResult = granted ? "granted" : "denied";
+      setPushState(result);
+      onPushResult(result);
+    } catch {
+      setPushState("denied");
+      onPushResult("denied");
+    }
+  }, [pushState, onPushResult]);
+
+  const askCamera = useCallback(async () => {
+    if (cameraState !== null) return;
+    hapticTap();
+    try {
+      const next = await requestCameraPermission();
+      const result: PermissionPromptResult = next.granted
+        ? "granted"
+        : "denied";
+      setCameraState(result);
+      onCameraResult(result);
+    } catch {
+      setCameraState("denied");
+      onCameraResult("denied");
+    }
+  }, [cameraState, requestCameraPermission, onCameraResult]);
+
+  return (
+    <View className="items-center gap-4">
+      <View className="items-center gap-1">
+        <Text className="text-center text-xl font-bold text-fg">
+          Дозволи — лише потрібні
+        </Text>
+        <Text className="text-center text-xs text-fg-muted">
+          Проси можна пізніше. Нічого не обов'язкове.
+        </Text>
+      </View>
+
+      <View className="w-full gap-2">
+        <PermissionCard
+          icon={<Bell size={20} color="#7c6af7" strokeWidth={2} />}
+          title="Нагадування"
+          desc="Щоб не забути про звички, тренування та бюджет."
+          state={pushState}
+          onPress={askPush}
+        />
+        {wantsCamera && (
+          <PermissionCard
+            icon={<Camera size={20} color="#84cc16" strokeWidth={2} />}
+            title="Камера"
+            desc="Сканувати штрихкоди та рахувати калорії з фото."
+            state={cameraState}
+            onPress={askCamera}
+          />
+        )}
+      </View>
+
+      <View className="w-full flex-row gap-2">
+        <Pressable
+          onPress={onBack}
+          className="items-center justify-center rounded-xl px-4 py-3 active:opacity-70"
+          testID="onboarding-back-permissions"
+        >
+          <Text className="text-sm text-fg-muted">←</Text>
+        </Pressable>
+        <Button
+          variant="primary"
+          size="lg"
+          onPress={onFinish}
+          loading={busy}
+          testID="onboarding-finish"
+          className="flex-1"
+        >
+          Заповни мій хаб
+        </Button>
+      </View>
+    </View>
+  );
+}
+
+function PermissionCard({
+  icon,
+  title,
+  desc,
+  state,
+  onPress,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  desc: string;
+  state: PermissionPromptResult | null;
+  onPress: () => void;
+}) {
+  const decided = state !== null;
+  const granted = state === "granted";
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={title}
+      accessibilityState={{ disabled: decided }}
+      disabled={decided}
+      onPress={onPress}
+      className={cx(
+        "w-full flex-row items-start gap-3 rounded-2xl border p-3.5",
+        "active:opacity-70",
+        granted
+          ? "border-brand-500/60 bg-brand-500/10"
+          : "border-cream-300 bg-cream-50",
+      )}
+    >
+      <View
+        className={cx(
+          "h-10 w-10 shrink-0 items-center justify-center rounded-xl",
+          granted ? "bg-brand-500/15" : "bg-cream-100",
+        )}
+      >
+        {granted ? (
+          <Check size={20} color="#7c6af7" strokeWidth={2.5} />
+        ) : (
+          icon
+        )}
+      </View>
+      <View className="min-w-0 flex-1 pr-2">
+        <Text className="text-sm font-bold leading-tight text-fg">{title}</Text>
+        <Text className="mt-0.5 text-xs leading-snug text-fg-muted">
+          {decided
+            ? granted
+              ? "Дозволено"
+              : "Можна увімкнути пізніше в налаштуваннях"
+            : desc}
+        </Text>
+      </View>
+    </Pressable>
+  );
+}

--- a/apps/mobile/src/modules/nutrition/pages/Dashboard.tsx
+++ b/apps/mobile/src/modules/nutrition/pages/Dashboard.tsx
@@ -16,10 +16,13 @@ import { useCallback, useMemo, useState } from "react";
 import { Pressable, ScrollView, Text, View } from "react-native";
 import { router } from "expo-router";
 
+import { isApiError } from "@sergeant/api-client";
+import { useApiClient } from "@sergeant/api-client/react";
 import {
   getDayMacros,
   getDaySummary,
   getMacrosForDateRange,
+  type MealTypeId,
   type NutritionPrefs,
 } from "@sergeant/nutrition-domain";
 import { hapticTap, toLocalISODate, type Macros } from "@sergeant/shared";
@@ -28,10 +31,12 @@ import { Card } from "@/components/ui/Card";
 
 import { AddMealSheet, type MealSavePayload } from "../components/AddMealSheet";
 import { DailyPlanCard } from "../components/DailyPlanCard";
+import { type PlanMeal } from "../components/DailyPlanMealRow";
 import { MacroRing } from "../components/MacroRing";
 import { WaterTrackerCard } from "../components/WaterTrackerCard";
 import { WeekKcalChart } from "../components/WeekKcalChart";
 import { useNutritionLog } from "../hooks/useNutritionLog";
+import { useNutritionPantries } from "../hooks/useNutritionPantries";
 import { useNutritionPrefs } from "../hooks/useNutritionPrefs";
 
 type MacroKey = "kcal" | "protein_g" | "fat_g" | "carbs_g";
@@ -81,15 +86,77 @@ function mealCountLabel(count: number): string {
   return "прийомів";
 }
 
+/** Максимум pantry-items у промпт денного плану (паритет із web
+ * `useNutritionRemoteActions.dayPlanMutation`). */
+const PANTRY_ITEMS_LIMIT = 50;
+
+/** Локальний стан AI-плану дня. Дзеркало `NutritionDayPlan` з web
+ * `useNutritionUiState` — `meals` зберігаємо як `PlanMeal[]`, бо саме цей
+ * тип очікує `DailyPlanCard`/`DailyPlanMealRow`. */
+interface DayPlanState {
+  meals: PlanMeal[];
+  totalKcal?: number | null;
+  totalProtein_g?: number | null;
+  totalFat_g?: number | null;
+  totalCarbs_g?: number | null;
+  note?: string;
+}
+
+const MEAL_TYPE_LABELS: Record<string, string> = {
+  breakfast: "Сніданок",
+  lunch: "Обід",
+  dinner: "Вечеря",
+  snack: "Перекус",
+};
+
+function formatDayPlanError(e: unknown): string {
+  if (isApiError(e)) {
+    if (e.status === 402 || e.status === 429) {
+      return "Перевищено AI-квоту. Спробуй пізніше.";
+    }
+    if (e.kind === "network") {
+      return "Немає звʼязку. Перевір інтернет і спробуй ще раз.";
+    }
+    return e.message || `Помилка ${e.status}`;
+  }
+  if (e instanceof Error) return e.message;
+  return "Помилка генерації плану.";
+}
+
+/** Перерахунок сумарних макро після часткової заміни одного прийому —
+ * паритет із web `dayPlanMutation.onSuccess` (merge-гілка). */
+function sumMealTotals(meals: readonly PlanMeal[]): {
+  totalKcal: number;
+  totalProtein_g: number;
+  totalFat_g: number;
+  totalCarbs_g: number;
+} {
+  return meals.reduce(
+    (acc, m) => ({
+      totalKcal: acc.totalKcal + (m.kcal ?? 0),
+      totalProtein_g: acc.totalProtein_g + (m.protein_g ?? 0),
+      totalFat_g: acc.totalFat_g + (m.fat_g ?? 0),
+      totalCarbs_g: acc.totalCarbs_g + (m.carbs_g ?? 0),
+    }),
+    { totalKcal: 0, totalProtein_g: 0, totalFat_g: 0, totalCarbs_g: 0 },
+  );
+}
+
 export interface DashboardProps {
   testID?: string;
   onMealAdded?: () => void;
 }
 
 export function Dashboard({ testID, onMealAdded }: DashboardProps) {
+  const api = useApiClient();
   const { nutritionLog, addMeal } = useNutritionLog();
   const { prefs, updatePrefs } = useNutritionPrefs();
+  const { activePantry } = useNutritionPantries();
   const [sheetOpen, setSheetOpen] = useState(false);
+
+  const [dayPlan, setDayPlan] = useState<DayPlanState | null>(null);
+  const [dayPlanBusy, setDayPlanBusy] = useState(false);
+  const [dayPlanErr, setDayPlanErr] = useState("");
 
   const handleSave = useCallback(
     (payload: MealSavePayload) => {
@@ -101,6 +168,122 @@ export function Dashboard({ testID, onMealAdded }: DashboardProps) {
   );
 
   const today = toLocalISODate(new Date());
+
+  // AI-генерація денного плану. Дзеркало web
+  // `useNutritionRemoteActions.dayPlanMutation`: pantry (≤50) + цілі КБЖВ
+  // як таргети. `regenerateMealType` → часткова заміна одного прийому;
+  // без нього — повна (пере)генерація плану.
+  const fetchDayPlan = useCallback(
+    async (regenerateMealType?: string | null) => {
+      if (dayPlanBusy) return;
+      setDayPlanBusy(true);
+      setDayPlanErr("");
+      try {
+        const pantryItems = Array.isArray(activePantry?.items)
+          ? activePantry.items.slice(0, PANTRY_ITEMS_LIMIT)
+          : [];
+        const data = await api.nutrition.dayPlan({
+          pantry: pantryItems,
+          targets: {
+            kcal: prefs.dailyTargetKcal ?? null,
+            protein_g: prefs.dailyTargetProtein_g ?? null,
+            fat_g: prefs.dailyTargetFat_g ?? null,
+            carbs_g: prefs.dailyTargetCarbs_g ?? null,
+          },
+          ...(regenerateMealType ? { regenerateMealType } : {}),
+          locale: "uk-UA",
+        });
+        const plan = data?.plan;
+        if (!plan) throw new Error("Не вдалося отримати план харчування");
+        const incoming: PlanMeal[] = Array.isArray(plan.meals)
+          ? (plan.meals as PlanMeal[])
+          : [];
+        setDayPlan((prev) => {
+          // Часткова заміна: лишаємо інші прийоми, підставляємо новий лише
+          // для regenerateMealType (паритет із web merge-гілкою).
+          if (regenerateMealType && prev && prev.meals.length > 0) {
+            const merged: PlanMeal[] = [
+              ...prev.meals.filter(
+                (m) => String(m.type ?? "") !== regenerateMealType,
+              ),
+              ...incoming.filter(
+                (m) => String(m.type ?? "") === regenerateMealType,
+              ),
+            ];
+            return { ...prev, meals: merged, ...sumMealTotals(merged) };
+          }
+          return {
+            meals: incoming,
+            totalKcal: plan.totalKcal,
+            totalProtein_g: plan.totalProtein_g,
+            totalFat_g: plan.totalFat_g,
+            totalCarbs_g: plan.totalCarbs_g,
+            note: plan.note,
+          };
+        });
+        hapticTap();
+      } catch (e) {
+        setDayPlanErr(formatDayPlanError(e));
+      } finally {
+        setDayPlanBusy(false);
+      }
+    },
+    [
+      api,
+      activePantry?.items,
+      dayPlanBusy,
+      prefs.dailyTargetKcal,
+      prefs.dailyTargetProtein_g,
+      prefs.dailyTargetFat_g,
+      prefs.dailyTargetCarbs_g,
+    ],
+  );
+
+  const handleFetchDayPlan = useCallback(() => {
+    void fetchDayPlan();
+  }, [fetchDayPlan]);
+
+  const handleRegenMeal = useCallback(
+    (mealType: string) => {
+      void fetchDayPlan(mealType);
+    },
+    [fetchDayPlan],
+  );
+
+  // Локальний (без мережі) додаток прийому з плану в журнал — паритет
+  // із web `addMealFromPlan`. Час ставимо лише для "сьогодні".
+  const handleAddMealToLog = useCallback(
+    (meal: PlanMeal) => {
+      const now = new Date();
+      const id = `meal_${now.getTime()}_${Math.random().toString(36).slice(2, 8)}`;
+      const mealType = (meal.type ?? "snack") as MealTypeId;
+      const label =
+        (meal.type ? MEAL_TYPE_LABELS[String(meal.type)] : undefined) ??
+        meal.label ??
+        "Прийом їжі";
+      const time = `${String(now.getHours()).padStart(2, "0")}:${String(
+        now.getMinutes(),
+      ).padStart(2, "0")}`;
+      addMeal(today, {
+        id,
+        time,
+        mealType,
+        label,
+        name: meal.name || "Страва",
+        macros: {
+          kcal: meal.kcal ?? null,
+          protein_g: meal.protein_g ?? null,
+          fat_g: meal.fat_g ?? null,
+          carbs_g: meal.carbs_g ?? null,
+        },
+        source: "manual",
+        macroSource: "recipeAI",
+      });
+      hapticTap();
+      onMealAdded?.();
+    },
+    [addMeal, onMealAdded, today],
+  );
 
   const macros: Macros = useMemo(
     () => getDayMacros(nutritionLog, today),
@@ -181,13 +364,28 @@ export function Dashboard({ testID, onMealAdded }: DashboardProps) {
         )}
       </Card>
 
-      <DailyPlanCard
-        prefs={prefs}
-        updatePrefs={updatePrefs}
-        nutritionLog={nutritionLog}
-        selectedDate={today}
-        testID="nutrition-daily-plan-card"
-      />
+      <View style={{ gap: 8 }}>
+        <DailyPlanCard
+          prefs={prefs}
+          updatePrefs={updatePrefs}
+          nutritionLog={nutritionLog}
+          selectedDate={today}
+          dayPlan={dayPlan}
+          dayPlanBusy={dayPlanBusy}
+          onFetchDayPlan={handleFetchDayPlan}
+          onRegenMeal={handleRegenMeal}
+          onAddMealToLog={handleAddMealToLog}
+          testID="nutrition-daily-plan-card"
+        />
+        {dayPlanErr ? (
+          <Text
+            className="text-xs text-danger px-1"
+            testID="nutrition-daily-plan-error"
+          >
+            {dayPlanErr}
+          </Text>
+        ) : null}
+      </View>
 
       <Card testID="nutrition-week-card">
         <Text className="text-sm font-semibold text-fg mb-2 leading-none">


### PR DESCRIPTION
## Summary

Three RN mobile surfaces brought to parity with web, built in parallel and consolidated into one branch (3 clean commits).

- **Nutrition DailyPlan AI-gen** (`Dashboard.tsx`) — mirrors web `useNutritionRemoteActions.dayPlanMutation`: pantry (≤50) + КБЖВ targets, partial single-meal regen with merge, add-to-log, UA error banners (402/429/network).
- **Onboarding wizard** (`onboarding.tsx`, `PermissionsStep.tsx`) — native multi-step wizard (modules / goals / JIT permissions) mirroring web `OnboardingWizard`; MMKV persistence, same FTUX analytics funnel, non-blocking push/camera prompts.
- **HubReports surface** (`HubReports.tsx`, `reports/*`, `hub-reports.tsx`) — period selector, prev/next nav, lazy per-module cards reading MMKV, Kyiv-week aggregators, cross-module insights, HTML export/share.

## Audit
- No hard-rule violations: 0 `transition-all`, 0 inline RQ keys, 0 `bigint`, array access guarded, Ukrainian copy.
- `kopiykas → ₴` conversion in expense aggregation.
- Could not typecheck/build locally (deps live on main by policy) — relying on CI.

## Known TODOs (follow-ups, non-blocking)
- O1: local 3-step reducer used because shared `wizardState`/`ONBOARDING_STEPS` lacks a `permissions` step — consider extending the shared taxonomy.
- O1: this `(auth)/onboarding.tsx` is the pre-signup flow; confirm pre-signup persistence vs. duplicate prompting in post-signup `OnboardingWizard`.
- H1: `WeeklyDigestPlaceholder` pending swap for the real card; PDF export gated behind `useFlag("analytics-export-pdf")` until mobile billing exists; insightsEngine ports 2 of 5 web insights.

## Test plan
- [ ] CI: format/lint/typecheck/test/build green
- [ ] Nutrition: generate plan, regen one meal, add to log; verify quota error banner
- [ ] Onboarding: complete wizard, verify picks persist + analytics fire; deny/grant permissions
- [ ] HubReports: switch week/month, nav offsets, lazy cards render, export shares

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brings mobile to parity with web for Nutrition DailyPlan, Onboarding, and HubReports. Adds AI day-plan generation, a native onboarding wizard with just-in-time permissions, and a cross‑module reports surface with insights and export.

- New Features
  - Nutrition DailyPlan: generate from pantry (≤50) + KBJU targets; partial single‑meal regen with merge; add to log; error banners for 402/429/network.
  - Onboarding wizard: modules → goals → permissions; MMKV persistence; same FTUX analytics; non‑blocking push/camera prompts.
  - HubReports: modal route with week/month and prev/next; lazy Fitness/Expenses/Routine/Nutrition cards reading MMKV; Kyiv‑week aggregation; cross‑module insights; HTML export/share gated behind `analytics-export-pdf`.

<sup>Written for commit 8a30b3ed3d893278fb7192d63535b6c2903c9681. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3140?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

