### PR TITLE
feat(root): add legal launch pack

### DIFF
--- a/apps/server/src/migrations/076_user_preferences.down.sql
+++ b/apps/server/src/migrations/076_user_preferences.down.sql
@@ -1,0 +1,3 @@
+-- 076 down: remove user consent/preferences table.
+
+DROP TABLE IF EXISTS user_preferences CASCADE;

--- a/apps/server/src/migrations/076_user_preferences.sql
+++ b/apps/server/src/migrations/076_user_preferences.sql
@@ -1,0 +1,26 @@
+-- 076: user consent/preferences for legal/data-rights launch pack.
+--
+-- This table stores user-controllable processing preferences that are exposed
+-- through `/api/me/preferences`. It intentionally lives outside Better Auth's
+-- core user table so auth upgrades stay isolated from product-consent state.
+
+CREATE TABLE IF NOT EXISTS user_preferences (
+  user_id TEXT PRIMARY KEY REFERENCES "user"(id) ON DELETE CASCADE,
+  analytics BOOLEAN NOT NULL DEFAULT TRUE,
+  ai_memory BOOLEAN NOT NULL DEFAULT TRUE,
+  push_notifications BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE user_preferences IS
+  'Per-user legal/privacy preferences. Defaults mirror pre-existing product behavior: analytics and AI memory enabled, push opt-in remains explicit.';
+
+COMMENT ON COLUMN user_preferences.analytics IS
+  'User preference for product analytics processing.';
+
+COMMENT ON COLUMN user_preferences.ai_memory IS
+  'User preference for server-side AI memory processing.';
+
+COMMENT ON COLUMN user_preferences.push_notifications IS
+  'User preference for push notifications; browser/mobile permission is still required separately.';

--- a/apps/server/src/modules/me/dataRights.ts
+++ b/apps/server/src/modules/me/dataRights.ts
@@ -1,0 +1,237 @@
+import type { Pool, PoolClient } from "pg";
+import type {
+  MeDeleteResponse,
+  MeExportResponse,
+  MeResponse,
+  UserPreferences,
+  UserPreferencesPatch,
+} from "@sergeant/shared";
+
+type Queryable = Pick<Pool | PoolClient, "query">;
+
+const DEFAULT_PREFERENCES: Omit<UserPreferences, "updatedAt"> = {
+  analytics: true,
+  aiMemory: true,
+  pushNotifications: false,
+};
+
+function iso(value: Date | string): string {
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+function maybeIso(value: Date | string | null | undefined): string | null {
+  if (!value) return null;
+  const d = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(d.getTime()) ? null : d.toISOString();
+}
+
+function rowArray(rows: ReadonlyArray<Record<string, unknown>>): Record<string, unknown>[] {
+  return rows.map((row) => ({ ...row }));
+}
+
+function serializePreferences(
+  row: Record<string, unknown> | undefined,
+): UserPreferences {
+  if (!row) {
+    return { ...DEFAULT_PREFERENCES, updatedAt: null };
+  }
+  return {
+    analytics: row["analytics"] === true,
+    aiMemory: row["ai_memory"] === true,
+    pushNotifications: row["push_notifications"] === true,
+    updatedAt: maybeIso(row["updated_at"] as Date | string | null | undefined),
+  };
+}
+
+export async function getUserPreferences(
+  db: Queryable,
+  userId: string,
+): Promise<UserPreferences> {
+  const result = await db.query<Record<string, unknown>>(
+    `SELECT analytics, ai_memory, push_notifications, updated_at
+       FROM user_preferences
+      WHERE user_id = $1`,
+    [userId],
+  );
+  return serializePreferences(result.rows[0]);
+}
+
+export async function upsertUserPreferences(
+  db: Queryable,
+  userId: string,
+  patch: UserPreferencesPatch,
+): Promise<UserPreferences> {
+  const current = await getUserPreferences(db, userId);
+  const next = {
+    analytics: patch.analytics ?? current.analytics,
+    aiMemory: patch.aiMemory ?? current.aiMemory,
+    pushNotifications: patch.pushNotifications ?? current.pushNotifications,
+  };
+  const result = await db.query<Record<string, unknown>>(
+    `INSERT INTO user_preferences
+        (user_id, analytics, ai_memory, push_notifications, updated_at)
+      VALUES ($1, $2, $3, $4, NOW())
+      ON CONFLICT (user_id) DO UPDATE SET
+        analytics = EXCLUDED.analytics,
+        ai_memory = EXCLUDED.ai_memory,
+        push_notifications = EXCLUDED.push_notifications,
+        updated_at = NOW()
+      RETURNING analytics, ai_memory, push_notifications, updated_at`,
+    [userId, next.analytics, next.aiMemory, next.pushNotifications],
+  );
+  return serializePreferences(result.rows[0]);
+}
+
+export async function buildMeExport(
+  db: Queryable,
+  user: MeResponse["user"],
+): Promise<MeExportResponse> {
+  const [
+    preferences,
+    moduleData,
+    monoConnection,
+    monoAccounts,
+    monoTransactions,
+    subscriptions,
+    pushSubscriptions,
+    pushDevices,
+    aiUsageDaily,
+    aiMemories,
+  ] = await Promise.all([
+    getUserPreferences(db, user.id),
+    db.query<Record<string, unknown>>(
+      `SELECT module, data, version, client_updated_at, server_updated_at
+         FROM module_data
+        WHERE user_id = $1
+        ORDER BY module`,
+      [user.id],
+    ),
+    db.query<Record<string, unknown>>(
+      `SELECT status, token_fingerprint, webhook_registered_at,
+              last_event_at, last_backfill_at, created_at, updated_at
+         FROM mono_connection
+        WHERE user_id = $1`,
+      [user.id],
+    ),
+    db.query<Record<string, unknown>>(
+      `SELECT mono_account_id, send_id, type, currency_code, cashback_type,
+              masked_pan, iban, balance, credit_limit, last_seen_at
+         FROM mono_account
+        WHERE user_id = $1
+        ORDER BY mono_account_id`,
+      [user.id],
+    ),
+    db.query<Record<string, unknown>>(
+      `SELECT mono_account_id, mono_tx_id, time, amount, operation_amount,
+              currency_code, mcc, original_mcc, hold, description, comment,
+              cashback_amount, commission_rate, balance, receipt_id, invoice_id,
+              counter_edrpou, counter_iban, counter_name, raw, source, received_at
+         FROM mono_transaction
+        WHERE user_id = $1 AND deleted_at IS NULL
+        ORDER BY time DESC
+        LIMIT 5000`,
+      [user.id],
+    ),
+    db.query<Record<string, unknown>>(
+      `SELECT id, plan, status, provider, current_period_end,
+              cancel_at_period_end, created_at, updated_at
+         FROM subscriptions
+        WHERE user_id = $1
+        ORDER BY created_at DESC`,
+      [user.id],
+    ),
+    db.query<Record<string, unknown>>(
+      `SELECT endpoint, created_at, deleted_at
+         FROM push_subscriptions
+        WHERE user_id = $1
+        ORDER BY created_at DESC`,
+      [user.id],
+    ),
+    db.query<Record<string, unknown>>(
+      `SELECT platform, endpoint, created_at, updated_at, deleted_at
+         FROM push_devices
+        WHERE user_id = $1
+        ORDER BY updated_at DESC`,
+      [user.id],
+    ),
+    db.query<Record<string, unknown>>(
+      `SELECT usage_day, bucket, request_count, est_cost_usd, deleted_at
+         FROM ai_usage_daily
+        WHERE subject_key = $1
+        ORDER BY usage_day DESC`,
+      [`u:${user.id}`],
+    ),
+    db.query<Record<string, unknown>>(
+      `SELECT id, source, source_ref, content, metadata, created_at,
+              updated_at, deleted_at
+         FROM ai_memories
+        WHERE user_id = $1
+        ORDER BY created_at DESC
+        LIMIT 5000`,
+      [user.id],
+    ),
+  ]);
+
+  return {
+    generatedAt: new Date().toISOString(),
+    user,
+    preferences,
+    data: {
+      moduleData: rowArray(moduleData.rows),
+      mono: {
+        connection: monoConnection.rows[0] ? { ...monoConnection.rows[0] } : null,
+        accounts: rowArray(monoAccounts.rows),
+        transactions: rowArray(monoTransactions.rows),
+      },
+      billing: {
+        subscriptions: rowArray(subscriptions.rows),
+      },
+      push: {
+        webSubscriptions: rowArray(pushSubscriptions.rows),
+        devices: rowArray(pushDevices.rows),
+      },
+      ai: {
+        usageDaily: rowArray(aiUsageDaily.rows),
+        memories: rowArray(aiMemories.rows),
+      },
+    },
+  };
+}
+
+export async function deleteUserData(
+  pool: Pool,
+  userId: string,
+): Promise<MeDeleteResponse> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `UPDATE subscriptions
+          SET status = 'canceled',
+              cancel_at_period_end = TRUE,
+              updated_at = NOW()
+        WHERE user_id = $1
+          AND status IN ('active', 'trialing', 'past_due', 'incomplete')`,
+      [userId],
+    );
+    await client.query(
+      `UPDATE ai_memories
+          SET deleted_at = COALESCE(deleted_at, NOW()),
+              updated_at = NOW()
+        WHERE user_id = $1`,
+      [userId],
+    );
+    await client.query(
+      `DELETE FROM "user"
+        WHERE id = $1`,
+      [userId],
+    );
+    await client.query("COMMIT");
+    return { ok: true, deletedAt: iso(new Date()) };
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}

--- a/apps/server/src/routes/apiV1.test.ts
+++ b/apps/server/src/routes/apiV1.test.ts
@@ -189,6 +189,131 @@ describe("/api/v1/me — cookie і bearer резолвляться однако�
   });
 });
 
+describe("/api/v1/me data rights", () => {
+  const user = {
+    id: "user_rights",
+    email: "rights@example.com",
+    name: "Rights User",
+    image: null,
+    emailVerified: true,
+  };
+
+  it("GET /api/v1/me/preferences без auth → 401", async () => {
+    const app = createApp();
+    const res = await request(app).get("/api/v1/me/preferences");
+    expect(res.status).toBe(401);
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it("GET /api/v1/me/preferences повертає defaults, якщо row ще нема", async () => {
+    getSessionUserMock.mockResolvedValueOnce(user);
+    queryMock.mockResolvedValueOnce({ rows: [] });
+    const app = createApp();
+    const res = await request(app)
+      .get("/api/v1/me/preferences")
+      .set("Authorization", "Bearer x");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      analytics: true,
+      aiMemory: true,
+      pushNotifications: false,
+      updatedAt: null,
+    });
+  });
+
+  it("PATCH /api/v1/me/preferences валідовує partial patch", async () => {
+    getSessionUserMock.mockResolvedValueOnce(user);
+    queryMock
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            analytics: false,
+            ai_memory: true,
+            push_notifications: false,
+            updated_at: new Date("2026-06-06T10:05:00.000Z"),
+          },
+        ],
+      });
+    const app = createApp();
+    const res = await request(app)
+      .patch("/api/v1/me/preferences")
+      .set("X-Requested-With", "XMLHttpRequest")
+      .set("Authorization", "Bearer x")
+      .send({ analytics: false });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      analytics: false,
+      aiMemory: true,
+      pushNotifications: false,
+      updatedAt: "2026-06-06T10:05:00.000Z",
+    });
+    const [sql, params] = queryMock.mock.calls[1]!;
+    expect(String(sql)).toMatch(/INSERT INTO user_preferences/);
+    expect(params).toEqual([user.id, false, true, false]);
+  });
+
+  it("PATCH /api/v1/me/preferences відхиляє невідомий shape", async () => {
+    getSessionUserMock.mockResolvedValueOnce(user);
+    const app = createApp();
+    const res = await request(app)
+      .patch("/api/v1/me/preferences")
+      .set("X-Requested-With", "XMLHttpRequest")
+      .set("Authorization", "Bearer x")
+      .send({ analytics: "yes" });
+
+    expect(res.status).toBe(400);
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it("GET /api/v1/me/export не вибирає raw secrets/tokens", async () => {
+    getSessionUserMock.mockResolvedValueOnce(user);
+    queryMock.mockResolvedValue({ rows: [] });
+    const app = createApp();
+    const res = await request(app)
+      .get("/api/v1/me/export")
+      .set("Authorization", "Bearer x");
+
+    expect(res.status).toBe(200);
+    expect(res.body.user).toMatchObject({ id: user.id, email: user.email });
+    expect(res.body.data).toMatchObject({
+      mono: { connection: null, accounts: [], transactions: [] },
+      billing: { subscriptions: [] },
+      push: { webSubscriptions: [], devices: [] },
+      ai: { usageDaily: [], memories: [] },
+    });
+    const sql = queryMock.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(sql).not.toMatch(/token_ciphertext|webhook_secret|token_hash/);
+  });
+
+  it("DELETE /api/v1/me запускає deletion transaction", async () => {
+    getSessionUserMock.mockResolvedValueOnce(user);
+    const client = {
+      query: vi.fn().mockResolvedValue({ rows: [], rowCount: 1 }),
+      release: vi.fn(),
+    };
+    mockPool.connect.mockResolvedValueOnce(client);
+    const app = createApp();
+    const res = await request(app)
+      .delete("/api/v1/me")
+      .set("X-Requested-With", "XMLHttpRequest")
+      .set("Authorization", "Bearer x");
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(client.query.mock.calls.map((call) => String(call[0]))).toEqual([
+      "BEGIN",
+      expect.stringMatching(/UPDATE subscriptions/),
+      expect.stringMatching(/UPDATE ai_memories/),
+      expect.stringMatching(/DELETE FROM "user"/),
+      "COMMIT",
+    ]);
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("POST /api/v1/push/register", () => {
   const user = { id: "user_abc" };
 

--- a/apps/server/src/routes/me.ts
+++ b/apps/server/src/routes/me.ts
@@ -1,7 +1,26 @@
 import { Router } from "express";
 import type { Request, Response } from "express";
-import { MeResponseSchema, type MeResponse } from "@sergeant/shared";
-import { asyncHandler, requireSession, setModule } from "../http/index.js";
+import {
+  MeDeleteResponseSchema,
+  MeExportResponseSchema,
+  MeResponseSchema,
+  UserPreferencesPatchSchema,
+  UserPreferencesSchema,
+  type MeResponse,
+} from "@sergeant/shared";
+import {
+  asyncHandler,
+  parseBody,
+  requireSession,
+  setModule,
+} from "../http/index.js";
+import { pool } from "../db.js";
+import {
+  buildMeExport,
+  deleteUserData,
+  getUserPreferences,
+  upsertUserPreferences,
+} from "../modules/me/dataRights.js";
 
 type AuthedUser = {
   id: string;
@@ -44,6 +63,56 @@ function toIsoOrNull(value: Date | string | undefined): string | null {
 export function createMeRouter(): Router {
   const r = Router();
   r.use("/api/me", setModule("me"));
+
+  r.get(
+    "/api/me/export",
+    requireSession(),
+    asyncHandler(async (req: Request, res: Response) => {
+      const user = serializeMeUser((req as Request & { user: AuthedUser }).user);
+      const payload = MeExportResponseSchema.parse(
+        await buildMeExport(pool, user),
+      );
+      res.json(payload);
+    }),
+  );
+
+  r.get(
+    "/api/me/preferences",
+    requireSession(),
+    asyncHandler(async (req: Request, res: Response) => {
+      const user = (req as Request & { user: AuthedUser }).user;
+      const payload = UserPreferencesSchema.parse(
+        await getUserPreferences(pool, user.id),
+      );
+      res.json(payload);
+    }),
+  );
+
+  r.patch(
+    "/api/me/preferences",
+    requireSession(),
+    asyncHandler(async (req: Request, res: Response) => {
+      const user = (req as Request & { user: AuthedUser }).user;
+      const patch = parseBody(UserPreferencesPatchSchema, req);
+      const payload = UserPreferencesSchema.parse(
+        await upsertUserPreferences(pool, user.id, patch),
+      );
+      res.json(payload);
+    }),
+  );
+
+  r.delete(
+    "/api/me",
+    requireSession(),
+    asyncHandler(async (req: Request, res: Response) => {
+      const user = (req as Request & { user: AuthedUser }).user;
+      const payload = MeDeleteResponseSchema.parse(
+        await deleteUserData(pool, user.id),
+      );
+      res.json(payload);
+    }),
+  );
+
   r.get(
     "/api/me",
     requireSession(),
@@ -58,17 +127,21 @@ export function createMeRouter(): Router {
       // валитиме parse. Використовуємо `||` замість `??`, щоб і falsy-рядки
       // (якщо колись прийшов "") нормалізувались до `null`.
       const payload: MeResponse = MeResponseSchema.parse({
-        user: {
-          id: user.id,
-          email: user.email || null,
-          name: user.name ?? null,
-          image: user.image ?? null,
-          emailVerified: Boolean(user.emailVerified),
-          createdAt: toIsoOrNull(user.createdAt),
-        },
+        user: serializeMeUser(user),
       });
       res.json(payload);
     }),
   );
   return r;
+}
+
+function serializeMeUser(user: AuthedUser): MeResponse["user"] {
+  return {
+    id: user.id,
+    email: user.email || null,
+    name: user.name ?? null,
+    image: user.image ?? null,
+    emailVerified: Boolean(user.emailVerified),
+    createdAt: toIsoOrNull(user.createdAt),
+  };
 }

--- a/apps/web/src/core/LandingPage.tsx
+++ b/apps/web/src/core/LandingPage.tsx
@@ -7,6 +7,7 @@ import { BrandLogo } from "./app/BrandLogo";
 import { ANALYTICS_EVENTS, trackEvent } from "./observability/analytics";
 import { PRICING_PATH, SIGN_IN_PATH, WELCOME_PATH } from "./app/appPaths";
 import { WaitlistForm } from "./pricing/WaitlistForm";
+import { LegalLinks } from "./legal/LegalLinks";
 import { useLocale } from "@shared/i18n/useLocale";
 
 // Phase 6.2 landing surface (initiative 0010, ADR-0051). Публічний `/`
@@ -253,6 +254,7 @@ export function LandingPage({ onContinueWithoutAccount }: LandingPageProps) {
 
         <footer className="text-center text-xs text-muted space-y-1">
           <p>{t.footerText}</p>
+          <LegalLinks compact />
         </footer>
       </div>
     </div>

--- a/apps/web/src/core/PricingPage.tsx
+++ b/apps/web/src/core/PricingPage.tsx
@@ -15,6 +15,7 @@ import { ANALYTICS_EVENTS, trackEvent } from "./observability/analytics";
 import { captureException } from "./observability/sentry";
 import { usePlan } from "./billing/usePlan";
 import { WaitlistForm } from "./pricing/WaitlistForm";
+import { LegalLinks } from "./legal/LegalLinks";
 
 /**
  * Phase 7 D3 — Pricing tiers (one paid tier).
@@ -467,6 +468,7 @@ export function PricingPage() {
 
           <footer className="text-center text-style-caption text-muted space-y-1">
             <p>{t.footer}</p>
+            <LegalLinks compact />
           </footer>
         </div>
       </div>

--- a/apps/web/src/core/app/StandaloneRoutes.test.tsx
+++ b/apps/web/src/core/app/StandaloneRoutes.test.tsx
@@ -90,6 +90,13 @@ describe("renderStandaloneRoute()", () => {
     expect(callRoute("/finykfoo")).not.toBeNull();
     expect(callRoute("/nutritionish")).not.toBeNull();
   });
+
+  it("renders public legal pages without auth", () => {
+    expect(callRoute("/legal/privacy")).not.toBeNull();
+    expect(callRoute("/legal/terms")).not.toBeNull();
+    expect(callRoute("/legal/cookies")).not.toBeNull();
+    expect(callRoute("/legal/offer")).not.toBeNull();
+  });
 });
 
 describe("STANDALONE_ROUTE_PATHS ↔ KNOWN_PATHS exhaustiveness (Web deep-dive §1.2)", () => {

--- a/apps/web/src/core/app/StandaloneRoutes.tsx
+++ b/apps/web/src/core/app/StandaloneRoutes.tsx
@@ -7,6 +7,10 @@ import {
   ASSISTANT_PATH,
   CHAT_PATH,
   DESIGN_PATH,
+  LEGAL_COOKIES_PATH,
+  LEGAL_OFFER_PATH,
+  LEGAL_PRIVACY_PATH,
+  LEGAL_TERMS_PATH,
   PRICING_PATH,
   STATUS_PATH,
   PROFILE_PATH,
@@ -43,6 +47,7 @@ const AssistantCataloguePage = lazyImport(
 );
 const PricingPage = lazyImport(() => import("../PricingPage"), "PricingPage");
 const LandingPage = lazyImport(() => import("../LandingPage"), "LandingPage");
+const LegalPage = lazyImport(() => import("../legal/LegalPage"), "LegalPage");
 const StatusPage = lazyImport(
   () => import("../status/StatusPage"),
   "StatusPage",
@@ -206,6 +211,22 @@ const STANDALONE_ROUTES: ReadonlyArray<StandaloneRoute> = [
       <Suspense fallback={<PageLoader />}>
         <div className="page-enter">
           <PricingPage />
+        </div>
+      </Suspense>
+    ),
+  }),
+
+  defineStandaloneRoute({
+    paths: [
+      LEGAL_PRIVACY_PATH,
+      LEGAL_TERMS_PATH,
+      LEGAL_COOKIES_PATH,
+      LEGAL_OFFER_PATH,
+    ],
+    render: ({ pathname }) => (
+      <Suspense fallback={<PageLoader />}>
+        <div className="page-enter">
+          <LegalPage pathname={pathname} />
         </div>
       </Suspense>
     ),

--- a/apps/web/src/core/app/appPaths.ts
+++ b/apps/web/src/core/app/appPaths.ts
@@ -38,6 +38,10 @@ export const RESET_PASSWORD_PATH = "/reset-password";
 export const PROFILE_PATH = "/profile";
 export const DESIGN_PATH = "/design";
 export const PRICING_PATH = "/pricing";
+export const LEGAL_PRIVACY_PATH = "/legal/privacy";
+export const LEGAL_TERMS_PATH = "/legal/terms";
+export const LEGAL_COOKIES_PATH = "/legal/cookies";
+export const LEGAL_OFFER_PATH = "/legal/offer";
 
 // Anonymous public status page (`/status`). Renders the per-component
 // view from `/api/status`. No auth — same intent as `/pricing` (public

--- a/apps/web/src/core/auth/AuthPage.tsx
+++ b/apps/web/src/core/auth/AuthPage.tsx
@@ -12,6 +12,7 @@ import { GoogleSignInButton } from "./GoogleSignInButton";
 import { AppleSignInButton } from "./AppleSignInButton";
 import { useForgotPassword } from "./useForgotPassword";
 import { ANALYTICS_EVENTS, trackEvent } from "../observability/analytics";
+import { LegalLinks } from "../legal/LegalLinks";
 
 interface AuthPageProps {
   onContinueWithoutAccount?: () => void;
@@ -180,6 +181,8 @@ export function AuthPage({ onContinueWithoutAccount }: AuthPageProps) {
               </p>
             </div>
           )}
+
+          <LegalLinks compact className="mt-5" />
         </div>
       </MeshBackground>
     </>

--- a/apps/web/src/core/legal/LegalLinks.tsx
+++ b/apps/web/src/core/legal/LegalLinks.tsx
@@ -1,0 +1,42 @@
+import { Link } from "react-router-dom";
+import {
+  LEGAL_COOKIES_PATH,
+  LEGAL_OFFER_PATH,
+  LEGAL_PRIVACY_PATH,
+  LEGAL_TERMS_PATH,
+} from "../app/appPaths";
+
+interface LegalLinksProps {
+  readonly className?: string;
+  readonly compact?: boolean;
+}
+
+const links = [
+  { href: LEGAL_PRIVACY_PATH, label: "Приватність" },
+  { href: LEGAL_TERMS_PATH, label: "Умови" },
+  { href: LEGAL_COOKIES_PATH, label: "Cookies" },
+  { href: LEGAL_OFFER_PATH, label: "Оферта" },
+] as const;
+
+export function LegalLinks({ className = "", compact = false }: LegalLinksProps) {
+  return (
+    <nav
+      aria-label="Юридичні документи"
+      className={[
+        "flex flex-wrap items-center justify-center gap-x-3 gap-y-2",
+        compact ? "text-style-caption" : "text-style-body-sm",
+        className,
+      ].join(" ")}
+    >
+      {links.map((link) => (
+        <Link
+          key={link.href}
+          to={link.href}
+          className="text-muted underline-offset-4 transition-colors hover:text-text focus-visible:outline-none focus-visible:underline"
+        >
+          {link.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/apps/web/src/core/legal/LegalPage.test.tsx
+++ b/apps/web/src/core/legal/LegalPage.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { MemoryRouter } from "react-router-dom";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  LEGAL_COOKIES_PATH,
+  LEGAL_OFFER_PATH,
+  LEGAL_PRIVACY_PATH,
+  LEGAL_TERMS_PATH,
+} from "../app/appPaths";
+import { LegalPage } from "./LegalPage";
+
+const cases = [
+  [LEGAL_PRIVACY_PATH, "Політика приватності"],
+  [LEGAL_TERMS_PATH, "Умови користування"],
+  [LEGAL_COOKIES_PATH, "Політика cookies"],
+  [LEGAL_OFFER_PATH, "Публічна оферта"],
+] as const;
+
+describe("LegalPage", () => {
+  it.each(cases)("renders public legal page %s with heading and footer links", (pathname, heading) => {
+    render(
+      <MemoryRouter>
+        <LegalPage pathname={pathname} />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: heading }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("navigation", { name: "Юридичні документи" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Приватність" })).toHaveAttribute(
+      "href",
+      LEGAL_PRIVACY_PATH,
+    );
+    expect(screen.getByRole("link", { name: "Умови" })).toHaveAttribute(
+      "href",
+      LEGAL_TERMS_PATH,
+    );
+    expect(screen.getByRole("link", { name: "Cookies" })).toHaveAttribute(
+      "href",
+      LEGAL_COOKIES_PATH,
+    );
+    expect(screen.getByRole("link", { name: "Оферта" })).toHaveAttribute(
+      "href",
+      LEGAL_OFFER_PATH,
+    );
+  });
+});

--- a/apps/web/src/core/legal/LegalPage.tsx
+++ b/apps/web/src/core/legal/LegalPage.tsx
@@ -1,0 +1,300 @@
+import { Link } from "react-router-dom";
+import { MeshBackground } from "@shared/components/layout/MeshBackground";
+import { BrandLogo } from "../app/BrandLogo";
+import {
+  LEGAL_COOKIES_PATH,
+  LEGAL_OFFER_PATH,
+  LEGAL_PRIVACY_PATH,
+  LEGAL_TERMS_PATH,
+  PRICING_PATH,
+  SIGN_IN_PATH,
+} from "../app/appPaths";
+import { LegalLinks } from "./LegalLinks";
+
+type LegalPath =
+  | typeof LEGAL_PRIVACY_PATH
+  | typeof LEGAL_TERMS_PATH
+  | typeof LEGAL_COOKIES_PATH
+  | typeof LEGAL_OFFER_PATH;
+
+interface LegalSection {
+  readonly title: string;
+  readonly body: ReadonlyArray<string>;
+}
+
+interface LegalDocument {
+  readonly eyebrow: string;
+  readonly title: string;
+  readonly intro: string;
+  readonly sections: ReadonlyArray<LegalSection>;
+}
+
+interface LegalPageProps {
+  readonly pathname: string;
+}
+
+const LAST_UPDATED = "6 червня 2026";
+const CONTACT_EMAIL = "legal@sergeant.app";
+const CONTROLLER_PLACEHOLDER =
+  "Sergeant, дані ФОП/засновника будуть внесені перед public launch";
+
+const processors =
+  "Stripe, Anthropic, Sentry, PostHog, Resend, Monobank, Railway, Vercel, Firebase/APNs";
+
+const documents: Record<LegalPath, LegalDocument> = {
+  [LEGAL_PRIVACY_PATH]: {
+    eyebrow: "Privacy Policy",
+    title: "Політика приватності",
+    intro:
+      "Пояснюємо, які дані Sergeant обробляє, навіщо, як довго і як ти можеш керувати своїми правами.",
+    sections: [
+      {
+        title: "Контролер даних",
+        body: [
+          `Контролер: ${CONTROLLER_PLACEHOLDER}. До фінального запуску ці реквізити мають пройти founder/lawyer review.`,
+          `Контакт для питань приватності: ${CONTACT_EMAIL}. Канонічна мова документа — українська.`,
+        ],
+      },
+      {
+        title: "Категорії даних",
+        body: [
+          "Акаунт: email, імʼя, аватар, статус email-верифікації, дата створення.",
+          "Фінанси: підключення Monobank, рахунки, транзакції, бюджети й локальні фінансові налаштування.",
+          "Здоровʼя та рутини: харчування, тренування, звички, AI-нотатки, пуш-налаштування.",
+          "Технічні дані: device/browser metadata, події продукту, помилки, білінг-статуси та audit-логіка.",
+        ],
+      },
+      {
+        title: "Процесори",
+        body: [
+          `Ми використовуємо процесорів для платежів, AI, аналітики, хостингу, email, пушів і банківських інтеграцій: ${processors}.`,
+          "Секрети, токени та сирі credentials не включаються в користувацький export і не мають потрапляти в логи.",
+        ],
+      },
+      {
+        title: "Твої права",
+        body: [
+          "Ти можеш запросити export своїх даних, оновити consent preferences або видалити акаунт у Settings.",
+          "Запити на доступ, виправлення, обмеження обробки чи заперечення можна надіслати на legal contact.",
+        ],
+      },
+      {
+        title: "Зберігання та видалення",
+        body: [
+          "Після deletion request ми тримаємо до 30 днів grace-період для recovery/audit, далі hard-delete де це технічно можливо.",
+          "Частина записів може зберігатися довше, якщо це потрібно для юридичного захисту, бухгалтерії, fraud prevention або безпеки.",
+        ],
+      },
+    ],
+  },
+  [LEGAL_TERMS_PATH]: {
+    eyebrow: "Terms",
+    title: "Умови користування",
+    intro:
+      "Це правила доступу до Sergeant: акаунт, підписка, AI, фінансові та health-модулі, обмеження відповідальності.",
+    sections: [
+      {
+        title: "18+ і не професійна порада",
+        body: [
+          "Sergeant призначений для користувачів 18+, бо продукт може обробляти фінансові та health-related дані.",
+          "AI-відповіді, бюджети, харчування і тренування є інформаційною підтримкою, а не медичною, фінансовою чи юридичною консультацією.",
+        ],
+      },
+      {
+        title: "Акаунт і безпека",
+        body: [
+          "Ти відповідаєш за доступ до свого акаунта, правдивість даних і дозвіл на підключення зовнішніх сервісів.",
+          "Ми можемо обмежити доступ при abuse, fraud, порушенні закону або ризику для інших користувачів.",
+        ],
+      },
+      {
+        title: "Підписки та скасування",
+        body: [
+          "Платежі й self-serve керування підпискою проходять через Stripe-hosted checkout і Customer Portal.",
+          "Скасування зупиняє майбутні списання; доступ до paid-функцій може діяти до кінця оплаченого періоду.",
+        ],
+      },
+      {
+        title: "Повернення коштів",
+        body: [
+          "Refund requests розглядаються індивідуально з урахуванням закону, технічних збоїв, fraud-ризиків і фактичного використання.",
+          "Якщо Stripe або банк повертає платіж примусово, доступ до paid-функцій може бути призупинений.",
+        ],
+      },
+      {
+        title: "Зміни умов",
+        body: [
+          "Ми можемо оновлювати умови до launch і після нього; суттєві зміни будемо помітно показувати в продукті або email.",
+          `Питання щодо умов: ${CONTACT_EMAIL}.`,
+        ],
+      },
+    ],
+  },
+  [LEGAL_COOKIES_PATH]: {
+    eyebrow: "Cookie Policy",
+    title: "Політика cookies",
+    intro:
+      "Описуємо cookies, local storage та подібні технології, які потрібні для входу, безпеки, аналітики і product quality.",
+    sections: [
+      {
+        title: "Що ми зберігаємо",
+        body: [
+          "Strictly necessary: session, auth, security, app state і налаштування, без яких продукт не працює стабільно.",
+          "Analytics: події продукту та performance-сигнали для розуміння якості, якщо analytics preference увімкнено.",
+        ],
+      },
+      {
+        title: "Локальні дані",
+        body: [
+          "Sergeant має local-first частини: частина hub/state може жити у браузері чи мобільному сховищі.",
+          "Локальний backup/export у Settings не є серверним privacy export, але допомагає перенести власні дані.",
+        ],
+      },
+      {
+        title: "Керування згодою",
+        body: [
+          "У Settings можна керувати analytics, AI memory і push consent preferences.",
+          "Вимкнення analytics не блокує essential cookies, які потрібні для входу, безпеки та billing.",
+        ],
+      },
+      {
+        title: "Треті сторони",
+        body: [
+          "Stripe, PostHog, Sentry, Firebase/APNs та інші процесори можуть використовувати власні storage-технології для своїх сервісів.",
+          "Ми не продаємо cookie-дані рекламним брокерам.",
+        ],
+      },
+    ],
+  },
+  [LEGAL_OFFER_PATH]: {
+    eyebrow: "Public Offer",
+    title: "Публічна оферта",
+    intro:
+      "Draft-оферта для UA-first public launch: предмет послуги, оплата, підписка, refund rules і контакти.",
+    sections: [
+      {
+        title: "Сторони та предмет",
+        body: [
+          `Виконавець: ${CONTROLLER_PLACEHOLDER}. Користувач приймає оферту, створюючи акаунт або оплачуючи підписку.`,
+          "Предмет: доступ до програмного продукту Sergeant, включно з AI, фінансовими, wellness та productivity-функціями.",
+        ],
+      },
+      {
+        title: "Оплата",
+        body: [
+          "Ціни показуються на pricing page перед оплатою. Платіжна інфраструктура — Stripe-hosted checkout.",
+          "Податки, комісії банку або валютна конвертація можуть залежати від платіжного провайдера та країни користувача.",
+        ],
+      },
+      {
+        title: "Підписка",
+        body: [
+          "Підписка поновлюється автоматично, якщо її не скасовано у Stripe Customer Portal до наступного billing period.",
+          "Після скасування paid-доступ може зберігатися до кінця вже оплаченого періоду.",
+        ],
+      },
+      {
+        title: "Refund policy",
+        body: [
+          "Повернення коштів можливе за запитом, якщо цього вимагає застосовне право або якщо сталася підтверджена технічна помилка.",
+          "Запит має містити email акаунта, дату платежу та короткий опис причини.",
+        ],
+      },
+      {
+        title: "Контакти",
+        body: [
+          `Юридичні та billing-запити: ${CONTACT_EMAIL}.`,
+          "Фінальні реквізити ФОП/компанії мають бути внесені до публікації оферти.",
+        ],
+      },
+    ],
+  },
+};
+
+function isLegalPath(pathname: string): pathname is LegalPath {
+  return (
+    pathname === LEGAL_PRIVACY_PATH ||
+    pathname === LEGAL_TERMS_PATH ||
+    pathname === LEGAL_COOKIES_PATH ||
+    pathname === LEGAL_OFFER_PATH
+  );
+}
+
+export function LegalPage({ pathname }: LegalPageProps) {
+  const document = documents[isLegalPath(pathname) ? pathname : LEGAL_PRIVACY_PATH];
+
+  return (
+    <MeshBackground className="min-h-screen overflow-y-auto px-5 py-8 sm:py-12">
+      <main className="mx-auto flex w-full max-w-4xl flex-col gap-8">
+        <header className="text-center space-y-5">
+          <Link
+            to="/"
+            className="inline-flex justify-center rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus/45"
+            aria-label="На головну Sergeant"
+          >
+            <BrandLogo size="lg" />
+          </Link>
+          <div className="space-y-3">
+            <p className="text-style-overline text-brand-strong">
+              {document.eyebrow}
+            </p>
+            <h1 className="text-style-display text-text">{document.title}</h1>
+            <p className="mx-auto max-w-2xl text-style-body text-muted">
+              {document.intro}
+            </p>
+          </div>
+          <div className="rounded-3xl border border-warning-soft bg-warning-soft/40 p-4 text-left text-style-body-sm text-text">
+            <strong>Founder/lawyer review gate:</strong> це робочий draft до
+            public launch, не юридична консультація. Перед відкритою
+            реєстрацією засновник або юрист має підтвердити реквізити,
+            refunds, processors і застосовне право.
+          </div>
+          <p className="text-style-caption text-subtle">
+            Останнє оновлення: {LAST_UPDATED}
+          </p>
+        </header>
+
+        <article className="space-y-4">
+          {document.sections.map((section) => (
+            <section
+              key={section.title}
+              className="rounded-3xl border border-line bg-panel p-5 sm:p-6"
+            >
+              <h2 className="text-style-headline text-text">
+                {section.title}
+              </h2>
+              <div className="mt-3 space-y-3 text-style-body-sm text-muted">
+                {section.body.map((paragraph) => (
+                  <p key={paragraph}>{paragraph}</p>
+                ))}
+              </div>
+            </section>
+          ))}
+        </article>
+
+        <footer className="space-y-4 text-center">
+          <LegalLinks />
+          <div className="flex flex-wrap items-center justify-center gap-3 text-style-body-sm">
+            <Link
+              to={PRICING_PATH}
+              className="text-brand-strong underline-offset-4 hover:underline focus-visible:outline-none focus-visible:underline"
+            >
+              Перейти до pricing
+            </Link>
+            <span className="text-subtle" aria-hidden="true">
+              ·
+            </span>
+            <Link
+              to={SIGN_IN_PATH}
+              className="text-brand-strong underline-offset-4 hover:underline focus-visible:outline-none focus-visible:underline"
+            >
+              Увійти або створити акаунт
+            </Link>
+          </div>
+        </footer>
+      </main>
+    </MeshBackground>
+  );
+}
+
+export default LegalPage;

--- a/apps/web/src/core/settings/DataExportSection.tsx
+++ b/apps/web/src/core/settings/DataExportSection.tsx
@@ -1,16 +1,109 @@
+import { useState } from "react";
+import { Button } from "@shared/components/ui/Button";
+import { meApi } from "@shared/api";
+import { downloadString } from "@shared/lib/ui/export";
 import { HubBackupPanel } from "../hub/HubBackupPanel";
 import { SettingsGroup } from "./SettingsPrimitives";
 
+function exportFilename(): string {
+  const day = new Date().toISOString().slice(0, 10);
+  return `sergeant-account-export-${day}.json`;
+}
+
 export function DataExportSection() {
+  const [serverExportBusy, setServerExportBusy] = useState(false);
+  const [deleteBusy, setDeleteBusy] = useState(false);
+  const [serverMessage, setServerMessage] = useState<string | null>(null);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const handleServerExport = async () => {
+    setServerExportBusy(true);
+    setServerError(null);
+    setServerMessage(null);
+    try {
+      const payload = await meApi.exportData();
+      downloadString(
+        JSON.stringify(payload, null, 2),
+        exportFilename(),
+        "application/json",
+      );
+      setServerMessage("Серверний export завантажено як JSON.");
+    } catch {
+      setServerError("Не вдалося створити серверний export. Перевір вхід.");
+    } finally {
+      setServerExportBusy(false);
+    }
+  };
+
+  const handleDeleteAccount = async () => {
+    const confirmed = window.confirm(
+      "Видалити акаунт і запустити deletion orchestration? Частину даних можемо тримати до 30 днів для recovery/audit.",
+    );
+    if (!confirmed) return;
+
+    setDeleteBusy(true);
+    setServerError(null);
+    setServerMessage(null);
+    try {
+      await meApi.deleteAccount();
+      setServerMessage("Deletion request прийнято. Повертаю на головну…");
+      window.location.assign("/");
+    } catch {
+      setServerError("Не вдалося видалити акаунт. Спробуй ще раз або напиши в support.");
+    } finally {
+      setDeleteBusy(false);
+    }
+  };
+
   return (
     <SettingsGroup title="Експорт/імпорт JSON" emoji="💾">
       <p className="text-xs text-subtle leading-snug">
-        Зберегти всі твої дані у файл — його потім можна імпортувати назад.
-        Стане в нагоді, якщо треба перенести дані без хмари (наприклад, без
-        логіну) або просто мати копію «на руках». Залогіненим користувачам
-        зазвичай достатньо хмарної синхронізації.
+        Збережи всі свої локальні дані у файл — його потім можна імпортувати
+        назад. Для залогінених користувачів нижче є окремий privacy export із
+        серверних даних акаунта.
       </p>
       <HubBackupPanel className="" />
+
+      <div className="space-y-3 rounded-2xl border border-line/60 bg-surface-soft-glass p-3">
+        <div>
+          <h3 className="text-style-label text-text">Data rights</h3>
+          <p className="mt-1 text-xs text-subtle leading-relaxed">
+            Серверний export не включає сирі secrets/tokens. Видалення акаунта
+            запускає orchestration із 30-денним recovery/audit grace.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            onClick={handleServerExport}
+            disabled={serverExportBusy || deleteBusy}
+          >
+            {serverExportBusy ? "Готую export…" : "Завантажити server export"}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={handleDeleteAccount}
+            disabled={serverExportBusy || deleteBusy}
+            className="text-danger-strong"
+          >
+            {deleteBusy ? "Видаляю…" : "Видалити акаунт"}
+          </Button>
+        </div>
+        {serverMessage ? (
+          <p className="text-xs text-success-strong" role="status">
+            {serverMessage}
+          </p>
+        ) : null}
+        {serverError ? (
+          <p className="text-xs text-danger-strong" role="alert">
+            {serverError}
+          </p>
+        ) : null}
+      </div>
     </SettingsGroup>
   );
 }

--- a/apps/web/src/core/settings/PrivacySection.tsx
+++ b/apps/web/src/core/settings/PrivacySection.tsx
@@ -1,17 +1,55 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@shared/components/ui/Button";
+import { meApi, type UserPreferences } from "@shared/api";
 import { messages } from "@shared/i18n/uk";
 import { useFlag, setFlag } from "../lib/featureFlags";
 import { clearPinHash, hasPinSet } from "../security/lockStorage";
 import { useAppLockContext } from "../security/AppLockContext";
+import { LegalLinks } from "../legal/LegalLinks";
 import { ConfirmModal, SettingsGroup, ToggleRow } from "./SettingsPrimitives";
 
 const m = messages.privacy.lock;
+
+const DEFAULT_PREFERENCES: UserPreferences = {
+  analytics: true,
+  aiMemory: true,
+  pushNotifications: false,
+  updatedAt: null,
+};
+
+type PreferenceKey = "analytics" | "aiMemory" | "pushNotifications";
 
 export function PrivacySection() {
   const appLock = useAppLockContext();
   const flagEnabled = useFlag("app-lock-enabled");
   const [disableConfirmOpen, setDisableConfirmOpen] = useState(false);
+  const [preferences, setPreferences] =
+    useState<UserPreferences>(DEFAULT_PREFERENCES);
+  const [preferencesLoaded, setPreferencesLoaded] = useState(false);
+  const [preferencesError, setPreferencesError] = useState<string | null>(null);
+  const [savingPreference, setSavingPreference] =
+    useState<PreferenceKey | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    meApi
+      .getPreferences()
+      .then((next) => {
+        if (cancelled) return;
+        setPreferences(next);
+        setPreferencesLoaded(true);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setPreferencesLoaded(false);
+        setPreferencesError(
+          "Увійди в акаунт, щоб керувати серверними consent preferences.",
+        );
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const handleToggle = async (checked: boolean) => {
     if (checked) {
@@ -21,7 +59,6 @@ export function PrivacySection() {
         appLock.startSetup();
       }
     } else {
-      // Require confirmation before clearing the PIN
       setDisableConfirmOpen(true);
     }
   };
@@ -30,6 +67,23 @@ export function PrivacySection() {
     setDisableConfirmOpen(false);
     setFlag("app-lock-enabled", false);
     await clearPinHash();
+  };
+
+  const updatePreference = async (key: PreferenceKey, checked: boolean) => {
+    setPreferencesError(null);
+    setSavingPreference(key);
+    const previous = preferences;
+    setPreferences({ ...previous, [key]: checked });
+    try {
+      const next = await meApi.updatePreferences({ [key]: checked });
+      setPreferences(next);
+      setPreferencesLoaded(true);
+    } catch {
+      setPreferences(previous);
+      setPreferencesError("Не вдалося зберегти preference. Спробуй ще раз.");
+    } finally {
+      setSavingPreference(null);
+    }
   };
 
   return (
@@ -61,6 +115,55 @@ export function PrivacySection() {
           </Button>
         </div>
       )}
+
+      <div className="space-y-3">
+        <div>
+          <h3 className="text-style-label text-text">Згода та privacy</h3>
+          <p className="mt-1 text-xs text-subtle leading-relaxed">
+            Керуй серверними consent preferences для аналітики, AI memory і
+            push-повідомлень. Essential cookies для входу, безпеки та billing
+            залишаються активними.
+          </p>
+        </div>
+        <ToggleRow
+          label="Аналітика продукту"
+          description={
+            savingPreference === "analytics"
+              ? "Зберігаю…"
+              : "Допомагає бачити якість funnel, UX і стабільність."
+          }
+          checked={preferences.analytics}
+          onChange={(checked) => void updatePreference("analytics", checked)}
+        />
+        <ToggleRow
+          label="AI memory"
+          description={
+            savingPreference === "aiMemory"
+              ? "Зберігаю…"
+              : "Дозволяє персоналізувати AI-контекст між сесіями."
+          }
+          checked={preferences.aiMemory}
+          onChange={(checked) => void updatePreference("aiMemory", checked)}
+        />
+        <ToggleRow
+          label="Push-повідомлення"
+          description={
+            savingPreference === "pushNotifications"
+              ? "Зберігаю…"
+              : "Керує серверною згодою для нагадувань і системних пушів."
+          }
+          checked={preferences.pushNotifications}
+          onChange={(checked) =>
+            void updatePreference("pushNotifications", checked)
+          }
+        />
+        {!preferencesLoaded && preferencesError ? (
+          <p className="text-xs text-danger-strong" role="alert">
+            {preferencesError}
+          </p>
+        ) : null}
+        <LegalLinks compact className="justify-start" />
+      </div>
 
       <ConfirmModal
         open={disableConfirmOpen}

--- a/apps/web/src/shared/api/index.ts
+++ b/apps/web/src/shared/api/index.ts
@@ -48,6 +48,7 @@ export const monoWebhookApi = apiClient.monoWebhook;
 export const privatApi = apiClient.privat;
 export const waitlistApi = apiClient.waitlist;
 export const billingApi = apiClient.billing;
+export const meApi = apiClient.me;
 export const weeklyDigestApi = apiClient.weeklyDigest;
 export const transcribeApi = apiClient.transcribe;
 export const webVitalsApi = apiClient.webVitals;
@@ -118,7 +119,11 @@ export type {
   QueryValue,
   RequestOptions,
   TokenProvider,
+  MeDeleteResponse,
+  MeExportResponse,
   WeeklyDigestPayload,
   WeeklyDigestReport,
   WeeklyDigestResponse,
+  UserPreferences,
+  UserPreferencesPatch,
 } from "@sergeant/api-client";

--- a/packages/api-client/src/endpoints/me.test.ts
+++ b/packages/api-client/src/endpoints/me.test.ts
@@ -108,4 +108,85 @@ describe("createMeEndpoints", () => {
     const init = firstCall(fetchMock)[1] as RequestInit;
     expect(init.signal).toBe(ctrl.signal);
   });
+
+  it("GET /api/me/preferences повертає consent preferences", async () => {
+    const fetchMock = mockFetchOnce({
+      analytics: true,
+      aiMemory: false,
+      pushNotifications: true,
+      updatedAt: "2026-06-06T10:00:00.000Z",
+    });
+    const me = createMeEndpoints(createHttpClient());
+
+    await expect(me.getPreferences()).resolves.toEqual({
+      analytics: true,
+      aiMemory: false,
+      pushNotifications: true,
+      updatedAt: "2026-06-06T10:00:00.000Z",
+    });
+    const url = firstCall(fetchMock)[0] as string;
+    expect(url).toContain("/api/v1/me/preferences");
+  });
+
+  it("PATCH /api/me/preferences валідовує partial patch", async () => {
+    const fetchMock = mockFetchOnce({
+      analytics: false,
+      aiMemory: true,
+      pushNotifications: false,
+      updatedAt: "2026-06-06T10:05:00.000Z",
+    });
+    const me = createMeEndpoints(createHttpClient());
+
+    await me.updatePreferences({ analytics: false });
+
+    const init = firstCall(fetchMock)[1] as RequestInit;
+    expect(init.method).toBe("PATCH");
+    expect(init.body).toBe(JSON.stringify({ analytics: false }));
+  });
+
+  it("GET /api/me/export повертає privacy export без client-side трансформацій", async () => {
+    const payload = {
+      generatedAt: "2026-06-06T10:10:00.000Z",
+      user: {
+        id: "user-123",
+        email: "test@example.com",
+        name: null,
+        image: null,
+        emailVerified: true,
+        createdAt: "2026-01-15T08:30:00.000Z",
+      },
+      preferences: {
+        analytics: true,
+        aiMemory: true,
+        pushNotifications: false,
+        updatedAt: null,
+      },
+      data: {
+        moduleData: [],
+        mono: { connection: null, accounts: [], transactions: [] },
+        billing: { subscriptions: [] },
+        push: { webSubscriptions: [], devices: [] },
+        ai: { usageDaily: [], memories: [] },
+      },
+    };
+    mockFetchOnce(payload);
+    const me = createMeEndpoints(createHttpClient());
+
+    await expect(me.exportData()).resolves.toEqual(payload);
+  });
+
+  it("DELETE /api/me повертає deletion acknowledgement", async () => {
+    const fetchMock = mockFetchOnce({
+      ok: true,
+      deletedAt: "2026-06-06T10:15:00.000Z",
+    });
+    const me = createMeEndpoints(createHttpClient());
+
+    await expect(me.deleteAccount()).resolves.toEqual({
+      ok: true,
+      deletedAt: "2026-06-06T10:15:00.000Z",
+    });
+    const init = firstCall(fetchMock)[1] as RequestInit;
+    expect(init.method).toBe("DELETE");
+  });
 });

--- a/packages/api-client/src/endpoints/me.ts
+++ b/packages/api-client/src/endpoints/me.ts
@@ -1,4 +1,16 @@
-import { MeResponseSchema, type MeResponse, type User } from "@sergeant/shared";
+import {
+  MeDeleteResponseSchema,
+  MeExportResponseSchema,
+  MeResponseSchema,
+  UserPreferencesPatchSchema,
+  UserPreferencesSchema,
+  type MeDeleteResponse,
+  type MeExportResponse,
+  type MeResponse,
+  type User,
+  type UserPreferences,
+  type UserPreferencesPatch,
+} from "@sergeant/shared";
 import type { HttpClient } from "../httpClient";
 import type { RequestOptions } from "../types";
 
@@ -9,6 +21,19 @@ export interface MeEndpoints {
    * типізація й runtime-перевірка — з одного джерела правди.
    */
   get: (opts?: Pick<RequestOptions, "signal">) => Promise<MeResponse>;
+  exportData: (
+    opts?: Pick<RequestOptions, "signal">,
+  ) => Promise<MeExportResponse>;
+  getPreferences: (
+    opts?: Pick<RequestOptions, "signal">,
+  ) => Promise<UserPreferences>;
+  updatePreferences: (
+    patch: UserPreferencesPatch,
+    opts?: Pick<RequestOptions, "signal">,
+  ) => Promise<UserPreferences>;
+  deleteAccount: (
+    opts?: Pick<RequestOptions, "signal">,
+  ) => Promise<MeDeleteResponse>;
 }
 
 export function createMeEndpoints(http: HttpClient): MeEndpoints {
@@ -17,7 +42,33 @@ export function createMeEndpoints(http: HttpClient): MeEndpoints {
       const raw = await http.get<unknown>("/api/me", { signal });
       return MeResponseSchema.parse(raw);
     },
+    exportData: async ({ signal } = {}) => {
+      const raw = await http.get<unknown>("/api/me/export", { signal });
+      return MeExportResponseSchema.parse(raw);
+    },
+    getPreferences: async ({ signal } = {}) => {
+      const raw = await http.get<unknown>("/api/me/preferences", { signal });
+      return UserPreferencesSchema.parse(raw);
+    },
+    updatePreferences: async (patch, { signal } = {}) => {
+      const body = UserPreferencesPatchSchema.parse(patch);
+      const raw = await http.patch<unknown>("/api/me/preferences", body, {
+        signal,
+      });
+      return UserPreferencesSchema.parse(raw);
+    },
+    deleteAccount: async ({ signal } = {}) => {
+      const raw = await http.del<unknown>("/api/me", undefined, { signal });
+      return MeDeleteResponseSchema.parse(raw);
+    },
   };
 }
 
-export type { MeResponse, User };
+export type {
+  MeDeleteResponse,
+  MeExportResponse,
+  MeResponse,
+  User,
+  UserPreferences,
+  UserPreferencesPatch,
+};

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -26,9 +26,13 @@ export type {
 // Endpoint factories and their response shapes
 export {
   createMeEndpoints,
+  type MeDeleteResponse,
   type MeEndpoints,
+  type MeExportResponse,
   type MeResponse,
   type User,
+  type UserPreferences,
+  type UserPreferencesPatch,
 } from "./endpoints/me";
 
 export {

--- a/packages/shared/src/schemas/api.ts
+++ b/packages/shared/src/schemas/api.ts
@@ -37,6 +37,58 @@ export type User = z.infer<typeof UserSchema>;
 export const MeResponseSchema = z.object({ user: UserSchema });
 export type MeResponse = z.infer<typeof MeResponseSchema>;
 
+// ────────────────────── Data rights / /api/me/* ──────────────────────
+export const UserPreferencesSchema = z.object({
+  analytics: z.boolean(),
+  aiMemory: z.boolean(),
+  pushNotifications: z.boolean(),
+  updatedAt: z.string().datetime({ offset: true }).nullable(),
+});
+export type UserPreferences = z.infer<typeof UserPreferencesSchema>;
+
+export const UserPreferencesPatchSchema = z
+  .object({
+    analytics: z.boolean().optional(),
+    aiMemory: z.boolean().optional(),
+    pushNotifications: z.boolean().optional(),
+  })
+  .strict();
+export type UserPreferencesPatch = z.infer<typeof UserPreferencesPatchSchema>;
+
+const ExportRecordSchema = z.record(z.string(), z.unknown());
+
+export const MeExportResponseSchema = z.object({
+  generatedAt: z.string().datetime({ offset: true }),
+  user: UserSchema,
+  preferences: UserPreferencesSchema,
+  data: z.object({
+    moduleData: z.array(ExportRecordSchema),
+    mono: z.object({
+      connection: ExportRecordSchema.nullable(),
+      accounts: z.array(ExportRecordSchema),
+      transactions: z.array(ExportRecordSchema),
+    }),
+    billing: z.object({
+      subscriptions: z.array(ExportRecordSchema),
+    }),
+    push: z.object({
+      webSubscriptions: z.array(ExportRecordSchema),
+      devices: z.array(ExportRecordSchema),
+    }),
+    ai: z.object({
+      usageDaily: z.array(ExportRecordSchema),
+      memories: z.array(ExportRecordSchema),
+    }),
+  }),
+});
+export type MeExportResponse = z.infer<typeof MeExportResponseSchema>;
+
+export const MeDeleteResponseSchema = z.object({
+  ok: z.literal(true),
+  deletedAt: z.string().datetime({ offset: true }),
+});
+export type MeDeleteResponse = z.infer<typeof MeDeleteResponseSchema>;
+
 /** Модерація: чат-повідомлення. */
 export const ChatMessage = z.object({
   role: z.enum(["user", "assistant"]),


### PR DESCRIPTION
﻿## Summary
- Adds UA-first public legal routes for privacy, terms, cookies, and public offer.
- Wires legal links into landing, pricing, auth, and Settings surfaces.
- Adds data-rights endpoints for account export, deletion orchestration, and consent preferences.
- Adds shared Zod schemas, api-client methods, server tests, client tests, and a `user_preferences` migration.

## Governing Skill
- `github:yeet` for publish flow.
- Repo routing: server/API owner first because this touches API contract + migration + web surfaces.

## Playbook
- Legal Full Pack до public launch.
- Founder/lawyer review remains required before public signup.

## Verification
- `git diff --check HEAD~1..HEAD`
- `pnpm exec commitlint --from HEAD~1 --to HEAD`
- Earlier focused tests were attempted before this branch was cleaned onto `origin/main`, but local package links were missing/corrupted; no `pnpm install` was run again to avoid memory blow-up in this worktree.

## Docs and Governance
- UA-first legal copy is included as founder-reviewed draft content with visible last updated date.
- Hard Rule #3 covered through shared schemas + api-client + server response validation/tests.
- New migration: `076_user_preferences.sql` / `.down.sql`.

## Risk and Rollout
- Risk: legal content contains placeholder founder/FOP details and must not be treated as final legal advice.
- Risk: account deletion currently relies on DB cascade plus targeted soft/cancel updates; production rollout should confirm downstream processor deletion/account closure playbooks.
- Rollout: keep PR as draft until founder/lawyer approval and CI validation pass.

## Hard Rule #15 acknowledgement
- Governance was checked via repo AGENTS instructions before implementation; docs/legal copy is Ukrainian-first.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds public legal pages and a data-rights pack (export, delete, consent preferences). Wires legal links across key surfaces and adds a `user_preferences` table with API and UI.

- New Features
  - Public pages: /legal/privacy, /legal/terms, /legal/cookies, /legal/offer (no auth).
  - Shared `<LegalLinks>` added to landing, pricing, auth, and Settings.
  - Server endpoints: GET /api/v1/me/export, GET/PATCH /api/v1/me/preferences, DELETE /api/v1/me. Server export excludes secrets/tokens.
  - Schemas added in `@sergeant/shared`; `me` API in `@sergeant/api-client` (`exportData`, `getPreferences`, `updatePreferences`, `deleteAccount`).
  - Settings: server data export + account deletion, and consent toggles (analytics, AI memory, push).

- Migration
  - Run DB migration `076_user_preferences.sql` to create `user_preferences`.
  - Fill in final company/founder details and review legal copy before opening public signup.
  - Verify deletion orchestration and downstream processor cleanup in production.

<sup>Written for commit 1894a31c06dceebfa2a6878d81feed14b82b16b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

