### PR TITLE
fix(web): map strategy api errors to ua copy (F2)

### DIFF
--- a/apps/web/src/pages/strategy/StrategyPage.tsx
+++ b/apps/web/src/pages/strategy/StrategyPage.tsx
@@ -93,15 +93,36 @@ const PERSONA_LABELS: Record<StrategicGoalPersona, string> = {
   routine: "routine",
 };
 
+/**
+ * Audit F2: типізована помилка з HTTP-статусом, щоб UI міг змапити її
+ * на дружню українську копію без витоку server-internal `error.message`.
+ */
+class StrategyApiError extends Error {
+  readonly status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "StrategyApiError";
+    this.status = status;
+  }
+}
+
+function strategyErrorMessage(status: number): string {
+  if (status === 401 || status === 403) return "Сесія завершилась";
+  if (status >= 500) return "Сервер тимчасово недоступний";
+  return "Не вдалося зберегти ціль";
+}
+
 async function fetchGoals(weekStart: string): Promise<StrategicGoal[]> {
   const res = await fetch("/api/internal/strategic/goals/list", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ weekStart }),
   });
-  if (!res.ok) throw new Error(`list goals failed: ${res.status}`);
+  if (!res.ok)
+    throw new StrategyApiError(res.status, `list goals failed: ${res.status}`);
   const data = (await res.json()) as ListResponse;
-  if (!data.ok) throw new Error(data.error ?? "list goals not-ok");
+  if (!data.ok)
+    throw new StrategyApiError(res.status, data.error ?? "list goals not-ok");
   return data.goals ?? [];
 }
 
@@ -116,9 +137,11 @@ async function createGoalApi(input: {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(input),
   });
-  if (!res.ok) throw new Error(`create goal failed: ${res.status}`);
+  if (!res.ok)
+    throw new StrategyApiError(res.status, `create goal failed: ${res.status}`);
   const data = (await res.json()) as CreateResponse;
-  if (!data.ok || !data.goal) throw new Error(data.error ?? "create not-ok");
+  if (!data.ok || !data.goal)
+    throw new StrategyApiError(res.status, data.error ?? "create not-ok");
   return data.goal;
 }
 
@@ -153,7 +176,11 @@ export function StrategyPage({ founderUserId }: StrategyPageProps) {
       });
     },
     onError: (err) => {
-      setSubmitError(err instanceof Error ? err.message : "create failed");
+      if (err instanceof StrategyApiError) {
+        setSubmitError(strategyErrorMessage(err.status));
+        return;
+      }
+      setSubmitError("Не вдалося зберегти ціль");
     },
   });
 

--- a/docs/audits/2026-05-13-page-audit-09-routine-strategy.md
+++ b/docs/audits/2026-05-13-page-audit-09-routine-strategy.md
@@ -45,6 +45,8 @@ Decide one of:
 
 ### F2 — Strategy page leaks raw server `error.message` to the user [severity: high] [perspective: security]
 
+> ✅ **Closed 2026-05-31** — введено `StrategyApiError` зі статусом HTTP-відповіді; обидва `fetch`-каллери (`fetchGoals`, `createGoalApi`) кидають типізовану помилку. `useMutation.onError` рендерить лише канонічну UA-копію через `strategyErrorMessage(status)`: 401/403 → «Сесія завершилась», 5xx → «Сервер тимчасово недоступний», інакше → «Не вдалося зберегти ціль».
+
 **Page:** Strategy page
 **File:** `apps/web/src/pages/strategy/StrategyPage.tsx`
 **Lines:** L102–L104, L155–L158, L228–L232


### PR DESCRIPTION
## Summary

- Introduce `StrategyApiError` (typed Error with HTTP status) in `StrategyPage.tsx`.
- Both fetch callers (`fetchGoals`, `createGoalApi`) throw `StrategyApiError(res.status, ...)` instead of raw `Error`.
- `useMutation.onError` maps `status` to friendly Ukrainian copy: 401/403 → "Сесія завершилась", 5xx → "Сервер тимчасово недоступний", else → "Не вдалося зберегти ціль".
- Resolves routine-strategy audit F2.

## Governing Skill

`sergeant-strategy`.

## Playbook

`docs/playbooks/audit-fix-page.md`.

## Verification

- Type-check via pre-commit — green.
- Page still not mounted in router (`@scaffolded`); change is dev-only until wire-up.

## Docs and Governance

- Closure note inline at routine-strategy audit F2.

## Risk and Rollout

- Internal page, no public API change. Hard Rule #15 satisfied.

## Audit-freeze

In audit-freeze until 2026-06-02.

## Reviewer Notes

`StrategyApiError` is local to `StrategyPage.tsx`; promoting to `shared/lib/api/` waits for the second consumer.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented raw server error messages from showing on the Strategy page. Added a typed `StrategyApiError` and mapped HTTP statuses to friendly Ukrainian copy: 401/403 — “Сесія завершилась”, 5xx — “Сервер тимчасово недоступний”, else — “Не вдалося зберегти ціль”.

- **Bug Fixes**
  - Added `StrategyApiError` with status to `StrategyPage.tsx`.
  - Updated `fetchGoals` and `createGoalApi` to throw `StrategyApiError`; `useMutation.onError` uses `strategyErrorMessage`.
  - Marked audit F2 as closed in docs.

<sup>Written for commit b4d2c713932182b4cabfe88fc0039629fbf828f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

