### PR TITLE
fix: drift-audit code tail — max-lines gate, Kyiv day key, reminder ordering, Stripe plus

### DIFF
--- a/apps/server/src/modules/billing/stripe.ts
+++ b/apps/server/src/modules/billing/stripe.ts
@@ -273,20 +273,24 @@ function getStripeSecretKey(): string {
   return key;
 }
 
-function getPriceId(plan: BillingPlan): string {
-  // P0-7 (docs/audits/2026-05-13-revenue-monetization-roast.md): read
-  // from the Zod-validated `env` so the `price_*` format is checked
-  // up-front and `assertStartupEnv` can refuse to boot in production
-  // when billing is wired but the price ID is missing.
-  const envName =
-    plan === "plus"
-      ? "STRIPE_PRICE_ID_PLUS_MONTHLY"
-      : "STRIPE_PRICE_ID_PRO_MONTHLY";
-  const priceId =
-    plan === "plus"
-      ? env.STRIPE_PRICE_ID_PLUS_MONTHLY
-      : env.STRIPE_PRICE_ID_PRO_MONTHLY;
-  if (!priceId) throw new BillingConfigurationError(`${envName} is not set`);
+function getPriceId(_plan: BillingPlan): string {
+  // Pricing v3 (ADR-0051): Stripe sells Pro only — the legacy 'plus' tier was
+  // removed, so every checkout maps to the Pro price regardless of the
+  // requested plan (consistent with `normalizePlan` always returning "pro").
+  // FOLLOW-UP: narrow `BillingPlanSchema` to `["pro"]` and drop
+  // `STRIPE_PRICE_ID_PLUS_MONTHLY` once the api-client contract can be
+  // regenerated together (Hard Rule #3 triplet).
+  //
+  // P0-7 (docs/audits/2026-05-13-revenue-monetization-roast.md): read from the
+  // Zod-validated `env` so the `price_*` format is checked up-front and
+  // `assertStartupEnv` can refuse to boot when billing is wired but the price
+  // ID is missing.
+  const priceId = env.STRIPE_PRICE_ID_PRO_MONTHLY;
+  if (!priceId) {
+    throw new BillingConfigurationError(
+      "STRIPE_PRICE_ID_PRO_MONTHLY is not set",
+    );
+  }
   return priceId;
 }
 

--- a/apps/web/src/modules/finyk/components/ManualExpenseSheet.tsx
+++ b/apps/web/src/modules/finyk/components/ManualExpenseSheet.tsx
@@ -18,7 +18,6 @@ import {
 import { hapticSuccess } from "@shared/lib/adapters/haptic";
 import { formatMoney } from "@sergeant/shared";
 import { Icon } from "@shared/components/ui/Icon";
-import type { IconName } from "@shared/components/ui/Icon";
 import { Badge } from "@shared/components/ui/Badge";
 import {
   CANONICAL_TO_MANUAL_LABEL,
@@ -26,161 +25,24 @@ import {
   type FrequentMerchant,
 } from "@sergeant/finyk-domain/domain/personalization";
 
-// ─── Category slug system (F5b, 2026-05) ────────────────────────────────────
-//
-// Era 1 — pre-emoji (legacy): category stored as bare UA label, e.g. "їжа",
-//   "транспорт". Upgraded at read-time via LEGACY_RAW_TO_SLUG.
-//
-// Era 2 — emoji-prefixed (legacy): "🍴 їжа", "🚗 транспорт". Upgraded at
-//   read-time by stripping leading emoji, then mapping the UA label to slug
-//   via UA_LABEL_TO_SLUG.
-//
-// Era 3 — slug (current): "food", "transport", "groceries", etc. Used
-//   directly. Write path always emits a slug.
-//
-// Historical records in localStorage are NOT batch-migrated. upgradeCategory()
-// normalises them on every read, then the result (always a slug) is stored
-// on submit.
+// Category-slug system (types, display map, three-era upgrade) extracted to
+// `./manualExpenseCategories` to keep this component under the 600-LOC
+// `max-lines` gate (Hard Rule #18 / initiative 0013). Re-exported below for
+// backward-compat with existing importers.
+import {
+  CATEGORY_DISPLAY,
+  CATEGORY_SLUGS,
+  DEFAULT_CATEGORY,
+  isCategorySlug,
+  upgradeCategory,
+  type CategorySlug,
+} from "./manualExpenseCategories";
 
-/** Typed category slugs. */
-export type CategorySlug =
-  | "food"
-  | "groceries"
-  | "cafe"
-  | "transport"
-  | "entertainment"
-  | "health"
-  | "shopping"
-  | "utilities"
-  | "tech"
-  | "subscriptions"
-  | "education"
-  | "travel"
-  | "other";
-
-interface CategoryDisplay {
-  iconName: IconName;
-  /** Human-readable Ukrainian label shown in the chip. */
-  label: string;
-}
-
-/**
- * Canonical display map: slug → { iconName, label }.
- * Single source of truth for rendering. No emoji — icons only.
- */
-export const CATEGORY_DISPLAY: Record<CategorySlug, CategoryDisplay> = {
-  food: { iconName: "utensils", label: "Їжа" },
-  groceries: { iconName: "shopping-cart", label: "Продукти" },
-  cafe: { iconName: "coffee", label: "Кафе та ресторани" },
-  transport: { iconName: "truck", label: "Транспорт" },
-  entertainment: { iconName: "sparkles", label: "Розваги" },
-  health: { iconName: "heart", label: "Здоров'я" },
-  shopping: { iconName: "tag", label: "Покупки" },
-  utilities: { iconName: "home", label: "Комунальні" },
-  tech: { iconName: "monitor", label: "Техніка" },
-  subscriptions: { iconName: "repeat", label: "Підписки" },
-  education: { iconName: "book", label: "Навчання" },
-  travel: { iconName: "compass", label: "Подорожі" },
-  other: { iconName: "tag", label: "Інше" },
-};
-
-/**
- * The ordered list of slugs used for the category picker.
- * Matches the former CATEGORIES array in display order.
- */
-const CATEGORY_SLUGS: CategorySlug[] = [
-  "food",
-  "groceries",
-  "cafe",
-  "transport",
-  "entertainment",
-  "health",
-  "shopping",
-  "utilities",
-  "tech",
-  "subscriptions",
-  "education",
-  "travel",
-  "other",
-];
-
-const DEFAULT_CATEGORY: CategorySlug = "other";
-
-// Era 1 upgrade map: bare UA label (lower-case) → slug.
-// Covers all the pre-emoji strings that were stored before the emoji era.
-const LEGACY_RAW_TO_SLUG: Record<string, CategorySlug> = {
-  їжа: "food",
-  продукти: "groceries",
-  "кафе та ресторани": "cafe",
-  кафе: "cafe",
-  транспорт: "transport",
-  розваги: "entertainment",
-  "здоров'я": "health",
-  здоров: "health",
-  одяг: "shopping",
-  покупки: "shopping",
-  комунальні: "utilities",
-  техніка: "tech",
-  підписки: "subscriptions",
-  навчання: "education",
-  подорожі: "travel",
-  інше: "other",
-};
-
-// Era 2 upgrade map: stripped UA label from emoji string → slug.
-// Keys are the labels that appear AFTER the emoji prefix (lower-case).
-// Identical to LEGACY_RAW_TO_SLUG — the strip makes them equivalent,
-// so we reuse the same map for both eras.
-const UA_LABEL_TO_SLUG = LEGACY_RAW_TO_SLUG;
-
-/** Returns true if the value is a known slug. */
-function isCategorySlug(value: string): value is CategorySlug {
-  return Object.prototype.hasOwnProperty.call(CATEGORY_DISPLAY, value);
-}
-
-/**
- * Strips leading emoji + space so "🍴 їжа" → "їжа".
- * Accepts any run of non-letter / non-digit grapheme chunks so compound
- * emoji (ZWJ sequences, variation selectors) are all peeled off.
- */
-function stripLeadingEmoji(str: string): string {
-  const s = String(str || "");
-  let i = 0;
-  while (i < s.length && !/[\p{L}\p{N}]/u.test(s[i]!)) i++;
-  return s.slice(i).trim();
-}
-
-/**
- * Normalises any stored category value to a CategorySlug.
- *
- * Era 3 (slug): returned directly if recognised.
- * Era 2 (emoji-prefixed): emoji stripped, UA label looked up in UA_LABEL_TO_SLUG.
- * Era 1 (bare UA label): looked up directly in LEGACY_RAW_TO_SLUG.
- * Unknown: falls back to "other".
- *
- * @example
- * upgradeCategory("food")      // Era 3 → "food"
- * upgradeCategory("🍴 їжа")   // Era 2 → "food"
- * upgradeCategory("їжа")       // Era 1 → "food"
- * upgradeCategory(null)         // → "other"
- */
-export function upgradeCategory(raw: string | null | undefined): CategorySlug {
-  if (!raw) return DEFAULT_CATEGORY;
-
-  const trimmed = raw.trim();
-
-  // Era 3: known slug — use directly.
-  if (isCategorySlug(trimmed)) return trimmed;
-
-  // Era 2: emoji-prefixed string — strip emoji then map the UA label.
-  // Era 1: bare UA label — also matched by the stripped path (no-op strip).
-  const stripped = stripLeadingEmoji(trimmed).toLocaleLowerCase("uk-UA");
-  const fromLabel = UA_LABEL_TO_SLUG[stripped];
-  if (fromLabel) return fromLabel;
-
-  // Unknown legacy value — graceful fallback.
-  return DEFAULT_CATEGORY;
-}
+export {
+  CATEGORY_DISPLAY,
+  upgradeCategory,
+  type CategorySlug,
+} from "./manualExpenseCategories";
 
 // Amount suggestion pills. Defaults give a first-run user sane round
 // values; personalised «часті» amounts (from top merchants' average

--- a/apps/web/src/modules/finyk/components/manualExpenseCategories.ts
+++ b/apps/web/src/modules/finyk/components/manualExpenseCategories.ts
@@ -1,0 +1,166 @@
+/**
+ * Last validated: 2026-05-29
+ * Status: Active
+ *
+ * Category-slug system for ManualExpenseSheet. Extracted from
+ * `ManualExpenseSheet.tsx` so that component stays under the 600-LOC
+ * `max-lines` gate (Hard Rule #18 / initiative 0013). Pure logic + data —
+ * no React.
+ */
+import type { IconName } from "@shared/components/ui/Icon";
+
+// ─── Category slug system (F5b, 2026-05) ────────────────────────────────────
+//
+// Era 1 — pre-emoji (legacy): category stored as bare UA label, e.g. "їжа",
+//   "транспорт". Upgraded at read-time via LEGACY_RAW_TO_SLUG.
+//
+// Era 2 — emoji-prefixed (legacy): "🍴 їжа", "🚗 транспорт". Upgraded at
+//   read-time by stripping leading emoji, then mapping the UA label to slug
+//   via UA_LABEL_TO_SLUG.
+//
+// Era 3 — slug (current): "food", "transport", "groceries", etc. Used
+//   directly. Write path always emits a slug.
+//
+// Historical records in localStorage are NOT batch-migrated. upgradeCategory()
+// normalises them on every read, then the result (always a slug) is stored
+// on submit.
+
+/** Typed category slugs. */
+export type CategorySlug =
+  | "food"
+  | "groceries"
+  | "cafe"
+  | "transport"
+  | "entertainment"
+  | "health"
+  | "shopping"
+  | "utilities"
+  | "tech"
+  | "subscriptions"
+  | "education"
+  | "travel"
+  | "other";
+
+export interface CategoryDisplay {
+  iconName: IconName;
+  /** Human-readable Ukrainian label shown in the chip. */
+  label: string;
+}
+
+/**
+ * Canonical display map: slug → { iconName, label }.
+ * Single source of truth for rendering. No emoji — icons only.
+ */
+export const CATEGORY_DISPLAY: Record<CategorySlug, CategoryDisplay> = {
+  food: { iconName: "utensils", label: "Їжа" },
+  groceries: { iconName: "shopping-cart", label: "Продукти" },
+  cafe: { iconName: "coffee", label: "Кафе та ресторани" },
+  transport: { iconName: "truck", label: "Транспорт" },
+  entertainment: { iconName: "sparkles", label: "Розваги" },
+  health: { iconName: "heart", label: "Здоров'я" },
+  shopping: { iconName: "tag", label: "Покупки" },
+  utilities: { iconName: "home", label: "Комунальні" },
+  tech: { iconName: "monitor", label: "Техніка" },
+  subscriptions: { iconName: "repeat", label: "Підписки" },
+  education: { iconName: "book", label: "Навчання" },
+  travel: { iconName: "compass", label: "Подорожі" },
+  other: { iconName: "tag", label: "Інше" },
+};
+
+/**
+ * The ordered list of slugs used for the category picker.
+ * Matches the former CATEGORIES array in display order.
+ */
+export const CATEGORY_SLUGS: CategorySlug[] = [
+  "food",
+  "groceries",
+  "cafe",
+  "transport",
+  "entertainment",
+  "health",
+  "shopping",
+  "utilities",
+  "tech",
+  "subscriptions",
+  "education",
+  "travel",
+  "other",
+];
+
+export const DEFAULT_CATEGORY: CategorySlug = "other";
+
+// Era 1 upgrade map: bare UA label (lower-case) → slug.
+// Covers all the pre-emoji strings that were stored before the emoji era.
+const LEGACY_RAW_TO_SLUG: Record<string, CategorySlug> = {
+  їжа: "food",
+  продукти: "groceries",
+  "кафе та ресторани": "cafe",
+  кафе: "cafe",
+  транспорт: "transport",
+  розваги: "entertainment",
+  "здоров'я": "health",
+  здоров: "health",
+  одяг: "shopping",
+  покупки: "shopping",
+  комунальні: "utilities",
+  техніка: "tech",
+  підписки: "subscriptions",
+  навчання: "education",
+  подорожі: "travel",
+  інше: "other",
+};
+
+// Era 2 upgrade map: stripped UA label from emoji string → slug.
+// Keys are the labels that appear AFTER the emoji prefix (lower-case).
+// Identical to LEGACY_RAW_TO_SLUG — the strip makes them equivalent,
+// so we reuse the same map for both eras.
+const UA_LABEL_TO_SLUG = LEGACY_RAW_TO_SLUG;
+
+/** Returns true if the value is a known slug. */
+export function isCategorySlug(value: string): value is CategorySlug {
+  return Object.prototype.hasOwnProperty.call(CATEGORY_DISPLAY, value);
+}
+
+/**
+ * Strips leading emoji + space so "🍴 їжа" → "їжа".
+ * Accepts any run of non-letter / non-digit grapheme chunks so compound
+ * emoji (ZWJ sequences, variation selectors) are all peeled off.
+ */
+function stripLeadingEmoji(str: string): string {
+  const s = String(str || "");
+  let i = 0;
+  while (i < s.length && !/[\p{L}\p{N}]/u.test(s[i]!)) i++;
+  return s.slice(i).trim();
+}
+
+/**
+ * Normalises any stored category value to a CategorySlug.
+ *
+ * Era 3 (slug): returned directly if recognised.
+ * Era 2 (emoji-prefixed): emoji stripped, UA label looked up in UA_LABEL_TO_SLUG.
+ * Era 1 (bare UA label): looked up directly in LEGACY_RAW_TO_SLUG.
+ * Unknown: falls back to "other".
+ *
+ * @example
+ * upgradeCategory("food")      // Era 3 → "food"
+ * upgradeCategory("🍴 їжа")   // Era 2 → "food"
+ * upgradeCategory("їжа")       // Era 1 → "food"
+ * upgradeCategory(null)         // → "other"
+ */
+export function upgradeCategory(raw: string | null | undefined): CategorySlug {
+  if (!raw) return DEFAULT_CATEGORY;
+
+  const trimmed = raw.trim();
+
+  // Era 3: known slug — use directly.
+  if (isCategorySlug(trimmed)) return trimmed;
+
+  // Era 2: emoji-prefixed string — strip emoji then map the UA label.
+  // Era 1: bare UA label — also matched by the stripped path (no-op strip).
+  const stripped = stripLeadingEmoji(trimmed).toLocaleLowerCase("uk-UA");
+  const fromLabel = UA_LABEL_TO_SLUG[stripped];
+  if (fromLabel) return fromLabel;
+
+  // Unknown legacy value — graceful fallback.
+  return DEFAULT_CATEGORY;
+}

--- a/apps/web/src/modules/fizruk/hooks/useFizrukWorkoutReminder.ts
+++ b/apps/web/src/modules/fizruk/hooks/useFizrukWorkoutReminder.ts
@@ -74,35 +74,51 @@ export function useFizrukWorkoutReminder({
       if (typeof Notification === "undefined") return;
       if (Notification.permission !== "granted") return;
 
+      // Optimistic in-memory guard so the 30s interval doesn't double-fire
+      // while the (async) notification is being shown. The day is persisted to
+      // localStorage only AFTER a successful show — otherwise a failed
+      // notification would permanently suppress today's reminder across
+      // reloads. On failure we clear the in-memory guard so the next tick
+      // retries.
       firedRef.current = dayStr;
-      safeWriteLS(LAST_KEY, dayStr);
+      const persistFired = () => safeWriteLS(LAST_KEY, dayStr);
+      const onShowFailed = () => {
+        firedRef.current = null;
+      };
+
+      const title = "Фізрук — тренування";
+      const body =
+        "Заплановане тренування на сьогодні. Відкрий застосунок, щоб стартувати.";
 
       try {
         if ("serviceWorker" in navigator) {
           navigator.serviceWorker.ready
-            .then((reg) => {
-              reg.showNotification("Фізрук — тренування", {
-                body: "Заплановане тренування на сьогодні. Відкрий застосунок, щоб стартувати.",
+            .then((reg) =>
+              reg.showNotification(title, {
+                body,
                 tag: `fizruk-plan-${dayStr}`,
                 icon: "/icon-192.png",
                 badge: "/icon-192.png",
                 requireInteraction: false,
                 data: { action: "open", module: "fizruk" },
-              });
-            })
+              }),
+            )
+            .then(persistFired)
             .catch(() => {
-              new Notification("Фізрук — тренування", {
-                body: "Заплановане тренування на сьогодні. Відкрий застосунок, щоб стартувати.",
-                tag: "fizruk-plan",
-              });
+              try {
+                new Notification(title, { body, tag: "fizruk-plan" });
+                persistFired();
+              } catch {
+                onShowFailed();
+              }
             });
         } else {
-          new Notification("Фізрук — тренування", {
-            body: "Заплановане тренування на сьогодні. Відкрий застосунок, щоб стартувати.",
-            tag: "fizruk-plan",
-          });
+          new Notification(title, { body, tag: "fizruk-plan" });
+          persistFired();
         }
-      } catch {}
+      } catch {
+        onShowFailed();
+      }
     };
 
     const id = setInterval(tick, 30_000);

--- a/packages/shared/src/lib/nudges.ts
+++ b/packages/shared/src/lib/nudges.ts
@@ -23,7 +23,7 @@ const REENGAGEMENT_SHOWN_KEY = "hub_reengagement_shown_v1";
  * surfaces. Day-2 is the earliest meaningful loop: D1 covers itself with the
  * primary daily nudge, while D7+ is owned by the email drip (S4.3) and push
  * scheduling (S4.2). The 1-per-day rate limit (`REENGAGEMENT_SHOWN_KEY`) keeps
- * the card from re-firing within the same UTC day.
+ * the card from re-firing within the same Europe/Kyiv day.
  */
 export const REENGAGEMENT_INACTIVE_DAYS = 2;
 
@@ -165,7 +165,12 @@ export function getActiveNudge(
 
 function todayKey(now?: Date): string {
   const d = now ?? new Date();
-  return d.toISOString().slice(0, 10);
+  // Europe/Kyiv day boundary (domain invariant) — NOT UTC. A user active at
+  // 01:00 Kyiv (23:00 UTC the day before) must count as "today", otherwise the
+  // re-engagement gap is off by a day near midnight. `en-CA` formats YYYY-MM-DD.
+  return new Intl.DateTimeFormat("en-CA", { timeZone: "Europe/Kyiv" }).format(
+    d,
+  );
 }
 
 /** Record the current date as last active. Call on every hub mount. */


### PR DESCRIPTION
## Summary

The genuine **code** findings from the 2026-05-29 drift audit (the doc-drift tail ships separately). 4 independent commits.

## Fixes

- **`refactor(web)` — ManualExpenseSheet max-lines gate (the "red lint gate").** The file was 601 effective LOC, over the 600 `max-lines` gate → `pnpm lint` was red on it. (My earlier 0013 closure note "allowlist empty / lint green" was inaccurate — an empty allowlist ≠ every file under threshold.) Extracted the self-contained category-slug system (types, `CATEGORY_DISPLAY`, three-era `upgradeCategory` + legacy maps) into a pure `manualExpenseCategories.ts`; component re-exports `upgradeCategory`/`CATEGORY_DISPLAY`/`CategorySlug` for back-compat. No behaviour change; file now passes `max-lines`.
- **`fix(shared)` — re-engagement day key uses Europe/Kyiv, not UTC** (Hard Rule / domain invariant). `nudges.todayKey` used `toISOString()` (UTC); a user active at 01:00 Kyiv counted as the previous day. Now `Intl.DateTimeFormat("en-CA", { timeZone: "Europe/Kyiv" })`, matching the server-side pattern.
- **`fix(web)` — Fizruk reminder marks the day fired only after the notification shows.** It persisted "fired" *before* awaiting `showNotification`, so a failed notification permanently suppressed today's reminder across reloads. Now persists only on success; the optimistic in-memory guard is cleared on failure so the next 30s tick retries.
- **`fix(server)` — `getPriceId` always maps to the Pro price (ADR-0051).** Removed the dead `plan === "plus"` branch. Narrowing `BillingPlanSchema` to `["pro"]` + dropping the plus env var is a documented follow-up (needs a coordinated api-client contract regen, Hard Rule #3).

## Verification note ⚠️

Ran locally: **`eslint` clean** on all 5 files + **pre-commit `staged-typecheck` passed** on each commit + **`max-lines` confirmed passing** on ManualExpenseSheet. Could not run the full vitest suites locally (this clone lacks the `@sergeant/shared` workspace symlink; full typecheck times out on this hardware — repo slow-hardware policy). **CI must confirm green before merge.**

Part of finishing the 2026-05-29 drift audit (code tail). Doc-drift tail in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)