### PR TITLE
docs(agents): scrub live production user ID from public docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agents in Sergeant
 
-> **Last validated:** 2026-06-09 by @claude. **Next review:** 2026-09-07.
+> **Last validated:** 2026-06-11 by @Skords-01. **Next review:** 2026-09-09.
 > **Status:** Active
 
 > **If you are an agent:** start with `.agents/skills/sergeant-start-here/SKILL.md`, then load exactly one Sergeant specialist skill for the touched surface. The routing catalog lives in `docs/00-start/agents/agent-skills-catalog.md`.
@@ -202,7 +202,7 @@ PR body follows [`.github/PULL_REQUEST_TEMPLATE.md`](./.github/PULL_REQUEST_TEMP
 
 - **Frontend:** Vercel (preview deploy on each PR; free tier may rate-limit).
 - **Backend:** Railway via `Dockerfile.api`. Pre-deploy: `pnpm db:migrate`. Health endpoint: `/health`. Migrations require `MIGRATE_DATABASE_URL` (= public DB URL).
-- **Test users:** `I3BUW5atld8oOHM7lpFEJBIInpW1hzv7` — primary test user, 6 Monobank accounts, ~2 246 ₴ on UAH cards.
+- **Test users:** primary test-user ID живе поза репо (Railway variables / локальний `.env`-нотатник власника) — репо публічне, не комітьте реальні user ID чи фінансову топологію.
 
 ## See also
 

--- a/docs/02-engineering/architecture/domain-invariants.md
+++ b/docs/02-engineering/architecture/domain-invariants.md
@@ -1,6 +1,6 @@
 # Domain invariants
 
-> **Last validated:** 2026-06-09 by @claude. **Next review:** 2026-09-07.
+> **Last validated:** 2026-06-11 by @Skords-01. **Next review:** 2026-09-09.
 > **Status:** Active
 
 > Things that bite hard if assumed wrong. Compact pointer in [`AGENTS.md § Domain invariants`](../../../AGENTS.md#domain-invariants); deep prose lives here. Treat this file as canonical when web ↔ mobile ↔ server logic disagrees.
@@ -21,7 +21,7 @@
 
 ## Identity
 
-- User IDs are Better Auth opaque strings (e.g. `I3BUW5atld8oOHM7lpFEJBIInpW1hzv7`). Do not assume UUID format. Cookies are HTTP-only; auth in tests goes via Better Auth test session helpers.
+- User IDs are Better Auth opaque strings (32 alphanumeric chars, **не UUID** — приклад синтетичного формату: `a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6`). Do not assume UUID format. Cookies are HTTP-only; auth in tests goes via Better Auth test session helpers. Реальні production user ID не комітимо — репо публічне.
 - Canonical auth surface for the server: `apps/server/src/auth.ts` (Better Auth wiring) + `apps/server/src/http/requireSession.ts` (`requireSession()` / `requireSessionSoft()` middleware). Never re-read the cookie manually — go through these.
 
 ## AI tool execution path


### PR DESCRIPTION
## Summary

The repo is public, but `AGENTS.md § Deployment & test users` and `docs/02-engineering/architecture/domain-invariants.md` carried a **real production Better Auth user ID together with the owner's Monobank financial topology** (account count + balance). Replaced with synthetic examples and a pointer to the private location (Railway variables / owner's local notes).

Closes **ws-07** from the independent audit 2026-06-11 (dimension 5 — Security, severity MEDIUM, adversarially verified).

## Governing Skill

`sergeant-security-audit`

## Verification

- `grep I3BUW5` across the repo → zero hits after this change.
- Docs-only diff; no code paths touched.

## Docs and Governance

- Freshness headers auto-bumped by pre-commit hook.

## Risk and Rollout

- None — documentation-only. Note: the ID remains in git history; rotating the test user (or treating the account as burned) is a follow-up founder decision.

## Hard Rule #15

- [x] Docs updated alongside the change (this PR is the docs change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed a real Better Auth user ID and Monobank account details from `AGENTS.md` and `docs/02-engineering/architecture/domain-invariants.md`. Added synthetic examples and guidance to keep real IDs in private variables; docs-only with updated “Last validated” headers and no code impact.

<sup>Written for commit cc337cdc55f87fb9087b0b74463fd3fcb4dd1a0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation headers and metadata across engineering guides.
  * Enhanced security practices by removing hardcoded test credentials from repository; sensitive identifiers now stored in external configuration.
  * Refined examples for identity authentication format documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->