### PR TITLE
feat(web): zod-validate hub-chat tool_calls envelope (F3 critical security)

### DIFF
--- a/apps/web/src/core/hub/chat/toolCallSchema.ts
+++ b/apps/web/src/core/hub/chat/toolCallSchema.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+
+/**
+ * Audit 03 F3 (severity: critical, perspective: security).
+ *
+ * `useChatSend` accepts `data.tool_calls` from the Anthropic-proxy and feeds
+ * each entry straight into `executeActions` — which routes by `name` and
+ * destructures `input` into LocalStorage mutators (`create_transaction`,
+ * `mark_habit_done`, `log_meal`, `create_habit`, …). Without runtime
+ * validation a contract drift between server↔client (or a model that emits
+ * `input: null`, `name: 42`, or a missing `id`) reaches the executor and
+ * either crashes the turn or performs a mutation with a corrupted payload.
+ *
+ * This schema is the **structural firewall**: every entry must have
+ * `id: string`, `name: string`, `input: object` before any handler runs.
+ * Per-tool input shape is still enforced by the TS `ChatAction` union at
+ * compile time + each handler's own narrowing. The audit also recommends a
+ * full discriminated union per tool-name; that lands as a server-side mirror
+ * + per-tool strict variants in a follow-up — gating critical attack surface
+ * at the envelope is the load-bearing change here.
+ *
+ * AI-CONTEXT: if `safeParse` fails we DO NOT execute any tool from the batch.
+ * The caller surfaces a "Не вдалося виконати дію" toast and falls back to
+ * rendering `data.text` (or the raw assistant turn) without mutations.
+ */
+export const ToolCallEnvelopeSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  input: z.record(z.string(), z.unknown()),
+});
+
+export type ToolCallEnvelope = z.infer<typeof ToolCallEnvelopeSchema>;
+
+export const ToolCallsArraySchema = z.array(ToolCallEnvelopeSchema);
+
+export function parseToolCalls(value: unknown):
+  | { ok: true; value: ToolCallEnvelope[] }
+  | { ok: false; issues: string[] } {
+  const parsed = ToolCallsArraySchema.safeParse(value);
+  if (parsed.success) return { ok: true, value: parsed.data };
+  const issues = parsed.error.issues
+    .slice(0, 5)
+    .map((iss) => `${iss.path.join(".") || "<root>"}: ${iss.message}`);
+  return { ok: false, issues };
+}

--- a/apps/web/src/core/hub/chat/useChatSend.ts
+++ b/apps/web/src/core/hub/chat/useChatSend.ts
@@ -23,6 +23,8 @@ import {
 } from "../../lib/hubChatUtils";
 import { buildContextMeasured } from "../../lib/hubChatContext";
 import { executeActions } from "../../lib/hubChatActions";
+import { logger } from "@shared/lib";
+import { parseToolCalls } from "./toolCallSchema";
 import { VOICE_KEYWORDS, speak } from "../../lib/hubChatSpeech";
 import { buildActionCard } from "../../lib/hubChatActionCards";
 import type { ChatActionCard } from "../../lib/hubChatActionCards";
@@ -321,14 +323,24 @@ export function useChatSend({
         }
 
         if (data.tool_calls && data.tool_calls.length > 0) {
-          // Cast tool_calls to ChatAction[] — the API guarantees the
-          // name+id+input shape.
-          type ToolCall = {
-            id: string;
-            name: string;
-            input: Record<string, unknown>;
-          };
-          const toolCalls = data.tool_calls as ToolCall[];
+          // Audit 03 F3 (critical/security): every entry must clear the
+          // structural firewall — `{id: string, name: string, input: object}`
+          // — before any handler runs. On failure we drop the whole batch,
+          // toast the user, and fall back to plain-text rendering. Spending
+          // tokens > silently writing to LocalStorage with a corrupted
+          // payload.
+          const parsed = parseToolCalls(data.tool_calls);
+          if (!parsed.ok) {
+            logger.warn("[hub-chat] tool_calls schema mismatch", {
+              issues: parsed.issues,
+            });
+            toast.error("Не вдалося виконати дію");
+            const fallback = data.text || "Немає відповіді.";
+            setMessages((m) => [...m, makeAssistantMsg(fallback)]);
+            if (shouldSpeak) maybeSpeak(fallback);
+            return;
+          }
+          const toolCalls = parsed.value;
           const handlerResults = await executeActions(
             toolCalls as Parameters<typeof executeActions>[0],
           );

--- a/docs/audits/2026-05-13-page-audit-03-hub-chat-search.md
+++ b/docs/audits/2026-05-13-page-audit-03-hub-chat-search.md
@@ -78,6 +78,8 @@ There is no zod / typia / hand-written guard between the JSON and `executeAction
 
 **Recommendation.** Define a discriminated union `ToolCallEnvelope` (one variant per tool name) with a zod / typia schema; parse `data.tool_calls` through it before `executeActions`. On parse failure, surface a "не вдалося виконати дію" toast and fall back to plain-text rendering. Mirror the same schema on the server.
 
+> **Closure note (2026-06-01, PR-4 of "9 decisions"):** Resolved (client-side gate). Новий `apps/web/src/core/hub/chat/toolCallSchema.ts` експортує zod-`ToolCallEnvelopeSchema` (`{id:string, name:string, input:object}`) і `parseToolCalls(value)`. `useChatSend` тепер парсить `data.tool_calls` через цей schema **перед** `executeActions`. На fail — `logger.warn` з first-5 issue-paths, `toast.error("Не вдалося виконати дію")`, fallback на plain-text rendering з `data.text`, **жоден handler не виконується**. Це покриває критичний вектор F3 (envelope-firewall). Per-tool strict variants для mutator-ів (`create_transaction`, `mark_habit_done`, `log_meal`, `create_habit`) + server-mirror — окремий PR (доменний union у `chatActions/types.*.ts` має ~50 варіантів і потребує refactor під zod).
+
 ---
 
 ### F4 — `/chat?q=…&autoSend=1` deep link auto-sends arbitrary text to the AI on render [severity: high] [perspective: security]


### PR DESCRIPTION
## Summary

Audit 03 **F3** (severity: critical, perspective: security) — `useChatSend` ran `data.tool_calls` from the model through `executeActions` with **no runtime validation**. Mutator handlers (`create_transaction`, `mark_habit_done`, `log_meal`, `create_habit`, …) write to LocalStorage and only the 5-second undo-toast was a recovery path.

This PR adds the structural firewall.

- **New file:** [`apps/web/src/core/hub/chat/toolCallSchema.ts`](apps/web/src/core/hub/chat/toolCallSchema.ts)
  - `ToolCallEnvelopeSchema = z.object({ id: z.string().min(1), name: z.string().min(1), input: z.record(z.string(), z.unknown()) })`
  - `parseToolCalls(value)` returns `{ ok: true, value } | { ok: false, issues }` with the first 5 issue-paths formatted for `logger.warn`.
- **Wired in:** [`apps/web/src/core/hub/chat/useChatSend.ts`](apps/web/src/core/hub/chat/useChatSend.ts) parses `data.tool_calls` through `parseToolCalls()` **before** `executeActions`. On parse failure:
  1. `logger.warn("[hub-chat] tool_calls schema mismatch", { issues })`
  2. `toast.error("Не вдалося виконати дію")`
  3. Fallback to plain-text rendering of `data.text` (or `"Немає відповіді."`)
  4. **No handler runs.** No LocalStorage mutation. No undo-toast race.

## Why not full per-tool union here

The audit recommends a full discriminated union (one variant per tool name). The domain `ChatAction` union in `chatActions/types.ts` covers ~50 distinct tool payloads — a full mirror to zod is a separate refactor (the per-tool schemas would live alongside the existing TS types and the server side would need to mirror them as well). The envelope is the load-bearing gate against the critical attack surface: malformed `input`, missing `id`, wrong type for `name`. Per-tool input shape is still enforced at compile time by the `ChatAction` union and at runtime by each handler's own narrowing.

## Governing Skill

`sergeant-hubchat`.

## Playbook

`docs/playbooks/audit-fix-page.md`.

## Verification

- `tsc --noEmit` clean for `useChatSend.ts` / `toolCallSchema.ts` (pre-existing errors in unrelated `@sergeant/design-tokens` consumers are unchanged).
- Manual: send a valid tool-call turn through HubChat → handler runs as before. Forcing `data.tool_calls = [{ name: 42 }]` in devtools network override → toast appears, no mutation, fallback text rendered.

## Docs and Governance

- Closure note inline at [`docs/audits/2026-05-13-page-audit-03-hub-chat-search.md`](docs/audits/2026-05-13-page-audit-03-hub-chat-search.md) F3 — explicit scope note that per-tool strict variants + server-mirror remain follow-up.

## Risk and Rollout

- Behavior-preserving on the happy path — same data is fed to `executeActions`, just after a zod gate.
- On envelope mismatch the user now sees a toast + text fallback instead of an exception or a corrupted write. Net-positive UX.
- Hard Rule #15 (code + closure together) satisfied.

## Audit-freeze

In audit-freeze until 2026-06-02 — remediation only.

## Reviewer Notes

- This PR closes Decision #1 ("A — Zod discriminated union, client + server mirror") from the 9-decision plan; the server-mirror half is the next remediation PR.
- `toolCallSchema.ts` is intentionally tiny and isolated — it does not import from `hubChatActions` so that a later per-tool union can drop in without circular concerns.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `zod` envelope to validate HubChat `tool_calls` before `executeActions`, blocking malformed entries and preventing unsafe LocalStorage writes. On validation failure we warn, show a toast, and render a text fallback; no handlers run.

- **Bug Fixes**
  - Added toolCallSchema.ts with `ToolCallEnvelopeSchema` and `parseToolCalls()` that formats the first 5 issue paths for logs.
  - Updated useChatSend to parse `data.tool_calls` before execution; invalid batches trigger `logger.warn` from `@shared/lib`, show "Не вдалося виконати дію", and render `data.text` or "Немає відповіді."
  - Updated the F3 audit doc with a closure note.

<sup>Written for commit 1aa12daf434b422c474ee533dc9aa09e9c4f024f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

