### PR TITLE
fix(web): harden sw.ts notificationclick allow-list + push payload clamps (F8+F9)

### DIFF
--- a/apps/web/src/sw.ts
+++ b/apps/web/src/sw.ts
@@ -39,10 +39,24 @@ self.addEventListener("install", (event) => {
 
 self.addEventListener("message", handleSwMessage);
 
+// Audit 2026-05-13 §F8: push payload приходить підписаним VAPID, але
+// VAPID-key compromise або mis-routed subscription може підкинути
+// довільний `module`. Без allow-list рядок одразу йде у URL і у postMessage.
+const ALLOWED_NOTIFICATION_MODULES = new Set([
+  "finyk",
+  "fizruk",
+  "nutrition",
+  "routine",
+]);
+
 self.addEventListener("notificationclick", (event) => {
   event.notification.close();
-  const module = (event.notification.data as { module?: string } | null)
+  const rawModule = (event.notification.data as { module?: string } | null)
     ?.module;
+  const module =
+    rawModule && ALLOWED_NOTIFICATION_MODULES.has(rawModule)
+      ? rawModule
+      : undefined;
   const url = module ? `/?module=${module}` : "/";
   event.waitUntil(
     self.clients
@@ -81,6 +95,16 @@ self.addEventListener("activate", (event) => {
 });
 
 // ── Web Push ─────────────────────────────────────────────────────
+// Audit 2026-05-13 §F9: defensive clamps on adversary-controlled payloads.
+// VAPID-signed, але якщо backend скомпрометовано — SW виконає довільний
+// `title`/`body`. Обрізаємо довжину і вирізаємо BiDi-overrides
+// (U+202A..U+202E, U+2066..U+2069) і zero-width joiners (U+200B..U+200D,
+// U+FEFF), які зловмисник може використати для візуального спуфінгу.
+const sanitize = (input: unknown, max: number): string =>
+  String(input ?? "")
+    .replace(/[‪-‮⁦-⁩​-‍﻿]/g, "")
+    .slice(0, max);
+
 self.addEventListener("push", (event) => {
   if (!event.data) return;
   let payload: { title?: string; body?: string; tag?: string; module?: string };
@@ -90,12 +114,13 @@ self.addEventListener("push", (event) => {
     payload = { title: event.data.text() };
   }
 
-  const title = payload.title || "Мій простір";
+  const title = sanitize(payload.title, 80) || "Мій простір";
+  const tag = sanitize(payload.tag, 120) || `push_${Date.now()}`;
   const options = {
-    body: payload.body || "",
+    body: sanitize(payload.body, 200),
     icon: "/icon-192.png",
     badge: "/icon-192.png",
-    tag: payload.tag || `push_${Date.now()}`,
+    tag,
     requireInteraction: false,
     data: { module: payload.module || null },
   };

--- a/docs/audits/2026-05-13-page-audit-10-errors-pwa-marketing.md
+++ b/docs/audits/2026-05-13-page-audit-10-errors-pwa-marketing.md
@@ -247,6 +247,8 @@ for (const h of HOP_BY_HOP) headers.delete(h);
 
 ### F8 — SW `notificationclick` opens `/?module=${module}` with no allow-list on `module` [severity: medium] [perspective: security]
 
+> ✅ **Closed 2026-05-31** — `apps/web/src/sw.ts` тепер має `ALLOWED_NOTIFICATION_MODULES = {finyk, fizruk, nutrition, routine}`. `notificationclick` бере `module` з push-payload лише якщо він у allow-list; інакше падає на `/` без `OPEN_MODULE` postMessage. Отруєний VAPID-push не може стиснути користувача в довільний клієнтський роут.
+
 **Page:** PWA / Service Worker
 **File:** `apps/web/src/sw.ts`
 **Lines:** L38–L58
@@ -268,6 +270,8 @@ const url = module && ALLOWED_MODULES.has(module) ? `/?module=${module}` : "/";
 ---
 
 ### F9 — SW `push` handler renders `payload.title`/`body` verbatim with no length/charset clamp [severity: medium] [perspective: security]
+
+> ✅ **Closed 2026-05-31** — `apps/web/src/sw.ts` додав `sanitize(input, max)` helper, який вирізає BiDi-overrides + zero-width joiners і кламповує довжину. `push` handler тепер обмежує `title` до 80, `body` до 200, `tag` до 120 символів — спам/спуфінг через скомпрометований VAPID payload локалізовано.
 
 **Page:** PWA / Service Worker
 **File:** `apps/web/src/sw.ts`


### PR DESCRIPTION
## Summary

Bundle of two SW hardening fixes (audit F8 + F9 of `docs/audits/2026-05-13-page-audit-10-errors-pwa-marketing.md`).

- **F8 — notificationclick allow-list.** Add `ALLOWED_NOTIFICATION_MODULES = {finyk, fizruk, nutrition, routine}`; only pass `module` through to URL / `OPEN_MODULE` postMessage when it matches. Other values fall back to `/`.
- **F9 — push payload clamps.** Add `sanitize(input, max)` helper that strips BiDi-overrides + zero-width joiners and slices to length. Apply to `title` (80), `body` (200), `tag` (120). Compromised VAPID payload can no longer spam or spoof.

## Governing Skill

`sergeant-pwa` (Service Worker push + notification surface).

## Playbook

`docs/playbooks/audit-fix-page.md` — two related findings, same file → one PR.

## Verification

- Type-check via pre-commit — green.
- Manual: simulated push with `module="javascript:alert(1)"` → falls back to `/`; payload with 500-char `title` → clamped to 80.

## Docs and Governance

- Closure notes added inline at audit F8 and F9.

## Risk and Rollout

- Defense-in-depth; happy-path push payloads (≤ limits, valid module) unaffected.
- Hard Rule #15 satisfied.

## Audit-freeze

In audit-freeze until 2026-06-02 — remediation of existing findings.

## Reviewer Notes

The sanitize regex uses character ranges (`‪-‮`, `⁦-⁩`, `​-‍`, `﻿`) which TypeScript renders literally — they cover U+202A-202E, U+2066-2069, U+200B-200D, U+FEFF respectively.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the service worker to block malicious notification redirects and push spoofing. Only known modules are allowed on click, and push payload fields are sanitized and clamped.

- **Bug Fixes**
  - Added `ALLOWED_NOTIFICATION_MODULES` (`finyk`, `fizruk`, `nutrition`, `routine`) in `apps/web/src/sw.ts`; only forwards `module` to URL/postMessage if allowed, otherwise opens `/`.
  - Introduced `sanitize(input, max)` to strip BiDi overrides and zero-width chars, and enforce limits: `title` 80, `body` 200, `tag` 120; default `tag` is `push_<timestamp>`.

<sup>Written for commit becb3c180f6113306ba2f4553331a27939ba5dd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

