### PR TITLE
feat(web): safe sessionStorage wrappers + adopt in fizruk (audit-06 F10)

### DIFF
--- a/apps/web/src/modules/fizruk/hooks/useFizrukProgramStart.ts
+++ b/apps/web/src/modules/fizruk/hooks/useFizrukProgramStart.ts
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
 import { ACTIVE_WORKOUT_KEY } from "@sergeant/fizruk-domain";
 import type { WorkoutItem } from "@sergeant/fizruk-domain/domain";
-import { safeWriteLS } from "@shared/lib/storage/storage";
+import { safeWriteLS, safeWriteSS } from "@shared/lib/storage/storage";
 
 interface Exercise {
   id: string;
@@ -89,12 +89,9 @@ export function useFizrukProgramStart({
         });
       }
       safeWriteLS(ACTIVE_WORKOUT_KEY, w.id);
-      try {
-        sessionStorage.setItem("fizruk_workouts_mode", "log");
-      } catch {
-        // best-effort session handoff; failure just means the Workouts
-        // page opens in its default mode.
-      }
+      // best-effort session handoff; failure just means the Workouts page
+      // opens in its default mode.
+      safeWriteSS("fizruk_workouts_mode", "log");
       navigate("workouts");
     },
     [workouts, createWorkout, addItem, exercises, navigate],

--- a/apps/web/src/modules/fizruk/hooks/useWorkoutsLifecycle.ts
+++ b/apps/web/src/modules/fizruk/hooks/useWorkoutsLifecycle.ts
@@ -1,7 +1,11 @@
 import { useEffect } from "react";
 import type { Dispatch, SetStateAction } from "react";
-import { logger } from "@shared/lib";
-import { safeRemoveLS, safeWriteLS } from "@shared/lib/storage/storage";
+import {
+  safeReadStringSS,
+  safeRemoveLS,
+  safeRemoveSS,
+  safeWriteLS,
+} from "@shared/lib/storage/storage";
 import { ACTIVE_WORKOUT_KEY, type Workout } from "@sergeant/fizruk-domain";
 import type { RestTimerState } from "./useFizrukRestSound";
 import type { WorkoutsView } from "../pages/Workouts.types";
@@ -48,19 +52,12 @@ export function useWorkoutsViewFromSession(
   setView: (v: WorkoutsView) => void,
 ): void {
   useEffect(() => {
-    try {
-      const m = sessionStorage.getItem(VIEW_FROM_SESSION_KEY);
-      if (m === "templates") {
-        setView("templates");
-        sessionStorage.removeItem(VIEW_FROM_SESSION_KEY);
-      } else if (m === "log") {
-        setView("log");
-        sessionStorage.removeItem(VIEW_FROM_SESSION_KEY);
-      }
-    } catch (err) {
-      logger.warn("useWorkoutsViewFromSession: sessionStorage unavailable", {
-        err,
-      });
+    // `safeReadStringSS`/`safeRemoveSS` centralise the private-mode-Safari /
+    // disabled-storage guard that used to live as an inline try/catch here.
+    const m = safeReadStringSS(VIEW_FROM_SESSION_KEY);
+    if (m === "templates" || m === "log") {
+      setView(m);
+      safeRemoveSS(VIEW_FROM_SESSION_KEY);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only; setView identity is stable
   }, []);

--- a/apps/web/src/modules/fizruk/pages/Dashboard.tsx
+++ b/apps/web/src/modules/fizruk/pages/Dashboard.tsx
@@ -6,7 +6,7 @@ import type { FizrukPage } from "../shell/fizrukRoute";
 // FizrukPage is referenced in the JSDoc above and in the onNavigate type
 // signature — keep the import even when TS doesn't track JSDoc refs.
 
-import { safeWriteLS } from "@shared/lib/storage/storage";
+import { safeWriteLS, safeWriteSS } from "@shared/lib/storage/storage";
 import { getKyivDateParts } from "@shared/lib/time/kyivTime";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Button } from "@shared/components/ui/Button";
@@ -143,11 +143,8 @@ export function Dashboard({
     }
     if (templateId) markTemplateUsed(templateId);
     safeWriteLS(ACTIVE_WORKOUT_KEY, w.id);
-    try {
-      sessionStorage.setItem("fizruk_workouts_mode", "log");
-    } catch {
-      /* non-fatal: workouts tab remains reachable */
-    }
+    // non-fatal: workouts tab remains reachable in its default mode
+    safeWriteSS("fizruk_workouts_mode", "log");
     onNavigate("workouts");
   };
 
@@ -342,18 +339,12 @@ export function Dashboard({
     // sessionStorage (see `apps/web/src/modules/fizruk/pages/Workouts.tsx`).
     // When the hero CTA resumes an active session we want the user to
     // land directly on the log — one extra tap is a real UX regression
-    // otherwise.
-    try {
-      sessionStorage.setItem("fizruk_workouts_mode", "log");
-    } catch {
-      /* non-fatal: default view is still reachable */
-    }
+    // otherwise. non-fatal: default view is still reachable.
+    safeWriteSS("fizruk_workouts_mode", "log");
     onNavigate("workouts");
   };
   const openTemplates = () => {
-    try {
-      sessionStorage.setItem("fizruk_workouts_mode", "templates");
-    } catch {}
+    safeWriteSS("fizruk_workouts_mode", "templates");
     onNavigate("workouts");
   };
   const openPlan = () => {

--- a/apps/web/src/shared/lib/storage/storage.test.ts
+++ b/apps/web/src/shared/lib/storage/storage.test.ts
@@ -6,27 +6,37 @@ import {
   safeReadStringLS,
   safeWriteLS,
   safeRemoveLS,
+  safeReadStringSS,
+  safeWriteSS,
+  safeRemoveSS,
 } from "./storage";
+
+function installStoragePolyfill(): Storage {
+  const store = new Map<string, string>();
+  return {
+    getItem: (k) => (store.has(k) ? (store.get(k) as string) : null),
+    setItem: (k, v) => {
+      store.set(k, String(v));
+    },
+    removeItem: (k) => {
+      store.delete(k);
+    },
+    clear: () => store.clear(),
+    key: (i) => Array.from(store.keys())[i] ?? null,
+    get length() {
+      return store.size;
+    },
+  } as Storage;
+}
 
 // vitest is configured with environment: "node" so we need a minimal
 // localStorage polyfill for these tests.
 beforeAll(() => {
   if (typeof globalThis.localStorage === "undefined") {
-    const store = new Map();
-    globalThis.localStorage = {
-      getItem: (k) => (store.has(k) ? store.get(k) : null),
-      setItem: (k, v) => {
-        store.set(k, String(v));
-      },
-      removeItem: (k) => {
-        store.delete(k);
-      },
-      clear: () => store.clear(),
-      key: (i) => Array.from(store.keys())[i] ?? null,
-      get length() {
-        return store.size;
-      },
-    };
+    globalThis.localStorage = installStoragePolyfill();
+  }
+  if (typeof globalThis.sessionStorage === "undefined") {
+    globalThis.sessionStorage = installStoragePolyfill();
   }
 });
 
@@ -114,5 +124,50 @@ describe("shared storage helpers", () => {
       localStorage.setItem("ok", JSON.stringify(value));
       expect(safeReadLSValidated("ok", Schema, fallback)).toEqual(value);
     });
+  });
+});
+
+describe("sessionStorage helpers (SS)", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("safeReadStringSS returns fallback when key is missing", () => {
+    expect(safeReadStringSS("missing")).toBeNull();
+    expect(safeReadStringSS("missing", "dflt")).toBe("dflt");
+  });
+
+  it("safeWriteSS persists a raw string round-trip", () => {
+    expect(safeWriteSS("mode", "log")).toBe(true);
+    expect(sessionStorage.getItem("mode")).toBe("log");
+    expect(safeReadStringSS("mode")).toBe("log");
+  });
+
+  it("safeRemoveSS clears the key and read falls back", () => {
+    safeWriteSS("mode", "templates");
+    expect(safeRemoveSS("mode")).toBe(true);
+    expect(safeReadStringSS("mode")).toBeNull();
+  });
+
+  it("never throws and reports false when sessionStorage access throws", () => {
+    const original = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "sessionStorage",
+    );
+    Object.defineProperty(globalThis, "sessionStorage", {
+      configurable: true,
+      get() {
+        throw new Error("SecurityError: storage disabled");
+      },
+    });
+    try {
+      expect(safeReadStringSS("k", "fb")).toBe("fb");
+      expect(safeWriteSS("k", "v")).toBe(false);
+      expect(safeRemoveSS("k")).toBe(false);
+    } finally {
+      if (original) {
+        Object.defineProperty(globalThis, "sessionStorage", original);
+      }
+    }
   });
 });

--- a/apps/web/src/shared/lib/storage/storage.ts
+++ b/apps/web/src/shared/lib/storage/storage.ts
@@ -257,3 +257,69 @@ export function safeRemoveLS(key: string): boolean {
 export function safeListLSKeys(): string[] {
   return webKVStore.listKeys();
 }
+
+// ─── sessionStorage helpers ────────────────────────────────────────────────
+// sessionStorage holds ephemeral, tab-scoped view-state — e.g. a one-shot
+// "open Workouts in log mode" hand-off flag between routes. It has no SQLite
+// overlay and no cross-tab story, so these wrappers stay deliberately thin:
+// they add the same private-mode-Safari / disabled-storage / quota safety net
+// the LS helpers give, and a single place to mock in tests, without the
+// KVStore machinery. Mirrors the `*LS` string API (page-audit-06 F10).
+
+function resolveSessionStorage(): Storage | null {
+  try {
+    const candidate = (globalThis as { sessionStorage?: Storage })
+      .sessionStorage;
+    return candidate ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read a raw string from sessionStorage. Returns `fallback` on
+ * missing/unavailable/throwing storage; never throws.
+ */
+export function safeReadStringSS(
+  key: string,
+  fallback: string | null = null,
+): string | null {
+  const ss = resolveSessionStorage();
+  if (!ss) return fallback;
+  try {
+    const raw = ss.getItem(key);
+    return raw === null ? fallback : raw;
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * Write a string to sessionStorage. Returns `false` when storage is
+ * unavailable or the write threw (quota / private mode); never throws.
+ */
+export function safeWriteSS(key: string, value: string): boolean {
+  const ss = resolveSessionStorage();
+  if (!ss) return false;
+  try {
+    ss.setItem(key, value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Remove a key from sessionStorage. Best-effort; returns `false` only when
+ * storage is unavailable or the remove threw; never throws.
+ */
+export function safeRemoveSS(key: string): boolean {
+  const ss = resolveSessionStorage();
+  if (!ss) return false;
+  try {
+    ss.removeItem(key);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/docs/audits/2026-05-13-page-audit-06-fizruk-part1.md
+++ b/docs/audits/2026-05-13-page-audit-06-fizruk-part1.md
@@ -266,6 +266,8 @@ Expose CSS custom properties on `:root` (e.g. `--chart-strength`, `--chart-volum
 
 ### F10 — Direct `sessionStorage` access without a shared safe-wrapper [severity: medium] [perspective: rule] [perspective: bug]
 
+> ✅ **Closed 2026-06-02** — додано `safeReadStringSS` / `safeWriteSS` / `safeRemoveSS` у `@shared/lib/storage/storage.ts` (тонкі обгортки навколо `sessionStorage` з private-mode-Safari / disabled-storage / quota guard-ом, дзеркало `*LS`-API). Усі raw-сайти переведено: `useWorkoutsViewFromSession` (reader — inline `try/catch`+`logger.warn` прибрано), `useFizrukProgramStart`, `Dashboard.tsx` (3 write-сайти `fizruk_workouts_mode`). Failure-handling тепер централізований. Додано 4 unit-тести (round-trip + throwing-storage). Окремий `no-raw-session-storage` ESLint-rule свідомо НЕ додано в цьому PR — він має repo-wide blast radius (впав би на всіх наявних `sessionStorage`-сайтах поза fizruk) і потребує окремого burndown-sweep.
+
 **Page:** Dashboard + Workouts
 **File:** `pages/Dashboard.tsx` L311, L319; `hooks/useFizrukProgramStart.ts` L86; `hooks/useWorkoutsLifecycle.ts` L51, L54, L57
 **Lines:** see above


### PR DESCRIPTION
## Summary

**audit-06 fizruk F10** — три fizruk view-handoff сайти писали в `sessionStorage` напряму з непослідовним failure-handling (`bare catch {}` / ad-hoc / `logger.warn`), в обхід shared safety-net.

- **`storage.ts`:** нові `safeReadStringSS` / `safeWriteSS` / `safeRemoveSS` — тонкі try/catch обгортки навколо `sessionStorage`, дзеркало `*LS` API (ephemeral tab-scoped state, без KVStore/SQLite overlay).
- **fizruk:** `useWorkoutsViewFromSession` (reader, inline try/catch + невикористаний `logger` import прибрано), `useFizrukProgramStart`, `Dashboard.tsx` (3 write-сайти) → на helpers.
- **`storage.test.ts`:** +4 тести (round-trip + throwing-storage).

Sibling `no-raw-session-storage` ESLint-rule свідомо НЕ додано — repo-wide blast radius, потребує окремого burndown.

## Governing Skill

- Primary skill: shared-lib + web module fix (audit finding); ad-hoc.
- Secondary skill (if truly needed): —

## Playbook

- Primary playbook: —
- Why this playbook: —
- If no playbook matched, why: одиничний rule/bug finding з page-audit-06.

## Verification

```bash
cd apps/web && pnpm exec tsc -p tsconfig.json --noEmit                       # 0 errors
pnpm exec eslint src/shared/lib/storage/storage.ts src/shared/lib/storage/storage.test.ts \
  src/modules/fizruk/hooks/useWorkoutsLifecycle.ts \
  src/modules/fizruk/hooks/useFizrukProgramStart.ts \
  src/modules/fizruk/pages/Dashboard.tsx                                     # clean
pnpm exec vitest run src/shared/lib/storage/storage.test.ts                  # 16 passed (4 new SS)
pnpm exec vitest run src/modules/fizruk/hooks src/modules/fizruk/pages/Dashboard  # 12 passed
```

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed (no leftover raw sessionStorage in fizruk; no `as unknown as`)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. (audit-06 F10 closure note)
- [x] I checked whether `AGENTS.md` needed an update. (no)
- [x] I checked whether a playbook or skill needed an update. (no)
- [x] I checked whether governance docs or review docs needed an update. (no)

Updated docs:

- `docs/audits/2026-05-13-page-audit-06-fizruk-part1.md` (F10 closure note)

## Risk and Rollout

- User-visible risk: low — view-handoff behavior preserved; wrappers are behavior-equivalent to the prior try/catch.
- Rollout / deploy order: standard.
- Backout plan: revert the PR.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

https://claude.ai/code/session_019PVt4ZXgHL2bxTA4C1mVmu