### PR TITLE
ci(root): align pnpm action-setup version to packageManager (9.15.1)

### DIFF
--- a/.github/workflows/detox-ios.yml
+++ b/.github/workflows/detox-ios.yml
@@ -107,7 +107,7 @@ jobs:
       # which crashes setup-node `cache: pnpm` on macOS runners.
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
         with:
-          version: 9.15.9
+          version: 9.15.1
 
       # actions/setup-node v6.4.0 (SHA-pinned for supply-chain hardening)
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e

--- a/.github/workflows/mobile-shell-ios-release.yml
+++ b/.github/workflows/mobile-shell-ios-release.yml
@@ -102,7 +102,7 @@ jobs:
       # which crashes setup-node `cache: pnpm` on macOS runners.
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
         with:
-          version: 9.15.9
+          version: 9.15.1
 
       # actions/setup-node v6.4.0 (SHA-pinned for supply-chain hardening)
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e

--- a/.github/workflows/mobile-shell-ios.yml
+++ b/.github/workflows/mobile-shell-ios.yml
@@ -69,7 +69,7 @@ jobs:
       # Linux ones (where the cache step is skipped on miss).
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
         with:
-          version: 9.15.9
+          version: 9.15.1
 
       # actions/setup-node v6.4.0 (SHA-pinned for supply-chain hardening)
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 9.15.9
+          version: 9.15.1
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

Four macOS workflows pinned `version: 9.15.9` in the `pnpm/action-setup` step, while the root `package.json` `packageManager` field — and every `Dockerfile`, `vercel.json`, and `engines.pnpm` — declares **`pnpm@9.15.1`**. `pnpm/action-setup` errors on that mismatch:

```
Error: Multiple versions of pnpm specified:
  - version 9.15.9 in the GitHub Action config with the key "version"
  - version pnpm@9.15.1 in the package.json with the key "packageManager"
Remove one of these versions to avoid version mismatch errors
```

…which fails `Build iOS Simulator`, `detox-ios`, `mobile-shell-ios(-release)`, and `mutation-testing` at the setup step, **before any work runs**.

The steps' own comments state `version:` should *mirror* `packageManager` (the explicit pin is required on macOS so the action doesn't default to `pnpm@latest` 10.x, which needs Node ≥22.13 and crashes setup-node's `cache: pnpm`). This aligns the four pins to the canonical `9.15.1` — keeping the macOS-required explicit `version` while removing the mismatch.

Files: `detox-ios.yml`, `mutation-testing.yml`, `mobile-shell-ios.yml`, `mobile-shell-ios-release.yml`.

## Governing Skill

- Primary skill: `sergeant-deploy-and-observability`
- Secondary skill (if truly needed): —

## Playbook

- Primary playbook: —
- Why this playbook: CI workflow config alignment; no playbook covers it.
- If no playbook matched, why: four one-line version pins; mechanical alignment to the canonical declaration.

## Verification

```bash
grep -rn "9.15.9" .github/workflows/   # → none; all aligned to 9.15.1
```

Canonical version cross-checked: `package.json` (`packageManager` + `engines.pnpm`), `Dockerfile.api`, `Dockerfile.console`, `Dockerfile.openclaw-gateway`, `apps/web/vercel.json` all use `9.15.1`. actionlint runs in CI.

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [ ] I checked whether `AGENTS.md` needed an update.
- [ ] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a — CI config alignment, no doc/contract change.

## Risk and Rollout

- User-visible risk: none. CI-only change; aligns to the version already used by all builds/Dockerfiles.
- Rollout / deploy order: standard merge. Unblocks the four macOS/mobile workflows.
- Backout plan: revert the four one-line edits.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

Second of three independent infra fixes surfaced while diagnosing red CI on #3284 (others: `jose` direct dep #3287, repo-wide `format:check` drift). The version `9.15.9` appears nowhere else in the repo — `9.15.1` is unambiguously canonical, so no version-direction decision is needed.

https://claude.ai/code/session_01PZwSid1YWxKNUXjams82Vz

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZwSid1YWxKNUXjams82Vz)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `pnpm` in macOS workflows to the root `packageManager` version `9.15.1` to resolve setup errors and unblock iOS and mutation testing jobs.

- **Bug Fixes**
  - Set `pnpm/action-setup` `version: 9.15.1` in `detox-ios.yml`, `mobile-shell-ios.yml`, `mobile-shell-ios-release.yml`, and `mutation-testing.yml`.
  - Prevents the "Multiple versions of pnpm specified" error and avoids defaulting to `pnpm@10.x` on macOS.

<sup>Written for commit 8f2e89fd5394f0881e4c46effe29a5b8c70c7ea6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

