### PR TITLE
test(api-client): retry pact contract suites to absorb FFI mock-server flake

### DIFF
--- a/packages/api-client/src/__tests__/contracts/_pact.ts
+++ b/packages/api-client/src/__tests__/contracts/_pact.ts
@@ -41,6 +41,22 @@ export const PACT_DIR = path.resolve(
  * gymnastics, and we don't need V4-only features (sync messages,
  * GraphQL) for HTTP REST contracts.
  */
+/**
+ * Vitest suite options for every pact contract `describe`.
+ *
+ * `retry: 2` absorbs a known pact-core FFI race: under loaded CI runners
+ * the mock server occasionally reports `missing-request` ("The following
+ * request was expected but not received") even though the client received
+ * the fully matched response and every assertion passed (the error is the
+ * `Promise.reject` branch of `executeTest`, which is only reachable when
+ * the test callback resolved). The race lives in the Rust mock-server
+ * match bookkeeping, not in our request shape, and surfaces in files with
+ * several sequential interactions (the PactV4 builder is torn down and
+ * re-created between `executeTest` calls). A real contract mismatch is
+ * deterministic and still fails all three attempts.
+ */
+export const CONTRACT_SUITE_OPTIONS = { retry: 2 } as const;
+
 export function createPact(): PactV4 {
   return new PactV4({
     consumer: CONSUMER,

--- a/packages/api-client/src/__tests__/contracts/barcode.contract.test.ts
+++ b/packages/api-client/src/__tests__/contracts/barcode.contract.test.ts
@@ -19,9 +19,9 @@ import type { PactV4 } from "@pact-foundation/pact";
 
 import { createHttpClient } from "../../httpClient";
 import { createBarcodeEndpoints } from "../../endpoints/barcode";
-import { createPact } from "./_pact";
+import { CONTRACT_SUITE_OPTIONS, createPact } from "./_pact";
 
-describe("contract @ GET /api/v1/barcode", () => {
+describe("contract @ GET /api/v1/barcode", CONTRACT_SUITE_OPTIONS, () => {
   let pact: PactV4;
   beforeAll(() => {
     pact = createPact();

--- a/packages/api-client/src/__tests__/contracts/chat.contract.test.ts
+++ b/packages/api-client/src/__tests__/contracts/chat.contract.test.ts
@@ -17,52 +17,56 @@ import type { PactV4 } from "@pact-foundation/pact";
 
 import { createHttpClient } from "../../httpClient";
 import { createChatEndpoints } from "../../endpoints/chat";
-import { createPact } from "./_pact";
+import { CONTRACT_SUITE_OPTIONS, createPact } from "./_pact";
 
-describe("contract @ POST /api/v1/chat (non-streaming)", () => {
-  let pact: PactV4;
-  beforeAll(() => {
-    pact = createPact();
-  });
-  afterAll(() => {});
+describe(
+  "contract @ POST /api/v1/chat (non-streaming)",
+  CONTRACT_SUITE_OPTIONS,
+  () => {
+    let pact: PactV4;
+    beforeAll(() => {
+      pact = createPact();
+    });
+    afterAll(() => {});
 
-  it("returns assistant text for a simple user prompt (hub persona)", async () => {
-    await pact
-      .addInteraction()
-      .given(
-        "authenticated user-pact-001 with a clean conversation; Anthropic stub returns fixed assistant text",
-      )
-      .uponReceiving(
-        "a POST /api/v1/chat request without tool-calls (non-streaming)",
-      )
-      .withRequest("POST", "/api/v1/chat", (req) => {
-        req.headers({
-          accept: "application/json",
-          "content-type": "application/json",
+    it("returns assistant text for a simple user prompt (hub persona)", async () => {
+      await pact
+        .addInteraction()
+        .given(
+          "authenticated user-pact-001 with a clean conversation; Anthropic stub returns fixed assistant text",
+        )
+        .uponReceiving(
+          "a POST /api/v1/chat request without tool-calls (non-streaming)",
+        )
+        .withRequest("POST", "/api/v1/chat", (req) => {
+          req.headers({
+            accept: "application/json",
+            "content-type": "application/json",
+          });
+          req.jsonBody({
+            context: "hub",
+            messages: [{ role: "user", content: "Привіт, як справи?" }],
+            stream: false,
+          });
+        })
+        .willRespondWith(200, (res) => {
+          res.headers({ "content-type": "application/json" });
+          res.jsonBody({
+            text: "Все ок, що треба зробити?",
+          });
+        })
+        .executeTest(async (mockServer) => {
+          const http = createHttpClient({ baseUrl: mockServer.url });
+          const chat = createChatEndpoints(http);
+          const out = await chat.send({
+            context: "hub",
+            messages: [{ role: "user", content: "Привіт, як справи?" }],
+            stream: false,
+          });
+          expect(out.text).toBe("Все ок, що треба зробити?");
+          expect(out.tool_calls).toBeUndefined();
+          expect(out.error).toBeUndefined();
         });
-        req.jsonBody({
-          context: "hub",
-          messages: [{ role: "user", content: "Привіт, як справи?" }],
-          stream: false,
-        });
-      })
-      .willRespondWith(200, (res) => {
-        res.headers({ "content-type": "application/json" });
-        res.jsonBody({
-          text: "Все ок, що треба зробити?",
-        });
-      })
-      .executeTest(async (mockServer) => {
-        const http = createHttpClient({ baseUrl: mockServer.url });
-        const chat = createChatEndpoints(http);
-        const out = await chat.send({
-          context: "hub",
-          messages: [{ role: "user", content: "Привіт, як справи?" }],
-          stream: false,
-        });
-        expect(out.text).toBe("Все ок, що треба зробити?");
-        expect(out.tool_calls).toBeUndefined();
-        expect(out.error).toBeUndefined();
-      });
-  });
-});
+    });
+  },
+);

--- a/packages/api-client/src/__tests__/contracts/coach-memory.contract.test.ts
+++ b/packages/api-client/src/__tests__/contracts/coach-memory.contract.test.ts
@@ -17,9 +17,9 @@ import type { PactV4 } from "@pact-foundation/pact";
 
 import { createHttpClient } from "../../httpClient";
 import { createCoachEndpoints } from "../../endpoints/coach";
-import { createPact } from "./_pact";
+import { CONTRACT_SUITE_OPTIONS, createPact } from "./_pact";
 
-describe("contract @ GET /api/v1/coach/memory", () => {
+describe("contract @ GET /api/v1/coach/memory", CONTRACT_SUITE_OPTIONS, () => {
   let pact: PactV4;
   beforeAll(() => {
     pact = createPact();

--- a/packages/api-client/src/__tests__/contracts/food-search.contract.test.ts
+++ b/packages/api-client/src/__tests__/contracts/food-search.contract.test.ts
@@ -20,9 +20,9 @@ import type { PactV4 } from "@pact-foundation/pact";
 
 import { createHttpClient } from "../../httpClient";
 import { createFoodSearchEndpoints } from "../../endpoints/foodSearch";
-import { createPact } from "./_pact";
+import { CONTRACT_SUITE_OPTIONS, createPact } from "./_pact";
 
-describe("contract @ GET /api/food-search", () => {
+describe("contract @ GET /api/food-search", CONTRACT_SUITE_OPTIONS, () => {
   let pact: PactV4;
   beforeAll(() => {
     pact = createPact();

--- a/packages/api-client/src/__tests__/contracts/me.contract.test.ts
+++ b/packages/api-client/src/__tests__/contracts/me.contract.test.ts
@@ -14,9 +14,9 @@ import type { PactV4 } from "@pact-foundation/pact";
 
 import { createHttpClient } from "../../httpClient";
 import { createMeEndpoints } from "../../endpoints/me";
-import { createPact } from "./_pact";
+import { CONTRACT_SUITE_OPTIONS, createPact } from "./_pact";
 
-describe("contract @ GET /api/v1/me", () => {
+describe("contract @ GET /api/v1/me", CONTRACT_SUITE_OPTIONS, () => {
   let pact: PactV4;
   beforeAll(() => {
     pact = createPact();

--- a/packages/api-client/src/__tests__/contracts/mono-syncState.contract.test.ts
+++ b/packages/api-client/src/__tests__/contracts/mono-syncState.contract.test.ts
@@ -15,44 +15,48 @@ import type { PactV4 } from "@pact-foundation/pact";
 
 import { createHttpClient } from "../../httpClient";
 import { createMonoWebhookEndpoints } from "../../endpoints/mono";
-import { createPact } from "./_pact";
+import { CONTRACT_SUITE_OPTIONS, createPact } from "./_pact";
 
-describe("contract @ GET /api/v1/mono/sync-state", () => {
-  let pact: PactV4;
-  beforeAll(() => {
-    pact = createPact();
-  });
-  afterAll(() => {});
+describe(
+  "contract @ GET /api/v1/mono/sync-state",
+  CONTRACT_SUITE_OPTIONS,
+  () => {
+    let pact: PactV4;
+    beforeAll(() => {
+      pact = createPact();
+    });
+    afterAll(() => {});
 
-  it("returns MonoSyncState for a connected, active webhook (finyk persona)", async () => {
-    await pact
-      .addInteraction()
-      .given(
-        "an authenticated session for user-pact-001 with an active Monobank webhook (2 accounts)",
-      )
-      .uponReceiving("a GET /api/v1/mono/sync-state request")
-      .withRequest("GET", "/api/v1/mono/sync-state", (req) => {
-        req.headers({ accept: "application/json" });
-      })
-      .willRespondWith(200, (res) => {
-        res.headers({ "content-type": "application/json" });
-        res.jsonBody({
-          status: "active",
-          webhookActive: true,
-          lastEventAt: "2026-05-13T08:30:00.000Z",
-          lastBackfillAt: "2026-05-12T22:00:00.000Z",
-          accountsCount: 2,
+    it("returns MonoSyncState for a connected, active webhook (finyk persona)", async () => {
+      await pact
+        .addInteraction()
+        .given(
+          "an authenticated session for user-pact-001 with an active Monobank webhook (2 accounts)",
+        )
+        .uponReceiving("a GET /api/v1/mono/sync-state request")
+        .withRequest("GET", "/api/v1/mono/sync-state", (req) => {
+          req.headers({ accept: "application/json" });
+        })
+        .willRespondWith(200, (res) => {
+          res.headers({ "content-type": "application/json" });
+          res.jsonBody({
+            status: "active",
+            webhookActive: true,
+            lastEventAt: "2026-05-13T08:30:00.000Z",
+            lastBackfillAt: "2026-05-12T22:00:00.000Z",
+            accountsCount: 2,
+          });
+        })
+        .executeTest(async (mockServer) => {
+          const http = createHttpClient({ baseUrl: mockServer.url });
+          const mono = createMonoWebhookEndpoints(http);
+          const state = await mono.syncState();
+          expect(state.status).toBe("active");
+          expect(state.webhookActive).toBe(true);
+          expect(state.lastEventAt).toBe("2026-05-13T08:30:00.000Z");
+          expect(state.lastBackfillAt).toBe("2026-05-12T22:00:00.000Z");
+          expect(state.accountsCount).toBe(2);
         });
-      })
-      .executeTest(async (mockServer) => {
-        const http = createHttpClient({ baseUrl: mockServer.url });
-        const mono = createMonoWebhookEndpoints(http);
-        const state = await mono.syncState();
-        expect(state.status).toBe("active");
-        expect(state.webhookActive).toBe(true);
-        expect(state.lastEventAt).toBe("2026-05-13T08:30:00.000Z");
-        expect(state.lastBackfillAt).toBe("2026-05-12T22:00:00.000Z");
-        expect(state.accountsCount).toBe(2);
-      });
-  });
-});
+    });
+  },
+);

--- a/packages/api-client/src/__tests__/contracts/mono-transactions.contract.test.ts
+++ b/packages/api-client/src/__tests__/contracts/mono-transactions.contract.test.ts
@@ -20,111 +20,115 @@ import type { PactV4 } from "@pact-foundation/pact";
 
 import { createHttpClient } from "../../httpClient";
 import { createMonoWebhookEndpoints } from "../../endpoints/mono";
-import { createPact } from "./_pact";
+import { CONTRACT_SUITE_OPTIONS, createPact } from "./_pact";
 
-describe("contract @ GET /api/v1/mono/transactions", () => {
-  let pact: PactV4;
-  beforeAll(() => {
-    pact = createPact();
-  });
-  afterAll(() => {});
+describe(
+  "contract @ GET /api/v1/mono/transactions",
+  CONTRACT_SUITE_OPTIONS,
+  () => {
+    let pact: PactV4;
+    beforeAll(() => {
+      pact = createPact();
+    });
+    afterAll(() => {});
 
-  it("returns a paginated MonoTransactionsPage (finyk persona)", async () => {
-    await pact
-      .addInteraction()
-      .given(
-        "an authenticated session for user-pact-001 with 1 mono account and 2 transactions in 2026-05",
-      )
-      .uponReceiving(
-        "a GET /api/v1/mono/transactions request with limit=2 and a date range",
-      )
-      .withRequest("GET", "/api/v1/mono/transactions", (req) => {
-        req.headers({ accept: "application/json" });
-        req.query({
-          from: "2026-05-01",
-          to: "2026-05-13",
-          limit: "2",
+    it("returns a paginated MonoTransactionsPage (finyk persona)", async () => {
+      await pact
+        .addInteraction()
+        .given(
+          "an authenticated session for user-pact-001 with 1 mono account and 2 transactions in 2026-05",
+        )
+        .uponReceiving(
+          "a GET /api/v1/mono/transactions request with limit=2 and a date range",
+        )
+        .withRequest("GET", "/api/v1/mono/transactions", (req) => {
+          req.headers({ accept: "application/json" });
+          req.query({
+            from: "2026-05-01",
+            to: "2026-05-13",
+            limit: "2",
+          });
+        })
+        .willRespondWith(200, (res) => {
+          res.headers({ "content-type": "application/json" });
+          res.jsonBody({
+            data: [
+              {
+                userId: "user-pact-001",
+                monoAccountId: "acct-pact-001",
+                monoTxId: "tx-pact-0001",
+                time: "2026-05-12T18:42:11.000Z",
+                amount: -12345,
+                operationAmount: -12345,
+                currencyCode: 980,
+                mcc: 5411,
+                originalMcc: 5411,
+                hold: false,
+                description: "ATB Market",
+                comment: null,
+                cashbackAmount: 123,
+                commissionRate: 0,
+                balance: 4567890,
+                receiptId: null,
+                invoiceId: null,
+                counterEdrpou: null,
+                counterIban: null,
+                counterName: null,
+                categorySlug: "groceries",
+                categoryOverridden: false,
+                source: "webhook",
+                receivedAt: "2026-05-12T18:42:12.500Z",
+              },
+              {
+                userId: "user-pact-001",
+                monoAccountId: "acct-pact-001",
+                monoTxId: "tx-pact-0002",
+                time: "2026-05-11T09:14:00.000Z",
+                amount: 100000,
+                operationAmount: 100000,
+                currencyCode: 980,
+                mcc: null,
+                originalMcc: null,
+                hold: null,
+                description: "Salary",
+                comment: null,
+                cashbackAmount: null,
+                commissionRate: null,
+                balance: 4680235,
+                receiptId: null,
+                invoiceId: null,
+                counterEdrpou: null,
+                counterIban: null,
+                counterName: null,
+                categorySlug: null,
+                categoryOverridden: false,
+                source: "webhook",
+                receivedAt: "2026-05-11T09:14:01.250Z",
+              },
+            ],
+            nextCursor: "2026-05-11T09:14:00.000Z:tx-pact-0002",
+          });
+        })
+        .executeTest(async (mockServer) => {
+          const http = createHttpClient({ baseUrl: mockServer.url });
+          const mono = createMonoWebhookEndpoints(http);
+          const page = await mono.transactions({
+            from: "2026-05-01",
+            to: "2026-05-13",
+            limit: 2,
+          });
+          expect(page.data).toHaveLength(2);
+          // bigint-as-number invariant (Hard Rule #1) — must already be
+          // a number on the wire; the api-client does NO coercion.
+          expect(typeof page.data[0]!.amount).toBe("number");
+          expect(typeof page.data[0]!.balance).toBe("number");
+          expect(page.data[0]!.amount).toBe(-12345);
+          expect(page.data[1]!.amount).toBe(100000);
+          // Cursor format is `<time>:<monoTxId>` — both the time and the id
+          // of the last row in the page are needed to break ties on equal
+          // `time` and resume pagination deterministically.
+          expect(page.nextCursor).toBe("2026-05-11T09:14:00.000Z:tx-pact-0002");
         });
-      })
-      .willRespondWith(200, (res) => {
-        res.headers({ "content-type": "application/json" });
-        res.jsonBody({
-          data: [
-            {
-              userId: "user-pact-001",
-              monoAccountId: "acct-pact-001",
-              monoTxId: "tx-pact-0001",
-              time: "2026-05-12T18:42:11.000Z",
-              amount: -12345,
-              operationAmount: -12345,
-              currencyCode: 980,
-              mcc: 5411,
-              originalMcc: 5411,
-              hold: false,
-              description: "ATB Market",
-              comment: null,
-              cashbackAmount: 123,
-              commissionRate: 0,
-              balance: 4567890,
-              receiptId: null,
-              invoiceId: null,
-              counterEdrpou: null,
-              counterIban: null,
-              counterName: null,
-              categorySlug: "groceries",
-              categoryOverridden: false,
-              source: "webhook",
-              receivedAt: "2026-05-12T18:42:12.500Z",
-            },
-            {
-              userId: "user-pact-001",
-              monoAccountId: "acct-pact-001",
-              monoTxId: "tx-pact-0002",
-              time: "2026-05-11T09:14:00.000Z",
-              amount: 100000,
-              operationAmount: 100000,
-              currencyCode: 980,
-              mcc: null,
-              originalMcc: null,
-              hold: null,
-              description: "Salary",
-              comment: null,
-              cashbackAmount: null,
-              commissionRate: null,
-              balance: 4680235,
-              receiptId: null,
-              invoiceId: null,
-              counterEdrpou: null,
-              counterIban: null,
-              counterName: null,
-              categorySlug: null,
-              categoryOverridden: false,
-              source: "webhook",
-              receivedAt: "2026-05-11T09:14:01.250Z",
-            },
-          ],
-          nextCursor: "2026-05-11T09:14:00.000Z:tx-pact-0002",
-        });
-      })
-      .executeTest(async (mockServer) => {
-        const http = createHttpClient({ baseUrl: mockServer.url });
-        const mono = createMonoWebhookEndpoints(http);
-        const page = await mono.transactions({
-          from: "2026-05-01",
-          to: "2026-05-13",
-          limit: 2,
-        });
-        expect(page.data).toHaveLength(2);
-        // bigint-as-number invariant (Hard Rule #1) — must already be
-        // a number on the wire; the api-client does NO coercion.
-        expect(typeof page.data[0]!.amount).toBe("number");
-        expect(typeof page.data[0]!.balance).toBe("number");
-        expect(page.data[0]!.amount).toBe(-12345);
-        expect(page.data[1]!.amount).toBe(100000);
-        // Cursor format is `<time>:<monoTxId>` — both the time and the id
-        // of the last row in the page are needed to break ties on equal
-        // `time` and resume pagination deterministically.
-        expect(page.nextCursor).toBe("2026-05-11T09:14:00.000Z:tx-pact-0002");
-      });
-  });
-});
+    });
+  },
+);

--- a/packages/api-client/src/__tests__/contracts/mono.contract.test.ts
+++ b/packages/api-client/src/__tests__/contracts/mono.contract.test.ts
@@ -14,9 +14,9 @@ import type { PactV4 } from "@pact-foundation/pact";
 
 import { createHttpClient } from "../../httpClient";
 import { createMonoWebhookEndpoints } from "../../endpoints/mono";
-import { createPact } from "./_pact";
+import { CONTRACT_SUITE_OPTIONS, createPact } from "./_pact";
 
-describe("contract @ GET /api/v1/mono/accounts", () => {
+describe("contract @ GET /api/v1/mono/accounts", CONTRACT_SUITE_OPTIONS, () => {
   let pact: PactV4;
   beforeAll(() => {
     pact = createPact();

--- a/packages/api-client/src/__tests__/contracts/nutrition-day-plan.contract.test.ts
+++ b/packages/api-client/src/__tests__/contracts/nutrition-day-plan.contract.test.ts
@@ -18,97 +18,101 @@ import type { PactV4 } from "@pact-foundation/pact";
 
 import { createHttpClient } from "../../httpClient";
 import { createNutritionEndpoints } from "../../endpoints/nutrition";
-import { createPact } from "./_pact";
+import { CONTRACT_SUITE_OPTIONS, createPact } from "./_pact";
 
-describe("contract @ POST /api/v1/nutrition/day-plan", () => {
-  let pact: PactV4;
-  beforeAll(() => {
-    pact = createPact();
-  });
-  afterAll(() => {});
+describe(
+  "contract @ POST /api/v1/nutrition/day-plan",
+  CONTRACT_SUITE_OPTIONS,
+  () => {
+    let pact: PactV4;
+    beforeAll(() => {
+      pact = createPact();
+    });
+    afterAll(() => {});
 
-  it("returns a normalized NutritionDayPlan for the given targets (nutrition persona)", async () => {
-    await pact
-      .addInteraction()
-      .given(
-        "an authenticated session with Anthropic key + AI quota available; pantry has milk, oats, eggs",
-      )
-      .uponReceiving(
-        "a POST /api/v1/nutrition/day-plan request with targets and a small pantry",
-      )
-      .withRequest("POST", "/api/v1/nutrition/day-plan", (req) => {
-        req.headers({
-          accept: "application/json",
-          "content-type": "application/json",
-        });
-        req.jsonBody({
-          targets: { kcal: 2000, protein_g: 120, fat_g: 70, carbs_g: 220 },
-          pantry: [
-            { name: "milk", qty: 1, unit: "L" },
-            { name: "oats", qty: 500, unit: "g" },
-            { name: "eggs", qty: 6, unit: "pcs" },
-          ],
-          locale: "uk-UA",
-        });
-      })
-      .willRespondWith(200, (res) => {
-        res.headers({ "content-type": "application/json" });
-        res.jsonBody({
-          plan: {
-            meals: [
-              {
-                type: "breakfast",
-                label: "Сніданок",
-                name: "Вівсянка з молоком",
-                description: "Тепла вівсяна каша з молоком 2% і ягодами.",
-                ingredients: ["вівсянка 80г", "молоко 250мл", "ягоди 100г"],
-                kcal: 420,
-                protein_g: 18,
-                fat_g: 10,
-                carbs_g: 65,
-              },
-              {
-                type: "lunch",
-                label: "Обід",
-                name: "Омлет з овочами",
-                description: "З 3 яєць, шпинатом, чорним хлібом.",
-                ingredients: ["яйця 3шт", "шпинат 80г", "хліб 60г"],
-                kcal: 540,
-                protein_g: 32,
-                fat_g: 24,
-                carbs_g: 40,
-              },
+    it("returns a normalized NutritionDayPlan for the given targets (nutrition persona)", async () => {
+      await pact
+        .addInteraction()
+        .given(
+          "an authenticated session with Anthropic key + AI quota available; pantry has milk, oats, eggs",
+        )
+        .uponReceiving(
+          "a POST /api/v1/nutrition/day-plan request with targets and a small pantry",
+        )
+        .withRequest("POST", "/api/v1/nutrition/day-plan", (req) => {
+          req.headers({
+            accept: "application/json",
+            "content-type": "application/json",
+          });
+          req.jsonBody({
+            targets: { kcal: 2000, protein_g: 120, fat_g: 70, carbs_g: 220 },
+            pantry: [
+              { name: "milk", qty: 1, unit: "L" },
+              { name: "oats", qty: 500, unit: "g" },
+              { name: "eggs", qty: 6, unit: "pcs" },
             ],
-            totalKcal: 960,
-            totalProtein_g: 50,
-            totalFat_g: 34,
-            totalCarbs_g: 105,
-            note: "Партіальний план — лише сніданок і обід для прикладу.",
-          },
-          rawText: null,
+            locale: "uk-UA",
+          });
+        })
+        .willRespondWith(200, (res) => {
+          res.headers({ "content-type": "application/json" });
+          res.jsonBody({
+            plan: {
+              meals: [
+                {
+                  type: "breakfast",
+                  label: "Сніданок",
+                  name: "Вівсянка з молоком",
+                  description: "Тепла вівсяна каша з молоком 2% і ягодами.",
+                  ingredients: ["вівсянка 80г", "молоко 250мл", "ягоди 100г"],
+                  kcal: 420,
+                  protein_g: 18,
+                  fat_g: 10,
+                  carbs_g: 65,
+                },
+                {
+                  type: "lunch",
+                  label: "Обід",
+                  name: "Омлет з овочами",
+                  description: "З 3 яєць, шпинатом, чорним хлібом.",
+                  ingredients: ["яйця 3шт", "шпинат 80г", "хліб 60г"],
+                  kcal: 540,
+                  protein_g: 32,
+                  fat_g: 24,
+                  carbs_g: 40,
+                },
+              ],
+              totalKcal: 960,
+              totalProtein_g: 50,
+              totalFat_g: 34,
+              totalCarbs_g: 105,
+              note: "Партіальний план — лише сніданок і обід для прикладу.",
+            },
+            rawText: null,
+          });
+        })
+        .executeTest(async (mockServer) => {
+          const http = createHttpClient({ baseUrl: mockServer.url });
+          const nutrition = createNutritionEndpoints(http);
+          const out = await nutrition.dayPlan({
+            targets: { kcal: 2000, protein_g: 120, fat_g: 70, carbs_g: 220 },
+            pantry: [
+              { name: "milk", qty: 1, unit: "L" },
+              { name: "oats", qty: 500, unit: "g" },
+              { name: "eggs", qty: 6, unit: "pcs" },
+            ],
+            locale: "uk-UA",
+          });
+          expect(out.plan.meals).toHaveLength(2);
+          expect(out.plan.meals[0]!.type).toBe("breakfast");
+          expect(out.plan.meals[1]!.type).toBe("lunch");
+          // Numeric envelope (Hard Rule #1 sibling — LLM JSON often
+          // arrives stringified; the normalizer in day-plan.ts must coerce).
+          expect(typeof out.plan.totalKcal).toBe("number");
+          expect(out.plan.totalKcal).toBe(960);
+          expect(out.plan.note).toContain("Партіальний");
+          expect(out.rawText).toBeNull();
         });
-      })
-      .executeTest(async (mockServer) => {
-        const http = createHttpClient({ baseUrl: mockServer.url });
-        const nutrition = createNutritionEndpoints(http);
-        const out = await nutrition.dayPlan({
-          targets: { kcal: 2000, protein_g: 120, fat_g: 70, carbs_g: 220 },
-          pantry: [
-            { name: "milk", qty: 1, unit: "L" },
-            { name: "oats", qty: 500, unit: "g" },
-            { name: "eggs", qty: 6, unit: "pcs" },
-          ],
-          locale: "uk-UA",
-        });
-        expect(out.plan.meals).toHaveLength(2);
-        expect(out.plan.meals[0]!.type).toBe("breakfast");
-        expect(out.plan.meals[1]!.type).toBe("lunch");
-        // Numeric envelope (Hard Rule #1 sibling — LLM JSON often
-        // arrives stringified; the normalizer in day-plan.ts must coerce).
-        expect(typeof out.plan.totalKcal).toBe("number");
-        expect(out.plan.totalKcal).toBe(960);
-        expect(out.plan.note).toContain("Партіальний");
-        expect(out.rawText).toBeNull();
-      });
-  });
-});
+    });
+  },
+);

--- a/packages/api-client/src/__tests__/contracts/nutrition.contract.test.ts
+++ b/packages/api-client/src/__tests__/contracts/nutrition.contract.test.ts
@@ -16,70 +16,74 @@ import type { PactV4 } from "@pact-foundation/pact";
 
 import { createHttpClient } from "../../httpClient";
 import { createNutritionEndpoints } from "../../endpoints/nutrition";
-import { createPact } from "./_pact";
+import { CONTRACT_SUITE_OPTIONS, createPact } from "./_pact";
 
-describe("contract @ POST /api/v1/nutrition/analyze-photo", () => {
-  let pact: PactV4;
-  beforeAll(() => {
-    pact = createPact();
-  });
-  afterAll(() => {});
+describe(
+  "contract @ POST /api/v1/nutrition/analyze-photo",
+  CONTRACT_SUITE_OPTIONS,
+  () => {
+    let pact: PactV4;
+    beforeAll(() => {
+      pact = createPact();
+    });
+    afterAll(() => {});
 
-  it("returns NutritionPhotoResponse for an analyzed meal photo (nutrition persona)", async () => {
-    await pact
-      .addInteraction()
-      .given(
-        "authenticated user-pact-001 within nutrition daily quota; Anthropic stub returns the deterministic borscht fixture",
-      )
-      .uponReceiving("a POST /api/v1/nutrition/analyze-photo request")
-      .withRequest("POST", "/api/v1/nutrition/analyze-photo", (req) => {
-        req.headers({
-          accept: "application/json",
-          "content-type": "application/json",
-        });
-        // We deliberately send a fixed payload so the provider replays
-        // a deterministic request. Real photos go through pre-upload
-        // compression upstream of this client method.
-        req.jsonBody({
-          imageBase64: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAAD-pact-fixture",
-          mimeType: "image/png",
-          locale: "uk-UA",
-        });
-      })
-      .willRespondWith(200, (res) => {
-        res.headers({ "content-type": "application/json" });
-        res.jsonBody({
-          result: {
-            dishName: "Борщ із сметаною",
-            confidence: 0.87,
-            portion: { label: "тарілка", gramsApprox: 350 },
-            ingredients: [
-              { name: "буряк", notes: null },
-              { name: "капуста", notes: null },
-              { name: "м'ясо", notes: "телятина" },
-            ],
-            macros: {
-              kcal: 280,
-              protein_g: 18,
-              fat_g: 12,
-              carbs_g: 22,
+    it("returns NutritionPhotoResponse for an analyzed meal photo (nutrition persona)", async () => {
+      await pact
+        .addInteraction()
+        .given(
+          "authenticated user-pact-001 within nutrition daily quota; Anthropic stub returns the deterministic borscht fixture",
+        )
+        .uponReceiving("a POST /api/v1/nutrition/analyze-photo request")
+        .withRequest("POST", "/api/v1/nutrition/analyze-photo", (req) => {
+          req.headers({
+            accept: "application/json",
+            "content-type": "application/json",
+          });
+          // We deliberately send a fixed payload so the provider replays
+          // a deterministic request. Real photos go through pre-upload
+          // compression upstream of this client method.
+          req.jsonBody({
+            imageBase64: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAAD-pact-fixture",
+            mimeType: "image/png",
+            locale: "uk-UA",
+          });
+        })
+        .willRespondWith(200, (res) => {
+          res.headers({ "content-type": "application/json" });
+          res.jsonBody({
+            result: {
+              dishName: "Борщ із сметаною",
+              confidence: 0.87,
+              portion: { label: "тарілка", gramsApprox: 350 },
+              ingredients: [
+                { name: "буряк", notes: null },
+                { name: "капуста", notes: null },
+                { name: "м'ясо", notes: "телятина" },
+              ],
+              macros: {
+                kcal: 280,
+                protein_g: 18,
+                fat_g: 12,
+                carbs_g: 22,
+              },
+              questions: ["Чи був хліб?", "Скільки сметани було?"],
             },
-            questions: ["Чи був хліб?", "Скільки сметани було?"],
-          },
-          rawText: null,
+            rawText: null,
+          });
+        })
+        .executeTest(async (mockServer) => {
+          const http = createHttpClient({ baseUrl: mockServer.url });
+          const nutrition = createNutritionEndpoints(http);
+          const out = await nutrition.analyzePhoto({
+            imageBase64: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAAD-pact-fixture",
+            mimeType: "image/png",
+            locale: "uk-UA",
+          });
+          expect(out.result?.dishName).toBe("Борщ із сметаною");
+          expect(out.result?.macros.kcal).toBe(280);
+          expect(out.result?.ingredients).toHaveLength(3);
         });
-      })
-      .executeTest(async (mockServer) => {
-        const http = createHttpClient({ baseUrl: mockServer.url });
-        const nutrition = createNutritionEndpoints(http);
-        const out = await nutrition.analyzePhoto({
-          imageBase64: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAAD-pact-fixture",
-          mimeType: "image/png",
-          locale: "uk-UA",
-        });
-        expect(out.result?.dishName).toBe("Борщ із сметаною");
-        expect(out.result?.macros.kcal).toBe(280);
-        expect(out.result?.ingredients).toHaveLength(3);
-      });
-  });
-});
+    });
+  },
+);

--- a/packages/api-client/src/__tests__/contracts/parse-pantry.contract.test.ts
+++ b/packages/api-client/src/__tests__/contracts/parse-pantry.contract.test.ts
@@ -21,157 +21,161 @@ import type { PactV4 } from "@pact-foundation/pact";
 
 import { createHttpClient } from "../../httpClient";
 import { createNutritionEndpoints } from "../../endpoints/nutrition";
-import { createPact } from "./_pact";
+import { CONTRACT_SUITE_OPTIONS, createPact } from "./_pact";
 
-describe("contract @ POST /api/nutrition/parse-pantry", () => {
-  let pact: PactV4;
-  beforeAll(() => {
-    pact = createPact();
-  });
-  afterAll(() => {});
+describe(
+  "contract @ POST /api/nutrition/parse-pantry",
+  CONTRACT_SUITE_OPTIONS,
+  () => {
+    let pact: PactV4;
+    beforeAll(() => {
+      pact = createPact();
+    });
+    afterAll(() => {});
 
-  it("returns NutritionParsePantryResponse with normalised items (nutrition persona)", async () => {
-    await pact
-      .addInteraction()
-      .given(
-        "authenticated user-pact-001 within AI quota; Anthropic stub returns a deterministic 2-item pantry parse",
-      )
-      .uponReceiving(
-        "a POST /api/nutrition/parse-pantry request with two-item free text",
-      )
-      .withRequest("POST", "/api/v1/nutrition/parse-pantry", (req) => {
-        req.headers({
-          accept: "application/json",
-          "content-type": "application/json",
-        });
-        req.jsonBody({
-          text: "молоко 1л, яйця 6шт",
-          locale: "uk-UA",
-        });
-      })
-      .willRespondWith(200, (res) => {
-        res.headers({ "content-type": "application/json" });
-        res.jsonBody({
-          items: [
-            { name: "молоко", qty: 1, unit: "л", notes: null },
-            { name: "яйця", qty: 6, unit: "шт", notes: null },
-          ],
-          rawText:
-            '{"items":[{"name":"молоко","qty":1,"unit":"л","notes":null},{"name":"яйця","qty":6,"unit":"шт","notes":null}]}',
-        });
-      })
-      .executeTest(async (mockServer) => {
-        const http = createHttpClient({ baseUrl: mockServer.url });
-        const nutrition = createNutritionEndpoints(http);
-        const out = await nutrition.parsePantry({
-          text: "молоко 1л, яйця 6шт",
-          locale: "uk-UA",
-        });
+    it("returns NutritionParsePantryResponse with normalised items (nutrition persona)", async () => {
+      await pact
+        .addInteraction()
+        .given(
+          "authenticated user-pact-001 within AI quota; Anthropic stub returns a deterministic 2-item pantry parse",
+        )
+        .uponReceiving(
+          "a POST /api/nutrition/parse-pantry request with two-item free text",
+        )
+        .withRequest("POST", "/api/v1/nutrition/parse-pantry", (req) => {
+          req.headers({
+            accept: "application/json",
+            "content-type": "application/json",
+          });
+          req.jsonBody({
+            text: "молоко 1л, яйця 6шт",
+            locale: "uk-UA",
+          });
+        })
+        .willRespondWith(200, (res) => {
+          res.headers({ "content-type": "application/json" });
+          res.jsonBody({
+            items: [
+              { name: "молоко", qty: 1, unit: "л", notes: null },
+              { name: "яйця", qty: 6, unit: "шт", notes: null },
+            ],
+            rawText:
+              '{"items":[{"name":"молоко","qty":1,"unit":"л","notes":null},{"name":"яйця","qty":6,"unit":"шт","notes":null}]}',
+          });
+        })
+        .executeTest(async (mockServer) => {
+          const http = createHttpClient({ baseUrl: mockServer.url });
+          const nutrition = createNutritionEndpoints(http);
+          const out = await nutrition.parsePantry({
+            text: "молоко 1л, яйця 6шт",
+            locale: "uk-UA",
+          });
 
-        expect(Array.isArray(out.items)).toBe(true);
-        expect(out.items).toHaveLength(2);
+          expect(Array.isArray(out.items)).toBe(true);
+          expect(out.items).toHaveLength(2);
 
-        const first = out.items[0]!;
-        expect(first.name).toBe("молоко");
-        // Hard Rule #1 sibling: qty must be a number, not a string.
-        // The normaliser in parse-pantry.ts calls `normalizePantryItems()`
-        // which coerces qty to Number before `res.json()`.
-        expect(typeof first.qty).toBe("number");
-        expect(first.qty).toBe(1);
-        expect(first.unit).toBe("л");
-        expect(first.notes).toBeNull();
+          const first = out.items[0]!;
+          expect(first.name).toBe("молоко");
+          // Hard Rule #1 sibling: qty must be a number, not a string.
+          // The normaliser in parse-pantry.ts calls `normalizePantryItems()`
+          // which coerces qty to Number before `res.json()`.
+          expect(typeof first.qty).toBe("number");
+          expect(first.qty).toBe(1);
+          expect(first.unit).toBe("л");
+          expect(first.notes).toBeNull();
 
-        const second = out.items[1]!;
-        expect(second.name).toBe("яйця");
-        expect(second.qty).toBe(6);
-        expect(second.unit).toBe("шт");
+          const second = out.items[1]!;
+          expect(second.name).toBe("яйця");
+          expect(second.qty).toBe(6);
+          expect(second.unit).toBe("шт");
 
-        // rawText is preserved for audit / debugging.
-        expect(typeof out.rawText).toBe("string");
-      });
-  });
+          // rawText is preserved for audit / debugging.
+          expect(typeof out.rawText).toBe("string");
+        });
+    });
 
-  it("returns empty items array when no parseable products in input (nutrition persona)", async () => {
-    await pact
-      .addInteraction()
-      .given(
-        "authenticated user-pact-001 within AI quota; Anthropic stub returns empty items for gibberish input",
-      )
-      .uponReceiving(
-        "a POST /api/nutrition/parse-pantry request with unparseable input",
-      )
-      .withRequest("POST", "/api/v1/nutrition/parse-pantry", (req) => {
-        req.headers({
-          accept: "application/json",
-          "content-type": "application/json",
-        });
-        req.jsonBody({
-          text: "…",
-          locale: "uk-UA",
-        });
-      })
-      .willRespondWith(200, (res) => {
-        res.headers({ "content-type": "application/json" });
-        res.jsonBody({
-          items: [],
-          rawText: '{"items":[]}',
-        });
-      })
-      .executeTest(async (mockServer) => {
-        const http = createHttpClient({ baseUrl: mockServer.url });
-        const nutrition = createNutritionEndpoints(http);
-        const out = await nutrition.parsePantry({
-          text: "…",
-          locale: "uk-UA",
-        });
+    it("returns empty items array when no parseable products in input (nutrition persona)", async () => {
+      await pact
+        .addInteraction()
+        .given(
+          "authenticated user-pact-001 within AI quota; Anthropic stub returns empty items for gibberish input",
+        )
+        .uponReceiving(
+          "a POST /api/nutrition/parse-pantry request with unparseable input",
+        )
+        .withRequest("POST", "/api/v1/nutrition/parse-pantry", (req) => {
+          req.headers({
+            accept: "application/json",
+            "content-type": "application/json",
+          });
+          req.jsonBody({
+            text: "…",
+            locale: "uk-UA",
+          });
+        })
+        .willRespondWith(200, (res) => {
+          res.headers({ "content-type": "application/json" });
+          res.jsonBody({
+            items: [],
+            rawText: '{"items":[]}',
+          });
+        })
+        .executeTest(async (mockServer) => {
+          const http = createHttpClient({ baseUrl: mockServer.url });
+          const nutrition = createNutritionEndpoints(http);
+          const out = await nutrition.parsePantry({
+            text: "…",
+            locale: "uk-UA",
+          });
 
-        expect(out.items).toHaveLength(0);
-        expect(out.rawText).toBe('{"items":[]}');
-      });
-  });
+          expect(out.items).toHaveLength(0);
+          expect(out.rawText).toBe('{"items":[]}');
+        });
+    });
 
-  it("returns items with null qty/unit when quantity is absent from the input", async () => {
-    await pact
-      .addInteraction()
-      .given(
-        "authenticated user-pact-001 within AI quota; Anthropic stub returns items with null qty",
-      )
-      .uponReceiving(
-        "a POST /api/nutrition/parse-pantry request with quantity-free items",
-      )
-      .withRequest("POST", "/api/v1/nutrition/parse-pantry", (req) => {
-        req.headers({
-          accept: "application/json",
-          "content-type": "application/json",
-        });
-        req.jsonBody({
-          text: "сіль, перець",
-          locale: "uk-UA",
-        });
-      })
-      .willRespondWith(200, (res) => {
-        res.headers({ "content-type": "application/json" });
-        res.jsonBody({
-          items: [
-            { name: "сіль", qty: null, unit: null, notes: null },
-            { name: "перець", qty: null, unit: null, notes: null },
-          ],
-          rawText:
-            '{"items":[{"name":"сіль","qty":null,"unit":null,"notes":null},{"name":"перець","qty":null,"unit":null,"notes":null}]}',
-        });
-      })
-      .executeTest(async (mockServer) => {
-        const http = createHttpClient({ baseUrl: mockServer.url });
-        const nutrition = createNutritionEndpoints(http);
-        const out = await nutrition.parsePantry({
-          text: "сіль, перець",
-          locale: "uk-UA",
-        });
+    it("returns items with null qty/unit when quantity is absent from the input", async () => {
+      await pact
+        .addInteraction()
+        .given(
+          "authenticated user-pact-001 within AI quota; Anthropic stub returns items with null qty",
+        )
+        .uponReceiving(
+          "a POST /api/nutrition/parse-pantry request with quantity-free items",
+        )
+        .withRequest("POST", "/api/v1/nutrition/parse-pantry", (req) => {
+          req.headers({
+            accept: "application/json",
+            "content-type": "application/json",
+          });
+          req.jsonBody({
+            text: "сіль, перець",
+            locale: "uk-UA",
+          });
+        })
+        .willRespondWith(200, (res) => {
+          res.headers({ "content-type": "application/json" });
+          res.jsonBody({
+            items: [
+              { name: "сіль", qty: null, unit: null, notes: null },
+              { name: "перець", qty: null, unit: null, notes: null },
+            ],
+            rawText:
+              '{"items":[{"name":"сіль","qty":null,"unit":null,"notes":null},{"name":"перець","qty":null,"unit":null,"notes":null}]}',
+          });
+        })
+        .executeTest(async (mockServer) => {
+          const http = createHttpClient({ baseUrl: mockServer.url });
+          const nutrition = createNutritionEndpoints(http);
+          const out = await nutrition.parsePantry({
+            text: "сіль, перець",
+            locale: "uk-UA",
+          });
 
-        expect(out.items).toHaveLength(2);
-        expect(out.items[0]!.qty).toBeNull();
-        expect(out.items[0]!.unit).toBeNull();
-        expect(out.items[1]!.qty).toBeNull();
-      });
-  });
-});
+          expect(out.items).toHaveLength(2);
+          expect(out.items[0]!.qty).toBeNull();
+          expect(out.items[0]!.unit).toBeNull();
+          expect(out.items[1]!.qty).toBeNull();
+        });
+    });
+  },
+);

--- a/packages/api-client/src/__tests__/contracts/push.contract.test.ts
+++ b/packages/api-client/src/__tests__/contracts/push.contract.test.ts
@@ -14,53 +14,59 @@ import type { PactV4 } from "@pact-foundation/pact";
 
 import { createHttpClient } from "../../httpClient";
 import { createPushEndpoints } from "../../endpoints/push";
-import { createPact } from "./_pact";
+import { CONTRACT_SUITE_OPTIONS, createPact } from "./_pact";
 
-describe("contract @ POST /api/v1/push/register", () => {
-  let pact: PactV4;
-  beforeAll(() => {
-    pact = createPact();
-  });
-  afterAll(() => {});
+describe(
+  "contract @ POST /api/v1/push/register",
+  CONTRACT_SUITE_OPTIONS,
+  () => {
+    let pact: PactV4;
+    beforeAll(() => {
+      pact = createPact();
+    });
+    afterAll(() => {});
 
-  it("registers a web-push subscription (fizruk persona, web)", async () => {
-    await pact
-      .addInteraction()
-      .given("authenticated session for user-pact-001 with no prior push token")
-      .uponReceiving("a POST /api/v1/push/register request (platform=web)")
-      .withRequest("POST", "/api/v1/push/register", (req) => {
-        req.headers({
-          accept: "application/json",
-          "content-type": "application/json",
+    it("registers a web-push subscription (fizruk persona, web)", async () => {
+      await pact
+        .addInteraction()
+        .given(
+          "authenticated session for user-pact-001 with no prior push token",
+        )
+        .uponReceiving("a POST /api/v1/push/register request (platform=web)")
+        .withRequest("POST", "/api/v1/push/register", (req) => {
+          req.headers({
+            accept: "application/json",
+            "content-type": "application/json",
+          });
+          req.jsonBody({
+            platform: "web",
+            token:
+              "https://fcm.googleapis.com/fcm/send/cZ4VGTbVtps:APA91bF…example",
+            keys: {
+              p256dh: "BFx8e_X-3FAKE-PUBKEY-NOT-A-REAL-CRED-pact-test-vector-=",
+              auth: "FAKE-AUTH-PACT-CONTRACT-TEST-VECTOR-=",
+            },
+          });
+        })
+        .willRespondWith(200, (res) => {
+          res.headers({ "content-type": "application/json" });
+          res.jsonBody({ ok: true, platform: "web" });
+        })
+        .executeTest(async (mockServer) => {
+          const http = createHttpClient({ baseUrl: mockServer.url });
+          const push = createPushEndpoints(http);
+          const out = await push.register({
+            platform: "web",
+            token:
+              "https://fcm.googleapis.com/fcm/send/cZ4VGTbVtps:APA91bF…example",
+            keys: {
+              p256dh: "BFx8e_X-3FAKE-PUBKEY-NOT-A-REAL-CRED-pact-test-vector-=",
+              auth: "FAKE-AUTH-PACT-CONTRACT-TEST-VECTOR-=",
+            },
+          });
+          expect(out.ok).toBe(true);
+          expect(out.platform).toBe("web");
         });
-        req.jsonBody({
-          platform: "web",
-          token:
-            "https://fcm.googleapis.com/fcm/send/cZ4VGTbVtps:APA91bF…example",
-          keys: {
-            p256dh: "BFx8e_X-3FAKE-PUBKEY-NOT-A-REAL-CRED-pact-test-vector-=",
-            auth: "FAKE-AUTH-PACT-CONTRACT-TEST-VECTOR-=",
-          },
-        });
-      })
-      .willRespondWith(200, (res) => {
-        res.headers({ "content-type": "application/json" });
-        res.jsonBody({ ok: true, platform: "web" });
-      })
-      .executeTest(async (mockServer) => {
-        const http = createHttpClient({ baseUrl: mockServer.url });
-        const push = createPushEndpoints(http);
-        const out = await push.register({
-          platform: "web",
-          token:
-            "https://fcm.googleapis.com/fcm/send/cZ4VGTbVtps:APA91bF…example",
-          keys: {
-            p256dh: "BFx8e_X-3FAKE-PUBKEY-NOT-A-REAL-CRED-pact-test-vector-=",
-            auth: "FAKE-AUTH-PACT-CONTRACT-TEST-VECTOR-=",
-          },
-        });
-        expect(out.ok).toBe(true);
-        expect(out.platform).toBe("web");
-      });
-  });
-});
+    });
+  },
+);

--- a/packages/api-client/src/__tests__/contracts/sync-v2.contract.test.ts
+++ b/packages/api-client/src/__tests__/contracts/sync-v2.contract.test.ts
@@ -30,9 +30,9 @@ import type { PactV4 } from "@pact-foundation/pact";
 
 import { createHttpClient } from "../../httpClient";
 import { createSyncV2Endpoints } from "../../endpoints/syncV2";
-import { createPact } from "./_pact";
+import { CONTRACT_SUITE_OPTIONS, createPact } from "./_pact";
 
-describe("contract @ POST /api/v2/sync/push", () => {
+describe("contract @ POST /api/v2/sync/push", CONTRACT_SUITE_OPTIONS, () => {
   let pact: PactV4;
   beforeAll(() => {
     pact = createPact();
@@ -305,7 +305,7 @@ describe("contract @ POST /api/v2/sync/push", () => {
   });
 });
 
-describe("contract @ GET /api/v2/sync/pull", () => {
+describe("contract @ GET /api/v2/sync/pull", CONTRACT_SUITE_OPTIONS, () => {
   let pact: PactV4;
   beforeAll(() => {
     pact = createPact();


### PR DESCRIPTION
## Summary

Лагодить червоний чек **Test coverage (vitest)** на `main`: `parse-pantry.contract.test.ts → "returns items with null qty/unit when quantity is absent from the input"` падав з «Mock server failed with the following mismatches».

**Діагноз — флейк pact-core, а не зміна request shape:**

- Падіння сталося на docs-only коміті `31c9e05` (run [27359551114](https://github.com/Skords-01/Sergeant/actions/runs/27359551114)); за 75 хв до того той самий тест був зелений, і ніхто не чіпав `api-client`/`shared` між цими ранами.
- Локально тест детерміновано зелений: 5/5 прогонів точною CI-командою (`vitest run --coverage`).
- У лозі — лише `missing-request` mismatch (без «unexpected request»), кинутий через `Promise.reject` гілку `executeTest` у `@pact-foundation/pact` — ця гілка досяжна **тільки коли callback тесту пройшов** (клієнт отримав повністю змачений response, усі expect-и зелені). Тобто mock server відповів коректно, але FFI-облік «matched» не встиг зафіксуватися на навантаженому раннері. Проявляється у файлах із кількома послідовними інтеракціями (PactV4 перестворюється між `executeTest`).

**Фікс:** спільні suite-опції `CONTRACT_SUITE_OPTIONS = { retry: 2 }` у `_pact.ts`, застосовані до всіх 13 consumer contract describe-ів. Справжній contract mismatch детермінований і падає всі 3 спроби — покриття Hard Rule #3 не слабшає. Unit-тести пакета retry не отримують.

## Governing Skill

`sergeant-server-api` (API contract surface, `packages/api-client`).

## Verification

- `pnpm --filter @sergeant/api-client typecheck` ✅
- `pnpm --filter @sergeant/api-client lint` ✅
- `pnpm --filter @sergeant/api-client test:coverage` ✅ (227 passed)
- Contract suite окремо: 13 files / 22 tests passed ✅

## Docs and Governance

Без змін канонічних доків. Hard Rule #3 (contract triplet) не торкнуто — response/request shape, типи й тести незмінні; додано лише vitest retry options.

## Risk and Rollout

Низький ризик: зміни тільки в тестовій інфрі contract-тестів. Rollback — revert одного коміта.

Acknowledged Hard Rule #15.

https://claude.ai/code/session_014Kug8duhYEwSgq2zgF1xsY

---
_Generated by [Claude Code](https://claude.ai/code/session_014Kug8duhYEwSgq2zgF1xsY)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes pact contract tests in `@sergeant/api-client` by adding shared suite-level retries to absorb an intermittent mock-server flake. No production or contract shape changes.

- **Bug Fixes**
  - Added `CONTRACT_SUITE_OPTIONS = { retry: 2 }` in `_pact.ts` and applied to all 13 contract `describe` blocks.
  - Mitigates a known `@pact-foundation/pact` FFI race that sporadically reports `missing-request` despite matched responses; real mismatches still fail all attempts.
  - Verified via `pnpm --filter @sergeant/api-client test:coverage`, plus typecheck and lint.

<sup>Written for commit 69d12f154b10c3579b45b8984fe4ca87c382a7a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

