### PR TITLE
fix(server): n8n.test.ts mockEnv returns undefined, not empty string

### DIFF
--- a/apps/server/src/modules/openclaw/n8n.test.ts
+++ b/apps/server/src/modules/openclaw/n8n.test.ts
@@ -9,6 +9,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // factory closure must not reference local `const`s declared below it — they
 // would be in the TDZ at factory-evaluation time. `vi.hoisted` lifts the
 // shared `mockEnv` alongside the mock so the Proxy can read from it safely.
+//
+// Return `undefined` (NOT empty string) for unset keys: `n8n.ts` transitively
+// imports `obs/logger.ts` which initializes pino with
+// `level: env.LOG_LEVEL ?? (isDev ? "debug" : "info")`. The `??` only falls
+// through on null/undefined, so an empty-string default would land as
+// `level: ""` and pino throws `default level: must be included in custom
+// levels` at module load — breaking every test before it can run. Returning
+// `undefined` lets the `??` fallback fire and pino picks a valid level.
 const { mockEnv } = vi.hoisted(() => ({
   mockEnv: {} as Record<string, string>,
 }));
@@ -17,7 +25,7 @@ vi.mock("../../env/env.js", () => ({
     {},
     {
       get(_target, prop: string) {
-        return mockEnv[prop] ?? "";
+        return mockEnv[prop];
       },
     },
   ),


### PR DESCRIPTION
## Summary

Follow-up to [#3328](https://github.com/Skords-01/Sergeant/pull/3328) (vi.hoisted TDZ fix on n8n.test.ts). The hoisted Proxy kept the original `mockEnv[prop] ?? ""` fallback, which falls over because `n8n.ts` transitively imports `obs/logger.ts` (env single-source sweep, commit `4223c68ba`), and logger initializes pino at module load with:

```ts
level: env.LOG_LEVEL ?? (isDev ? "debug" : "info")
```

JS `??` only fires on null/undefined, NOT empty string, so the mock's empty-string default lands as `level: ""` and pino throws `default level: must be included in custom levels` before any test runs. The whole suite reports 0 tests, marked failed.

Drop the `?? ""` so the Proxy returns `undefined` for unset keys — logger's `??` fallback then picks a valid level. Behaviour-preserving for `n8n.ts` itself, which already guards on `!env.N8N_API_URL` (undefined and "" are both falsy).

## Governing Skill

- Primary skill: sergeant-server-api
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a — surgical 8-line follow-up
- Why this playbook: no schema or contract change; restores #3328's intended green state
- If no playbook matched, why: minimal test-only fix

## Verification

```bash
# Cannot run server vitest locally — exFAT volume can't materialize pnpm workspace symlinks for @sergeant/shared.
# Validation defers to CI Test coverage lane.
```

Additional checks:

- [x] Bug surfaced on PR #3333 CI logs after #3328 merged — pino `default level` error reproduced at `src/modules/openclaw/n8n.test.ts > src/obs/logger.ts:266:31`.
- [ ] CI Test coverage runs n8n.test.ts (all tests pass, no `default level` error).

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. (inline comment in test file explains the gotcha)
- [x] I checked whether `AGENTS.md` needed an update. (no)
- [x] I checked whether a playbook or skill needed an update. (no)
- [x] I checked whether governance docs or review docs needed an update. (no)

Updated docs:

- inline comment in `apps/server/src/modules/openclaw/n8n.test.ts` near the Proxy `get` trap.

## Risk and Rollout

- User-visible risk: none — test-only change, no production behavior touched.
- Rollout / deploy order: standard merge to main.
- Backout plan: revert single commit.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian. (no Ukrainian docs touched)
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files (or override is justified below).

## Reviewer Notes

- Companion to PR [#3331](https://github.com/Skords-01/Sergeant/pull/3331) (billing.test env-stub — 6/6 passing in CI) and PR [#3333](https://github.com/Skords-01/Sergeant/pull/3333) (webhook string body — 8/8 passing in CI). With this PR landed, server-side Test coverage should go green on main.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the env mock in `apps/server/src/modules/openclaw/n8n.test.ts` to return undefined for missing keys instead of an empty string. This enables the logger’s `LOG_LEVEL` fallback, avoids a `pino` init error, and restores the test run; also documents the reason inline.

<sup>Written for commit ae9ae9bb526a10a21a996a53ff0c61ad86269984. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

