### PR TITLE
docs(agents): fix Sergeant skill loading for Claude Code (Read, not Skill tool)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@
 ## Startup flow
 
 1. Прочитай [AGENTS.md](./AGENTS.md). Claude Code: вже в контексті через `@import` вище — не витрачай tool-call на повторне читання.
-2. Завантаж `.agents/skills/sergeant-start-here/SKILL.md`, далі рівно один specialist skill для основної поверхні зміни.
+2. Завантаж `.agents/skills/sergeant-start-here/SKILL.md` через **`Read`**, далі рівно один specialist skill для основної поверхні зміни. **Sergeant-скіли НЕ в реєстрі Claude `Skill` tool** — вони живуть у `.agents/skills/`, який Claude не сканує. Ім'я скіла `X` з routing-таблиці резолвиться у `Read .agents/skills/X/SKILL.md` (НЕ `Skill(X)` — це дасть «not found»).
 3. Routing surface→skill: таблиця в § «Agent harnesses & routing» нижче (mapping tool-agnostic, валідний і для тебе).
 4. Є playbook під задачу в [docs/playbooks/](./docs/playbooks/README.md)? Виконуй як canonical recipe.
 5. Перший раз у репо? Пройди [docs/agents/onboarding.md](./docs/agents/onboarding.md).
@@ -19,7 +19,7 @@
 
 § «Agent harnesses & routing» в AGENTS.md повністю нейтральний — Kilo-примітиви там НЕ згадуються (вони живуть лише в `~/.config/kilo/rules.md`). Якщо натрапиш на них у legacy-PR чи Kilo-доках, ось нативні еквіваленти Claude Code:
 
-- `skill`→`Skill` (SKILL.md можна й через `Read`); Kilo `task` + agent-defs→`Agent`+`~/.claude/agents/*`, `Task*` для teams; `agent_manager`→`EnterWorktree`.
+- Kilo `skill` → **`Read .agents/skills/<name>/SKILL.md`** (Claude `Skill` tool індексує лише plugin / `~/.claude/skills` скіли — Sergeant-скілів там НЕМА, тому Read, не `Skill`); Kilo `task` + agent-defs→`Agent`+`~/.claude/agents/*`, `Task*` для teams; `agent_manager`→`EnterWorktree`.
 - `kilo_local_recall`→auto-memory+`Explore`; Kilo MCP (context7/github/memory)→`ToolSearch` (`.mcp.json`); Kilo commands→`pnpm check` або `.claude/commands/*`.
 
 Спільне для всіх харнесів і валідне для тебе: routing-таблиця surface→skill і список hard rules / invariants нижче по AGENTS.md. Конфіг Kilo живе глобально в `~/.config/kilo/`, не в репо — у репо більше немає `.kilo/`.


### PR DESCRIPTION
## Summary

Agents driving the repo with **Claude Code** sometimes report *«file not found»* when loading `sergeant-start-here` (or any specialist). Root cause: the Claude `Skill` tool only indexes plugin / `~/.claude/skills` / `.claude/skills` entries, but Sergeant skills live in **`.agents/skills/`** (harness-neutral), which Claude does not scan. `CLAUDE.md` mapped `skill → Skill`, sending agents straight into that dead end.

The files are all present and git-tracked — this is purely an instruction fix:

- **Startup flow**: load `sergeant-start-here` via `Read .agents/skills/<name>/SKILL.md`, and spell out that a skill name `X` resolves to that path, **not** `Skill(X)`.
- **Native-equivalents bullet**: replace the misleading `skill → Skill` with `Kilo skill → Read .agents/skills/<name>/SKILL.md`, noting Sergeant skills are not in the Claude Skill registry.

Kilo is unaffected — its `skills.paths` already points at `.agents/skills/`. No files moved or duplicated (a `.claude/skills` symlink is impossible on the exFAT trunk, and a copy would break single-source).

## Governing Skill

`sergeant-tech-debt` (agent-docs correctness).

## Verification

- Single-file doc change (`CLAUDE.md`, +2/−2).
- `gitleaks` stage ran (graceful-skip); `prettier` unavailable locally (exFAT module flap) — change is plain prose edits to existing lines. CI `format:check` is the gate.

## Risk and Rollout

- **Minimal.** Doc-only; revert the one commit to roll back.

## Hard Rule #15 acknowledgement

Governance read; docs updated alongside; internal-doc language preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update CLAUDE.md to load Sergeant skills via `Read .agents/skills/<name>/SKILL.md` instead of the `Skill` tool, which doesn’t index `.agents/skills/`. This removes “file not found” errors for `sergeant-start-here` and other specialists; docs-only change.

<sup>Written for commit d681b6c9acc36536176e35fc6232405c1c360a43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Sergeant startup instructions for specialist skill initialization.
  * Clarified skill resolution procedures in developer documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->