### PR TITLE
fix(web): ukrainian StrategyPage via messages catalog + 44px submit (F11+F13)

### DIFF
--- a/apps/web/src/pages/strategy/StrategyPage.tsx
+++ b/apps/web/src/pages/strategy/StrategyPage.tsx
@@ -32,6 +32,7 @@
 import { useMemo, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { strategicKeys } from "@shared/lib/api/queryKeys";
+import { messages } from "../../shared/i18n/uk";
 import { internalFetch } from "@shared/lib/api/internalFetch";
 
 /** Канонічний catalog персон (mirror з `apps/server/src/lib/strategicGoals.ts`). */
@@ -93,10 +94,10 @@ export function kyivMondayISO(now: Date = new Date()): string {
 }
 
 const PERSONA_LABELS: Record<StrategicGoalPersona, string> = {
-  finyk: "finyk (finance)",
-  fizruk: "fizruk (fitness)",
-  nutrition: "nutrition",
-  routine: "routine",
+  finyk: "Фінік (фінанси)",
+  fizruk: "Фізрук (фітнес)",
+  nutrition: "Харчування",
+  routine: "Рутина",
 };
 
 /**
@@ -203,7 +204,7 @@ export function StrategyPage({ founderUserId }: StrategyPageProps) {
     e.preventDefault();
     const trimmed = goalText.trim();
     if (!trimmed) {
-      setSubmitError("goal_text не може бути порожнім");
+      setSubmitError(messages.strategy.goalTextRequired);
       return;
     }
     createMutation.mutate({
@@ -217,20 +218,20 @@ export function StrategyPage({ founderUserId }: StrategyPageProps) {
   return (
     <main className="mx-auto max-w-3xl p-6">
       <header className="mb-6">
-        <h1 className="text-2xl font-semibold">Strategic Goals</h1>
+        <h1 className="text-2xl font-semibold">{messages.strategy.title}</h1>
         <p className="text-sm text-muted-foreground">
-          Week starting <code>{weekStart}</code> &middot; placeholder UI (PR-34
-          skeleton)
+          {messages.strategy.weekPrefix} <code>{weekStart}</code> &middot;{" "}
+          {messages.strategy.placeholderTag}
         </p>
       </header>
 
       <section aria-labelledby="add-goal-heading" className="mb-8">
         <h2 id="add-goal-heading" className="mb-2 text-lg font-medium">
-          Add goal
+          {messages.strategy.addGoal}
         </h2>
         <form onSubmit={handleSubmit} className="space-y-3">
           <label className="block">
-            <span className="text-sm">Persona</span>
+            <span className="text-sm">{messages.strategy.personaLabel}</span>
             <select
               value={persona}
               onChange={(e) =>
@@ -246,14 +247,14 @@ export function StrategyPage({ founderUserId }: StrategyPageProps) {
             </select>
           </label>
           <label className="block">
-            <span className="text-sm">Goal text</span>
+            <span className="text-sm">{messages.strategy.goalTextLabel}</span>
             <textarea
               value={goalText}
               onChange={(e) => setGoalText(e.target.value)}
               rows={3}
               maxLength={2048}
               className="mt-1 block w-full rounded-md border px-3 py-2"
-              placeholder="e.g. Cut 'Coffee' category spend by 60% before Sunday"
+              placeholder={messages.strategy.goalTextPlaceholder}
             />
           </label>
           {submitError !== null && (
@@ -264,23 +265,27 @@ export function StrategyPage({ founderUserId }: StrategyPageProps) {
           <button
             type="submit"
             disabled={createMutation.isPending}
-            className="rounded-md bg-info-strong px-4 py-2 text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-info disabled:opacity-50"
+            className="rounded-md bg-info-strong px-4 py-2 text-white text-style-label min-h-touch-target focus-visible:outline focus-visible:outline-2 focus-visible:outline-info disabled:opacity-50"
           >
-            {createMutation.isPending ? "Saving…" : "Add goal"}
+            {createMutation.isPending
+              ? messages.strategy.saving
+              : messages.strategy.addGoal}
           </button>
         </form>
       </section>
 
       <section aria-labelledby="goals-heading">
         <h2 id="goals-heading" className="mb-2 text-lg font-medium">
-          This week&apos;s goals
+          {messages.strategy.thisWeeksGoals}
         </h2>
         {isLoading ? (
-          <p className="text-sm text-muted-foreground">Loading…</p>
+          <p className="text-sm text-muted-foreground">
+            {messages.strategy.loading}
+          </p>
         ) : goals.length === 0 ? (
           <p className="text-sm text-muted-foreground">
-            No goals for week starting {weekStart}. WF-26 cron fires Mon 09:00
-            Kyiv, or add a goal manually using the form above.
+            {messages.strategy.emptyStatePrefix} {weekStart}{" "}
+            {messages.strategy.emptyStateSuffix}
           </p>
         ) : (
           <div className="space-y-4">

--- a/apps/web/src/shared/i18n/uk.ts
+++ b/apps/web/src/shared/i18n/uk.ts
@@ -220,6 +220,26 @@ export const messages = {
     historyEmpty: "Історія порожня",
   },
 
+  // Audit 09 F11 — Ukrainian copy for the strategy page (PR-34 skeleton).
+  // Persona id strings stay English (server API contract).
+  strategy: {
+    title: "Стратегічні цілі",
+    weekPrefix: "Тиждень з",
+    placeholderTag: "placeholder UI (PR-34 skeleton)",
+    addGoal: "Додати ціль",
+    personaLabel: "Персона",
+    goalTextLabel: "Текст цілі",
+    goalTextPlaceholder:
+      "напр.: Скоротити витрати в категорії «Кава» на 60% до неділі",
+    saving: "Зберігаю…",
+    thisWeeksGoals: "Цілі цього тижня",
+    loading: "Завантаження…",
+    emptyStatePrefix: "Цілей на тиждень з",
+    emptyStateSuffix:
+      "немає. WF-26 cron стартує понеділок 09:00 Kyiv, або додай ціль вручну через форму вище.",
+    goalTextRequired: "Текст цілі не може бути порожнім",
+  },
+
   errors: {
     generic: {
       // Phase 2 — generic-помилки, що рендеряться у банері/toast-і коли
@@ -662,8 +682,7 @@ export const messages = {
       freeTagline: "Базові ліміти у всіх 4 модулях. Local-first, без cloud.",
       premiumName: "Premium",
       premiumCadence: "/міс",
-      premiumTagline:
-        "Усе розблоковано. Один план — без рівнів і доплат.",
+      premiumTagline: "Усе розблоковано. Один план — без рівнів і доплат.",
     },
     features: {
       expensesFinyk: "Витрати у Фініку",
@@ -712,8 +731,7 @@ export const messages = {
     },
     waitlist: {
       headline: "Email для waitlist",
-      subtitle:
-        "Один лист, коли Premium стартує. Без спаму, без авто-списань.",
+      subtitle: "Один лист, коли Premium стартує. Без спаму, без авто-списань.",
     },
     footer:
       "Ціни у EUR; для UA-ринку Stripe виставляє ₴-еквівалент. Фінальна цифра — у pricing-strategy PR після market-research.",

--- a/docs/audits/2026-05-13-page-audit-09-routine-strategy.md
+++ b/docs/audits/2026-05-13-page-audit-09-routine-strategy.md
@@ -239,6 +239,8 @@ When PR-35+ wires the page to `/strategy`, every shipped string will need a foll
 **Recommendation.**
 Translate the strings now (it's a 10-line diff) and rename `PERSONA_LABELS` to Ukrainian: `"Фінік (фінанси)"`, `"Фізрук (фітнес)"`, `"Харчування"`, `"Рутина"`. Keep the persona id strings English (they are an API contract with the server).
 
+> **Closure note (2026-06-01, PR-B1 of 15-pack):** Resolved. `apps/web/src/pages/strategy/StrategyPage.tsx` now ships Ukrainian copy across all surfaces: header "Стратегічні цілі" / "Тиждень з …"; form "Додати ціль", "Персона", "Текст цілі", placeholder; submit "Додати ціль" / "Зберігаю…"; empty/loading "Цілей на тиждень… немає" / "Завантаження…"; error-text "Текст цілі не може бути порожнім". `PERSONA_LABELS` map → Ukrainian as recommended. Persona id strings (`"finyk"` etc.) intentionally stay English as the server-side API contract.
+
 ---
 
 ### F12 — Strategy page uses raw Tailwind palette pairs (`bg-blue-600`, `text-red-600`, `text-gray-200`) [severity: medium] [perspective: tailwind]
@@ -274,6 +276,8 @@ The page is meant to be touched on mobile (Capacitor shell + PWA both list it). 
 
 **Recommendation.**
 Replace the bare `<button>` with the design-system `<Button variant="primary">` from `@shared/components/ui/Button` — it auto-applies `min-h-[44px]` and the correct focus ring.
+
+> **Closure note (2026-06-01, PR-B1 of 15-pack):** Resolved minimally. Submit button keeps the bare `<button>` (StrategyPage is still PR-34 skeleton + unmounted) but adds `min-h-touch-target` + `text-style-label` to the className. Resolves to ≥44 px floor on coarse-pointer devices; WCAG 2.5.5 satisfied. Full `<Button>` migration deferred to the PR-35+ conversation-UI rewrite (StrategyPage will get a router-mount + design-system pass together).
 
 ---
 


### PR DESCRIPTION
Audit 09 F11 + F13 bundled. StrategyPage UI strings now route through messages.strategy.* in shared/i18n/uk.ts; PERSONA_LABELS + submit error → Ukrainian; persona ids stay English (server contract). Submit gets min-h-touch-target + text-style-label so WCAG 2.5.5 holds without full Button migration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localized StrategyPage to Ukrainian via `messages.strategy` and raised the submit button to a 44px touch target to meet WCAG 2.5.5. Persona labels are now Ukrainian; persona IDs stay English to match the server contract.

- **Refactors**
  - Routed all StrategyPage UI strings through `messages.strategy.*` in `shared/i18n/uk.ts` (titles, form labels, placeholders, loading/empty, saving, errors).
  - Updated `PERSONA_LABELS` to Ukrainian while keeping persona IDs (`finyk`, etc.) in English.
  - Added `min-h-touch-target` and `text-style-label` to the submit button; defers full design-system `<Button>` migration.
  - Updated audit doc with closure notes for F11 (i18n) and F13 (touch target).

<sup>Written for commit c1e88e6b5739938b5c3b31a2b0b142eb4ede6d68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

