### PR TITLE
fix(web): remove fake price placeholder and unimplemented trial promise

### DIFF
--- a/apps/web/src/core/PricingPage.tsx
+++ b/apps/web/src/core/PricingPage.tsx
@@ -51,9 +51,12 @@ interface Tier {
   readonly highlight: boolean;
 }
 
-// Placeholder — real price locked in pricing strategy PR (D3 § Out of scope).
-// Tracked: docs/design/redesign-v2/phase-7-product-decisions-2026-05-22.md → D3.
-const PREMIUM_PRICE_MONTHLY_PLACEHOLDER = "€X";
+// D3 § Out of scope: final price is not decided yet. Until the pricing PR
+// lands we deliberately show NO number — a fake "€X" placeholder shipped on
+// the public funnel (independent audit 2026-06-11, dimension 1, CRITICAL).
+// The cadence line under the dash carries the localized "announced at launch"
+// copy; Stripe Checkout shows the real dashboard-configured price.
+const PREMIUM_PRICE_PENDING = "—";
 
 // Defense-in-depth open-redirect guard (audit F4,
 // docs/audits/2026-05-13-page-audit-10-errors-pwa-marketing.md). Backend
@@ -95,7 +98,7 @@ function buildTiers(
     {
       id: "free",
       name: pricing.tiers.freeName,
-      price: "€0",
+      price: pricing.tiers.freePrice,
       cadence: pricing.tiers.freeCadence,
       tagline: pricing.tiers.freeTagline,
       highlight: false,
@@ -121,7 +124,7 @@ function buildTiers(
     {
       id: "premium",
       name: pricing.tiers.premiumName,
-      price: PREMIUM_PRICE_MONTHLY_PLACEHOLDER,
+      price: PREMIUM_PRICE_PENDING,
       cadence: pricing.tiers.premiumCadence,
       tagline: pricing.tiers.premiumTagline,
       highlight: true,

--- a/apps/web/src/core/settings/PlanSection.tsx
+++ b/apps/web/src/core/settings/PlanSection.tsx
@@ -79,8 +79,8 @@ export function PlanSection() {
           <div data-testid="plan-trial-info" className="space-y-1">
             <span className="text-style-label block">Пробний період</span>
             <p className="text-sm text-text leading-snug">
-              Закінчується {periodEnd}. Після цього спишемо $7/міс — скасуй до
-              цієї дати, якщо передумаєш.
+              Закінчується {periodEnd}. Після цього підписка стане платною за
+              тарифом з чекауту — скасуй до цієї дати, якщо передумаєш.
             </p>
           </div>
         )}

--- a/apps/web/src/shared/i18n/en.ts
+++ b/apps/web/src/shared/i18n/en.ts
@@ -114,7 +114,7 @@ export const messagesEn: Partial<MessageCatalog> = {
         "Your data lives on your device. Cloud sync is optional (Premium) and never turns on without your confirmation.",
       noHiddenTitle: "No surprise charges",
       noHiddenBody:
-        "Free tier — forever. Premium — 7-day trial, no card required, $7/mo or UAH equivalent for UA.",
+        "Free tier — forever. Premium — one paid plan, no surprise charges. Pricing will be announced at launch.",
     },
 
     // Waitlist section
@@ -155,10 +155,11 @@ export const messagesEn: Partial<MessageCatalog> = {
     },
     tiers: {
       freeName: "Free",
+      freePrice: "₴0",
       freeCadence: "forever",
       freeTagline: "Basic limits across all 4 modules. Local-first, no cloud.",
       premiumName: "Premium",
-      premiumCadence: "/mo",
+      premiumCadence: "price announced at launch",
       premiumTagline: "Everything unlocked. One plan — no tiers, no add-ons.",
     },
     features: {

--- a/apps/web/src/shared/i18n/uk.ts
+++ b/apps/web/src/shared/i18n/uk.ts
@@ -734,7 +734,7 @@ export const messages = {
         "Дані живуть на твоєму пристрої. Cloud sync — опціональний (Pro), не вмикається без твого підтвердження.",
       noHiddenTitle: "Без зайвих списань",
       noHiddenBody:
-        "Free-тір — назавжди. Pro — 7 днів тріал без картки, $7/міс або ₴-еквівалент для UA.",
+        "Free-тір — назавжди. Premium — один платний план без прихованих списань. Ціну оголосимо на запуску.",
     },
 
     // Waitlist section
@@ -777,10 +777,11 @@ export const messages = {
     },
     tiers: {
       freeName: "Free",
+      freePrice: "0 ₴",
       freeCadence: "назавжди",
       freeTagline: "Базові ліміти у всіх 4 модулях. Local-first, без cloud.",
       premiumName: "Premium",
-      premiumCadence: "/міс",
+      premiumCadence: "ціну оголосимо на запуску",
       premiumTagline: "Усе розблоковано. Один план — без рівнів і доплат.",
     },
     features: {


### PR DESCRIPTION
## Summary

The public `/pricing` page rendered a literal **€X placeholder** as the Premium price, and landing/settings copy promised a **7-day no-card trial** and **$7/mo** that have no implementation (no code path creates a trialing subscription; checkout collects a card by Stripe default; the price decision is open after Phase-7 D3 reset ADR-0051). Per founder decision 2026-06-11: show an honest no-price state and retract the trial promise until the pricing decision lands.

- Premium price renders an em dash; cadence line: «ціну оголосимо на запуску» / «price announced at launch» (uk/en).
- Free tier price moved to i18n (0 ₴) instead of hardcoded €0 — kills the three-currency inconsistency on one surface.
- Landing «no hidden charges» copy and PlanSection trialing copy no longer promise a trial or a specific price.

Closes **ws-01 (interim)** + **ws-05 (retract)** from the independent audit 2026-06-11 (dimension 1 CRITICAL/HIGH, adversarially verified). Follow-up when the founder picks the price: wire the real number + amend ADR-0051.

## Governing Skill

`sergeant-web-ui`

## Verification

- `vitest run PricingPage.test.tsx PlanSection.test.tsx src/shared/i18n` → **42/42 passed**.
- `pnpm --filter @sergeant/web typecheck` → clean.
- UI not click-tested in a live browser this round — copy/price-only diff, no layout/logic changes.

## Risk and Rollout

- Copy-only + one i18n key added (`tiers.freePrice`). No server contract touched.

## Hard Rule #15

- [x] ADR-0051 amendment deliberately deferred to the price-decision PR (this is the interim honest state, not the decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the fake Premium price ("€X") and removed the unimplemented 7‑day no‑card trial promise. The pricing page now shows no number for Premium and Free price is localized to fix currency mismatches.

- **Bug Fixes**
  - Pricing: Premium price displays an em dash; cadence reads “price announced at launch” (en/uk).
  - Settings: trial text no longer promises $7/mo or a no‑card trial; now references the checkout plan.
  - i18n: added `tiers.freePrice` (₴0) and updated landing “No surprise charges” copy.

<sup>Written for commit d49dfa1770397e5921d23e914e3fc3388b34b1ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

