### PR TITLE
test(root): raise domain package coverage

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,6 +20,13 @@ import globals from "globals";
 import security from "eslint-plugin-security";
 import eslintConfigPrettier from "eslint-config-prettier";
 import { baseline } from "./eslint.baseline.js";
+import { webBlocks } from "./eslint.web.js";
+import { serverBlocks } from "./eslint.server.js";
+import { mobileBlocks } from "./eslint.mobile.js";
+import { shellBlocks } from "./eslint.shell.js";
+import { openclawBlocks } from "./eslint.openclaw.js";
+import { packageBlocks } from "./eslint.packages.js";
+import { crossSurfaceBlocks } from "./eslint.cross-surface.js";
 
 // Root still carries legacy web-rule blocks while PR-31 phase 2 extraction is
 // being reconciled. Keep these allowlists available here so ESLint config
@@ -41,35 +48,6 @@ const toastErrorActionAllowlist = JSON.parse(
   ),
 );
 
-const bareFixedInsetModalAllowlist = JSON.parse(
-  readFileSync(
-    new URL(
-      "./apps/web/eslint.bare-fixed-inset-modal-allowlist.json",
-      import.meta.url,
-    ),
-    "utf8",
-  ),
-);
-
-// These allowlists are defined in eslint.web.js for the webBlocks export, but
-// the duplicate web block below (introduced by a botched merge of 023fd88 onto
-// c2eed3c's extraction) also needs them. Loading them here keeps the file
-// parseable until the duplicate block is removed in a follow-up cleanup.
-const i18nAllowlist = JSON.parse(
-  readFileSync(
-    new URL("./apps/web/eslint.i18n-allowlist.json", import.meta.url),
-    "utf8",
-  ),
-);
-const toastErrorActionAllowlist = JSON.parse(
-  readFileSync(
-    new URL(
-      "./apps/web/eslint.toast-error-action-allowlist.json",
-      import.meta.url,
-    ),
-    "utf8",
-  ),
-);
 const bareFixedInsetModalAllowlist = JSON.parse(
   readFileSync(
     new URL(

--- a/packages/fizruk-domain/src/lib/restSettings.test.ts
+++ b/packages/fizruk-domain/src/lib/restSettings.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  REST_CATEGORY_LABELS,
+  REST_DEFAULTS,
+  getRestCategory,
+} from "./restSettings.js";
+
+describe("fizruk-domain/restSettings", () => {
+  it("classifies missing and unknown groups as compound", () => {
+    expect(getRestCategory(null)).toBe("compound");
+    expect(getRestCategory(undefined)).toBe("compound");
+    expect(getRestCategory("unknown")).toBe("compound");
+  });
+
+  it("classifies cardio and isolation groups", () => {
+    expect(getRestCategory("cardio")).toBe("cardio");
+    expect(getRestCategory("shoulders")).toBe("isolation");
+    expect(getRestCategory("biceps")).toBe("isolation");
+    expect(getRestCategory("calves")).toBe("isolation");
+  });
+
+  it("keeps labels/defaults in sync with known rest categories", () => {
+    expect(Object.keys(REST_CATEGORY_LABELS).sort()).toEqual(
+      Object.keys(REST_DEFAULTS).sort(),
+    );
+    expect(REST_DEFAULTS).toEqual({
+      compound: 90,
+      isolation: 60,
+      cardio: 30,
+    });
+  });
+});

--- a/packages/fizruk-domain/src/lib/trainingPrograms.test.ts
+++ b/packages/fizruk-domain/src/lib/trainingPrograms.test.ts
@@ -2,8 +2,10 @@
  * Integrity invariant: every schedule sessionKey in BUILTIN_PROGRAMS
  * must exist in the corresponding program's sessions map.
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { BUILTIN_PROGRAMS } from "../index.js";
+import type { TrainingProgramDef } from "../domain/programs/index.js";
+import { getDefaultRestSec, getTodaySession } from "./trainingPrograms.js";
 
 describe("BUILTIN_PROGRAMS integrity", () => {
   it("exports at least 4 programs", () => {
@@ -88,5 +90,39 @@ describe("BUILTIN_PROGRAMS integrity", () => {
     expect(ss).toBeDefined();
     expect(ss!.sessions["ss_a"]).toBeDefined();
     expect(ss!.sessions["ss_b"]).toBeDefined();
+  });
+
+  it("legacy getTodaySession returns today's schedule slot or null", () => {
+    const program: TrainingProgramDef = {
+      id: "test",
+      name: "Test",
+      description: "Test",
+      days: 1,
+      durationWeeks: 4,
+      schedule: [{ day: 1, sessionKey: "a", name: "A" }],
+      sessions: {
+        a: {
+          name: "A",
+          exerciseIds: ["bench"],
+          progressionKg: 2.5,
+          defaultRestSec: 90,
+        },
+      },
+    };
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 0, 5, 12, 0, 0, 0));
+    expect(getTodaySession(program)).toEqual(program.schedule[0]);
+    expect(getTodaySession(null)).toBeNull();
+    vi.setSystemTime(new Date(2026, 0, 6, 12, 0, 0, 0));
+    expect(getTodaySession(program)).toBeNull();
+    vi.useRealTimers();
+  });
+
+  it("legacy getDefaultRestSec maps known muscle groups", () => {
+    expect(getDefaultRestSec(null)).toBe(90);
+    expect(getDefaultRestSec("chest")).toBe(90);
+    expect(getDefaultRestSec("biceps")).toBe(60);
+    expect(getDefaultRestSec("cardio")).toBe(30);
   });
 });

--- a/packages/fizruk-domain/src/lib/workoutUi.test.ts
+++ b/packages/fizruk-domain/src/lib/workoutUi.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { Workout } from "../domain/types.js";
+import {
+  formatDurShort,
+  formatRestClock,
+  summarizeWorkoutForFinish,
+} from "./workoutUi.js";
+
+function workout(partial: Partial<Workout> = {}): Workout {
+  return {
+    id: "w1",
+    startedAt: "2026-01-05T10:00:00.000Z",
+    endedAt: "2026-01-05T10:10:30.000Z",
+    items: [],
+    groups: [],
+    warmup: null,
+    cooldown: null,
+    note: "",
+    ...partial,
+  };
+}
+
+describe("fizruk-domain/workoutUi", () => {
+  it("returns null for missing or invalid workout timestamps", () => {
+    expect(summarizeWorkoutForFinish(null)).toBeNull();
+    expect(summarizeWorkoutForFinish(undefined)).toBeNull();
+    expect(summarizeWorkoutForFinish({})).toBeNull();
+    expect(
+      summarizeWorkoutForFinish(workout({ startedAt: "not-a-date" })),
+    ).toBeNull();
+    expect(
+      summarizeWorkoutForFinish(
+        workout({
+          endedAt: "not-a-date",
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("summarizes duration, item count, and strength tonnage", () => {
+    expect(
+      summarizeWorkoutForFinish(
+        workout({
+          items: [
+            {
+              id: "bench",
+              exerciseId: "bench",
+              nameUk: "Bench",
+              primaryGroup: "chest",
+              musclesPrimary: [],
+              musclesSecondary: [],
+              type: "strength",
+              sets: [
+                { weightKg: 100, reps: 5 },
+                { weightKg: 80, reps: 8 },
+                { weightKg: Number.NaN, reps: 10 },
+              ],
+            },
+            {
+              id: "run",
+              exerciseId: "run",
+              nameUk: "Run",
+              primaryGroup: "cardio",
+              musclesPrimary: [],
+              musclesSecondary: [],
+              type: "distance",
+              distanceM: 1000,
+            },
+          ],
+        }),
+      ),
+    ).toEqual({
+      durationSec: 630,
+      items: 2,
+      tonnageKg: 1140,
+    });
+  });
+
+  it("uses Date.now for active workouts and clamps negative durations", () => {
+    vi.spyOn(Date, "now").mockReturnValue(
+      Date.parse("2026-01-05T10:05:00.000Z"),
+    );
+
+    expect(summarizeWorkoutForFinish(workout({ endedAt: null }))).toMatchObject(
+      {
+        durationSec: 300,
+      },
+    );
+    expect(
+      summarizeWorkoutForFinish(
+        workout({
+          startedAt: "2026-01-05T10:10:00.000Z",
+          endedAt: "2026-01-05T10:00:00.000Z",
+        }),
+      ),
+    ).toMatchObject({
+      durationSec: 0,
+    });
+
+    vi.restoreAllMocks();
+  });
+
+  it("formats compact durations and rest clocks", () => {
+    expect(formatDurShort(45).startsWith("45 ")).toBe(true);
+    expect(formatDurShort(125).startsWith("2 ")).toBe(true);
+    expect(formatRestClock(5)).toBe("00:05");
+    expect(formatRestClock(125)).toBe("02:05");
+  });
+});

--- a/packages/routine-domain/src/calendarEvents.test.ts
+++ b/packages/routine-domain/src/calendarEvents.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  FINYK_SUB_GROUP_LABEL,
+  FIZRUK_GROUP_LABEL,
+  buildFinykSubscriptionEvents,
+  buildHubCalendarEvents,
+  countEventsByDate,
+} from "./calendarEvents.js";
+import { completionNoteKey } from "./completionNoteKey.js";
+import type { Habit, HubCalendarEvent, RoutineState } from "./types.js";
+
+function habit(partial: Partial<Habit>): Habit {
+  return {
+    id: "habit-1",
+    name: "Read",
+    emoji: "R",
+    archived: false,
+    recurrence: "daily",
+    startDate: "2026-01-01",
+    endDate: null,
+    weekdays: [0, 1, 2, 3, 4, 5, 6],
+    ...partial,
+  };
+}
+
+function state(partial: Partial<RoutineState> = {}): RoutineState {
+  return {
+    schemaVersion: 3,
+    prefs: {
+      showFizrukInCalendar: true,
+      showFinykSubscriptionsInCalendar: true,
+      routineRemindersEnabled: false,
+    },
+    tags: [],
+    categories: [],
+    habits: [],
+    completions: {},
+    pushupsByDate: {},
+    habitOrder: [],
+    completionNotes: {},
+    ...partial,
+  };
+}
+
+function finykEvent(id: string, date: string): HubCalendarEvent {
+  return {
+    id,
+    source: "finyk_subscription",
+    date,
+    title: id,
+    subtitle: "",
+    tagLabels: [FINYK_SUB_GROUP_LABEL],
+    sortKey: `${date} 0b ${id}`,
+    finykSub: true,
+    sourceKind: "finyk_sub",
+  };
+}
+
+describe("routine-domain/calendarEvents", () => {
+  it("builds sorted habit and Fizruk events with tags, completion, and notes", () => {
+    const noteKey = completionNoteKey("habit-1", "2026-01-05");
+    const events = buildHubCalendarEvents(
+      state({
+        tags: [
+          { id: "energy", name: "Energy" },
+          { id: "missing", name: "Unused" },
+        ],
+        categories: [{ id: "mind", name: "Mind" }],
+        habits: [
+          habit({
+            id: "archived",
+            archived: true,
+            name: "Archived",
+          }),
+          habit({
+            categoryId: "mind",
+            tagIds: ["energy", "unknown"],
+            timeOfDay: "08:30",
+          }),
+        ],
+        completions: { "habit-1": ["2026-01-05"] },
+        completionNotes: { [noteKey]: "Felt focused" },
+        habitOrder: ["habit-1"],
+      }),
+      { startKey: "2026-01-05", endKey: "2026-01-05" },
+      {},
+      {
+        fizrukPlanDays: { "2026-01-05": { templateId: "tpl-1" } },
+        fizrukTemplateNames: new Map([["tpl-1", "Upper body"]]),
+      },
+    );
+
+    expect(events.map((event) => event.sourceKind)).toEqual([
+      "fizruk",
+      "habit",
+    ]);
+    expect(events[0]).toMatchObject({
+      id: "fizruk_2026-01-05_tpl-1",
+      title: "Upper body",
+      tagLabels: [FIZRUK_GROUP_LABEL],
+    });
+    expect(events[1]).toMatchObject({
+      id: "habit_habit-1_2026-01-05",
+      completed: true,
+      habitId: "habit-1",
+      note: "Felt focused",
+      tagLabels: ["Energy", "Mind"],
+      timeOfDay: "08:30",
+    });
+    expect(events.some((event) => event.id.includes("archived"))).toBe(false);
+  });
+
+  it("uses fallback labels and respects Fizruk/Finyk visibility switches", () => {
+    const injectedFinyk = finykEvent("sub-1", "2026-01-05");
+    const baseState = state({
+      habits: [habit({ tagIds: ["missing"], categoryId: "missing" })],
+    });
+
+    const visible = buildHubCalendarEvents(
+      baseState,
+      { startKey: "2026-01-05", endKey: "2026-01-05" },
+      { showFizruk: false },
+      {
+        fizrukPlanDays: { "2026-01-05": { templateId: "tpl-1" } },
+        finykSubscriptionEvents: [injectedFinyk],
+      },
+    );
+    expect(visible.map((event) => event.sourceKind)).toEqual([
+      "finyk_sub",
+      "habit",
+    ]);
+    expect(visible[1]?.tagLabels).toHaveLength(1);
+
+    const hidden = buildHubCalendarEvents(
+      {
+        ...baseState,
+        prefs: { ...baseState.prefs, showFinykSubscriptionsInCalendar: false },
+      },
+      { startKey: "2026-01-05", endKey: "2026-01-05" },
+      { showFinykSubs: true },
+      { finykSubscriptionEvents: [injectedFinyk] },
+    );
+    expect(hidden.map((event) => event.sourceKind)).toEqual(["habit"]);
+  });
+
+  it("counts events per date", () => {
+    const events = [
+      finykEvent("a", "2026-01-05"),
+      finykEvent("b", "2026-01-05"),
+      finykEvent("c", "2026-01-06"),
+    ];
+
+    expect([...countEventsByDate(events).entries()]).toEqual([
+      ["2026-01-05", 2],
+      ["2026-01-06", 1],
+    ]);
+  });
+
+  it("builds Finyk subscription events and clamps billing days to month end", () => {
+    const seen: string[] = [];
+    const events = buildFinykSubscriptionEvents(
+      { startKey: "2026-02-01", endKey: "2026-03-31" },
+      [
+        { id: "ok", name: "Music", emoji: "M", billingDay: 31 },
+        { id: "bad-low", billingDay: 0 },
+        { id: "bad-high", billingDay: 32 },
+        { id: "bad-text", billingDay: "nope" },
+      ],
+      (sub) => {
+        seen.push(sub.id);
+        return { amount: sub.id === "ok" ? 129.5 : null, currency: "UAH" };
+      },
+    );
+
+    expect(seen).toEqual(["ok"]);
+    expect(events.map((event) => event.date)).toEqual([
+      "2026-02-28",
+      "2026-03-31",
+    ]);
+    expect(events[0]).toMatchObject({
+      id: "finyk_sub_ok_2026-02-28",
+      title: "M Music",
+      tagLabels: [FINYK_SUB_GROUP_LABEL],
+      finykSub: true,
+      sourceKind: "finyk_sub",
+    });
+    expect(events[0]?.subtitle).toContain("129,5 UAH");
+  });
+});

--- a/packages/routine-domain/src/reminders.test.ts
+++ b/packages/routine-domain/src/reminders.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ROUTINE_NOTIFY_PREFIX,
+  buildReminderSchedule,
+  habitShouldNotifyNow,
+  isStaleNotifyKey,
+  reminderDueNow,
+  reminderNotifyKey,
+} from "./reminders.js";
+import type { Habit, RoutineState } from "./types.js";
+
+function habit(partial: Partial<Habit>): Habit {
+  return {
+    id: "habit-1",
+    name: "Stretch",
+    emoji: "S",
+    archived: false,
+    recurrence: "daily",
+    startDate: "2026-01-01",
+    endDate: null,
+    weekdays: [0, 1, 2, 3, 4, 5, 6],
+    ...partial,
+  };
+}
+
+function state(partial: Partial<RoutineState> = {}): RoutineState {
+  return {
+    schemaVersion: 3,
+    prefs: {
+      showFizrukInCalendar: true,
+      showFinykSubscriptionsInCalendar: true,
+      routineRemindersEnabled: true,
+    },
+    tags: [],
+    categories: [],
+    habits: [],
+    completions: {},
+    pushupsByDate: {},
+    habitOrder: [],
+    completionNotes: {},
+    ...partial,
+  };
+}
+
+describe("routine-domain/reminders", () => {
+  it("returns no descriptors when reminders are disabled", () => {
+    expect(
+      buildReminderSchedule(
+        state({
+          prefs: { routineRemindersEnabled: false },
+          habits: [habit({ reminderTimes: ["10:00"] })],
+        }),
+        { now: new Date(2026, 0, 5, 9, 0, 0, 0) },
+      ),
+    ).toEqual([]);
+  });
+
+  it("builds future reminders, skips past/completed/archived habits, and sorts by fire time", () => {
+    const reminders = buildReminderSchedule(
+      state({
+        habits: [
+          habit({
+            id: "daily",
+            name: "Daily",
+            reminderTimes: ["08:00", "12:00", "bad"],
+          }),
+          habit({
+            id: "legacy",
+            name: "Legacy",
+            reminderTimes: [],
+            timeOfDay: "09:30",
+          }),
+          habit({
+            id: "done",
+            name: "Done",
+            reminderTimes: ["13:00"],
+          }),
+          habit({
+            id: "archived",
+            archived: true,
+            reminderTimes: ["14:00"],
+          }),
+        ],
+        completions: { done: ["2026-01-05"] },
+      }),
+      { now: new Date(2026, 0, 5, 9, 0, 0, 0), daysAhead: 2 },
+    );
+
+    expect(
+      reminders.map((reminder) => [
+        reminder.habitId,
+        reminder.dateKey,
+        reminder.time,
+      ]),
+    ).toEqual([
+      ["legacy", "2026-01-05", "09:30"],
+      ["daily", "2026-01-05", "12:00"],
+      ["daily", "2026-01-06", "08:00"],
+      ["legacy", "2026-01-06", "09:30"],
+      ["daily", "2026-01-06", "12:00"],
+      ["done", "2026-01-06", "13:00"],
+    ]);
+    expect(
+      reminders.find(
+        (reminder) =>
+          reminder.habitId === "daily" &&
+          reminder.dateKey === "2026-01-05" &&
+          reminder.time === "12:00",
+      ),
+    ).toMatchObject({
+      title: "S Daily",
+      notifyKey: reminderNotifyKey("daily", "12:00", "2026-01-05"),
+    });
+  });
+
+  it("can include already-completed habits when requested", () => {
+    const reminders = buildReminderSchedule(
+      state({
+        habits: [habit({ id: "done", reminderTimes: ["13:00"] })],
+        completions: { done: ["2026-01-05"] },
+      }),
+      {
+        now: new Date(2026, 0, 5, 9, 0, 0, 0),
+        includeAlreadyCompleted: true,
+      },
+    );
+
+    expect(reminders).toHaveLength(1);
+    expect(reminders[0]?.habitId).toBe("done");
+  });
+
+  it("respects weekly schedules and keeps daysAhead at one day minimum", () => {
+    const reminders = buildReminderSchedule(
+      state({
+        habits: [
+          habit({
+            id: "weekly",
+            recurrence: "weekly",
+            weekdays: [1],
+            reminderTimes: ["10:00"],
+          }),
+        ],
+      }),
+      { now: new Date(2026, 0, 5, 9, 0, 0, 0), daysAhead: 0 },
+    );
+
+    expect(reminders).toEqual([]);
+  });
+
+  it("builds stable notification keys", () => {
+    expect(reminderNotifyKey("h1", "08:00", "2026-01-05")).toBe(
+      `${ROUTINE_NOTIFY_PREFIX}h1_08:00_2026-01-05`,
+    );
+  });
+
+  it("detects stale notification keys by date suffix only for routine keys", () => {
+    const now = new Date(2026, 1, 20, 12, 0, 0, 0);
+
+    expect(
+      isStaleNotifyKey(reminderNotifyKey("h1", "08:00", "2026-01-01"), now, 30),
+    ).toBe(true);
+    expect(
+      isStaleNotifyKey(reminderNotifyKey("h1", "08:00", "2026-02-01"), now, 30),
+    ).toBe(false);
+    expect(isStaleNotifyKey("other_2026-01-01", now, 30)).toBe(false);
+    expect(isStaleNotifyKey(`${ROUTINE_NOTIFY_PREFIX}bad`, now, 30)).toBe(
+      false,
+    );
+  });
+
+  it("matches exact HH:MM reminder due time", () => {
+    const now = new Date(2026, 0, 5, 8, 7, 30, 0);
+
+    expect(reminderDueNow("08:07", now)).toBe(true);
+    expect(reminderDueNow("08:08", now)).toBe(false);
+  });
+
+  it("decides whether a habit should notify now", () => {
+    const now = new Date(2026, 0, 5, 10, 0, 0, 0);
+    const active = habit({ reminderTimes: ["10:00"] });
+
+    expect(habitShouldNotifyNow(active, [], now)).toEqual({
+      should: true,
+      dateKey: "2026-01-05",
+      time: "10:00",
+    });
+    expect(habitShouldNotifyNow(active, ["2026-01-05"], now)).toBeNull();
+    expect(
+      habitShouldNotifyNow(
+        habit({ archived: true, reminderTimes: ["10:00"] }),
+        [],
+        now,
+      ),
+    ).toBeNull();
+    expect(
+      habitShouldNotifyNow(
+        habit({
+          recurrence: "weekly",
+          weekdays: [1],
+          reminderTimes: ["10:00"],
+        }),
+        [],
+        now,
+      ),
+    ).toBeNull();
+    expect(
+      habitShouldNotifyNow(habit({ reminderTimes: [] }), [], now),
+    ).toBeNull();
+    expect(
+      habitShouldNotifyNow(habit({ reminderTimes: ["11:00"] }), [], now),
+    ).toBeNull();
+  });
+});

--- a/packages/routine-domain/src/storage.test.ts
+++ b/packages/routine-domain/src/storage.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  ROUTINE_SCHEMA_VERSION,
+  defaultRoutineState,
+  ensureHabitOrder,
+  normalizeCompletionList,
+  normalizeCompletionsMap,
+  normalizeHabit,
+  normalizeReminderTimesStorage,
+  normalizeRoutineState,
+  parseRoutineState,
+  routineUid,
+  serializeRoutineState,
+} from "./storage.js";
+import type { Habit, RoutineState } from "./types.js";
+
+function habit(partial: Partial<Habit>): Habit {
+  return {
+    id: "h1",
+    name: "Habit",
+    archived: false,
+    recurrence: "daily",
+    startDate: "2026-01-01",
+    endDate: null,
+    ...partial,
+  };
+}
+
+function state(partial: Partial<RoutineState> = {}): RoutineState {
+  return {
+    ...defaultRoutineState(),
+    ...partial,
+  };
+}
+
+describe("routine-domain/storage", () => {
+  it("generates stable-shape ids with the requested prefix", () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    vi.spyOn(Math, "random").mockReturnValue(0.123456789);
+
+    expect(routineUid("habit")).toBe("habit_loyw3v28_4fzzzxj");
+
+    vi.restoreAllMocks();
+  });
+
+  it("normalizes reminder times and completion maps", () => {
+    expect(
+      normalizeReminderTimesStorage(["08:00", "bad", 12, "20:30"]),
+    ).toEqual(["08:00", "20:30"]);
+    expect(normalizeReminderTimesStorage("08:00")).toEqual([]);
+    expect(
+      normalizeCompletionList([
+        "2026-01-02",
+        "nope",
+        "2026-01-01",
+        "2026-01-02",
+      ]),
+    ).toEqual(["2026-01-01", "2026-01-02"]);
+    expect(normalizeCompletionList("2026-01-01")).toEqual([]);
+    expect(
+      normalizeCompletionsMap({
+        h1: ["2026-01-02", "2026-01-01"],
+        h2: "bad",
+      }),
+    ).toEqual({ h1: ["2026-01-01", "2026-01-02"], h2: [] });
+    expect(normalizeCompletionsMap(null)).toEqual({});
+    expect(normalizeCompletionsMap([])).toEqual({});
+  });
+
+  it("normalizes habit defaults from createdAt and invalid optional arrays", () => {
+    expect(
+      normalizeHabit({
+        id: "h1",
+        name: "Habit",
+        createdAt: "2026-02-03T10:00:00.000Z",
+        reminderTimes: ["08:00", "bad"],
+        weekdays: [],
+      }),
+    ).toMatchObject({
+      recurrence: "daily",
+      startDate: "2026-02-03",
+      endDate: null,
+      timeOfDay: "",
+      reminderTimes: ["08:00"],
+      weekdays: [0, 1, 2, 3, 4, 5, 6],
+    });
+
+    expect(
+      normalizeHabit({
+        id: "h2",
+        name: "Timed",
+        startDate: "2026-01-05",
+        endDate: "2026-01-10",
+        timeOfDay: 930,
+        weekdays: [0, 2],
+      }),
+    ).toMatchObject({
+      startDate: "2026-01-05",
+      endDate: "2026-01-10",
+      timeOfDay: "930",
+      weekdays: [0, 2],
+    });
+  });
+
+  it("returns fresh default state objects", () => {
+    const a = defaultRoutineState();
+    const b = defaultRoutineState();
+
+    a.habits.push(habit({ id: "mutated" }));
+
+    expect(b.habits).toEqual([]);
+    expect(b.schemaVersion).toBe(ROUTINE_SCHEMA_VERSION);
+  });
+
+  it("ensures habitOrder references active habits exactly once", () => {
+    const input = state({
+      habits: [
+        habit({ id: "b" }),
+        habit({ id: "a" }),
+        habit({ id: "archived", archived: true }),
+      ],
+      habitOrder: ["missing", "a", "archived"],
+    });
+
+    const result = ensureHabitOrder(input);
+
+    expect(result.changed).toBe(true);
+    expect(result.state.habitOrder).toEqual(["a", "b"]);
+
+    const stable = ensureHabitOrder(
+      state({ habits: [habit({ id: "a" })], habitOrder: ["a"] }),
+    );
+    expect(stable.changed).toBe(false);
+    expect(stable.state.habitOrder).toEqual(["a"]);
+  });
+
+  it("normalizes routine state with defensive defaults", () => {
+    const normalized = normalizeRoutineState({
+      prefs: { routineRemindersEnabled: true },
+      tags: "bad",
+      categories: [{ id: "cat", name: "Category" }],
+      habits: [
+        {
+          id: "h1",
+          name: "Habit",
+          createdAt: "2026-01-05T00:00:00.000Z",
+          reminderTimes: ["08:00"],
+        },
+      ],
+      completions: { h1: ["2026-01-06", "bad"] },
+      pushupsByDate: null,
+      habitOrder: "bad",
+      completionNotes: { "h1__2026-01-06": "Good" },
+    });
+
+    expect(normalized.prefs).toMatchObject({
+      showFizrukInCalendar: true,
+      showFinykSubscriptionsInCalendar: true,
+      routineRemindersEnabled: true,
+    });
+    expect(normalized.tags).toEqual([]);
+    expect(normalized.categories).toEqual([{ id: "cat", name: "Category" }]);
+    expect(normalized.habits[0]).toMatchObject({
+      id: "h1",
+      startDate: "2026-01-05",
+      reminderTimes: ["08:00"],
+    });
+    expect(normalized.completions).toEqual({ h1: ["2026-01-06"] });
+    expect(normalized.pushupsByDate).toEqual({});
+    expect(normalized.habitOrder).toEqual([]);
+    expect(normalized.completionNotes).toEqual({ "h1__2026-01-06": "Good" });
+  });
+
+  it("parses and serializes routine state safely", () => {
+    const parsed = parseRoutineState(
+      JSON.stringify({
+        prefs: { routineRemindersEnabled: true },
+        habits: [{ id: "h1", name: "Habit", startDate: "2026-01-01" }],
+      }),
+    );
+
+    expect(parsed.prefs.routineRemindersEnabled).toBe(true);
+    expect(parsed.habits[0]?.startDate).toBe("2026-01-01");
+    expect(parseRoutineState(null)).toEqual(defaultRoutineState());
+    expect(parseRoutineState(undefined)).toEqual(defaultRoutineState());
+    expect(parseRoutineState("{")).toEqual(defaultRoutineState());
+    expect(parseRoutineState("[]")).toEqual(defaultRoutineState());
+    expect(serializeRoutineState(parsed)).toBe(JSON.stringify(parsed));
+  });
+});

--- a/packages/routine-domain/src/streaks.test.ts
+++ b/packages/routine-domain/src/streaks.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   completionRateForRange,
+  habitCompletionRate,
+  maxActiveStreak,
   maxStreakAllTime,
   streakForHabit,
 } from "./streaks.js";
@@ -33,6 +35,22 @@ describe("routine-domain/streaks", () => {
     expect(streakForHabit(h, undefined, "2026-01-10")).toBe(0);
   });
 
+  it("streakForHabit skips unscheduled days when counting backwards", () => {
+    const h: Habit = {
+      ...dailyHabit("weekly"),
+      recurrence: "weekly",
+      weekdays: [0, 2, 4],
+    };
+
+    expect(
+      streakForHabit(
+        h,
+        ["2026-01-05", "2026-01-07", "2026-01-09"],
+        "2026-01-09",
+      ),
+    ).toBe(3);
+  });
+
   it("maxStreakAllTime finds best streak", () => {
     const h = dailyHabit("h");
     const completions = [
@@ -43,6 +61,10 @@ describe("routine-domain/streaks", () => {
       "2026-01-06",
     ];
     expect(maxStreakAllTime(h, completions)).toBe(3);
+  });
+
+  it("maxStreakAllTime returns 0 for empty completion history", () => {
+    expect(maxStreakAllTime(dailyHabit("h"), undefined)).toBe(0);
   });
 
   it("maxStreakAllTime keeps historical completions after schedule narrowing", () => {
@@ -111,5 +133,40 @@ describe("routine-domain/streaks", () => {
     expect(r.scheduled).toBe(0);
     expect(r.completed).toBe(0);
     expect(r.rate).toBe(0);
+  });
+
+  it("maxActiveStreak ignores archived habits", () => {
+    const active = dailyHabit("active");
+    const archived = { ...dailyHabit("archived"), archived: true };
+
+    expect(
+      maxActiveStreak(
+        [active, archived],
+        {
+          active: ["2026-01-09", "2026-01-10"],
+          archived: ["2026-01-08", "2026-01-09", "2026-01-10"],
+        },
+        "2026-01-10",
+      ),
+    ).toBe(2);
+  });
+
+  it("habitCompletionRate calculates a rolling range ending today", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 0, 10, 9, 0, 0, 0));
+
+    const r = habitCompletionRate(
+      dailyHabit("h"),
+      ["2026-01-08", "2026-01-10"],
+      3,
+    );
+
+    expect(r).toEqual({
+      scheduled: 3,
+      completed: 2,
+      rate: 2 / 3,
+    });
+
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
﻿## Summary

- Raised `@sergeant/routine-domain` pure-helper coverage with focused tests for calendar events, reminders, storage normalization, and streak/rate helpers.
- Raised `@sergeant/fizruk-domain` coverage for pure workout helpers, rest settings, and the legacy training-program shim.
- Reconciled the root ESLint flat-config composition so lint-staged can import the config after the PR-31 split/rebase state.

## Governing Skill

- Primary skill: `sergeant-tech-debt`
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a
- Why this playbook: This is a focused test-coverage lift plus a lint-config unblocker; no migration/deploy playbook matched.
- If no playbook matched, why: No runtime behavior, schema, deployment, or user workflow changed.

## Verification

```bash
pnpm --filter @sergeant/routine-domain test
pnpm --filter @sergeant/routine-domain typecheck
pnpm --filter @sergeant/routine-domain test:coverage
pnpm --filter @sergeant/fizruk-domain test
pnpm --filter @sergeant/fizruk-domain typecheck
pnpm --filter @sergeant/fizruk-domain test:coverage
pnpm exec eslint --max-warnings=0 --no-warn-ignored packages/routine-domain/src/calendarEvents.test.ts packages/routine-domain/src/reminders.test.ts packages/routine-domain/src/storage.test.ts packages/routine-domain/src/streaks.test.ts packages/fizruk-domain/src/lib/restSettings.test.ts packages/fizruk-domain/src/lib/workoutUi.test.ts packages/fizruk-domain/src/lib/trainingPrograms.test.ts
```

Additional checks:

- [ ] Local smoke / manual validation completed
- [x] Surface-specific checks completed

Coverage deltas observed locally:

- `@sergeant/routine-domain`: statements `73.96% -> 97.37%`, lines `74.80% -> 98.77%`
- `@sergeant/fizruk-domain`: statements `90.24% -> 92.93%`, lines `94.12% -> 96.61%`

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a; tests/config only, no docs contract changed.

## Risk and Rollout

- User-visible risk: Low. Runtime code is unchanged except ESLint config composition; package changes are tests only.
- Rollout / deploy order: Normal CI/merge flow.
- Backout plan: Revert the three commits in this PR.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

The ESLint config fix is included because pre-commit and targeted ESLint could not import the root config after rebasing onto the latest `origin/main`; the patch removes duplicated allowlist declarations and restores the surface block imports used by the root composition.

Local pre-commit ran for all commits. The local gitleaks hook reported `gitleaks is not installed` and skipped; CI still runs the repository secret scan.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raised pure-helper test coverage in `@sergeant/routine-domain` and `@sergeant/fizruk-domain`, and fixed the root ESLint flat-config so `lint-staged` and targeted `eslint` runs can import it. No runtime behavior changed.

- **Bug Fixes**
  - Reconciled `eslint.config.js` composition by importing shared blocks and removing duplicated allowlists, restoring config loading for pre-commit and CLI runs.

<sup>Written for commit 0b25e808ee1d366c4d0d964f1b47d9cf34ef35ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

