### PR TITLE
fix(web): move FTUX_MODULES_HINT_KEY to STORAGE_KEYS registry (F13)

### DIFF
--- a/apps/web/src/core/hub/HubModulesGrid.tsx
+++ b/apps/web/src/core/hub/HubModulesGrid.tsx
@@ -13,7 +13,11 @@ import { cn } from "@shared/lib/ui/cn";
 import { Icon } from "@shared/components/ui/Icon";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { useLocalStorageState } from "@shared/hooks/useLocalStorageState";
-import { isActiveModule, type DashboardModuleId } from "@sergeant/shared";
+import {
+  STORAGE_KEYS,
+  isActiveModule,
+  type DashboardModuleId,
+} from "@sergeant/shared";
 import {
   DndContext,
   closestCenter,
@@ -31,11 +35,9 @@ import { DENSITY_BENTO_GAP } from "./hub.types";
 // FTUX inline hint
 // ─────────────────────────────────────────────────────────────────────
 
-const FTUX_MODULES_HINT_KEY = "sergeant.hub.ftuxModulesHint.dismissed.v1";
-
 function FtuxModulesHint() {
   const [dismissed, setDismissed] = useLocalStorageState<boolean>(
-    FTUX_MODULES_HINT_KEY,
+    STORAGE_KEYS.FTUX_MODULES_HINT_DISMISSED,
     false,
     { validate: (v): v is boolean => typeof v === "boolean" },
   );

--- a/docs/audits/2026-05-13-page-audit-02-hub-dashboard.md
+++ b/docs/audits/2026-05-13-page-audit-02-hub-dashboard.md
@@ -461,6 +461,8 @@ return () => clearTimeout(timer);
 
 ### F13 — Inline `FTUX_MODULES_HINT_KEY` за межами `STORAGE_KEYS` registry [severity: low] [perspective: rule]
 
+> **Closure note (2026-05-31, audits-runner triage):** Resolved. Додано `FTUX_MODULES_HINT_DISMISSED: "sergeant.hub.ftuxModulesHint.dismissed.v1"` у `packages/shared/src/lib/storageKeys.ts` (Hub section, поряд із `ONBOARDING_DONE`), зберігши існуючий літерал щоб не зламати state користувачів. У `apps/web/src/core/hub/HubModulesGrid.tsx` локальну `const FTUX_MODULES_HINT_KEY` прибрано, `useLocalStorageState` тепер читає `STORAGE_KEYS.FTUX_MODULES_HINT_DISMISSED` через імпорт з `@sergeant/shared`.
+
 **Page:** Modules Grid
 **File:** `apps/web/src/core/hub/HubModulesGrid.tsx`
 **Lines:** L30–L34

--- a/packages/shared/src/lib/storageKeys.ts
+++ b/packages/shared/src/lib/storageKeys.ts
@@ -30,6 +30,7 @@ export const STORAGE_KEYS = {
   ROUTINE_MAIN_TAB: "hub_routine_main_tab_v1",
   NUTRITION_MAIN_TAB: "hub_nutrition_main_tab_v1",
   ONBOARDING_DONE: "hub_onboarding_done_v1",
+  FTUX_MODULES_HINT_DISMISSED: "sergeant.hub.ftuxModulesHint.dismissed.v1",
   DASHBOARD_ORDER: "hub_dashboard_order_v1",
   HUB_PREFS: "hub_prefs_v1",
   USER_PROFILE: "hub_user_profile_v1",


### PR DESCRIPTION
## Summary

Adds `FTUX_MODULES_HINT_DISMISSED` to `packages/shared/src/lib/storageKeys.ts` (Hub section, preserving literal value). HubModulesGrid now uses `STORAGE_KEYS.FTUX_MODULES_HINT_DISMISSED`.

Closes F13 (hub-dash) from `docs/audits/2026-05-13-page-audit-02-hub-dashboard.md` (Batch 11).

## Governing Skill
- Primary: `sergeant-web`
- Secondary: `sergeant-shared`

## Verification
- staged-typecheck passed.

## Docs and Governance
- [x] Closure note added.

## Risk and Rollout
- User-visible risk: none (literal value preserved → state intact).

## Hard Rule #15
- [x] Read AGENTS.md.
- [x] Internal docs in Ukrainian.

## Audit-freeze (until 2026-06-02)
- [x] No new top-level files.

## Reviewer Notes
- Spec by fanout-fixes workflow agent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move the FTUX modules hint key into the centralized `STORAGE_KEYS` registry and update `HubModulesGrid` to use `STORAGE_KEYS.FTUX_MODULES_HINT_DISMISSED`. Literal value stays `sergeant.hub.ftuxModulesHint.dismissed.v1`, so existing dismissed state is preserved; closes audit item F13.

<sup>Written for commit 09472f46a2cefe8d1e09dd14ef75daed8fdfe233. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

