### PR TITLE
fix(web): add aria-label to BarChart bars across 4 module cards (Batch 6)

### DIFF
--- a/apps/web/src/core/hub/ExpensesCard.tsx
+++ b/apps/web/src/core/hub/ExpensesCard.tsx
@@ -89,6 +89,8 @@ function BarChart({
             <button
               key={dates[i]}
               type="button"
+              aria-label={formatTooltip(dates[i] ?? "", v)}
+              aria-pressed={isSelected}
               className="flex-1 flex flex-col items-center justify-end gap-0.5 h-full appearance-none bg-transparent border-0 p-0 cursor-pointer"
               onClick={() => setSelected(isSelected ? null : i)}
             >

--- a/apps/web/src/core/hub/FitnessCard.tsx
+++ b/apps/web/src/core/hub/FitnessCard.tsx
@@ -86,6 +86,8 @@ function BarChart({
             <button
               key={dates[i]}
               type="button"
+              aria-label={formatTooltip(dates[i] ?? "", v)}
+              aria-pressed={isSelected}
               className="flex-1 flex flex-col items-center justify-end gap-0.5 h-full appearance-none bg-transparent border-0 p-0 cursor-pointer"
               onClick={() => setSelected(isSelected ? null : i)}
             >

--- a/apps/web/src/core/hub/NutritionCard.tsx
+++ b/apps/web/src/core/hub/NutritionCard.tsx
@@ -85,6 +85,8 @@ function BarChart({
             <button
               key={dates[i]}
               type="button"
+              aria-label={formatTooltip(dates[i] ?? "", v)}
+              aria-pressed={isSelected}
               className="flex-1 flex flex-col items-center justify-end gap-0.5 h-full appearance-none bg-transparent border-0 p-0 cursor-pointer"
               onClick={() => setSelected(isSelected ? null : i)}
             >

--- a/apps/web/src/core/hub/RoutineCard.tsx
+++ b/apps/web/src/core/hub/RoutineCard.tsx
@@ -85,6 +85,8 @@ function BarChart({
             <button
               key={dates[i]}
               type="button"
+              aria-label={formatTooltip(dates[i] ?? "", v)}
+              aria-pressed={isSelected}
               className="flex-1 flex flex-col items-center justify-end gap-0.5 h-full appearance-none bg-transparent border-0 p-0 cursor-pointer"
               onClick={() => setSelected(isSelected ? null : i)}
             >

--- a/docs/audits/2026-05-13-page-audit-02-hub-dashboard.md
+++ b/docs/audits/2026-05-13-page-audit-02-hub-dashboard.md
@@ -55,6 +55,8 @@ const rawNutritionLog = safeReadLS(STORAGE_KEYS.NUTRITION_LOG, {});
 
 ### F2 — BarChart bar-buttons без accessible name [severity: high] [perspective: a11y]
 
+> **Closure note (2026-05-31, audits-runner triage):** Resolved. Після Sprint 2 0017 split `BarChart` компонент скопіювався у 4 module cards: `ExpensesCard.tsx`, `FitnessCard.tsx`, `NutritionCard.tsx`, `RoutineCard.tsx`. На кожному `<button>` додано `aria-label={formatTooltip(date, value)}` (формат `"31.05: 1 250 ₴"`) + `aria-pressed={isSelected}`. WCAG 4.1.2 виконано. Окремий root-level `BarChart` у `HubReports.tsx` більше не існує — splittout-консолідація закрила початковий scope.
+
 **Page:** Hub Reports
 **File:** `apps/web/src/core/hub/HubReports.tsx`
 **Lines:** L92–L141 (`BarChart` component)


### PR DESCRIPTION
## Summary

Closes **F2** from [`docs/audits/2026-05-13-page-audit-02-hub-dashboard.md`](docs/audits/2026-05-13-page-audit-02-hub-dashboard.md) — BarChart bar-buttons gain an accessible name.

Originally Batch 6 was scoped as F1 (text-error → text-danger, 14 occurrences). Grep across `apps/` and `packages/` finds zero matches for `text-error` — that finding was already resolved in a follow-up after the audit ran. Pivoted to the next actionable item, F2.

Each BarChart bar is an interactive `<button>` with only a visual `<div>` inside (height = bar %). The container had `aria-label="Графік"`, but every bar was an unnamed button — screen-reader users heard "button, button, button, …, Графік" with no values. WCAG 4.1.2 (Name, Role, Value) violation.

After Sprint 2 0017 split, `BarChart` was duplicated into 4 module cards. Added `aria-label={formatTooltip(date, value)}` (format: `"31.05: 1 250 ₴"`) and `aria-pressed={isSelected}` to every bar across:

- `apps/web/src/core/hub/ExpensesCard.tsx`
- `apps/web/src/core/hub/FitnessCard.tsx`
- `apps/web/src/core/hub/NutritionCard.tsx`
- `apps/web/src/core/hub/RoutineCard.tsx`

## Governing Skill

- Primary skill: `sergeant-web` (a11y fix on web UI components)
- Secondary skill: none

## Playbook

- Primary playbook: none directly matched.
- Why this playbook: follows the same finding-closure pattern as PR #3155 and PR #3159.
- If no playbook matched, why: no codified playbook for "add aria-label to chart components"; this is an audit-driven hotfix.

## Verification

```bash
# All 4 module-card bars now have aria-label and aria-pressed:
grep -n "aria-label={formatTooltip" apps/web/src/core/hub/{ExpensesCard,FitnessCard,NutritionCard,RoutineCard}.tsx
# 4 matches, one per file

# F1 (text-error) is a no-op — already cleaned in repo:
grep -rn "text-error\|bg-error\|border-error" apps/ packages/
# (empty)

# Pre-commit staged-typecheck, bump-last-validated, prettier + eslint — all green.
# Commit: 627f4aa4.
```

Additional checks:

- [x] Local smoke / manual validation completed — `formatTooltip` returns the same `"DD.MM: <value>"` string used in the hover tooltip; aria-label matches the visual hover text
- [x] Surface-specific checks completed — staged-typecheck passed; no API change to BarChart props

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update — no.
- [x] I checked whether a playbook or skill needed an update — no.
- [x] I checked whether governance docs or review docs needed an update — no.

Updated docs:

- `docs/audits/2026-05-13-page-audit-02-hub-dashboard.md` — F2 closure note

## Risk and Rollout

- User-visible risk: **none** for sighted users. Screen-reader users now hear "31.05: 1 250 ₴, pressed" instead of "button". This is an improvement but technically a screen-reader output change — any a11y test snapshots that asserted on the old (broken) output need updating. None found in this repo.
- Rollout / deploy order: merge → next Vite build picks up the changes. No env/DB change.
- Backout plan: revert the commit. Screen-reader users go back to hearing "button" without values.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian (closure note in Ukrainian).
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files — modifies an existing active audit's closure note only.

## Reviewer Notes

- Batch 6 of the audits-runner Execute now / Plan-first plan. Batches 1–5 already merged (#3155, #3156, #3157, #3158, #3159).
- The audit originally cited `HubReports.tsx:L92–L141`, but after Sprint 2 0017 split there is no `BarChart` left in `HubReports.tsx` — only the 4 cargo-culted copies in the module cards. The closure note documents this.
- Cargo-cult observation: the same `BarChart` body appears in 4 files. Worth tracking as a separate refactor (extract to `apps/web/src/core/hub/reports/BarChart.tsx`) but **not in this PR** — scope creep would defeat the point. Adding the extraction as a separate follow-up item to the audit-runner backlog.
- F2's "Recommendation" block in the audit also suggests adding `<title>` inside an SVG-tooltip — but the current BarChart doesn't render an SVG, only flex-divs. That part of the recommendation was based on an older version of the file and is moot.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add accessible names to BarChart bar buttons in four hub module cards so screen readers announce the date and value for each bar. This meets WCAG 4.1.2 and improves navigation for keyboard and screen-reader users.

- **Bug Fixes**
  - Added `aria-label={formatTooltip(date, value)}` and `aria-pressed={isSelected}` to each bar button in `ExpensesCard.tsx`, `FitnessCard.tsx`, `NutritionCard.tsx`, and `RoutineCard.tsx`.
  - Updated `docs/audits/2026-05-13-page-audit-02-hub-dashboard.md` with F2 closure.
  - No visual or API changes.

<sup>Written for commit 627f4aa4374a6c49f68e5b940ee212188d6dc6d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

