### PR TITLE
fix(ci): align Detox Android AVD name with .detoxrc.js

### DIFF
--- a/.github/workflows/detox-android.yml
+++ b/.github/workflows/detox-android.yml
@@ -197,6 +197,13 @@ jobs:
           target: google_apis
           arch: x86_64
           profile: pixel_5
+          # Explicit AVD name aligned with `apps/mobile/.detoxrc.js:67`
+          # (`avdName: "Pixel_5_API_34"`). Without it the action defaults
+          # to `test`, and Detox's `AVDValidator._assertAVDMatch` fails
+          # with `Cannot boot Android Emulator with the name: 'Pixel_5
+          # _API_34'`. Same name has to be passed on both action calls
+          # (snapshot create + run) so the cached snapshot is reusable.
+          avd-name: Pixel_5_API_34
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
@@ -214,6 +221,7 @@ jobs:
           target: google_apis
           arch: x86_64
           profile: pixel_5
+          avd-name: Pixel_5_API_34
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true


### PR DESCRIPTION
## Summary

After [#3310](https://github.com/Skords-01/Sergeant/pull/3310) closed the Detox 20.x listener import, `Detox (Android)` is still failing — but on the next step:

```
DetoxRuntimeError: Cannot boot Android Emulator with the name: 'Pixel_5_API_34'
HINT: Make sure you choose one of the available emulators: test
```

Root cause: the workflow's two [`reactivecircus/android-emulator-runner`](https://github.com/ReactiveCircus/android-emulator-runner) calls (snapshot create + suite run) never pass an `avd-name`. The action's default AVD name is `test`. But [`apps/mobile/.detoxrc.js:67`](apps/mobile/.detoxrc.js:67) declares `avdName: "Pixel_5_API_34"`, and Detox's `AVDValidator._assertAVDMatch` validates the exact name before booting.

The mismatch is silent at config-time — `.detoxrc.js` even has a misleading comment ("overridden via --device-name on CI"), but [`apps/mobile/package.json:e2e:test:android:ci`](apps/mobile/package.json:22) runs `detox test --configuration android.emu.debug --headless --record-logs all` with no `--device-name` flag, so Detox falls back to the static `avdName` from the config.

Pass an explicit `avd-name: Pixel_5_API_34` on both action calls (must match between them so the AVD snapshot cache is reusable across the two action invocations within a single run). Header comment documents the link back to `.detoxrc.js:67` so a future edit on either side sees the other.

## Governing Skill

- Primary skill: `sergeant-mobile-expo` (touches mobile CI infra)
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a
- Why this playbook: —
- If no playbook matched, why: workflow + Detox config sync — one input added on both action calls. No procedural playbook applies.

## Verification

```bash
grep avdName apps/mobile/.detoxrc.js
# → Pixel_5_API_34 (single source of truth)

grep avd-name .github/workflows/detox-android.yml
# → Pixel_5_API_34 (both action calls now match)
```

`actionlint` will verify the YAML on CI; the action input is documented at [ReactiveCircus/android-emulator-runner#avd-name](https://github.com/ReactiveCircus/android-emulator-runner/blob/main/README.md#configurations).

Additional checks:

- [x] Local smoke / manual validation completed — config grep confirms single source of truth alignment.
- [x] Surface-specific checks completed — both action calls updated identically so cache key matches.

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. — the workflow comment is the self-documentation.
- [x] I checked whether \`AGENTS.md\` needed an update. — no rule change.
- [x] I checked whether a playbook or skill needed an update. — none affected.
- [x] I checked whether governance docs or review docs needed an update. — none affected.

Updated docs:

- n/a (header comment inside the touched file)

## Risk and Rollout

- User-visible risk: **none** — CI-only infra change. Detox config is unchanged; only the workflow now creates the AVD that Detox already expected.
- Rollout / deploy order: merge to \`main\`; next \`Detox (Android)\` run boots the AVD by the expected name.
- Backout plan: revert — CI returns to today's red (the same red that existed before [#3310](https://github.com/Skords-01/Sergeant/pull/3310) which fixed the import path, and after #3310 which unmasked this AVD name layer).

## Hard Rule #15

- [x] I read \`AGENTS.md\` before coding.
- [x] Internal docs I touched are in Ukrainian. — n/a, only English workflow + Detox config touched.
- [x] I did not use \`--no-verify\`.

## Reviewer Notes

iOS Detox is failing for a different reason (\`Expo prebuild\` hits \`DOMParser.parseFromString: provided mimeType "undefined" is not valid\` inside \`withIosInfoPlistBaseMod\`) — that's an xmldom / Expo config plugin version skew, not an AVD/sim name issue. Kept as a separate follow-up so this PR is narrowly scoped to the Android emulator name alignment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix failing Android Detox CI by aligning the emulator name with the Detox config. Sets `avd-name: Pixel_5_API_34` on both `reactivecircus/android-emulator-runner` steps so Detox boots the expected AVD and reuses the snapshot.

<sup>Written for commit c1b3525b853ae679ee16a9af36732e4a3a27b10c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Android testing infrastructure configuration to improve build and emulator reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->