### PR TITLE
fix(web): mount auth provider above RootLayout

### DIFF
--- a/apps/web/src/core/App.test.tsx
+++ b/apps/web/src/core/App.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import { isValidElement } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { render } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -26,6 +27,9 @@ import { MemoryRouter } from "react-router-dom";
  * behaviour of individual providers (those have their own tests).
  */
 
+vi.mock("./app/RootLayout", () => ({
+  RootLayout: () => null,
+}));
 vi.mock("./app/ShellDeepLinkBridge", () => ({
   ShellDeepLinkBridge: () => null,
 }));
@@ -47,6 +51,11 @@ vi.mock("./auth/authClient", () => ({
 vi.mock("./observability/posthog", () => ({
   identifyPostHogUser: vi.fn(),
   resetPostHog: vi.fn(),
+}));
+vi.mock("./db/kvStoreBoot", () => ({
+  bootstrapKvStore: () => Promise.resolve(),
+  getActiveSqliteKvStore: () => null,
+  kvStoreBoot: { loaded: false, warmCache: new Map() },
 }));
 vi.mock("./observability/analytics", async () => {
   const real = await vi.importActual<
@@ -86,6 +95,8 @@ vi.mock("@sergeant/api-client/react", async () => {
 });
 
 import { Providers } from "./app/Providers";
+import { RootLayout } from "./app/RootLayout";
+import { RootRoute } from "./app/router";
 import { useToast } from "@shared/hooks/useToast";
 import { useAnnounce } from "@shared/components/ui/ScreenReaderAnnouncer";
 import { useAuth } from "./auth/AuthContext";
@@ -137,6 +148,24 @@ describe("<Providers /> — provider-tree invariant (Web deep-dive §1.1)", () =
     // invariant — `auth.status` simply must be defined, i.e.
     // `AuthProvider` is in the ancestor chain.
     expect(leaf.dataset["authStatus"]).toBeDefined();
+  });
+
+  it("mounts Providers above RootLayout so layout hooks can read auth context", () => {
+    const rootElement = RootRoute();
+
+    expect(isValidElement<{ children: unknown }>(rootElement)).toBe(true);
+    if (!isValidElement<{ children: unknown }>(rootElement)) {
+      throw new Error("RootRoute did not return a React element");
+    }
+
+    expect(rootElement.type).toBe(Providers);
+    const layoutElement = rootElement.props.children;
+
+    expect(isValidElement(layoutElement)).toBe(true);
+    if (!isValidElement(layoutElement)) {
+      throw new Error("RootRoute did not render RootLayout as child");
+    }
+    expect(layoutElement.type).toBe(RootLayout);
   });
 
   it("renders the children exactly once (no provider remounts the subtree on its own)", () => {

--- a/apps/web/src/core/app/RootLayout.tsx
+++ b/apps/web/src/core/app/RootLayout.tsx
@@ -15,7 +15,6 @@ import {
   useHubChatOverlay,
   useHubChatOverlayState,
 } from "../hub/useHubChatOverlay";
-import { Providers } from "./Providers";
 import { SIGN_IN_PATH } from "./appPaths";
 import { useHubKeyboardShortcuts } from "../hooks/useHubKeyboardShortcuts";
 import { useBrowserLocation } from "../hooks/useBrowserLocation";
@@ -70,7 +69,7 @@ function AppShell({ children }: { children: React.ReactNode }) {
 /**
  * Root layout route — initiative 0006 Phase 5.
  *
- * Mounts the full provider tree + global effects once, then renders
+ * Runs global effects once, then renders
  * matched child routes via `<Outlet />`. Each child route gets a
  * **different** component, which fixes the React Router 7 location-
  * context propagation bug (mixed-shape match objects when multiple
@@ -196,12 +195,10 @@ export function RootLayout() {
   };
 
   return (
-    <Providers>
-      <HubShellProvider value={hubShellValue}>
-        <AppShell>
-          <Outlet />
-        </AppShell>
-      </HubShellProvider>
-    </Providers>
+    <HubShellProvider value={hubShellValue}>
+      <AppShell>
+        <Outlet />
+      </AppShell>
+    </HubShellProvider>
   );
 }

--- a/apps/web/src/core/app/router.tsx
+++ b/apps/web/src/core/app/router.tsx
@@ -1,5 +1,6 @@
 import { createBrowserRouter } from "react-router-dom";
 import { RootLayout } from "./RootLayout";
+import { Providers } from "./Providers";
 
 /**
  * Root router config for `apps/web` (initiative 0006 — frontend routing).
@@ -10,7 +11,8 @@ import { RootLayout } from "./RootLayout";
  * and `useLocation()` always returns the current pathname.
  *
  * Architecture:
- *   RootLayout (providers + shared state + global effects + <Outlet />)
+ *   RootRoute (providers)
+ *    └── RootLayout (shared state + global effects + <Outlet />)
  *    ├── /finyk/*    → FinykRoute   (lazy chunk)
  *    ├── /fizruk/*   → FizrukRoute  (lazy chunk)
  *    ├── /nutrition/* → NutritionRoute (lazy chunk)
@@ -25,10 +27,18 @@ import { RootLayout } from "./RootLayout";
  * Auth contract: auth guard lives at component level (each page checks
  * `useAuth().status`), not at router level. See `AuthContext.tsx`.
  */
+export function RootRoute() {
+  return (
+    <Providers>
+      <RootLayout />
+    </Providers>
+  );
+}
+
 export const router = createBrowserRouter([
   {
     path: "/",
-    element: <RootLayout />,
+    element: <RootRoute />,
     children: [
       // Per-module lazy routes — each renders a DIFFERENT component,
       // fixing the mixed-shape match-object bug (see Phase 2 history above).


### PR DESCRIPTION
### Motivation
- Tests and runtime crashed with `useAuth must be used within AuthProvider` because `RootLayout` was calling hooks before the `Providers` (which include `AuthProvider`) were mounted at the router root.
- The intent is to ensure layout-level hooks like `useAuth()` run inside the expected provider stack so layout effects and boot steps have access to auth/session state.

### Description
- Introduced a `RootRoute` in `apps/web/src/core/app/router.tsx` that wraps `RootLayout` with the `Providers` stack and changed the router root `element` to `<RootRoute />` so providers are mounted at the router level.
- Removed the nested `Providers` wrapper from `apps/web/src/core/app/RootLayout.tsx` so `RootLayout` focuses on shell state/effects and child route rendering.
- Added an invariant unit test in `apps/web/src/core/App.test.tsx` that asserts `RootRoute()` renders `Providers` above `RootLayout` and preserved the provider-tree invariant test that exercises `useToast()`, `useAnnounce()`, and `useAuth()`.
- Test helper: the test file mocks `./db/kvStoreBoot` to avoid importing the SQLite WASM bundle during the unit run.

### Testing
- Ran `pnpm --filter @sergeant/web test -- App.test.tsx` and the updated tests passed.
- Ran `pnpm --filter @sergeant/web typecheck` and there were no type errors.
- Ran `pnpm exec prettier --check apps/web/src/core/app/router.tsx apps/web/src/core/app/RootLayout.tsx apps/web/src/core/App.test.tsx` and formatting passed.
- Ran `pnpm --filter @sergeant/web build` and the build completed successfully.
- Ran `pnpm --filter @sergeant/web lint` which finished with the existing repo warnings and no new errors, and Husky pre-commit hooks (lint-staged + staged typecheck) passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a293d2b357c8330b6927910d04cf4cf)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mount `Providers` (including `AuthProvider`) at the router root so `RootLayout` hooks run inside the auth context. Fixes crashes like “useAuth must be used within AuthProvider” at startup and in tests.

- **Bug Fixes**
  - Added `RootRoute` that wraps `RootLayout` with `Providers`, and set the router root `element` to `<RootRoute />`.
  - Removed the `Providers` wrapper from `RootLayout` so it only handles shell state/effects and renders `<Outlet />`.
  - Added a unit test to assert `Providers` render above `RootLayout` and kept the provider-tree invariant test for `useToast`, `useAnnounce`, and `useAuth`.
  - Mocked `./db/kvStoreBoot` in tests to avoid loading the SQLite WASM bundle.

<sup>Written for commit c4ff04c28a23e4e1f54c098a99e9b38c86304d53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized application provider architecture to ensure consistent context availability across routes and components.

* **Tests**
  * Added validation tests for provider component hierarchy and structural integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->