### PR TITLE
fix(web): explicit dismiss aria-labels on DemoModeBanner + DailyNudge (F24)

### DIFF
--- a/apps/web/src/core/onboarding/DailyNudge.tsx
+++ b/apps/web/src/core/onboarding/DailyNudge.tsx
@@ -110,7 +110,7 @@ export function DailyNudge({
           size="xs"
           iconOnly
           onClick={handleDismiss}
-          aria-label="Закрити"
+          aria-label="Сховати щоденну пораду"
           className="shrink-0 -mt-1 -mr-1 text-muted hover:text-text"
         >
           <Icon name="close" size={14} />

--- a/apps/web/src/core/onboarding/DemoModeBanner.tsx
+++ b/apps/web/src/core/onboarding/DemoModeBanner.tsx
@@ -95,7 +95,7 @@ export function DemoModeBanner() {
           size="xs"
           iconOnly
           onClick={dismiss}
-          aria-label="Сховати"
+          aria-label="Сховати банер демо-режиму"
           className="shrink-0 -mt-1 -mr-1 text-muted hover:text-text"
         >
           <Icon name="close" size={16} />

--- a/docs/audits/2026-05-13-page-audit-01-auth-onboarding.md
+++ b/docs/audits/2026-05-13-page-audit-01-auth-onboarding.md
@@ -621,6 +621,8 @@ Same pattern as everywhere else in the codebase.
 
 ### F24 — DemoModeBanner / DailyNudge `aria-label` doesn't communicate dismiss-X separately [severity: low] [perspective: a11y]
 
+> **Closure note (2026-05-31, audits-runner triage):** Resolved. Dismiss-X кнопкам у `DemoModeBanner.tsx:98` і `DailyNudge.tsx:113` замінено generic `aria-label="Сховати"` / `"Закрити"` на explicit `"Сховати банер демо-режиму"` / `"Сховати щоденну пораду"`. Screen-reader юзери тепер чують, що саме приховує кнопка, без TAB-розвідки в region/section.
+
 **Page:** Hub (DemoModeBanner, DailyNudge)
 **Files:** `apps/web/src/core/onboarding/DemoModeBanner.tsx:70–98`, `apps/web/src/core/onboarding/DailyNudge.tsx:65–115`
 


### PR DESCRIPTION
## Summary

Replaces generic `aria-label='Сховати'` / `'Закрити'` with explicit `'Сховати банер демо-режиму'` and `'Сховати щоденну пораду'` on the dismiss-X buttons of `DemoModeBanner` and `DailyNudge`.

Closes F24 from `docs/audits/2026-05-13-page-audit-01-auth-onboarding.md` (Batch 11).

## Governing Skill
- Primary: `sergeant-web`

## Verification
- staged-typecheck passed.

## Docs and Governance
- [x] Closure note added.

## Risk and Rollout
- User-visible risk: none (a11y improvement only).

## Hard Rule #15
- [x] Read AGENTS.md.
- [x] Internal docs in Ukrainian.

## Audit-freeze (until 2026-06-02)
- [x] No new top-level files.

## Reviewer Notes
- Spec by fanout-fixes workflow agent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced generic dismiss aria-labels in DemoModeBanner and DailyNudge with explicit labels that state what the X hides. Improves screen-reader clarity and closes F24 in docs/audits/2026-05-13-page-audit-01-auth-onboarding.md.

<sup>Written for commit 0edc08465ebb827a789afd9dc9f5a6b2d514be76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

