### PR TITLE
chore(agents): make AGENTS.md fully harness-neutral, isolate Kilo primitives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 Sergeant is **tool-agnostic**. Any AI agent harness — Claude Code, Kilo Code, Devin, Cursor — drives this repo through the same shared primitives: harness-neutral skills in `.agents/skills/`, this `AGENTS.md` as the policy source of truth, and the surface→specialist routing table below. **Harness-specific config (models, permissions, MCP wiring, custom agents, commands) lives outside the checkout**, in each tool's own global config directory — the repo itself carries no tool config.
 
 - **Source of truth.** For all project / policy / hard-rules questions, this file (`AGENTS.md`) wins. `CLAUDE.md` and `DEVIN.md` are thin wrappers that add only runtime/tool notes and must not duplicate policy.
-- **Skills.** Load the skill for the touched surface — start with `.agents/skills/sergeant-start-here/SKILL.md`, then exactly one specialist. Catalog: `docs/agents/agent-skills-catalog.md`. Skills are plain SKILL.md files; each harness loads them its own way (Claude Code via the `Skill` tool, Kilo via its `skill` tool). Prefer the harness's loader over reading SKILL.md by hand when one exists.
+- **Skills.** Load the skill for the touched surface — start with `.agents/skills/sergeant-start-here/SKILL.md`, then exactly one specialist. Catalog: `docs/agents/agent-skills-catalog.md`. Skills are plain SKILL.md files; each harness loads them through its own skill loader — prefer that loader over reading SKILL.md by hand when one exists.
 - **Specialists.** 12 Sergeant specialists own the routing below (web-ui, server-api, mobile, data-and-migrations, deploy, openclaw, hubchat, e2e-testing, security-audit, bugfix, tech-debt, review-and-merge). Each harness ships its own agent definitions in its global config; the surface→specialist mapping is what they all share.
 
 **Routing (surface → specialist).** Pick the smallest specialist that owns the touched surface; escalate to `sergeant-review-and-merge` only at PR-boundary.
@@ -34,12 +34,17 @@ If two surfaces overlap (e.g. web + e2e), load the **owner** first; ask the othe
 
 ### Harness config lives outside the repo
 
-Each agent tool keeps its models, permissions, MCP servers, custom agents and commands in **its own global config directory**, never in the checkout. The repo no longer carries a `.kilo/` (or any tool-config) directory.
+No harness stores tool config in the checkout — the repo carries no `.kilo/`, no tool-specific agent files, nothing. Every harness is an **equal peer**: it reads `AGENTS.md` + `.agents/skills/` from the repo for shared policy, then keeps its own models, permissions, MCP wiring, custom agents and commands in its own global config home. **None of them is "the" driver of this repo.**
 
-- **Kilo Code** → `C:\Users\dmytr\.config\kilo\` (Windows global). Holds `kilo.jsonc` (models + permissions), `kilo.json` (MCP: `context7`, `github`, `memory`), `agents/` (incl. the 12 `sergeant-*` specialists), `command/`, and `rules.md`. Kilo treats this checkout as an ordinary working tree — it reads `AGENTS.md` and `.agents/skills/` from the repo, but its own config stays global. Kilo-only primitives, when you drive the repo with Kilo: `kilo_local_recall` (recall past sessions before re-deriving context), `agent_manager` (isolated worktrees for parallel tasks), `background_process` (dev servers — never `&` / `Start-Process`), `context7_*` / `github_*` / `memory_*` MCP tools.
-- **Claude Code** → `~/.claude/` (global) + the repo's `.claude/` for worktrees and agents the tool manages itself. Native equivalents are mapped in `CLAUDE.md`.
+| Harness     | Config home (global, outside the repo)                      | Tool-specific wrapper      |
+| ----------- | ----------------------------------------------------------- | -------------------------- |
+| Claude Code | `~/.claude/` (+ repo `.claude/` for tool-managed worktrees) | [`CLAUDE.md`](./CLAUDE.md) |
+| Kilo Code   | `~/.config/kilo/` (`agents/`, `command/`, `rules.md`, MCP)  | `~/.config/kilo/rules.md`  |
+| Devin       | Devin workspace settings                                    | [`DEVIN.md`](./DEVIN.md)   |
 
-> **SECURITY.** The Kilo `github` MCP stores a PAT in `~/.config/kilo/kilo.json` (outside git). Treat it as a secret: never echo, commit, or log it. Hard Rule #20 also forbids OpenClaw PATs in production.
+Harness-specific primitives — session recall, worktree/branch managers, MCP tool names, dev-server runners — live in that harness's **own wrapper**, never in this file. **If you are reading `AGENTS.md` and see a tool you don't have, it is not yours — use your own harness's equivalent.**
+
+> **SECURITY.** A harness that wires a `github` (or any) MCP with a Personal Access Token keeps that token in its **own** global config (e.g. `~/.config/kilo/kilo.json`), outside git. Treat such tokens as secrets — never echo, commit, or log them. Hard Rule #20 also forbids OpenClaw PATs in production.
 
 ## Agent operating system (project)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@
 
 ## Claude Code native equivalents
 
-§ «Agent harnesses & routing» в AGENTS.md tool-agnostic, але підрозділ «Harness config lives outside the repo» згадує Kilo-примітиви. Бери їх нативні еквіваленти Claude Code:
+§ «Agent harnesses & routing» в AGENTS.md повністю нейтральний — Kilo-примітиви там НЕ згадуються (вони живуть лише в `~/.config/kilo/rules.md`). Якщо натрапиш на них у legacy-PR чи Kilo-доках, ось нативні еквіваленти Claude Code:
 
 - `skill`→`Skill` (SKILL.md можна й через `Read`); Kilo `task` + agent-defs→`Agent`+`~/.claude/agents/*`, `Task*` для teams; `agent_manager`→`EnterWorktree`.
 - `kilo_local_recall`→auto-memory+`Explore`; Kilo MCP (context7/github/memory)→`ToolSearch` (`.mcp.json`); Kilo commands→`pnpm check` або `.claude/commands/*`.


### PR DESCRIPTION
## Summary

Follow-up to #3417. That PR moved Kilo config out of the repo but left Kilo **visually dominant** inside `AGENTS.md`: a long Kilo-only paragraph (`kilo_local_recall`, `agent_manager` "isolated worktrees", `background_process`, `context7_*`) sat in the neutral policy file while Claude got a single line. Agents from other harnesses reading `AGENTS.md` saw tools they don't have and got confused about which harness "drives" the repo.

This makes the policy file fully harness-neutral:

- **`AGENTS.md` § "Harness config lives outside the repo"**: replaced the Kilo-heavy prose with a **symmetric Claude / Kilo / Devin peer table**. Every harness is an equal peer; none is "the" driver. Removed **all** Kilo primitives — they already live, isolated, in `~/.config/kilo/rules.md` (§ Kilo-Specific), so nothing is lost.
- Added an explicit cross-harness guard: *"If you are reading `AGENTS.md` and see a tool you don't have, it is not yours — use your own harness's equivalent."*
- **`AGENTS.md` skills bullet**: dropped per-tool loader examples → neutral wording.
- **`CLAUDE.md`**: updated the stale reference that pointed at the now-removed primitives.

Net result: harness-specific tooling is isolated per wrapper (`CLAUDE.md`, `DEVIN.md`, `~/.config/kilo/rules.md`); `AGENTS.md` carries only shared policy.

## Governing Skill

`sergeant-tech-debt` (governance/docs reconciliation).

## Playbook

None — ad-hoc governance cleanup.

## Verification

- Docs-only change (2 files, +11/−6). No runtime code.
- `prettier` unavailable locally (exFAT module flap — `MODULE_NOT_FOUND` on the trunk binary); the two `.md` files were aligned by hand against the existing table style. `bump-last-validated` ran; `gitleaks` stage ran (graceful-skip, CI covers).
- CI `format:check`, `lint`, `secret-scan`, and hard-rules-registry sync are the real gates on this PR.

## Docs and Governance

- `AGENTS.md` / `CLAUDE.md` already at `Last validated: 2026-06-07`.
- Hard-rules table, routing table, and all invariants untouched — only the Kilo narrative was neutralized.

## Risk and Rollout

- **Low risk.** Pure doc neutralization; no config, no code, no deletions beyond prose.
- **Rollback:** revert the single commit.

## Hard Rule #15 acknowledgement

Read governance before acting; docs updated alongside; internal-doc language preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `AGENTS.md` fully harness-neutral by removing Kilo-specific primitives and adding a peer table for Claude/Kilo/Devin. Update `CLAUDE.md` to reflect the neutral policy and point Kilo-only details to their own wrapper.

- **Refactors**
  - Replaced Kilo-heavy prose with a symmetric Claude/Kilo/Devin table and an explicit cross-harness guard.
  - Neutralized the skills bullet by dropping per-tool loader examples.
  - Updated `CLAUDE.md` to reference Kilo primitives living in `~/.config/kilo/rules.md`.
  - Clarified security note: PATs stay in each harness’s global config and must be treated as secrets.

<sup>Written for commit 5db900d7d41bf84dcd9652be8c7d32a62ddf9515. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

