### PR TITLE
refactor(web): destructure routine group sort comparator (F23)

### DIFF
--- a/apps/web/src/modules/routine/RoutineApp.helpers.ts
+++ b/apps/web/src/modules/routine/RoutineApp.helpers.ts
@@ -94,10 +94,10 @@ export function groupEventsForList(
     if (existing) existing.push(e);
     else map.set(head, [e]);
   }
-  return [...map.entries()].sort((a, b) => {
-    const ai = GROUP_ORDER.indexOf(a[0]);
-    const bi = GROUP_ORDER.indexOf(b[0]);
-    if (ai === -1 && bi === -1) return a[0].localeCompare(b[0], "uk");
+  return [...map.entries()].sort(([aKey], [bKey]) => {
+    const ai = GROUP_ORDER.indexOf(aKey);
+    const bi = GROUP_ORDER.indexOf(bKey);
+    if (ai === -1 && bi === -1) return aKey.localeCompare(bKey, "uk");
     if (ai === -1) return 1;
     if (bi === -1) return -1;
     return ai - bi;

--- a/apps/web/src/modules/routine/RoutineApp.helpers.ts
+++ b/apps/web/src/modules/routine/RoutineApp.helpers.ts
@@ -59,8 +59,13 @@ export function monthGrid(
   y: number,
   monthIndex: number,
 ): { cells: Array<number | null> } {
-  const last = new Date(y, monthIndex + 1, 0).getDate();
-  const firstWd = (new Date(y, monthIndex, 1).getDay() + 6) % 7;
+  // Civil-calendar arithmetic only: we want "how many days in month X of year Y"
+  // and "what weekday is the 1st of X/Y" — both are timezone-independent for a
+  // fixed (y, monthIndex) tuple, so UTC getters give the same answer as host-
+  // local while satisfying sergeant-design/prefer-kyiv-time (Kyiv-tz routing is
+  // for *current-time* boundaries, not abstract month skeletons).
+  const last = new Date(Date.UTC(y, monthIndex + 1, 0)).getUTCDate();
+  const firstWd = (new Date(Date.UTC(y, monthIndex, 1)).getUTCDay() + 6) % 7;
   const cells: Array<number | null> = [];
   for (let i = 0; i < firstWd; i++) cells.push(null);
   for (let d = 1; d <= last; d++) cells.push(d);

--- a/docs/audits/2026-05-13-page-audit-09-routine-strategy.md
+++ b/docs/audits/2026-05-13-page-audit-09-routine-strategy.md
@@ -480,6 +480,8 @@ return [...map.entries()].sort(([ah], [bh]) => {
 });
 ```
 
+> **Closure note (2026-06-01, PR-A9 of 15-pack):** Resolved. `apps/web/src/modules/routine/RoutineApp.helpers.ts:97-104` now destructures: `.sort(([aKey], [bKey]) => …)`. No tuple indexing; locals read directly so a future refactor that changes the entries shape forces a compile-time fix instead of silently shifting a bang.
+
 ---
 
 ## Per-page coverage matrix


### PR DESCRIPTION
Audit 09 F23 (low/ts). Routine group comparator destructures tuple instead of indexing. Closure inline at docs/audits/2026-05-13-page-audit-09-routine-strategy.md F23.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the routine group sort comparator to destructure map entry keys (`.sort(([aKey], [bKey]) => …)`), and routed `monthGrid` through UTC getters to keep day counts and first-weekday math timezone-safe and satisfy `sergeant-design/prefer-kyiv-time`. Added an audit note closing F23 in `docs/audits/2026-05-13-page-audit-09-routine-strategy.md`.

<sup>Written for commit 356c39f219e697fa98eb874910037d3e504f9a10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

