### PR TITLE
fix(web): bump filter-pill coarse-pointer floor to 44px (F12)

### DIFF
--- a/apps/web/src/modules/finyk/pages/transactions/TransactionFilters.tsx
+++ b/apps/web/src/modules/finyk/pages/transactions/TransactionFilters.tsx
@@ -46,7 +46,14 @@ export function TransactionFilters({
             onClick={() => onChangeFilter(f.id)}
             aria-pressed={filter === f.id}
             className={cn(
+              // Audit 05 F12: keep the compact `h-7` visual on fine
+              // pointers (mouse) but extend the touch-target floor on
+              // coarse pointers (mobile finger-tap) to the WCAG 2.5.5 ≥44
+              // px contract via `pointer-coarse:min-h-[44px]`. The pill
+              // outline stays 28px on desktop; the hit area only grows
+              // where it actually matters.
               "shrink-0 inline-flex items-center h-7 px-3 text-style-caption font-medium rounded-full border transition-colors",
+              "pointer-coarse:min-h-[44px]",
               "focus:outline-none focus-visible:ring-2 focus-visible:ring-finyk/50 focus-visible:ring-offset-1",
               filter === f.id
                 ? "bg-primary border-primary text-bg shadow-sm"

--- a/docs/audits/2026-05-13-page-audit-05-finyk.md
+++ b/docs/audits/2026-05-13-page-audit-05-finyk.md
@@ -672,6 +672,8 @@ and `c.label.replace(/^\S+\s/, "")` instead.
 
 ### F12 — Filter pills opt out of 44×44 touch target via `data-compact` [severity: medium] [perspective: a11y]
 
+> **Closure note (2026-06-01, PR-B12 of 15-pack):** Resolved. `TransactionFilters.tsx` button gets `pointer-coarse:min-h-[44px]`. Visual 28px pill (`h-7`) preserved on fine-pointer (desktop) so the chip strip stays dense; coarse-pointer devices (mobile finger-tap) get the WCAG 2.5.5 ≥44px hit area without changing the visible rendering. Standard `Button` `needsCoarseMinTarget` policy mirrored locally since `data-compact` is the project-wide opt-out signal for the dense-on-fine, ergonomic-on-coarse pattern.
+
 **Page:** `transactions`
 **File:** `apps/web/src/modules/finyk/pages/transactions/TransactionFilters.tsx`
 **Lines:** L39–L58


### PR DESCRIPTION
Audit 05 F12 — TransactionFilters button gets pointer-coarse:min-h-[44px]. h-7 visual preserved on desktop, touch-target floor satisfied on mobile. WCAG 2.5.5.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make transaction filter pills accessible on touch devices by enforcing a 44px minimum touch target (WCAG 2.5.5) via `pointer-coarse:min-h-[44px]`, while keeping the 28px visual height on desktop. Updated `TransactionFilters.tsx` and the audit doc to close F12.

<sup>Written for commit cecde9fb4ae687f9d83839effe89385bba4243b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

