### PR TITLE
fix(web): RQ keys factory for webhook-tx prefix in useActivationV2Boot (Hard Rule #2)

### DIFF
--- a/apps/web/src/core/activation/useActivationV2Boot.ts
+++ b/apps/web/src/core/activation/useActivationV2Boot.ts
@@ -119,7 +119,7 @@ function countCategorizedTransactions(
   // `["finyk", "mono", "webhook-tx"]` (the live webhook txn
   // buckets — date-bounded keys collapse under this prefix).
   for (const query of cache.findAll({
-    queryKey: ["finyk", "mono", "webhook-tx"] as const,
+    queryKey: finykKeys.monoWebhookTransactionsPrefix,
   })) {
     const data = query.state.data as MonoTransactionDto[] | undefined;
     if (!Array.isArray(data)) continue;

--- a/apps/web/src/shared/lib/api/queryKeys.ts
+++ b/apps/web/src/shared/lib/api/queryKeys.ts
@@ -76,6 +76,12 @@ export const finykKeys = {
   monoWebhookAccounts: ["finyk", "mono", "webhook-accounts"] as const,
   monoWebhookTransactions: (params?: string) =>
     ["finyk", "mono", "webhook-tx", params ?? "all"] as const,
+  /**
+   * Prefix over every `monoWebhookTransactions(...)` bucket — the 3-element
+   * head shared by all date-bounded keys. Use with `findAll`/`removeQueries`
+   * to match every webhook-tx cache entry regardless of its `params` tail.
+   */
+  monoWebhookTransactionsPrefix: ["finyk", "mono", "webhook-tx"] as const,
 
   // Privatbank read endpoints
   privat: ["finyk", "privat"] as const,


### PR DESCRIPTION
## Summary

Fixes the one **Hard Rule #2** violation confirmed (high severity) by the 2026-05-29 drift audit: `apps/web/src/core/activation/useActivationV2Boot.ts:122` passed an inline `["finyk","mono","webhook-tx"]` literal to `cache.findAll` instead of a centralized factory key.

The existing `finykKeys.monoWebhookTransactions(params?)` returns a **4-element** date-bounded key (`[...,"webhook-tx", params ?? "all"]`), but this call site needs the **3-element prefix** for a `findAll` prefix-match across all date buckets — so it couldn't just reuse the existing factory entry.

## Fix

- `queryKeys.ts` — add `finykKeys.monoWebhookTransactionsPrefix = ["finyk","mono","webhook-tx"] as const` (the shared head over every `monoWebhookTransactions(...)` bucket).
- `useActivationV2Boot.ts:122` — reference the factory prefix instead of the inline literal.

Same runtime key; now single-sourced (HR#2-compliant) and bulk-invalidate-friendly. Also keeps the RQ-factory roster honest — this is exactly the kind of inline-key drift the audit flagged in AGENTS.md/rules (addressed in #3146).

## Test plan

- [x] `eslint` on both files — clean (rq-keys rule no longer flags)
- [x] pre-commit `staged-typecheck` — passed (factory prop is `as const`, consumed as a readonly queryKey)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized the Mono webhook transactions RQ key: added `finykKeys.monoWebhookTransactionsPrefix` and replaced the inline key in `useActivationV2Boot`. Fixes the Hard Rule #2 violation and enables consistent prefix-based cache ops via `cache.findAll`/`removeQueries`.

<sup>Written for commit 710e2749236dd5f907f0d03cc62cc72e8544fa6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

