### PR TITLE
fix(web): disable Measurements save until at least one numeric field (F4)

### DIFF
--- a/apps/web/src/modules/fizruk/pages/Measurements.tsx
+++ b/apps/web/src/modules/fizruk/pages/Measurements.tsx
@@ -112,9 +112,7 @@ export function Measurements() {
           <Card radius="lg" padding="sm">
             <Stat
               label="Останній"
-              value={
-                <span className="text-style-label">{stats.latestAt}</span>
-              }
+              value={<span className="text-style-label">{stats.latestAt}</span>}
               size="sm"
               align="center"
             />
@@ -160,23 +158,38 @@ export function Measurements() {
             ))}
           </div>
           <div className="mt-3">
-            <button
-              type="button"
-              className="w-full py-4 rounded-full font-bold text-base bg-fizruk-strong text-white transition-[background-color,box-shadow,opacity,transform] active:scale-[0.98]"
-              onClick={() => {
-                const payload: Record<string, number> = {};
-                for (const f of MEASURE_FIELDS) {
-                  const v = (form[f.id] || "").trim();
-                  if (v) payload[f.id] = Number(v.replace(",", "."));
-                }
-                addEntry(payload);
-                setForm(
-                  Object.fromEntries(MEASURE_FIELDS.map((f) => [f.id, ""])),
-                );
-              }}
-            >
-              Зберегти замір
-            </button>
+            {(() => {
+              // Audit 09 F4: forbid saving a fully-empty form. The button stays
+              // visible (no surprise disappearance) but is disabled until at
+              // least one field has a parseable numeric value. We also strip
+              // entries that parse to NaN so a stray "abc" doesn't pollute the
+              // stored snapshot.
+              const parsedPayload: Record<string, number> = {};
+              for (const f of MEASURE_FIELDS) {
+                const v = (form[f.id] || "").trim();
+                if (!v) continue;
+                const n = Number(v.replace(",", "."));
+                if (Number.isFinite(n)) parsedPayload[f.id] = n;
+              }
+              const hasAnyValue = Object.keys(parsedPayload).length > 0;
+              return (
+                <button
+                  type="button"
+                  disabled={!hasAnyValue}
+                  aria-disabled={!hasAnyValue}
+                  className="w-full py-4 rounded-full font-bold text-base bg-fizruk-strong text-white transition-[background-color,box-shadow,opacity,transform] active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed disabled:active:scale-100"
+                  onClick={() => {
+                    if (!hasAnyValue) return;
+                    addEntry(parsedPayload);
+                    setForm(
+                      Object.fromEntries(MEASURE_FIELDS.map((f) => [f.id, ""])),
+                    );
+                  }}
+                >
+                  Зберегти замір
+                </button>
+              );
+            })()}
           </div>
         </Card>
 

--- a/docs/audits/2026-05-13-page-audit-07-fizruk-part2.md
+++ b/docs/audits/2026-05-13-page-audit-07-fizruk-part2.md
@@ -156,6 +156,8 @@ addEntry(payload);
 
 Або disable submit-кнопки, якщо немає жодного непорожнього поля у `form`.
 
+> **Closure note (2026-06-01, PR-A13 of 15-pack):** Resolved by disabling the submit button (audit option B — "disable submit if no field set"). `apps/web/src/modules/fizruk/pages/Measurements.tsx` button click handler now computes `parsedPayload` (only `Number.isFinite` numeric values land in the object) and renders `disabled + aria-disabled + opacity-50` when `Object.keys(parsedPayload).length === 0`. `onClick` also re-guards `if (!hasAnyValue) return` so a focus-+enter keyboard activation cannot bypass. NaN inputs ("abc") are stripped before persisting so a stray entry can never pollute the snapshot.
+
 ---
 
 ### F5 — Жоден з 4 page-файлів не має unit-тестів [severity: high] [perspective: test]


### PR DESCRIPTION
Audit 07 F4 — Measurements save button disabled until parsedPayload has at least one Number.isFinite value. NaN inputs stripped. Closure inline.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable the Measurements "Save" button until at least one field contains a valid number to prevent empty or invalid entries.

- **Bug Fixes**
  - Build `parsedPayload` using only `Number.isFinite` values (NaN like "abc" is ignored), and save from this object.
  - Button stays visible but disabled (`disabled` + `aria-disabled` + styles) until there’s at least one value; `onClick` also guards against empty saves. Audit doc updated to close F4.

<sup>Written for commit d04fc438748e631a868fcb865ba99860b4b1bb02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

