### PR TITLE
refactor(web): migrate hub report cards to i18n catalog + Kyiv-time helpers

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -67,12 +67,3 @@ mockups/_shared/components/deck-stage.js
 mockups/_shared/components/design-canvas.jsx
 mockups/_shared/components/tweaks-panel.jsx
 mockups/_shared/components/motion-variants.jsx
-
-# i18n/kyiv-time migration debt — these 3 components carry pre-existing
-# sergeant-design/no-cyrillic-jsx-literal + prefer-kyiv-time warnings that the
-# pre-commit `eslint --max-warnings=0` gate blocks on any touch. Exempted from
-# Prettier so the repo-wide format:check stays green until the proper i18n
-# (uk.ts catalog) + Kyiv-time-helper migration lands in a dedicated PR.
-apps/web/src/core/hub/NutritionCard.tsx
-apps/web/src/core/hub/RoutineCard.tsx
-apps/web/src/modules/fizruk/components/dashboard/PrBadge.tsx

--- a/apps/web/src/core/hub/NutritionCard.tsx
+++ b/apps/web/src/core/hub/NutritionCard.tsx
@@ -5,6 +5,8 @@
 import { useMemo, useState } from "react";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { cn } from "@shared/lib/ui/cn";
+import { messages } from "@shared/i18n/uk";
+import { getKyivDateParts, parseKyivDate } from "@shared/lib/time/kyivTime";
 import { useLocalStorageState } from "@shared/hooks/useLocalStorageState";
 import { safeReadLS } from "@shared/lib/storage/storage";
 import {
@@ -40,7 +42,7 @@ function BarChart({
   if (!hasData) {
     return (
       <div className="h-24 flex items-center justify-center text-xs text-muted">
-        Немає даних
+        {messages.hub.reportNoData}
       </div>
     );
   }
@@ -53,18 +55,21 @@ function BarChart({
   const step = labelStep(dates.length);
 
   function formatLabel(dateStr: string) {
-    const d = new Date(dateStr + "T00:00:00");
+    // `dateStr` is a `YYYY-MM-DD` Kyiv day-key; read its calendar parts
+    // in Europe/Kyiv (kyivTime) rather than host-local `getDay/getDate`,
+    // so labels never drift on a roaming clock (domain-invariants spec).
+    const parts = getKyivDateParts(parseKyivDate(dateStr) ?? new Date(dateStr));
     if (isWeek) {
       const dayNames = ["Нд", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб"];
-      return dayNames[d.getDay()];
+      return dayNames[parts.weekday];
     }
-    return String(d.getDate());
+    return String(parts.day);
   }
 
   function formatTooltip(dateStr: string, value: number) {
-    const d = new Date(dateStr + "T00:00:00");
-    const day = String(d.getDate()).padStart(2, "0");
-    const month = String(d.getMonth() + 1).padStart(2, "0");
+    const parts = getKyivDateParts(parseKyivDate(dateStr) ?? new Date(dateStr));
+    const day = String(parts.day).padStart(2, "0");
+    const month = String(parts.month).padStart(2, "0");
     return `${day}.${month}: ${value.toLocaleString("uk-UA")}${unit}`;
   }
 
@@ -76,7 +81,10 @@ function BarChart({
         </div>
       )}
       {selected === null && <div className="h-4 mb-1" />}
-      <div className="flex items-end gap-0.5 h-20" aria-label="Графік">
+      <div
+        className="flex items-end gap-0.5 h-20"
+        aria-label={messages.hub.reportChartAria}
+      >
         {vals.map((v, i) => {
           const pct = Math.max(0, Math.min(100, (v / max) * 100));
           const isToday = dates[i] === localDateKey();
@@ -184,7 +192,10 @@ export default function NutritionCard({ period, offset }: NutritionCardProps) {
   );
 
   const { cur, prev, dates } = useMemo(() => {
-    const nutritionLog = safeReadLS("nutrition_log_v1", {}) as NutritionLog | null;
+    const nutritionLog = safeReadLS(
+      "nutrition_log_v1",
+      {},
+    ) as NutritionLog | null;
     const curRange = getPeriodRange(period, offset);
     const prevRange = getPeriodRange(period, offset - 1);
     const curDates = datesInRange(curRange.start, curRange.end);
@@ -223,12 +234,12 @@ export default function NutritionCard({ period, offset }: NutritionCardProps) {
           size="xs"
           className="flex-1 min-w-0 text-muted truncate"
         >
-          Харчування (ккал/день)
+          {messages.nutrition.reportHeading}
         </SectionHeading>
         {collapsed && (
           <span className="flex items-baseline gap-2 shrink-0">
             <span className="text-base font-bold text-text">
-              {formattedCurrent} ккал
+              {formattedCurrent} {messages.nutrition.kcalUnit}
             </span>
             <Delta cur={cur.avg} prev={prev.avg} higherIsBetter={true} />
           </span>
@@ -255,17 +266,20 @@ export default function NutritionCard({ period, offset }: NutritionCardProps) {
         <>
           <div className="flex items-baseline gap-2">
             <span className="text-style-hero text-text">
-              {formattedCurrent} ккал
+              {formattedCurrent} {messages.nutrition.kcalUnit}
             </span>
             <Delta cur={cur.avg} prev={prev.avg} higherIsBetter={true} />
           </div>
-          <p className="text-xs text-muted">Минулий: {formattedPrev} ккал</p>
+          <p className="text-xs text-muted">
+            {messages.hub.reportPrevious} {formattedPrev}{" "}
+            {messages.nutrition.kcalUnit}
+          </p>
           <BarChart
             key={`${period}-${offset}`}
             data={cur.daily}
             dates={dates}
             colorClass="bg-chart-nutrition"
-            unit=" ккал"
+            unit={` ${messages.nutrition.kcalUnit}`}
           />
         </>
       )}

--- a/apps/web/src/core/hub/RoutineCard.tsx
+++ b/apps/web/src/core/hub/RoutineCard.tsx
@@ -5,6 +5,8 @@
 import { useMemo, useState } from "react";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { cn } from "@shared/lib/ui/cn";
+import { messages } from "@shared/i18n/uk";
+import { getKyivDateParts, parseKyivDate } from "@shared/lib/time/kyivTime";
 import { useLocalStorageState } from "@shared/hooks/useLocalStorageState";
 import { safeReadLS } from "@shared/lib/storage/storage";
 import {
@@ -40,7 +42,7 @@ function BarChart({
   if (!hasData) {
     return (
       <div className="h-24 flex items-center justify-center text-xs text-muted">
-        Немає даних
+        {messages.hub.reportNoData}
       </div>
     );
   }
@@ -53,18 +55,21 @@ function BarChart({
   const step = labelStep(dates.length);
 
   function formatLabel(dateStr: string) {
-    const d = new Date(dateStr + "T00:00:00");
+    // `dateStr` is a `YYYY-MM-DD` Kyiv day-key; read its calendar parts
+    // in Europe/Kyiv (kyivTime) rather than host-local `getDay/getDate`,
+    // so labels never drift on a roaming clock (domain-invariants spec).
+    const parts = getKyivDateParts(parseKyivDate(dateStr) ?? new Date(dateStr));
     if (isWeek) {
       const dayNames = ["Нд", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб"];
-      return dayNames[d.getDay()];
+      return dayNames[parts.weekday];
     }
-    return String(d.getDate());
+    return String(parts.day);
   }
 
   function formatTooltip(dateStr: string, value: number) {
-    const d = new Date(dateStr + "T00:00:00");
-    const day = String(d.getDate()).padStart(2, "0");
-    const month = String(d.getMonth() + 1).padStart(2, "0");
+    const parts = getKyivDateParts(parseKyivDate(dateStr) ?? new Date(dateStr));
+    const day = String(parts.day).padStart(2, "0");
+    const month = String(parts.month).padStart(2, "0");
     return `${day}.${month}: ${value.toLocaleString("uk-UA")}${unit}`;
   }
 
@@ -76,7 +81,10 @@ function BarChart({
         </div>
       )}
       {selected === null && <div className="h-4 mb-1" />}
-      <div className="flex items-end gap-0.5 h-20" aria-label="Графік">
+      <div
+        className="flex items-end gap-0.5 h-20"
+        aria-label={messages.hub.reportChartAria}
+      >
         {vals.map((v, i) => {
           const pct = Math.max(0, Math.min(100, (v / max) * 100));
           const isToday = dates[i] === localDateKey();
@@ -184,7 +192,10 @@ export default function RoutineCard({ period, offset }: RoutineCardProps) {
   );
 
   const { cur, prev, dates } = useMemo(() => {
-    const routineState = safeReadLS("hub_routine_v1", null) as RoutineState | null;
+    const routineState = safeReadLS(
+      "hub_routine_v1",
+      null,
+    ) as RoutineState | null;
     const curRange = getPeriodRange(period, offset);
     const prevRange = getPeriodRange(period, offset - 1);
     const curDates = datesInRange(curRange.start, curRange.end);
@@ -223,7 +234,7 @@ export default function RoutineCard({ period, offset }: RoutineCardProps) {
           size="xs"
           className="flex-1 min-w-0 text-muted truncate"
         >
-          Рутина (виконання звичок)
+          {messages.routine.reportHeading}
         </SectionHeading>
         {collapsed && (
           <span className="flex items-baseline gap-2 shrink-0">
@@ -259,7 +270,9 @@ export default function RoutineCard({ period, offset }: RoutineCardProps) {
             </span>
             <Delta cur={cur.pct} prev={prev.pct} higherIsBetter={true} />
           </div>
-          <p className="text-xs text-muted">Минулий: {formattedPrev}%</p>
+          <p className="text-xs text-muted">
+            {messages.hub.reportPrevious} {formattedPrev}%
+          </p>
           <BarChart
             key={`${period}-${offset}`}
             data={cur.daily}

--- a/apps/web/src/modules/fizruk/components/dashboard/PrBadge.tsx
+++ b/apps/web/src/modules/fizruk/components/dashboard/PrBadge.tsx
@@ -19,6 +19,7 @@
  * the additional 14-day display gate keeps the surface motivating.
  */
 
+import { messages } from "@shared/i18n/uk";
 import type { PrLatest } from "../../hooks/usePrLatest";
 
 /**
@@ -74,9 +75,7 @@ export function PrBadge({ pr }: PrBadgeProps) {
       aria-hidden
       className="absolute top-3 right-3 min-h-[44px] min-w-[44px] flex items-center justify-end pointer-events-none motion-safe:animate-in motion-safe:fade-in motion-safe:duration-300"
     >
-      <span
-        className="inline-flex items-center gap-1 h-6 px-2 rounded-xl border whitespace-nowrap bg-fizruk-soft text-fizruk-strong border-fizruk-ring/50 dark:bg-fizruk-surface-dark/15 dark:text-fizruk dark:border-fizruk-border-dark/30 text-xs font-semibold"
-      >
+      <span className="inline-flex items-center gap-1 h-6 px-2 rounded-xl border whitespace-nowrap bg-fizruk-soft text-fizruk-strong border-fizruk-ring/50 dark:bg-fizruk-surface-dark/15 dark:text-fizruk dark:border-fizruk-border-dark/30 text-xs font-semibold">
         <svg
           width={12}
           height={12}
@@ -93,7 +92,9 @@ export function PrBadge({ pr }: PrBadgeProps) {
           <circle cx={12} cy={8} r={6} />
           <path d="M15.477 12.89 17 22l-5-3-5 3 1.523-9.11" />
         </svg>
-        <span>PR · {exerciseShort} · {weightLabel} кг</span>
+        <span>
+          PR · {exerciseShort} · {weightLabel} {messages.fizruk.kgUnit}
+        </span>
       </span>
     </div>
   );

--- a/apps/web/src/shared/i18n/uk.ts
+++ b/apps/web/src/shared/i18n/uk.ts
@@ -308,6 +308,12 @@ export const messages = {
     chatEmptySuggestionFizruk: "Як мої тренування?",
     chatEmptySuggestionNutrition: "Що я їв сьогодні?",
     chatEmptySuggestionRoutine: "Стан моїх звичок",
+
+    // HubReports per-domain cards (NutritionCard / RoutineCard) — shared
+    // inline labels for the lazy-loaded report charts.
+    reportNoData: "Немає даних",
+    reportChartAria: "Графік",
+    reportPrevious: "Минулий:",
   },
 
   onboarding: {
@@ -418,18 +424,25 @@ export const messages = {
   fizruk: {
     returnToActiveWorkout: "Повернутись до активного тренування",
     workoutRest: "Відпочинок",
+    // PrBadge weight-unit suffix on the Fizruk hero PR pill.
+    kgUnit: "кг",
   },
 
   nutrition: {
     fromPantry: "Зі складу",
     mealType: "Прийом їжі",
     templates: "Шаблони",
+    // HubReports NutritionCard
+    reportHeading: "Харчування (ккал/день)",
+    kcalUnit: "ккал",
   },
 
   routine: {
     dayReport: "Денний звіт",
     weekdays: "Дні тижня",
     archive: "Архів",
+    // HubReports RoutineCard
+    reportHeading: "Рутина (виконання звичок)",
     firstRun: {
       title: "Перша звичка — попередня",
       description:


### PR DESCRIPTION
## Summary

Closes the one tracked follow-up from #3293: the three components that were exempted via `.prettierignore` because they carried **pre-existing** `sergeant-design/no-cyrillic-jsx-literal` (13) + `prefer-kyiv-time` (8) warnings the pre-commit `eslint --max-warnings=0` gate blocks on touch. This migrates them properly and **removes the exemption** so they auto-format again.

- **`NutritionCard` / `RoutineCard`** (near-identical sibling hub-report cards):
  - Move inline Cyrillic labels (`Немає даних`, `Графік`, `Минулий:`, the kcal unit, and the card headings) into `messages.{hub,nutrition,routine}` in `apps/web/src/shared/i18n/uk.ts`.
  - Switch the `BarChart` date formatters from host-local `new Date(dayKey).getDay()/getDate()/getMonth()` to `getKyivDateParts(parseKyivDate(dayKey))`. **Behaviour-identical** — the inputs are already `YYYY-MM-DD` Kyiv day-keys, so the rendered calendar parts are unchanged; the change only removes the host-clock leak the rule targets (Europe/Kyiv is a domain invariant).
- **`PrBadge`**: move the `кг` weight suffix into `messages.fizruk.kgUnit`.
- **`.prettierignore`**: drop the 3 now-clean components.

All migrated strings keep their **exact** original text (new catalog keys, not reuse of near-identical ones), so no rendered copy changes.

## Governing Skill

- Primary skill: `sergeant-web-ui`
- Secondary skill (if truly needed): `sergeant-tech-debt`

## Playbook

- Primary playbook: —
- Why this playbook: targeted lint-debt migration (i18n + time-helper); no playbook covers it.
- If no playbook matched, why: mechanical string-extraction + behaviour-preserving helper swap in 3 components.

## Verification

```bash
pnpm format:check                                   # exit 0 — all files
pnpm exec eslint --max-warnings=0 <the 3 files>     # 0 warnings (was 21)
pnpm --filter @sergeant/web typecheck               # exit 0
pnpm --filter @sergeant/web exec vitest run src/core/hub/HubReports   # 50 passed
```

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [ ] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- `apps/web/src/shared/i18n/uk.ts` catalog (canonical UA-copy source per Hard Rule #15 / `docs/i18n/readiness.md`).

## Risk and Rollout

- User-visible risk: none. Strings preserved verbatim; date labels render identical calendar parts (now Kyiv-anchored instead of host-local).
- Rollout / deploy order: standard merge.
- Backout plan: revert the PR; the 3 files return to `.prettierignore` with their pre-existing warnings.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

Follow-up to the three infra fixes (#3287 jose, #3289 pnpm, #3293 format). The `prefer-kyiv-time` swap is the only behaviour-adjacent part — please sanity-check the `getKyivDateParts(parseKyivDate(dateStr))` reasoning: `parseKyivDate` returns Kyiv-midnight of the day-key and `getKyivDateParts` reads that day's year/month/day/weekday, which equals the key's own components (the old code read the same components off a local-midnight parse). After this lands the `.prettierignore` carries no source-component exemptions.

https://claude.ai/code/session_01PZwSid1YWxKNUXjams82Vz

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZwSid1YWxKNUXjams82Vz)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates Hub report cards to the `uk` i18n catalog and Kyiv-time helpers, clearing `sergeant-design/no-cyrillic-jsx-literal` and `prefer-kyiv-time` warnings in `NutritionCard`, `RoutineCard`, and `PrBadge`. Removes their `.prettierignore` exemptions; UI copy and chart labels remain unchanged.

- **Refactors**
  - Moved inline UA strings to `@shared/i18n/uk` (hub, nutrition, routine; added `fizruk.kgUnit`).
  - Switched chart label/tooltip formatting to `getKyivDateParts(parseKyivDate())` from `@shared/lib/time/kyivTime` to anchor dates to Europe/Kyiv.

<sup>Written for commit 08a9481ee0603646426ddf7143724ecf629eb457. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

