### PR TITLE
fix(web): respect stick-to-bottom in HubChatBody auto-scroll (F12)

### DIFF
--- a/apps/web/src/core/hub/chat/HubChatBody.tsx
+++ b/apps/web/src/core/hub/chat/HubChatBody.tsx
@@ -28,14 +28,18 @@ export interface HubChatBodyProps {
 
 /**
  * Scrollable message list + inline cancel pill while a request is
- * in flight. Auto-scrolls to bottom on every new message and on the
- * `loading` flip so the typing indicator (and the cancel pill next
- * to it) stay visible.
+ * in flight. Auto-scrolls to bottom on new messages / on the `loading`
+ * flip **only when the user is already stuck near the bottom** — once
+ * they scroll up more than `STICK_THRESHOLD_PX` to re-read history,
+ * streamed deltas no longer yank the view back (F12). Sending a new
+ * user message re-sticks (signal: user just sent → wants to see reply).
  *
  * Якщо `messages.length === 0` — рендерить `<ChatEmpty>` як
  * empty-state-placeholder з 4 chip-suggestion-ами, що префілять
  * composer (PR-26 / §A12).
  */
+const STICK_THRESHOLD_PX = 32;
+
 export function HubChatBody({
   messages,
   loading,
@@ -44,17 +48,30 @@ export function HubChatBody({
   onPickSuggestion,
 }: HubChatBodyProps) {
   const chatRef = useRef<HTMLDivElement | null>(null);
+  const stickToBottomRef = useRef(true);
+
+  const lastRole = messages[messages.length - 1]?.role;
+  // Re-stick the moment the user sends a new message — they want the reply.
+  if (lastRole === "user") stickToBottomRef.current = true;
 
   useEffect(() => {
-    if (chatRef.current)
+    if (chatRef.current && stickToBottomRef.current)
       chatRef.current.scrollTop = chatRef.current.scrollHeight;
   }, [messages, loading]);
+
+  const handleScroll = () => {
+    const el = chatRef.current;
+    if (!el) return;
+    stickToBottomRef.current =
+      el.scrollTop + el.clientHeight >= el.scrollHeight - STICK_THRESHOLD_PX;
+  };
 
   const isEmpty = messages.length === 0 && !loading;
 
   return (
     <div
       ref={chatRef}
+      onScroll={handleScroll}
       className="flex-1 overflow-y-auto overscroll-contain px-4 py-3 space-y-3 min-h-0"
       aria-live="polite"
       aria-relevant="additions"

--- a/docs/audits/2026-05-13-page-audit-03-hub-chat-search.md
+++ b/docs/audits/2026-05-13-page-audit-03-hub-chat-search.md
@@ -203,6 +203,8 @@ Any third-party site can post a link like `https://app.sergeant.lol/chat?q=<arbi
 
 ### F12 — `HubChatBody` auto-scrolls to bottom on every message change, breaking "scroll up to read history" [severity: medium] [perspective: ux]
 
+> **Closure note (2026-05-31, audits-runner triage):** Resolved. `HubChatBody` тепер тримає `stickToBottomRef` (default `true`), який гаситься в `onScroll`, коли користувач відходить від низу більш ніж на 32px, і повертається назад, коли останнє повідомлення — від користувача (signal "user just sent → wants to see reply"). Auto-scroll-effect стрибає до низу лише коли ref `true`, тож stream-delta не висмикує view під час перечитування історії.
+
 **Page:** `HubChatBody`
 **File:** `apps/web/src/core/hub/chat/HubChatBody.tsx`
 **Lines:** L44–L47


### PR DESCRIPTION
## Summary

HubChatBody used to snap `scrollTop = scrollHeight` on every message/loading change, yanking view back during streamed deltas. Now tracks `stickToBottomRef` (default true), flips false once user scrolls 32px+ from bottom, re-sticks when last message has `role === 'user'`.

Closes F12 from `docs/audits/2026-05-13-page-audit-03-hub-chat-search.md` (audits-runner Batch 11, fanout-fixes workflow).

## Governing Skill
- Primary: `sergeant-web`

## Playbook
- None.

## Verification
- staged-typecheck passed.

## Docs and Governance
- [x] Closure note added.
- [x] AGENTS.md unchanged.

## Risk and Rollout
- User-visible risk: low (UX improvement).
- Backout: revert.

## Hard Rule #15
- [x] Read AGENTS.md.
- [x] Internal docs in Ukrainian.

## Audit-freeze (until 2026-06-02)
- [x] No new top-level files.

## Reviewer Notes
- Spec by fanout-fixes workflow agent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix HubChatBody auto-scroll to only snap to bottom when the user is already near it; stop auto-scroll once they scroll 32px up and re-stick after a new `user` message so replies stay visible. Closes audit F12 in `docs/audits/2026-05-13-page-audit-03-hub-chat-search.md`.

<sup>Written for commit cbda47cf0c218ab592d514aa7e8598f57c340862. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

