### PR TITLE
fix(web): observe useRoutineReminders failures + react to permission flips (F7+F8)

### DIFF
--- a/apps/web/src/modules/routine/hooks/useRoutineReminders.ts
+++ b/apps/web/src/modules/routine/hooks/useRoutineReminders.ts
@@ -1,4 +1,5 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
+import { logger } from "@shared/lib";
 import {
   safeListLSKeys,
   safeReadStringLS,
@@ -52,10 +53,14 @@ async function showNotification(
       });
       return;
     }
-  } catch {}
+  } catch (err) {
+    logger.warn("[routine.reminders] sw-show-failed", err);
+  }
   try {
     new Notification(title, { body, tag, requireInteraction: false });
-  } catch {}
+  } catch (err) {
+    logger.warn("[routine.reminders] notification-ctor-failed", err);
+  }
 }
 
 function sendRoutineStateToSW(routine: RoutineState): void {
@@ -70,11 +75,82 @@ function sendRoutineStateToSW(routine: RoutineState): void {
         prefs: routine.prefs,
       },
     });
-  } catch {}
+  } catch (err) {
+    logger.warn("[routine.reminders] sw-state-postmessage-failed", err);
+  }
+}
+
+function readNotificationPermission(): NotificationPermission | "unsupported" {
+  if (typeof Notification === "undefined") return "unsupported";
+  return Notification.permission;
+}
+
+/**
+ * Audit F8: відстежує runtime `Notification.permission` через
+ * Permissions API change-event + fallback на `visibilitychange`/`focus`,
+ * щоб scheduler коректно стопився на revoke і рестартував на re-grant.
+ */
+function useNotificationPermission(): NotificationPermission | "unsupported" {
+  const [perm, setPerm] = useState<NotificationPermission | "unsupported">(() =>
+    readNotificationPermission(),
+  );
+
+  useEffect(() => {
+    if (typeof Notification === "undefined") return undefined;
+    let disposed = false;
+    const sync = () => {
+      if (disposed) return;
+      const next = readNotificationPermission();
+      setPerm((prev) => (prev === next ? prev : next));
+    };
+
+    sync();
+
+    let permStatus: PermissionStatus | null = null;
+    const onPermChange = () => sync();
+    try {
+      const permissions = navigator.permissions;
+      if (permissions && typeof permissions.query === "function") {
+        permissions
+          .query({ name: "notifications" as PermissionName })
+          .then((status) => {
+            if (disposed) return;
+            permStatus = status;
+            status.addEventListener("change", onPermChange);
+            sync();
+          })
+          .catch(() => {
+            /* Permissions API недоступна — лишається fallback */
+          });
+      }
+    } catch {
+      /* Safari старіших версій кидає на name="notifications" — fallback */
+    }
+
+    const onVisibility = () => sync();
+    document.addEventListener("visibilitychange", onVisibility);
+    window.addEventListener("focus", onVisibility);
+
+    return () => {
+      disposed = true;
+      document.removeEventListener("visibilitychange", onVisibility);
+      window.removeEventListener("focus", onVisibility);
+      if (permStatus) {
+        try {
+          permStatus.removeEventListener("change", onPermChange);
+        } catch {
+          /* noop */
+        }
+      }
+    };
+  }, []);
+
+  return perm;
 }
 
 export function useRoutineReminders(routine: RoutineState): void {
   const enabled = routine.prefs?.routineRemindersEnabled === true;
+  const permission = useNotificationPermission();
   const routineRef = useRef<RoutineState>(routine);
   routineRef.current = routine;
 
@@ -88,6 +164,7 @@ export function useRoutineReminders(routine: RoutineState): void {
 
   useEffect(() => {
     if (!enabled) return undefined;
+    if (permission !== "granted") return undefined;
     let timerId: ReturnType<typeof setTimeout> | null = null;
     let disposed = false;
 
@@ -127,7 +204,9 @@ export function useRoutineReminders(routine: RoutineState): void {
               data: { storageKey },
             });
           }
-        } catch {}
+        } catch (err) {
+          logger.warn("[routine.reminders] sw-sent-postmessage-failed", err);
+        }
       }
 
       scheduleNext();
@@ -147,7 +226,7 @@ export function useRoutineReminders(routine: RoutineState): void {
       disposed = true;
       if (timerId) clearTimeout(timerId);
     };
-  }, [enabled]);
+  }, [enabled, permission]);
 }
 
 export async function requestRoutineNotificationPermission() {
@@ -156,7 +235,8 @@ export async function requestRoutineNotificationPermission() {
   if (Notification.permission === "denied") return "denied";
   try {
     return await Notification.requestPermission();
-  } catch {
+  } catch (err) {
+    logger.warn("[routine.reminders] request-permission-failed", err);
     return "denied";
   }
 }

--- a/docs/audits/2026-05-13-page-audit-09-routine-strategy.md
+++ b/docs/audits/2026-05-13-page-audit-09-routine-strategy.md
@@ -141,6 +141,8 @@ Replace the regex with `parseDateKey(q)` round-trip validation: if `dateKeyFromD
 
 ### F7 — `useRoutineReminders` swallows every error via empty `catch {}` [severity: high] [perspective: bug]
 
+> ✅ **Closed 2026-05-31** — чотири порожні `catch {}` замінено на `logger.warn` з префіксами `[routine.reminders] *-failed` (SW `showNotification`, нативний `Notification` fallback, `ROUTINE_STATE_UPDATE`/`ROUTINE_NOTIFICATION_SENT` postMessage, `Notification.requestPermission`). У production шлях іде через Sentry breadcrumbs (`logger.warn` з `@shared/lib`); у DEV — `console.warn`.
+
 **Page:** Routine module / Reminders hook
 **File:** `apps/web/src/modules/routine/hooks/useRoutineReminders.ts`
 **Lines:** L43–L59 (showNotification), L62–L74 (sendRoutineStateToSW), L123–L130 (SW postMessage), L155–L160 (requestRoutineNotificationPermission)
@@ -157,6 +159,8 @@ Each catch should at minimum call `logError("routine.reminders.notify-failed", e
 ---
 
 ### F8 — `useRoutineReminders` scheduler is bound only to `enabled` flag; runtime permission flips are ignored [severity: medium] [perspective: bug]
+
+> ✅ **Closed 2026-05-31** — додано `useNotificationPermission` хук: підписка на `navigator.permissions.query({ name: "notifications" })` change-event + fallback `visibilitychange`/`focus`. Стан permission тепер у deps scheduler-ефекту — revoke зупиняє цикл, re-grant автоматично рестартує без перезавантаження SPA.
 
 **Page:** Routine module / Reminders hook
 **File:** `apps/web/src/modules/routine/hooks/useRoutineReminders.ts`


### PR DESCRIPTION
## Summary

Bundle of two `useRoutineReminders` fixes (audit F7 + F8 in `docs/audits/2026-05-13-page-audit-09-routine-strategy.md`).

- **F7 — observe swallowed errors.** Four empty `catch {}` blocks now call `logger.warn` with `[routine.reminders] *-failed` prefixes: SW `showNotification`, native `Notification` constructor, `ROUTINE_STATE_UPDATE` postMessage, `ROUTINE_NOTIFICATION_SENT` postMessage, `Notification.requestPermission`. In prod the logger routes to Sentry breadcrumbs; in DEV to `console.warn`.
- **F8 — runtime permission flips.** Added `useNotificationPermission` hook that tracks `Notification.permission` via Permissions API change-event with `visibilitychange`/`focus` fallback. Scheduler effect now depends on permission state, so revoke stops the loop and re-grant restarts it without SPA reload.

## Governing Skill

`sergeant-routine` (Reminders hook lifecycle).

## Playbook

`docs/playbooks/audit-fix-page.md` — two related findings, same file → one PR.

## Verification

- Type-check via pre-commit — green.
- Manual: toggle Notifications permission in browser settings → scheduler stops/restarts without reload. Empty catch blocks now surface via `logger.warn` in DevTools console.

## Docs and Governance

- Closure notes inline at routine-strategy audit F7 and F8.

## Risk and Rollout

- Scheduler effect logic preserved; new permission dep just guards the early-return.
- Hard Rule #15 satisfied.

## Audit-freeze

In audit-freeze until 2026-06-02 — remediation of existing findings.

## Reviewer Notes

`PermissionName` cast is required because TS `lib.dom` does not include `"notifications"` in the strict permission name union; the runtime accepts it on all modern browsers, with Safari fallback through the `visibilitychange`/`focus` path.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds error logging to `useRoutineReminders` and makes the reminders scheduler react to notification permission changes at runtime. Errors now surface via `logger.warn` to Sentry in prod and `console.warn` in dev; the loop stops on revoke and restarts on re-grant without a reload.

- **Bug Fixes**
  - Log failures for SW `showNotification`, native `Notification`, `ROUTINE_STATE_UPDATE`/`ROUTINE_NOTIFICATION_SENT` postMessage, and `Notification.requestPermission` using `logger.warn` from `@shared/lib`.
  - Add `useNotificationPermission` (Permissions API change event with `visibilitychange`/`focus` fallback) and include permission in the scheduler effect deps; guard the loop when permission is not "granted".

<sup>Written for commit 4be81159666de0a7cc8c82c91a88b277aef0a88e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

