### PR TITLE
feat(web): drop URL-driven autoSend on /chat (F4 high security)

### DIFF
--- a/apps/web/src/core/hub/HubChatPage.tsx
+++ b/apps/web/src/core/hub/HubChatPage.tsx
@@ -25,14 +25,20 @@ const IN_APP_ENTRY_FLAG = "hub-chat:in-app-entry";
  *   in-chat history drawer is folded into a real two-pane layout.
  *
  * Dedicated `/chat` route. Replaces the fullscreen modal that used to
- * slam over the dashboard. Reads `?q=` and `?autoSend=1` from the URL
- * so launcher / catalogue / hint hand-offs all use the same shape:
+ * slam over the dashboard. Reads `?q=` from the URL so launcher /
+ * catalogue / hint hand-offs all use the same shape:
  *
  *   navigate(`/chat?q=${encodeURIComponent(message)}`);
  *
  * `onClose` and `onOpenCatalogue` route through `react-router` instead
  * of imperative state, so the back button and deep-links behave as
  * expected.
+ *
+ * Audit 03 F4 (high/security): `?autoSend=1` is **not** honored on this
+ * surface. The pre-fill stays so a user can review the text and hit
+ * Send themselves; the auto-send path is only reachable from the
+ * in-process `openChat` hub-bus event (`HubChatOverlay`), which is
+ * not attacker-controllable from a hand-crafted URL.
  */
 export function HubChatPage() {
   const navigate = useNavigate();
@@ -43,11 +49,6 @@ export function HubChatPage() {
     const raw = searchParams.get("q");
     return raw && raw.trim().length > 0 ? raw : "";
   }, [searchParams]);
-
-  const autoSendInitial = useMemo(
-    () => searchParams.get("autoSend") === "1",
-    [searchParams],
-  );
 
   useEffect(() => {
     if (navigationType !== "PUSH") {
@@ -88,7 +89,7 @@ export function HubChatPage() {
         <HubChat
           onClose={handleClose}
           initialMessage={initialMessage}
-          autoSendInitial={autoSendInitial}
+          autoSendInitial={false}
           onOpenCatalogue={handleOpenCatalogue}
         />
       </SuspenseWithMinDelay>

--- a/docs/audits/2026-05-13-page-audit-03-hub-chat-search.md
+++ b/docs/audits/2026-05-13-page-audit-03-hub-chat-search.md
@@ -104,6 +104,8 @@ Any third-party site can post a link like `https://app.sergeant.lol/chat?q=<arbi
 
 **Recommendation.** Require an explicit confirmation step for any `autoSend=1` originating outside the in-app launcher: either gate `autoSend` on `document.referrer` matching `location.origin`, or always prefill the input and let the user press Send. Alternatively, sign the launcher's `autoSend` hand-off with a short-lived nonce.
 
+> **Closure note (2026-06-01, PR-A6 of 15-pack):** Resolved by dropping URL-driven auto-send. `apps/web/src/core/hub/HubChatPage.tsx` now hard-codes `autoSendInitial={false}` and ignores the `autoSend` search param entirely; the `q=` pre-fill stays so the user can review + edit before pressing Send themselves. The auto-send path remains available **only** to the in-process `openChat` hub-bus event (`HubChatOverlay`), which is not reachable from a hand-crafted URL. Net effect: a malicious link `https://app.sergeant.lol/chat?q=...&autoSend=1` now opens chat with the text pre-filled but does not ship a turn until the user explicitly sends.
+
 ---
 
 ### F5 — Voice-keyword regex auto-triggers TTS playback without user consent [severity: medium] [perspective: security]


### PR DESCRIPTION
Audit 03 F4 — HubChatPage now hard-codes autoSendInitial=false and ignores ?autoSend=1. q= pre-fill stays. Internal openChat hub-bus event still works (HubChatOverlay). Closure inline at docs/audits/2026-05-13-page-audit-03-hub-chat-search.md F4.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable URL-driven auto-send on `/chat` to block deep links from auto-submitting prompts; keep `q=` prefill so users can review before sending. Addresses Audit 03 F4 (high).

- **Bug Fixes**
  - Ignore `?autoSend=1` and set `autoSendInitial={false}` in `HubChatPage`; only the in-app `openChat` hub-bus (`HubChatOverlay`) can auto-send.
  - Updated `docs/audits/2026-05-13-page-audit-03-hub-chat-search.md` with a closure note; `/chat?q=...&autoSend=1` now pre-fills but requires manual Send.

<sup>Written for commit def13ef98fb932b3ee4c9330053bbc2bc6428a8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

