### PR TITLE
fix(server): triage first real integration run — exempt public routes, fix LWW-tie test

### DIFF
--- a/apps/server/src/__tests__/session-protection.integration.test.ts
+++ b/apps/server/src/__tests__/session-protection.integration.test.ts
@@ -231,6 +231,18 @@ const EXEMPT_ROUTES: ReadonlySet<string> = new Set([
   // Public VAPID key — frontend reads this to subscribe a push
   // subscription. By design no session, no rate-limit (it's static).
   "/api/push/vapid-public",
+  // Public status page (PR-41) — unauthenticated by design, consumed by
+  // StatusPage.tsx; info-leak invariants covered by health.infoleak.test.ts.
+  "/api/status",
+  // Sync v1 — deliberate 410 Gone stubs mounted BEFORE requireSession()
+  // (T2 audit #7): deprecated clients must receive the migration signal
+  // without a session, otherwise a logged-out stale client sees 401 and
+  // retries forever instead of upgrading. The live v2 surface stays
+  // behind requireSession (`/api/v2/sync/*`). See routes/sync.ts:62-76.
+  "/api/sync/push",
+  "/api/sync/pull",
+  "/api/sync/pull-all",
+  "/api/sync/push-all",
   // Internal-only push fan-out — M14 hardening uses `requireInternalIp`
   // + `requireApiSecret("API_SECRET")` with constant-time compare. The
   // surface is not exposed to browsers (CGN range / loopback only), so

--- a/apps/server/src/modules/sync/syncV2.integration.test.ts
+++ b/apps/server/src/modules/sync/syncV2.integration.test.ts
@@ -3808,7 +3808,14 @@ describe("syncV2Push — op='increment' engine-level gate (PR #042a)", () => {
       if (!dockerAvailable || !testPool) return ctx.skip();
       await ensureUser("u-incr-2");
 
+      // LWW-guard для routine_streaks порівнює `MAX(client_ts) >= clientTs`
+      // (tie → lww_conflict; та сама семантика була і в монолітному движку
+      // до декомпозиції). Update тому МУСИТЬ нести строго новіший
+      // client_ts за insert — перший реальний прогін suite (audit
+      // 2026-06-11 ws-04) зловив, що тест слав однаковий ts і другий op
+      // коректно відкидався движком.
       const ts = isoNow();
+      const tsLater = isoNow(1_000);
       const pushRes = makeRes();
       await syncV2Push(
         makeReq({
@@ -3834,9 +3841,9 @@ describe("syncV2Push — op='increment' engine-level gate (PR #042a)", () => {
                   user_id: "u-incr-2",
                   current_streak: 1,
                   longest_streak: 1,
-                  last_completed_at: ts,
+                  last_completed_at: tsLater,
                 },
-                client_ts: ts,
+                client_ts: tsLater,
                 idempotency_key: "incr-2-update",
               },
             ],


### PR DESCRIPTION
## Summary

Тріаж **першого реального прогону** integration-tier (після merge #3507): **83/85 зелених**, 2 фейли — обидва виявились боргом самих тестів, що ніколи не виконувались (двигун і security-поверхня чисті):

1. **session-protection guard** зловив 6 роутів без `requireSession*` — усі навмисно публічні, додані ПІСЛЯ написання guard-а: `/api/status` (публічна status-сторінка, info-leak покритий `health.infoleak.test.ts`) і 5 sync-v1 **410 Gone** стабів, свідомо змонтованих до auth (T2 audit #7 — застарілий клієнт без сесії має отримати сигнал міграції, а не вічний 401). Додані в `EXEMPT_ROUTES` з обґрунтуванням.
2. **increment-gate тест** слав insert+update з однаковим `client_ts` і чекав обидва applied — движок (і до, і після декомпозиції: `MAX(client_ts) >= clientTs`) коректно відкидає tie як `lww_conflict`. Update тепер несе строго новіший ts.

## Governing Skill

`sergeant-server-api`

## Playbook

n/a — тріаж результатів нового CI-gate.

## Verification

- `pnpm --filter @sergeant/server typecheck` → clean.
- Повна верифікація — job `Server integration tests (Testcontainers)` на цьому PR: очікую **85/85**.

## Docs and Governance

- Rationale інлайн у EXEMPT_ROUTES і тесті.

## Risk and Rollout

- Лише тестовий код. Exempt-додавання звужені до фактично публічних роутів з документованим дизайн-рішенням.

## Hard Rule #15

- [x] Governance прочитано.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exempt intentionally public routes from the session-protection test and fix the LWW increment test to use a newer `client_ts`, bringing the integration tier to 85/85 green. Test-only changes.

- **Bug Fixes**
  - Added `/api/status` and v1 sync stubs (`/api/sync/push`, `/api/sync/pull`, `/api/sync/pull-all`, `/api/sync/push-all`) to `EXEMPT_ROUTES` as public by design.
  - Updated `syncV2Push` increment test to send a strictly newer `client_ts` for the update (avoid LWW tie).

<sup>Written for commit 2642ea13c1e9586f571093553d7662a44f20569b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

