### PR TITLE
docs(agents): ADR-0066 + initiative 0018 — agent semantic retrieval

### DIFF
--- a/docs/adr/0066-agent-semantic-retrieval-over-knowledge-graph.md
+++ b/docs/adr/0066-agent-semantic-retrieval-over-knowledge-graph.md
@@ -1,0 +1,92 @@
+# ADR-0066: Agent semantic retrieval over the knowledge graph
+
+> **Last validated:** 2026-06-08 by @claude. **Next review:** 2026-09-06.
+> **Status:** Active
+
+- **Status:** Proposed
+- **Date:** 2026-06-08
+- **Deciders:** @Skords-01
+- **Supersedes:** —
+- **Related:**
+  - [`docs/adr/0058-knowledge-graph-schema.md`](./0058-knowledge-graph-schema.md) — джерело нод/ребер, що індексуються
+  - [`docs/adr/0059-symbol-extraction-via-typescript-compiler-api.md`](./0059-symbol-extraction-via-typescript-compiler-api.md) — `symbol-index.json` як ще одне джерело пойнтерів
+  - [`docs/adr/0028-pgvector-ai-memory.md`](./0028-pgvector-ai-memory.md) — наявний production-RAG-стек (Voyage + pgvector), який ми **не** перевикористовуємо як стор (див. Decision)
+  - [`docs/architecture/ai-memory.md`](../architecture/ai-memory.md), [`docs/architecture/rag-eval.md`](../architecture/rag-eval.md) — embedding-конвеєр і eval-harness, який перевикористовуємо
+  - [`docs/initiatives/0018-agent-semantic-retrieval.md`](../initiatives/0018-agent-semantic-retrieval.md) — план виконання
+
+---
+
+## Context and Problem Statement
+
+У Sergeant **достатньо** машино-читабельного знання про себе: `knowledge-graph.json` (10 типів нод, 6 типів ребер), `symbol-index.json` (≈298 експортів із usage-графом), 33 skills, 61 playbook, 62 ADR, 26 hard rules, per-file freshness/lifecycle-маркери. Проблема не в **кількості** артефактів, а в **активації**: агент на старті задачі мусить *здогадатися*, котрий із цих сотень файлів релевантний. Наслідки спостережувані щодня:
+
+- **Палений час/токени** — агент grep-ає монорепо наосліп замість одного точного пойнтера.
+- **Хибні висновки** — агент читає не той (або застарілий) файл і робить неправильний висновок.
+- **Maintainer розжовує контекст щоразу** — бо нічого не тицяє агента носом у потрібний артефакт у *момент* задачі.
+
+Усе наявне знання — **pull**: лежить як файли, які треба свідомо відкрити. Бракує одного запитуваного входу, що на природномовний запит («де серіалізація bigint балансу», «який playbook для нового SQL-міграційного кроку») повертає рейтинговані `file:line`-пойнтери з типом артефакту.
+
+`knowledge-graph.json` уже агрегує ноди — але він queryable лише структурно (за `id`/`type`/`edge`), не семантично. Немає шару «схоже за змістом».
+
+## Considered Options
+
+1. **Committed build-time retrieval index + CLI/MCP entrypoint** — генератор чанкує ноди графа + секції docs + symbol-index, ембедить через Voyage, пише **маніфест** чанків у git і **вектори** у gitignored content-hash cache. Запит — `pnpm agent:find "<q>"` (+ тонкий MCP-врапер): ембедить запит, cosine по локальному індексу, повертає top-K пойнтерів. Lexical-фолбек (BM25-подібний) працює без `VOYAGE_API_KEY`.
+2. **Перевикористати production `ai_memories` (pgvector)** — додати `source='repo'`, інжестити docs у той самий стор, запит через наявний `POST /api/ai-memory/recall`.
+3. **Чисто lexical** — keyword/BM25 поверх графа+symbol-index, без ембеддингів узагалі.
+4. **Do nothing** — лишити агентам grep + ручний вибір skill за routing-таблицею.
+
+## Decision
+
+Обираємо **Option 1 — committed build-time index + entrypoint**, з обовʼязковим **lexical-фолбеком** (тобто Option 3 як degraded-режим усередині Option 1).
+
+Конкретно:
+
+- **Джерела індексу:** `knowledge-graph.json` (ноди core+extended), секції canonical-docs (`docs/adr`, `docs/playbooks`, `docs/governance/rules`, `docs/architecture`, `.agents/skills/**/SKILL.md`), `symbol-index.json` (export → file:line + owning-package).
+- **Чанкінг:** одна нода/секція = один чанк; кожен чанк несе `{ id, type, path, line, title, text, tier }`. `type` повторює enum нод графа + `export` + `doc-section`.
+- **Сторідж (ключове):** **маніфест** `docs/governance/retrieval-index.json` (чанки без векторів — diffable, queryable, у git) + **вектори** у `.cache/retrieval/<contentHash>.bin` (**gitignored**, регенерується лазі за content-hash). Жодних векторів у git → нема noisy diff (мітигація болю з ADR-0058).
+- **Ембеддинги:** той самий `voyage-3.5-lite` (1024d), що й `ai-memory` — спільний клієнт/budget-guard, але **окремий код-шлях** (не runtime-стор).
+- **Entrypoint:** `pnpm agent:find "<query>" [--type skill|adr|...] [--k 8] [--json]` + тонкий MCP-tool `agent_find`, що викликає той самий движок. Вивід — рейтингований список `path:line — <title> [<type>]` зі score.
+- **Degradation:** нема `VOYAGE_API_KEY` → автоматично lexical-режим (token-overlap rerank поверх маніфесту). Агент завжди отримує відповідь, навіть офлайн.
+- **Якість:** перевикористати golden-set + `eval-rag-recall.mjs` harness (ADR-0028/`rag-eval.md`) з окремим golden-сетом «query → expected chunk id» для repo-retrieval; gate `recall@K`/`MRR`.
+
+## Rationale
+
+- **Чому не runtime `ai_memories` (Option 2):** той стор `HALFVEC(1024)`, **партиційований per `user_id`**, із CHECK-enum source-ів під продуктові домени (`chat`/`finyk`/`nutrition`/…) і вимагає **живого сервера + Postgres + BullMQ**. Агент у CI чи локальній сесії їх не має — прив'язка retrieval-тулу до бекенду зробила б його недоступним саме там, де він найпотрібніший. Repo-знання — не user-data; змішувати їх у одному партиційованому сторі семантично хибно.
+- **Чому committed-маніфест + cache, а не SQLite/runtime (узгоджено з ADR-0058):** ADR-0058 уже обрав «JSON over SQLite: Git-friendly, no runtime» для графа. Той самий принцип: маніфест diff-иться у PR, працює без native-deps і без сервера. Вектори тримаємо поза git (binary, регенеровані) — отримуємо Git-friendliness без noisy binary diff.
+- **Чому lexical-фолбек обовʼязковий:** інакше тул німіє без API-ключа (CI без секретів, офлайн-сесія). Degraded-режим гарантує, що агент **завжди** має кращу за сліпий grep відповідь.
+- **Чому reuse Voyage/eval, а не нова залежність:** клієнт, budget-guard і `eval-rag-recall.mjs` уже існують і протестовані; новий код — лише чанкер + cosine + CLI. Мінімальна площа.
+- **Чому це б'є саме у три болі:** один вхід замість сліпого grep (час/токени), пойнтер із freshness-tier і типом (менше хибних висновків — видно, чи джерело Active/Deprecated), і push-точка для SessionStart-хука та start-here (менше розжовування).
+
+## Consequences
+
+### Positive
+
+- Один запитуваний семантичний вхід над усім наявним знанням; агент перестає grep-ати наосліп.
+- Decoupled від runtime — працює у CI, локально, офлайн (lexical), без сервера/БД.
+- Перевикористовує Voyage + eval-harness; нова площа коду мінімальна.
+- Маніфест diff-иться у PR — видно, що додалось/змістилось в індексі.
+- Природний споживач для майбутнього SessionStart-auto-routing і symbol-lookup (Tier 2 ініціативи).
+
+### Negative
+
+- Ще один generated-артефакт із `--check`-gate (Hard Rule #24) → треба wired у `pnpm lint` і regen у `docs:gen-daily`. Мітигація: дотримуємось наявного generator-and-validator патерну.
+- Ембеддинг-стійл: маніфест/вектори можуть відстати від docs. Мітигація: content-hash інвалідація + `--check` у CI (як `docs:check-graph`).
+- Voyage-вартість на regen. Мітигація: ембедимо лише чанки зі зміненим content-hash; budget-guard спільний з ai-memory.
+
+### Neutral
+
+- Не змінює `ai_memories`, `knowledge-graph.json`-генератор чи `symbol-index.json` — лише **читає** їхній вихід.
+- Не вводить нових рантайм-залежностей у застосунки (тул живе у `scripts/` + опційний MCP).
+
+## Compliance
+
+- `pnpm agent:find:check` (CI gate, wired у `pnpm lint`) — exit 1, якщо committed `retrieval-index.json` ≠ regenerated із поточних джерел (Hard Rule #24 — catalog має `--check` generator).
+- Маніфест `retrieval-index.json` має `<!-- AUTO-GENERATED: ... -->`-семантику через схему (Hard Rule #25 — generated-артефакт).
+- Repo-retrieval golden-set + `recall@K`/`MRR` gate через наявний `eval-rag-recall.mjs` режим (узгоджено з `rag-eval.md`).
+- Lifecycle/freshness-маркери на нових docs (Hard Rule #10) + discoverability з AGENTS.md (Hard Rule #15 doc-sync).
+
+## Links
+
+- [`docs/initiatives/0018-agent-semantic-retrieval.md`](../initiatives/0018-agent-semantic-retrieval.md)
+- [`docs/adr/0058-knowledge-graph-schema.md`](./0058-knowledge-graph-schema.md)
+- [`docs/architecture/rag-eval.md`](../architecture/rag-eval.md)

--- a/docs/initiatives/0018-agent-semantic-retrieval.md
+++ b/docs/initiatives/0018-agent-semantic-retrieval.md
@@ -1,0 +1,106 @@
+# 0018 — Agent semantic retrieval (agent:find)
+
+> **Last validated:** 2026-06-08 by @claude. **Next review:** 2026-09-06.
+> **Status:** Proposed — чекає на founder-погодження ADR-0066 перед стартом Phase 1.
+> **Agent-ready:** yes
+
+## TL;DR
+
+Sergeant має багатий машино-читабельний індекс себе (`knowledge-graph.json`, `symbol-index.json`, 33 skills, 61 playbook, 62 ADR), але все знання — **pull**: агент мусить здогадатися, що відкрити. Будуємо один семантичний вхід `pnpm agent:find "<query>"` (+ MCP-tool `agent_find`), що повертає рейтинговані `file:line`-пойнтери з типом і freshness-tier артефакту. Перевикористовуємо Voyage + eval-harness зі стеку `ai-memory`, але як **committed build-time індекс** (decoupled від runtime-БД), з lexical-фолбеком на випадок відсутності API-ключа. Архітектура — у [ADR-0066](../adr/0066-agent-semantic-retrieval-over-knowledge-graph.md).
+
+## Чому зараз
+
+- Спостережуваний патерн: агент grep-ає монорепо наосліп → палить час/токени, інколи читає не той/застарілий файл → хибні висновки.
+- Maintainer розжовує контекст щоразу, бо немає шару, що тицяє агента носом у потрібний артефакт у момент задачі.
+- Уся дорога інфраструктура (граф, symbol-index, Voyage-конвеєр, golden-eval) **уже стоїть** — бракує тонкого retrieval-входу поверх неї. Вартість входу мінімальна саме зараз.
+- `eval-rag-recall.mjs` має `--mode=live` як placeholder — ця ініціатива дає йому перше реальне застосування на repo-retrieval.
+
+## Скоуп
+
+### In scope
+
+- **Phase 1** — чанкер + committed-маніфест `retrieval-index.json` + `pnpm agent:find` CLI з lexical-режимом (без ембеддингів).
+- **Phase 2** — Voyage-ембеддинги у gitignored content-hash cache + семантичний ranking + degradation на lexical без ключа.
+- **Phase 3** — `--check`-gate (Hard Rule #24) + regen у `docs:gen-daily` + repo-retrieval golden-set і `recall@K`/`MRR` через `eval-rag-recall.mjs`.
+- **Phase 4** — тонкий MCP-tool `agent_find` + промоція у `sergeant-start-here` як перший крок орієнтації.
+
+### Out of scope
+
+- Зміни в `ai_memories` runtime-сторі чи `POST /api/ai-memory/recall` (свідомо не чіпаємо — див. ADR-0066 Rationale).
+- SessionStart auto-routing і `agent:where` symbol-lookup — це Tier 2, окрема ініціатива (споживатимуть цей індекс).
+- Переписування `knowledge-graph.json` / `symbol-index.json`-генераторів — лише читаємо їхній вихід.
+
+## План змін
+
+### Phase 1 — Lexical-кістяк (committed) — ETA TBD після погодження
+
+**Acceptance:** `pnpm agent:find "coerce bigint balance"` повертає `≤8` рейтингованих `path:line — title [type]` пойнтерів за <1с, без `VOYAGE_API_KEY`.
+
+| PR         | Що ввозиться                                                                 | Файли                                                                                  |
+| ---------- | ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| **PR-1.1** | Чанкер: граф-ноди + canonical-doc-секції + symbol-index → маніфест            | `scripts/agent/build-retrieval-index.mjs`, `docs/governance/retrieval-index.json`      |
+| **PR-1.2** | `pnpm agent:find` CLI (lexical token-overlap rerank, `--type`/`--k`/`--json`) | `scripts/agent/find.mjs`, `package.json`                                                |
+| **PR-1.3** | `retrieval-index.schema.json` + `.gitignore` для `.cache/retrieval/`          | `docs/governance/schemas/retrieval-index.schema.json`, `.gitignore`                    |
+
+### Phase 2 — Семантичний шар (committed)
+
+**Acceptance:** з `VOYAGE_API_KEY` той самий запит повертає семантично-релевантні пойнтери (не лише keyword-overlap); без ключа — автоматичний lexical-фолбек, нуль помилок.
+
+| PR         | Що ввозиться                                                            | Файли                                                                     |
+| ---------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| **PR-2.1** | Voyage-ембеддер чанків у content-hash cache (reuse budget-guard)        | `scripts/agent/embed-chunks.mjs`, `.cache/retrieval/*.bin`                |
+| **PR-2.2** | Cosine ranking + degradation-логіка (semantic → lexical без ключа)      | `scripts/agent/find.mjs` (extend)                                         |
+
+### Phase 3 — Gates і якість (committed)
+
+**Acceptance:** stale-маніфест валить CI; repo-retrieval `recall@K` ≥ baseline.
+
+| PR         | Що ввозиться                                                                  | Файли                                                                          |
+| ---------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| **PR-3.1** | `pnpm agent:find:check` (content-hash diff vs committed) wired у `pnpm lint`    | `scripts/agent/build-retrieval-index.mjs` (`--check`), `package.json`           |
+| **PR-3.2** | Regen у `docs:gen-daily` + Hard Rule #24-реєстрація каталогу                    | `package.json`, `docs/governance/hard-rules.json`, `knowledge-graph.json`       |
+| **PR-3.3** | Repo-retrieval golden-set + `eval-rag-recall.mjs`-режим                         | `scripts/eval/golden-retrieval.json`, `scripts/eval-rag-recall.mjs` (extend)    |
+
+### Phase 4 — MCP + промоція (committed)
+
+**Acceptance:** агент у будь-якій сесії викликає `agent_find` як перший крок орієнтації замість сліпого grep; `sergeant-start-here` його рекомендує.
+
+| PR         | Що ввозиться                                                  | Файли                                                                |
+| ---------- | ------------------------------------------------------------- | -------------------------------------------------------------------- |
+| **PR-4.1** | Тонкий MCP-tool `agent_find` поверх движка з find.mjs         | `scripts/agent/mcp-server.mjs` (або наявний MCP-host), `.mcp.json`   |
+| **PR-4.2** | Промоція у `sergeant-start-here` + `docs/agents/onboarding.md` | `.agents/skills/sergeant-start-here/SKILL.md`, `docs/agents/onboarding.md` |
+
+## Критерії DONE
+
+- [ ] `pnpm agent:find "<q>"` працює офлайн (lexical) і повертає рейтинговані `path:line [type]` пойнтери
+- [ ] З `VOYAGE_API_KEY` ранжування семантичне; без ключа — graceful lexical-фолбек, нуль крашів
+- [ ] `pnpm agent:find:check` блокує merge при stale-маніфесті; каталог зареєстровано під Hard Rule #24
+- [ ] Маніфест регенерується у `docs:gen-daily`; вектори — у gitignored cache (нуль binary-diff у git)
+- [ ] Repo-retrieval golden-set + `recall@K`/`MRR` gate проходить ≥ baseline
+- [ ] MCP-tool `agent_find` доступний; `sergeant-start-here` його промотує
+- [ ] Заміряно: на репрезентативній вибірці задач агент робить менше сліпих grep-ів (before/after — у session-log)
+
+## Ризики
+
+| Ризик                                                              | Митигація                                                                                                       |
+| ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| **Ще один generated-артефакт, який стає stale**                    | `--check`-gate у CI (як `docs:check-graph`) + content-hash інвалідація + regen у `docs:gen-daily`               |
+| **Vendor lock / вартість Voyage на regen**                         | Ембедимо лише змінені (за content-hash) чанки; спільний budget-guard з ai-memory; lexical-режим повністю безкоштовний |
+| **Lexical-режим дає низьку якість і агенти його ігнорують**        | Phase 3 golden-eval вимірює recall обох режимів; якщо lexical < поріг — піднімаємо як known-limitation у docs   |
+| **Маніфест роздувається з symbol-index (≈300 → тисячі чанків)**    | Tier-фільтр з графа (core завжди, extended за `--type`); symbol-чанки тільки `export`-рівня, не кожен identifier |
+| **Дубль з наявним runtime-recall плутає агентів**                  | ADR-0066 чітко розділяє: `agent_find` = repo-знання (build-time), `ai-memory/recall` = user-data (runtime)      |
+
+## Власник / ETA
+
+- **Owner:** @Skords-01
+- **Implementation agent:** Claude Code
+- **ETA:** TBD — старт після founder-погодження ADR-0066; Phase 1 ≈ невеликий (lexical-кістяк), Phase 2–4 інкрементально.
+
+## Посилання
+
+- [ADR-0066 — Agent semantic retrieval over the knowledge graph](../adr/0066-agent-semantic-retrieval-over-knowledge-graph.md)
+- [`docs/architecture/ai-memory.md`](../architecture/ai-memory.md) — embedding-конвеєр, який перевикористовуємо
+- [`docs/architecture/rag-eval.md`](../architecture/rag-eval.md) — eval-harness і `recall@K`/`MRR` метрики
+- [`docs/governance/knowledge-graph.json`](../governance/knowledge-graph.json) — головне джерело нод для індексу
+- [`docs/governance/symbol-index.json`](../governance/symbol-index.json) — export-пойнтери
+- Rule #24 [`catalog-check-generator.md`](../governance/rules/24-catalog-check-generator.md), Rule #25 [`auto-generated-marker.md`](../governance/rules/25-auto-generated-marker.md)


### PR DESCRIPTION
## Summary

Чернетки під напрям **Tier 1 — семантичний retrieval** для покращення роботи агентів із репо (менше сліпого grep, менше хибних висновків, менше розжовування контексту вручну).

Два документи, обидва для рев'ю-рішення (нічого виконавчого ще не запускається):

- **`docs/adr/0066-…`** (`Status: Proposed`) — архітектурне рішення: build-time **committed retrieval index** + `pnpm agent:find` entrypoint поверх наявних `knowledge-graph.json` + `symbol-index.json` + canonical docs. Перевикористовує Voyage + `eval-rag-recall.mjs`, але **свідомо decoupled** від per-user runtime-стору `ai_memories` (він партиційований і вимагає живого сервера+БД — недоступний агенту в CI/локально). Вектори — у gitignored content-hash cache, маніфест — у git (узгоджено з принципом ADR-0058 «JSON over SQLite, no runtime»). Lexical-фолбек гарантує роботу без `VOYAGE_API_KEY`.
- **`docs/initiatives/0018-…`** (`Status: Proposed`, `Agent-ready: yes`) — фазований план (P1 lexical-кістяк → P2 Voyage-шар → P3 gates+golden-eval → P4 MCP-tool + промоція у `sergeant-start-here`).

## Governing Skill

`sergeant-start-here` → governance/docs surface (це agent-OS policy зміна — нові ADR/initiative).

## Playbook

Немає прямого playbook для ADR-авторства; слідував конвенціям `docs/adr/TEMPLATE.md` + `docs/initiatives/README.md` (структура, lifecycle-маркери, мова UA per Rule #15).

## Verification

⚠️ **Heavy-gate regen НЕ запускався** (ephemeral-середовище, щоб не тягнути повний `pnpm install`). Перед merge треба прогнати:

- [ ] `pnpm docs:gen-graph` — новий ADR-0066 / initiative-0018 потраплять у `knowledge-graph.json`, інакше `docs:check-graph` буде red
- [ ] `pnpm lint:discoverability` — переконатися, що ADR/initiative reachable
- [ ] `pnpm docs:check-freshness-single-marker --check-coverage` — lifecycle-маркери присутні (додані вручну за конвенцією)

Можу прогнати їх у цій сесії, якщо погодиш напрям — або це робиться на наступному кроці разом із Phase 1.

## Docs and Governance

Нові docs самодостатні; жодних наявних docs не чіпав. ADR-0066 реєструє майбутній каталог `retrieval-index.json` під Hard Rule #24 (виконається у Phase 3, не в цьому PR).

## Risk and Rollout

Zero runtime-ризику — лише два markdown-документи з пропозицією. Виконавчий код стартує окремими PR-ами за планом ініціативи лише після погодження ADR-0066.

## Hard Rule #15 acknowledgement

Прочитав governance перед написанням; internal docs — українською; оновлюю docs разом зі змінами (тут зміна = самі docs).

https://claude.ai/code/session_01M8Jtxtv1pCuGhQvJTeGcsF

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8Jtxtv1pCuGhQvJTeGcsF)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ADR-0066 and Initiative 0018 that define a build-time, committed semantic retrieval index and `pnpm agent:find` CLI over `knowledge-graph.json`, `symbol-index.json`, and canonical docs. The plan uses Voyage embeddings (with a lexical fallback and no dependency on `ai_memories`) to help agents find relevant files faster and avoid blind grep.

<sup>Written for commit 4a917f1aeff10143c2666fa498980878f572ec41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added architectural decision record for agent semantic retrieval over knowledge graph.
  * Added initiative documentation for the agent semantic retrieval feature, outlining a multi-phase implementation plan with a committed build-time retrieval index, `agent:find` command, Voyage-based semantic search, and lexical fallback capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->