### PR TITLE
docs(docs): add worktree-volume hygiene note to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Sergeant
 
-> **Last validated:** 2026-05-14 by @codex. **Next review:** 2026-08-12.
+> **Last validated:** 2026-06-07 by @Skords-01. **Next review:** 2026-09-05.
 > **Status:** Active
 
 `CONTRIBUTING.md` - канонічний manual для людей. Repo policy і hard rules описані в [AGENTS.md](./AGENTS.md), а repeatable execution recipes - у [docs/playbooks/README.md](./docs/playbooks/README.md).
@@ -50,6 +50,15 @@ pnpm update -r
 Якщо `pnpm install` (без `--frozen-lockfile`) залишив `git diff pnpm-lock.yaml` непустим, а ти не додавав/оновлював deps свідомо — значить, drift. Скинь зміни (`git checkout -- pnpm-lock.yaml`) і перерозберись, чому твоє локальне дерево не сходиться з lockfile (типово — нова версія `pnpm` сама, або забутий `pnpm install --frozen-lockfile` після `git pull`).
 
 Кожен override у `pnpm.overrides` (root `package.json`) трекається окремо — `pnpm lint:pnpm-overrides` падає, якщо range уже не resolves до одного major-а ([L1](./docs/security/hardening/L1-uuid-override.md)).
+
+### Worktrees: тримай на тому ж томі, що й pnpm store
+
+Для паралельної роботи над кількома гілками зручно піднімати git-worktree (`git worktree add <path> -b <branch>`). Розміщуй worktree на **тому ж файловому томі, що й твій pnpm store** (`pnpm config get store-dir`) — тоді `pnpm install` усередині worktree робить **hardlink** зі store замість повної копії дерева залежностей, тобто near-zero додаткового диску на кожен worktree.
+
+Hardlink працює лише в межах **одного тому** й лише на ФС, що його підтримує:
+
+- **NTFS / APFS / ext4** — hardlink ок; worktree та store на одному такому томі шерять файли.
+- **exFAT hardlink не підтримує** — worktree на exFAT-томі завжди **full-copy** (сотні МБ–ГБ на кожен install, повільно, забиває диск). Якщо твоя основна тека на exFAT, винеси і store, і worktree на сусідній NTFS/APFS/ext4-том — store і worktree мусять бути на одному томі, інакше pnpm все одно копіює.
 
 Запуск локально:
 


### PR DESCRIPTION
## Summary

Adds a short, machine-neutral subsection to `CONTRIBUTING.md § Setup` explaining that a git worktree should live on the **same filesystem volume as the pnpm store** so `pnpm install` **hardlinks** from the store instead of full-copying the dependency tree. Calls out that **exFAT cannot hardlink** (full-copy fallback) and that store + worktree must share one NTFS/APFS/ext4 volume for the saving.

Motivation: contributors doing parallel worktree-based work were silently full-copying multi-GB `node_modules` per worktree on exFAT. This documents the fix as generic dev-environment hygiene — **no personal paths, no tool config** — consistent with the just-merged "repo is tool-agnostic; harness/machine config lives outside the checkout" direction.

## Governing Skill

`sergeant-tech-debt` (docs / dev-experience hygiene). Tool-agnostic, no code surface touched.

## Playbook

None — single-file docs note, no procedural recipe applies.

## Verification

- Husky pre-commit ran clean (lint-staged: prettier + bump-last-validated; gitleaks). `Last validated` auto-bumped.
- Single-file diff (`CONTRIBUTING.md`, +10/-1); no lockfile drift, no code touched.

## Docs and Governance

- Internal doc kept in Ukrainian (Hard Rule #15). File-level lifecycle marker already present (Status: Active); `Last validated` refreshed by hook.
- Machine-neutral by design: no `D:\` / `E:\` or personal paths — the host-specific worktree convention stays in each harness's global config, not the repo.

## Risk and Rollout

Zero runtime risk — documentation only. No migration, no rollback concern.

## Hard Rule #15

Acknowledged — read governance before editing; internal doc updated in Ukrainian alongside the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
