### PR TITLE
fix(web): dock bottom nav edge-to-edge in PWA standalone via bottom-nav-shell utility

### DIFF
--- a/apps/web/src/core/app/HubBottomNav.test.tsx
+++ b/apps/web/src/core/app/HubBottomNav.test.tsx
@@ -92,18 +92,16 @@ describe("HubBottomNav", () => {
     expect(onChange).toHaveBeenCalledWith("settings");
   });
 
-  it("renders as a floating pill — inset, rounded, framed", () => {
+  it("renders as a bottom-nav-shell — inset, rounded, framed", () => {
     renderNav({});
     const nav = screen.getByRole("navigation");
     const settingsTab = screen.getByRole("tab", { name: /Налаштування/ });
 
-    // Floating-pill shape (navbar-dead-space → floating-pill direction):
-    // inset from the edges + rounded + a panel surface with a border, so
-    // it reads as a distinct panel with the page background continuing
-    // around it. We assert on the className because jsdom doesn't compute
-    // styles from arbitrary / at-rule declarations.
-    expect(nav.className).toContain("mx-3");
-    expect(nav.className).toContain("rounded-3xl");
+    // bottom-nav-shell utility (utilities.css) handles floating-pill
+    // layout in browser mode and edge-to-edge dock in PWA standalone.
+    // The styles are applied via CSS (not Tailwind classes), so we
+    // assert the utility class name and the co-applied surface classes.
+    expect(nav.className).toContain("bottom-nav-shell");
     expect(nav.className).toContain("bg-panel");
     expect(nav.className).toContain("border");
     expect(settingsTab.className).toContain("justify-end");

--- a/apps/web/src/core/app/HubBottomNav.tsx
+++ b/apps/web/src/core/app/HubBottomNav.tsx
@@ -20,14 +20,15 @@ import { messages } from "@shared/i18n/uk";
  *
  * Canonical shape:
  * - 60 px height (64 px on coarse-pointer devices).
- * - Floating pill: `mx-3 mb-[calc(env(safe-area-inset-bottom)+0.5rem)]
- *   rounded-3xl border border-line bg-panel shadow-lg`. Inset + rounded
- *   so it reads as a distinct panel "lying on" the page background
- *   (which shows through the surrounding gap) instead of an edge-to-edge
- *   bar — an edge-to-edge bar made the bottom safe-area read as dead
- *   space / a black strip (navbar-dead-space, 2026-05-28 → floating-pill
- *   direction, matching the surrounding AIPill / FAB offsets that always
- *   assumed a floating nav).
+ * - Browser: floating pill via `bottom-nav-shell` utility — `mx-3`,
+ *   `mb-[calc(env(safe-area-inset-bottom)+0.5rem)]`, `rounded-3xl`.
+ *   Inset + rounded so it reads as a distinct panel "lying on" the
+ *   page background.
+ * - PWA standalone: `bottom-nav-shell` docks the nav edge-to-edge
+ *   against the screen bottom — no horizontal margins, flat bottom,
+ *   rounded only at the top. The panel background fills the safe-area
+ *   strip so there's no page-coloured dead space below the labels
+ *   (user report 2026-06-05 / bottom-nav-gap).
  * - Active indicator: a rounded outline (`rounded-2xl border
  *   border-ink-strong/25`) framing the active tab — outline only, no
  *   fill. Module-agnostic by design.
@@ -263,8 +264,7 @@ export function HubBottomNav({
       aria-label={messages.nav.hubSections}
       className={cn(
         "shrink-0 relative z-30",
-        "mx-3 mb-[calc(env(safe-area-inset-bottom)_+_0.5rem)]",
-        "rounded-3xl border border-line bg-panel shadow-lg",
+        "bottom-nav-shell border border-line bg-panel shadow-lg",
       )}
     >
       <div

--- a/apps/web/src/shared/components/ui/ModuleBottomNav.stories.tsx
+++ b/apps/web/src/shared/components/ui/ModuleBottomNav.stories.tsx
@@ -5,13 +5,12 @@ import { RoutineBottomNav } from "../../../modules/routine/components/RoutineBot
 
 /**
  * `ModuleBottomNav` — спільна bottom-navigation shell для Finyk /
- * Fizruk / Routine / Nutrition. Edge-to-edge `border-t` панель flush
- * з низом екрану. Surface — `bg-bg/95` (matches page background,
- * щоб nav читалась частиною поверхні, а не окремим panel-ом).
- * Активний таб маркується тонкою 4 px sliding-стрічкою зверху
- * (`top-0 h-1 w-10 rounded-full`) з module-tinted градієнтом — це
- * носій module identity. Активна іконка приймає `tokens.text`, label
- * лишається `text-text`.
+ * Fizruk / Routine / Nutrition. Browser: floating pill (`bottom-nav-shell`
+ * utility — mx-3, mb-[safe-area+0.5rem], rounded-3xl). PWA standalone:
+ * edge-to-edge dock (mx-0, mb-0, rounded-t-3xl, pb-[safe-area]).
+ * Активний таб маркується тонким кольоровим контуром (`rounded-2xl border`)
+ * з module-tinted кольором — це носій module identity. Активна іконка
+ * приймає `tokens.text`, label лишається `text-text`.
  */
 const meta: Meta<typeof ModuleBottomNav> = {
   title: "Shared / ModuleBottomNav",

--- a/apps/web/src/shared/components/ui/ModuleBottomNav.test.tsx
+++ b/apps/web/src/shared/components/ui/ModuleBottomNav.test.tsx
@@ -21,7 +21,7 @@ describe("ModuleBottomNav", () => {
     cleanup();
   });
 
-  it("renders as a floating pill — inset, rounded, framed", () => {
+it("renders as a bottom-nav-shell — inset, rounded, framed", () => {
     render(
       <ModuleBottomNav
         items={items}
@@ -35,8 +35,7 @@ describe("ModuleBottomNav", () => {
     const nav = screen.getByRole("navigation", { name: "Module sections" });
     const statsTab = screen.getByRole("button", { name: "Stats" });
 
-    expect(nav.className).toContain("mx-3");
-    expect(nav.className).toContain("rounded-3xl");
+    expect(nav.className).toContain("bottom-nav-shell");
     expect(nav.className).toContain("bg-panel");
     expect(nav.className).toContain("border");
     expect(statsTab.className).toContain("justify-end");

--- a/apps/web/src/shared/components/ui/ModuleBottomNav.tsx
+++ b/apps/web/src/shared/components/ui/ModuleBottomNav.tsx
@@ -11,13 +11,15 @@ import { cn } from "../../lib/ui/cn";
  *
  * Canonical shape:
  * - Height 60 px (64 px on coarse-pointer devices).
- * - Floating pill: `mx-3 mb-[calc(env(safe-area-inset-bottom)+0.5rem)]
- *   rounded-3xl border border-line bg-panel shadow-lg`. Inset + rounded
- *   so it reads as a distinct panel with the page background continuing
- *   behind and below it, instead of an edge-to-edge bar whose bottom
- *   safe-area read as dead space / a black strip (navbar-dead-space,
- *   2026-05-28 → floating-pill direction). The Routine FAB's `-top-[22px]`
- *   offset assumes this pill's top edge.
+ * - Browser: floating pill via `bottom-nav-shell` utility — `mx-3`,
+ *   `mb-[calc(env(safe-area-inset-bottom)+0.5rem)]`, `rounded-3xl`.
+ *   Inset + rounded so it reads as a distinct panel with the page
+ *   background continuing behind and below it.
+ * - PWA standalone: `bottom-nav-shell` docks the nav edge-to-edge
+ *   against the screen bottom — no horizontal margins, flat bottom,
+ *   rounded only at the top. The panel background fills the safe-area
+ *   strip so there's no page-coloured dead space below the labels
+ *   (user report 2026-06-05 / bottom-nav-gap).
  * - Active indicator: a rounded outline (`rounded-2xl border`)
  *   framing the active tab, tinted with the module accent
  *   (`tokens.outline`) — outline only, no fill. Carries module
@@ -115,8 +117,7 @@ export const ModuleBottomNav = memo(function ModuleBottomNav({
       aria-label={ariaLabel}
       className={cn(
         "shrink-0 relative z-30",
-        "mx-3 mb-[calc(env(safe-area-inset-bottom)_+_0.5rem)]",
-        "rounded-3xl border border-line bg-panel shadow-lg",
+        "bottom-nav-shell border border-line bg-panel shadow-lg",
         className,
       )}
     >

--- a/apps/web/src/styles/utilities.css
+++ b/apps/web/src/styles/utilities.css
@@ -413,6 +413,31 @@
   height: calc(60px + env(safe-area-inset-bottom, 0px));
 }
 
+@utility bottom-nav-shell {
+  /* ── Browser mode: floating pill ────────────────────────────────────
+     Inset from screen edges so the page background shows through the
+     surround gap — reads as a distinct panel "lying on" the mesh surface.
+     The bottom margin clears the home indicator / browser chrome. */
+  margin-left: 0.75rem;
+  margin-right: 0.75rem;
+  margin-bottom: calc(env(safe-area-inset-bottom, 0px) + 0.5rem);
+  border-radius: 1.5rem; /* rounded-3xl */
+
+  /* ── PWA standalone: edge-to-edge dock ──────────────────────────────
+     No horizontal insets, no bottom gap, rounded only at the top so the
+     nav panel sits flush against the screen bottom. The panel background
+     (bg-panel) extends into the safe-area strip, filling what would
+     otherwise be page-coloured dead space below the labels
+     (user report 2026-06-05 / bottom-nav-gap). */
+  @media (display-mode: standalone) {
+    margin-left: 0;
+    margin-right: 0;
+    margin-bottom: 0;
+    border-radius: 1.5rem 1.5rem 0 0; /* rounded-t-3xl */
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+  }
+}
+
 @utility no-scrollbar {
   /* ═══════════════════════════════════════════════════════════════════════
      SCROLLBAR UTILITIES


### PR DESCRIPTION
## Summary

- Додано CSS utility `bottom-nav-shell` в `utilities.css`, яка в `@media (display-mode: standalone)` перемикає HubBottomNav та ModuleBottomNav із floating pill на edge-to-edge dock — нульові відступи, заокруглення тільки зверху, фон заповнює safe-area смугу
- У браузерному режимі floating pill дизайн не змінюється

## Problem

У PWA standalone (iPhone) нижній навбар мав ~42px порожнього простору під собою: `env(safe-area-inset-bottom)` ≈ 34px + 0.5rem (8px) відступ. У браузері цей простір заповнювався URL-баром/кнопками, але в PWA там було просто порожнє тло.

## Changes

| File | Change |
|---|---|
| `apps/web/src/styles/utilities.css` | Додано `@utility bottom-nav-shell` з умовним `@media (display-mode: standalone)` |
| `apps/web/src/core/app/HubBottomNav.tsx` | `mx-3 mb-[...] rounded-3xl` → `bottom-nav-shell` |
| `apps/web/src/shared/components/ui/ModuleBottomNav.tsx` | Аналогічно |
| `apps/web/src/core/app/HubBottomNav.test.tsx` | Тест: `mx-3` → `bottom-nav-shell` |
| `apps/web/src/shared/components/ui/ModuleBottomNav.test.tsx` | Аналогічно |
| `apps/web/src/shared/components/ui/ModuleBottomNav.stories.tsx` | Оновлено JSDoc |

## Verification

- Typecheck: node_modules відсутні в worktree, CI проганяє в PR
- Tests: перевірка на `bottom-nav-shell` замість `mx-3`
- FloatingActionButton / AIPill / ActiveWorkoutBanner — `bottom` offset-и залишаються коректними в обох режимах

## Risk

Низький. Чистий CSS-only change — логіка компонентів не змінена. Floating pill у браузері працює як і раніше.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the ~42px dead space under the bottom nav in iPhone PWA by docking the nav edge-to-edge in standalone mode. Adds a `bottom-nav-shell` CSS utility that keeps the floating pill in browser mode.

- **Bug Fixes**
  - Added `@utility bottom-nav-shell` in `utilities.css`; switches to docked layout in `@media (display-mode: standalone)` (no margins, top-only rounding, safe-area padding).
  - Replaced margin/rounded classes with `bottom-nav-shell` in `HubBottomNav` and `ModuleBottomNav`; updated tests and story.
  - Verified FAB/AIPill/ActiveWorkoutBanner bottom offsets remain correct; no logic changes.

<sup>Written for commit 9a081e6a90492d0f049a6d068872e5b8e3094f8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

