### PR TITLE
fix(web): gate OfflinePage reload CTA behind navigator.onLine (F12)

### DIFF
--- a/apps/web/src/core/errors/OfflinePage.tsx
+++ b/apps/web/src/core/errors/OfflinePage.tsx
@@ -18,8 +18,10 @@
  */
 import { Button, EmptyState, Icon } from "@shared/components/ui";
 import { OfflineIllustration } from "@assets/illustrations";
+import { useOnlineStatus } from "@shared/hooks";
 
 export function OfflinePage() {
+  const online = useOnlineStatus();
   return (
     <main className="min-h-svh flex items-center justify-center bg-bg px-6">
       <EmptyState
@@ -28,18 +30,29 @@ export function OfflinePage() {
         eyebrow="Офлайн"
         illustration={<OfflineIllustration size={200} />}
         title="Немає зʼєднання"
-        description="Зараз немає інтернету, але дані не загубляться — вони збережуться локально і синхронізуються, коли зʼєднання повернеться."
+        description={
+          online
+            ? "Зараз немає інтернету, але дані не загубляться — вони збережуться локально і синхронізуються, коли зʼєднання повернеться."
+            : "Зʼєднання ще не повернулося. Дані збережуться локально і синхронізуються автоматично — зачекай хвильку або спробуй пізніше."
+        }
         primaryAction={
           <Button
             type="button"
             variant="primary"
             size="lg"
+            disabled={!online}
             onClick={() => {
+              if (
+                typeof navigator !== "undefined" &&
+                navigator.onLine === false
+              ) {
+                return;
+              }
               window.location.reload();
             }}
           >
             <Icon name="refresh-cw" size={16} />
-            Спробувати ще
+            {online ? "Спробувати ще" : "Очікуємо мережу…"}
           </Button>
         }
         hint="Модулі Фінік, Фізрук, Рутина та Харчування зберігають дані офлайн — вони доступні навіть без мережі."

--- a/docs/audits/2026-05-13-page-audit-10-errors-pwa-marketing.md
+++ b/docs/audits/2026-05-13-page-audit-10-errors-pwa-marketing.md
@@ -337,6 +337,8 @@ Move to `messages.publicStatus.componentName.{server,database,n8n,consoleBot}` a
 
 ### F12 — `OfflinePage` reload CTA blindly reloads regardless of `navigator.onLine` [severity: medium] [perspective: ux]
 
+> ✅ **Closed 2026-05-31** — `OfflinePage` тепер слухає `useOnlineStatus`: офлайн → кнопка `disabled`, копія «Очікуємо мережу…», description нагадує почекати; онлайн → CTA знову активний і викликає `window.location.reload()`. Захист у глибину: `onClick` додатково перевіряє `navigator.onLine === false`.
+
 **Page:** Error / Offline
 **File:** `apps/web/src/core/errors/OfflinePage.tsx`
 **Lines:** L29–L41


### PR DESCRIPTION
## Summary

- Wire `OfflinePage` to existing `useOnlineStatus()` hook.
- Reload CTA is `disabled` while offline; label flips to "Очікуємо мережу…" and description tells the user to wait.
- Belt-and-suspenders: `onClick` rechecks `navigator.onLine === false` so stale React state can't fire a futile reload.
- Resolves errors-pwa-marketing audit F12.

## Governing Skill

`sergeant-error-pages` (OfflinePage UX).

## Playbook

`docs/playbooks/audit-fix-page.md`.

## Verification

- Type-check via pre-commit — green.
- Manual: DevTools → offline → CTA disabled with "Очікуємо мережу…"; back online → CTA re-enables.

## Docs and Governance

- Closure note added inline at errors-pwa-marketing audit F12.

## Risk and Rollout

- Hook + conditional copy. No API change, no migration.
- Hard Rule #15 satisfied.

## Audit-freeze

In audit-freeze until 2026-06-02.

## Reviewer Notes

`@scaffolded` marker remains until `/offline` is registered in `StandaloneRoutes` and SW navigation fallback wires up (F1 — out of scope here).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gated the OfflinePage reload button behind online status and updated copy, so users can’t trigger a reload while offline. Resolves errors-pwa-marketing audit F12.

- **Bug Fixes**
  - Wired `OfflinePage` to `useOnlineStatus` from `@shared/hooks`.
  - Disabled reload CTA when offline; label switches to “Очікуємо мережу…” and description asks the user to wait.
  - Added an `onClick` guard that rechecks `navigator.onLine` to prevent futile reloads.

<sup>Written for commit 7c4f15ec4b09b3187b2261e609f692ae645d2c4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

