### PR TITLE
fix(server): repair cacheMiddleware test (setHeader spy) — unblocks main CI

### DIFF
--- a/apps/server/src/http/cacheMiddleware.test.ts
+++ b/apps/server/src/http/cacheMiddleware.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import type { Request, Response } from "express";
 import { cachingMiddleware, noStoreMiddleware, publicCacheMiddleware } from "./cacheMiddleware";
 
@@ -6,9 +6,9 @@ describe("cacheMiddleware", () => {
   const createMockRes = (): Response => {
     const headers: Record<string, string> = {};
     return {
-      setHeader: (name: string, value: string) => {
+      setHeader: vi.fn((name: string, value: string) => {
         headers[name] = value;
-      },
+      }),
     } as unknown as Response;
   };
 


### PR DESCRIPTION
`apps/server/src/http/cacheMiddleware.test.ts` fails 7/7 on `main` (red `Test coverage (vitest)` + `check`):

```
TypeError: [Function setHeader] is not a spy or a call to a spy!
```

`createMockRes()` defined `setHeader` as a plain arrow, but every assertion calls `expect(res.setHeader).toHaveBeenCalledWith(...)`. Fix: wrap it in `vi.fn()` (keeps the `headers` side-effect) and import `vi`. The `cachingMiddleware` implementation itself is fine — only the test mock was wrong.

Pre-existing breakage on main, independent of any feature work. Unblocks the vitest + `check` gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failing `cacheMiddleware` tests on `main` by turning the mock `res.setHeader` into a `vi.fn` spy while preserving the headers side-effect. Adds `vi` import; no middleware changes; unblocks the `vitest` suite and the `check` job.

<sup>Written for commit 26c60a19faa01c4b5cc50f48956926d289b7ad72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

