### PR TITLE
docs: close audit-09 F8 — routine reminders react to perm flip (verified-done)

### DIFF
--- a/docs/audits/2026-05-13-page-audit-09-routine-strategy.md
+++ b/docs/audits/2026-05-13-page-audit-09-routine-strategy.md
@@ -164,6 +164,8 @@ Each catch should at minimum call `logError("routine.reminders.notify-failed", e
 
 ### F8 — `useRoutineReminders` scheduler is bound only to `enabled` flag; runtime permission flips are ignored [severity: medium] [perspective: bug]
 
+> **Closure note (2026-06-01, PR-B15 of 15-pack):** Verified-already-done. `apps/web/src/modules/routine/hooks/useRoutineReminders.ts:93-149` introduced `useNotificationPermission` — listens to the Permissions API `change` event with `visibilitychange` / `focus` fallback. Scheduler effect tuple now includes `[enabled, permission]`, so revoke stops the loop and re-grant restarts it without a tab refresh. Audit-flagged "ignored runtime permission flip" closed.
+
 > ✅ **Closed 2026-05-31** — додано `useNotificationPermission` хук: підписка на `navigator.permissions.query({ name: "notifications" })` change-event + fallback `visibilitychange`/`focus`. Стан permission тепер у deps scheduler-ефекту — revoke зупиняє цикл, re-grant автоматично рестартує без перезавантаження SPA.
 
 **Page:** Routine module / Reminders hook


### PR DESCRIPTION
F8 verified-already-done: useRoutineReminders has useNotificationPermission listening to Permissions API change + visibilitychange/focus fallback. Scheduler tuple [enabled, permission] stops on revoke and restarts on re-grant. Doc-only closure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update audit doc to close F8. `useRoutineReminders` already reacts to runtime notification permission flips via `useNotificationPermission` (Permissions API change + `visibilitychange`/`focus` fallback), and the scheduler deps `[enabled, permission]` stop on revoke and restart on re‑grant.

<sup>Written for commit 10cb368f307646ca4a9515e990e4a1caf44ae56d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

