### PR TITLE
feat(server): hard-fail boot on missing VAPID keys in production (PR-01)

### DIFF
--- a/apps/server/src/env/__tests__/assertStartupEnv.test.ts
+++ b/apps/server/src/env/__tests__/assertStartupEnv.test.ts
@@ -36,6 +36,10 @@ const PROD_BASELINE = {
   // exercise the negative path for this gate live in a dedicated
   // `describe` block below and DELETE this key from the baseline.
   METRICS_TOKEN: "c".repeat(64),
+  // backend-perf PR-01 — VAPID keypair is required in production. Negative
+  // path lives in its own `describe` block below (with a VAPID-less baseline).
+  VAPID_PUBLIC_KEY: "d".repeat(80),
+  VAPID_PRIVATE_KEY: "e".repeat(40),
 };
 
 describe("assertStartupEnv — AI_QUOTA_DISABLED hard-block (H9)", () => {
@@ -368,6 +372,10 @@ describe("assertStartupEnv — METRICS_TOKEN hard-fail (T2 audit #4)", () => {
     DATABASE_URL: "postgres://hub:hub@127.0.0.1:5432/hub",
     BETTER_AUTH_TOKEN_ENC_KEY: "a".repeat(64),
     NUTRITION_BACKUP_KEY_SECRET: "b".repeat(64),
+    // backend-perf PR-01 — keep VAPID present so the not-throw case reaches
+    // the METRICS gate instead of tripping the (later) VAPID check.
+    VAPID_PUBLIC_KEY: "d".repeat(80),
+    VAPID_PRIVATE_KEY: "e".repeat(40),
     OPENCLAW_GITHUB_PAT: "",
     Git_PAT: "",
   };
@@ -518,6 +526,57 @@ describe("assertStartupEnv — AI_MEMORY_ENABLED requires VOYAGE_API_KEY (D3)", 
       NODE_ENV: "test",
       AI_MEMORY_ENABLED: "true",
       VOYAGE_API_KEY: "",
+    });
+    expect(() => assertStartupEnv()).not.toThrow();
+  });
+});
+
+describe("assertStartupEnv — backend-perf PR-01: VAPID keypair required in production", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  // Prod baseline WITHOUT the VAPID keypair so we exercise the negative path.
+  // All other production-required gates are satisfied, so only the VAPID
+  // check fires. Legacy PATs cleared (same Git_PAT gate as PROD_BASELINE).
+  const VAPID_MISSING_BASELINE = {
+    NODE_ENV: "production" as const,
+    DATABASE_URL: "postgres://hub:hub@127.0.0.1:5432/hub",
+    BETTER_AUTH_TOKEN_ENC_KEY: "a".repeat(64),
+    NUTRITION_BACKUP_KEY_SECRET: "b".repeat(64),
+    METRICS_TOKEN: "c".repeat(64),
+    OPENCLAW_GITHUB_PAT: "",
+    Git_PAT: "",
+  };
+
+  it("throws in production when both VAPID keys are missing", async () => {
+    const assertStartupEnv = await loadAssertStartupEnv(VAPID_MISSING_BASELINE);
+    expect(() => assertStartupEnv()).toThrow(
+      /VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY/,
+    );
+  });
+
+  it("throws in production when only the public key is set", async () => {
+    const assertStartupEnv = await loadAssertStartupEnv({
+      ...VAPID_MISSING_BASELINE,
+      VAPID_PUBLIC_KEY: "d".repeat(80),
+    });
+    expect(() => assertStartupEnv()).toThrow(/VAPID/);
+  });
+
+  it("does NOT throw in production when both VAPID keys are present", async () => {
+    const assertStartupEnv = await loadAssertStartupEnv({
+      ...VAPID_MISSING_BASELINE,
+      VAPID_PUBLIC_KEY: "d".repeat(80),
+      VAPID_PRIVATE_KEY: "e".repeat(40),
+    });
+    expect(() => assertStartupEnv()).not.toThrow();
+  });
+
+  it("does NOT throw in NODE_ENV=development when VAPID keys are missing (warn-only)", async () => {
+    const assertStartupEnv = await loadAssertStartupEnv({
+      NODE_ENV: "development",
     });
     expect(() => assertStartupEnv()).not.toThrow();
   });

--- a/apps/server/src/env/env.ts
+++ b/apps/server/src/env/env.ts
@@ -1313,6 +1313,21 @@ export function assertStartupEnv(): void {
     );
   }
 
+  // backend-perf PR-01 — VAPID keypair enforcement. Without both keys
+  // `/api/push/*` silently degrades to 503 at request time (a misconfigured
+  // prod deploy looks healthy until a push is attempted). Hard-fail at boot
+  // in production so the misconfiguration surfaces before traffic; warn-only
+  // outside production so local dev without push keys still boots.
+  if (isProduction && (!env.VAPID_PUBLIC_KEY || !env.VAPID_PRIVATE_KEY)) {
+    throw new Error(
+      "VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY are required in production. Without them /api/push/* silently returns 503. Generate a keypair with `npx web-push generate-vapid-keys`.",
+    );
+  } else if (!env.VAPID_PUBLIC_KEY || !env.VAPID_PRIVATE_KEY) {
+    warnings.push(
+      "VAPID_PUBLIC_KEY / VAPID_PRIVATE_KEY not set — web push is unavailable (/api/push/* → 503).",
+    );
+  }
+
   // T2 audit finding #1 — Stripe webhook secret enforcement. If billing is
   // wired (STRIPE_SECRET_KEY is set) then STRIPE_WEBHOOK_SECRET MUST also
   // be set in production; otherwise `verifyStripeSignature` had no secret

--- a/docs/planning/pr-plan-backend-perf-2026-05.md
+++ b/docs/planning/pr-plan-backend-perf-2026-05.md
@@ -64,6 +64,8 @@ PR-розкладка по решті open / Partial / Follow-up / Backlog items
 
 ## PR-01 — `refactor(server): centralize push env reads through env.ts`
 
+- **Status:** ✅ Виконано — env reads were already centralized (push.ts / routes/push.ts read `env.*`, 6 fields in schema); this PR closed the last acceptance item: `assertStartupEnv()` now hard-fails in production when `VAPID_PUBLIC_KEY`/`VAPID_PRIVATE_KEY` are missing (warn-only outside prod), so a misconfigured push deploy surfaces at boot instead of silent `/api/push/*` 503. Tests: `assertStartupEnv.test.ts` 47/47 (incl. new VAPID describe block).
+
 **Surface**
 
 - `apps/server/src/modules/push/push.ts` — `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_EMAIL`, `PUSH_SEND_TARGET_LIMIT`, `PUSH_SEND_TARGET_WINDOW_MS`.


### PR DESCRIPTION
## Summary

Завершує backend-perf **PR-01** (push env centralization). Env-читання вже були через `env.ts`; цей PR закриває останній acceptance-пункт картки — production-required guard для VAPID:

- **env.ts `assertStartupEnv()`**: у production кидає, якщо відсутній `VAPID_PUBLIC_KEY` або `VAPID_PRIVATE_KEY` (інакше `/api/push/*` тихо віддає 503 — misconfigured prod-деплой виглядає здоровим, поки не спробуєш push). Поза production — warn-only (локальний dev без ключів стартує). Лягає 1-в-1 за наявним патерном `DATABASE_URL` / `METRICS_TOKEN` / `NUTRITION_BACKUP_KEY_SECRET`.
- **assertStartupEnv.test.ts**: VAPID-ключі додано в `PROD_BASELINE` + `METRICS_BASELINE` (щоб unrelated prod not-throw кейси проходили новий gate), + окремий VAPID describe-блок (throws коли відсутні/частково, passes коли обидва, warn-only у development).
- Reconciled PR-01 card → ✅.

## Governing Skill

- Primary skill: `sergeant-server-api`

## Playbook

- Primary playbook: [`docs/playbooks/execute-planning-batch.md`](https://github.com/Skords-01/Sergeant/blob/main/docs/playbooks/execute-planning-batch.md) — finish-крок батч-workflow.
- Why this playbook: PR-01 — open planning-картка з беклогу.

## Verification

```bash
pnpm --filter @sergeant/server exec vitest run src/env/__tests__/assertStartupEnv.test.ts   # 47/47
pnpm docs:check-freshness-dashboard
```

- [x] Local smoke / manual validation completed — assertStartupEnv 47/47 (incl. new VAPID cases); staged typecheck passed; freshness gates green.
- [x] Surface-specific checks completed — server env startup gate.

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update. — ні.
- [x] I checked whether a playbook or skill needed an update. — ні.
- [x] I checked whether governance docs or review docs needed an update. — freshness-dashboard у синхроні.

Updated docs: `docs/planning/pr-plan-backend-perf-2026-05.md`.

## Risk and Rollout

- **User-visible risk:** поведінкова зміна — prod-деплой **без** `VAPID_PUBLIC_KEY`/`VAPID_PRIVATE_KEY` тепер fail-fast на boot замість тихого 503 на `/api/push/*`. Це навмисний намір картки (рання сигналізація misconfiguration). Railway prod уже має ці ключі (push працює); dev/test — warn-only, без падіння.
- **Rollout / deploy order:** переконатись, що `VAPID_*` виставлені в Railway prod env перед деплоєм (вони вже є). Жодних env-міграцій (поля існували в схемі).
- **Backout plan:** revert PR — повертає warn-only поведінку.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files.

## Reviewer Notes

Поведінкова зміна boot-fail-fast — підтвердьте, що Railway prod має `VAPID_PUBLIC_KEY` + `VAPID_PRIVATE_KEY` (push наразі живий, тож мають бути). Pre-existing/середовищні CI-чеки (Trivy image scan, `pnpm audit`, bootstrap Node-version, Hard-rules matrix, Codecov, Playwright/Argos) — не від цього diff.

https://claude.ai/code/session_01VsEdtHoMWip6NxATgRABj4

---
_Generated by [Claude Code](https://claude.ai/code/session_01VsEdtHoMWip6NxATgRABj4)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail fast on boot in production if `VAPID_PUBLIC_KEY` or `VAPID_PRIVATE_KEY` is missing to prevent silent 503s on `/api/push/*`. Completes PR-01 (push env centralization).

- **Migration**
  - Set `VAPID_PUBLIC_KEY` and `VAPID_PRIVATE_KEY` in all production environments before deploy.
  - To generate a keypair: `npx web-push generate-vapid-keys`.

<sup>Written for commit fb1ed39aceb8d66a0f8229f0673f6b1eb3013f62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

