### PR TITLE
docs(agents): repair governance signal layer — routing names + pr-ledger install

### DIFF
--- a/.github/workflows/pr-backlinks.yml
+++ b/.github/workflows/pr-backlinks.yml
@@ -65,10 +65,24 @@ jobs:
           ref: main
           fetch-depth: 0
 
+      # pnpm/action-setup v6.0.3 (SHA-pinned for supply-chain hardening)
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
+
       # actions/setup-node v6.4.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: "22"
+          cache: pnpm
+
+      - name: Install dependencies
+        # update-pr-backlinks.mjs lazy-imports `prettier` to format the
+        # regenerated PR-BACKLINKS blocks. The workflow ran WITHOUT any
+        # install for ~25 days: the upsert succeeded, then the script
+        # crashed on `Cannot find package 'prettier'` BEFORE committing —
+        # the ledger froze at 6 PRs while ~600 doc-touching merges went
+        # unrecorded (Hard Rule #26 dead; independent audit 2026-06-11
+        # ws-09).
+        run: pnpm install --frozen-lockfile
 
       - name: Configure git author
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,20 +15,20 @@ Sergeant is **tool-agnostic**. Any AI agent harness — Claude Code, Kilo Code, 
 
 **Routing (surface → specialist).** Pick the smallest specialist that owns the touched surface; escalate to `sergeant-review-and-merge` only at PR-boundary.
 
-| Signal in the task                                                  | Load                           |
-| ------------------------------------------------------------------- | ------------------------------ |
-| Touches `apps/web/**`, RQ keys, design tokens, a11y                 | `sergeant-web-ui`              |
-| Touches `apps/server/**`, API contract, `api-client`, pino, OpenAPI | `sergeant-server-api`          |
-| Touches `apps/mobile/**` or `apps/mobile-shell/**`, Expo, EAS       | `sergeant-mobile`              |
-| Touches `db-schema/`, migrations, drill-down, index audit           | `sergeant-data-and-migrations` |
-| Railway / Vercel / Sentry / Alertmanager / CI workflow change       | `sergeant-deploy`              |
-| OpenClaw gateway / plugin / PAT lifecycle                           | `sergeant-openclaw`            |
-| HubChat module / HubChat reset / HubChat E2E                        | `sergeant-hubchat`             |
-| Writing or running E2E (Playwright/Vitest browser)                  | `sergeant-e2e-testing`         |
-| Security review, vuln triage, secret scan, dependency CVE           | `sergeant-security-audit`      |
-| Regression, hotfix, "this used to work"                             | `sergeant-bugfix`              |
-| Refactor, dead code, Knip baseline, eslint baseline reduction       | `sergeant-tech-debt`           |
-| PR review, squash-merge, release-cut, changelog                     | `sergeant-review-and-merge`    |
+| Signal in the task                                                  | Load                                |
+| ------------------------------------------------------------------- | ----------------------------------- |
+| Touches `apps/web/**`, RQ keys, design tokens, a11y                 | `sergeant-web-ui`                   |
+| Touches `apps/server/**`, API contract, `api-client`, pino, OpenAPI | `sergeant-server-api`               |
+| Touches `apps/mobile/**` or `apps/mobile-shell/**`, Expo, EAS       | `sergeant-mobile-expo`              |
+| Touches `db-schema/`, migrations, drill-down, index audit           | `sergeant-data-and-migrations`      |
+| Railway / Vercel / Sentry / Alertmanager / CI workflow change       | `sergeant-deploy-and-observability` |
+| OpenClaw gateway / plugin / PAT lifecycle                           | `sergeant-openclaw`                 |
+| HubChat module / HubChat reset / HubChat E2E                        | `sergeant-hubchat`                  |
+| Writing or running E2E (Playwright/Vitest browser)                  | `sergeant-e2e-testing`              |
+| Security review, vuln triage, secret scan, dependency CVE           | `sergeant-security-audit`           |
+| Regression, hotfix, "this used to work"                             | `sergeant-bugfix-and-regression`    |
+| Refactor, dead code, Knip baseline, eslint baseline reduction       | `sergeant-tech-debt`                |
+| PR review, squash-merge, release-cut, changelog                     | `sergeant-review-and-merge`         |
 
 If two surfaces overlap (e.g. web + e2e), load the **owner** first; ask the other only when blocked. Full catalog: [`docs/00-start/agents/agent-skills-catalog.md`](./docs/00-start/agents/agent-skills-catalog.md).
 
@@ -76,7 +76,7 @@ Surface-scoped quick references (commands, gotchas, specialist skill pointer) li
 ## Repo overview
 
 - **pnpm 9.15.1** (enforced via `packageManager`) + **Turborepo** monorepo, **Node 22.x** (Volta pins 22.19.0), **TypeScript 6**.
-- 4 apps (`apps/web`, `apps/server`, `apps/mobile`, `apps/mobile-shell`) + `tools/openclaw` (a `tools/` workspace, not under `apps/`) + 12 packages (`@sergeant/*`, `eslint-plugin-sergeant-design`, 4 domain packages).
+- 4 apps (`apps/web`, `apps/server`, `apps/mobile`, `apps/mobile-shell`) + 12 packages (`@sergeant/*`, `eslint-plugin-sergeant-design`, 4 domain packages).
 - Pre-commit: **Husky** runs `lint-staged` — ESLint --fix + Prettier for code, `staged-typecheck.mjs` for staged TS/TSX, `bump-last-validated.mjs` for `.md`. Pipeline matrix: [`CONTRIBUTING.md § Pre-commit hooks`](./CONTRIBUTING.md#pre-commit-hooks).
 - Deep tech-stack matrix (per-app stack, per-package purpose, build/deploy outputs): [`docs/02-engineering/architecture/repo-map.md`](./docs/02-engineering/architecture/repo-map.md).
 
@@ -89,7 +89,6 @@ Per-app owner + secondary reviewer for the bus-factor contract (Stack-pulse PR-0
 | `apps/web/**`                            | `@Skords-01` | TBD (frontend-engineer) | [`module-ownership.md § Apps`](./docs/02-engineering/architecture/module-ownership.md#apps)                 |
 | `apps/server/**`                         | `@Skords-01` | TBD (backend-engineer)  | [`module-ownership.md § Apps`](./docs/02-engineering/architecture/module-ownership.md#apps)                 |
 | `apps/mobile/**`, `apps/mobile-shell/**` | `@Skords-01` | TBD (mobile-engineer)   | [`module-ownership.md § Apps`](./docs/02-engineering/architecture/module-ownership.md#apps)                 |
-| `tools/openclaw/**`                      | `@Skords-01` | TBD (backend-engineer)  | [`module-ownership.md § Apps`](./docs/02-engineering/architecture/module-ownership.md#apps)                 |
 | `packages/**`                            | `@Skords-01` | TBD (any-engineer)      | [`module-ownership.md § Packages`](./docs/02-engineering/architecture/module-ownership.md#packages)         |
 | `ops/**`, `tools/**`, `scripts/**`       | `@Skords-01` | TBD (any-engineer)      | [`module-ownership.md § Ops surfaces`](./docs/02-engineering/architecture/module-ownership.md#ops-surfaces) |
 


### PR DESCRIPTION
## Summary

**ws-09 з незалежного аудиту 2026-06-11** — ремонт governance-сигналів, яким довіряють агенти:

1. **AGENTS.md routing 404** — таблиця маршрутизації називала трьох спеціалістів, яких не існує на диску (`sergeant-mobile`/`sergeant-deploy`/`sergeant-bugfix`): буквальний `Read .agents/skills/X/SKILL.md` падав для 3 із 12 рядків найзавантажуванішого канонічного документа. Виправлено на реальні імена директорій; прибрано фантомний `tools/openclaw` (видалений у #3470, `tools/` тримає лише `tsconfig-guard`) з repo overview і ownership map.
2. **Hard Rule #26 був мертвий ~25 днів** — `pr-backlinks.yml` запускав node без жодного install: upsert проходив, потім скрипт падав на `Cannot find package 'prettier'` ДО коміту. Ledger завмер на 6 PR проти ~600 doc-touching merges. Додано pnpm setup + `pnpm install --frozen-lockfile`.
3. ws-09 item 3 (server max-lines регресія f28d8d5ff) — **уже полагоджено на main** (`eslint.server.js:97-120` + allowlist повернулись 2026-06-09), без змін тут.

## Governing Skill

`sergeant-tech-debt`

## Playbook

n/a — точкові фікси за audit work-stream.

## Verification

- Локально зелені: `check-governance-sync` (warnings-only), `check-codeowners-coverage` (35/35), `check-agents-family-sync`, `check-hard-rules-registry` (26/26).
- pr-backlinks workflow перевіриться першим post-merge doc-touching PR-ом (його тригер — `pull_request_target: closed`).

## Docs and Governance

- Це і є docs/governance-фікс; freshness header бампнуто хуком.

## Risk and Rollout

- pr-backlinks тепер тягне повний install (~90 с) на кожен doc-touching merge — прийнятна ціна за живий ledger; backfill ~600 пропущених PR-ів — окреме рішення (повний регенерат чи forward-only).

## Hard Rule #15

- [x] Governance прочитано; зміни в самих governance-доках.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix broken agent routing in AGENTS.md and unfreeze the PR backlinks ledger by adding a proper `pnpm` install step to the `pr-backlinks` workflow. Agents now map to real skill directories, and the workflow has `prettier` available to commit updates.

- **Bug Fixes**
  - Updated AGENTS routing names to `sergeant-mobile-expo`, `sergeant-deploy-and-observability`, and `sergeant-bugfix-and-regression`; removed `tools/openclaw` from repo overview and ownership.
  - In `.github/workflows/pr-backlinks.yml`, added `pnpm/action-setup`, enabled `pnpm` cache in `actions/setup-node`, and run `pnpm install --frozen-lockfile` so the ledger update script can find `prettier` (fixes Hard Rule #26 failures).

<sup>Written for commit aa9861000120c28f2885567979e56738d73c949f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

