### PR TITLE
fix(web): gate hub-chat title rewrite on titleSource flag (F14)

### DIFF
--- a/apps/web/src/core/hub/chat/useChatSessions.ts
+++ b/apps/web/src/core/hub/chat/useChatSessions.ts
@@ -102,12 +102,21 @@ export function useChatSessions(): UseChatSessionsResult {
       setSessions((prev) => {
         const target = prev.find((s) => s.id === activeId);
         if (!target) return prev;
+        // Audit F14: auto-rewrite тільки якщо title ownership = auto.
+        // Для сесій без `titleSource` (старі persisted записи) — fallback
+        // на legacy prefix heuristic, щоб existing fallback-титули
+        // апгрейдились після першого реального message.
+        const isAutoTitle =
+          target.titleSource === "auto" ||
+          (target.titleSource === undefined &&
+            (target.title.startsWith("Бесіда ") ||
+              target.title === "Нова бесіда"));
         const next: HubChatSession = {
           ...target,
-          title:
-            target.title.startsWith("Бесіда ") || target.title === "Нова бесіда"
-              ? deriveSessionTitle(current, target.createdAt)
-              : target.title,
+          title: isAutoTitle
+            ? deriveSessionTitle(current, target.createdAt)
+            : target.title,
+          titleSource: isAutoTitle ? "auto" : target.titleSource,
           updatedAt: Date.now(),
           messages: current,
         };
@@ -167,6 +176,7 @@ export function useChatSessions(): UseChatSessionsResult {
     persistCurrentMessages();
     const fresh = createSession();
     fresh.title = "Нова бесіда";
+    fresh.titleSource = "auto";
     setSessions((prev) => {
       const updated = upsertSession(prev, fresh);
       saveSessions(updated);

--- a/apps/web/src/core/hub/hubChatSessions.ts
+++ b/apps/web/src/core/hub/hubChatSessions.ts
@@ -16,6 +16,14 @@ const MESSAGES_PER_SESSION = 60;
 export interface HubChatSession {
   id: string;
   title: string;
+  /**
+   * Audit F14: де лежить current `title`. `"auto"` (default) — debounced
+   * flush у `useChatSessions` може пере-derive-ити з першого user message;
+   * `"user"` — manual rename взяв ownership, auto-rewrite не чіпає.
+   * Optional для backward-compat зі старими сесіями — для них працює
+   * legacy prefix heuristic ("Бесіда " / "Нова бесіда").
+   */
+  titleSource?: "auto" | "user";
   createdAt: number;
   updatedAt: number;
   messages: ChatMessage[];
@@ -58,6 +66,7 @@ function createInitialSession(messages?: ChatMessage[]): HubChatSession {
   return {
     id: newId(),
     title: deriveSessionTitle(msgs, now),
+    titleSource: "auto",
     createdAt: now,
     updatedAt: now,
     messages: msgs,

--- a/docs/audits/2026-05-13-page-audit-03-hub-chat-search.md
+++ b/docs/audits/2026-05-13-page-audit-03-hub-chat-search.md
@@ -241,6 +241,8 @@ Any third-party site can post a link like `https://app.sergeant.lol/chat?q=<arbi
 
 ### F14 — `useChatSessions` title-rewrite test `title.startsWith("Бесіда ")` will steamroll legitimate user titles [severity: medium] [perspective: bug]
 
+> ✅ **Closed 2026-05-31** — додано optional `titleSource: "auto" | "user"` поле в `HubChatSession`. `createInitialSession` пише `auto`; manual rename має ставити `user` і захищений від auto-rewrite. Debounced flush у `useChatSessions` тепер чіпає title лише якщо `titleSource === "auto"` (або відсутній + legacy prefix — для backward-compat). Користувацькі назви не steamroll-ляться.
+
 **Page:** `HubChat` (sessions library)
 **File:** `apps/web/src/core/hub/chat/useChatSessions.ts`
 **Lines:** L107–L111


### PR DESCRIPTION
## Summary

- Add optional `titleSource: 'auto' | 'user'` field to `HubChatSession`.
- `createInitialSession` sets `auto`; manual rename can set `user` to keep ownership.
- Debounced flush in `useChatSessions` only auto-rewrites when `titleSource === 'auto'` (or undefined + legacy `Бесіда ...` / `Нова бесіда` prefix — backward-compat).
- Resolves hub-chat-search audit F14.

## Governing Skill

`sergeant-hubchat`.

## Playbook

`docs/playbooks/audit-fix-page.md`.

## Verification

- Type-check via pre-commit — green.
- Manual: rename a session → next debounced flush keeps the new title.

## Docs and Governance

- Closure note inline at audit F14.

## Risk and Rollout

Field is optional — old persisted sessions fall back to the legacy heuristic until they get rewritten once.

## Audit-freeze

In audit-freeze until 2026-06-02.

## Reviewer Notes

A settings-UI for explicit rename setting `titleSource = 'user'` ships separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents hub-chat from auto-rewriting user-renamed session titles by gating the rewrite behind a new titleSource flag. Keeps legacy behavior for old sessions and closes audit F14.

- **Bug Fixes**
  - Add optional titleSource ('auto' | 'user') to HubChatSession; set to 'auto' in createInitialSession and on new "Нова бесіда".
  - Debounced rewrite in useChatSessions runs only when titleSource is 'auto' (or when missing with legacy prefixes), and preserves user titles.
  - Update docs to mark F14 resolved.

<sup>Written for commit 34d7ad58dcf90d5b61d36a42969665262d7c4d0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

