### PR TITLE
fix(web): keyboard-accessible BodyAtlas muscle map + toggle a11y (audit-06 F2)

### DIFF
--- a/apps/web/src/modules/fizruk/components/BodyAtlas.test.tsx
+++ b/apps/web/src/modules/fizruk/components/BodyAtlas.test.tsx
@@ -1,0 +1,242 @@
+// @vitest-environment jsdom
+/**
+ * BodyAtlas a11y tests — audit-06 F2
+ *
+ * Covers:
+ *  - Toggle buttons have aria-pressed and update it correctly.
+ *  - Every selectable muscle in the current view is keyboard-focusable
+ *    (present in the DOM with role="button" / as a <button>).
+ *  - Enter and Space activate muscle selection (updates selected state).
+ *  - aria-labels include both the muscle name and its recovery status.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { BodyAtlas } from "./BodyAtlas";
+
+// body-highlighter calls document.createElementNS and appends DOM nodes.
+// In jsdom that works without issues but we mock the module to avoid
+// triggering the real imperative SVG build (which is unrelated to these tests).
+vi.mock("body-highlighter", () => ({
+  default: vi.fn(() => ({
+    destroy: vi.fn(),
+  })),
+}));
+
+const STATUS_BY_MUSCLE = {
+  chest: "red",
+  biceps: "yellow",
+  abs: "green",
+  quadriceps: "red",
+} as const;
+
+function renderAtlas(
+  statusByMuscle: Record<string, string> = STATUS_BY_MUSCLE,
+) {
+  return render(<BodyAtlas statusByMuscle={statusByMuscle} height={320} />);
+}
+
+beforeEach(cleanup);
+
+describe("BodyAtlas · toggle buttons", () => {
+  it("renders both toggle buttons with aria-pressed", () => {
+    renderAtlas();
+
+    const anteriorBtn = screen.getByRole("button", {
+      name: /вигляд спереду/i,
+    });
+    const posteriorBtn = screen.getByRole("button", {
+      name: /вигляд ззаду/i,
+    });
+
+    expect(anteriorBtn).toBeInTheDocument();
+    expect(posteriorBtn).toBeInTheDocument();
+  });
+
+  it("anterior toggle starts as aria-pressed=true, posterior as false", () => {
+    renderAtlas();
+
+    const anteriorBtn = screen.getByRole("button", {
+      name: /вигляд спереду/i,
+    });
+    const posteriorBtn = screen.getByRole("button", {
+      name: /вигляд ззаду/i,
+    });
+
+    expect(anteriorBtn).toHaveAttribute("aria-pressed", "true");
+    expect(posteriorBtn).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("clicking posterior sets posterior aria-pressed=true and anterior to false", () => {
+    renderAtlas();
+
+    const posteriorBtn = screen.getByRole("button", {
+      name: /вигляд ззаду/i,
+    });
+    fireEvent.click(posteriorBtn);
+
+    expect(posteriorBtn).toHaveAttribute("aria-pressed", "true");
+    expect(
+      screen.getByRole("button", { name: /вигляд спереду/i }),
+    ).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("clicking anterior after posterior resets aria-pressed correctly", () => {
+    renderAtlas();
+
+    fireEvent.click(screen.getByRole("button", { name: /вигляд ззаду/i }));
+    fireEvent.click(screen.getByRole("button", { name: /вигляд спереду/i }));
+
+    expect(
+      screen.getByRole("button", { name: /вигляд спереду/i }),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(
+      screen.getByRole("button", { name: /вигляд ззаду/i }),
+    ).toHaveAttribute("aria-pressed", "false");
+  });
+});
+
+describe("BodyAtlas · keyboard-accessible muscle list (anterior view)", () => {
+  it("renders sr-only muscle buttons for anterior muscles", () => {
+    renderAtlas();
+
+    // Chest is an anterior muscle — must be present in the DOM with an
+    // aria-label that contains the Ukrainian name.
+    const chestBtn = screen.getByRole("button", { name: /грудні/i });
+    expect(chestBtn).toBeInTheDocument();
+  });
+
+  it("muscle buttons include recovery status in aria-label", () => {
+    renderAtlas();
+
+    // chest = "red" → status label = "уникати"
+    const chestBtn = screen.getByRole("button", {
+      name: /грудні.*уникати/i,
+    });
+    expect(chestBtn).toBeInTheDocument();
+
+    // biceps = "yellow" → "відновлюється"
+    const bicepsBtn = screen.getByRole("button", {
+      name: /біцепс.*відновлюється/i,
+    });
+    expect(bicepsBtn).toBeInTheDocument();
+
+    // abs = "green" → "готовий"
+    const absBtn = screen.getByRole("button", { name: /прес.*готовий/i });
+    expect(absBtn).toBeInTheDocument();
+  });
+
+  it("Enter key activates muscle selection", () => {
+    renderAtlas();
+
+    const chestBtn = screen.getByRole("button", { name: /грудні.*уникати/i });
+    fireEvent.keyDown(chestBtn, { key: "Enter" });
+
+    // After selection the "Обрано:" readout should appear with the muscle key.
+    expect(screen.getByText(/Обрано:/)).toBeInTheDocument();
+    expect(screen.getByText("chest")).toBeInTheDocument();
+  });
+
+  it("Space key activates muscle selection", () => {
+    renderAtlas();
+
+    const absBtn = screen.getByRole("button", { name: /прес.*готовий/i });
+    fireEvent.keyDown(absBtn, { key: " " });
+
+    expect(screen.getByText(/Обрано:/)).toBeInTheDocument();
+    expect(screen.getByText("abs")).toBeInTheDocument();
+  });
+
+  it("click on muscle button activates selection", () => {
+    renderAtlas();
+
+    const quadBtn = screen.getByRole("button", {
+      name: /квадрицепс.*уникати/i,
+    });
+    fireEvent.click(quadBtn);
+
+    expect(screen.getByText(/Обрано:/)).toBeInTheDocument();
+    expect(screen.getByText("quadriceps")).toBeInTheDocument();
+  });
+
+  it("selected muscle gets aria-pressed=true", () => {
+    renderAtlas();
+
+    const chestBtn = screen.getByRole("button", { name: /грудні.*уникати/i });
+    expect(chestBtn).toHaveAttribute("aria-pressed", "false");
+
+    fireEvent.click(chestBtn);
+    expect(chestBtn).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("only one muscle has aria-pressed=true after selection", () => {
+    renderAtlas();
+
+    const chestBtn = screen.getByRole("button", { name: /грудні.*уникати/i });
+    const bicepsBtn = screen.getByRole("button", {
+      name: /біцепс.*відновлюється/i,
+    });
+
+    fireEvent.click(chestBtn);
+    expect(chestBtn).toHaveAttribute("aria-pressed", "true");
+
+    fireEvent.click(bicepsBtn);
+    expect(bicepsBtn).toHaveAttribute("aria-pressed", "true");
+    expect(chestBtn).toHaveAttribute("aria-pressed", "false");
+  });
+});
+
+describe("BodyAtlas · posterior view muscle list", () => {
+  it("shows posterior-specific muscles after switching view", () => {
+    renderAtlas();
+
+    fireEvent.click(screen.getByRole("button", { name: /вигляд ззаду/i }));
+
+    // "upper-back" is a posterior muscle — should appear after switching.
+    expect(
+      screen.getByRole("button", { name: /верхня спина/i }),
+    ).toBeInTheDocument();
+
+    // "chest" is anterior-only — should NOT appear in posterior list.
+    expect(
+      screen.queryByRole("button", { name: /грудні/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("gluteal muscle appears in posterior view", () => {
+    renderAtlas();
+
+    fireEvent.click(screen.getByRole("button", { name: /вигляд ззаду/i }));
+
+    expect(
+      screen.getByRole("button", { name: /сідниці/i }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("BodyAtlas · muscle map container", () => {
+  it("muscle map container has aria-label attribute", () => {
+    renderAtlas();
+
+    // The wrapping div around the SVG and sr-only list should carry
+    // aria-label="Карта м'язів". A plain div does not get a landmark
+    // role, so we query the DOM directly.
+    const mapCard = document.querySelector('[aria-label="Карта м\'язів"]');
+    expect(mapCard).not.toBeNull();
+  });
+
+  it("sr-only list has its own aria-label", () => {
+    renderAtlas();
+
+    const list = document.querySelector('[aria-label="Список м\'язів"]');
+    expect(list).not.toBeNull();
+  });
+
+  it("visual SVG container is aria-hidden", () => {
+    renderAtlas();
+
+    // The inner div wrapping the body-highlighter SVG must be aria-hidden
+    // so AT skips the SVG polygons in favour of the sr-only list.
+    const hiddenDivs = document.querySelectorAll('[aria-hidden="true"]');
+    expect(hiddenDivs.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/modules/fizruk/components/BodyAtlas.tsx
+++ b/apps/web/src/modules/fizruk/components/BodyAtlas.tsx
@@ -1,5 +1,5 @@
 /**
- * Last validated: 2026-05-14
+ * Last validated: 2026-06-02
  * Status: Active
  */
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -8,6 +8,65 @@ import { cn } from "@shared/lib/ui/cn";
 import { THEME_HEX } from "@shared/lib/ui/themeHex";
 
 const STATUS_TO_FREQ: Record<string, number> = { yellow: 1, red: 2 };
+
+/** Human-readable Ukrainian labels for each body-highlighter muscle key. */
+const MUSCLE_LABELS: Record<string, string> = {
+  chest: "Грудні",
+  "upper-back": "Верхня спина",
+  "lower-back": "Нижня спина",
+  trapezius: "Трапеція",
+  biceps: "Біцепс",
+  triceps: "Трицепс",
+  forearm: "Передпліччя",
+  "front-deltoids": "Передні дельти",
+  "back-deltoids": "Задні дельти",
+  abs: "Прес",
+  obliques: "Косі м'язи",
+  quadriceps: "Квадрицепс",
+  hamstring: "Біцепс стегна",
+  calves: "Литки",
+  adductor: "Привідні",
+  abductors: "Відвідні",
+  gluteal: "Сідниці",
+  neck: "Шия",
+};
+
+/** Muscles visible on the anterior (front) view. */
+const ANTERIOR_MUSCLES = [
+  "chest",
+  "biceps",
+  "triceps",
+  "forearm",
+  "front-deltoids",
+  "abs",
+  "obliques",
+  "quadriceps",
+  "calves",
+  "adductor",
+  "abductors",
+  "neck",
+] as const;
+
+/** Muscles visible on the posterior (back) view. */
+const POSTERIOR_MUSCLES = [
+  "upper-back",
+  "lower-back",
+  "trapezius",
+  "triceps",
+  "forearm",
+  "back-deltoids",
+  "hamstring",
+  "calves",
+  "gluteal",
+  "neck",
+] as const;
+
+/** Ukrainian status label shown in aria-label strings. */
+const STATUS_LABELS: Record<string, string> = {
+  green: "готовий",
+  yellow: "відновлюється",
+  red: "уникати",
+};
 
 function buildDataFromStatuses(
   statusByMuscle: Record<string, string> | null | undefined,
@@ -83,6 +142,25 @@ export function BodyAtlas({
     };
   }, [view, data]);
 
+  /** Muscles relevant to the current view, in render order. */
+  const visibleMuscles =
+    view === "anterior" ? ANTERIOR_MUSCLES : POSTERIOR_MUSCLES;
+
+  function handleMuscleClick(muscle: string) {
+    const freq = STATUS_TO_FREQ[statusByMuscle?.[muscle] ?? ""] ?? undefined;
+    setSelected(freq !== undefined ? { muscle, frequency: freq } : { muscle });
+  }
+
+  function handleMuscleKeyDown(
+    e: React.KeyboardEvent<HTMLButtonElement>,
+    muscle: string,
+  ) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      handleMuscleClick(muscle);
+    }
+  }
+
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between gap-2">
@@ -90,8 +168,9 @@ export function BodyAtlas({
           <button
             type="button"
             aria-pressed={view === "anterior"}
+            aria-label="Вигляд спереду"
             className={cn(
-              "text-xs px-3 min-h-[44px] rounded-full border transition-colors",
+              "text-xs px-3 min-h-[44px] min-w-[44px] rounded-full border transition-colors",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fizruk/50",
               view === "anterior"
                 ? "bg-text text-bg border-text"
@@ -104,8 +183,9 @@ export function BodyAtlas({
           <button
             type="button"
             aria-pressed={view === "posterior"}
+            aria-label="Вигляд ззаду"
             className={cn(
-              "text-xs px-3 min-h-[44px] rounded-full border transition-colors",
+              "text-xs px-3 min-h-[44px] min-w-[44px] rounded-full border transition-colors",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fizruk/50",
               view === "posterior"
                 ? "bg-text text-bg border-text"
@@ -131,12 +211,55 @@ export function BodyAtlas({
         )}
       </div>
 
-      <div className="bg-bg border border-line rounded-2xl p-3">
+      {/*
+       * Keyboard-accessible muscle map container.
+       *
+       * body-highlighter renders SVG polygons imperatively via DOM
+       * manipulation — they are pointer-only with no keyboard handling.
+       * The sr-only <ul> below is a parallel keyboard path: every muscle
+       * in the current view is Tab-reachable, activatable with Enter/Space,
+       * and announces its name + recovery status via aria-label.
+       *
+       * Both paths share `setSelected` as the single source of truth.
+       * The visual SVG is aria-hidden so screen-readers skip it and use
+       * the parallel list instead.
+       */}
+      <div
+        className="bg-bg border border-line rounded-2xl p-3"
+        aria-label="Карта м'язів"
+      >
+        {/* Visual SVG body map — pointer-only, hidden from AT */}
         <div
           ref={containerRef}
+          aria-hidden="true"
           className="w-full overflow-hidden"
           style={{ height, maxHeight: height }}
         />
+
+        {/* Parallel keyboard-accessible muscle list (sr-only, NOT display:none) */}
+        <ul className="sr-only" aria-label="Список м'язів">
+          {visibleMuscles.map((muscle) => {
+            const rawStatus = statusByMuscle?.[muscle] ?? "green";
+            const statusLabel =
+              STATUS_LABELS[rawStatus] ?? STATUS_LABELS["green"];
+            const muscleName = MUSCLE_LABELS[muscle] ?? muscle;
+            const isSelected = selected?.muscle === muscle;
+            return (
+              <li key={muscle}>
+                <button
+                  type="button"
+                  aria-label={`${muscleName} — ${statusLabel}`}
+                  aria-pressed={isSelected}
+                  className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fizruk/50"
+                  onClick={() => handleMuscleClick(muscle)}
+                  onKeyDown={(e) => handleMuscleKeyDown(e, muscle)}
+                >
+                  {muscleName}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
       </div>
 
       {selected && (

--- a/docs/audits/2026-05-13-page-audit-06-fizruk-part1.md
+++ b/docs/audits/2026-05-13-page-audit-06-fizruk-part1.md
@@ -47,6 +47,8 @@ Add the marker as the first JSDoc-style block in each TS/TSX file, e.g.:
 
 ### F2 — Atlas page: `BodyAtlas` muscle highlighter is keyboard-inaccessible [severity: high] [perspective: a11y]
 
+> ✅ **Closed 2026-06-02** — `body-highlighter` будує SVG-полігони прямою DOM-маніпуляцією поза React (немає стабільного ref на полігон для tabIndex/onKeyDown), тож обрано підхід (a): паралельний `sr-only` `<ul aria-label="Список м'язів">` — по одній `<button>` на кожен м'яз поточного вигляду, `aria-label="<назва> — <статус>"`, `aria-pressed`, `onClick`+`onKeyDown` (Enter/Space), усі через спільний `setSelected` (single source of truth). Візуальний SVG `aria-hidden`, контейнер мапи `aria-label="Карта м'язів"`. Anterior/posterior toggle: `aria-label` + `min-h-[44px] min-w-[44px]` (+ pre-existing `aria-pressed`/`focus-visible:ring`). WCAG 2.1.1 + 4.1.2 виконано. Додано `BodyAtlas.test.tsx` (16 тестів: toggle-стан, keyboard-активація Enter/Space/click, aria-label зі статусом, view-switch). tsc/eslint clean.
+
 **Page:** Atlas
 **File:** `apps/web/src/modules/fizruk/components/BodyAtlas.tsx`
 **Lines:** L113–L142 (body-highlighter render block) + `pages/Atlas.tsx` L112–L118 (host card)


### PR DESCRIPTION
## Summary

**audit-06 fizruk F2** (high, a11y) — Atlas muscle highlighter був keyboard-недоступний (WCAG 2.1.1 / 4.1.2): миша працювала, клавіатура/screen-reader — ні.

`body-highlighter` будує SVG-полігони прямою DOM-маніпуляцією **поза React** (немає стабільного ref на полігон для `tabIndex`/`onKeyDown`), тож обрано підхід **(a) — паралельний sr-only список**:
- `<ul aria-label="Список м'язів">` (sr-only, не `display:none`) — по одній `<button>` на кожен м'яз поточного вигляду: `aria-label="<назва> — <статус>"`, `aria-pressed`, `onClick`+`onKeyDown` (Enter/Space), усі через спільний `setSelected` (**single source of truth** — і миша, і клавіатура).
- Візуальний SVG → `aria-hidden="true"`; контейнер мапи → `aria-label="Карта м'язів"`.
- Anterior/posterior toggle: `aria-label` + `min-h-[44px] min-w-[44px]` (+ pre-existing `aria-pressed` / `focus-visible:ring`).

## Governing Skill

- Primary skill: web a11y fix; делеговано web-агенту субагенту, диф + гейти + якість зверені вручну.
- Secondary skill (if truly needed): —

## Playbook

- Primary playbook: —
- Why this playbook: —
- If no playbook matched, why: одиничний a11y finding з page-audit-06.

## Verification

```bash
cd apps/web && pnpm exec tsc -p tsconfig.json --noEmit   # 0 errors у fizruk/BodyAtlas (2 worktree-only @sergeant/design-tokens resolution errors — infra, чисто в CI/main)
pnpm exec eslint <BodyAtlas.tsx + test>                  # clean
pnpm exec vitest run src/modules/fizruk/components/BodyAtlas  # 16 passed
```

Additional checks:

- [x] Local smoke / manual validation completed (gates re-run by me; confirmed the only tsc errors are worktree-infra design-tokens resolution, none in BodyAtlas; reviewed the a11y diff)
- [x] Surface-specific checks completed (focus-visible not focus; 44px targets; `aria-hidden` on the inaccessible SVG; no `as unknown as`)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. (audit-06 F2 closure note)
- [x] I checked whether `AGENTS.md` needed an update. (no)
- [x] I checked whether a playbook or skill needed an update. (no)
- [x] I checked whether governance docs or review docs needed an update. (no)

Updated docs:

- `docs/audits/2026-05-13-page-audit-06-fizruk-part1.md` (F2 closure note)

## Risk and Rollout

- User-visible risk: none for sighted/pointer users (SVG visuals unchanged); pure additive a11y for keyboard/SR users.
- Rollout / deploy order: standard.
- Backout plan: revert the PR.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

https://claude.ai/code/session_019PVt4ZXgHL2bxTA4C1mVmu

---
_Generated by [Claude Code](https://claude.ai/code/session_019PVt4ZXgHL2bxTA4C1mVmu)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the BodyAtlas muscle map keyboard-accessible and fix toggle a11y (audit-06 F2). Meets WCAG 2.1.1 and 4.1.2 without changing visuals.

- **Bug Fixes**
  - Added a parallel sr-only <ul> with one <button> per visible muscle; aria-label "<name> — <status>", aria-pressed, and activation via Enter/Space/click; uses the same setSelected as the SVG path.
  - Marked the imperative `body-highlighter` SVG as aria-hidden and labeled the map container "Карта м'язів".
  - Improved view toggles with aria-pressed, aria-labels, 44×44 targets, and focus-visible ring; added tests (`BodyAtlas.test.tsx`) for toggles, keyboard selection, view switching, and aria labels.

<sup>Written for commit 5c8f4d8d931f2573da4e658c9061cefec4ca2f97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

