### PR TITLE
feat(web): talk-to-your-data PR2 — read-only Fizruk query tools

### DIFF
--- a/apps/server/src/modules/chat/toolDefs/__snapshots__/systemPrompt.test.ts.snap
+++ b/apps/server/src/modules/chat/toolDefs/__snapshots__/systemPrompt.test.ts.snap
@@ -8,7 +8,7 @@ exports[`SYSTEM_PREFIX — registry-driven > matches the canonical snapshot 1`] 
 - Якщо потрібно порахувати (середня/день, прогноз, залишок ліміту, відсоток виконання) — рахуй на основі наданих чисел.
 - Якщо користувач просить змінити або записати дані — використай відповідний tool.
   - Фінанси: create_transaction, change_category, find_transaction, batch_categorize (dry_run спершу), hide_transaction, delete_transaction (лише ручні m_<id>), create_debt, create_receivable, mark_debt_paid, set_budget_limit, update_budget (ліміт або ціль), set_monthly_plan, add_asset, import_monobank_range, split_transaction, recurring_expense, export_report, query_transactions (read-only вибірка), aggregate_spending (сума по групах), compare_periods (2 періоди)
-  - Фізрук: start_workout, log_set, finish_workout, plan_workout, add_program_day, log_measurement, log_weight, log_wellbeing, suggest_workout, copy_workout, compare_progress
+  - Фізрук: start_workout, log_set, finish_workout, plan_workout, add_program_day, log_measurement, log_weight, log_wellbeing, suggest_workout, copy_workout, compare_progress, query_workouts (read-only список), exercise_progress (динаміка вправи), training_stats (частота+м'язи)
   - Рутина: mark_habit_done, complete_habit_for_date, create_habit, create_reminder, edit_habit, set_habit_schedule (примусово weekly), pause_habit (ідемпотентно), archive_habit, reorder_habits, habit_stats, add_calendar_event
   - Харчування: log_meal, log_water, set_daily_plan, suggest_meal, add_recipe, add_to_shopping_list, consume_from_pantry, copy_meal_from_date, plan_meals_for_day
   - Кросмодульні: morning_briefing, weekly_summary, compare_weeks (YYYY-Www; default цей+минулий), set_goal

--- a/apps/server/src/modules/chat/toolDefs/queryFizruk.ts
+++ b/apps/server/src/modules/chat/toolDefs/queryFizruk.ts
@@ -1,0 +1,78 @@
+import type { AnthropicTool } from "./types.js";
+
+/**
+ * Read-only "talk to your data" query tools для Фізрука (PR2 talk-to-your-data).
+ * Лише читають журнал тренувань (`fizruk_workouts_v1`) на клієнті й повертають
+ * числові відповіді / агрегації — без запису. Виконавці живуть у
+ * `apps/web/src/core/lib/chatActions/queryFizrukActions.ts`.
+ *
+ * Навмисно НЕ `strict: true` — Anthropic ліміт 20 strict-tools на запит
+ * (див. INCIDENT 2026-05-16 у `tools.ts`).
+ */
+export const QUERY_FIZRUK_TOOLS: AnthropicTool[] = [
+  {
+    name: "query_workouts",
+    description:
+      "Пошук і вибірка завершених тренувань Фізрука за період, з опційним фільтром за вправою або м'язовою групою. Read-only. Для 'покажи мої тренування за останній тиждень'. Повертає кількість, сумарний об'єм і список.",
+    input_schema: {
+      type: "object",
+      properties: {
+        period_days: {
+          type: "number",
+          description: "За скільки останніх днів, 1-365 (опційно, default 30)",
+        },
+        exercise: {
+          type: "string",
+          description: "Фільтр за назвою вправи (опційно)",
+        },
+        muscle: {
+          type: "string",
+          description: "Фільтр за м'язовою групою (опційно)",
+        },
+        limit: {
+          type: "number",
+          description:
+            "Максимум тренувань у списку, 1-50 (опційно, default 15)",
+        },
+      },
+    },
+  },
+  {
+    name: "exercise_progress",
+    description:
+      "Динаміка прогресу в конкретній вправі (макс. вага, об'єм, повтори) за період у Фізруці. Read-only. Для 'як змінилась моя жим лежачи за місяць?'. Повертає зміну від першої до останньої сесії та найкращі показники.",
+    input_schema: {
+      type: "object",
+      properties: {
+        exercise_name: {
+          type: "string",
+          description: "Назва вправи (напр. 'жим лежачи', 'присідання')",
+        },
+        period_days: {
+          type: "number",
+          description: "За скільки останніх днів, 1-365 (опційно, default 90)",
+        },
+      },
+      required: ["exercise_name"],
+    },
+  },
+  {
+    name: "training_stats",
+    description:
+      "Агрегована статистика тренувань Фізрука за період: частота на тиждень, улюблені вправи, розподіл по м'язових групах. Read-only. Для 'які м'язи я треную найчастіше?'.",
+    input_schema: {
+      type: "object",
+      properties: {
+        period_days: {
+          type: "number",
+          description: "За скільки останніх днів, 1-365 (опційно, default 30)",
+        },
+        top: {
+          type: "number",
+          description:
+            "Скільки топ-вправ і топ-м'язів повернути, 1-20 (опційно, default 8)",
+        },
+      },
+    },
+  },
+];

--- a/apps/server/src/modules/chat/toolDefs/systemPrompt.ts
+++ b/apps/server/src/modules/chat/toolDefs/systemPrompt.ts
@@ -29,8 +29,11 @@ import {
  *   query-tools (query_transactions, aggregate_spending, compare_periods) з
  *   `QUERY_FINYK_TOOLS`. Реджистр лишається джерелом істини; bullet
  *   регенерується автоматично. Чергова cache-prefix invalidation.
+ * v10 (2026-06-07): talk-to-your-data PR2 — у Фізрук-bullet додано read-only
+ *   query-tools (query_workouts, exercise_progress, training_stats) з
+ *   `QUERY_FIZRUK_TOOLS`. Знову cache-prefix invalidation.
  */
-export const SYSTEM_PROMPT_VERSION = "v9";
+export const SYSTEM_PROMPT_VERSION = "v10";
 
 // AI-CONTEXT: модульний label у промпті відрізняється від `CAPABILITY_MODULE_META.title`,
 // бо UI показує "Фінік", а промпту історично подавали "Фінанси" (тон-нейтральніше для

--- a/apps/server/src/modules/chat/tools.ts
+++ b/apps/server/src/modules/chat/tools.ts
@@ -23,6 +23,7 @@ export type { AnthropicTool } from "./toolDefs/types.js";
 import { FINYK_TOOLS } from "./toolDefs/finyk.js";
 import { QUERY_FINYK_TOOLS } from "./toolDefs/queryFinyk.js";
 import { FIZRUK_TOOLS } from "./toolDefs/fizruk.js";
+import { QUERY_FIZRUK_TOOLS } from "./toolDefs/queryFizruk.js";
 import { ROUTINE_TOOLS } from "./toolDefs/routine.js";
 import { NUTRITION_TOOLS } from "./toolDefs/nutrition.js";
 import { CROSS_MODULE_TOOLS } from "./toolDefs/crossModule.js";
@@ -36,6 +37,7 @@ export const TOOLS: AnthropicTool[] = [
   ...QUERY_FINYK_TOOLS,
   ...ROUTINE_TOOLS,
   ...FIZRUK_TOOLS,
+  ...QUERY_FIZRUK_TOOLS,
   ...NUTRITION_TOOLS,
   ...CROSS_MODULE_TOOLS,
   ...UTILITY_TOOLS,

--- a/apps/web/src/core/lib/chatActions/queryFizrukActions.test.ts
+++ b/apps/web/src/core/lib/chatActions/queryFizrukActions.test.ts
@@ -1,0 +1,215 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { handleQueryFizrukAction } from "./queryFizrukActions";
+import type { ChatAction } from "./types";
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-04-22T12:00:00"));
+});
+afterEach(() => {
+  localStorage.clear();
+  vi.useRealTimers();
+});
+
+function call(action: ChatAction): string {
+  const out = handleQueryFizrukAction(action);
+  if (out == null) {
+    throw new Error(`handler returned ${typeof out}, expected string|object`);
+  }
+  return typeof out === "string" ? out : out.result;
+}
+
+function item(
+  nameUk: string,
+  primary: string[],
+  sets: Array<{ weightKg: number; reps: number }>,
+) {
+  return {
+    id: `it_${nameUk}`,
+    nameUk,
+    type: "strength" as const,
+    musclesPrimary: primary,
+    musclesSecondary: [],
+    sets,
+    durationSec: 0,
+    distanceM: 0,
+  };
+}
+
+/** Seed completed (+ one planned/incomplete) workouts relative to 2026-04-22. */
+function seed(): void {
+  localStorage.setItem(
+    "fizruk_workouts_v1",
+    JSON.stringify([
+      {
+        id: "w1",
+        startedAt: "2026-04-20T10:00:00",
+        endedAt: "2026-04-20T11:00:00",
+        items: [
+          item(
+            "Жим лежачи",
+            ["Груди"],
+            [
+              { weightKg: 80, reps: 8 },
+              { weightKg: 82.5, reps: 6 },
+            ],
+          ),
+        ],
+      },
+      {
+        id: "w2",
+        startedAt: "2026-04-15T10:00:00",
+        endedAt: "2026-04-15T11:00:00",
+        items: [item("Присідання", ["Ноги"], [{ weightKg: 100, reps: 5 }])],
+      },
+      {
+        id: "w3",
+        startedAt: "2026-04-10T10:00:00",
+        endedAt: "2026-04-10T11:00:00",
+        items: [item("Жим лежачи", ["Груди"], [{ weightKg: 75, reps: 8 }])],
+      },
+      {
+        id: "w_old",
+        startedAt: "2026-01-01T10:00:00",
+        endedAt: "2026-01-01T11:00:00",
+        items: [item("Жим лежачи", ["Груди"], [{ weightKg: 70, reps: 8 }])],
+      },
+      {
+        id: "w_planned",
+        startedAt: "2026-04-21T10:00:00",
+        endedAt: null,
+        items: [item("Жим лежачи", ["Груди"], [{ weightKg: 90, reps: 5 }])],
+      },
+    ]),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// query_workouts
+// ---------------------------------------------------------------------------
+describe("query_workouts", () => {
+  it("happy: lists completed workouts in default window with volume", () => {
+    seed();
+    const out = call({ name: "query_workouts", input: {} });
+    expect(out).toContain("Тренувань за 30 днів: 3"); // w1,w2,w3 (not old, not planned)
+    expect(out).toMatch(/об'єм/i);
+  });
+
+  it("happy: filters by exercise", () => {
+    seed();
+    const out = call({
+      name: "query_workouts",
+      input: { exercise: "жим" },
+    });
+    expect(out).toContain("2"); // w1 + w3 bench
+    expect(out).toContain("Жим лежачи");
+    expect(out).not.toContain("Присідання");
+  });
+
+  it("happy: filters by muscle", () => {
+    seed();
+    const out = call({
+      name: "query_workouts",
+      input: { muscle: "ноги" },
+    });
+    expect(out).toContain("Присідання");
+    expect(out).not.toContain("Жим лежачи");
+  });
+
+  it("error: no matches returns message", () => {
+    seed();
+    const out = call({
+      name: "query_workouts",
+      input: { exercise: "плавання" },
+    });
+    expect(out).toContain("Немає");
+  });
+
+  it("shape: result is a non-empty string", () => {
+    seed();
+    const out = call({ name: "query_workouts", input: { period_days: 365 } });
+    expect(typeof out).toBe("string");
+    expect(out.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// exercise_progress
+// ---------------------------------------------------------------------------
+describe("exercise_progress", () => {
+  it("happy: trends max weight first → last session", () => {
+    seed();
+    const out = call({
+      name: "exercise_progress",
+      input: { exercise_name: "жим" },
+    });
+    expect(out).toContain("Прогрес");
+    expect(out).toMatch(/75 → 82\.5/); // w3 first (75) → w1 last (82.5)
+  });
+
+  it("error: missing exercise_name returns guidance", () => {
+    seed();
+    const out = call({ name: "exercise_progress", input: {} });
+    expect(out).toContain("Вкажи назву вправи");
+  });
+
+  it("error: unknown exercise returns no-data message", () => {
+    seed();
+    const out = call({
+      name: "exercise_progress",
+      input: { exercise_name: "плавання" },
+    });
+    expect(out).toContain("Немає записів");
+  });
+
+  it("shape: result is a non-empty string", () => {
+    seed();
+    const out = call({
+      name: "exercise_progress",
+      input: { exercise_name: "присід", period_days: 365 },
+    });
+    expect(typeof out).toBe("string");
+    expect(out.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// training_stats
+// ---------------------------------------------------------------------------
+describe("training_stats", () => {
+  it("happy: aggregates frequency and top exercises/muscles", () => {
+    seed();
+    const out = call({ name: "training_stats", input: {} });
+    expect(out).toContain("Статистика тренувань");
+    expect(out).toContain("Тренувань: 3");
+    expect(out).toContain("Жим лежачи (2)"); // bench in w1 + w3
+  });
+
+  it("error: empty window returns no-data message", () => {
+    seed();
+    const out = call({ name: "training_stats", input: { period_days: 1 } });
+    expect(out).toContain("Немає");
+  });
+
+  it("shape: result is a non-empty string", () => {
+    seed();
+    const out = call({ name: "training_stats", input: { period_days: 365 } });
+    expect(typeof out).toBe("string");
+    expect(out.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// router
+// ---------------------------------------------------------------------------
+describe("handleQueryFizrukAction router", () => {
+  it("returns undefined for non-fizruk-query actions", () => {
+    const out = handleQueryFizrukAction({
+      name: "query_transactions",
+      input: { query: "АТБ" },
+    } as ChatAction);
+    expect(out).toBeUndefined();
+  });
+});

--- a/apps/web/src/core/lib/chatActions/queryFizrukActions.ts
+++ b/apps/web/src/core/lib/chatActions/queryFizrukActions.ts
@@ -1,0 +1,249 @@
+import { getKyivDayKey } from "@shared/lib/time/kyivTime";
+import { readWorkouts } from "./fizrukActions/shared";
+import type {
+  ChatAction,
+  ChatActionResult,
+  Workout,
+  WorkoutItem,
+} from "./types";
+
+/**
+ * Read-only "talk to your data" виконавці для Фізрука (PR2 talk-to-your-data).
+ * Дзеркало серверних `QUERY_FIZRUK_TOOLS` (`toolDefs/queryFizruk.ts`). Лише
+ * читають журнал тренувань через спільний `readWorkouts` (з
+ * `fizrukActions/shared.ts`) і повертають числові відповіді / агрегації.
+ *
+ * Реєструється у `hubChatActions.ts` dispatch-chain окремою гілкою, не
+ * чіпаючи мутаційний `handleFizrukAction`. Періоди рахуються від `Date.now()`
+ * (days-ago cutoff) — як у наявному `fizrukActions/analytics.ts`.
+ */
+
+interface QueryWorkoutsAction {
+  name: "query_workouts";
+  input: {
+    period_days?: number | string;
+    exercise?: string;
+    muscle?: string;
+    limit?: number | string;
+  };
+}
+
+interface ExerciseProgressAction {
+  name: "exercise_progress";
+  input: { exercise_name?: string; period_days?: number | string };
+}
+
+interface TrainingStatsAction {
+  name: "training_stats";
+  input: { period_days?: number | string; top?: number | string };
+}
+
+const DAY_MS = 86_400_000;
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function normalizeText(value: unknown): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase();
+}
+
+function clampDays(value: unknown, fallback: number): number {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return fallback;
+  return Math.min(365, Math.floor(n));
+}
+
+function clamp(value: unknown, fallback: number, max: number): number {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(max, Math.max(1, Math.floor(n)));
+}
+
+function startedTs(w: Workout): number {
+  return new Date(w.startedAt).getTime();
+}
+
+function itemVolume(item: WorkoutItem): number {
+  return item.sets.reduce((s, set) => s + set.weightKg * set.reps, 0);
+}
+
+function workoutVolume(w: Workout): number {
+  return w.items.reduce((s, item) => s + itemVolume(item), 0);
+}
+
+function itemMatches(
+  item: WorkoutItem,
+  exercise: string,
+  muscle: string,
+): boolean {
+  if (exercise && !item.nameUk.toLowerCase().includes(exercise)) return false;
+  if (
+    muscle &&
+    ![...item.musclesPrimary, ...item.musclesSecondary].some((m) =>
+      m.toLowerCase().includes(muscle),
+    )
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/** Completed workouts within the last `days`, newest first. */
+function completedSince(days: number): Workout[] {
+  const cutoff = Date.now() - days * DAY_MS;
+  return readWorkouts()
+    .filter((w) => w.endedAt && startedTs(w) >= cutoff)
+    .sort((a, b) => startedTs(b) - startedTs(a));
+}
+
+function dayLabel(w: Workout): string {
+  return getKyivDayKey(new Date(w.startedAt));
+}
+
+function round(n: number): number {
+  return Math.round(n);
+}
+
+// ─── executors ──────────────────────────────────────────────────────────────
+
+export function queryWorkouts(action: QueryWorkoutsAction): ChatActionResult {
+  const input = action.input;
+  const days = clampDays(input.period_days, 30);
+  const exercise = normalizeText(input.exercise);
+  const muscle = normalizeText(input.muscle);
+  const limit = clamp(input.limit, 15, 50);
+
+  const matched = completedSince(days).filter((w) => {
+    if (!exercise && !muscle) return true;
+    return w.items.some((it) => itemMatches(it, exercise, muscle));
+  });
+
+  if (matched.length === 0) {
+    const flt = exercise || muscle ? ` (${exercise || muscle})` : "";
+    return `Немає завершених тренувань${flt} за останні ${days} днів.`;
+  }
+
+  const totalVolume = matched.reduce((s, w) => s + workoutVolume(w), 0);
+  const shown = matched.slice(0, limit);
+  const list = shown
+    .map((w) => {
+      const names = w.items.map((it) => it.nameUk).join(", ") || "без вправ";
+      const sets = w.items.reduce((s, it) => s + it.sets.length, 0);
+      return `${dayLabel(w)}: ${names} · ${sets} підх. · ${round(workoutVolume(w))} кг×повт`;
+    })
+    .join("; ");
+  const more =
+    matched.length > shown.length
+      ? ` (показано ${shown.length} з ${matched.length})`
+      : "";
+  return `Тренувань за ${days} днів: ${matched.length}, сумарний об'єм ${round(totalVolume)} кг×повт${more}: ${list}`;
+}
+
+export function exerciseProgress(
+  action: ExerciseProgressAction,
+): ChatActionResult {
+  const exercise = normalizeText(action.input.exercise_name);
+  if (!exercise) {
+    return "Вкажи назву вправи (exercise_name) для аналізу прогресу.";
+  }
+  const days = clampDays(action.input.period_days, 90);
+
+  const sessions = completedSince(days)
+    .map((w) => {
+      const items = w.items.filter((it) =>
+        it.nameUk.toLowerCase().includes(exercise),
+      );
+      if (items.length === 0) return null;
+      const maxWeight = Math.max(
+        0,
+        ...items.flatMap((it) => it.sets.map((s) => s.weightKg)),
+      );
+      const reps = items.reduce(
+        (s, it) => s + it.sets.reduce((ss, set) => ss + set.reps, 0),
+        0,
+      );
+      const volume = items.reduce((s, it) => s + itemVolume(it), 0);
+      return { ts: startedTs(w), day: dayLabel(w), maxWeight, reps, volume };
+    })
+    .filter((s): s is NonNullable<typeof s> => s !== null)
+    .sort((a, b) => a.ts - b.ts);
+
+  const first = sessions[0];
+  const last = sessions[sessions.length - 1];
+  if (!first || !last) {
+    return `Немає записів вправи "${exercise}" за останні ${days} днів.`;
+  }
+  const bestWeight = Math.max(...sessions.map((s) => s.maxWeight));
+  const bestVolume = Math.max(...sessions.map((s) => s.volume));
+  const volPct =
+    first.volume > 0
+      ? round(((last.volume - first.volume) / first.volume) * 100)
+      : 0;
+  const wDelta = last.maxWeight - first.maxWeight;
+  const sign = (n: number): string => (n >= 0 ? "+" : "");
+
+  return [
+    `Прогрес "${exercise}" за ${days} днів (${sessions.length} сесій):`,
+    `Макс. вага: ${first.maxWeight} → ${last.maxWeight} кг (${sign(wDelta)}${wDelta})`,
+    `Об'єм: ${round(first.volume)} → ${round(last.volume)} кг×повт (${sign(volPct)}${volPct}%)`,
+    `Найкраще: ${bestWeight} кг, об'єм ${round(bestVolume)} кг×повт`,
+  ].join("\n");
+}
+
+export function trainingStats(action: TrainingStatsAction): ChatActionResult {
+  const days = clampDays(action.input.period_days, 30);
+  const top = clamp(action.input.top, 8, 20);
+  const completed = completedSince(days);
+
+  if (completed.length === 0) {
+    return `Немає завершених тренувань за останні ${days} днів.`;
+  }
+
+  const perWeek = completed.length / Math.max(1, days / 7);
+  const exerciseFreq = new Map<string, number>();
+  const muscleFreq = new Map<string, number>();
+  let totalSets = 0;
+  for (const w of completed) {
+    for (const item of w.items) {
+      exerciseFreq.set(item.nameUk, (exerciseFreq.get(item.nameUk) ?? 0) + 1);
+      totalSets += item.sets.length;
+      for (const m of item.musclesPrimary) {
+        muscleFreq.set(m, (muscleFreq.get(m) ?? 0) + 1);
+      }
+    }
+  }
+
+  const topList = (m: Map<string, number>): string =>
+    [...m.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, top)
+      .map(([k, v]) => `${k} (${v})`)
+      .join(", ");
+
+  return [
+    `Статистика тренувань за ${days} днів:`,
+    `Тренувань: ${completed.length} (~${perWeek.toFixed(1)}/тиждень), підходів: ${totalSets}`,
+    `Топ вправи: ${topList(exerciseFreq) || "—"}`,
+    `Топ м'язи: ${topList(muscleFreq) || "—"}`,
+  ].join("\n");
+}
+
+/**
+ * Доменний router для read-only fizruk query-tools. Повертає `undefined` для
+ * нерелевантних дій, щоб `hubChatActions.dispatch` пішов далі по ланцюгу.
+ */
+export function handleQueryFizrukAction(
+  action: ChatAction,
+): ChatActionResult | undefined {
+  switch (action.name) {
+    case "query_workouts":
+      return queryWorkouts(action as QueryWorkoutsAction);
+    case "exercise_progress":
+      return exerciseProgress(action as ExerciseProgressAction);
+    case "training_stats":
+      return trainingStats(action as TrainingStatsAction);
+    default:
+      return undefined;
+  }
+}

--- a/apps/web/src/core/lib/hubChatActions.ts
+++ b/apps/web/src/core/lib/hubChatActions.ts
@@ -1,6 +1,7 @@
 import { handleFinykAction } from "./chatActions/finykActions";
 import { handleQueryFinykAction } from "./chatActions/queryFinykActions";
 import { handleFizrukAction } from "./chatActions/fizrukActions";
+import { handleQueryFizrukAction } from "./chatActions/queryFizrukActions";
 import { handleRoutineAction } from "./chatActions/routineActions";
 import { handleNutritionAction } from "./chatActions/nutritionActions";
 import { handleCrossAction } from "./chatActions/crossActions";
@@ -36,6 +37,7 @@ function dispatch(action: ChatAction): ExecutedAction {
       normalize(handleFinykAction(action)) ??
       normalize(handleQueryFinykAction(action)) ??
       normalize(handleFizrukAction(action)) ??
+      normalize(handleQueryFizrukAction(action)) ??
       normalize(handleRoutineAction(action)) ??
       normalize(handleNutritionAction(action)) ??
       normalize(handleCrossAction(action)) ?? {

--- a/packages/shared/src/lib/assistantCatalogue.ts
+++ b/packages/shared/src/lib/assistantCatalogue.ts
@@ -416,7 +416,7 @@ export const ASSISTANT_CAPABILITIES: readonly AssistantCapability[] = [
     keywords: ["compare", "порівняння", "період", "різниця"],
   },
 
-  // ───── Фізрук (11) ────────────────────────────────────────────────────
+  // ───── Фізрук (14) ────────────────────────────────────────────────────
   {
     id: "start_workout",
     module: "fizruk",
@@ -544,6 +544,63 @@ export const ASSISTANT_CAPABILITIES: readonly AssistantCapability[] = [
     prompt: "Порівняй прогрес: ",
     requiresInput: true,
     requiresOnline: true,
+  },
+  {
+    id: "query_workouts",
+    module: "fizruk",
+    label: "Запит по тренуваннях",
+    shortLabel: "Тренування",
+    icon: "list",
+    description:
+      "Вибірка завершених тренувань за період з опційним фільтром за вправою чи м'язом. Read-only — з кількістю й сумарним об'ємом.",
+    examples: [
+      "покажи мої тренування за останній тиждень",
+      "скільки разів я робив присідання за місяць",
+      "тренування на спину за 2 тижні",
+    ],
+    prompt: "Знайди тренування: ",
+    requiresInput: true,
+    requiresOnline: true,
+    aiHint: "read-only список",
+    keywords: ["query", "workout", "тренування", "вибірка"],
+  },
+  {
+    id: "exercise_progress",
+    module: "fizruk",
+    label: "Динаміка вправи",
+    shortLabel: "Динаміка",
+    icon: "trending-up",
+    description:
+      "Зміна показників у конкретній вправі (вага, об'єм, повтори) за період — від першої до останньої сесії плюс найкращі результати.",
+    examples: [
+      "як змінилась моя жим лежачи за місяць",
+      "динаміка присідань за 3 місяці",
+      "прогрес станової за квартал",
+    ],
+    prompt: "Динаміка вправи: ",
+    requiresInput: true,
+    requiresOnline: true,
+    aiHint: "динаміка вправи",
+    keywords: ["progress", "динаміка", "вага", "об'єм"],
+  },
+  {
+    id: "training_stats",
+    module: "fizruk",
+    label: "Статистика тренувань",
+    shortLabel: "Статистика",
+    icon: "bar-chart-2",
+    description:
+      "Агрегована статистика за період: частота на тиждень, улюблені вправи, розподіл по м'язових групах.",
+    examples: [
+      "які м'язи я треную найчастіше",
+      "статистика тренувань за місяць",
+      "як часто я тренуюсь",
+    ],
+    prompt: "Статистика тренувань: ",
+    requiresInput: true,
+    requiresOnline: true,
+    aiHint: "частота+м'язи",
+    keywords: ["stats", "статистика", "частота", "м'язи"],
   },
 
   // ───── Рутина (12) ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

talk-to-your-data **PR2** ([`docs/planning/talk-to-your-data.md`](docs/planning/talk-to-your-data.md)): three read-only "talk to your data" query tools for Фізрук, mirroring PR1's pattern for the workout domain.

- **`query_workouts`** — completed workouts over a period, optionally filtered by exercise / muscle, with count + total volume
- **`exercise_progress`** — per-exercise trend (max weight, volume, reps) first → last session + best results
- **`training_stats`** — frequency per week, top exercises, muscle-group distribution

Read-only: reuses the already-exported `readWorkouts()` from `fizrukActions/shared.ts` (no new `localStorage` reads, no rule-disable needed); period windows via `Date.now()` day-cutoffs, matching `fizrukActions/analytics.ts`. New `handleQueryFizrukAction` dispatch branch; the mutating `handleFizrukAction` is untouched.

> **🔗 Stacked on [#3423](https://github.com/Skords-01/Sergeant/pull/3423) (PR1).** Base is `feat/talk-to-data-finyk-queries` so the diff shows only PR2's delta (shared `tools.ts` / `systemPrompt` version / `assistantCatalogue` / snapshot would otherwise conflict with PR1). Retarget to `main` once PR1 merges. PR1 also carries the prerequisite `eslint.config.js` fix that unblocks committing.

## Governing Skill

`sergeant-server-api` (tool defs) + `sergeant-web-ui` (executors).

## Verification

- `apps/web` fizruk executor tests: **13/13** (`queryFizrukActions.test.ts`).
- web typecheck ✓ · web/server/shared eslint ✓ (`--max-warnings=0`).
- server chat suite (tool↔capability bijection, registry, token-budget, systemPrompt snapshot) green; shared catalogue suite green (35/35).
- ⚠️ Same pre-existing local limitation as PR1: full `pnpm check` not runnable (server project typecheck spuriously fails on the untouched `mono/backfill.ts`). CI is the authoritative gate.

## Docs and Governance

- Hard Rules #1 (bigint) / #2 (RQ keys) / #4 (migrations): **N/A** — read-only client-side, no DB / React Query / migrations.
- `SYSTEM_PROMPT_VERSION` bumped **v9 → v10** (registry-driven prompt) + snapshot refreshed; Фізрук capability count 11 → 14.
- No `no-raw-storage-key` exception needed — workout reads go through the existing exported reader.

## Risk and Rollout

Low. Additive read-only tools; one-time Anthropic prompt-cache invalidation. No flags, migrations, or schema. PR3 (Routine + Nutrition) and PR4 (data cards) follow.

## Hard Rule #15

Governance read before coding; planning doc + system-prompt version updated alongside; description completed. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three read‑only Fizruk “talk to your data” tools — `query_workouts`, `exercise_progress`, and `training_stats` — with server tool defs and web executors wired into HubChat. Enhances workout insights without writing data; bumps system prompt to `v10`.

- New Features
  - Server: add `QUERY_FIZRUK_TOOLS` and register in `TOOLS`; bump `SYSTEM_PROMPT_VERSION` to `v10` and refresh prompt snapshot. Tools are non‑strict to stay under Anthropic’s strict‑tool limit.
  - Web: implement executors in `apps/web/src/core/lib/chatActions/queryFizrukActions.ts` and route via `handleQueryFizrukAction` in `hubChatActions.ts`. Read‑only via `readWorkouts()`, period windows based on `Date.now()`.
  - Shared: register capabilities in `packages/shared/src/lib/assistantCatalogue.ts` (Фізрук count 11 → 14).
  - Tests: 13 unit tests for the executors in `apps/web` (cover listing, filtering, trends, and aggregates).

<sup>Written for commit 63823b217b82eebc188f910c6c670ca50c7e6775. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

