### PR TITLE
docs(docs): close hub-dashboard F16+F18 findings (Batch 1)

### DIFF
--- a/docs/audits/2026-05-13-page-audit-02-hub-dashboard.md
+++ b/docs/audits/2026-05-13-page-audit-02-hub-dashboard.md
@@ -579,6 +579,8 @@ for (let i = 0; i < order.length; i++) {
 
 ### F16 — `HubReports.tsx` ≈603 LOC — на межі Hard Rule #18 (max-lines: 600) [severity: medium] [perspective: rule]
 
+> **Closure note (2026-05-31, audits-runner triage):** Resolved — Sprint 2 0017 split shipped. `apps/web/src/core/hub/HubReports.tsx` тепер 261 LOC (було 603). Файл — чистий container; BarChart, StatCard, useReportData, generateInsights винесені у свої модулі. Hard Rule #18 проходить з широким запасом.
+
 **Page:** Hub Reports
 **File:** `apps/web/src/core/hub/HubReports.tsx`
 **Lines:** entire file
@@ -632,6 +634,8 @@ brand: { ... },
 ---
 
 ### F18 — `HubReports.tsx` `raw!.txs` — non-null на narrowed union [severity: low] [perspective: ts]
+
+> **Closure note (2026-05-31, audits-runner triage):** Resolved — після F16 split логіка переїхала у `apps/web/src/core/hub/ExpensesCard.tsx:189-197`. Поточна реалізація використовує безпечний `Array.isArray((raw as { txs?: unknown[] } | null)?.txs)` + `(raw as { txs: unknown[] }).txs` cast; non-null assertion `raw!.txs` прибрано. F18 більше не актуальний.
 
 **Page:** Hub Reports
 **File:** `apps/web/src/core/hub/HubReports.tsx`


### PR DESCRIPTION
## Summary

audits-runner triage (per [PR #3153](https://github.com/Skords-01/Sergeant/pull/3153) and `docs/audits/_runner-report.md`) flagged 4 autoSafe doc edits as Batch 1 (XS). Two of them were already applied to the codebase since their audits ran; the other two need inline closure notes on the audit doc.

This PR adds those two closure notes. Tiny by design — one file, 4 inserted lines.

- **F16** (`HubReports.tsx` 603 LOC vs Hard Rule #18 max-lines=600) — resolved by Sprint 2 0017 split. File is now 261 LOC; `BarChart`, `StatCard`, `useReportData`, `generateInsights` live in their own modules.
- **F18** (`raw!.txs` non-null assertion on narrowed union) — resolved by the F16 split. The logic moved to `apps/web/src/core/hub/ExpensesCard.tsx:189-197` and now uses a safe `Array.isArray + cast` pattern; the non-null bang is gone.

Two no-ops (already applied):

- **doc-hygiene#1** (canonicalize 3 date params in `docs/audits/archive/2026-04-28-ux-ui-audit.md`) — already done in the 2026-05-02 doc-hygiene PR; only `Last validated:` remains as single source of truth.
- **app-audit#env-example** (`.env.example` warnings for `NUTRITION_BACKUP_KEY_SECRET` and `BETTER_AUTH_TOKEN_ENC_KEY`) — already present with `⚠ prod required` warnings on `.env.example:11-12`.

## Governing Skill

- Primary skill: `sergeant-docs-governance` (audit lifecycle, closure-note convention, Hard Rule #10 freshness)
- Secondary skill: none

## Playbook

- Primary playbook: none directly matched — closure notes on audit findings follow the same pattern as `docs/audits/archive/*.md` closure notes but applied to individual findings, not whole audits.
- Why this playbook: pattern reuse from how individual items get closed inline in active audits.
- If no playbook matched, why: F-level closure-note convention is well-established in the audit corpus but not codified in a playbook. Could be a Batch-N tooling improvement.

## Verification

```bash
git diff --stat       # 1 file, 4 inserted lines
wc -l apps/web/src/core/hub/HubReports.tsx   # 261 (was 603)
grep -n "finyk_tx_cache" apps/web/src/core/hub/ExpensesCard.tsx   # L189 uses safe Array.isArray cast
grep -E "NUTRITION_BACKUP|BETTER_AUTH_TOKEN_ENC" .env.example     # both already documented
# lint-staged + commitlint passed at commit time (bd47aaf4)
```

Additional checks:

- [x] Local smoke / manual validation completed — read both source files, confirmed audit claims match current code
- [x] Surface-specific checks completed — no code paths touched; docs-only

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update — no, no policy change.
- [x] I checked whether a playbook or skill needed an update — no, see Playbook section above.
- [x] I checked whether governance docs or review docs needed an update — no, closure-note convention is unchanged.

Updated docs:

- `docs/audits/2026-05-13-page-audit-02-hub-dashboard.md` — added F16 and F18 closure notes

## Risk and Rollout

- User-visible risk: **none**. Docs-only.
- Rollout / deploy order: merge → CI re-runs `docs:check-open-work` on main (no count change — F-level closures don't affect tracker totals).
- Backout plan: revert the commit. F16/F18 findings re-appear as open in the audit text.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian (closure notes written in Ukrainian).
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files — modifies an existing active audit only.

## Reviewer Notes

- This is Batch 1 of the audits-runner Execute now plan. Batches 2–4 follow in separate PRs.
- The closure-note convention used here matches the pattern in `docs/audits/2026-05-03-readme-gap-analysis.md` and `docs/audits/2026-05-13-documentation-hygiene-roast.md` (closed in PR #3153), but applied to F-level findings inside an active audit rather than to whole-audit closure.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add closure notes to the Hub Dashboard audit to close F16 and F18 as resolved. Notes reflect the Sprint 2 split (`HubReports.tsx` now 261 LOC) and the removal of `raw!.txs` via a safe Array.isArray + cast in `ExpensesCard.tsx`.

<sup>Written for commit bd47aaf4b0eb32e297f8409c30ad8832b8fdbd7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated audit documentation to reflect completed code quality improvements and refactoring efforts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->