### PR TITLE
docs(docs): close 6 batch-15 verified-already-done findings

### DIFF
--- a/docs/audits/2026-05-13-page-audit-06-fizruk-part1.md
+++ b/docs/audits/2026-05-13-page-audit-06-fizruk-part1.md
@@ -375,6 +375,8 @@ Subscribe to `document.visibilitychange` and force-recompute `elapsedSec = (Date
 
 ### F14 — `<select>` in WorkoutItemCard has no accessible name [severity: medium] [perspective: a11y]
 
+> ✅ **Closed 2026-05-31** — `<select>` більше не існує у `WorkoutItemCard.tsx` (grep повертає 0 matches). Exercise-type control мігровано на `Segmented` компонент з `ariaLabel="Тип вправи"` + per-item `ariaLabel`. WCAG 1.3.1 задоволено через `aria-label`.
+
 **Page:** Workouts → log
 **File:** `apps/web/src/modules/fizruk/components/workouts/WorkoutItemCard.tsx`
 **Lines:** L207–L239
@@ -543,6 +545,8 @@ Demote the page-level title to `<h2>` (and keep the visual size via `text-hero f
 ---
 
 ### F23 — `text-2xs` used for prose sub-heading outside its sanctioned use case [severity: low] [perspective: tailwind] [perspective: rule]
+
+> ✅ **Closed 2026-05-31** — `Dashboard.tsx:416` («Нещодавно використані» / «Останні шаблони») мігровано на `text-style-caption text-muted`. Решта `text-2xs` usage у `WorkoutTemplatesSection.tsx`/`SupersetBadge.tsx` — санкціоновані pill/badge з explicit lint disables, поза scope.
 
 **Page:** Dashboard
 **File:** `apps/web/src/modules/fizruk/pages/Dashboard.tsx`

--- a/docs/audits/2026-05-13-page-audit-08-nutrition.md
+++ b/docs/audits/2026-05-13-page-audit-08-nutrition.md
@@ -40,6 +40,8 @@ Bonus theme — **дубльовані Meal-ID generators** (7 sites) із не�
 
 ### F1 — Raw-palette кольори макро-міток у Daily Plan (Hard Rule #11/#13) [severity: high] [perspective: tailwind]
 
+> ✅ **Closed 2026-05-31** — `DailyPlanCard.tsx` L135/141/147 уже використовує семантичні токени `text-info`/`text-warning`/`text-success`. Raw-palette (`text-blue-400`/`text-yellow-400`/`text-green-400`) відсутній.
+
 **Page:** Menu (`plan` sub-tab)
 **File:** `apps/web/src/modules/nutrition/components/DailyPlanCard.tsx`
 **Lines:** 131, 137, 143
@@ -57,6 +59,8 @@ Module-accent для Nutrition — lime/green; `text-blue-400` і `text-yellow-4
 
 ### F2 — Sky-палітра у water-tracker progress bar (Hard Rule #11) [severity: high] [perspective: tailwind]
 
+> ✅ **Closed 2026-05-31** — `WaterTrackerCard.tsx:121` `done ? "bg-success" : "bg-info"`. Quick-add buttons також на `bg-info-soft`/`text-info-strong`. `bg-sky-500` відсутній.
+
 **Page:** Start (`WaterTrackerCard` рендериться через `NutritionDashboard`)
 **File:** `apps/web/src/modules/nutrition/components/WaterTrackerCard.tsx`
 **Lines:** 117
@@ -73,6 +77,8 @@ Hard Rule #11 (no arbitrary hex/raw palette) — це блокер convention. �
 ---
 
 ### F3 — Raw-palette `amber-500` у banner про великий журнал (Hard Rule #11/#13) [severity: high] [perspective: tailwind]
+
+> ✅ **Closed 2026-05-31** — `LogCard.tsx:137` уже на `border-warning/40 bg-warning/10 text-warning-strong`. `amber-500` не знайдено в `apps/web/src/modules/nutrition/components/`.
 
 **Page:** Log
 **File:** `apps/web/src/modules/nutrition/components/LogCard.tsx`
@@ -93,6 +99,8 @@ Hard Rule #11 (no arbitrary hex/raw palette) — це блокер convention. �
 ---
 
 ### F4 — Touch target нижче 44×44 px на ItemRow delete button (WCAG 2.5.5) [severity: high] [perspective: a11y]
+
+> ✅ **Closed 2026-05-31** — закрито commit `f108399f`. `PantryCard.tsx` ItemRow і `MealRow.tsx` delete тепер на `<Button variant="ghost" size="xs" iconOnly>`. Shared Button auto-applies `pointer-coarse:min-h-[44px] pointer-coarse:min-w-[44px]` при `iconOnly || size === "xs"|"sm"` — WCAG 2.5.5 виконано для finger-tap precision.
 
 **Page:** Pantry (`items` sub-tab)
 **File:** `apps/web/src/modules/nutrition/components/PantryCard.tsx`


### PR DESCRIPTION
## Summary

Doc-only PR closing **6 audit findings** that the Batch 15 fanout discovered are already resolved in main.

- **Fizruk-1 F14** — `<select>` no longer in `WorkoutItemCard`; mig­rated to `Segmented` with proper `aria-label`.
- **Fizruk-1 F23** — `Dashboard.tsx` sub-heading already on `text-style-caption`; remaining `text-2xs` usages are sanctioned pills.
- **Nutrition F1** — `DailyPlanCard.tsx` already uses `text-info`/`text-warning`/`text-success`.
- **Nutrition F2** — `WaterTrackerCard.tsx` already on `bg-info`/`bg-success`.
- **Nutrition F3** — `LogCard.tsx` already on `border-warning/bg-warning`.
- **Nutrition F4** — closed in commit `f108399f`; `<Button iconOnly size="xs">` auto-applies pointer-coarse 44×44.

Each finding gets an inline closure note. No code change.

## Governing Skill

`sergeant-docs-audit`.

## Playbook

`docs/playbooks/audit-fix-page.md` — reconcile, no new audit.

## Verification

- Manual grep at each cited location confirms the resolved state.

## Docs and Governance

- Six closure notes inline.

## Risk and Rollout

- Pure docs reconcile.

## Audit-freeze

In audit-freeze until 2026-06-02.

## Reviewer Notes

Closes the six `skipped` specs from the Batch 15 fanout.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add closure notes to two audit docs to close six Batch 15 findings already fixed in `main`. Confirms `WorkoutItemCard` uses `Segmented` with `aria-label`, Dashboard subheading uses `text-style-caption`, Nutrition components use semantic `text-*`/`bg-*` tokens (including warning banner), and delete buttons meet 44×44 WCAG; no code changes.

<sup>Written for commit 3ea1860974b7542e024f2c96a9653b5248ab2db7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

