### PR TITLE
feat(mobile): complete Sentry RN wiring — release/env tags, .env.example, docs

### DIFF
--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -9,3 +9,11 @@ EXPO_PUBLIC_API_BASE_URL=http://localhost:5000
 # Той самий project key, що й `VITE_POSTHOG_KEY` у root `.env.example`.
 # EXPO_PUBLIC_POSTHOG_KEY=phc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 # EXPO_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
+
+# Sentry — error tracking для native crashes (React Native SDK).
+# Без DSN `initObservability()` виконує no-op; жодних подій у Sentry.
+# Парний до `VITE_SENTRY_DSN` (web) і `SENTRY_DSN` (server).
+# Дивись docs/integrations/env-vars.md §21 та apps/mobile/src/lib/observability.ts.
+# EXPO_PUBLIC_SENTRY_DSN=https://xxxx@oXXXXXX.ingest.sentry.io/XXXXXXX
+# EXPO_PUBLIC_SENTRY_ENVIRONMENT=development
+# EXPO_PUBLIC_SENTRY_RELEASE=

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -8,6 +8,9 @@
       "developmentClient": true,
       "distribution": "internal",
       "channel": "development",
+      "env": {
+        "EXPO_PUBLIC_SENTRY_ENVIRONMENT": "development"
+      },
       "ios": {
         "resourceClass": "m-medium",
         "simulator": true
@@ -19,6 +22,9 @@
     "preview": {
       "distribution": "internal",
       "channel": "preview",
+      "env": {
+        "EXPO_PUBLIC_SENTRY_ENVIRONMENT": "preview"
+      },
       "ios": {
         "resourceClass": "m-medium",
         "simulator": true
@@ -31,6 +37,9 @@
       "distribution": "store",
       "channel": "production",
       "autoIncrement": true,
+      "env": {
+        "EXPO_PUBLIC_SENTRY_ENVIRONMENT": "production"
+      },
       "ios": {
         "resourceClass": "m-medium"
       },

--- a/apps/mobile/src/core/ErrorBoundary.tsx
+++ b/apps/mobile/src/core/ErrorBoundary.tsx
@@ -17,9 +17,9 @@
  *
  * Differences from web (intentional — see PR body):
  * - Telemetry: web forwards to `captureException` from `./sentry.js`
- *   (a lazy bridge to `@sentry/react`). Mobile uses plain
- *   `console.error` — `@sentry/react-native` is deliberately **not**
- *   added yet; observability lands in Phase 10+.
+ *   (a lazy bridge to `@sentry/react`). Mobile forwards to
+ *   `captureError` from `@/lib/observability` (lazy bridge to
+ *   `@sentry/react-native`; no-op when DSN is unset).
  * - Default fallback: web leaves `Fallback || null` when no prop is
  *   supplied; mobile renders a shared `Card` + `Button` card with the
  *   same Ukrainian strings the web host screens use

--- a/apps/mobile/src/lib/observability.ts
+++ b/apps/mobile/src/lib/observability.ts
@@ -18,7 +18,11 @@ import {
   redactSensitiveQueryParams,
 } from "@sergeant/shared";
 
-import { getSentryDsn } from "./observability/env";
+import {
+  getSentryDsn,
+  getSentryEnvironment,
+  getSentryRelease,
+} from "./observability/env";
 
 /**
  * Minimal structural subset of `Sentry.ErrorEvent` so the
@@ -124,6 +128,14 @@ export function initObservability(): void {
   }
   Sentry.init({
     dsn,
+    // Release + environment mirror the web pattern so crash groups and
+    // performance data are attributed to the correct build in the Sentry
+    // UI. `EXPO_PUBLIC_SENTRY_RELEASE` is set by EAS build pipelines;
+    // omitting it falls back to Sentry's own native build-time injection
+    // (via the `@sentry/react-native/expo` config plugin). Mirrors
+    // `release: import.meta.env["VITE_SENTRY_RELEASE"]` in the web SDK.
+    release: getSentryRelease(),
+    environment: getSentryEnvironment(),
     enableAutoSessionTracking: true,
     // 5% of transactions — enough for p95/p99 latency visibility without
     // significant overhead. Bump to 0.1 if mobile APM data is sparse in prod.

--- a/apps/mobile/src/lib/observability/env.ts
+++ b/apps/mobile/src/lib/observability/env.ts
@@ -1,11 +1,20 @@
 /**
- * DSN accessor split into its own module so Jest can `jest.mock` the
- * read and drive `initObservability` through both the DSN-set and
- * DSN-absent branches in a single test file. At production build time
- * Expo's babel preset inlines the `process.env.EXPO_PUBLIC_SENTRY_DSN`
- * literal here — the inlined value is the only thing that ships.
+ * DSN / release / environment accessors split into their own module so
+ * Jest can `jest.mock` the reads and drive `initObservability` through
+ * both the DSN-set and DSN-absent branches in a single test file. At
+ * production build time Expo's babel preset inlines the
+ * `process.env.EXPO_PUBLIC_*` literals here — the inlined values are
+ * the only things that ship.
  */
 
 export function getSentryDsn(): string | undefined {
   return process.env.EXPO_PUBLIC_SENTRY_DSN;
+}
+
+export function getSentryRelease(): string | undefined {
+  return process.env.EXPO_PUBLIC_SENTRY_RELEASE || undefined;
+}
+
+export function getSentryEnvironment(): string {
+  return process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT || "production";
 }

--- a/apps/mobile/src/lib/observability/env.ts
+++ b/apps/mobile/src/lib/observability/env.ts
@@ -8,7 +8,7 @@
  */
 
 export function getSentryDsn(): string | undefined {
-  return process.env.EXPO_PUBLIC_SENTRY_DSN;
+  return process.env.EXPO_PUBLIC_SENTRY_DSN || undefined;
 }
 
 export function getSentryRelease(): string | undefined {

--- a/docs/initiatives/follow-ups.md
+++ b/docs/initiatives/follow-ups.md
@@ -1,6 +1,6 @@
 # Initiative follow-ups
 
-> **Last validated:** 2026-06-04 by @Skords-01. **Next review:** 2026-09-02.
+> **Last validated:** 2026-06-05 by @Skords-01. **Next review:** 2026-09-03.
 > **Status:** Active
 
 <!-- AUTO-GENERATED FILE. Do not edit by hand. Regenerate via `pnpm docs:gen-initiative-followups`. -->

--- a/docs/integrations/env-vars.md
+++ b/docs/integrations/env-vars.md
@@ -1,6 +1,6 @@
 # Environment variables — повний reference
 
-> **Last validated:** 2026-05-14 by @Skords-01. **Next review:** 2026-08-12.
+> **Last validated:** 2026-06-05 by @claude. **Next review:** 2026-09-03.
 > **Status:** Active
 
 Цей документ — канонічний reference усіх змінних оточення Sergeant. Мінімальний `.env` (12 змінних, потрібних для `pnpm dev:web` + `pnpm dev:server`) лежить у [`/.env.example`](../../.env.example) у корені репо. Сюди винесено: повний опис, формати, default-и, наслідки незаповненості, перехресні посилання на код / ADR / hardening-ноти.
@@ -573,7 +573,15 @@ GitHub PAT з `contents:write` для opening PR-ів з decision markdown у `d
 
 ### `EXPO_PUBLIC_SENTRY_DSN` _(optional)_
 
-Публічний Sentry DSN для RN-клієнта. Інлайниться у бандл на build-time (префікс `EXPO_PUBLIC_` → доступно в `process.env`). Optional — без нього `initObservability()` виконує no-op і жодних подій у Sentry не відправляється. Дивись [`apps/mobile/src/lib/observability.ts`](../../apps/mobile/src/lib/observability.ts).
+Публічний Sentry DSN для RN-клієнта. Інлайниться у бандл на build-time (префікс `EXPO_PUBLIC_` → доступно в `process.env`). Optional — без нього `initObservability()` виконує no-op і жодних подій у Sentry не відправляється. Парний до `VITE_SENTRY_DSN` (web) і `SENTRY_DSN` (server). Дивись [`apps/mobile/src/lib/observability.ts`](../../apps/mobile/src/lib/observability.ts).
+
+### `EXPO_PUBLIC_SENTRY_RELEASE` _(optional)_
+
+Ідентифікатор білду / релізу для прив'язки краш-репортів до конкретної версії у Sentry UI. Зазвичай встановлюється EAS-білд-пайплайном (наприклад `1.0.0+42` або Git SHA). Якщо не задано — Sentry-плагін `@sentry/react-native/expo` інжектує власний хеш нативного білду. Парний до `VITE_SENTRY_RELEASE` (web).
+
+### `EXPO_PUBLIC_SENTRY_ENVIRONMENT` _(optional)_
+
+Sentry environment-тег для сегментації подій між `development`, `staging` і `production`. Default: `"production"`. Парний до `VITE_SENTRY_ENVIRONMENT` (web) та `SENTRY_ENVIRONMENT` (server).
 
 ### `EXPO_PUBLIC_POSTHOG_KEY`, `EXPO_PUBLIC_POSTHOG_HOST` _(optional)_
 


### PR DESCRIPTION
## Summary

Closes the infra-audit MED gap: `apps/mobile` ships PostHog but lacked full Sentry wiring, making native crashes invisible.

The Phase 12 scaffold already had `@sentry/react-native ~6.10.0` installed, `initObservability()` hooked into `_layout.tsx`, and `captureError` plumbed into the error boundary. Three concrete gaps remained vs the web setup:

- **Release + environment tags missing from `Sentry.init()`** — crash groups in the Sentry UI could not be attributed to a specific EAS build or env tier. Added `getSentryRelease()` / `getSentryEnvironment()` env accessors in `observability/env.ts` (same Jest-mockable split as the existing `getSentryDsn`) and passed them into `Sentry.init`. Mirrors `release: import.meta.env["VITE_SENTRY_RELEASE"]` and `environment: …` from the web SDK (`apps/web/src/core/observability/sentry.ts`).
- **`EXPO_PUBLIC_SENTRY_DSN` absent from `apps/mobile/.env.example`** — contributors cloning the repo had no indication that Sentry could be enabled. Added all three new vars as commented-out examples.
- **Stale comment in `ErrorBoundary.tsx`** claimed Sentry was "not added yet / Phase 10+", but `captureError` already bridges to `@sentry/react-native`. Updated to reflect reality.
- **`docs/integrations/env-vars.md` §21** updated with `EXPO_PUBLIC_SENTRY_RELEASE` and `EXPO_PUBLIC_SENTRY_ENVIRONMENT` entries.

## Version compatibility

- Expo SDK: **52.0.0** (`expo ~52.0.0` in `package.json`)
- React Native: **0.76.9**
- `@sentry/react-native`: **~6.10.0** (already present; uses the official `@sentry/react-native/expo` config plugin, not the deprecated `sentry-expo`)
- Sentry v6.x supports Expo SDK 51+ / RN 0.73+; see [Sentry RN 6.x changelog](https://github.com/getsentry/sentry-react-native/releases).

No package.json changes — the dependency was already correct.

## Features mirrored from web

| Feature | Web | Mobile |
|---|---|---|
| DSN-gated no-op | `VITE_SENTRY_DSN` | `EXPO_PUBLIC_SENTRY_DSN` |
| PII scrubbing (`beforeSend`) | `applyWebBeforeSend` | `applyMobileBeforeSend` |
| Release tag | `VITE_SENTRY_RELEASE` | `EXPO_PUBLIC_SENTRY_RELEASE` ← **added** |
| Environment tag | `VITE_SENTRY_ENVIRONMENT` | `EXPO_PUBLIC_SENTRY_ENVIRONMENT` ← **added** |
| Error boundary → captureError | `captureException` lazy bridge | `captureError` lazy bridge ✅ |
| denyUrls | chrome/moz/safari-extension | N/A — React Native has no browser extensions |

## Test plan

- [x] `pnpm --filter @sergeant/mobile typecheck` — **0 errors**
- [ ] Set `EXPO_PUBLIC_SENTRY_DSN` in `.env` and run `expo start`; verify Sentry initialises (`[observability] sentry disabled (no DSN)` should NOT appear in Metro logs)
- [ ] Without DSN, verify Metro logs show `[observability] sentry disabled (no DSN)` and the app starts cleanly
- [ ] Trigger a test error in an error boundary; verify it appears in Sentry dashboard with correct `release` and `environment` tags when DSN is set

---
_Generated by [Claude Code](https://claude.ai/code/session_01S1t8hdQp2Pea9cvAixxh1m)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completed Sentry wiring in `apps/mobile` with release/env tags and EAS profile defaults. Native crash reports now include the correct build and environment in Sentry.

- **New Features**
  - `Sentry.init()` now sets `release` and `environment` via `getSentryRelease()` and `getSentryEnvironment()` (env default is `"production"`).
  - EAS build profiles pin `EXPO_PUBLIC_SENTRY_ENVIRONMENT` in `eas.json` (`development`, `preview`, `production`).
  - Added Sentry vars to `.env.example`, documented them in `docs/integrations/env-vars.md`, and updated `ErrorBoundary.tsx` to reflect the `captureError` bridge.

- **Bug Fixes**
  - `getSentryDsn()` treats empty strings as `undefined` to prevent accidental Sentry init.

<sup>Written for commit a4a65ff11294ad1d2108d3a3470d4bd82198d11b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mobile app crash error reporting now captures release and environment context, improving error attribution and debugging across different deployment stages.

* **Documentation**
  * Added mobile crash tracking configuration guide with environment variable documentation, setup instructions, and behavior details for different deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->