### PR TITLE
perf(web): scope nutrition coach/digest invalidate per-day (F11)

### DIFF
--- a/apps/web/src/modules/nutrition/hooks/useNutritionLog.ts
+++ b/apps/web/src/modules/nutrition/hooks/useNutritionLog.ts
@@ -102,17 +102,26 @@ export function useNutritionLog() {
 
   // Coach insight and weekly digest both derive from the nutrition log.
   // Invalidate them whenever the log changes so the next mount / user
-  // refresh regenerates with the latest context. `staleTime: Infinity`
-  // on those queries means invalidation only marks them stale — it does
-  // not trigger unsolicited AI calls.
+  // refresh regenerates with the latest context.
+  //
+  // Audit 08 F11 scope-tightening: previously called `coachKeys.all` /
+  // `digestKeys.all` — a broad sweep that refetched every coach query
+  // and every weekly-digest variant on each meal save. Now scoped to
+  // `coachKeys.insight(selectedDate)` (the only key whose data depends
+  // on the day the user edited) and `digestKeys.history` (the rolling
+  // list the user might be scrolling). Other coach / digest queries
+  // keep their `staleTime: Infinity` cache; they re-derive on their own
+  // next mount-cycle without a sync write storm here.
   useEffect(() => {
     if (!didMountRef.current) {
       didMountRef.current = true;
       return;
     }
-    queryClient.invalidateQueries({ queryKey: coachKeys.all });
-    queryClient.invalidateQueries({ queryKey: digestKeys.all });
-  }, [nutritionLog, queryClient]);
+    queryClient.invalidateQueries({
+      queryKey: coachKeys.insight(selectedDate),
+    });
+    queryClient.invalidateQueries({ queryKey: digestKeys.history });
+  }, [nutritionLog, selectedDate, queryClient]);
 
   /**
    * Add a meal to the currently selected date and close the add-meal sheet.

--- a/docs/audits/2026-05-13-page-audit-08-nutrition.md
+++ b/docs/audits/2026-05-13-page-audit-08-nutrition.md
@@ -279,6 +279,8 @@ Hard Rule #12 (`module-accent containment`) — буква правила про
 
 ### F11 — `staleTime: Infinity` на nutritionLog без явного invalidate-strategy [severity: medium] [perspective: perf]
 
+> **Closure note (2026-06-01, PR-B7 of 15-pack):** Resolved. `apps/web/src/modules/nutrition/hooks/useNutritionLog.ts` invalidations are scoped: `coachKeys.all` → `coachKeys.insight(selectedDate)` (per-day, only the dayKey the user edited), `digestKeys.all` → `digestKeys.history` (rolling list user might be scrolling). Other coach / digest variants keep their `staleTime: Infinity` cache and re-derive lazily. Mobile bandwidth-tax on `handleAddMeal` reduced from "all coach + all digest" to "one insight + history list". Inline comment rewritten to reflect the new contract; deps tuple updated to include `selectedDate`.
+
 **Page:** Log
 **File:** `apps/web/src/modules/nutrition/hooks/useNutritionLog.ts`
 **Lines:** 105–115


### PR DESCRIPTION
Audit 08 F11 — useNutritionLog invalidates only coachKeys.insight(selectedDate) + digestKeys.history instead of broad .all. Mobile bandwidth tax on handleAddMeal cut from all-coach-storm to single per-day refetch. Closure inline.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes nutrition cache invalidation to per-day keys to stop broad refetches when adding a meal. Invalidates only `coachKeys.insight(selectedDate)` and `digestKeys.history`, reducing mobile bandwidth; other coach/digest queries keep `staleTime: Infinity` and refresh on next mount.

<sup>Written for commit 26048f57799f13f02805e43f005cd80af3745a4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

