### PR TITLE
fix(web): use text-success-strong for income amount in TxRow

### DIFF
--- a/apps/web/src/modules/finyk/components/TxRow.tsx
+++ b/apps/web/src/modules/finyk/components/TxRow.tsx
@@ -341,7 +341,9 @@ function TxRowImpl({
             <div
               className={cn(
                 "text-style-label tabular-nums",
-                tx.amount > 0 ? "text-success" : "text-text",
+                tx.amount > 0
+                  ? "text-success-strong dark:text-success"
+                  : "text-text",
               )}
             >
               {hideAmount ? "••••" : fmtAmt(tx.amount, CURRENCY.UAH)}


### PR DESCRIPTION
## Summary

The income (positive-amount) row total in `TxRow` used bare `text-success` (emerald-500, ≈2:1 on the light surface) for `text-style-label` normal text — failing WCAG AA contrast in light mode.

Switch to the canonical `text-success-strong dark:text-success` pair:
- **light**: `text-success-strong` = emerald-700 (`#047857`, **5.48:1** on white — passes AA);
- **dark**: `text-success` = emerald-500, where the dark surface already provides contrast.

This is the pattern already used in the same file (the split badge) and across the finyk module (`Analytics.tsx`, `AssetsAssetsSection.tsx`, `ManualExpenseSheet.tsx`).

`apps/web/src/modules/finyk/components/TxRow.tsx:344`

## Governing Skill

`sergeant-web-ui`.

## Playbook

N/A — single-line a11y/contrast fix.

## Verification

- `pnpm --filter @sergeant/web typecheck` — clean for the changed file (staged-typecheck passed at commit time). Note: `main` currently carries pre-existing TS2303 errors in `fizruk/dualWrite/diff.ts` unrelated to this change.
- eslint pre-commit — clean.
- Browser-verify (visual contrast check) not run in-session — local browser MCPs were unavailable; the change is a one-line swap to a documented design token whose AA ratio (5.48:1) is recorded in `packages/design-tokens/tailwind-preset.js`.

## Docs and Governance

No docs touched. Directly satisfies Hard Rule #9 (saturated brand colour AA companion) intent for `text-success`.

## Risk and Rollout

Minimal — colour-token swap only, no logic change. Visible effect: income amounts render in a darker, AA-compliant green in light mode; dark mode unchanged.

## Hard Rule #15 acknowledgement

Read governance before coding; change aligns with the `-strong` companion convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes low-contrast income amounts in `TxRow` by switching from `text-success` to `text-success-strong dark:text-success`. Income values now meet WCAG AA in light mode; dark mode is unchanged and consistent with the rest of the module.

<sup>Written for commit 9d067c14e459eca93f1dea0f3761d32715d40b5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

