### PR TITLE
Audit triage digest (auto, twice-weekly)

### DIFF
--- a/docs/audits/_runner-report.md
+++ b/docs/audits/_runner-report.md
@@ -2,12 +2,12 @@
 
 # Audit runner report
 
-> **Last validated:** 2026-06-04 by audit-triage routine. **Next review:** 2026-09-02.
-> **Status:** Active
+> **Last validated:** 2026-06-08 by audit-triage routine. **Next review:** 2026-09-06.
+> **Status:** Reference
 
-## Triage digest — 2026-06-04
+## Triage digest — 2026-06-08
 
-Source: `docs/open-work.md §Аудити й прожарки` (20 open docs) + direct reads of each audit file. Audits with `Closed` / `Archived` status excluded. Sorted by impact within each bucket.
+Source: `docs/open-work.md §Аудити й прожарки` (17 open docs) + direct reads of each audit file. Audits with `Closed` / `Archived` / `Done` status excluded. Sorted by impact within each bucket.
 
 ---
 
@@ -15,29 +15,33 @@ Source: `docs/open-work.md §Аудити й прожарки` (20 open docs) + 
 
 Highest blast radius; fix before next release.
 
-1. **`docs/audits/2026-05-13-consolidated-page-audit.md` C1** — `useChatSend.ts` dispatches AI `tool_calls` with no allow-list or Zod schema validation; prompt injection → arbitrary action execution with full Better Auth cookie context. **Add a Zod-validated tool registry; reject + log unknown tool names before dispatch.**
+1. **`docs/audits/2026-05-13-consolidated-page-audit.md` C1** — `useChatSend.ts` dispatches AI `tool_calls` with no allow-list or Zod schema validation; prompt injection → arbitrary action execution with full Better Auth cookie context. **Add Zod-validated tool registry; reject + log unknown tool names before dispatch.**
 
-2. **`docs/audits/2026-05-13-consolidated-page-audit.md` C2 / `docs/audits/2026-05-13-page-audit-10-errors-pwa-marketing.md`** — Service-worker `Cache` namespace for `/api/*` is keyed by URL only; after user A signs out on a shared device, user B receives A's cached API responses. **Key API cache by hashed session id; flush cache in `signOut` handler; add `Cache-Control: private` on all `/api/*` server responses.**
+2. **`docs/audits/2026-05-13-consolidated-page-audit.md` C2 / `docs/audits/2026-05-13-page-audit-10-errors-pwa-marketing.md`** — Service-worker `Cache` namespace for `/api/*` keyed by URL only; after user A signs out on a shared device, user B receives A's cached API responses. **Key API cache by hashed session id; flush cache in `signOut` handler; add `Cache-Control: private` on all `/api/*` server responses.**
 
-3. **`docs/audits/2026-05-13-dead-code-hard-rules-roast.md` P1.4** — Four `process.env` callers (`requireAnthropicKey`, `requireGroqKey`, `posthogCapture` ×2, `authTransactionalMail`) bypass the typed `env` object; `lint:env-single-source` budget drifts with each feature PR. **Ship PR(A): migrate `requireAnthropicKey` + refactor `coach.route.test.ts` to `vi.resetModules + vi.stubEnv` pattern** (net −1; establishes canonical test pattern for remaining 3 PRs).
+3. **`docs/audits/2026-05-13-page-audit-10-errors-pwa-marketing.md` F3 + F4** — Sentry Session Replay records text without `maskAllText: true` (PII leak); `PricingPage` redirects to `checkout.url` without origin allow-list (open redirect). **Add `maskAllText: true` to Sentry Replay init; validate `checkout.url` origin against an explicit allowlist before redirect.**
 
-4. **`docs/audits/2026-08-XX-openclaw-internal-roast.md`** — Security boundary of 1781-LOC `routes/internal/openclaw.ts` (bearer-token guard coverage, audit-log gaps for write-tools, write-tool approval-gate drift vs ADR-0027) is a stub awaiting Q3 audit. **Assign backend owner and schedule full audit session before 2026-08-11 trigger window.**
+4. **`docs/audits/2026-05-13-page-audit-01-auth-onboarding.md` F1** — 14× `text-error`/`bg-error` references a non-existent design token; auth error banners and the password-strength bar render colorless in production (Tailwind silently drops unknown utilities). **Replace all 14 occurrences with `text-danger`/`bg-danger`** (pure rename, no logic change, zero risk).
+
+5. **`docs/audits/2026-05-13-dead-code-hard-rules-roast.md` P1.4** — Four `process.env` callers (`requireAnthropicKey`, `requireGroqKey`, `posthogCapture` ×2, `authTransactionalMail`) bypass the typed `env` object; `lint:env-single-source` budget drifts with each feature PR. **Ship PR(A): migrate `requireAnthropicKey` + refactor `coach.route.test.ts` to `vi.resetModules + vi.stubEnv` pattern (net −1; establishes canonical test pattern for remaining 3 PRs).**
+
+6. **`docs/audits/2026-08-XX-openclaw-internal-roast.md`** — Security boundary of 1819-LOC `routes/internal/openclaw.ts` has been stub-audited (bearer-token guard on all 57 routes confirmed; HMAC grace-mode noted); audit-log gaps for write-tools and approval-gate drift vs ADR-0027 are not yet fully verified. **Assign a backend owner and schedule a full audit session before the 2026-08-11 trigger window.**
 
 ---
 
 ## B — Cheap AutoSafe Wins
 
-Low-effort, high signal-to-noise; can ship independently.
+Low-effort, high signal-to-noise; can ship independently without cross-team coordination.
 
-1. **`docs/audits/2026-05-13-testing-devx-roast.md` P1-4 PARTIAL** — Seven Detox e2e specs are authored (`auth-flows`, `nutrition-full`, `nutrition-water-barcode`, `fizruk-full`, `fizruk-measurements`, `deep-link`, `offline-sync`) but not green because component `testID` props are missing in source. **Add missing `testID` attributes to auth/nutrition/fizruk components** to unblock the authored suite without new spec work.
+1. **`docs/audits/2026-05-25-hubsettings-cls-chunk-load.md` MEDIUM #1** — `HubSettingsPage.tsx` lazy sections throw `ChunkLoadError` on stale-chunk PWA deploys → permanent white screen with no recovery UI. **Create `ChunkErrorBoundary.tsx`; wrap all 4 `<Suspense>` blocks; add retry button calling `window.location.reload()`** (5 files, branch `fix/hub-settings-cls-error-boundary`).
 
-2. **`docs/audits/2026-05-13-dead-code-hard-rules-roast.md` P1.5** — Five exported symbols in `apps/mobile-shell/` (`requestNativeBarcode`, `requestPermissions`, `subscribePushTokens`, `isCapacitorReady`, `getPlatform`) have zero JS importers. **Delete or wire into the Capacitor shell entry point** (micro-PR, no test changes needed).
+2. **`docs/audits/2026-05-25-hubsettings-cls-chunk-load.md` MEDIUM #2** — All 4 lazy sections share `minH: 72` (collapsed-state height); real painted height is 160–280 px → CLS jump when user has already scrolled. **Measure real heights via DevTools on `/hub#settings`; set per-section `minH` in `HubSettingsPage.tsx:254-277`** (can combine with MEDIUM #1 in one PR).
 
-3. **`docs/audits/2026-05-13-consolidated-page-audit.md` Theme 2 (touch targets)** — Three surfaces remain below 44×44 px after the audits-runner pass: FTUX 5 components (01 F8 — `DailyNudge`, `DemoModeBanner`, `SoftAuthPromptCard`, `ReEngagementCard`, `FirstRunHintBanner`), Finyk analytics month-nav (05 F5), Fizruk Atlas anterior/posterior toggle (06). ESLint `no-small-button-touch-target` already warns. **Batch-add `min-h-[44px] min-w-[44px]` across the 3 remaining surfaces** (pure CSS, no logic change).
+3. **`docs/audits/2026-05-13-testing-devx-roast.md` P1-4 PARTIAL** — 7 Detox e2e specs authored (`auth-flows`, `nutrition-full`, `nutrition-water-barcode`, `fizruk-full`, `fizruk-measurements`, `deep-link`, `offline-sync`) but not green because component `testID` props are missing in source. **Add missing `testID` attributes to auth/nutrition/fizruk source components** to unblock the authored suite without writing any new specs.
 
-4. **`docs/audits/2026-05-13-page-audit-01-auth-onboarding.md`** — 25 findings (0C, 6H, 16M, 3L); no execution PRs beyond F1 (token rename) closed in the audits-runner pass. **Pick the top-H item and ship** (H-class items: a11y hit-area + CSRF/CORS surface + FTUX flow gaps per consolidated §01 cluster).
+4. **`docs/audits/2026-05-13-dead-code-hard-rules-roast.md` P1.5** — Five exported symbols in `apps/mobile-shell` (`requestNativeBarcode`, `requestPermissions`, `subscribePushTokens`, `isCapacitorReady`, `getPlatform`) have zero JS importers. **Delete or wire into the Capacitor shell entry point** (micro-PR, no test-file changes needed).
 
-5. **`docs/audits/2026-05-13-web-frontend-ergonomics-roast.md` F2-II / F4 / F7** — Three ergonomics findings deferred from the 2026-06-02 runner pass. **Review and ship at least one** (F4 is likely smallest; confirm scope from the roast file).
+5. **`docs/audits/2026-05-13-consolidated-page-audit.md` Theme 2 (touch targets, partial)** — Three surfaces remain below 44×44 px after the previous audits-runner pass: 5 FTUX components (01 F8 — `DailyNudge`, `DemoModeBanner`, `SoftAuthPromptCard`, `ReEngagementCard`, `FirstRunHintBanner`), Finyk analytics month-nav (05 F5), Fizruk Atlas anterior/posterior toggle (06). **Batch-add `min-h-[44px] min-w-[44px]`** (pure CSS; ESLint `no-small-button-touch-target` already surfaces these as `warn`).
 
 ---
 
@@ -45,33 +49,33 @@ Low-effort, high signal-to-noise; can ship independently.
 
 Shipping these removes blockers on downstream work.
 
-1. **`docs/audits/2026-05-06-ux-roast-pr-plan.md` Sprint 0 PR-0** — Telemetry ADR + PostHog event taxonomy foundation has not started; it blocks A1 (App-lock UX), A4, A8, and ~21 downstream Sprint 2/3 UX PRs (20/41 shipped so far). **Ship PR-0** to unblock roughly half the remaining UX execution plan.
+1. **`docs/audits/2026-05-06-ux-roast-pr-plan.md` Sprint 0 PR-0** — 9 PostHog events already catalogued in `analyticsEvents.ts`; Sprint 0 is formally open and blocks App-lock (PR-1a/1b), module settings (A4), error-boundary (A8) and ~11 other downstream items (20/41 PRs shipped; 21 remain). **Formally close PR-0** with a landing note pointing to the existing events, unblocking the full Sprint 1 queue.
 
-2. **`docs/audits/2026-05-13-web-architecture-state-roast.md` P1-E** — `fizrukActions`, `finykActions`, and `nutritionActions` still write via `safeWriteLS` (localStorage bypass), violating the state-write-paths doctrine; migration is impossible without server endpoints. **Create `POST /api/v1/finyk/manual-expenses`** as priority-1 domain endpoint to enable the finyk chatActions migration (per P1-E migration plan in the roast).
+2. **`docs/audits/2026-05-13-web-architecture-state-roast.md` P1-E** — `fizrukActions`, `finykActions`, `nutritionActions` still write via `safeWriteLS` (localStorage bypass), violating the state-write-paths doctrine; migration is impossible without server endpoints. **Create `POST /api/v1/finyk/manual-expenses`** as priority-1 domain endpoint to enable the finyk chatActions migration (per P1-E migration plan in the roast).
 
-3. **`docs/audits/2026-05-13-consolidated-page-audit.md` audit-04 coverage gap** — Hub Settings, Profile & Assistant Catalogue were **never audited** (VM infra failure; 0 findings recorded). **Re-run page-audit-04** to complete the consolidated 10-scope coverage matrix before Sprint 9 planning.
+3. **`docs/audits/2026-05-13-consolidated-page-audit.md` audit-04 coverage gap** — Hub Settings, Profile & Assistant Catalogue were **never audited** (VM infra failure at 2026-05-13 session); 0 findings recorded for these pages. **Re-run page-audit-04** to complete the 10-scope coverage matrix and close the blind spot before Sprint 9 planning.
 
-4. **`docs/audits/2026-08-XX-sync-engine-roast.md`** — Atomic-transaction boundaries and DLQ TTL in the 3031-LOC `syncV2.ts` are undocumented; this must be clarified before Stage 8/9 SQLite dual-write is wired. **Trigger Q3 audit session** (gated on sprint-roadmap Спринт 8 closeout, planned 2026-08-11).
+4. **`docs/audits/2026-05-13-consolidated-page-audit.md` individual page audits 02, 05–09** — Scopes for Hub Dashboard, Finyk, Fizruk Part 1/2, Nutrition, Routine+Strategy contain individual H/M findings beyond the 7 consolidated themes (e.g., 06 F3: rest-timer silently broken on navigation; 07 F3/F4: Measurements accepts `weightKg=99999` with no validation; 09 F1/F2: Strategy page calls internal API without bearer auth). **Triage each audit for H/M items not already in consolidated themes 1–7**; target at least one fix per sprint.
 
 ---
 
 ## D — Blocked / Gated
 
-No immediate action possible without external input or gating milestone.
+No immediate action possible without external input or a gating milestone.
 
-1. **`docs/audits/2026-05-06-ux-roast-pr-plan.md` PR-11 + PR-28** — CSV export (PR-11) and Avatar upload (PR-28) are explicitly **paused pending S3/R2 credentials** from founder. Skeleton can be started; upload storage half must wait.
+1. **`docs/audits/2026-05-06-ux-roast-pr-plan.md` PR-11 + PR-28** — CSV export and Avatar upload explicitly **paused pending S3/R2 credentials** from founder; skeleton work can start but the upload-storage half must wait.
 
-2. **`docs/audits/2026-05-13-web-architecture-state-roast.md` P1-E full migration** — chatActions `safeWriteLS` → `apiClient` migration for fizruk/nutrition blocked until their server endpoints exist (no `POST /api/v1/fizruk/workouts`, `POST /api/v1/nutrition/log`). Unblocked incrementally as each domain API ships (see C2 above for finyk priority).
+2. **`docs/audits/2026-05-13-web-architecture-state-roast.md` P1-E full migration** — `fizrukActions`/`nutritionActions` → `apiClient` migration blocked until `POST /api/v1/fizruk/workouts` and `POST /api/v1/nutrition/log` server endpoints exist; unblocks incrementally as each domain API ships (C2 above covers finyk priority-1).
 
-3. **`docs/audits/2026-08-XX-openclaw-internal-roast.md` + `docs/audits/2026-08-XX-sync-engine-roast.md`** — Both are stubs in Draft status, **gated on Q3 2026 backend-roast cycle** (trigger window 2026-08-11). No actionable findings yet.
+3. **`docs/audits/2026-08-XX-openclaw-internal-roast.md` + `docs/audits/2026-08-XX-sync-engine-roast.md`** — Both are stubs **gated on the Q3 2026 backend-roast cycle** (trigger window 2026-08-11); no actionable findings before that date.
 
-4. **`docs/audits/2026-05-15-deep-audit-state-of-repo.md`** — Status Active but 0 truly-outstanding items (D1–D4 all closed 2026-06-03); retained for cross-references only. **Candidate for archiving** once cross-ref consumers are updated.
+4. **`docs/audits/2026-05-13-web-architecture-state-roast.md` P2 open enhancements** — `STANDALONE_ROUTES` factory pattern and Provider HMR remount-invariant test are low-risk, deferred to a future tech-debt sprint.
 
 ---
 
 ## Coverage notes
 
-- **Zero findings — audit-04 (Hub Settings / Profile / Assistant Catalogue):** Never completed due to VM infra failure at the consolidated audit session (2026-05-13). This is an active blind spot covering Settings, Profile, and the Assistant Catalogue pages.
-- **Potential input truncation:** Page audits 06 (fizruk-part1, 27 findings), 07 (fizruk-part2, 50 findings), 08 (nutrition, 25 findings), and 09 (routine-strategy, 23 findings) were not read in detail this pass. Theme 1 (TZ correctness) and Theme 2 (touch targets) are accounted for via the consolidated audit; remaining H/M findings in these four files may have additional open work beyond what this triage captures.
-- **`docs/audits/2026-05-07-full-app-regression-ux-audit.md`:** Active with 7 PR mentions; content not fully read this pass — may contain residual findings beyond the archived `app-audit` cross-refs.
-- **`docs/audits/2026-05-02-doc-hygiene-audit.md`:** Active but all P0 items (ADR gap rule, lifecycle markers, CLAUDE/DEVIN thin-pointer) were closed in the original PR; remaining items appear cosmetic (duplicate `Last validated` dates).
+- **Audit-04 (Hub Settings / Profile / Assistant Catalogue):** Never completed — active blind spot covering an estimated 30–40 H/M findings.
+- **Individual page audits 02 (Hub Dashboard), 05–09 (Finyk, Fizruk Part 1/2, Nutrition, Routine+Strategy):** Read at consolidated-theme level only this pass; individual H/M findings not captured by themes 1–7 may require separate triage (see C4 above).
+- **`docs/audits/2026-05-13-testing-devx-roast.md` P2 items (P2-2 ESLint plugin coverage, P2-4 property-based tests, P2-5 `pnpm check` parallelisation):** Nice-to-have; not blocking any lane.
+- **`docs/audits/2026-05-13-web-architecture-state-roast.md` outstanding P2 items:** Low risk; tracked in `docs/tech-debt/frontend.md`.

--- a/docs/governance/freshness-dashboard.html
+++ b/docs/governance/freshness-dashboard.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<title>Sergeant — Docs Freshness Dashboard (2026-06-07)</title>
+<title>Sergeant — Docs Freshness Dashboard (2026-06-08)</title>
 <style>
   body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; margin: 2rem; color: #111; }
   h1 { margin-top: 0; }
@@ -28,11 +28,11 @@
 </head>
 <body>
 <h1>Sergeant — Docs Freshness Dashboard</h1>
-<p class="meta">Generated <strong>2026-06-07</strong> by <code>scripts/docs/generate-freshness-dashboard.mjs</code>. Data source: auto-discovered <code>**/*.md</code> + <code>scripts/docs/freshness-config.json</code>.</p>
+<p class="meta">Generated <strong>2026-06-08</strong> by <code>scripts/docs/generate-freshness-dashboard.mjs</code>. Data source: auto-discovered <code>**/*.md</code> + <code>scripts/docs/freshness-config.json</code>.</p>
 <div class="summary">
   <div class="chip fresh">Fresh: 548</div>
-  <div class="chip due-soon">Due soon (≤30d): 6</div>
-  <div class="chip overdue">Overdue: 0</div>
+  <div class="chip due-soon">Due soon (≤30d): 5</div>
+  <div class="chip overdue">Overdue: 1</div>
   <div class="chip no-header">No header: 0</div>
   <div class="chip missing">Missing: 0</div>
 </div>
@@ -51,4581 +51,4581 @@
 <tbody>
 <tr class="fresh">
   <td><code>AGENTS.md</code></td>
-  <td class="status">Fresh (90d)</td>
+  <td class="status">Fresh (89d)</td>
   <td>2026-06-07</td>
   <td>2026-09-05</td>
-  <td class="num days">90</td>
+  <td class="num days">89</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>CLAUDE.md</code></td>
-  <td class="status">Fresh (90d)</td>
+  <td class="status">Fresh (89d)</td>
   <td>2026-06-07</td>
   <td>2026-09-05</td>
-  <td class="num days">90</td>
+  <td class="num days">89</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>CONTRIBUTING.md</code></td>
-  <td class="status">Fresh (66d)</td>
-  <td>2026-05-14</td>
-  <td>2026-08-12</td>
-  <td class="num days">66</td>
-  <td>@codex.</td>
+  <td class="status">Fresh (89d)</td>
+  <td>2026-06-07</td>
+  <td>2026-09-05</td>
+  <td class="num days">89</td>
+  <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>DEVIN.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>README.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>SECURITY.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>apps/mobile-shell/CLAUDE.md</code></td>
-  <td class="status">Fresh (90d)</td>
+  <td class="status">Fresh (89d)</td>
   <td>2026-06-07</td>
   <td>2026-09-05</td>
-  <td class="num days">90</td>
-  <td>@claude.</td>
+  <td class="num days">89</td>
+  <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>apps/mobile/AGENTS.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>apps/mobile/CLAUDE.md</code></td>
-  <td class="status">Fresh (90d)</td>
+  <td class="status">Fresh (89d)</td>
   <td>2026-06-07</td>
   <td>2026-09-05</td>
-  <td class="num days">90</td>
-  <td>@claude.</td>
+  <td class="num days">89</td>
+  <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>apps/server/AGENTS.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>apps/server/CLAUDE.md</code></td>
-  <td class="status">Fresh (90d)</td>
+  <td class="status">Fresh (89d)</td>
   <td>2026-06-07</td>
   <td>2026-09-05</td>
-  <td class="num days">90</td>
-  <td>@claude.</td>
+  <td class="num days">89</td>
+  <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>apps/web/AGENTS.md</code></td>
-  <td class="status">Fresh (62d)</td>
+  <td class="status">Fresh (61d)</td>
   <td>2026-05-13</td>
   <td>2026-08-08</td>
-  <td class="num days">62</td>
+  <td class="num days">61</td>
   <td>@Skords-01</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>apps/web/CLAUDE.md</code></td>
-  <td class="status">Fresh (90d)</td>
+  <td class="status">Fresh (89d)</td>
   <td>2026-06-07</td>
   <td>2026-09-05</td>
-  <td class="num days">90</td>
-  <td>@claude.</td>
+  <td class="num days">89</td>
+  <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/README.md</code></td>
-  <td class="status">Fresh (90d)</td>
+  <td class="status">Fresh (89d)</td>
   <td>2026-06-07</td>
   <td>2026-09-05</td>
-  <td class="num days">90</td>
-  <td>@claude.</td>
+  <td class="num days">89</td>
+  <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/agents/README.md</code></td>
-  <td class="status">Fresh (70d)</td>
+  <td class="status">Fresh (69d)</td>
   <td>2026-05-18</td>
   <td>2026-08-16</td>
-  <td class="num days">70</td>
+  <td class="num days">69</td>
   <td>@codex.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/agents/agent-skills-catalog.md</code></td>
-  <td class="status">Fresh (85d)</td>
+  <td class="status">Fresh (84d)</td>
   <td>2026-06-02</td>
   <td>2026-08-31</td>
-  <td class="num days">85</td>
+  <td class="num days">84</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/agents/agent-workflows.md</code></td>
-  <td class="status">Fresh (86d)</td>
+  <td class="status">Fresh (85d)</td>
   <td>2026-06-03</td>
   <td>2026-09-01</td>
-  <td class="num days">86</td>
+  <td class="num days">85</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/agents/codex-capabilities.md</code></td>
-  <td class="status">Fresh (70d)</td>
+  <td class="status">Fresh (69d)</td>
   <td>2026-05-18</td>
   <td>2026-08-16</td>
-  <td class="num days">70</td>
+  <td class="num days">69</td>
   <td>@codex.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/agents/onboarding.md</code></td>
-  <td class="status">Fresh (85d)</td>
+  <td class="status">Fresh (84d)</td>
   <td>2026-06-02</td>
   <td>2026-08-31</td>
-  <td class="num days">85</td>
+  <td class="num days">84</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/agents/skills-evolution-roadmap.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/agents/specialists-mapping.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/api/README.md</code></td>
-  <td class="status">Fresh (85d)</td>
+  <td class="status">Fresh (84d)</td>
   <td>2026-06-02</td>
   <td>2026-08-31</td>
-  <td class="num days">85</td>
+  <td class="num days">84</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/api/rate-limiting.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/architecture/README.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-06-02</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@claude.</td>
+  <td class="status">Fresh (89d)</td>
+  <td>2026-06-07</td>
+  <td>2026-09-05</td>
+  <td class="num days">89</td>
+  <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/architecture/ai-memory.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-06-02</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/architecture/api-contracts.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-06-02</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/architecture/api-v1.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-06-02</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/architecture/apps-status-matrix.md</code></td>
-  <td class="status">Fresh (71d)</td>
+  <td class="status">Fresh (70d)</td>
   <td>2026-06-02</td>
   <td>2026-08-17</td>
-  <td class="num days">71</td>
+  <td class="num days">70</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/architecture/apps-web-exhaustive-deps.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-06-02</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/architecture/data-exchange-storage-audit.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-06-02</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/architecture/diagrams/README.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-06-02</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/architecture/diagrams/c1-system-context.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-06-02</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/architecture/diagrams/c2-containers.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-06-02</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/architecture/diagrams/c3-chat-tool-use.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-06-02</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/architecture/diagrams/c3-cloudsync.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-06-02</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/architecture/diagrams/c3-workspaces.md</code></td>
-  <td class="status">Fresh (90d)</td>
+  <td class="status">Fresh (89d)</td>
   <td>2026-06-07</td>
   <td>2026-09-05</td>
-  <td class="num days">90</td>
+  <td class="num days">89</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/architecture/diagrams/flow-chat-tool-use.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-06-02</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/architecture/diagrams/flow-cloudsync.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-06-02</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/architecture/diagrams/flow-reminder-fire.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-06-02</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/architecture/diagrams/flow-signin.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-06-02</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/architecture/domain-invariants.md</code></td>
-  <td class="status">Fresh (84d)</td>
+  <td class="status">Fresh (83d)</td>
   <td>2026-06-02</td>
   <td>2026-08-30</td>
-  <td class="num days">84</td>
+  <td class="num days">83</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/architecture/frontend-overview.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-06-02</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/architecture/hosting-evolution.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-06-02</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/architecture/module-ownership.md</code></td>
-  <td class="status">Fresh (84d)</td>
+  <td class="status">Fresh (83d)</td>
   <td>2026-06-02</td>
   <td>2026-08-30</td>
-  <td class="num days">84</td>
+  <td class="num days">83</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/architecture/module-structure.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-06-02</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/architecture/platforms.md</code></td>
-  <td class="status">Fresh (84d)</td>
+  <td class="status">Fresh (83d)</td>
   <td>2026-06-02</td>
   <td>2026-08-30</td>
-  <td class="num days">84</td>
+  <td class="num days">83</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/architecture/rag-eval.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-06-02</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/architecture/repo-map.md</code></td>
-  <td class="status">Fresh (81d)</td>
+  <td class="status">Fresh (80d)</td>
   <td>2026-06-02</td>
   <td>2026-08-27</td>
-  <td class="num days">81</td>
+  <td class="num days">80</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/architecture/service-catalog.md</code></td>
-  <td class="status">Fresh (67d)</td>
+  <td class="status">Fresh (66d)</td>
   <td>2026-06-02</td>
   <td>2026-08-13</td>
-  <td class="num days">67</td>
+  <td class="num days">66</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/architecture/state-write-paths.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-06-02</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/assets/README.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/2026-05-03-web-deep-dive/00-overview.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/2026-05-03-web-deep-dive/01-frontend-ergonomics.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/2026-05-03-web-deep-dive/02-architecture-and-state.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/2026-05-03-web-deep-dive/03-backend-and-performance.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/2026-05-03-web-deep-dive/04-security-observability-testing-devx.md</code></td>
-  <td class="status">Fresh (70d)</td>
+  <td class="status">Fresh (69d)</td>
   <td>2026-05-18</td>
   <td>2026-08-16</td>
-  <td class="num days">70</td>
+  <td class="num days">69</td>
   <td>@codex.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/2026-05-03-web-deep-dive/round-13-burndown-sprint.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/2026-05-06-ux-roast-pr-plan.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/2026-05-13-consolidated-page-audit.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/2026-05-13-dead-code-hard-rules-roast.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-06-03</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/2026-05-13-page-audit-01-auth-onboarding.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/2026-05-13-page-audit-02-hub-dashboard.md</code></td>
-  <td class="status">Fresh (86d)</td>
+  <td class="status">Fresh (85d)</td>
   <td>2026-06-03</td>
   <td>2026-09-01</td>
-  <td class="num days">86</td>
+  <td class="num days">85</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/2026-05-13-page-audit-03-hub-chat-search.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/2026-05-13-page-audit-05-finyk.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/2026-05-13-page-audit-06-fizruk-part1.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/2026-05-13-page-audit-07-fizruk-part2.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/2026-05-13-page-audit-08-nutrition.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/2026-05-13-page-audit-09-routine-strategy.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/2026-05-13-page-audit-10-errors-pwa-marketing.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/2026-05-13-testing-devx-roast.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-06-04</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/2026-05-13-web-architecture-state-roast.md</code></td>
-  <td class="status">Fresh (88d)</td>
+  <td class="status">Fresh (87d)</td>
   <td>2026-06-03</td>
   <td>2026-09-03</td>
-  <td class="num days">88</td>
+  <td class="num days">87</td>
   <td>@claude</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/2026-05-25-hubsettings-cls-chunk-load.md</code></td>
-  <td class="status">Fresh (77d)</td>
+  <td class="status">Fresh (76d)</td>
   <td>2026-05-25</td>
   <td>2026-08-23</td>
-  <td class="num days">77</td>
+  <td class="num days">76</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/2026-08-XX-openclaw-internal-roast.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-06-06</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/2026-08-XX-sync-engine-roast.md</code></td>
-  <td class="status">Fresh (91d)</td>
+  <td class="status">Fresh (90d)</td>
   <td>2026-06-06</td>
   <td>2026-09-06</td>
-  <td class="num days">91</td>
+  <td class="num days">90</td>
   <td>@claude</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/README.md</code></td>
-  <td class="status">Fresh (55d)</td>
+  <td class="status">Fresh (54d)</td>
   <td>2026-06-03</td>
   <td>2026-08-01</td>
-  <td class="num days">55</td>
+  <td class="num days">54</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/_runner-report.md</code></td>
-  <td class="status">Fresh (87d)</td>
-  <td>2026-06-04</td>
-  <td>2026-09-02</td>
-  <td class="num days">87</td>
+  <td class="status">Fresh (90d)</td>
+  <td>2026-06-08</td>
+  <td>2026-09-06</td>
+  <td class="num days">90</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/archive/2026-04-26-sergeant-audit-devin.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/archive/2026-04-28-implementation-roadmap.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/archive/2026-04-28-sergeant-comprehensive-audit.md</code></td>
-  <td class="status">Fresh (66d)</td>
+  <td class="status">Fresh (65d)</td>
   <td>2026-05-14</td>
   <td>2026-08-12</td>
-  <td class="num days">66</td>
+  <td class="num days">65</td>
   <td>@codex.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/archive/2026-04-28-ux-improvement-plan.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/archive/2026-04-28-ux-ui-audit.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/archive/2026-05-02-doc-hygiene-audit.md</code></td>
-  <td class="status">Fresh (86d)</td>
+  <td class="status">Fresh (85d)</td>
   <td>2026-06-03</td>
   <td>2026-09-01</td>
-  <td class="num days">86</td>
+  <td class="num days">85</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/archive/2026-05-03-ftux-onboarding-roast.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/archive/2026-05-03-readme-gap-analysis.md</code></td>
-  <td class="status">Fresh (83d)</td>
+  <td class="status">Fresh (82d)</td>
   <td>2026-05-31</td>
   <td>2026-08-29</td>
-  <td class="num days">83</td>
+  <td class="num days">82</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/archive/2026-05-04-csp-disable-retrospective.md</code></td>
-  <td class="status">Fresh (84d)</td>
+  <td class="status">Fresh (83d)</td>
   <td>2026-06-01</td>
   <td>2026-08-30</td>
-  <td class="num days">84</td>
+  <td class="num days">83</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/archive/2026-05-04-revenue-and-marketing-roast.md</code></td>
-  <td class="status">Fresh (70d)</td>
+  <td class="status">Fresh (69d)</td>
   <td>2026-05-18</td>
   <td>2026-08-16</td>
-  <td class="num days">70</td>
+  <td class="num days">69</td>
   <td>@codex.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/archive/2026-05-05-dead-code-and-stale-links-audit.md</code></td>
-  <td class="status">Fresh (70d)</td>
+  <td class="status">Fresh (69d)</td>
   <td>2026-05-18</td>
   <td>2026-08-16</td>
-  <td class="num days">70</td>
+  <td class="num days">69</td>
   <td>@codex.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/archive/2026-05-06-ux-roast.md</code></td>
-  <td class="status">Fresh (70d)</td>
+  <td class="status">Fresh (69d)</td>
   <td>2026-05-18</td>
   <td>2026-08-16</td>
-  <td class="num days">70</td>
+  <td class="num days">69</td>
   <td>@codex.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/archive/2026-05-07-app-audit.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-06-02</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/archive/2026-05-07-full-app-regression-ux-audit.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/archive/2026-05-11-docs-audit-summary.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/archive/2026-05-13-backend-performance-roast.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-06-02</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/archive/2026-05-13-documentation-hygiene-roast.md</code></td>
-  <td class="status">Fresh (83d)</td>
+  <td class="status">Fresh (82d)</td>
   <td>2026-05-31</td>
   <td>2026-08-29</td>
-  <td class="num days">83</td>
+  <td class="num days">82</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/archive/2026-05-13-ftux-onboarding-roast.md</code></td>
-  <td class="status">Fresh (71d)</td>
+  <td class="status">Fresh (70d)</td>
   <td>2026-05-19</td>
   <td>2026-08-17</td>
-  <td class="num days">71</td>
+  <td class="num days">70</td>
   <td>@codex.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/archive/2026-05-13-mobile-reliability-ux-roast.md</code></td>
-  <td class="status">Fresh (85d)</td>
+  <td class="status">Fresh (84d)</td>
   <td>2026-06-02</td>
   <td>2026-08-31</td>
-  <td class="num days">85</td>
+  <td class="num days">84</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/archive/2026-05-13-revenue-monetization-roast.md</code></td>
-  <td class="status">Fresh (70d)</td>
+  <td class="status">Fresh (69d)</td>
   <td>2026-05-18</td>
   <td>2026-08-16</td>
-  <td class="num days">70</td>
+  <td class="num days">69</td>
   <td>@codex.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/archive/2026-05-13-security-observability-roast.md</code></td>
-  <td class="status">Fresh (88d)</td>
+  <td class="status">Fresh (87d)</td>
   <td>2026-06-05</td>
   <td>2026-09-03</td>
-  <td class="num days">88</td>
+  <td class="num days">87</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/archive/2026-05-13-web-frontend-ergonomics-roast.md</code></td>
-  <td class="status">Fresh (91d)</td>
+  <td class="status">Fresh (90d)</td>
   <td>2026-06-06</td>
   <td>2026-09-06</td>
-  <td class="num days">91</td>
+  <td class="num days">90</td>
   <td>@claude</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/archive/2026-05-15-deep-audit-state-of-repo.md</code></td>
-  <td class="status">Fresh (91d)</td>
+  <td class="status">Fresh (90d)</td>
   <td>2026-06-06</td>
   <td>2026-09-06</td>
-  <td class="num days">91</td>
+  <td class="num days">90</td>
   <td>@claude</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/audits/archive/ux-audit-2025.md</code></td>
-  <td class="status">Fresh (340d)</td>
+  <td class="status">Fresh (339d)</td>
   <td>2026-05-13</td>
   <td>2027-05-13</td>
-  <td class="num days">340</td>
+  <td class="num days">339</td>
   <td>@Skords-01.</td>
   <td class="num">365</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/copy/README.md</code></td>
-  <td class="status">Fresh (85d)</td>
+  <td class="status">Fresh (84d)</td>
   <td>2026-06-02</td>
   <td>2026-08-31</td>
-  <td class="num days">85</td>
+  <td class="num days">84</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/copy/style-guide.uk.md</code></td>
-  <td class="status">Fresh (83d)</td>
+  <td class="status">Fresh (82d)</td>
   <td>2026-05-31</td>
   <td>2026-08-29</td>
-  <td class="num days">83</td>
+  <td class="num days">82</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/deploy/README.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="status">Fresh (89d)</td>
+  <td>2026-06-07</td>
+  <td>2026-09-05</td>
+  <td class="num days">89</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
-  <td><code>docs/deploy/console.md</code></td>
-  <td class="status">Fresh (85d)</td>
-  <td>2026-06-02</td>
-  <td>2026-08-31</td>
-  <td class="num days">85</td>
-  <td>@claude.</td>
+  <td><code>docs/deploy/monorepo-deploy-filtering.md</code></td>
+  <td class="status">Fresh (89d)</td>
+  <td>2026-06-07</td>
+  <td>2026-09-05</td>
+  <td class="num days">89</td>
+  <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
-  <td><code>docs/deploy/monorepo-deploy-filtering.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td><code>docs/deploy/openclaw.md</code></td>
+  <td class="status">Fresh (89d)</td>
+  <td>2026-06-07</td>
+  <td>2026-09-05</td>
+  <td class="num days">89</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/deploy/vercel.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/design/README.md</code></td>
-  <td class="status">Fresh (67d)</td>
+  <td class="status">Fresh (66d)</td>
   <td>2026-05-17</td>
   <td>2026-08-13</td>
-  <td class="num days">67</td>
+  <td class="num days">66</td>
   <td>@codex.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/design/archive/README.md</code></td>
-  <td class="status">Fresh (69d)</td>
+  <td class="status">Fresh (68d)</td>
   <td>2026-05-17</td>
   <td>2026-08-15</td>
-  <td class="num days">69</td>
+  <td class="num days">68</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/design/archive/brand-palette-wcag-aa-proposal.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/design/archive/dark-mode-audit.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Codex.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/design/brandbook.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/design/cross-module-prompts.md</code></td>
-  <td class="status">Fresh (63d)</td>
+  <td class="status">Fresh (62d)</td>
   <td>2026-05-11</td>
   <td>2026-08-09</td>
-  <td class="num days">63</td>
+  <td class="num days">62</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/design/design-system.md</code></td>
-  <td class="status">Fresh (70d)</td>
-  <td>2026-05-18</td>
-  <td>2026-08-16</td>
-  <td class="num days">70</td>
+  <td class="status">Fresh (89d)</td>
+  <td>2026-06-07</td>
+  <td>2026-09-05</td>
+  <td class="num days">89</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/design/empty-states.md</code></td>
-  <td class="status">Fresh (63d)</td>
+  <td class="status">Fresh (62d)</td>
   <td>2026-05-11</td>
   <td>2026-08-09</td>
-  <td class="num days">63</td>
+  <td class="num days">62</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="due-soon">
   <td><code>docs/design/mockups-backlog.md</code></td>
-  <td class="status">Due soon (24d)</td>
+  <td class="status">Due soon (23d)</td>
   <td>2026-05-18</td>
   <td>2026-07-01</td>
-  <td class="num days">24</td>
+  <td class="num days">23</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/design/module-accent.md</code></td>
-  <td class="status">Fresh (69d)</td>
+  <td class="status">Fresh (68d)</td>
   <td>2026-05-17</td>
   <td>2026-08-15</td>
-  <td class="num days">69</td>
+  <td class="num days">68</td>
   <td>@codex.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/design/radius-rhythm.md</code></td>
-  <td class="status">Fresh (63d)</td>
+  <td class="status">Fresh (62d)</td>
   <td>2026-05-11</td>
   <td>2026-08-09</td>
-  <td class="num days">63</td>
+  <td class="num days">62</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/design/redesign-v2/README.md</code></td>
-  <td class="status">Fresh (70d)</td>
+  <td class="status">Fresh (69d)</td>
   <td>2026-05-18</td>
   <td>2026-08-16</td>
-  <td class="num days">70</td>
+  <td class="num days">69</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/design/redesign-v2/alignment-audit-2026-05-18.md</code></td>
-  <td class="status">Fresh (70d)</td>
+  <td class="status">Fresh (69d)</td>
   <td>2026-05-18</td>
   <td>2026-08-16</td>
-  <td class="num days">70</td>
+  <td class="num days">69</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/design/redesign-v2/backlog.md</code></td>
-  <td class="status">Fresh (73d)</td>
+  <td class="status">Fresh (72d)</td>
   <td>2026-05-21</td>
   <td>2026-08-19</td>
-  <td class="num days">73</td>
+  <td class="num days">72</td>
   <td>@Skords-01</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/design/redesign-v2/execution-brief.md</code></td>
-  <td class="status">Fresh (69d)</td>
+  <td class="status">Fresh (68d)</td>
   <td>2026-05-17</td>
   <td>2026-08-15</td>
-  <td class="num days">69</td>
+  <td class="num days">68</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/design/redesign-v2/execution-plan.md</code></td>
-  <td class="status">Fresh (68d)</td>
+  <td class="status">Fresh (67d)</td>
   <td>2026-05-18</td>
   <td>2026-08-14</td>
-  <td class="num days">68</td>
+  <td class="num days">67</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/design/redesign-v2/execution-status.md</code></td>
-  <td class="status">Fresh (73d)</td>
+  <td class="status">Fresh (72d)</td>
   <td>2026-05-21</td>
   <td>2026-08-19</td>
-  <td class="num days">73</td>
+  <td class="num days">72</td>
   <td>@Skords-01</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/design/redesign-v2/governance.md</code></td>
-  <td class="status">Fresh (69d)</td>
-  <td>2026-05-17</td>
-  <td>2026-08-15</td>
-  <td class="num days">69</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/design/redesign-v2/migration.md</code></td>
-  <td class="status">Fresh (69d)</td>
-  <td>2026-05-17</td>
-  <td>2026-08-15</td>
-  <td class="num days">69</td>
-  <td>@codex.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/design/redesign-v2/phase-7-product-decisions-2026-05-22.md</code></td>
-  <td class="status">Fresh (74d)</td>
-  <td>2026-05-22</td>
-  <td>2026-08-20</td>
-  <td class="num days">74</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/design/redesign-v2/retrospective-2026-05-21.md</code></td>
-  <td class="status">Fresh (74d)</td>
-  <td>2026-05-22</td>
-  <td>2026-08-20</td>
-  <td class="num days">74</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/design/specs/2026-04-25-assistant-capability-catalogue-design.md</code></td>
-  <td class="status">Fresh (69d)</td>
-  <td>2026-05-17</td>
-  <td>2026-08-15</td>
-  <td class="num days">69</td>
-  <td>@codex.</td>
-  <td class="num">180</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/design/specs/2026-05-06-sync-engine-writer-wiring-design.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/design/specs/README.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-17</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@codex.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/design/specs/archive/2026-04-24-assistant-quick-actions-v1-design.md</code></td>
-  <td class="status">Fresh (69d)</td>
-  <td>2026-05-17</td>
-  <td>2026-08-15</td>
-  <td class="num days">69</td>
-  <td>@codex.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/design/specs/archive/README.md</code></td>
-  <td class="status">Fresh (69d)</td>
-  <td>2026-05-17</td>
-  <td>2026-08-15</td>
-  <td class="num days">69</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/design/storybook.md</code></td>
-  <td class="status">Fresh (70d)</td>
-  <td>2026-05-18</td>
-  <td>2026-08-16</td>
-  <td class="num days">70</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/design/undo-pattern.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/design/unified-bottom-nav.md</code></td>
-  <td class="status">Fresh (69d)</td>
-  <td>2026-05-17</td>
-  <td>2026-08-15</td>
-  <td class="num days">69</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/development/README.md</code></td>
-  <td class="status">Fresh (85d)</td>
-  <td>2026-06-02</td>
-  <td>2026-08-31</td>
-  <td class="num days">85</td>
-  <td>@claude.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/development/eslint-config.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/development/local-postgres-setup.md</code></td>
-  <td class="status">Fresh (86d)</td>
-  <td>2026-06-05</td>
-  <td>2026-09-01</td>
-  <td class="num days">86</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/development/pre-commit-timing.md</code></td>
-  <td class="status">Fresh (72d)</td>
-  <td>2026-05-20</td>
-  <td>2026-08-18</td>
-  <td class="num days">72</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/README.md</code></td>
-  <td class="status">Fresh (86d)</td>
-  <td>2026-06-03</td>
-  <td>2026-09-01</td>
-  <td class="num days">86</td>
-  <td>@claude.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/audit-freeze-2026-05-05.md</code></td>
-  <td class="status">Fresh (176d)</td>
-  <td>2026-06-03</td>
-  <td>2026-11-30</td>
-  <td class="num days">176</td>
-  <td>@claude.</td>
-  <td class="num">180</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/doc-freshness.md</code></td>
-  <td class="status">Fresh (66d)</td>
-  <td>2026-05-14</td>
-  <td>2026-08-12</td>
-  <td class="num days">66</td>
-  <td>@codex.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/feature-flags.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/hard-rules-matrix.md</code></td>
-  <td class="status">Fresh (90d)</td>
-  <td>2026-06-07</td>
-  <td>2026-09-05</td>
-  <td class="num days">90</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/incident-severity-policy.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/pnpm-overrides-policy.md</code></td>
-  <td class="status">Fresh (66d)</td>
-  <td>2026-05-14</td>
-  <td>2026-08-12</td>
-  <td class="num days">66</td>
-  <td>@codex.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/policy-review.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/release-policy.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/review-checklist.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/rules/01-db-types-coerce-bigint-to-number.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/rules/02-rq-keys-via-centralized-factories.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/rules/03-api-contract-server-client-test.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/rules/04-sql-migrations-sequential-two-phase.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/rules/05-conventional-commits-explicit-scope.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/rules/06-no-force-push-to-main.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/rules/07-pre-commit-hooks-via-husky.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/rules/08-tailwind-colour-opacity-scale.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/rules/09-saturated-brand-fills-strong-companion.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/rules/10-lifecycle-markers.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/rules/11-no-arbitrary-hex-in-classname.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/rules/12-module-accent-containment.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/rules/13-no-raw-palette-light-dark-pairs.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/rules/14-focus-visible-not-focus.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/rules/15-governance-and-doc-language.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/rules/16-typography-scale-12px-floor.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/rules/17-animation-budget.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/rules/18-module-size-discipline-600.md</code></td>
-  <td class="status">Fresh (86d)</td>
-  <td>2026-06-05</td>
-  <td>2026-09-01</td>
-  <td class="num days">86</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/rules/19-strict-mode-flag-canonical.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/rules/20-no-openclaw-pats-in-production.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/rules/21-pino-redaction-policy.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/rules/22-skill-body-security-scan.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/rules/23-archive-move-depth.md</code></td>
-  <td class="status">Fresh (66d)</td>
-  <td>2026-05-14</td>
-  <td>2026-08-12</td>
-  <td class="num days">66</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/rules/24-catalog-check-generator.md</code></td>
-  <td class="status">Fresh (67d)</td>
-  <td>2026-05-15</td>
-  <td>2026-08-13</td>
-  <td class="num days">67</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/rules/25-auto-generated-marker.md</code></td>
-  <td class="status">Fresh (67d)</td>
-  <td>2026-05-15</td>
-  <td>2026-08-13</td>
-  <td class="num days">67</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/rules/26-pr-ledger-update-on-merge.md</code></td>
-  <td class="status">Fresh (67d)</td>
-  <td>2026-05-15</td>
-  <td>2026-08-13</td>
-  <td class="num days">67</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/rules/README.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/rules/kyiv-time-helpers.md</code></td>
-  <td class="status">Fresh (86d)</td>
-  <td>2026-06-01</td>
-  <td>2026-09-01</td>
-  <td class="num days">86</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/governance/security-incident-policy.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/i18n/README.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/i18n/readiness.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/0003-sync-v2-rollout-and-v1-sunset.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/0006-frontend-routing-and-code-split.md</code></td>
-  <td class="status">Fresh (81d)</td>
-  <td>2026-06-01</td>
-  <td>2026-08-27</td>
-  <td class="num days">81</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/0010-revenue-first-launch.md</code></td>
-  <td class="status">Fresh (86d)</td>
-  <td>2026-06-03</td>
-  <td>2026-09-01</td>
-  <td class="num days">86</td>
-  <td>@claude.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="due-soon">
-  <td><code>docs/initiatives/0015-docs-automation-daily-ops.md</code></td>
-  <td class="status">Due soon (2d)</td>
-  <td>2026-06-07</td>
-  <td>2026-06-09</td>
-  <td class="num days">2</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/0017-hub-tabs-mount-perf.md</code></td>
-  <td class="status">Fresh (81d)</td>
-  <td>2026-06-06</td>
-  <td>2026-08-27</td>
-  <td class="num days">81</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/README.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/archive/2026-08-02-batch-archival-plan.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/archive/README.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/archive/_0001-module-decomposition.md</code></td>
-  <td class="status">Fresh (84d)</td>
-  <td>2026-06-01</td>
-  <td>2026-08-30</td>
-  <td class="num days">84</td>
-  <td>@claude.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/archive/_0002-mobile-platform-decision.md</code></td>
-  <td class="status">Fresh (84d)</td>
-  <td>2026-06-01</td>
-  <td>2026-08-30</td>
-  <td class="num days">84</td>
-  <td>@claude.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/archive/_0004-server-observability.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/archive/_0005-ai-cost-and-prompt-cache.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/archive/_0007-design-system-tooling.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/archive/_0008-platform-hardening.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/archive/_0009-agent-os-hardening.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/archive/_0011-foundation-adoption-and-process-discipline.md</code></td>
-  <td class="status">Fresh (84d)</td>
-  <td>2026-06-01</td>
-  <td>2026-08-30</td>
-  <td class="num days">84</td>
-  <td>@claude.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/archive/_0012-perfect-strictness-rollout.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/archive/_0013-module-decomposition-round-2.md</code></td>
-  <td class="status">Fresh (81d)</td>
-  <td>2026-05-29</td>
-  <td>2026-08-27</td>
-  <td class="num days">81</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/archive/_0014-knowledge-graph-and-catalogs.md</code></td>
-  <td class="status">Fresh (84d)</td>
-  <td>2026-06-01</td>
-  <td>2026-08-30</td>
-  <td class="num days">84</td>
-  <td>@claude.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/archive/_0016-changelog-release-cut.md</code></td>
-  <td class="status">Fresh (81d)</td>
-  <td>2026-05-29</td>
-  <td>2026-08-27</td>
-  <td class="num days">81</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/00-overview.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/01-session-log-2026-05-03.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/README.md</code></td>
-  <td class="status">Fresh (76d)</td>
-  <td>2026-05-24</td>
-  <td>2026-08-22</td>
-  <td class="num days">76</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-01-unify-env-modules.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-02-rate-limit-fail-closed.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-03-bcrypt-password-limit.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-04-bus-factor-secondary-owners.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-05-typescript-types-node-downgrade.md</code></td>
-  <td class="status">Fresh (85d)</td>
-  <td>2026-06-02</td>
-  <td>2026-08-31</td>
-  <td class="num days">85</td>
-  <td>@claude.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-06-openclaw-github-app.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-07-body-size-declarative-policy.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-08-api-versioning-consolidation.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-09-apns-library-adr.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-10-better-auth-security-review.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-11-drizzle-schema-drift-ci.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-12-sentry-traces-sampler.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-13-postgres-pool-sizing.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-14-vercel-coep-review.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-15-ai-quota-disabled-hardblock.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-16-pino-redaction-policy.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-17-env-vars-feature-flag-toggle.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-18-detox-server-shape-trigger.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-19-workers-health-registry.md</code></td>
-  <td class="status">Fresh (66d)</td>
-  <td>2026-05-14</td>
-  <td>2026-08-12</td>
-  <td class="num days">66</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-20-patches-readme.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-21-sw-prompt-mode-auto-update.md</code></td>
-  <td class="status">Fresh (66d)</td>
-  <td>2026-05-14</td>
-  <td>2026-08-12</td>
-  <td class="num days">66</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-22-mobile-expo-sdk-53.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-23-openapi-contract-tests.md</code></td>
-  <td class="status">Fresh (66d)</td>
-  <td>2026-05-14</td>
-  <td>2026-08-12</td>
-  <td class="num days">66</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-24-embedding-vendor-abstraction.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-25-two-production-origins.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-26-csp-report-uri.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-27-internal-api-key-rotation.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-28-sw-build-id-import-meta.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-29-shell-navigate-broadcast-channel.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-30-dockerfile-cleanup-cve.md</code></td>
-  <td class="status">Fresh (66d)</td>
-  <td>2026-05-14</td>
-  <td>2026-08-12</td>
-  <td class="num days">66</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-31-eslint-config-split.md</code></td>
-  <td class="status">Fresh (86d)</td>
-  <td>2026-06-01</td>
-  <td>2026-09-01</td>
-  <td class="num days">86</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-32-pnpm-overrides-cleanup.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-33-hard-rules-categorization.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-34-demo-seed-cleanup-gate.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-35-log-level-debug-window.md</code></td>
-  <td class="status">Fresh (66d)</td>
-  <td>2026-05-14</td>
-  <td>2026-08-12</td>
-  <td class="num days">66</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-36-lazy-import-chunk-reload-guard.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-37-postgres-image-sha-pin.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-38-pwa-precache-first-party.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/initiatives/stack-pulse-2026-05/pr-39-tools-console-anthropic-sdk.md</code></td>
-  <td class="status">Fresh (66d)</td>
-  <td>2026-05-14</td>
-  <td>2026-08-12</td>
-  <td class="num days">66</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/integrations/README.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@devin-ai-integration</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/integrations/env-vars.md</code></td>
-  <td class="status">Fresh (88d)</td>
-  <td>2026-06-05</td>
-  <td>2026-09-03</td>
-  <td class="num days">88</td>
-  <td>@claude.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/integrations/monobank-roadmap.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/integrations/railway-vercel.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/integrations/renovate-usage.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/integrations/voyage-pgvector.md</code></td>
-  <td class="status">Fresh (70d)</td>
-  <td>2026-05-18</td>
-  <td>2026-08-16</td>
-  <td class="num days">70</td>
-  <td>@codex.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/launch/README.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/launch/business/01-monetization-and-pricing.md</code></td>
-  <td class="status">Fresh (71d)</td>
-  <td>2026-05-19</td>
-  <td>2026-08-17</td>
-  <td class="num days">71</td>
-  <td>@codex.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/launch/business/02-go-to-market.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/launch/business/03-services-and-toolstack.md</code></td>
-  <td class="status">Fresh (71d)</td>
-  <td>2026-05-19</td>
-  <td>2026-08-17</td>
-  <td class="num days">71</td>
-  <td>@codex.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/launch/business/04-launch-readiness.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/launch/business/05-operations-and-automation.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/launch/business/06-monetization-architecture.md</code></td>
-  <td class="status">Fresh (71d)</td>
-  <td>2026-05-19</td>
-  <td>2026-08-17</td>
-  <td class="num days">71</td>
-  <td>@codex.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/launch/email-verification-sweep.md</code></td>
-  <td class="status">Fresh (84d)</td>
-  <td>2026-06-01</td>
-  <td>2026-08-30</td>
-  <td class="num days">84</td>
-  <td>@claude.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/launch/landing-decision.md</code></td>
-  <td class="status">Fresh (66d)</td>
-  <td>2026-05-14</td>
-  <td>2026-08-12</td>
-  <td class="num days">66</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/launch/phases/00-readiness-audit.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/launch/phases/01-web-launch-with-users.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/launch/phases/02-capacitor-launch.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/launch/phases/03-native-expo-launch.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/launch/phases/README.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/launch/product-os/ftux-master-tracker.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/launch/product-os/ftux-sprint-plan.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/launch/product-os/paywall-implementation-plan.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/launch/product-os/paywall-ux-placement.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/launch/product-os/sprint-retros/s1-honest-valueprop.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/launch/product-os/sprint-retros/s3-reward-moments.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/launch/tech/ai-memory-activation.md</code></td>
-  <td class="status">Fresh (70d)</td>
-  <td>2026-05-18</td>
-  <td>2026-08-16</td>
-  <td class="num days">70</td>
-  <td>@codex.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/launch/tech/openclaw-roadmap.md</code></td>
-  <td class="status">Fresh (70d)</td>
-  <td>2026-05-18</td>
-  <td>2026-08-16</td>
-  <td class="num days">70</td>
-  <td>@codex.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/launch/tech/telegram-improvements-roadmap.md</code></td>
-  <td class="status">Fresh (70d)</td>
-  <td>2026-05-18</td>
-  <td>2026-08-16</td>
-  <td class="num days">70</td>
-  <td>@codex.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/marketing/README.md</code></td>
-  <td class="status">Fresh (85d)</td>
-  <td>2026-06-02</td>
-  <td>2026-08-31</td>
-  <td class="num days">85</td>
-  <td>@claude.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/marketing/launch-plan.md</code></td>
   <td class="status">Fresh (68d)</td>
-  <td>2026-05-16</td>
-  <td>2026-08-14</td>
+  <td>2026-05-17</td>
+  <td>2026-08-15</td>
   <td class="num days">68</td>
   <td>@Skords-01</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
-  <td><code>docs/mobile/README.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td><code>docs/design/redesign-v2/migration.md</code></td>
+  <td class="status">Fresh (68d)</td>
+  <td>2026-05-17</td>
+  <td>2026-08-15</td>
+  <td class="num days">68</td>
+  <td>@codex.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/design/redesign-v2/phase-7-product-decisions-2026-05-22.md</code></td>
+  <td class="status">Fresh (73d)</td>
+  <td>2026-05-22</td>
+  <td>2026-08-20</td>
+  <td class="num days">73</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/design/redesign-v2/retrospective-2026-05-21.md</code></td>
+  <td class="status">Fresh (73d)</td>
+  <td>2026-05-22</td>
+  <td>2026-08-20</td>
+  <td class="num days">73</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/design/specs/2026-04-25-assistant-capability-catalogue-design.md</code></td>
+  <td class="status">Fresh (68d)</td>
+  <td>2026-05-17</td>
+  <td>2026-08-15</td>
+  <td class="num days">68</td>
+  <td>@codex.</td>
+  <td class="num">180</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/design/specs/2026-05-06-sync-engine-writer-wiring-design.md</code></td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/design/specs/README.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-17</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@codex.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/design/specs/archive/2026-04-24-assistant-quick-actions-v1-design.md</code></td>
+  <td class="status">Fresh (68d)</td>
+  <td>2026-05-17</td>
+  <td>2026-08-15</td>
+  <td class="num days">68</td>
+  <td>@codex.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/design/specs/archive/README.md</code></td>
+  <td class="status">Fresh (68d)</td>
+  <td>2026-05-17</td>
+  <td>2026-08-15</td>
+  <td class="num days">68</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/design/storybook.md</code></td>
+  <td class="status">Fresh (69d)</td>
+  <td>2026-05-18</td>
+  <td>2026-08-16</td>
+  <td class="num days">69</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/design/undo-pattern.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/design/unified-bottom-nav.md</code></td>
+  <td class="status">Fresh (68d)</td>
+  <td>2026-05-17</td>
+  <td>2026-08-15</td>
+  <td class="num days">68</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/development/README.md</code></td>
+  <td class="status">Fresh (84d)</td>
+  <td>2026-06-02</td>
+  <td>2026-08-31</td>
+  <td class="num days">84</td>
+  <td>@claude.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/development/eslint-config.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/development/local-postgres-setup.md</code></td>
+  <td class="status">Fresh (85d)</td>
+  <td>2026-06-05</td>
+  <td>2026-09-01</td>
+  <td class="num days">85</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/development/pre-commit-timing.md</code></td>
+  <td class="status">Fresh (71d)</td>
+  <td>2026-05-20</td>
+  <td>2026-08-18</td>
+  <td class="num days">71</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/README.md</code></td>
+  <td class="status">Fresh (85d)</td>
+  <td>2026-06-03</td>
+  <td>2026-09-01</td>
+  <td class="num days">85</td>
+  <td>@claude.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/audit-freeze-2026-05-05.md</code></td>
+  <td class="status">Fresh (175d)</td>
+  <td>2026-06-03</td>
+  <td>2026-11-30</td>
+  <td class="num days">175</td>
+  <td>@claude.</td>
+  <td class="num">180</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/doc-freshness.md</code></td>
+  <td class="status">Fresh (65d)</td>
+  <td>2026-05-14</td>
+  <td>2026-08-12</td>
   <td class="num days">65</td>
+  <td>@codex.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/feature-flags.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/hard-rules-matrix.md</code></td>
+  <td class="status">Fresh (89d)</td>
+  <td>2026-06-07</td>
+  <td>2026-09-05</td>
+  <td class="num days">89</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/incident-severity-policy.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/pnpm-overrides-policy.md</code></td>
+  <td class="status">Fresh (65d)</td>
+  <td>2026-05-14</td>
+  <td>2026-08-12</td>
+  <td class="num days">65</td>
+  <td>@codex.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/policy-review.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/release-policy.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/review-checklist.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/rules/01-db-types-coerce-bigint-to-number.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/rules/02-rq-keys-via-centralized-factories.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/rules/03-api-contract-server-client-test.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/rules/04-sql-migrations-sequential-two-phase.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/rules/05-conventional-commits-explicit-scope.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/rules/06-no-force-push-to-main.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/rules/07-pre-commit-hooks-via-husky.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/rules/08-tailwind-colour-opacity-scale.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/rules/09-saturated-brand-fills-strong-companion.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/rules/10-lifecycle-markers.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/rules/11-no-arbitrary-hex-in-classname.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/rules/12-module-accent-containment.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/rules/13-no-raw-palette-light-dark-pairs.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/rules/14-focus-visible-not-focus.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/rules/15-governance-and-doc-language.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/rules/16-typography-scale-12px-floor.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/rules/17-animation-budget.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/rules/18-module-size-discipline-600.md</code></td>
+  <td class="status">Fresh (85d)</td>
+  <td>2026-06-05</td>
+  <td>2026-09-01</td>
+  <td class="num days">85</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/rules/19-strict-mode-flag-canonical.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/rules/20-no-openclaw-pats-in-production.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/rules/21-pino-redaction-policy.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/rules/22-skill-body-security-scan.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/rules/23-archive-move-depth.md</code></td>
+  <td class="status">Fresh (65d)</td>
+  <td>2026-05-14</td>
+  <td>2026-08-12</td>
+  <td class="num days">65</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/rules/24-catalog-check-generator.md</code></td>
+  <td class="status">Fresh (66d)</td>
+  <td>2026-05-15</td>
+  <td>2026-08-13</td>
+  <td class="num days">66</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/rules/25-auto-generated-marker.md</code></td>
+  <td class="status">Fresh (66d)</td>
+  <td>2026-05-15</td>
+  <td>2026-08-13</td>
+  <td class="num days">66</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/rules/26-pr-ledger-update-on-merge.md</code></td>
+  <td class="status">Fresh (66d)</td>
+  <td>2026-05-15</td>
+  <td>2026-08-13</td>
+  <td class="num days">66</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/rules/README.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/rules/kyiv-time-helpers.md</code></td>
+  <td class="status">Fresh (85d)</td>
+  <td>2026-06-01</td>
+  <td>2026-09-01</td>
+  <td class="num days">85</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/governance/security-incident-policy.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/i18n/README.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/i18n/readiness.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/0003-sync-v2-rollout-and-v1-sunset.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/0006-frontend-routing-and-code-split.md</code></td>
+  <td class="status">Fresh (80d)</td>
+  <td>2026-06-07</td>
+  <td>2026-08-27</td>
+  <td class="num days">80</td>
+  <td>@claude.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/0010-revenue-first-launch.md</code></td>
+  <td class="status">Fresh (85d)</td>
+  <td>2026-06-03</td>
+  <td>2026-09-01</td>
+  <td class="num days">85</td>
+  <td>@claude.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="due-soon">
+  <td><code>docs/initiatives/0015-docs-automation-daily-ops.md</code></td>
+  <td class="status">Due soon (1d)</td>
+  <td>2026-06-07</td>
+  <td>2026-06-09</td>
+  <td class="num days">1</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/0017-hub-tabs-mount-perf.md</code></td>
+  <td class="status">Fresh (80d)</td>
+  <td>2026-06-06</td>
+  <td>2026-08-27</td>
+  <td class="num days">80</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/README.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/archive/2026-08-02-batch-archival-plan.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/archive/README.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/archive/_0001-module-decomposition.md</code></td>
+  <td class="status">Fresh (83d)</td>
+  <td>2026-06-01</td>
+  <td>2026-08-30</td>
+  <td class="num days">83</td>
+  <td>@claude.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/archive/_0002-mobile-platform-decision.md</code></td>
+  <td class="status">Fresh (83d)</td>
+  <td>2026-06-01</td>
+  <td>2026-08-30</td>
+  <td class="num days">83</td>
+  <td>@claude.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/archive/_0004-server-observability.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/archive/_0005-ai-cost-and-prompt-cache.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/archive/_0007-design-system-tooling.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/archive/_0008-platform-hardening.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/archive/_0009-agent-os-hardening.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/archive/_0011-foundation-adoption-and-process-discipline.md</code></td>
+  <td class="status">Fresh (83d)</td>
+  <td>2026-06-01</td>
+  <td>2026-08-30</td>
+  <td class="num days">83</td>
+  <td>@claude.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/archive/_0012-perfect-strictness-rollout.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/archive/_0013-module-decomposition-round-2.md</code></td>
+  <td class="status">Fresh (80d)</td>
+  <td>2026-05-29</td>
+  <td>2026-08-27</td>
+  <td class="num days">80</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/archive/_0014-knowledge-graph-and-catalogs.md</code></td>
+  <td class="status">Fresh (83d)</td>
+  <td>2026-06-01</td>
+  <td>2026-08-30</td>
+  <td class="num days">83</td>
+  <td>@claude.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/archive/_0016-changelog-release-cut.md</code></td>
+  <td class="status">Fresh (80d)</td>
+  <td>2026-05-29</td>
+  <td>2026-08-27</td>
+  <td class="num days">80</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/00-overview.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/01-session-log-2026-05-03.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/README.md</code></td>
+  <td class="status">Fresh (75d)</td>
+  <td>2026-05-24</td>
+  <td>2026-08-22</td>
+  <td class="num days">75</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-01-unify-env-modules.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-02-rate-limit-fail-closed.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-03-bcrypt-password-limit.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-04-bus-factor-secondary-owners.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-05-typescript-types-node-downgrade.md</code></td>
+  <td class="status">Fresh (84d)</td>
+  <td>2026-06-02</td>
+  <td>2026-08-31</td>
+  <td class="num days">84</td>
+  <td>@claude.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-06-openclaw-github-app.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-07-body-size-declarative-policy.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-08-api-versioning-consolidation.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-09-apns-library-adr.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-10-better-auth-security-review.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-11-drizzle-schema-drift-ci.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-12-sentry-traces-sampler.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-13-postgres-pool-sizing.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-14-vercel-coep-review.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-15-ai-quota-disabled-hardblock.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-16-pino-redaction-policy.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-17-env-vars-feature-flag-toggle.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-18-detox-server-shape-trigger.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-19-workers-health-registry.md</code></td>
+  <td class="status">Fresh (65d)</td>
+  <td>2026-05-14</td>
+  <td>2026-08-12</td>
+  <td class="num days">65</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-20-patches-readme.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-21-sw-prompt-mode-auto-update.md</code></td>
+  <td class="status">Fresh (65d)</td>
+  <td>2026-05-14</td>
+  <td>2026-08-12</td>
+  <td class="num days">65</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-22-mobile-expo-sdk-53.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-23-openapi-contract-tests.md</code></td>
+  <td class="status">Fresh (65d)</td>
+  <td>2026-05-14</td>
+  <td>2026-08-12</td>
+  <td class="num days">65</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-24-embedding-vendor-abstraction.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-25-two-production-origins.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-26-csp-report-uri.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-27-internal-api-key-rotation.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-28-sw-build-id-import-meta.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-29-shell-navigate-broadcast-channel.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-30-dockerfile-cleanup-cve.md</code></td>
+  <td class="status">Fresh (65d)</td>
+  <td>2026-05-14</td>
+  <td>2026-08-12</td>
+  <td class="num days">65</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-31-eslint-config-split.md</code></td>
+  <td class="status">Fresh (85d)</td>
+  <td>2026-06-01</td>
+  <td>2026-09-01</td>
+  <td class="num days">85</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-32-pnpm-overrides-cleanup.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-33-hard-rules-categorization.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-34-demo-seed-cleanup-gate.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-35-log-level-debug-window.md</code></td>
+  <td class="status">Fresh (65d)</td>
+  <td>2026-05-14</td>
+  <td>2026-08-12</td>
+  <td class="num days">65</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-36-lazy-import-chunk-reload-guard.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-37-postgres-image-sha-pin.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-38-pwa-precache-first-party.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/initiatives/stack-pulse-2026-05/pr-39-tools-console-anthropic-sdk.md</code></td>
+  <td class="status">Fresh (65d)</td>
+  <td>2026-05-14</td>
+  <td>2026-08-12</td>
+  <td class="num days">65</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/integrations/README.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@devin-ai-integration</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/integrations/env-vars.md</code></td>
+  <td class="status">Fresh (87d)</td>
+  <td>2026-06-05</td>
+  <td>2026-09-03</td>
+  <td class="num days">87</td>
+  <td>@claude.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/integrations/monobank-roadmap.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/integrations/railway-vercel.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/integrations/renovate-usage.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/integrations/voyage-pgvector.md</code></td>
+  <td class="status">Fresh (69d)</td>
+  <td>2026-05-18</td>
+  <td>2026-08-16</td>
+  <td class="num days">69</td>
+  <td>@codex.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/launch/README.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/launch/business/01-monetization-and-pricing.md</code></td>
+  <td class="status">Fresh (70d)</td>
+  <td>2026-05-19</td>
+  <td>2026-08-17</td>
+  <td class="num days">70</td>
+  <td>@codex.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/launch/business/02-go-to-market.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/launch/business/03-services-and-toolstack.md</code></td>
+  <td class="status">Fresh (70d)</td>
+  <td>2026-05-19</td>
+  <td>2026-08-17</td>
+  <td class="num days">70</td>
+  <td>@codex.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/launch/business/04-launch-readiness.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/launch/business/05-operations-and-automation.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/launch/business/06-monetization-architecture.md</code></td>
+  <td class="status">Fresh (70d)</td>
+  <td>2026-05-19</td>
+  <td>2026-08-17</td>
+  <td class="num days">70</td>
+  <td>@codex.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/launch/email-verification-sweep.md</code></td>
+  <td class="status">Fresh (83d)</td>
+  <td>2026-06-01</td>
+  <td>2026-08-30</td>
+  <td class="num days">83</td>
+  <td>@claude.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/launch/landing-decision.md</code></td>
+  <td class="status">Fresh (65d)</td>
+  <td>2026-05-14</td>
+  <td>2026-08-12</td>
+  <td class="num days">65</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/launch/phases/00-readiness-audit.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/launch/phases/01-web-launch-with-users.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/launch/phases/02-capacitor-launch.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/launch/phases/03-native-expo-launch.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/launch/phases/README.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/launch/product-os/ftux-master-tracker.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/launch/product-os/ftux-sprint-plan.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/launch/product-os/paywall-implementation-plan.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/launch/product-os/paywall-ux-placement.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/launch/product-os/sprint-retros/s1-honest-valueprop.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/launch/product-os/sprint-retros/s3-reward-moments.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/launch/tech/ai-memory-activation.md</code></td>
+  <td class="status">Fresh (69d)</td>
+  <td>2026-05-18</td>
+  <td>2026-08-16</td>
+  <td class="num days">69</td>
+  <td>@codex.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/launch/tech/openclaw-roadmap.md</code></td>
+  <td class="status">Fresh (69d)</td>
+  <td>2026-05-18</td>
+  <td>2026-08-16</td>
+  <td class="num days">69</td>
+  <td>@codex.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/launch/tech/telegram-improvements-roadmap.md</code></td>
+  <td class="status">Fresh (69d)</td>
+  <td>2026-05-18</td>
+  <td>2026-08-16</td>
+  <td class="num days">69</td>
+  <td>@codex.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/marketing/README.md</code></td>
+  <td class="status">Fresh (84d)</td>
+  <td>2026-06-02</td>
+  <td>2026-08-31</td>
+  <td class="num days">84</td>
+  <td>@claude.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/marketing/launch-plan.md</code></td>
+  <td class="status">Fresh (67d)</td>
+  <td>2026-05-16</td>
+  <td>2026-08-14</td>
+  <td class="num days">67</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/mobile/README.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/mobile/capacitor-deep-links.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/mobile/overview.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/mobile/react-native-migration.md</code></td>
-  <td class="status">Fresh (85d)</td>
+  <td class="status">Fresh (84d)</td>
   <td>2026-06-02</td>
   <td>2026-08-31</td>
-  <td class="num days">85</td>
+  <td class="num days">84</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/mobile/shell.md</code></td>
-  <td class="status">Fresh (71d)</td>
+  <td class="status">Fresh (70d)</td>
   <td>2026-05-19</td>
   <td>2026-08-17</td>
-  <td class="num days">71</td>
+  <td class="num days">70</td>
   <td>@codex.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/notes/README.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="status">Fresh (89d)</td>
+  <td>2026-06-07</td>
+  <td>2026-09-05</td>
+  <td class="num days">89</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/notes/spikes/2026-05-api-v1-usage.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/notes/spikes/2026-05-walkthrough-finyk.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/notes/spikes/2026-05-walkthrough-fizruk.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/notes/spikes/2026-05-walkthrough-hubchat.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/notes/spikes/2026-05-walkthrough-nutrition.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/notes/spikes/2026-05-walkthrough-routine.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/notes/spikes/2026-05-walkthrough-sync.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/notes/spikes/openclaw-poc.md</code></td>
-  <td class="status">Fresh (64d)</td>
+  <td class="status">Fresh (63d)</td>
   <td>2026-05-12</td>
   <td>2026-08-10</td>
-  <td class="num days">64</td>
+  <td class="num days">63</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/notes/spikes/openclaw-sdk-5.7-real-api.md</code></td>
-  <td class="status">Fresh (64d)</td>
+  <td class="status">Fresh (63d)</td>
   <td>2026-05-12</td>
   <td>2026-08-10</td>
-  <td class="num days">64</td>
+  <td class="num days">63</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/notes/spikes/openclaw-session-2026-05-12-recap.md</code></td>
-  <td class="status">Fresh (64d)</td>
+  <td class="status">Fresh (63d)</td>
   <td>2026-05-12</td>
   <td>2026-08-10</td>
-  <td class="num days">64</td>
+  <td class="num days">63</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/notes/spikes/openclaw-stage-4b-debugging-handoff-2026-05-12.md</code></td>
-  <td class="status">Fresh (64d)</td>
+  <td class="status">Fresh (63d)</td>
   <td>2026-05-12</td>
   <td>2026-08-10</td>
-  <td class="num days">64</td>
+  <td class="num days">63</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/notes/spikes/openclaw-stage-5b-pr-split-2026-05-12.md</code></td>
-  <td class="status">Fresh (64d)</td>
+  <td class="status">Fresh (63d)</td>
   <td>2026-05-12</td>
   <td>2026-08-10</td>
-  <td class="num days">64</td>
+  <td class="num days">63</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/notes/spikes/routine-sqlite-v2.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/observability/README.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/observability/SLO.md</code></td>
-  <td class="status">Fresh (71d)</td>
-  <td>2026-05-19</td>
-  <td>2026-08-17</td>
-  <td class="num days">71</td>
-  <td>@codex.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/observability/alert-bot-routing.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/observability/csp-monitoring.md</code></td>
-  <td class="status">Fresh (87d)</td>
-  <td>2026-06-02</td>
-  <td>2026-09-02</td>
-  <td class="num days">87</td>
-  <td>@claude.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/observability/dashboards.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/observability/dashboards/README.md</code></td>
-  <td class="status">Fresh (66d)</td>
-  <td>2026-05-14</td>
-  <td>2026-08-12</td>
-  <td class="num days">66</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/observability/engineering-metrics.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/observability/env-vars.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/observability/error-budget-policy.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/observability/frontend.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/observability/hub-perf-baseline.md</code></td>
-  <td class="status">Fresh (77d)</td>
-  <td>2026-05-25</td>
-  <td>2026-08-23</td>
-  <td class="num days">77</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/observability/log-levels.md</code></td>
-  <td class="status">Fresh (63d)</td>
-  <td>2026-05-11</td>
-  <td>2026-08-09</td>
-  <td class="num days">63</td>
-  <td>@claude.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/observability/log-retention.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/observability/logging.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/observability/metrics.md</code></td>
-  <td class="status">Fresh (66d)</td>
-  <td>2026-05-14</td>
-  <td>2026-08-12</td>
-  <td class="num days">66</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/observability/pg-pool-sizing.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/observability/posthog-founder-pulse.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/observability/posthog-ftux-dashboards.md</code></td>
-  <td class="status">Fresh (70d)</td>
-  <td>2026-05-18</td>
-  <td>2026-08-16</td>
-  <td class="num days">70</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/observability/runbook.md</code></td>
-  <td class="status">Fresh (70d)</td>
-  <td>2026-05-18</td>
-  <td>2026-08-16</td>
-  <td class="num days">70</td>
-  <td>@codex.</td>
-  <td class="num">60</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/observability/sentry-sampling.md</code></td>
-  <td class="status">Fresh (87d)</td>
-  <td>2026-06-02</td>
-  <td>2026-09-02</td>
-  <td class="num days">87</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/observability/telegram-control-plane.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/observability/telemetry-rollout-plan.md</code></td>
-  <td class="status">Fresh (85d)</td>
-  <td>2026-06-02</td>
-  <td>2026-08-31</td>
-  <td class="num days">85</td>
-  <td>@claude.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/ops/README.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/ops/docker-image-policy.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/ops/renovate.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/planning/README.md</code></td>
-  <td class="status">Fresh (85d)</td>
-  <td>2026-06-02</td>
-  <td>2026-08-31</td>
-  <td class="num days">85</td>
-  <td>@claude</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/planning/ai-coding-improvements.md</code></td>
-  <td class="status">Fresh (71d)</td>
-  <td>2026-05-19</td>
-  <td>2026-08-17</td>
-  <td class="num days">71</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/planning/archive/dev-stack-roadmap.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/planning/archive/mobile-e2e-testing.md</code></td>
-  <td class="status">Fresh (66d)</td>
-  <td>2026-05-14</td>
-  <td>2026-08-12</td>
-  <td class="num days">66</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/planning/archive/orm-drizzle-vs-kysely.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/planning/archive/pr-plan-docs-hygiene-2026-05.md</code></td>
-  <td class="status">Fresh (85d)</td>
-  <td>2026-06-02</td>
-  <td>2026-08-31</td>
-  <td class="num days">85</td>
-  <td>@claude.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/planning/archive/pr-plan-ftux-2026-05.md</code></td>
-  <td class="status">Fresh (71d)</td>
-  <td>2026-05-19</td>
-  <td>2026-08-17</td>
-  <td class="num days">71</td>
-  <td>@codex.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/planning/archive/pr-plan-mobile-reliability-2026-05.md</code></td>
-  <td class="status">Fresh (84d)</td>
-  <td>2026-06-01</td>
-  <td>2026-08-30</td>
-  <td class="num days">84</td>
-  <td>@claude.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/planning/archive/pr-plan-security-obs-2026-05.md</code></td>
-  <td class="status">Fresh (85d)</td>
-  <td>2026-06-02</td>
-  <td>2026-08-31</td>
-  <td class="num days">85</td>
-  <td>@claude.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/planning/archive/session-2026-05-15-revenue-security-testing.md</code></td>
-  <td class="status">Fresh (85d)</td>
-  <td>2026-06-02</td>
-  <td>2026-08-31</td>
-  <td class="num days">85</td>
-  <td>@claude.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/planning/dev-stack-roadmap.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/planning/flyio-vs-railway.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/planning/openclaw-migration-plan.md</code></td>
   <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
-  <td>2026-08-10</td>
+  <td>2026-08-11</td>
   <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
-  <td><code>docs/planning/openclaw-user-guide.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td><code>docs/observability/README.md</code></td>
+  <td class="status">Fresh (89d)</td>
+  <td>2026-06-07</td>
+  <td>2026-09-05</td>
+  <td class="num days">89</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/observability/SLO.md</code></td>
+  <td class="status">Fresh (70d)</td>
+  <td>2026-05-19</td>
+  <td>2026-08-17</td>
+  <td class="num days">70</td>
+  <td>@codex.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/observability/alert-bot-routing.md</code></td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/observability/csp-monitoring.md</code></td>
+  <td class="status">Fresh (86d)</td>
+  <td>2026-06-02</td>
+  <td>2026-09-02</td>
+  <td class="num days">86</td>
+  <td>@claude.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/observability/dashboards.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/observability/dashboards/README.md</code></td>
+  <td class="status">Fresh (65d)</td>
+  <td>2026-05-14</td>
+  <td>2026-08-12</td>
   <td class="num days">65</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/observability/engineering-metrics.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/observability/env-vars.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/observability/error-budget-policy.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/observability/frontend.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/observability/hub-perf-baseline.md</code></td>
+  <td class="status">Fresh (76d)</td>
+  <td>2026-05-25</td>
+  <td>2026-08-23</td>
+  <td class="num days">76</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/observability/log-levels.md</code></td>
+  <td class="status">Fresh (62d)</td>
+  <td>2026-05-11</td>
+  <td>2026-08-09</td>
+  <td class="num days">62</td>
+  <td>@claude.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/observability/log-retention.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/observability/logging.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/observability/metrics.md</code></td>
+  <td class="status">Fresh (65d)</td>
+  <td>2026-05-14</td>
+  <td>2026-08-12</td>
+  <td class="num days">65</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/observability/pg-pool-sizing.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/observability/posthog-founder-pulse.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/observability/posthog-ftux-dashboards.md</code></td>
+  <td class="status">Fresh (69d)</td>
+  <td>2026-05-18</td>
+  <td>2026-08-16</td>
+  <td class="num days">69</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/observability/runbook.md</code></td>
+  <td class="status">Fresh (69d)</td>
+  <td>2026-05-18</td>
+  <td>2026-08-16</td>
+  <td class="num days">69</td>
+  <td>@codex.</td>
+  <td class="num">60</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/observability/sentry-sampling.md</code></td>
+  <td class="status">Fresh (86d)</td>
+  <td>2026-06-02</td>
+  <td>2026-09-02</td>
+  <td class="num days">86</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/observability/telegram-control-plane.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/observability/telemetry-rollout-plan.md</code></td>
+  <td class="status">Fresh (84d)</td>
+  <td>2026-06-02</td>
+  <td>2026-08-31</td>
+  <td class="num days">84</td>
+  <td>@claude.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/ops/README.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/ops/docker-image-policy.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/ops/renovate.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/planning/README.md</code></td>
+  <td class="status">Fresh (84d)</td>
+  <td>2026-06-02</td>
+  <td>2026-08-31</td>
+  <td class="num days">84</td>
+  <td>@claude</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/planning/ai-coding-improvements.md</code></td>
+  <td class="status">Fresh (70d)</td>
+  <td>2026-05-19</td>
+  <td>2026-08-17</td>
+  <td class="num days">70</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/planning/archive/dev-stack-roadmap.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/planning/archive/mobile-e2e-testing.md</code></td>
+  <td class="status">Fresh (65d)</td>
+  <td>2026-05-14</td>
+  <td>2026-08-12</td>
+  <td class="num days">65</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/planning/archive/orm-drizzle-vs-kysely.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/planning/archive/pr-plan-docs-hygiene-2026-05.md</code></td>
+  <td class="status">Fresh (84d)</td>
+  <td>2026-06-02</td>
+  <td>2026-08-31</td>
+  <td class="num days">84</td>
+  <td>@claude.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/planning/archive/pr-plan-ftux-2026-05.md</code></td>
+  <td class="status">Fresh (70d)</td>
+  <td>2026-05-19</td>
+  <td>2026-08-17</td>
+  <td class="num days">70</td>
+  <td>@codex.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/planning/archive/pr-plan-mobile-reliability-2026-05.md</code></td>
+  <td class="status">Fresh (83d)</td>
+  <td>2026-06-01</td>
+  <td>2026-08-30</td>
+  <td class="num days">83</td>
+  <td>@claude.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/planning/archive/pr-plan-security-obs-2026-05.md</code></td>
+  <td class="status">Fresh (84d)</td>
+  <td>2026-06-02</td>
+  <td>2026-08-31</td>
+  <td class="num days">84</td>
+  <td>@claude.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/planning/archive/session-2026-05-15-revenue-security-testing.md</code></td>
+  <td class="status">Fresh (84d)</td>
+  <td>2026-06-02</td>
+  <td>2026-08-31</td>
+  <td class="num days">84</td>
+  <td>@claude.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/planning/dev-stack-roadmap.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/planning/flyio-vs-railway.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/planning/openclaw-migration-plan.md</code></td>
+  <td class="status">Fresh (63d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-10</td>
+  <td class="num days">63</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/planning/openclaw-user-guide.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/planning/pr-plan-2026-05.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/planning/pr-plan-backend-perf-2026-05.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-06-04</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/planning/pr-plan-dead-code-hard-rules-2026-05.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-06-07</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/planning/pr-plan-revenue-2026-05.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/planning/pr-plan-testing-devx-2026-05.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-06-07</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/planning/pr-plan-web-2026-05.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="due-soon">
   <td><code>docs/planning/sprint-9-10-plan-2026.md</code></td>
-  <td class="status">Due soon (24d)</td>
+  <td class="status">Due soon (23d)</td>
   <td>2026-06-07</td>
   <td>2026-07-01</td>
-  <td class="num days">24</td>
+  <td class="num days">23</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="due-soon">
   <td><code>docs/planning/sprint-roadmap-q2q3-2026.md</code></td>
-  <td class="status">Due soon (24d)</td>
+  <td class="status">Due soon (23d)</td>
   <td>2026-05-31</td>
   <td>2026-07-01</td>
-  <td class="num days">24</td>
+  <td class="num days">23</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/planning/storage-roadmap.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/planning/tailwind-v4-migration.md</code></td>
-  <td class="status">Fresh (70d)</td>
+  <td class="status">Fresh (69d)</td>
   <td>2026-05-18</td>
   <td>2026-08-16</td>
-  <td class="num days">70</td>
+  <td class="num days">69</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/planning/talk-to-your-data.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/planning/tools-research-2026-05-followup.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/planning/tools-research-2026-05.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/README.md</code></td>
-  <td class="status">Fresh (86d)</td>
+  <td class="status">Fresh (85d)</td>
   <td>2026-06-03</td>
   <td>2026-09-01</td>
-  <td class="num days">86</td>
+  <td class="num days">85</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/access-governance.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/add-api-endpoint.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/add-feature-flag.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/add-hard-rule.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/add-hubchat-tool.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/add-monobank-event-handler.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/add-new-page-route.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/add-onboarding-step.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/add-push-notification.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/add-react-query-hook.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/add-sql-migration.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/author-skill.md</code></td>
-  <td class="status">Fresh (86d)</td>
+  <td class="status">Fresh (85d)</td>
   <td>2026-06-03</td>
   <td>2026-09-01</td>
-  <td class="num days">86</td>
+  <td class="num days">85</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/bump-dep-safely.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/change-auth-flow.md</code></td>
-  <td class="status">Fresh (86d)</td>
+  <td class="status">Fresh (85d)</td>
   <td>2026-06-03</td>
   <td>2026-09-01</td>
-  <td class="num days">86</td>
+  <td class="num days">85</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/cleanup-codex-branch-after-pr.md</code></td>
-  <td class="status">Fresh (70d)</td>
+  <td class="status">Fresh (69d)</td>
   <td>2026-05-18</td>
   <td>2026-08-16</td>
-  <td class="num days">70</td>
+  <td class="num days">69</td>
   <td>@codex.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/cleanup-dead-code.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/cutover-openclaw-gateway.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/debug-chat-tool.md</code></td>
-  <td class="status">Fresh (35d)</td>
+  <td class="status">Fresh (34d)</td>
   <td>2026-05-13</td>
   <td>2026-07-12</td>
-  <td class="num days">35</td>
+  <td class="num days">34</td>
   <td>@Skords-01.</td>
   <td class="num">60</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/declare-incident.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/deploy-config-change.md</code></td>
-  <td class="status">Fresh (84d)</td>
+  <td class="status">Fresh (83d)</td>
   <td>2026-06-01</td>
   <td>2026-08-30</td>
-  <td class="num days">84</td>
+  <td class="num days">83</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/embedding-provider-migration.md</code></td>
-  <td class="status">Fresh (86d)</td>
+  <td class="status">Fresh (85d)</td>
   <td>2026-06-03</td>
   <td>2026-09-01</td>
-  <td class="num days">86</td>
+  <td class="num days">85</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/enable-prompt-caching.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/execute-planning-batch.md</code></td>
-  <td class="status">Fresh (85d)</td>
+  <td class="status">Fresh (84d)</td>
   <td>2026-06-02</td>
   <td>2026-08-31</td>
-  <td class="num days">85</td>
+  <td class="num days">84</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/fix-exhaustive-deps.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/fix-failing-ci.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/grant-privileged-access.md</code></td>
-  <td class="status">Fresh (85d)</td>
+  <td class="status">Fresh (84d)</td>
   <td>2026-06-02</td>
   <td>2026-08-31</td>
-  <td class="num days">85</td>
+  <td class="num days">84</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/hotfix-prod-regression.md</code></td>
-  <td class="status">Fresh (35d)</td>
+  <td class="status">Fresh (34d)</td>
   <td>2026-05-13</td>
   <td>2026-07-12</td>
-  <td class="num days">35</td>
+  <td class="num days">34</td>
   <td>@Skords-01.</td>
   <td class="num">60</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/investigate-alert.md</code></td>
-  <td class="status">Fresh (35d)</td>
+  <td class="status">Fresh (34d)</td>
   <td>2026-05-13</td>
   <td>2026-07-12</td>
-  <td class="num days">35</td>
+  <td class="num days">34</td>
   <td>@Skords-01.</td>
   <td class="num">60</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/migrate-localstorage-to-typedstore.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/modify-console-agent.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/modify-n8n-workflow.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/onboard-external-api.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/operational-continuity.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/playbook-catalog.md</code></td>
-  <td class="status">Fresh (85d)</td>
+  <td class="status">Fresh (84d)</td>
   <td>2026-06-02</td>
   <td>2026-08-31</td>
-  <td class="num days">85</td>
+  <td class="num days">84</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/port-web-screen-to-mobile.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/pre-merge-migration-checklist.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">60</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/prettier-pass-on-docs.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/reconcile-doc-drift.md</code></td>
-  <td class="status">Fresh (83d)</td>
+  <td class="status">Fresh (82d)</td>
   <td>2026-05-31</td>
   <td>2026-08-29</td>
-  <td class="num days">83</td>
+  <td class="num days">82</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/release-expo-mobile.md</code></td>
-  <td class="status">Fresh (85d)</td>
+  <td class="status">Fresh (84d)</td>
   <td>2026-06-02</td>
   <td>2026-08-31</td>
-  <td class="num days">85</td>
+  <td class="num days">84</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/release-mobile-shell.md</code></td>
-  <td class="status">Fresh (85d)</td>
+  <td class="status">Fresh (84d)</td>
   <td>2026-06-02</td>
   <td>2026-08-31</td>
-  <td class="num days">85</td>
+  <td class="num days">84</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/release-web-and-api.md</code></td>
-  <td class="status">Fresh (85d)</td>
+  <td class="status">Fresh (84d)</td>
   <td>2026-06-02</td>
   <td>2026-08-31</td>
-  <td class="num days">85</td>
+  <td class="num days">84</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/release.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/respond-to-suspected-account-compromise.md</code></td>
-  <td class="status">Fresh (85d)</td>
+  <td class="status">Fresh (84d)</td>
   <td>2026-06-02</td>
   <td>2026-08-31</td>
-  <td class="num days">85</td>
+  <td class="num days">84</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/restore-from-backup.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/retire-feature-flag.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/revoke-privileged-access.md</code></td>
-  <td class="status">Fresh (85d)</td>
+  <td class="status">Fresh (84d)</td>
   <td>2026-06-02</td>
   <td>2026-08-31</td>
-  <td class="num days">85</td>
+  <td class="num days">84</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/rotate-openclaw-credentials.md</code></td>
-  <td class="status">Fresh (63d)</td>
+  <td class="status">Fresh (62d)</td>
   <td>2026-05-11</td>
   <td>2026-08-09</td>
-  <td class="num days">63</td>
+  <td class="num days">62</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/rotate-secrets.md</code></td>
-  <td class="status">Fresh (35d)</td>
+  <td class="status">Fresh (34d)</td>
   <td>2026-05-13</td>
   <td>2026-07-12</td>
-  <td class="num days">35</td>
+  <td class="num days">34</td>
   <td>@Skords-01.</td>
   <td class="num">60</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/run-access-review.md</code></td>
-  <td class="status">Fresh (85d)</td>
+  <td class="status">Fresh (84d)</td>
   <td>2026-06-02</td>
   <td>2026-08-31</td>
-  <td class="num days">85</td>
+  <td class="num days">84</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/run-council.md</code></td>
-  <td class="status">Fresh (85d)</td>
+  <td class="status">Fresh (84d)</td>
   <td>2026-06-02</td>
   <td>2026-08-31</td>
-  <td class="num days">85</td>
+  <td class="num days">84</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/run-squad-deliver.md</code></td>
-  <td class="status">Fresh (85d)</td>
+  <td class="status">Fresh (84d)</td>
   <td>2026-06-02</td>
   <td>2026-08-31</td>
-  <td class="num days">85</td>
+  <td class="num days">84</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/run-squad-qa.md</code></td>
-  <td class="status">Fresh (85d)</td>
+  <td class="status">Fresh (84d)</td>
   <td>2026-06-02</td>
   <td>2026-08-31</td>
-  <td class="num days">85</td>
+  <td class="num days">84</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/run-squad-review.md</code></td>
-  <td class="status">Fresh (85d)</td>
+  <td class="status">Fresh (84d)</td>
   <td>2026-06-02</td>
   <td>2026-08-31</td>
-  <td class="num days">85</td>
+  <td class="num days">84</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/run-weekly-operator-digest.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/security-pen-test-checklist.md</code></td>
-  <td class="status">Fresh (84d)</td>
+  <td class="status">Fresh (83d)</td>
   <td>2026-06-01</td>
   <td>2026-08-30</td>
-  <td class="num days">84</td>
+  <td class="num days">83</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/stabilize-flaky-test.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/sync-rn-migration-progress.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/test-backup-restore.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/tune-system-prompt.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/write-e2e-test.md</code></td>
-  <td class="status">Fresh (86d)</td>
+  <td class="status">Fresh (85d)</td>
   <td>2026-06-03</td>
   <td>2026-09-01</td>
-  <td class="num days">86</td>
+  <td class="num days">85</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/playbooks/write-postmortem.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/postmortems/INDEX.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/postmortems/README.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/pr-ledger/README.md</code></td>
-  <td class="status">Fresh (85d)</td>
+  <td class="status">Fresh (84d)</td>
   <td>2026-06-02</td>
   <td>2026-08-31</td>
-  <td class="num days">85</td>
+  <td class="num days">84</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/runbooks/README.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/runbooks/database-backup-restore.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/runbooks/database-connection-pooling.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/runbooks/db-index-audit-template.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/runbooks/encryption-key-rotation.md</code></td>
-  <td class="status">Fresh (85d)</td>
+  <td class="status">Fresh (84d)</td>
   <td>2026-06-02</td>
   <td>2026-08-31</td>
-  <td class="num days">85</td>
+  <td class="num days">84</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/runbooks/openclaw-morning-briefing.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/runbooks/openclaw-telegram-tools.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/runbooks/operations-runbook.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/runbooks/postgres-read-replica.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/runbooks/security-events.md</code></td>
-  <td class="status">Fresh (84d)</td>
+  <td class="status">Fresh (83d)</td>
   <td>2026-06-01</td>
   <td>2026-08-30</td>
-  <td class="num days">84</td>
+  <td class="num days">83</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/README.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="status">Fresh (89d)</td>
+  <td>2026-06-07</td>
+  <td>2026-09-05</td>
+  <td class="num days">89</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/access-matrix.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/access-policy.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/ai-quota-kill-switch.md</code></td>
-  <td class="status">Fresh (87d)</td>
+  <td class="status">Fresh (86d)</td>
   <td>2026-06-04</td>
   <td>2026-09-02</td>
-  <td class="num days">87</td>
+  <td class="num days">86</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/api-internal-hmac.md</code></td>
-  <td class="status">Fresh (66d)</td>
+  <td class="status">Fresh (65d)</td>
   <td>2026-05-14</td>
   <td>2026-08-12</td>
-  <td class="num days">66</td>
+  <td class="num days">65</td>
   <td>@codex.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/audit-exceptions.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/better-auth-audit-2026-05.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/better-auth-crypto-review.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/codeql.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/container-scan.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/disaster-recovery.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/distroless-upgrade-plan.md</code></td>
-  <td class="status">Fresh (90d)</td>
+  <td class="status">Fresh (89d)</td>
   <td>2026-06-05</td>
   <td>2026-09-05</td>
-  <td class="num days">90</td>
+  <td class="num days">89</td>
   <td>@Skords-01</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/C1-mono-webhook-secret-in-url.md</code></td>
-  <td class="status">Fresh (81d)</td>
+  <td class="status">Fresh (80d)</td>
   <td>2026-05-29</td>
   <td>2026-08-27</td>
-  <td class="num days">81</td>
+  <td class="num days">80</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/C2-frontend-csp.md</code></td>
-  <td class="status">Fresh (84d)</td>
+  <td class="status">Fresh (83d)</td>
   <td>2026-06-01</td>
   <td>2026-08-30</td>
-  <td class="num days">84</td>
+  <td class="num days">83</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/H1-mobile-bearer-storage.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/H2-dependabot.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/H3-session-revoke-and-binding.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/H4-encryption-key-rotation.md</code></td>
-  <td class="status">Fresh (86d)</td>
+  <td class="status">Fresh (85d)</td>
   <td>2026-06-01</td>
   <td>2026-09-01</td>
-  <td class="num days">86</td>
+  <td class="num days">85</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/H5-trusted-origins-exp-scheme.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/H6-email-verification.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/H7-vercel-config-drift.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/H8-corp-per-route.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/H9-transcribe-usd-cap.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/I1-codeql-workflow.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/I2-secret-scanning-push-protection.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/I3-sbom-generation.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/I4-security-txt.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/I5-pre-commit-secret-detection.md</code></td>
-  <td class="status">Fresh (66d)</td>
+  <td class="status">Fresh (65d)</td>
   <td>2026-05-14</td>
   <td>2026-08-12</td>
-  <td class="num days">66</td>
+  <td class="num days">65</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/I6-threat-model.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/I7-security-events-openclaw.md</code></td>
-  <td class="status">Fresh (85d)</td>
+  <td class="status">Fresh (84d)</td>
   <td>2026-06-02</td>
   <td>2026-08-31</td>
-  <td class="num days">85</td>
+  <td class="num days">84</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/I8-periodic-external-pentest.md</code></td>
-  <td class="status">Fresh (84d)</td>
+  <td class="status">Fresh (83d)</td>
   <td>2026-06-01</td>
   <td>2026-08-30</td>
-  <td class="num days">84</td>
+  <td class="num days">83</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/L1-uuid-override.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/L10-user-id-hash-in-logs.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/L11-csp-monitoring-allowlist.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/L12-ios-app-transport-security.md</code></td>
-  <td class="status">Fresh (66d)</td>
+  <td class="status">Fresh (65d)</td>
   <td>2026-05-14</td>
   <td>2026-08-12</td>
-  <td class="num days">66</td>
+  <td class="num days">65</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/L13-docker-platform-pin.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/L14-pnpm-frozen-lockfile-dev.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/L2-permissions-policy-broader.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/L3-meta-referrer.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/L4-html-lang-attribute.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/L5-dns-prefetch-control.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/L6-no-sniff-explicit.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/L7-health-endpoint-info-leak.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/L8-openclaw-repo-root-traversal.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/L9-sentry-release-sha.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/M1-csp-disable-runtime-flag.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/M10-csrf-token-check.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/M11-eslint-plugin-security.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/M12-web-vitals-hardening.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/M13-require-session-soft-loud-fail.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/M14-internal-push-ip-allowlist.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/M15-console-allowlist-fail-closed.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/M16-telegram-markdown-v2.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/M17-console-global-rate-cap.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/M18-openclaw-per-call-usd-cap.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/M19-mobile-deeplink-sanitize.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/M2-trust-proxy-parameterize.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/M20-mobile-back-button-confirm.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/M21-coep-stripe-compatibility.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/M3-pino-redact-paths.md</code></td>
-  <td class="status">Fresh (81d)</td>
+  <td class="status">Fresh (80d)</td>
   <td>2026-05-29</td>
   <td>2026-08-27</td>
-  <td class="num days">81</td>
+  <td class="num days">80</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/security/hardening/M4-groq-model-allowlist.md</code></td>
-  <td class="status">Fresh (85d)</td>
-  <td>2026-06-02</td>
-  <td>2026-08-31</td>
-  <td class="num days">85</td>
-  <td>@claude.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/security/hardening/M5-audio-mime-normalize.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/security/hardening/M6-image-magic-byte-check.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/security/hardening/M7-chat-tool-iteration-cap.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/security/hardening/M8-prompt-injection-tool-output.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/security/hardening/M9-per-ip-secondary-rate-limit.md</code></td>
-  <td class="status">Fresh (85d)</td>
-  <td>2026-06-02</td>
-  <td>2026-08-31</td>
-  <td class="num days">85</td>
-  <td>@claude.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/security/hardening/README.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/security/hardening/sprint-1.md</code></td>
-  <td class="status">Fresh (81d)</td>
-  <td>2026-05-29</td>
-  <td>2026-08-27</td>
-  <td class="num days">81</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/security/hardening/sprint-2.md</code></td>
-  <td class="status">Fresh (85d)</td>
-  <td>2026-06-02</td>
-  <td>2026-08-31</td>
-  <td class="num days">85</td>
-  <td>@claude.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/security/hardening/sprint-3.md</code></td>
-  <td class="status">Fresh (85d)</td>
-  <td>2026-06-02</td>
-  <td>2026-08-31</td>
-  <td class="num days">85</td>
-  <td>@claude.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/security/hardening/sprint-4.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/security/hardening/sri-on-third-party-scripts.md</code></td>
-  <td class="status">Fresh (87d)</td>
-  <td>2026-06-02</td>
-  <td>2026-09-02</td>
-  <td class="num days">87</td>
-  <td>@claude.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/security/internal-api-keys.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-06-06</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/security/logging-redaction-policy.md</code></td>
-  <td class="status">Fresh (85d)</td>
-  <td>2026-06-02</td>
-  <td>2026-08-31</td>
-  <td class="num days">85</td>
-  <td>@claude.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/security/nightly-audit.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/security/pen-tests/2026-05-hardening-sweep.md</code></td>
-  <td class="status">Fresh (85d)</td>
-  <td>2026-06-02</td>
-  <td>2026-08-31</td>
-  <td class="num days">85</td>
-  <td>@claude.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/security/pii-handling.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/security/rate-limit-failure-mode.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/security/secret-ownership-register.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>@Skords-01.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/security/secret-rotation.md</code></td>
-  <td class="status">Fresh (88d)</td>
-  <td>2026-06-05</td>
-  <td>2026-09-03</td>
-  <td class="num days">88</td>
-  <td>@claude.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/security/threat-model.md</code></td>
-  <td class="status">Fresh (85d)</td>
-  <td>2026-06-02</td>
-  <td>2026-08-31</td>
-  <td class="num days">85</td>
-  <td>@claude.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/security/vulnerability-sla.md</code></td>
-  <td class="status">Fresh (71d)</td>
-  <td>2026-05-19</td>
-  <td>2026-08-17</td>
-  <td class="num days">71</td>
-  <td>@codex.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/superpowers/README.md</code></td>
-  <td class="status">Fresh (65d)</td>
-  <td>2026-05-13</td>
-  <td>2026-08-11</td>
-  <td class="num days">65</td>
-  <td>—</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/superpowers/plans/2026-05-06-sync-engine-writer-wiring.md</code></td>
-  <td class="status">Fresh (85d)</td>
-  <td>2026-06-02</td>
-  <td>2026-08-31</td>
-  <td class="num days">85</td>
-  <td>@claude.</td>
-  <td class="num">90</td>
-</tr>
-<tr class="fresh">
-  <td><code>docs/tech-debt/README.md</code></td>
   <td class="status">Fresh (84d)</td>
-  <td>2026-06-01</td>
-  <td>2026-08-30</td>
+  <td>2026-06-02</td>
+  <td>2026-08-31</td>
   <td class="num days">84</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
+  <td><code>docs/security/hardening/M5-audio-mime-normalize.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/security/hardening/M6-image-magic-byte-check.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/security/hardening/M7-chat-tool-iteration-cap.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/security/hardening/M8-prompt-injection-tool-output.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/security/hardening/M9-per-ip-secondary-rate-limit.md</code></td>
+  <td class="status">Fresh (84d)</td>
+  <td>2026-06-02</td>
+  <td>2026-08-31</td>
+  <td class="num days">84</td>
+  <td>@claude.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/security/hardening/README.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/security/hardening/sprint-1.md</code></td>
+  <td class="status">Fresh (80d)</td>
+  <td>2026-05-29</td>
+  <td>2026-08-27</td>
+  <td class="num days">80</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/security/hardening/sprint-2.md</code></td>
+  <td class="status">Fresh (84d)</td>
+  <td>2026-06-02</td>
+  <td>2026-08-31</td>
+  <td class="num days">84</td>
+  <td>@claude.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/security/hardening/sprint-3.md</code></td>
+  <td class="status">Fresh (84d)</td>
+  <td>2026-06-02</td>
+  <td>2026-08-31</td>
+  <td class="num days">84</td>
+  <td>@claude.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/security/hardening/sprint-4.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/security/hardening/sri-on-third-party-scripts.md</code></td>
+  <td class="status">Fresh (86d)</td>
+  <td>2026-06-02</td>
+  <td>2026-09-02</td>
+  <td class="num days">86</td>
+  <td>@claude.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/security/internal-api-keys.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-06-06</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/security/logging-redaction-policy.md</code></td>
+  <td class="status">Fresh (84d)</td>
+  <td>2026-06-02</td>
+  <td>2026-08-31</td>
+  <td class="num days">84</td>
+  <td>@claude.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/security/nightly-audit.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/security/pen-tests/2026-05-hardening-sweep.md</code></td>
+  <td class="status">Fresh (84d)</td>
+  <td>2026-06-02</td>
+  <td>2026-08-31</td>
+  <td class="num days">84</td>
+  <td>@claude.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/security/pii-handling.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/security/rate-limit-failure-mode.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/security/secret-ownership-register.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/security/secret-rotation.md</code></td>
+  <td class="status">Fresh (87d)</td>
+  <td>2026-06-05</td>
+  <td>2026-09-03</td>
+  <td class="num days">87</td>
+  <td>@claude.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/security/threat-model.md</code></td>
+  <td class="status">Fresh (84d)</td>
+  <td>2026-06-02</td>
+  <td>2026-08-31</td>
+  <td class="num days">84</td>
+  <td>@claude.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/security/vulnerability-sla.md</code></td>
+  <td class="status">Fresh (70d)</td>
+  <td>2026-05-19</td>
+  <td>2026-08-17</td>
+  <td class="num days">70</td>
+  <td>@codex.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/superpowers/README.md</code></td>
+  <td class="status">Fresh (64d)</td>
+  <td>2026-05-13</td>
+  <td>2026-08-11</td>
+  <td class="num days">64</td>
+  <td>—</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/superpowers/plans/2026-05-06-sync-engine-writer-wiring.md</code></td>
+  <td class="status">Fresh (84d)</td>
+  <td>2026-06-02</td>
+  <td>2026-08-31</td>
+  <td class="num days">84</td>
+  <td>@claude.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
+  <td><code>docs/tech-debt/README.md</code></td>
+  <td class="status">Fresh (89d)</td>
+  <td>2026-06-07</td>
+  <td>2026-09-05</td>
+  <td class="num days">89</td>
+  <td>@Skords-01.</td>
+  <td class="num">90</td>
+</tr>
+<tr class="fresh">
   <td><code>docs/tech-debt/backend.md</code></td>
-  <td class="status">Fresh (63d)</td>
+  <td class="status">Fresh (62d)</td>
   <td>2026-05-11</td>
   <td>2026-08-09</td>
-  <td class="num days">63</td>
+  <td class="num days">62</td>
   <td>@Skords-01</td>
   <td class="num">60</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/tech-debt/frontend.md</code></td>
-  <td class="status">Fresh (83d)</td>
+  <td class="status">Fresh (82d)</td>
   <td>2026-06-07</td>
   <td>2026-08-29</td>
-  <td class="num days">83</td>
+  <td class="num days">82</td>
   <td>—</td>
   <td class="num">60</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/tech-debt/mobile.md</code></td>
-  <td class="status">Fresh (67d)</td>
+  <td class="status">Fresh (66d)</td>
   <td>2026-05-15</td>
   <td>2026-08-13</td>
-  <td class="num days">67</td>
+  <td class="num days">66</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/tech-debt/priority-1-executive.md</code></td>
-  <td class="status">Fresh (91d)</td>
+  <td class="status">Fresh (90d)</td>
   <td>2026-06-06</td>
   <td>2026-09-06</td>
-  <td class="num days">91</td>
+  <td class="num days">90</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/tech-debt/syncV2-engineering-ticket.md</code></td>
   <td class="status">Fresh (91d)</td>
-  <td>2026-06-06</td>
-  <td>2026-09-06</td>
+  <td>2026-06-07</td>
+  <td>2026-09-07</td>
   <td class="num days">91</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
@@ -4633,8 +4633,8 @@
 <tr class="fresh">
   <td><code>docs/tech-debt/syncV2-refactor-execution.md</code></td>
   <td class="status">Fresh (91d)</td>
-  <td>2026-06-06</td>
-  <td>2026-09-06</td>
+  <td>2026-06-07</td>
+  <td>2026-09-07</td>
   <td class="num days">91</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
@@ -4642,396 +4642,396 @@
 <tr class="fresh">
   <td><code>docs/tech-debt/syncV2-refactor-plan.md</code></td>
   <td class="status">Fresh (91d)</td>
-  <td>2026-06-06</td>
-  <td>2026-09-06</td>
+  <td>2026-06-07</td>
+  <td>2026-09-07</td>
   <td class="num days">91</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/tech-debt/technical-assessment-2026-06-05.md</code></td>
-  <td class="status">Fresh (91d)</td>
+  <td class="status">Fresh (90d)</td>
   <td>2026-06-06</td>
   <td>2026-09-06</td>
-  <td class="num days">91</td>
+  <td class="num days">90</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/testing/2026-05-05-tests-pr-plan.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/testing/2026-05-05-tests-review.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/testing/README.md</code></td>
-  <td class="status">Fresh (91d)</td>
+  <td class="status">Fresh (90d)</td>
   <td>2026-06-06</td>
   <td>2026-09-06</td>
-  <td class="num days">91</td>
+  <td class="num days">90</td>
   <td>@claude</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/testing/pact-drift-runbook.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/testing/smoke-tests.md</code></td>
-  <td class="status">Fresh (62d)</td>
+  <td class="status">Fresh (61d)</td>
   <td>2026-05-13</td>
   <td>2026-08-08</td>
-  <td class="num days">62</td>
+  <td class="num days">61</td>
   <td>@Skords-01</td>
   <td class="num">90</td>
 </tr>
-<tr class="due-soon">
+<tr class="overdue">
   <td><code>docs/today.md</code></td>
-  <td class="status">Due soon (0d)</td>
+  <td class="status">Overdue (1d)</td>
   <td>2026-06-07</td>
   <td>2026-06-07</td>
-  <td class="num days">0</td>
+  <td class="num days">-1</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/ui/README.md</code></td>
-  <td class="status">Fresh (85d)</td>
+  <td class="status">Fresh (84d)</td>
   <td>2026-06-02</td>
   <td>2026-08-31</td>
-  <td class="num days">85</td>
+  <td class="num days">84</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/ui/shortcuts.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/ui/toast-policy.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/web/README.md</code></td>
-  <td class="status">Fresh (85d)</td>
+  <td class="status">Fresh (84d)</td>
   <td>2026-06-02</td>
   <td>2026-08-31</td>
-  <td class="num days">85</td>
+  <td class="num days">84</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/web/service-worker.md</code></td>
-  <td class="status">Fresh (66d)</td>
+  <td class="status">Fresh (65d)</td>
   <td>2026-05-14</td>
   <td>2026-08-12</td>
-  <td class="num days">66</td>
+  <td class="num days">65</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/whats-new/2026-05-06-cold-start.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>docs/whats-new/README.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>ops/n8n-workflows/15-railway-deployment-notify.README.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>ops/n8n-workflows/98-error-handler.README.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>ops/n8n-workflows/REPORTING-MATRIX.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>ops/openclaw/shortcuts/catalog.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>ops/openclaw/skills/council-roundtable/SKILL.md</code></td>
-  <td class="status">Fresh (63d)</td>
+  <td class="status">Fresh (62d)</td>
   <td>2026-05-11</td>
   <td>2026-08-09</td>
-  <td class="num days">63</td>
+  <td class="num days">62</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>ops/openclaw/skills/morning-digest/SKILL.md</code></td>
-  <td class="status">Fresh (66d)</td>
+  <td class="status">Fresh (65d)</td>
   <td>2026-05-12</td>
   <td>2026-08-12</td>
-  <td class="num days">66</td>
+  <td class="num days">65</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>ops/openclaw/skills/sergeant-cofounder/SKILL.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>ops/openclaw/skills/sergeant-content/SKILL.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>ops/openclaw/skills/sergeant-cs/SKILL.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>ops/openclaw/skills/sergeant-data/SKILL.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>ops/openclaw/skills/sergeant-devops/SKILL.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>ops/openclaw/skills/sergeant-eng/SKILL.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>ops/openclaw/skills/sergeant-finance/SKILL.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>ops/openclaw/skills/sergeant-growth/SKILL.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>ops/openclaw/skills/sergeant-mode-analyze/SKILL.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>ops/openclaw/skills/sergeant-mode-okr/SKILL.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>ops/openclaw/skills/sergeant-mode-plan/SKILL.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>ops/openclaw/skills/sergeant-pm/SKILL.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>ops/openclaw/skills/sergeant-seo/SKILL.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>packages/api-client/CLAUDE.md</code></td>
-  <td class="status">Fresh (90d)</td>
+  <td class="status">Fresh (89d)</td>
   <td>2026-06-07</td>
   <td>2026-09-05</td>
-  <td class="num days">90</td>
-  <td>@claude.</td>
+  <td class="num days">89</td>
+  <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>packages/db-schema/CLAUDE.md</code></td>
-  <td class="status">Fresh (90d)</td>
+  <td class="status">Fresh (89d)</td>
   <td>2026-06-07</td>
   <td>2026-09-05</td>
-  <td class="num days">90</td>
-  <td>@claude.</td>
+  <td class="num days">89</td>
+  <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>patches/README.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="due-soon">
   <td><code>plans/agent-fanout-plan-2026-06-06.md</code></td>
-  <td class="status">Due soon (29d)</td>
+  <td class="status">Due soon (28d)</td>
   <td>2026-06-06</td>
   <td>2026-07-06</td>
-  <td class="num days">29</td>
+  <td class="num days">28</td>
   <td>—</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>plans/syncv2-decomposition-detailed.md</code></td>
-  <td class="status">Fresh (91d)</td>
+  <td class="status">Fresh (90d)</td>
   <td>2026-06-06</td>
   <td>2026-09-06</td>
-  <td class="num days">91</td>
+  <td class="num days">90</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>pnpm-overrides.md</code></td>
-  <td class="status">Fresh (88d)</td>
+  <td class="status">Fresh (87d)</td>
   <td>2026-06-05</td>
   <td>2026-09-03</td>
-  <td class="num days">88</td>
+  <td class="num days">87</td>
   <td>@claude.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>scripts/codemods/README.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>scripts/codemods/i18n-burndown/README.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>scripts/codemods/strip-js-extensions/README.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>
 <tr class="fresh">
   <td><code>tools/openclaw/README.md</code></td>
-  <td class="status">Fresh (65d)</td>
+  <td class="status">Fresh (64d)</td>
   <td>2026-05-13</td>
   <td>2026-08-11</td>
-  <td class="num days">65</td>
+  <td class="num days">64</td>
   <td>@Skords-01.</td>
   <td class="num">90</td>
 </tr>


### PR DESCRIPTION
## Summary

Automated twice-weekly audit triage. Regenerates `docs/audits/_runner-report.md` and `docs/governance/freshness-dashboard.html`. **Do not merge manually** — branch is reset on each run via `--force-with-lease`.

Four-bucket digest (2026-06-08, 17 open audits):

### A — Security / Correctness

1. **`consolidated-page-audit.md` C1** — `useChatSend.ts` dispatches AI `tool_calls` with no Zod allow-list; prompt injection → arbitrary actions with full auth cookie context. **Add Zod-validated tool registry; reject + log unknown names.**
2. **`consolidated-page-audit.md` C2 / `page-audit-10`** — SW `Cache` for `/api/*` keyed by URL only; cross-user data leak on shared device after sign-out. **Key by hashed session id; flush in `signOut`; add `Cache-Control: private`.**
3. **`page-audit-10` F3+F4** — Sentry Replay `maskAllText` missing (PII); `PricingPage` → `checkout.url` without origin allow-list (open redirect). **Fix both.**
4. **`page-audit-01` F1** — 14× `text-error`/`bg-error` uses non-existent token; auth error UI renders colorless. **Replace with `text-danger`/`bg-danger`** (pure rename).
5. **`dead-code-hard-rules-roast.md` P1.4** — 4 `process.env` callers bypass typed `env`. **Ship PR(A): migrate `requireAnthropicKey` + refactor test to `vi.resetModules + vi.stubEnv`** (net −1).
6. **`2026-08-XX-openclaw-internal-roast.md`** — Write-tool audit-log gaps + approval-gate drift vs ADR-0027 unverified stub. **Assign backend owner; schedule before 2026-08-11.**

### B — Cheap AutoSafe Wins

1. **`hubsettings-cls-chunk-load.md` MEDIUM #1** — `ChunkLoadError` = white screen on stale deploy. **Create `ChunkErrorBoundary.tsx`; wrap 4 `<Suspense>` blocks.**
2. **`hubsettings-cls-chunk-load.md` MEDIUM #2** — `minH: 72` vs real 160–280 px → CLS jump. **Set per-section `minH` in `HubSettingsPage.tsx:254-277`.**
3. **`testing-devx-roast.md` P1-4 PARTIAL** — 7 Detox specs authored but not green (missing `testID`). **Add `testID` to source components.**
4. **`dead-code-hard-rules-roast.md` P1.5** — 5 `apps/mobile-shell` exports have 0 importers. **Delete or wire into Capacitor entry.**
5. **`consolidated-page-audit.md` Theme 2** — 3 touch-target surfaces still below 44×44 px (FTUX ×5, Finyk month-nav, Fizruk Atlas toggle). **Batch-add `min-h-[44px] min-w-[44px]`.**

### C — Unblock Chains

1. **UX roast Sprint 0 PR-0** — 9 events already in `analyticsEvents.ts`; formally open, blocking ~11 downstream Sprint 1/2/3 PRs. **Formally close PR-0.**
2. **`web-architecture-state-roast.md` P1-E** — chatActions still write via `safeWriteLS`. **Create `POST /api/v1/finyk/manual-expenses`** (priority-1 enabler).
3. **`consolidated-page-audit.md` audit-04 gap** — Hub Settings/Profile/Assistant never audited (VM failure). **Re-run page-audit-04.**
4. **Individual audits 02, 05–09** — H/M findings beyond consolidated themes (rest-timer broken, Measurements no range-check, Strategy auth gap). **Triage ≥1 fix/sprint.**

### D — Blocked / Gated

1. **UX roast PR-11 + PR-28** — CSV export + Avatar upload paused pending S3/R2 credentials.
2. **`web-architecture-state-roast.md` P1-E full migration** — blocked until fizruk/nutrition server endpoints exist.
3. **`2026-08-XX` stubs** — both gated on Q3 2026 backend-roast cycle (trigger 2026-08-11).
4. **`web-architecture-state-roast.md` P2** — `STANDALONE_ROUTES` factory + HMR invariant; deferred.

## Governing Skill

`docs` — triage-only run, no application code touched. No specialist skill required beyond `sergeant-start-here`.

## Playbook

`docs/playbooks/reconcile-doc-drift.md` — regenerate auto-generated doc and freshness dashboard in a single commit.

## Verification

- `docs/audits/_runner-report.md` regenerated with today's triage (2026-06-08).
- `docs/governance/freshness-dashboard.html` regenerated via `node scripts/docs/generate-freshness-dashboard.mjs` (554 docs tracked, exit 0).
- No application code changed; CI jobs that require a build/test/typecheck are expected to pass on no-op diff.

## Docs and Governance

- `docs/audits/_runner-report.md` — updated `Last validated:` header to 2026-06-08, `Next review:` to 2026-09-06.
- `docs/governance/freshness-dashboard.html` — regenerated to reflect updated header above.
- Hard Rule #10 (lifecycle markers): `_runner-report.md` carries `Status: Reference` and `Last validated:` per spec.
- Hard Rule #25 (AUTO-GENERATED marker): `<!-- AUTO-GENERATED -->` present at top of `_runner-report.md`.

## Risk and Rollout

- **Blast radius:** documentation only — no source code, no migrations, no API changes.
- **Rollback:** revert this commit; the previous `_runner-report.md` is the prior git state.
- **No deploy required.**

## Hard Rule #15

Internal documentation updated in Ukrainian where applicable (the `_runner-report.md` is an agent-runtime reference file kept in English per `sergeant-start-here` SKILL.md rationale — same as all SKILL.md files). Hard Rule #15 governance acknowledgement: docs updated alongside the triage run; no source-code docs were skipped.