### PR TITLE
test(web): playwright storageState fixture for authed smoke E2E

### DIFF
--- a/apps/web/playwright.smoke.config.ts
+++ b/apps/web/playwright.smoke.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from "@playwright/test";
+import { HUB_USER_AUTH_STATE } from "./tests/smoke/auth.setup";
 
 /**
  * Smoke E2E config (separate from the a11y lane).
@@ -7,6 +8,18 @@ import { defineConfig, devices } from "@playwright/test";
  *  - Postgres via docker-compose (root `docker-compose.yml`)
  *  - API server (`@sergeant/server`, :3000)
  *  - Web preview (`@sergeant/web`, :4173) built against VITE_API_BASE_URL=:3000
+ *
+ * Setup-project pattern: the `setup` project (`tests/smoke/auth.setup.ts`)
+ * runs once before any browser-engine project, signs up a Better Auth
+ * test user, and saves the post-signup browser state to
+ * `tests/smoke/.auth/hub-user.json`. The chromium/webkit/mobile-safari
+ * projects then inherit that state via `storageState`, so suites that
+ * visit `/` or `/?module=…` (e.g. `bottom-nav.spec.ts`) start from an
+ * authenticated session instead of being redirected to /sign-in.
+ *
+ * `auth.spec.ts` and `auth-webkit.spec.ts` are deliberately unaffected
+ * — they target the signup flow itself, so re-using a session would
+ * defeat the assertion.
  */
 export default defineConfig({
   testDir: "./tests/smoke",
@@ -27,16 +40,34 @@ export default defineConfig({
   // playwright install webkit`, тож chromium лишається default-project-ом для DX.
   projects: [
     {
+      // Runs `tests/smoke/auth.setup.ts` once before all browser-engine
+      // projects. Produces `tests/smoke/.auth/hub-user.json` (gitignored).
+      name: "setup",
+      testMatch: /.*\.setup\.ts/,
+    },
+    {
       name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
+      use: {
+        ...devices["Desktop Chrome"],
+        storageState: HUB_USER_AUTH_STATE,
+      },
+      dependencies: ["setup"],
     },
     {
       name: "webkit",
-      use: { ...devices["Desktop Safari"] },
+      use: {
+        ...devices["Desktop Safari"],
+        storageState: HUB_USER_AUTH_STATE,
+      },
+      dependencies: ["setup"],
     },
     {
       name: "mobile-safari",
-      use: { ...devices["iPhone 14"] },
+      use: {
+        ...devices["iPhone 14"],
+        storageState: HUB_USER_AUTH_STATE,
+      },
+      dependencies: ["setup"],
     },
   ],
   webServer: process.env.PW_SKIP_WEBSERVER

--- a/apps/web/tests/smoke/.gitignore
+++ b/apps/web/tests/smoke/.gitignore
@@ -1,0 +1,4 @@
+# Authenticated browser state produced by `auth.setup.ts` (Playwright
+# storageState). Created at test time, not part of the repo. Each CI run
+# generates its own.
+.auth/

--- a/apps/web/tests/smoke/auth-webkit.spec.ts
+++ b/apps/web/tests/smoke/auth-webkit.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect, type Page } from "@playwright/test";
 
+// Override the default `storageState` from `playwright.smoke.config.ts`
+// (pre-baked logged-in user) — this file's whole point is to test
+// signup + cookie semantics from a fresh browser context.
+test.use({ storageState: { cookies: [], origins: [] } });
+
 /**
  * Webkit / mobile-safari authentication regression suite (PR-48).
  *

--- a/apps/web/tests/smoke/auth.setup.ts
+++ b/apps/web/tests/smoke/auth.setup.ts
@@ -1,0 +1,56 @@
+import { test as setup, expect } from "@playwright/test";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Playwright setup project — signs up a single Better Auth test user once
+ * and saves the post-signup browser state (cookies + localStorage) to a
+ * JSON file that downstream `@critical` smoke tests reuse via the
+ * `storageState` option in `playwright.smoke.config.ts`.
+ *
+ * Why a single setup project instead of inline signup per test:
+ *   - `bottom-nav.spec.ts` visits `/` and `/?module=…` directly and
+ *     expects the authenticated hub surface. Without a session cookie
+ *     the app correctly redirects to `/sign-in`, so the suite has been
+ *     failing in CI even though the assertions are correct.
+ *   - Doing a full sign-up per test (the pattern in `auth.spec.ts`,
+ *     which is the right shape for testing the auth flow itself) bakes
+ *     ~5 s of HTTP latency into every other suite that just needs an
+ *     authenticated session. The setup runs once and feeds everyone.
+ *
+ * `auth.spec.ts` is unchanged — it still does its own per-test signup
+ * because the assertion target IS the signup flow, not the hub.
+ */
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+export const HUB_USER_AUTH_STATE = join(__dirname, ".auth/hub-user.json");
+
+setup("authenticate hub user", async ({ page }) => {
+  // Deterministic email per run (CI artifact persistence is bounded; we
+  // don't reuse accounts across runs because the smoke DB is wiped).
+  const nonce = `${Date.now()}_${Math.random().toString(16).slice(2)}`;
+  const email = `smoke_setup_${nonce}@example.com`;
+  const password = `pw_${nonce}_long_enough`;
+
+  await page.goto("/sign-in", { waitUntil: "domcontentloaded" });
+
+  // The shared `<AuthForm>` defaults to sign-in mode; toggle to register.
+  await page
+    .getByRole("button", { name: "Немає акаунту? Зареєструватися" })
+    .click();
+
+  await page.fill("#auth-name", "Smoke Setup User");
+  await page.fill("#auth-email", email);
+  await page.fill("#auth-password", password);
+
+  await page.getByRole("button", { name: "Зареєструватися" }).click();
+
+  // After successful sign-up, AuthContext invalidates `/api/v1/me` and the
+  // router redirects out of /sign-in (to /welcome for fresh accounts; the
+  // exact destination doesn't matter here — only that the cookie is set).
+  await expect(page).not.toHaveURL(/\/sign-in/, { timeout: 15_000 });
+
+  // Persist cookies + localStorage so subsequent projects start with the
+  // session already established.
+  await page.context().storageState({ path: HUB_USER_AUTH_STATE });
+});

--- a/apps/web/tests/smoke/auth.spec.ts
+++ b/apps/web/tests/smoke/auth.spec.ts
@@ -1,5 +1,12 @@
 import { test, expect, type Page } from "@playwright/test";
 
+// This file targets the signup flow itself, so override the default
+// `storageState` from `playwright.smoke.config.ts` (which logs in a
+// pre-baked user) and start every test from a clean browser context.
+// Without this override, `goto("/sign-in")` would immediately redirect
+// to the authenticated hub and the assertions below would never run.
+test.use({ storageState: { cookies: [], origins: [] } });
+
 const SEEDED_LS: Record<string, string> = {
   hub_onboarding_done_v1: "1",
   hub_first_action_done_v1: "1",

--- a/apps/web/tests/smoke/onboarding-happy-path.spec.ts
+++ b/apps/web/tests/smoke/onboarding-happy-path.spec.ts
@@ -1,5 +1,11 @@
 import { test, expect, type Page } from "@playwright/test";
 
+// Override the default `storageState` from `playwright.smoke.config.ts`
+// (pre-baked logged-in user). This file exercises the cold-start signup
+// → welcome wizard → hub-overview funnel, so it needs a fresh browser
+// context with no auth cookie.
+test.use({ storageState: { cookies: [], origins: [] } });
+
 /**
  * Happy-path founder-experience E2E:
  *


### PR DESCRIPTION
## Summary

`Critical-flow E2E (Playwright) > bottom-nav.spec.ts` has been failing on every PR because the tests `goto("/")` and `goto("/?module=…")` expecting the authenticated hub surface — but the Playwright browser context starts with no session cookie. The app correctly redirects to `/sign-in` and assertions for `getByRole("navigation", { name: "Розділи хабу" })` time out at 10s.

Add the canonical Playwright **setup-project pattern**:

1. [`tests/smoke/auth.setup.ts`](apps/web/tests/smoke/auth.setup.ts) (new) — runs once before any browser engine project, signs up a fresh Better Auth test user with a nonce-suffixed email, and writes the post-signup cookies + localStorage to `tests/smoke/.auth/hub-user.json`. Exports the path so the config can `import` it.

2. [`playwright.smoke.config.ts`](apps/web/playwright.smoke.config.ts) — add a `setup` project + make each browser-engine project (chromium / webkit / mobile-safari) declare `dependencies: ["setup"]` and `use.storageState: HUB_USER_AUTH_STATE`. Result: every `@critical` smoke spec starts with the session cookie already set — no inline signup required.

3. Three files (`auth.spec.ts`, `auth-webkit.spec.ts`, `onboarding-happy-path.spec.ts`) override with `test.use({ storageState: { cookies: [], origins: [] } })` because their assertion target IS the signup / cold-start flow — inheriting a pre-baked session would make `goto("/sign-in")` redirect away before the test can run.

4. `tests/smoke/.gitignore` keeps the per-run state JSON out of git.

The setup pattern matches the official Playwright "reusable signed-in state" recipe. Sign-up happens through the real Better Auth flow against the smoke server, no mocks needed. DB row gets a unique email per CI run so reruns don't collide.

## What's unchanged

- `bottom-nav.spec.ts`, `dashboard-health.spec.ts`, `navigation-offline-sw.spec.ts` — inherit the auth cookie naturally. Their existing `seedLocalStorage` calls just add FTUX flags on top.

## Verification

```bash
pnpm --filter @sergeant/web exec playwright test --config playwright.smoke.config.ts --grep @critical --project chromium
# Should pass bottom-nav tests now (locally requires the Postgres + API server stack — easier to validate on CI).
```

## Risk

- `webkit` + `mobile-safari` projects still fast-fail on CI runners without those browser binaries — that's a separate runner-image refresh, scope > this PR.
- DB grows by 1 row per CI smoke run (the setup-user email). Smoke DB is wiped between runs in the existing workflow, so this is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failing smoke E2E by bootstrapping an authenticated Playwright storage state so specs that visit `/` load the hub instead of redirecting to `/sign-in`. Chromium, WebKit, and mobile Safari projects now start logged in; auth-flow specs opt out.

- **Bug Fixes**
  - Added `tests/smoke/auth.setup.ts` to sign up a test user and save browser `storageState` to `tests/smoke/.auth/hub-user.json` (gitignored).
  - Updated `playwright.smoke.config.ts` to add a `setup` project, set `dependencies: ["setup"]`, and use `storageState: HUB_USER_AUTH_STATE` for all browser projects.
  - Overrode `storageState` in `auth.spec.ts`, `auth-webkit.spec.ts`, and `onboarding-happy-path.spec.ts` to keep cold-start signup coverage.

<sup>Written for commit a4933187fe2d2407cab6734bbd91838b33e2af7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

