### PR TITLE
fix(web): gate hub-chat keyword tts behind opt-in toggle (F5)

### DIFF
--- a/apps/web/src/core/hub/chat/useChatSend.ts
+++ b/apps/web/src/core/hub/chat/useChatSend.ts
@@ -33,6 +33,11 @@ import { usePlan } from "../../billing/usePlan";
 type ChatMessage = HubChatSession["messages"][number];
 const FREE_DAILY_AI_CHAT_LIMIT = 5;
 const DAILY_CHAT_COUNT_KEY = "sergeant:ai-chat:daily-count:v1";
+const AUTO_TTS_ENABLED_KEY = "sergeant:hub-chat:auto-tts:v1";
+
+function isAutoTtsEnabled(): boolean {
+  return safeReadLS<boolean>(AUTO_TTS_ENABLED_KEY) === true;
+}
 
 function kyivDayKey(date = new Date()): string {
   return new Intl.DateTimeFormat("en-CA", {
@@ -244,7 +249,9 @@ export function useChatSend({
       }
 
       const shouldSpeak =
-        fromVoice || lastWasVoice.current || VOICE_KEYWORDS.test(msg);
+        fromVoice ||
+        lastWasVoice.current ||
+        (isAutoTtsEnabled() && VOICE_KEYWORDS.test(msg));
       lastWasVoice.current = false;
 
       const userMsg = makeUserMsg(msg);

--- a/docs/audits/2026-05-13-page-audit-03-hub-chat-search.md
+++ b/docs/audits/2026-05-13-page-audit-03-hub-chat-search.md
@@ -114,6 +114,8 @@ Any third-party site can post a link like `https://app.sergeant.lol/chat?q=<arbi
 
 **Recommendation.** Add a `preferences.tts.autoSpeak` toggle (default off). Only invoke `maybeSpeak(...)` when the user explicitly typed via voice (`fromVoice`) or has the toggle on. Keep the regex as a hint for an inline "🔊 Озвучити" button, not as a silent trigger.
 
+> ✅ **Closed 2026-05-31** — `useChatSend.ts` now gates `VOICE_KEYWORDS.test(msg)` behind `isAutoTtsEnabled()` (reads `sergeant:hub-chat:auto-tts:v1` from local storage, default `false`). Voice-initiated sends (`fromVoice`) and follow-ups to the same voice turn (`lastWasVoice`) still speak. Settings UI for the toggle tracked separately.
+
 ---
 
 ### F6 — Touch targets in `HubChatHistoryDrawer` (close, delete) are below 44×44 px [severity: high] [perspective: a11y]


### PR DESCRIPTION
## Summary

- Gate the `VOICE_KEYWORDS.test(msg)` arm of HubChat's `shouldSpeak` behind an opt-in toggle (`sergeant:hub-chat:auto-tts:v1`, default `false`).
- Voice-initiated sends (`fromVoice`) and follow-ups to the same voice turn (`lastWasVoice`) still speak.
- Resolves audit F5 (`docs/audits/2026-05-13-page-audit-03-hub-chat-search.md`).

## Governing Skill

`sergeant-hubchat` (HubChat send pipeline and TTS gating).

## Playbook

`docs/playbooks/audit-fix-page.md` — close one finding cited in an audit; closure-note inline; no new audit.

## Verification

- Type-check via pre-commit `staged-typecheck` — green.
- Manual: with no `sergeant:hub-chat:auto-tts:v1` key, typing "скажи скільки в мене грошей" no longer auto-plays TTS; explicit voice send still speaks.
- No public API change.

## Docs and Governance

- Closure note added inline at hub-chat-search audit F5.
- No new audit, no new ADR.

## Risk and Rollout

- Behavior change: keyword-triggered TTS is now off by default. No public-API or storage migration. User can re-enable by setting `sergeant:hub-chat:auto-tts:v1=true` in local storage (settings UI tracked separately).
- Hard Rule #15: no docs without code; this PR ships both code and inline closure.

## Audit-freeze

Per `AGENTS.md`, in audit-freeze until 2026-06-02 — this is a remediation of an existing audit finding, not a new audit.

## Reviewer Notes

`safeReadLS<boolean>` returns `T | null`; helper only returns `true` for explicit `true`, so `null`/missing/invalid all stay off.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gated Hub Chat’s keyword-triggered TTS behind an opt-in toggle to prevent unexpected speech. Voice-initiated sends and immediate follow-ups still speak.

- **Bug Fixes**
  - Auto TTS is off by default; enable with `sergeant:hub-chat:auto-tts:v1=true` in local storage.
  - Gates the keyword path in `useChatSend.ts`; closes audit F5.

<sup>Written for commit a03a827a0522631aea2db3f37fc033119996c539. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

