### PR TITLE
ci(root): scope critical-flow E2E to chromium only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -537,7 +537,15 @@ jobs:
           echo "Both servers ready."
 
       - name: Run critical-flow E2E suite
-        run: pnpm --filter @sergeant/web exec playwright test -c playwright.smoke.config.ts --grep @critical
+        # Scope to chromium only: this job installs just chromium
+        # (`playwright install … chromium` above), while the smoke config also
+        # declares webkit + mobile-safari projects. Without --project those
+        # engines run too and fail with "Executable doesn't exist …/webkit-*"
+        # on any Playwright-browser cache miss. webkit/mobile-safari coverage
+        # lives in extended-e2e.yml (nightly + `extended-e2e` label), per the
+        # note in playwright.smoke.config.ts. chromium depends on `setup`, so
+        # the auth-state project still runs automatically.
+        run: pnpm --filter @sergeant/web exec playwright test -c playwright.smoke.config.ts --project=chromium --grep @critical
         env:
           CI: "true"
           PW_SKIP_WEBSERVER: "1"


### PR DESCRIPTION
## Summary

Fixes the intermittent-red `Critical-flow E2E (Playwright)` job (surfaced repeatedly on #3350). The job installs only chromium (`playwright install … chromium`) but ran the smoke config **without a `--project` filter**, so its `webkit` + `mobile-safari` projects also executed and failed with `Executable doesn't exist .../webkit-*/pw_run.sh` on any Playwright-browser **cache miss** — green only when the cache happened to hold webkit, hence the flaky red. Pass `--project=chromium` so only the installed engine runs.

- `.github/workflows/ci.yml` — add `--project=chromium` to the critical-flow `playwright test` command (+ explanatory comment).

`webkit` / `mobile-safari` coverage already lives in `extended-e2e.yml` (nightly + `extended-e2e` label), exactly as documented in `apps/web/playwright.smoke.config.ts`. The `chromium` project declares `dependencies: ["setup"]`, so the auth-state `setup` project still runs automatically — no behavioural loss for PR smoke.

## Governing Skill

- Primary skill: `sergeant-server` n/a — pure CI workflow change; no app surface
- Secondary skill (if truly needed): —

## Playbook

- Primary playbook: n/a
- Why this playbook: —
- If no playbook matched, why: single CI-config fix; no playbook covers GitHub Actions tuning.

## Verification

```bash
node -e "require('js-yaml').load(require('fs').readFileSync('.github/workflows/ci.yml','utf8'))"  # ✅ valid YAML
```

- Verified `apps/web/playwright.smoke.config.ts` projects: `setup`, `chromium` (`dependencies:["setup"]`), `webkit`, `mobile-safari` — only chromium is installed in this job.
- Verified the a11y job (`pnpm test:a11y` → `playwright.config.ts`) is single-project chromium, so it is **not** affected and is intentionally left unchanged.
- Definitive proof is the next CI run on this PR (the job should now pass on a cold browser cache).

Additional checks:

- [x] Local smoke / manual validation completed (YAML parse + config audit)
- [ ] Surface-specific checks completed (n/a — CI-only)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. (inline workflow comment)
- [x] I checked whether `AGENTS.md` needed an update. (no)
- [x] I checked whether a playbook or skill needed an update. (no)
- [x] I checked whether governance docs or review docs needed an update. (no)

Updated docs:

- n/a

## Risk and Rollout

- User-visible risk: **none** (CI-only). PR smoke coverage is unchanged (chromium + setup already the de-facto coverage); webkit/mobile-safari remain covered by `extended-e2e.yml`.
- Rollout / deploy order: merges as a normal workflow change; takes effect on next PR run.
- Backout plan: revert this one-line change.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian. (n/a — only an English workflow comment)
- [x] I did not use `--no-verify`.

## Audit-freeze (until 2026-06-02)

- [x] This PR does not add new top-level audit/initiative/playbook/ADR files. (freeze window also already elapsed — today 2026-06-03)

## Reviewer Notes

- Follow-up to #3350 (LiqPay scaffold), where this job flaked on webkit binary absence. Two other infra gates seen on #3350 are **out of scope** here: `Test coverage (vitest)` (codecov upload is already `fail_ci_if_error: false`; any failure is the vitest run / coverage floor, needs separate look) and `Lighthouse CI` (`NO_FCP` paint flake — needs `lighthouserc.json` readiness tuning).

https://claude.ai/code/session_011sto45vhPy4piXS7jf4S2a

---
_Generated by [Claude Code](https://claude.ai/code/session_011sto45vhPy4piXS7jf4S2a)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope the critical-flow E2E job to Chromium only to stop flaky failures when `webkit` binaries aren’t cached. CI becomes stable without changing PR smoke coverage.

- **Bug Fixes**
  - Run `playwright` with `--project=chromium` in `.github/workflows/ci.yml` for the critical-flow job.
  - Skip `webkit`/`mobile-safari` here (not installed); they remain in `extended-e2e.yml`, and the `setup` project still runs via the Chromium dependency.

<sup>Written for commit efcef5d03d923bb9b31206bf3412303557828b64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

