### PR TITLE
fix(docs): regen freshness-dashboard + add it to docs:gen-daily

### DIFF
--- a/docs/governance/freshness-dashboard.html
+++ b/docs/governance/freshness-dashboard.html
@@ -933,11 +933,11 @@
 </tr>
 <tr class="fresh">
   <td><code>docs/deploy/console.md</code></td>
-  <td class="status">Fresh (76d)</td>
-  <td>2026-05-19</td>
-  <td>2026-08-17</td>
-  <td class="num days">76</td>
-  <td>@codex.</td>
+  <td class="status">Fresh (90d)</td>
+  <td>2026-06-02</td>
+  <td>2026-08-31</td>
+  <td class="num days">90</td>
+  <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
@@ -1869,11 +1869,11 @@
 </tr>
 <tr class="fresh">
   <td><code>docs/initiatives/stack-pulse-2026-05/pr-05-typescript-types-node-downgrade.md</code></td>
-  <td class="status">Fresh (70d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">70</td>
-  <td>@Skords-01.</td>
+  <td class="status">Fresh (90d)</td>
+  <td>2026-06-02</td>
+  <td>2026-08-31</td>
+  <td class="num days">90</td>
+  <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
@@ -3309,10 +3309,10 @@
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/grant-privileged-access.md</code></td>
-  <td class="status">Fresh (70d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">70</td>
+  <td class="status">Fresh (90d)</td>
+  <td>2026-06-02</td>
+  <td>2026-08-31</td>
+  <td class="num days">90</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
@@ -3426,28 +3426,28 @@
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/release-expo-mobile.md</code></td>
-  <td class="status">Fresh (70d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">70</td>
+  <td class="status">Fresh (90d)</td>
+  <td>2026-06-02</td>
+  <td>2026-08-31</td>
+  <td class="num days">90</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/release-mobile-shell.md</code></td>
-  <td class="status">Fresh (70d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">70</td>
+  <td class="status">Fresh (90d)</td>
+  <td>2026-06-02</td>
+  <td>2026-08-31</td>
+  <td class="num days">90</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/release-web-and-api.md</code></td>
-  <td class="status">Fresh (70d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">70</td>
+  <td class="status">Fresh (90d)</td>
+  <td>2026-06-02</td>
+  <td>2026-08-31</td>
+  <td class="num days">90</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
@@ -3462,10 +3462,10 @@
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/respond-to-suspected-account-compromise.md</code></td>
-  <td class="status">Fresh (70d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">70</td>
+  <td class="status">Fresh (90d)</td>
+  <td>2026-06-02</td>
+  <td>2026-08-31</td>
+  <td class="num days">90</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
@@ -3489,10 +3489,10 @@
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/revoke-privileged-access.md</code></td>
-  <td class="status">Fresh (70d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">70</td>
+  <td class="status">Fresh (90d)</td>
+  <td>2026-06-02</td>
+  <td>2026-08-31</td>
+  <td class="num days">90</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
@@ -3516,10 +3516,10 @@
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/run-access-review.md</code></td>
-  <td class="status">Fresh (70d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">70</td>
+  <td class="status">Fresh (90d)</td>
+  <td>2026-06-02</td>
+  <td>2026-08-31</td>
+  <td class="num days">90</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
@@ -3687,11 +3687,11 @@
 </tr>
 <tr class="fresh">
   <td><code>docs/runbooks/encryption-key-rotation.md</code></td>
-  <td class="status">Fresh (91d)</td>
-  <td>2026-06-01</td>
-  <td>2026-09-01</td>
-  <td class="num days">91</td>
-  <td>@Skords-01.</td>
+  <td class="status">Fresh (90d)</td>
+  <td>2026-06-02</td>
+  <td>2026-08-31</td>
+  <td class="num days">90</td>
+  <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
@@ -4344,20 +4344,20 @@
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/sprint-2.md</code></td>
-  <td class="status">Fresh (70d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">70</td>
-  <td>@Skords-01.</td>
+  <td class="status">Fresh (90d)</td>
+  <td>2026-06-02</td>
+  <td>2026-08-31</td>
+  <td class="num days">90</td>
+  <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/sprint-3.md</code></td>
-  <td class="status">Fresh (91d)</td>
-  <td>2026-06-01</td>
-  <td>2026-09-01</td>
-  <td class="num days">91</td>
-  <td>@Skords-01.</td>
+  <td class="status">Fresh (90d)</td>
+  <td>2026-06-02</td>
+  <td>2026-08-31</td>
+  <td class="num days">90</td>
+  <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
@@ -4398,10 +4398,10 @@
 </tr>
 <tr class="fresh">
   <td><code>docs/security/pen-tests/2026-05-hardening-sweep.md</code></td>
-  <td class="status">Fresh (89d)</td>
-  <td>2026-06-01</td>
-  <td>2026-08-30</td>
-  <td class="num days">89</td>
+  <td class="status">Fresh (90d)</td>
+  <td>2026-06-02</td>
+  <td>2026-08-31</td>
+  <td class="num days">90</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
@@ -4434,11 +4434,11 @@
 </tr>
 <tr class="fresh">
   <td><code>docs/security/threat-model.md</code></td>
-  <td class="status">Fresh (76d)</td>
-  <td>2026-05-19</td>
-  <td>2026-08-17</td>
-  <td class="num days">76</td>
-  <td>@codex.</td>
+  <td class="status">Fresh (90d)</td>
+  <td>2026-06-02</td>
+  <td>2026-08-31</td>
+  <td class="num days">90</td>
+  <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
@@ -4461,11 +4461,11 @@
 </tr>
 <tr class="fresh">
   <td><code>docs/superpowers/plans/2026-05-06-sync-engine-writer-wiring.md</code></td>
-  <td class="status">Fresh (70d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">70</td>
-  <td>@Skords-01.</td>
+  <td class="status">Fresh (90d)</td>
+  <td>2026-06-02</td>
+  <td>2026-08-31</td>
+  <td class="num days">90</td>
+  <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "docs:check-wip-limits": "node scripts/docs/check-wip-limits.mjs",
     "docs:gen-trust-badge": "node scripts/docs/generate-trust-badge.mjs",
     "docs:check-trust-badge": "node scripts/docs/generate-trust-badge.mjs --check",
-    "docs:gen-daily": "pnpm docs:gen-open-work && pnpm docs:gen-today && pnpm docs:gen-trust-badge",
+    "docs:gen-daily": "pnpm docs:gen-open-work && pnpm docs:gen-today && pnpm docs:gen-trust-badge && pnpm docs:freshness-dashboard",
     "changelog:cut": "node scripts/changelog/cut-release.mjs",
     "docs:gen-graph": "node scripts/docs/generate-knowledge-graph.mjs",
     "docs:check-graph": "node scripts/docs/generate-knowledge-graph.mjs --check",


### PR DESCRIPTION
## Summary

`Docs automation` has been failing on every main push with the freshness-dashboard sync gate:

```
Check docs/governance/freshness-dashboard.html is up to date
❌ docs/governance/freshness-dashboard.html is out of date.
   Run: pnpm docs:freshness-dashboard
```

This is a **recurring** drift, not a one-off — every doc PR shifts at least one document's `Last validated:` / `Next review:` date, and the dashboard tracks all 533 of them. Today's snapshot is stale because the daily-brief cron only refreshes 3 artifacts:

```jsonc
// before
"docs:gen-daily": "pnpm docs:gen-open-work && pnpm docs:gen-today && pnpm docs:gen-trust-badge"
```

…freshness-dashboard wasn't on that list, so the cron never picked it up.

**Two-part fix in one PR:**

1. **Acute** — regenerate the file. `67 ins / 67 del` — every timestamp + counter tick shifted. Unblocks today's red.

2. **Chronic** — append `pnpm docs:freshness-dashboard` to `docs:gen-daily` so the [existing `docs-daily-brief.yml` cron](.github/workflows/docs-daily-brief.yml) (which already runs at 06:00 UTC and opens a daily refresh PR — fixed in [#3273](https://github.com/Skords-01/Sergeant/pull/3273)) picks up the new step automatically. No workflow change needed, just one extra `&&` in the script. After this lands, the dashboard will stay in sync via the same cron that already refreshes the other daily artifacts; per-PR drift becomes self-healing within 24 hours instead of accumulating until someone manually regens.

## Governing Skill

- Primary skill: `sergeant-start-here` (cross-tracker docs auto-gen orchestration)
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a
- Why this playbook: —
- If no playbook matched, why: pure script-orchestration one-liner with a regen ride-along; no procedural playbook applies.

## Verification

```bash
pnpm docs:gen-daily
# → all 4 generators run; the new step writes the freshness dashboard.

pnpm hard-rules:check && \
  pnpm docs:check-open-work && \
  pnpm docs:check-today && \
  pnpm docs:check-trust-badge && \
  node scripts/docs/generate-freshness-dashboard.mjs --check
# → all exit 0.
```

Additional checks:

- [x] Local smoke / manual validation completed — `docs:gen-daily` now runs 4 generators in series; freshness dashboard is the last (correct order, since the others write the input data it summarizes).
- [x] Surface-specific checks completed — both `docs:gen-daily` consumers (`.github/workflows/docs-daily-brief.yml:67` is the only one) get the new step automatically.

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. — n/a; the script + the AUTO-GENERATED dashboard are self-documenting.
- [x] I checked whether `AGENTS.md` needed an update. — no rule change.
- [x] I checked whether a playbook or skill needed an update. — none affected.
- [x] I checked whether governance docs or review docs needed an update. — none affected.

Updated docs:

- `package.json` (one script line extended)
- `docs/governance/freshness-dashboard.html` (auto-regenerated)

## Risk and Rollout

- User-visible risk: **none** — `docs:gen-daily` is a serial chain of regen scripts; adding one more `&&` extends the chain by one step. The freshness regen takes ~5s; daily cron walltime barely shifts.
- Rollout / deploy order: merge to `main`; the very next push to main re-runs `Docs automation` and the freshness `--check` goes green. The 06:00 UTC cron tomorrow will be the first one to use the extended chain.
- Backout plan: revert — CI returns to today's red (which is what it's been every day this week).

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian. — n/a, only English `package.json` and AUTO-GENERATED dashboard touched.
- [x] I did not use `--no-verify`.

## Reviewer Notes

If we ever want to add more auto-gen artifacts to the daily refresh (say, `docs:gen-graph` or `docs:gen-symbols`), the same `&&` pattern applies. Worth noting that the chronic-fix half of this PR is the load-bearing one — the acute regen would go stale again on the next doc-touching PR without the script extension.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Regenerated `docs/governance/freshness-dashboard.html` to unblock CI and added `pnpm docs:freshness-dashboard` to the `docs:gen-daily` chain so the daily cron keeps it up to date.

- **Bug Fixes**
  - Stopped recurring docs automation failures by updating the auto-generated dashboard (`+67/-67` date shifts).
  - Extended `docs:gen-daily` to include `docs:freshness-dashboard`, letting the existing daily brief cron refresh it automatically.

<sup>Written for commit 60d6ae405763c3a8e08108c262e19ea86a1504d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

