### PR TITLE
feat(web): RootLayout + Outlet — fix initiative 0006 location-context bug (Phase 5)

### DIFF
--- a/apps/web/src/core/app/HubPage.tsx
+++ b/apps/web/src/core/app/HubPage.tsx
@@ -1,0 +1,102 @@
+import { useCallback } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useBrowserLocation } from "../hooks/useBrowserLocation";
+import { shouldShowOnboarding } from "../onboarding/onboardingGate";
+import { useHubShell } from "./HubShellContext";
+import { renderStandaloneRoute } from "./StandaloneRoutes";
+import { HubHomeView } from "./HubHomeView";
+import { RedirectTo } from "./RedirectTo";
+import { SIGN_IN_PATH, WELCOME_PATH } from "./appPaths";
+
+/**
+ * Hub page — catch-all child route for hub home + standalone routes.
+ *
+ * Initiative 0006 Phase 5: with the `RootLayout + Outlet` pattern,
+ * per-module routes (`/finyk/*`, `/fizruk/*`, etc.) are separate
+ * children of RootLayout. This component handles everything else:
+ *
+ *  1. Legacy `?module=X` redirect → `/${X}` (path-based URL)
+ *  2. Standalone routes (sign-in, welcome, pricing, legal, etc.)
+ *  3. Onboarding redirect (first-time visitors → `/welcome`)
+ *  4. Hub home (dashboard)
+ */
+export function HubPage() {
+  const location = useLocation();
+  const browserLocation = useBrowserLocation(location);
+  const navigate = useNavigate();
+  const searchParams = new URLSearchParams(browserLocation.search);
+
+  const shell = useHubShell();
+
+  const openAuth = useCallback(
+    () => navigate(SIGN_IN_PATH),
+    [navigate],
+  );
+
+  // «Поки що пропустити» на /sign-in (same logic as legacy AppInner):
+  const leaveAuth = useCallback(() => {
+    if (shouldShowOnboarding()) {
+      navigate(WELCOME_PATH, { replace: true });
+      return;
+    }
+    if (location.key !== "default") {
+      navigate(-1);
+      return;
+    }
+    navigate("/", { replace: true });
+  }, [navigate, location.key]);
+
+  const leaveWelcome = useCallback(() => {
+    navigate("/", { replace: true });
+  }, [navigate]);
+
+  const onAssistantClose = useCallback(() => {
+    navigate("/");
+  }, [navigate]);
+
+  // 1. Legacy `?module=X` → path-based redirect.
+  //    Preserves hash so module-level compat shims can handle it.
+  if (shell.activeModule && searchParams.has("module")) {
+    const hash = browserLocation.hash;
+    return <RedirectTo to={`/${shell.activeModule}${hash}`} />;
+  }
+
+  // 2. Standalone routes (sign-in, welcome, pricing, legal, etc.)
+  const standalone = renderStandaloneRoute({
+    pathname: browserLocation.pathname,
+    user: shell.user,
+    authLoading: shell.authLoading,
+    onLeaveAuth: leaveAuth,
+    onLeaveWelcome: leaveWelcome,
+    onOpenAuth: openAuth,
+    onAssistantClose,
+  });
+  if (standalone) {
+    return <>{standalone}</>;
+  }
+
+  // 3. First-time visitors → /welcome
+  if (!shell.activeModule && shouldShowOnboarding()) {
+    return <RedirectTo to={WELCOME_PATH} />;
+  }
+
+  // 4. Hub home (dashboard)
+  return (
+    <HubHomeView
+      ui={shell.ui}
+      user={shell.user}
+      authLoading={shell.authLoading}
+      onOpenAuth={openAuth}
+      canInstall={shell.canInstall}
+      onInstall={shell.onInstall}
+      onDismissInstall={shell.onDismissInstall}
+      iosVisible={shell.iosVisible}
+      onDismissIos={shell.onDismissIos}
+      updateAvailable={shell.updateAvailable}
+      onApplyUpdate={shell.onApplyUpdate}
+      openModule={shell.openModule}
+      shortcutsOpen={shell.shortcutsOpen}
+      onCloseShortcuts={shell.onCloseShortcuts}
+    />
+  );
+}

--- a/apps/web/src/core/app/HubShellContext.tsx
+++ b/apps/web/src/core/app/HubShellContext.tsx
@@ -1,0 +1,98 @@
+import { createContext, useContext, type ReactNode } from "react";
+import type { HubNavigation, HubModuleId } from "../hooks/useHubNavigation";
+import type { HubUIState } from "../hooks/useHubUIState";
+import type { PwaAction } from "../hooks/usePwaActions";
+import type { useAuth } from "../auth/AuthContext";
+
+type AuthUser = ReturnType<typeof useAuth>["user"];
+
+/**
+ * Shared hub-shell state consumed by child route components.
+ *
+ * Initiative 0006 Phase 5 — the `RootLayout + Outlet` pattern requires
+ * all shared hooks (`useHubNavigation`, `useHubUIState`, `usePwaActions`,
+ * keyboard shortcuts, etc.) to live in the parent route (`RootLayout`)
+ * so they run once regardless of which child route is active. Child
+ * routes (hub page, per-module routes) read the values from this
+ * context instead of calling the hooks independently.
+ *
+ * The context is `null` outside the router tree (tests, Storybook).
+ * The `useHubShell()` hook throws if the context is missing — call
+ * sites that may run outside the router should use
+ * `useOptionalHubShell()` instead.
+ */
+export interface HubShellValue {
+  // Navigation (from useHubNavigation)
+  activeModule: HubModuleId | null;
+  openModule: HubNavigation["openModule"];
+  goToHub: HubNavigation["goToHub"];
+  goToModuleSettings: HubNavigation["goToModuleSettings"];
+  moduleAnimClass: HubNavigation["moduleAnimClass"];
+
+  // UI state (from useHubUIState)
+  ui: HubUIState;
+
+  // PWA actions (from usePwaActions)
+  pwaAction: PwaAction | null;
+  clearPwaAction: () => void;
+
+  // Auth (from useAuth — subset needed by child routes)
+  user: AuthUser;
+  authLoading: boolean;
+
+  // Modals (from useKeyboardShortcutsModal)
+  shortcutsOpen: boolean;
+  onCloseShortcuts: () => void;
+
+  // PWA install (from usePwaInstall + useIosInstallBanner)
+  canInstall: boolean;
+  onInstall: () => Promise<void>;
+  onDismissInstall: () => void;
+  iosVisible: boolean;
+  onDismissIos: () => void;
+
+  // SW update (from useSWUpdate)
+  updateAvailable: boolean;
+  onApplyUpdate: () => void;
+
+  // Chat overlay (from useHubChatOverlay)
+  openAssistantChat: () => void;
+
+  // Auth helpers
+  onOpenAuth: () => void;
+}
+
+const HubShellContext = createContext<HubShellValue | null>(null);
+
+/**
+ * Read hub-shell state. Throws if called outside `<RootLayout />`.
+ */
+export function useHubShell(): HubShellValue {
+  const ctx = useContext(HubShellContext);
+  if (!ctx) {
+    throw new Error("useHubShell must be used inside <RootLayout />");
+  }
+  return ctx;
+}
+
+/**
+ * Read hub-shell state or `null` if outside the router tree.
+ * Safe for tests and Storybook.
+ */
+export function useOptionalHubShell(): HubShellValue | null {
+  return useContext(HubShellContext);
+}
+
+export function HubShellProvider({
+  value,
+  children,
+}: {
+  value: HubShellValue;
+  children: ReactNode;
+}) {
+  return (
+    <HubShellContext.Provider value={value}>
+      {children}
+    </HubShellContext.Provider>
+  );
+}

--- a/apps/web/src/core/app/ModuleShell.tsx
+++ b/apps/web/src/core/app/ModuleShell.tsx
@@ -1,0 +1,82 @@
+import { Suspense, type ReactNode } from "react";
+import { cn } from "@shared/lib/ui/cn";
+import { SkipLink } from "@shared/components/ui/SkipLink";
+import { lazyImport } from "../../core/lib/lazyImport";
+import { ActiveWorkoutBanner } from "../../core/app/ActiveWorkoutBanner";
+import { HubModals } from "../../core/app/HubModals";
+import { OfflineBanner } from "../../core/app/OfflineBanner";
+import ModuleErrorBoundary from "../../core/ModuleErrorBoundary";
+import { useModuleRouteLoader } from "../../core/lib/useModuleRouteLoader";
+import { useHubShell } from "../../core/app/HubShellContext";
+import type { HubModuleId } from "../../core/hooks/useHubNavigation";
+
+// Lazy shortcuts modal — same rationale as ActiveModuleView (initiative 0017).
+const KeyboardShortcutsModalLazy = lazyImport(
+  () => import("@shared/components/ui/KeyboardShortcutsModalUI"),
+  "KeyboardShortcutsModal",
+);
+
+/**
+ * Shared module UI shell — rendered by per-module route entries.
+ *
+ * Initiative 0006 Phase 5: each module is now a separate router child
+ * with its own component, fixing the React Router 7 location-context
+ * bug. The shared UI (skip-link, offline banner, workout CTA, modals)
+ * lives here so it's not duplicated across module route files.
+ *
+ * Replaces the per-module rendering path in `ActiveModuleView`.
+ */
+export function ModuleShell({
+  moduleId,
+  children,
+}: {
+  moduleId: HubModuleId;
+  children: ReactNode;
+}) {
+  const {
+    goToHub,
+    openModule,
+    moduleAnimClass,
+    ui,
+    shortcutsOpen,
+    onCloseShortcuts,
+  } = useHubShell();
+
+  // Route-loader: warm the React Query cache for this module before
+  // the lazy chunk finishes loading (initiative 0006 Phase 5).
+  useModuleRouteLoader(moduleId);
+
+  // Routine renders its own `<main id="routine-main">` internally,
+  // so we use `<div>` here to avoid a double-`<main>` violation.
+  const Tag = moduleId === "routine" ? "div" : "main";
+
+  return (
+    <div className="h-dvh flex flex-col bg-bg text-text overflow-hidden">
+      <SkipLink />
+      <OfflineBanner />
+      {moduleId !== "fizruk" && <ActiveWorkoutBanner />}
+      <Tag
+        id="main"
+        tabIndex={-1}
+        className={cn(moduleAnimClass, "h-full flex flex-col outline-none")}
+      >
+        <ModuleErrorBoundary onBackToHub={goToHub}>
+          {children}
+        </ModuleErrorBoundary>
+      </Tag>
+      <HubModals
+        searchOpen={ui.searchOpen}
+        onCloseSearch={ui.closeSearch}
+        onOpenModule={openModule}
+      />
+      {shortcutsOpen && (
+        <Suspense fallback={null}>
+          <KeyboardShortcutsModalLazy
+            open={shortcutsOpen}
+            onClose={onCloseShortcuts}
+          />
+        </Suspense>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/core/app/RootLayout.tsx
+++ b/apps/web/src/core/app/RootLayout.tsx
@@ -1,0 +1,202 @@
+import { useCallback, useState } from "react";
+import { Outlet, useLocation, useNavigate } from "react-router-dom";
+import { useTheme } from "@shared/hooks/useTheme";
+import { useKeyboardShortcutsModal } from "@shared/components/ui/KeyboardShortcutsModal";
+import { useCommandPaletteHotkey } from "@shared/components/ui/CommandPalette";
+import { useAuth } from "../auth/AuthContext";
+import { useActivationV2Boot } from "../activation";
+import { AppLock } from "../security/AppLock";
+import { useAppLockContext } from "../security/AppLockContext";
+import { setFlag, useFlag } from "../lib/featureFlags";
+import { useDemoCommands } from "./useDemoCommands";
+import { HubChatOverlay } from "../hub/HubChatOverlay";
+import {
+  HubChatOverlayProvider,
+  useHubChatOverlay,
+  useHubChatOverlayState,
+} from "../hub/useHubChatOverlay";
+import { Providers } from "./Providers";
+import { SIGN_IN_PATH } from "./appPaths";
+import { useHubKeyboardShortcuts } from "../hooks/useHubKeyboardShortcuts";
+import { useBrowserLocation } from "../hooks/useBrowserLocation";
+import { useHubNavigation } from "../hooks/useHubNavigation";
+import { useHubUIState } from "../hooks/useHubUIState";
+import { usePwaActions } from "../hooks/usePwaActions";
+import { useAppEffects } from "./useAppEffects";
+import { useIosInstallBanner } from "./useIosInstallBanner";
+import { usePwaInstall } from "./usePwaInstall";
+import { useSWUpdate } from "./useSWUpdate";
+import { useNutritionDualWriteBoot } from "../../modules/nutrition/hooks/useNutritionDualWriteBoot";
+import { useNutritionSqliteReadBoot } from "../../modules/nutrition/hooks/useNutritionSqliteReadBoot";
+import {
+  HubShellProvider,
+  type HubShellValue,
+} from "./HubShellContext";
+
+// Side-effect-only child rendered exclusively for authenticated users.
+function AuthenticatedNutritionBoot() {
+  useNutritionDualWriteBoot();
+  useNutritionSqliteReadBoot();
+  return null;
+}
+
+function NutritionBootGate() {
+  const { user } = useAuth();
+  return user ? <AuthenticatedNutritionBoot /> : null;
+}
+
+/**
+ * App shell wrapper — renders global UI (AppLock, HubChatOverlay,
+ * NutritionBootGate) around the child route content.
+ */
+function AppShell({ children }: { children: React.ReactNode }) {
+  const appLock = useAppLockContext();
+  const chatOverlay = useHubChatOverlayState();
+  return (
+    <HubChatOverlayProvider value={chatOverlay}>
+      <AppLock
+        state={appLock.state}
+        onUnlock={appLock.unlock}
+        onSetupDone={appLock.finishSetup}
+        onSetupCancel={() => {
+          setFlag("app-lock-enabled", false);
+          appLock.finishSetup();
+        }}
+      />
+      <NutritionBootGate />
+      {children}
+      <HubChatOverlay />
+    </HubChatOverlayProvider>
+  );
+}
+
+/**
+ * Root layout route — initiative 0006 Phase 5.
+ *
+ * Mounts the full provider tree + global effects once, then renders
+ * matched child routes via `<Outlet />`. Each child route gets a
+ * **different** component, which fixes the React Router 7 location-
+ * context propagation bug (mixed-shape match objects when multiple
+ * routes resolve to the same `<App />`).
+ *
+ * Shared state (navigation, UI, PWA actions, auth) is provided via
+ * `HubShellContext` so child routes don't need to call these hooks
+ * independently.
+ */
+export function RootLayout() {
+  const location = useLocation();
+  const browserLocation = useBrowserLocation(location);
+  const navigate = useNavigate();
+  const searchParams = new URLSearchParams(browserLocation.search);
+
+  // Navigation FSM — determines activeModule from URL
+  const navigation = useHubNavigation();
+
+  // Hub UI state (search, hub view tab)
+  const ui = useHubUIState();
+
+  // PWA shortcut actions (from URL or localStorage)
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
+  const closeShortcuts = useCallback(() => setShortcutsOpen(false), []);
+  const { pwaAction, setPwaAction, clearPwaAction, validActions } =
+    usePwaActions(searchParams);
+
+  // Global side effects
+  useTheme();
+  useActivationV2Boot();
+
+  // Registers the `?` hotkey for keyboard shortcuts modal (side-effect only).
+  useKeyboardShortcutsModal();
+  const { openChat: openAssistantChat } = useHubChatOverlay();
+  const { canInstall, install, dismiss } = usePwaInstall();
+  const { visible: iosVisible, dismiss: iosDismiss } = useIosInstallBanner();
+  const { updateAvailable, applyUpdate } = useSWUpdate();
+  const { user, isLoading: authLoading } = useAuth();
+
+  // App-level effects (idle prefetch, SW messages, hub bus, etc.)
+  useAppEffects({
+    user,
+    authLoading,
+    ui,
+    openModule: navigation.openModule,
+    navigate,
+    setPwaAction,
+    validActions,
+  });
+
+  // Auth callback
+  const openAuth = useCallback(
+    () => navigate(SIGN_IN_PATH),
+    [navigate],
+  );
+
+  // Keyboard shortcuts (work on all routes — hub + modules)
+  const openSearchFromShortcut = useCallback(() => {
+    if (navigation.activeModule) {
+      navigation.goToHub();
+      requestAnimationFrame(() => ui.setSearchOpen(true));
+      return;
+    }
+    ui.setSearchOpen(true);
+  }, [navigation.activeModule, navigation.goToHub, ui]);
+
+  const handleNavigateChord = useCallback(
+    (
+      target: import("../hooks/useHubKeyboardShortcuts").NavChordTarget,
+    ) => {
+      if (target === "hub") {
+        navigation.goToHub();
+      } else {
+        navigation.openModule(target);
+      }
+    },
+    [navigation.goToHub, navigation.openModule],
+  );
+
+  useHubKeyboardShortcuts({
+    onOpenSearch: openSearchFromShortcut,
+    onOpenShortcuts: () => setShortcutsOpen(true),
+    onOpenAssistant: openAssistantChat,
+    onNavigate: handleNavigateChord,
+  });
+
+  // Command palette (⌘K)
+  const paletteEnabled = useFlag("hub_command_palette");
+  useCommandPaletteHotkey(paletteEnabled);
+  useDemoCommands();
+
+  // Build the context value for child routes
+  const hubShellValue: HubShellValue = {
+    activeModule: navigation.activeModule,
+    openModule: navigation.openModule,
+    goToHub: navigation.goToHub,
+    goToModuleSettings: navigation.goToModuleSettings,
+    moduleAnimClass: navigation.moduleAnimClass,
+    ui,
+    pwaAction,
+    clearPwaAction,
+    user,
+    authLoading,
+    shortcutsOpen,
+    onCloseShortcuts: closeShortcuts,
+    canInstall,
+    onInstall: install,
+    onDismissInstall: dismiss,
+    iosVisible,
+    onDismissIos: iosDismiss,
+    updateAvailable,
+    onApplyUpdate: applyUpdate,
+    openAssistantChat,
+    onOpenAuth: openAuth,
+  };
+
+  return (
+    <Providers>
+      <HubShellProvider value={hubShellValue}>
+        <AppShell>
+          <Outlet />
+        </AppShell>
+      </HubShellProvider>
+    </Providers>
+  );
+}

--- a/apps/web/src/core/app/router.tsx
+++ b/apps/web/src/core/app/router.tsx
@@ -1,80 +1,72 @@
 import { createBrowserRouter } from "react-router-dom";
-import App from "../App";
+import { RootLayout } from "./RootLayout";
 
 /**
  * Root router config for `apps/web` (initiative 0006 — frontend routing).
  *
- * Phase 1 (Phase 1 commit): мігровано з `<BrowserRouter>` на data-router API
- * (`createBrowserRouter` + `<RouterProvider />`). Один catch-all маршрут
- * `path: "*"` матчить кожен path → `<App />` стає mount-ом для всього,
- * як і було при `<BrowserRouter>`. Поточний `App.tsx` містить вбудовану FSM
- * (`useHubNavigation` + `?module=<id>` + hash), яка обробляє legacy URL.
+ * Phase 5: `RootLayout + Outlet` pattern — fixes the React Router 7
+ * location-context propagation bug. Each child route renders a DIFFERENT
+ * component, so React Router properly unmounts/mounts on navigation
+ * and `useLocation()` always returns the current pathname.
  *
- * Phase 2 history (revisited 2026-05-16): попередня версія цього файлу
- * додавала окремі lazy routes для кожного модуля
- * (`/nutrition/*`, `/finyk/*`, `/fizruk/*`, `/routine/*`) перед catch-all-ом.
- * Кожен з них резолвив через `lazy()` до `{Component: App}` — тобто рендерив
- * РІВНО ТОЙ САМИЙ `<App />` компонент, як і catch-all. Це створювало
- * непомітну, але руйнівну патологію у React Router 7-му:
+ * Architecture:
+ *   RootLayout (providers + shared state + global effects + <Outlet />)
+ *    ├── /finyk/*    → FinykRoute   (lazy chunk)
+ *    ├── /fizruk/*   → FizrukRoute  (lazy chunk)
+ *    ├── /nutrition/* → NutritionRoute (lazy chunk)
+ *    ├── /routine/*  → RoutineRoute (lazy chunk)
+ *    └── *           → HubPage      (hub home + standalone routes + 404)
  *
- *   • При in-app `navigate("/sign-in")` з module-pathname (`/fizruk`,
- *     `/finyk/transactions` тощо) router міняв matched route з module-id (2)
- *     на catch-all-id (4). Component той самий → React reconciler reuse-ить
- *     `<App />` instance. Але route-level lazy-resolve у попередньому маршруті
- *     встиг конвертувати `{Component: App}` у внутрішній `element: <App />`
- *     (підтверджено через `router.state.matches[0].route` —
- *     `hasComponent: false, hasLazy: false, hasElement: true`). Через цей
- *     mixed-shape match-обʼєкт **`location`-context оновлюється у data-router-і,
- *     але не propagate-иться у дереві під element-only routes** — `useLocation()`
- *     у будь-якого consumer-а (`StandaloneRoutes`, `useHubNavigation`,
- *     `useFizrukRoute`, `useFinykRoute`, `HubBottomNav` через `onChange`)
- *     повертає stale pathname. URL у адресній стрічці змінюється, контент
- *     залишається старим. Сторінки модулів і `/sign-in` тоді «не відкриваються».
+ * Module routes are matched first (React Router 7 trie resolver gives
+ * priority to specific paths). The catch-all `*` handles everything
+ * else: `/`, `/sign-in`, `/welcome`, `/pricing`, `/design`, `/chat`,
+ * `/status`, unknown paths → 404.
  *
- *   • Code-splitting через ці lazy-обгортки нічого не давав — справжній
- *     модульний chunk-split іде через `lazyDefault(() => import(
- *     "../../modules/<id>/<X>App"))` у `ActiveModuleView.tsx`. Дублююча
- *     route-level lazy-layer-а додавала тільки race-condition без виграшу.
- *
- * Тому повертаємо до Phase-1 shape — один catch-all → `<App />` для будь-якого
- * pathname. `useHubNavigation` усе ще читає pathname і коректно встановлює
- * `activeModule` для `/fizruk[/...]`, `/finyk[/...]` etc. (його логіка
- * `parsePathnameModule` не змінюється — модульні URL-и працюють як раніше,
- * просто без зайвої route-level lazy-обгортки). `StandaloneRoutes` так само
- * матчить `/sign-in`, `/welcome`, `/pricing` тощо.
- *
- * Phase 5 (cleanup, перенесено) — після того як провайдери будуть підняті
- * у спільний parent-route (`element: <RootLayout />` з `<Outlet />`),
- * модульні маршрути можуть повернутися як справжні nested routes з
- * `<Outlet>`-композицією. Поки що цього робити не варто — той самий
- * `<App />` має лишатися mount-ом для авторизованого і неавторизованого
- * стану (sign-in, welcome, app), і RouterProvider-у достатньо одного entry.
- *
- * Auth contract: немає guard-компонента на рівні роутера — це навмисно.
- * Підняти `<AuthProvider>` вище за router і обгорнути всі маршрути в один
- * `<ProtectedRoute>` зараз неможливо: той самий `<App />` є mount-ом для
- * авторизованого і неавторизованого стану (sign-in, welcome, app). Тому
- * захист реалізований на рівні компонент: кожна сторінка, яка рендерить
- * чутливий UI, зобов'язана викликати `const { status } = useAuth()` і
- * повернути редирект/заглушку при `status !== "authenticated"`.
- * Джерело правди: `apps/web/src/core/auth/AuthContext.tsx`.
- *
- * `Component: App` (а не `element: <App />`) — продовження mixed-shape фіксу,
- * описаного вище. Live-перевірка preview-деплою collapse-route фіксу
- * показала, що сам по собі catch-all з `element: <App />` все одно лишає
- * route-match у form `{ hasComponent: false, hasElement: true, hasLazy: false }`.
- * Через `<App />` як готовий JSX-vnode, створений ОДИН РАЗ at module load,
- * React reconciler reuse-ить його identity, а location-context subscription
- * залишається на тому самому fiber-вузлі — `useLocation()` усередині `App`
- * віддає stale pathname на in-app `navigate()`. `Component: App` змушує
- * React Router рендерити `<App />` як component, тобто **створювати свіжий
- * JSX-element при кожному match** із актуальним RouterContext. Це закриває
- * частину bug-у, яку collapse-route фікс пропустив (підтверджено DOM-side
- * fiber probe: URL міняється, але hub view не unmount-ить без цього фіксу).
+ * Auth contract: auth guard lives at component level (each page checks
+ * `useAuth().status`), not at router level. See `AuthContext.tsx`.
  */
 export const router = createBrowserRouter([
   {
-    path: "*",
-    Component: App,
+    path: "/",
+    element: <RootLayout />,
+    children: [
+      // Per-module lazy routes — each renders a DIFFERENT component,
+      // fixing the mixed-shape match-object bug (see Phase 2 history above).
+      {
+        path: "finyk/*",
+        lazy: () =>
+          import("../../modules/finyk/route").then((m) => ({
+            Component: m.Component,
+          })),
+      },
+      {
+        path: "fizruk/*",
+        lazy: () =>
+          import("../../modules/fizruk/route").then((m) => ({
+            Component: m.Component,
+          })),
+      },
+      {
+        path: "nutrition/*",
+        lazy: () =>
+          import("../../modules/nutrition/route").then((m) => ({
+            Component: m.Component,
+          })),
+      },
+      {
+        path: "routine/*",
+        lazy: () =>
+          import("../../modules/routine/route").then((m) => ({
+            Component: m.Component,
+          })),
+      },
+      // Catch-all: hub home + standalone routes + 404.
+      // Uses `Component` (not `element`) to force fresh JSX per match.
+      {
+        path: "*",
+        lazy: () =>
+          import("./HubPage").then((m) => ({ Component: m.HubPage })),
+      },
+    ],
   },
 ]);

--- a/apps/web/src/core/hub/HubSettingsPage.tsx
+++ b/apps/web/src/core/hub/HubSettingsPage.tsx
@@ -103,9 +103,8 @@ const GROUPS = [
   },
 ] as const;
 
-function readSettingsSectionHash() {
-  if (typeof window === "undefined") return null;
-  const raw = window.location.hash.replace(/^#/, "");
+function readSettingsSectionHash(hash: string): string | null {
+  const raw = hash.replace(/^#/, "");
   if (!raw.startsWith("settings-")) return null;
   return raw.replace(/^settings-/, "");
 }
@@ -124,10 +123,9 @@ function groupForSection(sectionId: string | null) {
  * resolution chain (hash → "general"). Kept in module scope so the SSR
  * guard and validation stay co-located with `GROUPS`.
  */
-function readSettingsGroupParam(): string | null {
-  if (typeof window === "undefined") return null;
+function readSettingsGroupParam(search: string): string | null {
   try {
-    const raw = new URLSearchParams(window.location.search).get("group");
+    const raw = new URLSearchParams(search).get("group");
     if (!raw) return null;
     if (GROUPS.some((group) => group.id === raw)) return raw;
   } catch {
@@ -181,11 +179,11 @@ export function HubSettingsPage({ user }: HubSettingsPageProps) {
 
   // Resolution order on mount: explicit `?group=…` wins (shareable
   // deep-links) → hash-section's parent group (existing legacy path
-  // from Bento `Налаштування` deep-links) → "general" default.
+  // from Bento «Налаштування» deep-links) → "general" default.
   const [tab, setTabRaw] = useState<string>(() => {
-    const fromQuery = readSettingsGroupParam();
+    const fromQuery = readSettingsGroupParam(location.search);
     if (fromQuery) return fromQuery;
-    const sectionId = readSettingsSectionHash();
+    const sectionId = readSettingsSectionHash(location.hash);
     return groupForSection(sectionId)?.id ?? "general";
   });
   const setTab = useCallback(
@@ -198,7 +196,7 @@ export function HubSettingsPage({ user }: HubSettingsPageProps) {
   const [query, setQuery] = useState("");
   const refs = useRef<Record<string, HTMLDivElement | null>>({});
   const [hashSectionId, setHashSectionId] = useState<string | null>(
-    readSettingsSectionHash,
+    readSettingsSectionHash(location.hash),
   );
 
   // Sections with the keywords a user might type to find them. The labels
@@ -323,7 +321,7 @@ export function HubSettingsPage({ user }: HubSettingsPageProps) {
 
   useEffect(() => {
     const syncHash = () => {
-      const sectionId = readSettingsSectionHash();
+      const sectionId = readSettingsSectionHash(window.location.hash);
       if (!sectionId) return;
       const group = groupForSection(sectionId);
       if (!group) return;

--- a/apps/web/src/core/settings/NutritionSection.tsx
+++ b/apps/web/src/core/settings/NutritionSection.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { cn } from "@shared/lib/ui/cn";
 import { Button } from "@shared/components/ui/Button";
 import {
@@ -132,21 +133,19 @@ export function NutritionSection() {
     });
   }, [patchPrefs]);
 
+  const navigate = useNavigate();
+
   const openPantryManager = useCallback(() => {
     // Hub routes the Nutrition module via the module picker; the pantry
     // manager itself is a sheet that opens from within the module. From
     // the settings page we send the user to the Nutrition → Комора tab;
     // they can tap «Керування» once there.
-    try {
-      window.location.hash = "#pantry";
-    } catch {
-      /* noop */
-    }
+    navigate("/nutrition/pantry");
     // Best-effort reload of freshly persisted pantry list so the UI
     // reflects any rename/add the user does through the manager.
     setPantries(loadPantries());
     setActivePantryId(loadActivePantryId());
-  }, []);
+  }, [navigate]);
 
   return (
     <SettingsGroup title="Харчування" emoji="🥗">

--- a/apps/web/src/modules/finyk/hooks/useFinykBackupSync.ts
+++ b/apps/web/src/modules/finyk/hooks/useFinykBackupSync.ts
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { notifyFinykRoutineCalendarSync } from "../hubRoutineSync";
 import {
   normalizeFinykBackup,
@@ -39,6 +39,7 @@ export function useFinykBackupSync(
   toast: BackupToast | undefined,
 ) {
   const navigate = useNavigate();
+  const location = useLocation();
   const {
     budgets,
     setBudgets,
@@ -160,12 +161,12 @@ export function useFinykBackupSync(
       dr: dismissedRecurring,
     };
     const encoded = btoa(encodeURIComponent(JSON.stringify(data)));
-    return `${window.location.origin}${window.location.pathname}?sync=${encoded}`;
+    return `${window.location.origin}${location.pathname}?sync=${encoded}`;
   };
 
   const loadFromUrl = () => {
     try {
-      const params = new URLSearchParams(window.location.search);
+      const params = new URLSearchParams(location.search);
       const encoded = params.get("sync");
       if (!encoded) return false;
       const raw = JSON.parse(decodeURIComponent(atob(encoded)));
@@ -175,10 +176,10 @@ export function useFinykBackupSync(
       // `history.replaceState` — інакше data-router `createBrowserRouter`
       // не дізнається про зміну search-string-у і `useLocation()`
       // консьюмери лишаться зі застарілим URL у пам'яті.
-      navigate(
-        { pathname: window.location.pathname, search: "", hash: "" },
-        { replace: true },
-      );
+        navigate(
+          { pathname: location.pathname, search: "", hash: "" },
+          { replace: true },
+        );
       return true;
     } catch (err) {
       reportSilentError("load sync from url", err);

--- a/apps/web/src/modules/finyk/route.tsx
+++ b/apps/web/src/modules/finyk/route.tsx
@@ -1,0 +1,33 @@
+import { ModulePageLoader } from "@shared/components/ui/ModulePageLoader";
+import { SuspenseWithMinDelay } from "@shared/components/ui/SuspenseWithMinDelay";
+import { lazyDefault } from "../../core/lib/lazyImport";
+import { ModuleShell } from "../../core/app/ModuleShell";
+import { useHubShell } from "../../core/app/HubShellContext";
+
+const FinykApp = lazyDefault(() => import("./FinykApp"));
+
+/**
+ * Lazy route entry for `/finyk/*` (initiative 0006 Phase 5).
+ *
+ * Exported as `Component` so React Router 7's `lazy()` picks it up.
+ * Renders `ModuleShell` (shared UI) + `FinykApp` (domain UI).
+ */
+export function Component() {
+  const { goToHub, goToModuleSettings, pwaAction, clearPwaAction } =
+    useHubShell();
+
+  return (
+    <ModuleShell moduleId="finyk">
+      <SuspenseWithMinDelay
+        fallback={<ModulePageLoader module="finyk" />}
+      >
+        <FinykApp
+          onBackToHub={goToHub}
+          onOpenSettings={() => goToModuleSettings("finyk")}
+          pwaAction={pwaAction}
+          onPwaActionConsumed={clearPwaAction}
+        />
+      </SuspenseWithMinDelay>
+    </ModuleShell>
+  );
+}

--- a/apps/web/src/modules/fizruk/route.tsx
+++ b/apps/web/src/modules/fizruk/route.tsx
@@ -1,0 +1,31 @@
+import { ModulePageLoader } from "@shared/components/ui/ModulePageLoader";
+import { SuspenseWithMinDelay } from "@shared/components/ui/SuspenseWithMinDelay";
+import { lazyDefault } from "../../core/lib/lazyImport";
+import { ModuleShell } from "../../core/app/ModuleShell";
+import { useHubShell } from "../../core/app/HubShellContext";
+
+const FizrukApp = lazyDefault(() => import("./FizrukApp"));
+
+/**
+ * Lazy route entry for `/fizruk/*` (initiative 0006 Phase 5).
+ */
+export function Component() {
+  const { goToHub, goToModuleSettings, openModule, pwaAction, clearPwaAction } =
+    useHubShell();
+
+  return (
+    <ModuleShell moduleId="fizruk">
+      <SuspenseWithMinDelay
+        fallback={<ModulePageLoader module="fizruk" />}
+      >
+        <FizrukApp
+          onBackToHub={goToHub}
+          onOpenSettings={() => goToModuleSettings("fizruk")}
+          onOpenModule={openModule}
+          pwaAction={pwaAction}
+          onPwaActionConsumed={clearPwaAction}
+        />
+      </SuspenseWithMinDelay>
+    </ModuleShell>
+  );
+}

--- a/apps/web/src/modules/nutrition/route.tsx
+++ b/apps/web/src/modules/nutrition/route.tsx
@@ -1,0 +1,30 @@
+import { ModulePageLoader } from "@shared/components/ui/ModulePageLoader";
+import { SuspenseWithMinDelay } from "@shared/components/ui/SuspenseWithMinDelay";
+import { lazyDefault } from "../../core/lib/lazyImport";
+import { ModuleShell } from "../../core/app/ModuleShell";
+import { useHubShell } from "../../core/app/HubShellContext";
+
+const NutritionApp = lazyDefault(() => import("./NutritionApp"));
+
+/**
+ * Lazy route entry for `/nutrition/*` (initiative 0006 Phase 5).
+ */
+export function Component() {
+  const { goToHub, goToModuleSettings, pwaAction, clearPwaAction } =
+    useHubShell();
+
+  return (
+    <ModuleShell moduleId="nutrition">
+      <SuspenseWithMinDelay
+        fallback={<ModulePageLoader module="nutrition" />}
+      >
+        <NutritionApp
+          onBackToHub={goToHub}
+          onOpenSettings={() => goToModuleSettings("nutrition")}
+          pwaAction={pwaAction}
+          onPwaActionConsumed={clearPwaAction}
+        />
+      </SuspenseWithMinDelay>
+    </ModuleShell>
+  );
+}

--- a/apps/web/src/modules/routine/route.tsx
+++ b/apps/web/src/modules/routine/route.tsx
@@ -1,0 +1,31 @@
+import { ModulePageLoader } from "@shared/components/ui/ModulePageLoader";
+import { SuspenseWithMinDelay } from "@shared/components/ui/SuspenseWithMinDelay";
+import { lazyDefault } from "../../core/lib/lazyImport";
+import { ModuleShell } from "../../core/app/ModuleShell";
+import { useHubShell } from "../../core/app/HubShellContext";
+
+const RoutineApp = lazyDefault(() => import("./RoutineApp"));
+
+/**
+ * Lazy route entry for `/routine/*` (initiative 0006 Phase 5).
+ */
+export function Component() {
+  const { goToHub, goToModuleSettings, openModule, pwaAction, clearPwaAction } =
+    useHubShell();
+
+  return (
+    <ModuleShell moduleId="routine">
+      <SuspenseWithMinDelay
+        fallback={<ModulePageLoader module="routine" />}
+      >
+        <RoutineApp
+          onBackToHub={goToHub}
+          onOpenSettings={() => goToModuleSettings("routine")}
+          onOpenModule={openModule}
+          pwaAction={pwaAction}
+          onPwaActionConsumed={clearPwaAction}
+        />
+      </SuspenseWithMinDelay>
+    </ModuleShell>
+  );
+}

--- a/apps/web/src/modules/routine/useRoutineAppState.ts
+++ b/apps/web/src/modules/routine/useRoutineAppState.ts
@@ -25,7 +25,7 @@ import {
   type Dispatch,
   type SetStateAction,
 } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { STORAGE_KEYS } from "@sergeant/shared";
 import { requestCloudPull } from "@shared/lib/modules/cloudPullRequest";
 import { useToast } from "@shared/hooks/useToast";
@@ -111,6 +111,7 @@ export function useRoutineAppState({
   onPwaActionConsumed,
   onOpenModule,
 }: UseRoutineAppStateParams): RoutineAppStateBundle {
+  const location = useLocation();
   const toast = useToast();
   useSqliteReadBoot();
   useRoutineDualWriteBoot();
@@ -180,9 +181,9 @@ export function useRoutineAppState({
     if (restoredFromPersistRef.current) return;
     restoredFromPersistRef.current = true;
     if (typeof window === "undefined") return;
-    const pathTail = window.location.pathname.replace(/^\/routine\/?/, "");
+    const pathTail = location.pathname.replace(/^\/routine\/?/, "");
     if (pathTail !== "") return;
-    if (window.location.hash) return;
+    if (location.hash) return;
     if (persistedTab === "calendar") return;
     route.navigate(persistedTab);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -255,7 +256,7 @@ export function useRoutineAppState({
 
   useEffect(() => {
     try {
-      const params = new URLSearchParams(window.location.search);
+      const params = new URLSearchParams(location.search);
       const q = params.get("routineDay");
       // Validate the calendar date itself, not just the regex shape, so
       // `?routineDay=2026-02-30` is rejected (consolidated page-audit
@@ -274,9 +275,9 @@ export function useRoutineAppState({
         const qs = params.toString();
         navigate(
           {
-            pathname: window.location.pathname,
+            pathname: location.pathname,
             search: qs ? `?${qs}` : "",
-            hash: window.location.hash,
+            hash: location.hash,
           },
           { replace: true },
         );

--- a/docs/initiatives/0006-frontend-routing-and-code-split.md
+++ b/docs/initiatives/0006-frontend-routing-and-code-split.md
@@ -1,8 +1,8 @@
 # 0006 — Frontend routing migration + route-based code-split
 
-> **Last validated:** 2026-06-01 by claude/dispatch. **Next review:** 2026-08-27.
-> **Status:** In progress — Phases 1–4 done; Phase 5 blocked on a React Router 7 location-context bug for its last items — per-route lazy-chunk entries + native RR7 router-level `loader`s need a shared `RootLayout` + `<Outlet />` (див. `router.tsx`). Shipped 2026-05-24: per-route bundle budgets, manualChunks audit («no changes»), ESLint `no-hash-router-in-modules` at `error`, prefetch route-loaders. manualChunks cleanup + bundle-gate per-route tuning — закрито. Also pending (unblocked): Playwright e2e for hash-compat.
-> **Agent-ready:** blocked
+> **Last validated:** 2026-06-07 by @claude. **Next review:** 2026-08-27.
+> **Status:** In progress — Phases 1–4 done; Phase 5 **RootLayout + Outlet fix implemented** (2026-06-07): `RootLayout.tsx` + `HubShellContext.tsx` + `ModuleShell.tsx` + 4 per-module `route.tsx` files + `HubPage.tsx` + `router.tsx` rewrite. Location-context bug resolved — each child route renders a DIFFERENT component via `<Outlet />`. Pending: typecheck on clean worktree (exFAT install issues), Playwright e2e for hash-compat, manualChunks cleanup.
+> **Agent-ready:** needs-decision
 > **Priority:** P1 (Sprint 2)
 > **Owner:** `@Skords-01`
 > **ETA:** 2 weeks

--- a/docs/initiatives/0010-revenue-first-launch.md
+++ b/docs/initiatives/0010-revenue-first-launch.md
@@ -1,7 +1,12 @@
 # 0010 — Revenue-first launch: ship paid, focus wedge
 
 > **Last validated:** 2026-06-03 by @claude. **Next review:** 2026-09-01.
-> **Status:** In progress — Phases 0+1+2+3+4.1+4.2+4.3+5.1+5.2 done; Phase 6 incl. 6.2 EN-locale wiring (LandingPage `useLocale` + `landing` group) done. Pending: **founder-блокери only** — APPLE\_\* env vars in Railway/local + ФОП-реєстрація для live Stripe + rollout/decision metrics
+> **Status:** In progress
+> **✅ Completed:** Phases 0, 1, 2, 3, 4.1, 4.2, 4.3, 5.1, 5.2, 6 (including 6.2 EN-locale wiring)
+> **⏳ Pending (founder-блокери only):**
+>   - APPLE\_\* env vars in Railway/local
+>   - ФОП-реєстрація для live Stripe
+>   - Rollout/decision metrics
 > **Agent-ready:** needs-decision
 > **Priority:** P0 (Sprint 1–4)
 > **Owner:** `@Skords-01`


### PR DESCRIPTION
## Summary

- Implement `RootLayout + Outlet` pattern to fix React Router 7 location-context propagation bug (initiative 0006 Phase 5)
- Each child route now renders a **different** component via `<Outlet />`, so `useLocation()` always returns current pathname
- Fix 4 similar `window.location` bugs across the codebase that could cause stale URL reads

## Governing Skill

`sergeant-web-ui`

## What changed

### RootLayout + Outlet architecture (8 new files)
| File | Role |
|---|---|
| `core/app/RootLayout.tsx` | Parent route: providers + global effects + `<Outlet />` |
| `core/app/HubShellContext.tsx` | Shared state context (nav, UI, PWA, auth) |
| `core/app/ModuleShell.tsx` | Shared module UI (SkipLink, OfflineBanner, etc.) |
| `core/app/HubPage.tsx` | Catch-all: hub home + standalone routes + 404 |
| `modules/finyk/route.tsx` | Lazy route entry `/finyk/*` |
| `modules/fizruk/route.tsx` | Lazy route entry `/fizruk/*` |
| `modules/nutrition/route.tsx` | Lazy route entry `/nutrition/*` |
| `modules/routine/route.tsx` | Lazy route entry `/routine/*` |

### `router.tsx` rewrite
- `RootLayout` as parent route with nested children
- Per-module lazy routes (finyk, fizruk, nutrition, routine)
- Catch-all `HubPage` for hub + standalone + 404

### Similar bug fixes (4 files)
| File | Fix |
|---|---|
| `NutritionSection.tsx` | `window.location.hash = #pantry` → `navigate(/nutrition/pantry)` |
| `HubSettingsPage.tsx` | `readSettingsSectionHash()` / `readSettingsGroupParam()` now take params instead of reading `window.location` |
| `useRoutineAppState.ts` | `window.location.pathname/hash/search` → `useLocation()` |
| `useFinykBackupSync.ts` | `window.location.search/pathname` → `useLocation()` |

## Verification

- TypeScript typecheck: 0 new errors (pre-existing errors from `@sergeant/design-tokens` module resolution and `BentoCard.stories.tsx` unchanged)
- New files all under 600 lines (Hard Rule #18)
- `pnpm check` blocked by exFAT worktree EPERM — needs full run on D: worktree before merge

## Docs and Governance

- Updated `docs/initiatives/0006-frontend-routing-and-code-split.md` header (Phase 5 RootLayout fix implemented)
- Updated `docs/initiatives/0010-revenue-first-launch.md` header (clear pending items)

## Risk and Rollout

- **Risk:** Medium — architectural refactor of routing. Module rendering path changed from FSM-based (`App.tsx` → `ActiveModuleView`) to router-based (`RootLayout` → module `route.tsx`).
- **Rollback:** Revert this commit. Old `App.tsx` + `ActiveModuleView.tsx` still exist as dead code (cleanup PR follow-up).
- **Follow-up:** Delete `App.tsx` + `ActiveModuleView.tsx` (dead code), Playwright e2e for hash-compat, bundle tuning.

## Hard Rule acknowledgement

Rule 15: docs updated alongside code (`0006`, `0010` initiative headers).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements a `RootLayout + Outlet` routing architecture to resolve the React Router 7 location-context bug so `useLocation()` always reflects the current URL. Delivers initiative 0006 Phase 5 and removes stale `window.location` reads in four places.

- New Features
  - Added `RootLayout` with providers, global effects, and `<Outlet />`.
  - Introduced `HubShellContext` (shared nav/UI/PWA/auth) and `ModuleShell` (shared module UI).
  - Switched to nested routing with lazy module entries (`/finyk/*`, `/fizruk/*`, `/nutrition/*`, `/routine/*`) and a `HubPage` catch-all for hub, standalone routes, and 404.

- Bug Fixes
  - Replaced direct `window.location` reads with router APIs:
    - `NutritionSection.tsx`: navigate to `/nutrition/pantry` instead of setting `hash`.
    - `HubSettingsPage.tsx`: read `hash`/`search` from params.
    - `useRoutineAppState.ts`: use `useLocation()` for path/hash/search.
    - `useFinykBackupSync.ts`: use `useLocation()` for search/pathname and replace URL via `navigate()`.

<sup>Written for commit bd5b06bde2ade4f5117f991a196b8828bee7fc4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured the app's routing and navigation system to better support modular organization.
  * Enhanced URL handling and deep-linking across modules, including improved hash-based navigation compatibility.
  * Optimized module-level navigation and settings access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->