### PR TITLE
feat(server): plan-aware AI quota — free=5/day, pro=unlimited (ADR-1.7)

### DIFF
--- a/apps/server/src/modules/chat/aiQuota.test.ts
+++ b/apps/server/src/modules/chat/aiQuota.test.ts
@@ -239,6 +239,73 @@ describe("assertAiQuota (default bucket)", () => {
   });
 });
 
+describe("assertAiQuota (plan-aware user limit — ADR-1.7)", () => {
+  const findUpsert = () =>
+    pool.query.mock.calls.find((c) =>
+      /INSERT INTO ai_usage_daily/.test(c[0] as string),
+    );
+
+  beforeEach(() => {
+    process.env["DATABASE_URL"] = "postgres://ignored";
+    process.env["AI_QUOTA_DISABLED"] = "0";
+  });
+
+  it("caps an authenticated FREE user at 5/day (billing FREE_LIMITS)", async () => {
+    getSessionUser.mockResolvedValue({ id: "u-free" });
+    pool.query.mockImplementation(async (sql: string) => {
+      // No subscription row → getUserPlan() returns synthetic free plan.
+      if (/FROM subscriptions/i.test(sql)) return { rows: [], rowCount: 0 };
+      return { rows: [{ request_count: 1 }], rowCount: 1 };
+    });
+    const res = makeRes();
+    const ok = await assertAiQuota(makeReq(), res);
+    expect(ok).toBe(true);
+    expect(res.headers["X-AI-Quota-Remaining"]).toBe("4"); // 5 - 1
+    const upsert = findUpsert();
+    expect(upsert).toBeDefined();
+    expect((upsert![1] as unknown[])[4]).toBe(5); // limit passed to UPSERT
+  });
+
+  it("leaves an authenticated PRO user unlimited (no quota row written)", async () => {
+    getSessionUser.mockResolvedValue({ id: "u-pro" });
+    pool.query.mockImplementation(async (sql: string) => {
+      if (/FROM subscriptions/i.test(sql))
+        return {
+          rows: [
+            {
+              plan: "pro",
+              status: "active",
+              current_period_end: null,
+              cancel_at_period_end: false,
+              provider: "stripe",
+            },
+          ],
+          rowCount: 1,
+        };
+      return { rows: [{ request_count: 1 }], rowCount: 1 };
+    });
+    const res = makeRes();
+    const ok = await assertAiQuota(makeReq(), res);
+    expect(ok).toBe(true);
+    expect(res.statusCode).toBe(200);
+    expect(findUpsert()).toBeUndefined(); // unlimited → no ai_usage_daily write
+  });
+
+  it("falls back to the FREE cap when the plan lookup throws", async () => {
+    getSessionUser.mockResolvedValue({ id: "u-err" });
+    pool.query.mockImplementation(async (sql: string) => {
+      if (/FROM subscriptions/i.test(sql)) throw new Error("subs db blip");
+      return { rows: [{ request_count: 1 }], rowCount: 1 };
+    });
+    const res = makeRes();
+    const ok = await assertAiQuota(makeReq(), res);
+    expect(ok).toBe(true);
+    const upsert = findUpsert();
+    expect(upsert).toBeDefined();
+    expect((upsert![1] as unknown[])[4]).toBe(5); // free cap enforced despite error
+  });
+});
+
 describe("consumeToolQuota (tool buckets)", () => {
   beforeEach(() => {
     process.env["DATABASE_URL"] = "postgres://ignored";

--- a/apps/server/src/modules/chat/aiQuota.ts
+++ b/apps/server/src/modules/chat/aiQuota.ts
@@ -5,6 +5,8 @@ import { getIp } from "../../http/rateLimit.js";
 import { logger } from "../../obs/logger.js";
 import { aiQuotaBlocksTotal, aiQuotaFailOpenTotal } from "../../obs/metrics.js";
 import { aiQuotaCircuitBreaker } from "./aiQuotaCircuitBreaker.js";
+import { getUserPlan } from "../billing/getUserPlan.js";
+import { effectiveLimits as planLimits } from "../billing/effectiveLimits.js";
 
 type SessionUser = { id: string } | null;
 
@@ -32,11 +34,6 @@ interface QuotaResult {
   remaining: number | null;
   limit: number | null;
   reason?: "disabled" | "limit" | "store_unavailable";
-}
-
-interface EffectiveLimits {
-  user: number | null;
-  anon: number | null;
 }
 
 interface ConsumeQuotaOpts {
@@ -105,12 +102,38 @@ export function isAiQuotaDisabled(): boolean {
   return v === "1" || v === "true";
 }
 
-function effectiveLimits(): EffectiveLimits {
-  if (isAiQuotaDisabled()) return { user: null, anon: null };
-  return {
-    user: parseLimit("AI_DAILY_USER_LIMIT", 120),
-    anon: parseLimit("AI_DAILY_ANON_LIMIT", 40),
-  };
+const DEFAULT_ANON_LIMIT = 40;
+
+/** Daily AI-message cap for an anonymous (IP-keyed) caller — env-tunable. */
+function anonDailyLimit(): number | null {
+  return parseLimit("AI_DAILY_ANON_LIMIT", DEFAULT_ANON_LIMIT);
+}
+
+/**
+ * Plan-aware daily AI-message cap for an authenticated user (ADR-1.7).
+ * Free → `FREE_LIMITS.aiRequestsPerDay` (5); Pro → `null` (unlimited).
+ * Sourced from `billing/effectiveLimits` so the paid limit lives in one place.
+ *
+ * On a plan-lookup error we fall back to the FREE cap — never silently grant
+ * unlimited (the monetization-safe default). A full DB outage is still
+ * absorbed by the `consumeQuota` fail-open path downstream, so a transient
+ * blip degrades to "free cap", not "blocked".
+ *
+ * No plan cache: the lookup is a single indexed point-read on `subscriptions`
+ * and is dwarfed by the upstream Anthropic call. Add a short-TTL cache here
+ * (ADR-1.7) only if profiling shows it matters.
+ */
+async function userDailyLimit(userId: string): Promise<number | null> {
+  let plan: "free" | "pro" = "free";
+  try {
+    plan = (await getUserPlan(pool, userId)).plan === "pro" ? "pro" : "free";
+  } catch (e: unknown) {
+    logger.warn({
+      msg: "ai_quota_plan_lookup_failed",
+      err: { message: (e as Error)?.message || String(e) },
+    });
+  }
+  return planLimits(plan).aiRequestsPerDay;
 }
 
 function toolCost(): number {
@@ -172,9 +195,10 @@ export async function assertAiQuota(
 ): Promise<boolean> {
   if (isAiQuotaDisabled()) return true;
 
-  const { user: userLimit, anon: anonLimit } = effectiveLimits();
   const sessionUser = await safeSessionUser(req);
-  const limit = sessionUser ? userLimit : anonLimit;
+  const limit = sessionUser
+    ? await userDailyLimit(sessionUser.id)
+    : anonDailyLimit();
 
   if (limit == null) return true;
 


### PR DESCRIPTION
## Summary

Implements the **accepted ADR-1.7** decision that was never wired up — the high-severity monetization gap from the 2026-05-29 drift audit. Founder decision (2026-05-29): **enforce now** (no live users yet → no migration impact; not gated on `STRIPE_ENABLED`).

**The gap:** `assertAiQuota` read a flat `AI_DAILY_USER_LIMIT` (default 120) for every authenticated user, so the free-tier "5 AI messages/day" cap (ADR-1.6/0051) was unenforced, and `billing/effectiveLimits()` (FREE=5/PRO=∞) was dead code with no production importer.

## Change

`assertAiQuota` now resolves the authenticated user's daily cap via `getUserPlan(pool, userId)` → `billing.effectiveLimits(plan).aiRequestsPerDay`:
- **free → 5/day**, **pro → unlimited** (`null`).
- Anonymous callers keep the env-tunable `AI_DAILY_ANON_LIMIT` (default 40).
- This gives `billing/effectiveLimits` its **first production consumer** (kills the dead-code finding).
- **Fail-safe:** a plan-lookup error falls back to the FREE cap — never silently grants unlimited. A full DB outage is still absorbed by the existing `consumeQuota` fail-open path.
- **No plan cache:** a single indexed point-read on `subscriptions`, dwarfed by the Anthropic call. ADR-1.7's `planCache` left as a future optimization (noted in code).
- Removed the now-unused local `effectiveLimits()` / `EffectiveLimits` and the flat `AI_DAILY_USER_LIMIT` user path.

## Tests

Added (existing anon tests unchanged):
- authenticated **free** user capped at 5 (UPSERT limit arg = 5, remaining header correct);
- authenticated **pro** user unlimited (no `ai_usage_daily` row written);
- plan-lookup **error** degrades to the free cap.

## Verification note ⚠️

Ran locally: **`eslint` clean** + **pre-commit `staged-typecheck` passed (280 ms)** — types are sound. I could **not** run the vitest suite locally — this clone is missing the `@sergeant/shared` workspace symlink (`pnpm install` not run here) and a full typecheck times out on this hardware (repo slow-hardware policy). The new/existing tests will run in **CI** on this PR. Please confirm CI green before merge.

Closes the last actionable finding from the 2026-05-29 drift audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * AI quota enforcement now varies by subscription plan: FREE users limited to 5 requests/day, PRO users enjoy unlimited access.
  * Anonymous user daily limits are now configurable via environment settings.

* **Tests**
  * Added test coverage for plan-aware quota behavior, including graceful fallback to FREE tier limits when plan lookup fails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Skords-01/Sergeant/pull/3150?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->