### PR TITLE
fix(deps): cap @xmldom/xmldom at <0.9 to unbreak Expo prebuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
     "overrides": {
       "react-server-dom-webpack": "^19.0.2",
       "tar": ">=7.5.11",
-      "@xmldom/xmldom": ">=0.8.13",
+      "@xmldom/xmldom": ">=0.8.13 <0.9.0",
       "serialize-javascript": ">=7.0.5",
       "postcss": ">=8.5.10",
       "uuid": "^14.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   react-server-dom-webpack: ^19.0.2
   tar: '>=7.5.11'
-  '@xmldom/xmldom': '>=0.8.13'
+  '@xmldom/xmldom': '>=0.8.13 <0.9.0'
   serialize-javascript: '>=7.0.5'
   postcss: '>=8.5.10'
   uuid: ^14.0.0
@@ -6055,9 +6055,9 @@ packages:
       detox: '>=20.33.0'
       expect: 29.x.x || 28.x.x || ^27.2.5
 
-  '@xmldom/xmldom@0.9.10':
-    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
-    engines: {node: '>=14.6'}
+  '@xmldom/xmldom@0.8.13':
+    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
+    engines: {node: '>=10.0.0'}
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -15422,7 +15422,7 @@ snapshots:
 
   '@expo/plist@0.2.2':
     dependencies:
-      '@xmldom/xmldom': 0.9.10
+      '@xmldom/xmldom': 0.8.13
       base64-js: 1.5.1
       xmlbuilder: 14.0.0
 
@@ -19310,7 +19310,7 @@ snapshots:
       detox: 20.51.1(@jest/environment@29.7.0)(@jest/types@29.6.3)(@types/bunyan@1.8.11)(expect@29.7.0)(jest-environment-jsdom@29.7.0)(jest-environment-node@29.7.0)(jest@29.7.0(@types/node@20.19.41))
       expect: 29.7.0
 
-  '@xmldom/xmldom@0.9.10': {}
+  '@xmldom/xmldom@0.8.13': {}
 
   '@xtuc/ieee754@1.2.0': {}
 
@@ -25108,7 +25108,7 @@ snapshots:
 
   plist@3.1.1:
     dependencies:
-      '@xmldom/xmldom': 0.9.10
+      '@xmldom/xmldom': 0.8.13
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 


### PR DESCRIPTION
## Summary

`Detox (iOS)` (and any other workflow that runs `expo prebuild`) has been failing with:

```
TypeError: [ios.infoPlist]: withIosInfoPlistBaseMod:
  DOMParser.parseFromString: the provided mimeType "undefined" is not valid.
```

**Root cause:** `@xmldom/xmldom@0.9.0` made the `mimeType` argument of `DOMParser.parseFromString` mandatory (it used to default to `text/xml` and warn). `@expo/plist@0.x` still calls it with no second arg.

The override in `pnpm.overrides` was `>=0.8.13`, which allowed 0.9.x. Tighten to `>=0.8.13 <0.9.0`. Lockfile flips from 0.9.10 → 0.8.13.

## Verification

```bash
grep -A 1 "@xmldom/xmldom@" pnpm-lock.yaml | head
# → '@xmldom/xmldom@0.8.13': {}
```

## Risk

None — 0.8.13 still receives CVE backports. Temporary pin until `@expo/plist` passes `mimeType` explicitly upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cap `@xmldom/xmldom` to 0.8.x to fix `expo prebuild` failures in Detox (iOS) and similar workflows. 0.9.x requires a `mimeType` in `DOMParser.parseFromString`, which `@expo/plist@0.x` does not pass.

- **Dependencies**
  - Tightened `pnpm.overrides` to `>=0.8.13 <0.9.0`, resolving to `0.8.13` (keeps CVE backports and avoids the breaking change).

<sup>Written for commit 67a3b413d4541e31620980543e407a92d9581b9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

