### PR TITLE
fix(web): fire PAYWALL_VIEWED once per open-edge in PaywallModal (F19)

### DIFF
--- a/apps/web/src/core/billing/PaywallModal.tsx
+++ b/apps/web/src/core/billing/PaywallModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@shared/components/ui/Button";
 import { Modal } from "@shared/components/ui/Modal";
@@ -64,15 +64,16 @@ export function PaywallModal({
   dismissLabel = "Не зараз",
 }: PaywallModalProps) {
   const navigate = useNavigate();
+  const prevOpen = useRef(false);
 
   useEffect(() => {
-    if (open) {
+    // Fire once per open false→true transition. Surface swaps while the
+    // modal stays open must NOT re-fire — that would inflate the
+    // `paywall_viewed → checkout_opened → subscription_started` funnel.
+    if (open && !prevOpen.current) {
       trackEvent(ANALYTICS_EVENTS.PAYWALL_VIEWED, { surface });
     }
-    // `surface` is part of the dependency tuple so a parent that swaps
-    // the surface while the modal stays open (rare, but possible during
-    // route transitions) re-fires the event. PostHog dedupes by uuid; we
-    // do not attempt client-side dedupe here.
+    prevOpen.current = open;
   }, [open, surface]);
 
   function handleCta() {

--- a/docs/audits/2026-05-13-page-audit-10-errors-pwa-marketing.md
+++ b/docs/audits/2026-05-13-page-audit-10-errors-pwa-marketing.md
@@ -496,6 +496,8 @@ Drop `refetchOnWindowFocus: "always"` to the default `true` (which honors `stale
 
 ### F19 — `PaywallModal` fires `PAYWALL_VIEWED` on every `surface` re-render via `[open, surface]` deps [severity: low] [perspective: bug]
 
+> ✅ **Closed 2026-05-31** — `useRef(false)` як `prevOpen` гейтить `PAYWALL_VIEWED` на переході `open: false → true`. Surface swaps при відкритій модалці більше не дублюють подію.
+
 **Page:** Billing / Paywall
 **File:** `apps/web/src/core/billing/PaywallModal.tsx`
 **Lines:** L68–L76


### PR DESCRIPTION
## Summary

- Gate `PAYWALL_VIEWED` analytics event in `PaywallModal` on the `open: false → true` edge using a `useRef` guard.
- Surface swaps while the modal stays open no longer re-fire the event, so the PostHog funnel `paywall_viewed → checkout_opened → subscription_started` is not inflated.
- Resolves errors-pwa-marketing audit F19.

## Governing Skill

`sergeant-billing` (PaywallModal analytics).

## Playbook

`docs/playbooks/audit-fix-page.md`.

## Verification

- Type-check via pre-commit `staged-typecheck` — green.
- Manual: opening modal once fires one event; swapping `surface` prop while open does not re-fire.

## Docs and Governance

- Closure note added inline at errors-pwa-marketing audit F19.

## Risk and Rollout

- One-line dedup. No public API change.
- Hard Rule #15 satisfied.

## Audit-freeze

In audit-freeze until 2026-06-02 — remediation of existing finding.

## Reviewer Notes

`prevOpen` ref is module-instance-scoped and never escapes the component; no test fixture cleanup needed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate `PAYWALL_VIEWED` in `PaywallModal` to fire only when `open` transitions from false to true. This stops re-firing on `surface` changes while the modal is open, keeps the PostHog funnel accurate, and closes audit F19.

<sup>Written for commit 30b12b152f1c1721739c1637a7ac9c11bb3f29a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

