### PR TITLE
refactor(web): replace row! bang with undefined guard in habit drag (F10)

### DIFF
--- a/apps/web/src/modules/routine/components/settings/ActiveHabitsSection.tsx
+++ b/apps/web/src/modules/routine/components/settings/ActiveHabitsSection.tsx
@@ -139,7 +139,8 @@ export function ActiveHabitsSection({
                 if (fi < 0 || ti < 0) return s;
                 const next = [...ordered];
                 const [row] = next.splice(fi, 1);
-                next.splice(ti, 0, row!);
+                if (row === undefined) return s;
+                next.splice(ti, 0, row);
                 return setHabitOrder(s, next);
               });
             }}

--- a/docs/audits/2026-05-13-page-audit-09-routine-strategy.md
+++ b/docs/audits/2026-05-13-page-audit-09-routine-strategy.md
@@ -222,6 +222,8 @@ if (!row) return s; // nothing to move
 next.splice(ti, 0, row);
 ```
 
+> **Closure note (2026-06-01, PR-B2 of 15-pack):** Resolved. `apps/web/src/modules/routine/components/settings/ActiveHabitsSection.tsx:141-144` now narrows via `if (row === undefined) return s;` before the second `splice`. No `!`. Hard Rule #19 friendly.
+
 ---
 
 ### F11 — Strategy page UI strings are in English; product is Ukrainian-first [severity: medium] [perspective: i18n]


### PR DESCRIPTION
Audit 09 F10 — drops the non-null assertion in ActiveHabitsSection drag-drop handler. Closure inline.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `row!` with an `undefined` guard in the habit drag-and-drop handler to prevent inserting an undefined row during reordering. Addresses audit F10.

- **Refactors**
  - `ActiveHabitsSection`: return early if `row === undefined` before the second `splice`; remove `row!`.
  - Added F10 closure note to the audit doc.

<sup>Written for commit ca01ec3f3e6e928bbe2a2efc4959bfcee2a3906d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

