### PR TITLE
feat(web): redesign Body Atlas — interactive heat map, drop body-highlighter

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -65,7 +65,6 @@
     "@zxing/browser": "^0.1.5",
     "@zxing/library": "^0.21.3",
     "better-auth": "^1.6.14",
-    "body-highlighter": "^3.0.2",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.2",
     "posthog-js": "^1.372.3",

--- a/apps/web/src/modules/fizruk/components/BodyAtlas.test.tsx
+++ b/apps/web/src/modules/fizruk/components/BodyAtlas.test.tsx
@@ -1,242 +1,141 @@
 // @vitest-environment jsdom
 /**
- * BodyAtlas a11y tests — audit-06 F2
+ * BodyAtlas tests — pure-SVG renderer (no body-highlighter).
  *
  * Covers:
- *  - Toggle buttons have aria-pressed and update it correctly.
- *  - Every selectable muscle in the current view is keyboard-focusable
- *    (present in the DOM with role="button" / as a <button>).
- *  - Enter and Space activate muscle selection (updates selected state).
- *  - aria-labels include both the muscle name and its recovery status.
+ *  - Mode + side segmented controls render and toggle aria-selected.
+ *  - Switching side swaps the muscle set (front-only vs back-only groups).
+ *  - Muscle groups are keyboard-focusable role="button" with a UA aria-label.
+ *  - Enter / Space / click select a muscle and populate the detail card.
+ *  - The detail card surfaces status, fatigue and exercise chips.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
-import { BodyAtlas } from "./BodyAtlas";
+import { BodyAtlas, type AtlasMuscleDatum } from "./BodyAtlas";
 
-// body-highlighter calls document.createElementNS and appends DOM nodes.
-// In jsdom that works without issues but we mock the module to avoid
-// triggering the real imperative SVG build (which is unrelated to these tests).
-vi.mock("body-highlighter", () => ({
-  default: vi.fn(() => ({
-    destroy: vi.fn(),
-  })),
-}));
+const DATA: Partial<Record<string, AtlasMuscleDatum>> = {
+  chest: {
+    fatigue: 0.9,
+    daysSince: 1,
+    load7d: 5000,
+    status: "red",
+    exercises: ["Жим лежачи"],
+  },
+  biceps: {
+    fatigue: 0.5,
+    daysSince: 2,
+    load7d: 2000,
+    status: "yellow",
+    exercises: [],
+  },
+  abs: {
+    fatigue: 0.1,
+    daysSince: 4,
+    load7d: 500,
+    status: "green",
+    exercises: [],
+  },
+  "upper-back": {
+    fatigue: 0.6,
+    daysSince: 2,
+    load7d: 4000,
+    status: "yellow",
+    exercises: [],
+  },
+  gluteal: {
+    fatigue: 0.35,
+    daysSince: 3,
+    load7d: 3000,
+    status: "yellow",
+    exercises: [],
+  },
+};
 
-const STATUS_BY_MUSCLE = {
-  chest: "red",
-  biceps: "yellow",
-  abs: "green",
-  quadriceps: "red",
-} as const;
-
-function renderAtlas(
-  statusByMuscle: Record<string, string> = STATUS_BY_MUSCLE,
-) {
-  return render(<BodyAtlas statusByMuscle={statusByMuscle} height={320} />);
-}
+const renderAtlas = () =>
+  render(<BodyAtlas data={DATA as Record<string, AtlasMuscleDatum>} />);
 
 beforeEach(cleanup);
 
-describe("BodyAtlas · toggle buttons", () => {
-  it("renders both toggle buttons with aria-pressed", () => {
+describe("BodyAtlas · segmented controls", () => {
+  it("renders mode + side tabs with the front view selected by default", () => {
     renderAtlas();
-
-    const anteriorBtn = screen.getByRole("button", {
-      name: /вигляд спереду/i,
-    });
-    const posteriorBtn = screen.getByRole("button", {
-      name: /вигляд ззаду/i,
-    });
-
-    expect(anteriorBtn).toBeInTheDocument();
-    expect(posteriorBtn).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Відновлення" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByRole("tab", { name: "Спереду" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByRole("tab", { name: "Ззаду" })).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
   });
 
-  it("anterior toggle starts as aria-pressed=true, posterior as false", () => {
+  it("switching side swaps muscle groups (front-only chest → back-only gluteal)", () => {
     renderAtlas();
+    expect(screen.getByRole("button", { name: "Груди" })).toBeInTheDocument();
 
-    const anteriorBtn = screen.getByRole("button", {
-      name: /вигляд спереду/i,
-    });
-    const posteriorBtn = screen.getByRole("button", {
-      name: /вигляд ззаду/i,
-    });
+    fireEvent.click(screen.getByRole("tab", { name: "Ззаду" }));
 
-    expect(anteriorBtn).toHaveAttribute("aria-pressed", "true");
-    expect(posteriorBtn).toHaveAttribute("aria-pressed", "false");
-  });
-
-  it("clicking posterior sets posterior aria-pressed=true and anterior to false", () => {
-    renderAtlas();
-
-    const posteriorBtn = screen.getByRole("button", {
-      name: /вигляд ззаду/i,
-    });
-    fireEvent.click(posteriorBtn);
-
-    expect(posteriorBtn).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("tab", { name: "Ззаду" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "Сідниці" })).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /вигляд спереду/i }),
-    ).toHaveAttribute("aria-pressed", "false");
-  });
-
-  it("clicking anterior after posterior resets aria-pressed correctly", () => {
-    renderAtlas();
-
-    fireEvent.click(screen.getByRole("button", { name: /вигляд ззаду/i }));
-    fireEvent.click(screen.getByRole("button", { name: /вигляд спереду/i }));
-
-    expect(
-      screen.getByRole("button", { name: /вигляд спереду/i }),
-    ).toHaveAttribute("aria-pressed", "true");
-    expect(
-      screen.getByRole("button", { name: /вигляд ззаду/i }),
-    ).toHaveAttribute("aria-pressed", "false");
-  });
-});
-
-describe("BodyAtlas · keyboard-accessible muscle list (anterior view)", () => {
-  it("renders sr-only muscle buttons for anterior muscles", () => {
-    renderAtlas();
-
-    // Chest is an anterior muscle — must be present in the DOM with an
-    // aria-label that contains the Ukrainian name.
-    const chestBtn = screen.getByRole("button", { name: /грудні/i });
-    expect(chestBtn).toBeInTheDocument();
-  });
-
-  it("muscle buttons include recovery status in aria-label", () => {
-    renderAtlas();
-
-    // chest = "red" → status label = "уникати"
-    const chestBtn = screen.getByRole("button", {
-      name: /грудні.*уникати/i,
-    });
-    expect(chestBtn).toBeInTheDocument();
-
-    // biceps = "yellow" → "відновлюється"
-    const bicepsBtn = screen.getByRole("button", {
-      name: /біцепс.*відновлюється/i,
-    });
-    expect(bicepsBtn).toBeInTheDocument();
-
-    // abs = "green" → "готовий"
-    const absBtn = screen.getByRole("button", { name: /прес.*готовий/i });
-    expect(absBtn).toBeInTheDocument();
-  });
-
-  it("Enter key activates muscle selection", () => {
-    renderAtlas();
-
-    const chestBtn = screen.getByRole("button", { name: /грудні.*уникати/i });
-    fireEvent.keyDown(chestBtn, { key: "Enter" });
-
-    // After selection the "Обрано:" readout should appear with the muscle key.
-    expect(screen.getByText(/Обрано:/)).toBeInTheDocument();
-    expect(screen.getByText("chest")).toBeInTheDocument();
-  });
-
-  it("Space key activates muscle selection", () => {
-    renderAtlas();
-
-    const absBtn = screen.getByRole("button", { name: /прес.*готовий/i });
-    fireEvent.keyDown(absBtn, { key: " " });
-
-    expect(screen.getByText(/Обрано:/)).toBeInTheDocument();
-    expect(screen.getByText("abs")).toBeInTheDocument();
-  });
-
-  it("click on muscle button activates selection", () => {
-    renderAtlas();
-
-    const quadBtn = screen.getByRole("button", {
-      name: /квадрицепс.*уникати/i,
-    });
-    fireEvent.click(quadBtn);
-
-    expect(screen.getByText(/Обрано:/)).toBeInTheDocument();
-    expect(screen.getByText("quadriceps")).toBeInTheDocument();
-  });
-
-  it("selected muscle gets aria-pressed=true", () => {
-    renderAtlas();
-
-    const chestBtn = screen.getByRole("button", { name: /грудні.*уникати/i });
-    expect(chestBtn).toHaveAttribute("aria-pressed", "false");
-
-    fireEvent.click(chestBtn);
-    expect(chestBtn).toHaveAttribute("aria-pressed", "true");
-  });
-
-  it("only one muscle has aria-pressed=true after selection", () => {
-    renderAtlas();
-
-    const chestBtn = screen.getByRole("button", { name: /грудні.*уникати/i });
-    const bicepsBtn = screen.getByRole("button", {
-      name: /біцепс.*відновлюється/i,
-    });
-
-    fireEvent.click(chestBtn);
-    expect(chestBtn).toHaveAttribute("aria-pressed", "true");
-
-    fireEvent.click(bicepsBtn);
-    expect(bicepsBtn).toHaveAttribute("aria-pressed", "true");
-    expect(chestBtn).toHaveAttribute("aria-pressed", "false");
-  });
-});
-
-describe("BodyAtlas · posterior view muscle list", () => {
-  it("shows posterior-specific muscles after switching view", () => {
-    renderAtlas();
-
-    fireEvent.click(screen.getByRole("button", { name: /вигляд ззаду/i }));
-
-    // "upper-back" is a posterior muscle — should appear after switching.
-    expect(
-      screen.getByRole("button", { name: /верхня спина/i }),
-    ).toBeInTheDocument();
-
-    // "chest" is anterior-only — should NOT appear in posterior list.
-    expect(
-      screen.queryByRole("button", { name: /грудні/i }),
+      screen.queryByRole("button", { name: "Груди" }),
     ).not.toBeInTheDocument();
   });
+});
 
-  it("gluteal muscle appears in posterior view", () => {
+describe("BodyAtlas · muscle selection", () => {
+  it("muscle groups are role=button with Ukrainian aria-labels", () => {
     renderAtlas();
+    expect(screen.getByRole("button", { name: "Груди" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Прес" })).toBeInTheDocument();
+  });
 
-    fireEvent.click(screen.getByRole("button", { name: /вигляд ззаду/i }));
+  it("Enter activates a muscle and fills the detail card", () => {
+    renderAtlas();
+    fireEvent.keyDown(screen.getByRole("button", { name: "Груди" }), {
+      key: "Enter",
+    });
+    expect(screen.getByText("потребує відпочинку")).toBeInTheDocument();
+    expect(screen.getByText("90%")).toBeInTheDocument();
+    expect(screen.getByText("Жим лежачи")).toBeInTheDocument();
+  });
 
-    expect(
-      screen.getByRole("button", { name: /сідниці/i }),
-    ).toBeInTheDocument();
+  it("Space activates a muscle", () => {
+    renderAtlas();
+    fireEvent.keyDown(screen.getByRole("button", { name: "Прес" }), {
+      key: " ",
+    });
+    expect(screen.getByText("готовий до роботи")).toBeInTheDocument();
+  });
+
+  it("click selects a muscle and shows its fatigue", () => {
+    renderAtlas();
+    fireEvent.click(screen.getByRole("button", { name: "Біцепс" }));
+    expect(screen.getByText("відновлюється")).toBeInTheDocument();
+    expect(screen.getByText("50%")).toBeInTheDocument();
+  });
+
+  it("changing side clears the current selection", () => {
+    renderAtlas();
+    fireEvent.click(screen.getByRole("button", { name: "Груди" }));
+    expect(screen.getByText("потребує відпочинку")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Ззаду" }));
+    expect(screen.getByText(/Оберіть м.?яз/)).toBeInTheDocument();
   });
 });
 
-describe("BodyAtlas · muscle map container", () => {
-  it("muscle map container has aria-label attribute", () => {
+describe("BodyAtlas · legend", () => {
+  it("renders the mode legend captions", () => {
     renderAtlas();
-
-    // The wrapping div around the SVG and sr-only list should carry
-    // aria-label="Карта м'язів". A plain div does not get a landmark
-    // role, so we query the DOM directly.
-    const mapCard = document.querySelector('[aria-label="Карта м\'язів"]');
-    expect(mapCard).not.toBeNull();
-  });
-
-  it("sr-only list has its own aria-label", () => {
-    renderAtlas();
-
-    const list = document.querySelector('[aria-label="Список м\'язів"]');
-    expect(list).not.toBeNull();
-  });
-
-  it("visual SVG container is aria-hidden", () => {
-    renderAtlas();
-
-    // The inner div wrapping the body-highlighter SVG must be aria-hidden
-    // so AT skips the SVG polygons in favour of the sr-only list.
-    const hiddenDivs = document.querySelectorAll('[aria-hidden="true"]');
-    expect(hiddenDivs.length).toBeGreaterThan(0);
+    expect(screen.getByText("відновлено")).toBeInTheDocument();
+    expect(screen.getByText("втомлено")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/modules/fizruk/components/BodyAtlas.tsx
+++ b/apps/web/src/modules/fizruk/components/BodyAtlas.tsx
@@ -1,277 +1,433 @@
 /**
- * Last validated: 2026-06-02
+ * Last validated: 2026-06-12
  * Status: Active
  */
-import { useEffect, useMemo, useRef, useState } from "react";
-import createBodyHighlighter from "body-highlighter";
+import { useMemo, useState } from "react";
+import {
+  ATLAS_VIEWBOX,
+  BODY_ATLAS_GEOMETRY,
+  BODY_ATLAS_MUSCLE_LABELS_UK,
+  atlasGroupCentroid,
+  type BodyAtlasMuscleId,
+  type BodyAtlasSide,
+} from "@sergeant/fizruk-domain/data";
+import type { RecoveryStatus } from "@sergeant/fizruk-domain";
 import { cn } from "@shared/lib/ui/cn";
 import { THEME_HEX } from "@shared/lib/ui/themeHex";
+import type { AtlasData, AtlasMuscleDatum } from "../lib/atlasData";
 
-const STATUS_TO_FREQ: Record<string, number> = { yellow: 1, red: 2 };
+export type { AtlasMuscleDatum, AtlasData } from "../lib/atlasData";
 
-/** Human-readable Ukrainian labels for each body-highlighter muscle key. */
-const MUSCLE_LABELS: Record<string, string> = {
-  chest: "Грудні",
-  "upper-back": "Верхня спина",
-  "lower-back": "Нижня спина",
-  trapezius: "Трапеція",
-  biceps: "Біцепс",
-  triceps: "Трицепс",
-  forearm: "Передпліччя",
-  "front-deltoids": "Передні дельти",
-  "back-deltoids": "Задні дельти",
-  abs: "Прес",
-  obliques: "Косі м'язи",
-  quadriceps: "Квадрицепс",
-  hamstring: "Біцепс стегна",
-  calves: "Литки",
-  adductor: "Привідні",
-  abductors: "Відвідні",
-  gluteal: "Сідниці",
-  neck: "Шия",
+type AtlasMode = "recovery" | "last" | "volume";
+
+const MODES: Array<{ id: AtlasMode; label: string }> = [
+  { id: "recovery", label: "Відновлення" },
+  { id: "last", label: "Останнє" },
+  { id: "volume", label: "Обʼєм 7д" },
+];
+
+const SIDES: Array<{ id: BodyAtlasSide; label: string }> = [
+  { id: "front", label: "Спереду" },
+  { id: "back", label: "Ззаду" },
+];
+
+const MUSCLE_NEUTRAL = "#cbc7ba";
+const SILHOUETTE_FILL = "#dad7cc";
+const SELECTED_STROKE = "#5f5e5a";
+
+/** Parse a `#rrggbb` string into an [r, g, b] tuple. */
+function toRgb(hex: string): [number, number, number] {
+  const n = parseInt(hex.replace("#", ""), 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+const HEAT_LOW = toRgb(THEME_HEX.success);
+const HEAT_MID = toRgb(THEME_HEX.warning);
+const HEAT_HIGH = toRgb(THEME_HEX.danger);
+
+const mix = (a: number, b: number, t: number) => Math.round(a + (b - a) * t);
+
+/**
+ * Map an intensity 0..1 to a heat colour (success → warning → danger).
+ * Returns `null` below a small floor so "cold" muscles keep the neutral
+ * silhouette fill instead of a washed-out brand tint.
+ */
+function heatColor(t: number): string | null {
+  if (t <= 0.02) return null;
+  const from = t < 0.5 ? HEAT_LOW : HEAT_MID;
+  const to = t < 0.5 ? HEAT_MID : HEAT_HIGH;
+  const k = t < 0.5 ? t / 0.5 : (t - 0.5) / 0.5;
+  return `#${[0, 1, 2]
+    .map((i) =>
+      mix(from[i] ?? 0, to[i] ?? 0, k)
+        .toString(16)
+        .padStart(2, "0"),
+    )
+    .join("")}`;
+}
+
+/** Intensity for the active mode: fatigue / recency / normalised volume. */
+function metricFor(
+  d: AtlasMuscleDatum,
+  mode: AtlasMode,
+  maxLoad: number,
+): number {
+  if (mode === "recovery") return d.fatigue;
+  if (mode === "last")
+    return d.daysSince == null ? 0 : Math.max(0, 1 - d.daysSince / 7);
+  return maxLoad > 0 ? d.load7d / maxLoad : 0;
+}
+
+const LEGEND_COPY: Record<
+  AtlasMode,
+  { label: string; left: string; right: string }
+> = {
+  recovery: {
+    label: "Втома: бірюзовий — відновлено, кораловий — потребує відпочинку",
+    left: "відновлено",
+    right: "втомлено",
+  },
+  last: {
+    label: "Давність: яскравіше — тренувалось нещодавно",
+    left: "давно",
+    right: "сьогодні",
+  },
+  volume: {
+    label: "Обʼєм за 7 днів: яскравіше — більше навантаження",
+    left: "0",
+    right: "макс",
+  },
 };
 
-/** Muscles visible on the anterior (front) view. */
-const ANTERIOR_MUSCLES = [
-  "chest",
-  "biceps",
-  "triceps",
-  "forearm",
-  "front-deltoids",
-  "abs",
-  "obliques",
-  "quadriceps",
-  "calves",
-  "adductor",
-  "abductors",
-  "neck",
-] as const;
-
-/** Muscles visible on the posterior (back) view. */
-const POSTERIOR_MUSCLES = [
-  "upper-back",
-  "lower-back",
-  "trapezius",
-  "triceps",
-  "forearm",
-  "back-deltoids",
-  "hamstring",
-  "calves",
-  "gluteal",
-  "neck",
-] as const;
-
-/** Ukrainian status label shown in aria-label strings. */
-const STATUS_LABELS: Record<string, string> = {
-  green: "готовий",
-  yellow: "відновлюється",
-  red: "уникати",
+const STATUS_PILL: Record<RecoveryStatus, { label: string; dot: string }> = {
+  green: { label: "готовий до роботи", dot: "bg-success" },
+  yellow: { label: "відновлюється", dot: "bg-warning" },
+  red: { label: "потребує відпочинку", dot: "bg-danger" },
 };
-
-function buildDataFromStatuses(
-  statusByMuscle: Record<string, string> | null | undefined,
-) {
-  const out: Array<{ name: string; muscles: string[]; frequency: number }> = [];
-  for (const [muscle, status] of Object.entries(statusByMuscle || {})) {
-    const freq = STATUS_TO_FREQ[status as string];
-    if (!freq) continue; // green = default bodyColor
-    out.push({ name: muscle, muscles: [muscle], frequency: freq });
-  }
-  return out;
-}
-
-interface BodyHighlighterInstance {
-  destroy?: () => void;
-}
-interface Selected {
-  muscle: string;
-  frequency?: number;
-}
 
 interface BodyAtlasProps {
-  statusByMuscle: Record<string, string> | null | undefined;
-  height?: number;
-  showLegend?: boolean;
+  data: AtlasData;
+  /**
+   * Compact preview (dashboard card): silhouette + legend + side toggle
+   * only — no mode switch, no leader labels, no detail card.
+   */
+  compact?: boolean;
+  /** Optional CTA: ask the coach for a session focused on a muscle. */
+  onAskCoach?: (muscleLabel: string) => void;
 }
 
 export function BodyAtlas({
-  statusByMuscle,
-  height = 320,
-  showLegend = true,
+  data,
+  compact = false,
+  onAskCoach,
 }: BodyAtlasProps) {
-  const [view, setView] = useState("anterior"); // anterior | posterior
-  const [selected, setSelected] = useState<Selected | null>(null);
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const instRef = useRef<BodyHighlighterInstance | null>(null);
+  const [side, setSide] = useState<BodyAtlasSide>("front");
+  const [mode, setMode] = useState<AtlasMode>("recovery");
+  const [selected, setSelected] = useState<BodyAtlasMuscleId | null>(null);
 
-  const data = useMemo(
-    () => buildDataFromStatuses(statusByMuscle),
-    [statusByMuscle],
-  );
+  const maxLoad = useMemo(() => {
+    let max = 0;
+    for (const d of Object.values(data))
+      if (d && d.load7d > max) max = d.load7d;
+    return max;
+  }, [data]);
 
-  useEffect(() => {
-    if (!containerRef.current) return;
-    if (instRef.current) {
-      instRef.current.destroy?.();
-      instRef.current = null;
-    }
-    const inst = createBodyHighlighter({
-      container: containerRef.current,
-      type: view as "anterior" | "posterior",
-      data,
-      // green as "ready" baseline
-      bodyColor: THEME_HEX.success,
-      highlightedColors: [THEME_HEX.warning, THEME_HEX.danger],
-      // body-highlighter sometimes injects an SVG with its own height;
-      // enforce scaling by constraining container and SVG.
-      svgStyle: {
-        width: "100%",
-        height: "100%",
-        maxHeight: "100%",
-        display: "block",
-      },
-      style: { width: "100%", height: "100%" },
-      onClick: ({ muscle, data: mdata }) => {
-        setSelected({ muscle, ...mdata });
-      },
-    });
-    instRef.current = inst;
-    return () => {
-      instRef.current?.destroy?.();
-      instRef.current = null;
-    };
-  }, [view, data]);
+  const geometry = BODY_ATLAS_GEOMETRY[side];
 
-  /** Muscles relevant to the current view, in render order. */
-  const visibleMuscles =
-    view === "anterior" ? ANTERIOR_MUSCLES : POSTERIOR_MUSCLES;
+  const centroids = useMemo(() => {
+    const out = {} as Record<BodyAtlasMuscleId, [number, number]>;
+    for (const m of geometry.muscles)
+      out[m.id] = atlasGroupCentroid(m.polygons);
+    return out;
+  }, [geometry]);
 
-  function handleMuscleClick(muscle: string) {
-    const freq = STATUS_TO_FREQ[statusByMuscle?.[muscle] ?? ""] ?? undefined;
-    setSelected(freq !== undefined ? { muscle, frequency: freq } : { muscle });
+  function fillFor(id: BodyAtlasMuscleId): string {
+    const d = data[id];
+    if (!d) return MUSCLE_NEUTRAL;
+    return heatColor(metricFor(d, mode, maxLoad)) ?? MUSCLE_NEUTRAL;
   }
 
-  function handleMuscleKeyDown(
-    e: React.KeyboardEvent<HTMLButtonElement>,
-    muscle: string,
-  ) {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      handleMuscleClick(muscle);
-    }
+  function pickSide(next: BodyAtlasSide) {
+    setSide(next);
+    setSelected(null);
   }
+
+  const selectedDatum = selected ? data[selected] : undefined;
 
   return (
-    <div className="space-y-2">
-      <div className="flex items-center justify-between gap-2">
-        <div className="flex items-center gap-2">
-          <button
-            type="button"
-            aria-pressed={view === "anterior"}
-            aria-label="Вигляд спереду"
-            className={cn(
-              "text-xs px-3 min-h-[44px] min-w-[44px] rounded-full border transition-colors",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fizruk/50",
-              view === "anterior"
-                ? "bg-text text-bg border-text"
-                : "border-line text-subtle hover:text-text",
-            )}
-            onClick={() => setView("anterior")}
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2">
+        {!compact && (
+          <SegGroup
+            options={MODES}
+            value={mode}
+            onChange={setMode}
+            ariaLabel="Режим карти м'язів"
+          />
+        )}
+        <div className="flex-1" />
+        <SegGroup
+          options={SIDES}
+          value={side}
+          onChange={pickSide}
+          ariaLabel="Бік тіла"
+        />
+      </div>
+
+      <div className="flex flex-wrap items-start gap-4">
+        <div
+          className={cn(
+            "rounded-2xl bg-bg p-3",
+            compact ? "mx-auto flex-[0_0_200px]" : "flex-[0_0_300px]",
+          )}
+        >
+          <div className="mb-1.5 flex items-center justify-center gap-2 text-2xs text-subtle">
+            <span>{LEGEND_COPY[mode].left}</span>
+            <div className="flex h-1.5 w-28 overflow-hidden rounded-full">
+              {Array.from({ length: 24 }, (_, i) => (
+                <span
+                  key={i}
+                  className="flex-1"
+                  style={{
+                    background:
+                      heatColor(Math.max(0.03, i / 23)) ?? MUSCLE_NEUTRAL,
+                  }}
+                />
+              ))}
+            </div>
+            <span>{LEGEND_COPY[mode].right}</span>
+          </div>
+
+          <svg
+            viewBox={ATLAS_VIEWBOX}
+            className="mx-auto block w-full max-w-[300px]"
+            role="img"
+            aria-label={`Атлас м'язів, вигляд ${side === "front" ? "спереду" : "ззаду"}`}
           >
-            Спереду
-          </button>
-          <button
-            type="button"
-            aria-pressed={view === "posterior"}
-            aria-label="Вигляд ззаду"
-            className={cn(
-              "text-xs px-3 min-h-[44px] min-w-[44px] rounded-full border transition-colors",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fizruk/50",
-              view === "posterior"
-                ? "bg-text text-bg border-text"
-                : "border-line text-subtle hover:text-text",
-            )}
-            onClick={() => setView("posterior")}
-          >
-            Ззаду
-          </button>
+            {geometry.neutral.map((s) => (
+              <polygon key={s.id} points={s.points} fill={SILHOUETTE_FILL} />
+            ))}
+
+            {geometry.muscles.map((m) => {
+              const isSel = selected === m.id;
+              const fill = fillFor(m.id);
+              return (
+                <g
+                  key={m.id}
+                  role="button"
+                  tabIndex={0}
+                  aria-label={BODY_ATLAS_MUSCLE_LABELS_UK[m.id]}
+                  className="cursor-pointer [&>polygon]:transition-colors"
+                  onClick={() => setSelected(m.id)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      setSelected(m.id);
+                    }
+                  }}
+                >
+                  {m.polygons.map((p, i) => (
+                    <polygon
+                      key={i}
+                      points={p}
+                      style={{
+                        fill,
+                        stroke: isSel ? SELECTED_STROKE : "none",
+                        strokeWidth: isSel ? 0.8 : 0,
+                      }}
+                    >
+                      <title>{BODY_ATLAS_MUSCLE_LABELS_UK[m.id]}</title>
+                    </polygon>
+                  ))}
+                </g>
+              );
+            })}
+
+            {!compact &&
+              geometry.labels.map((slot) => {
+                const c = centroids[slot.id];
+                if (!c) return null;
+                const isL = slot.column === "L";
+                const tx = isL ? -30 : 130;
+                const elbow = isL ? -6 : 106;
+                const isSel = selected === slot.id;
+                return (
+                  <g
+                    key={slot.id}
+                    className="cursor-pointer"
+                    onClick={() => setSelected(slot.id)}
+                  >
+                    <polyline
+                      points={`${isL ? tx + 22 : tx - 22} ${slot.y} ${elbow} ${slot.y} ${c[0]} ${c[1]}`}
+                      className="fill-none stroke-line"
+                      strokeWidth={0.4}
+                    />
+                    <circle
+                      cx={c[0]}
+                      cy={c[1]}
+                      r={0.9}
+                      className="fill-subtle"
+                    />
+                    <text
+                      x={tx}
+                      y={slot.y + 2}
+                      textAnchor={isL ? "start" : "end"}
+                      fontSize={7.6}
+                      className={cn(
+                        "select-none",
+                        isSel ? "fill-text font-medium" : "fill-subtle",
+                      )}
+                    >
+                      {BODY_ATLAS_MUSCLE_LABELS_UK[slot.id]}
+                    </text>
+                  </g>
+                );
+              })}
+          </svg>
         </div>
-        {showLegend && (
-          <div className="flex items-center gap-2 text-xs text-subtle">
-            <span className="inline-flex items-center gap-1">
-              <span className="w-2 h-2 rounded-full bg-success" /> готово
-            </span>
-            <span className="inline-flex items-center gap-1">
-              <span className="w-2 h-2 rounded-full bg-warning" /> норм
-            </span>
-            <span className="inline-flex items-center gap-1">
-              <span className="w-2 h-2 rounded-full bg-danger" /> рано
-            </span>
+
+        {!compact && (
+          <div className="min-w-[260px] flex-1">
+            <div className="rounded-2xl border border-line bg-bg p-4">
+              {selected && selectedDatum ? (
+                <SelectedCard
+                  label={BODY_ATLAS_MUSCLE_LABELS_UK[selected]}
+                  datum={selectedDatum}
+                  onAskCoach={onAskCoach}
+                />
+              ) : (
+                <>
+                  <p className="text-style-label text-text">Оберіть мʼяз</p>
+                  <p className="mt-1 text-xs text-subtle">
+                    Торкніться групи мʼязів або її назви — підсвітка покаже стан
+                    і вправи.
+                  </p>
+                </>
+              )}
+            </div>
           </div>
         )}
       </div>
+    </div>
+  );
+}
 
-      {/*
-       * Keyboard-accessible muscle map container.
-       *
-       * body-highlighter renders SVG polygons imperatively via DOM
-       * manipulation — they are pointer-only with no keyboard handling.
-       * The sr-only <ul> below is a parallel keyboard path: every muscle
-       * in the current view is Tab-reachable, activatable with Enter/Space,
-       * and announces its name + recovery status via aria-label.
-       *
-       * Both paths share `setSelected` as the single source of truth.
-       * The visual SVG is aria-hidden so screen-readers skip it and use
-       * the parallel list instead.
-       */}
-      <div
-        className="bg-bg border border-line rounded-2xl p-3"
-        aria-label="Карта м'язів"
-      >
-        {/* Visual SVG body map — pointer-only, hidden from AT */}
-        <div
-          ref={containerRef}
-          aria-hidden="true"
-          className="w-full overflow-hidden"
-          style={{ height, maxHeight: height }}
-        />
+interface SegOption<T extends string> {
+  id: T;
+  label: string;
+}
 
-        {/* Parallel keyboard-accessible muscle list (sr-only, NOT display:none) */}
-        <ul className="sr-only" aria-label="Список м'язів">
-          {visibleMuscles.map((muscle) => {
-            const rawStatus = statusByMuscle?.[muscle] ?? "green";
-            const statusLabel =
-              STATUS_LABELS[rawStatus] ?? STATUS_LABELS["green"];
-            const muscleName = MUSCLE_LABELS[muscle] ?? muscle;
-            const isSelected = selected?.muscle === muscle;
-            return (
-              <li key={muscle}>
-                <button
-                  type="button"
-                  aria-label={`${muscleName} — ${statusLabel}`}
-                  aria-pressed={isSelected}
-                  className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fizruk/50"
-                  onClick={() => handleMuscleClick(muscle)}
-                  onKeyDown={(e) => handleMuscleKeyDown(e, muscle)}
-                >
-                  {muscleName}
-                </button>
-              </li>
-            );
-          })}
-        </ul>
+function SegGroup<T extends string>({
+  options,
+  value,
+  onChange,
+  ariaLabel,
+}: {
+  options: ReadonlyArray<SegOption<T>>;
+  value: T;
+  onChange: (next: T) => void;
+  ariaLabel: string;
+}) {
+  return (
+    <div
+      role="tablist"
+      aria-label={ariaLabel}
+      className="flex gap-0.5 rounded-full bg-bg p-0.5"
+    >
+      {options.map((o) => {
+        const on = o.id === value;
+        return (
+          <button
+            key={o.id}
+            type="button"
+            role="tab"
+            aria-selected={on}
+            onClick={() => onChange(o.id)}
+            className={cn(
+              "min-h-[44px] rounded-full px-3 text-xs transition-colors",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fizruk/50",
+              on
+                ? "bg-surface font-medium text-text"
+                : "text-subtle hover:text-text",
+            )}
+          >
+            {o.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function SelectedCard({
+  label,
+  datum,
+  onAskCoach,
+}: {
+  label: string;
+  datum: AtlasMuscleDatum;
+  onAskCoach?: ((muscleLabel: string) => void) | undefined;
+}) {
+  const pill = STATUS_PILL[datum.status];
+  return (
+    <>
+      <div className="mb-1 flex items-center gap-2.5">
+        <p className="text-base font-medium text-text">{label}</p>
+        <span className="inline-flex items-center gap-1.5 rounded-full border border-line px-2.5 py-1 text-xs text-text">
+          <span className={cn("inline-block h-2 w-2 rounded-full", pill.dot)} />
+          {pill.label}
+        </span>
       </div>
 
-      {selected && (
-        <div className="text-xs text-subtle">
-          Обрано:{" "}
-          <span className="font-semibold text-muted">{selected.muscle}</span> ·
-          разів:{" "}
-          <span className="font-semibold text-muted">
-            {selected.frequency || 0}
-          </span>
-        </div>
+      <div className="mb-3 mt-2 grid grid-cols-3 gap-2.5">
+        <Stat
+          label="Останнє"
+          value={
+            datum.daysSince == null
+              ? "—"
+              : datum.daysSince === 0
+                ? "сьогодні"
+                : `${datum.daysSince} дн.`
+          }
+        />
+        <Stat label="Обʼєм 7д" value={datum.load7d.toLocaleString("uk-UA")} />
+        <Stat label="Втома" value={`${Math.round(datum.fatigue * 100)}%`} />
+      </div>
+
+      {datum.exercises.length > 0 && (
+        <>
+          <p className="mb-1.5 text-xs text-subtle">Вправи на цю групу</p>
+          <div className="flex flex-wrap gap-1.5">
+            {datum.exercises.map((ex) => (
+              <span
+                key={ex}
+                className="rounded-full bg-surface px-2.5 py-1 text-xs text-text"
+              >
+                {ex}
+              </span>
+            ))}
+          </div>
+        </>
       )}
+
+      {onAskCoach && (
+        <button
+          type="button"
+          onClick={() => onAskCoach(label)}
+          className="mt-3 min-h-[44px] rounded-full border border-line px-3 text-xs text-text transition-colors hover:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fizruk/50"
+        >
+          Підказати наступне тренування →
+        </button>
+      )}
+    </>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md bg-surface p-2.5">
+      <p className="text-2xs text-subtle">{label}</p>
+      <p className="mt-0.5 text-lg font-medium text-text">{value}</p>
     </div>
   );
 }

--- a/apps/web/src/modules/fizruk/components/RecoveryFocusCard.tsx
+++ b/apps/web/src/modules/fizruk/components/RecoveryFocusCard.tsx
@@ -8,38 +8,9 @@ import { Card } from "@shared/components/ui/Card";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { cn } from "@shared/lib/ui/cn";
 import { BodyAtlas } from "./BodyAtlas";
+import { buildAtlasData } from "../lib/atlasData";
 import { useExerciseCatalog } from "../hooks/useExerciseCatalog";
 import { useRecovery } from "../hooks/useRecovery";
-
-function mapMuscleId(id: string | undefined | null): string | null {
-  if (!id) return null;
-  if (id === "pectoralis_major" || id === "pectoralis_minor") return "chest";
-  if (id === "latissimus_dorsi") return "upper-back";
-  if (id === "rhomboids" || id === "upper_back") return "upper-back";
-  if (id === "erector_spinae") return "lower-back";
-  if (id === "trapezius") return "trapezius";
-  if (id === "biceps") return "biceps";
-  if (id === "triceps") return "triceps";
-  if (id === "forearms") return "forearm";
-  if (id === "front_deltoid") return "front-deltoids";
-  if (id === "rear_deltoid") return "back-deltoids";
-  if (id === "rectus_abdominis") return "abs";
-  if (id === "obliques") return "obliques";
-  if (id === "quadriceps") return "quadriceps";
-  if (id === "hamstrings") return "hamstring";
-  if (id === "calves") return "calves";
-  if (id === "adductors") return "adductor";
-  if (id === "abductors") return "abductors";
-  if (id === "gluteus_maximus" || id === "gluteus_medius") return "gluteal";
-  if (id === "neck") return "neck";
-  return null;
-}
-
-function worstStatus(a: string, b: string): string {
-  if (a === "red" || b === "red") return "red";
-  if (a === "yellow" || b === "yellow") return "yellow";
-  return "green";
-}
 
 export function RecoveryFocusCard({
   onOpenAtlas,
@@ -50,15 +21,7 @@ export function RecoveryFocusCard({
   const { musclesUk } = useExerciseCatalog();
   const [open, setOpen] = useState(false);
 
-  const statusByMuscle = useMemo(() => {
-    const out: Record<string, string> = {};
-    for (const m of Object.values(rec.by || {})) {
-      const key = mapMuscleId(m.id);
-      if (!key) continue;
-      out[key] = out[key] ? worstStatus(out[key], m.status) : m.status;
-    }
-    return out;
-  }, [rec.by]);
+  const atlasData = useMemo(() => buildAtlasData(rec.by), [rec.by]);
 
   const focus = useMemo(
     () =>
@@ -156,11 +119,7 @@ export function RecoveryFocusCard({
             </div>
           )}
 
-          <BodyAtlas
-            statusByMuscle={statusByMuscle}
-            height={120}
-            showLegend={false}
-          />
+          <BodyAtlas data={atlasData} compact />
 
           <div className="mt-4 pt-3 border-t border-line">
             <SectionHeading as="p" size="xs" variant="fizruk" className="mb-2">

--- a/apps/web/src/modules/fizruk/lib/atlasData.ts
+++ b/apps/web/src/modules/fizruk/lib/atlasData.ts
@@ -1,0 +1,43 @@
+/**
+ * Last validated: 2026-06-12
+ * Status: Active
+ *
+ * Bridges recovery state (`useRecovery().by`) to the BodyAtlas render input:
+ * folds domain muscles onto the canonical atlas keyspace (via the domain
+ * `aggregateRecoveryToAtlas`) and attaches the exercise chips each group
+ * shows in its detail card. Shared by the Atlas page and the dashboard
+ * RecoveryFocusCard so neither re-derives the muscle→atlas join.
+ */
+import {
+  aggregateRecoveryToAtlas,
+  getExerciseNamesByAtlasMuscle,
+  type BodyAtlasMuscleId,
+} from "@sergeant/fizruk-domain/data";
+import type { MuscleState, RecoveryStatus } from "@sergeant/fizruk-domain";
+
+/** Per-muscle data the atlas paints and surfaces in the selected card. */
+export interface AtlasMuscleDatum {
+  /** Recovery fatigue, 0..1 (drives the heat map in "recovery" mode). */
+  fatigue: number;
+  daysSince: number | null;
+  load7d: number;
+  status: RecoveryStatus;
+  /** Ukrainian exercise names targeting this group (card chips). */
+  exercises: string[];
+}
+
+export type AtlasData = Partial<Record<BodyAtlasMuscleId, AtlasMuscleDatum>>;
+
+/** Build atlas render input from a `useRecovery().by` map. */
+export function buildAtlasData(
+  by: Record<string, MuscleState> | null | undefined,
+): AtlasData {
+  const aggregated = aggregateRecoveryToAtlas(Object.values(by || {}));
+  const out: AtlasData = {};
+  for (const id of Object.keys(aggregated) as BodyAtlasMuscleId[]) {
+    const datum = aggregated[id];
+    if (!datum) continue;
+    out[id] = { ...datum, exercises: getExerciseNamesByAtlasMuscle(id) };
+  }
+  return out;
+}

--- a/apps/web/src/modules/fizruk/pages/Atlas.tsx
+++ b/apps/web/src/modules/fizruk/pages/Atlas.tsx
@@ -1,86 +1,20 @@
 /**
- * Last validated: 2026-06-05
+ * Last validated: 2026-06-12
  * Status: Active
  */
 import { useMemo } from "react";
 import { BodyAtlas } from "../components/BodyAtlas";
+import { buildAtlasData } from "../lib/atlasData";
 import { useRecovery } from "../hooks/useRecovery";
 import { Card } from "@shared/components/ui/Card";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 
-type MuscleStatus = "red" | "yellow" | "green";
-type HighlighterMuscle =
-  | "chest"
-  | "upper-back"
-  | "lower-back"
-  | "trapezius"
-  | "biceps"
-  | "triceps"
-  | "forearm"
-  | "front-deltoids"
-  | "back-deltoids"
-  | "abs"
-  | "obliques"
-  | "quadriceps"
-  | "hamstring"
-  | "calves"
-  | "adductor"
-  | "abductors"
-  | "gluteal"
-  | "neck";
-
 export function Atlas() {
   const rec = useRecovery();
 
-  // Audit 06 F8: memoize per `rec.by` so the SVG body-highlighter gets
-  // identity-stable input and can skip its internal re-paint on storage /
-  // BroadcastChannel ticks that don't actually change the recovery snapshot.
-  const statusByMuscle = useMemo<
-    Partial<Record<HighlighterMuscle, MuscleStatus>>
-  >(() => {
-    // Map our muscle ids to body-highlighter muscle keys.
-    const map = (id: string | null | undefined): HighlighterMuscle | null => {
-      if (!id) return null;
-      if (id === "pectoralis_major" || id === "pectoralis_minor")
-        return "chest";
-      if (id === "latissimus_dorsi") return "upper-back";
-      if (id === "rhomboids" || id === "upper_back") return "upper-back";
-      if (id === "erector_spinae") return "lower-back";
-      if (id === "trapezius") return "trapezius";
-      if (id === "biceps") return "biceps";
-      if (id === "triceps") return "triceps";
-      if (id === "forearms") return "forearm";
-      if (id === "front_deltoid") return "front-deltoids";
-      if (id === "rear_deltoid") return "back-deltoids";
-      if (id === "rectus_abdominis") return "abs";
-      if (id === "obliques") return "obliques";
-      if (id === "quadriceps") return "quadriceps";
-      if (id === "hamstrings") return "hamstring";
-      if (id === "calves") return "calves";
-      if (id === "adductors") return "adductor";
-      if (id === "abductors") return "abductors";
-      if (id === "gluteus_maximus" || id === "gluteus_medius") return "gluteal";
-      if (id === "neck") return "neck";
-      return null;
-    };
-    const worst = (a: MuscleStatus, b: MuscleStatus): MuscleStatus =>
-      a === "red" || b === "red"
-        ? "red"
-        : a === "yellow" || b === "yellow"
-          ? "yellow"
-          : "green";
-    const out: Partial<Record<HighlighterMuscle, MuscleStatus>> = {};
-    for (const m of Object.values(rec.by || {}) as Array<{
-      id?: string;
-      status: MuscleStatus;
-    }>) {
-      const key = map(m.id);
-      if (!key) continue;
-      const prev = out[key];
-      out[key] = prev ? worst(prev, m.status) : m.status;
-    }
-    return out;
-  }, [rec.by]);
+  // Memoized per `rec.by` so the SVG gets identity-stable input across
+  // storage / BroadcastChannel ticks that don't change the recovery snapshot.
+  const atlasData = useMemo(() => buildAtlasData(rec.by), [rec.by]);
 
   return (
     <div className="flex-1 overflow-y-auto">
@@ -106,35 +40,14 @@ export function Atlas() {
             <h1 className="text-hero font-black text-teal-900 dark:text-white mt-2 leading-tight">
               Стан відновлення
             </h1>
-            <div className="flex gap-4 mt-3">
-              <div className="flex items-center gap-1.5">
-                <span className="w-2.5 h-2.5 rounded-full bg-success inline-block" />
-                <span className="text-xs text-teal-700 dark:text-white/70">
-                  Готовий
-                </span>
-              </div>
-              <div className="flex items-center gap-1.5">
-                <span className="w-2.5 h-2.5 rounded-full bg-warning inline-block" />
-                <span className="text-xs text-teal-700 dark:text-white/70">
-                  Відновлюється
-                </span>
-              </div>
-              <div className="flex items-center gap-1.5">
-                <span className="w-2.5 h-2.5 rounded-full bg-danger inline-block" />
-                <span className="text-xs text-teal-700 dark:text-white/70">
-                  Уникати
-                </span>
-              </div>
-            </div>
+            <p className="text-xs text-teal-700 dark:text-white/70 mt-2">
+              Карта втоми, давності тренувань і обʼєму по групах мʼязів.
+            </p>
           </div>
         </Card>
 
         <Card radius="lg" padding="lg">
-          <BodyAtlas
-            statusByMuscle={statusByMuscle}
-            height={520}
-            showLegend={false}
-          />
+          <BodyAtlas data={atlasData} />
         </Card>
       </div>
     </div>

--- a/apps/web/src/shared/lib/ui/themeHex.ts
+++ b/apps/web/src/shared/lib/ui/themeHex.ts
@@ -1,5 +1,5 @@
 /**
- * Hex для inline-стилів (SVG, body-highlighter), збігаються з
+ * Hex для inline-стилів SVG (теплова мапа BodyAtlas тощо), збігаються з
  * tailwind.config.js theme.extend.colors.* (success, danger, warning).
  *
  * Джерело істини — `@sergeant/design-tokens/tokens` (`statusHex`

--- a/packages/fizruk-domain/src/data/bodyAtlas.ts
+++ b/packages/fizruk-domain/src/data/bodyAtlas.ts
@@ -1,18 +1,17 @@
 /**
  * Canonical muscle-group ids for the Fizruk BodyAtlas.
  *
- * The web client renders the atlas through the `body-highlighter` npm
- * package (web-only SVG). Its muscle keys (`chest`, `front-deltoids`,
- * `upper-back`, …) are mirrored here so the mobile `BodyAtlas` (Phase 6
- * PR-C, `react-native-svg`) can consume the very same `statusByMuscle`
- * shape that `apps/web/src/modules/fizruk/pages/Atlas.tsx` builds from
- * `useRecovery()`.
- *
- * In other words: the data layer (`useRecovery` + `mapDomainMuscleToAtlas`)
- * is platform-agnostic; only the rendering differs.
+ * The canonical muscle keys (`chest`, `front-deltoids`, `upper-back`, …)
+ * are the shared contract between the web and mobile `BodyAtlas` renderers
+ * (both draw the silhouette from `bodyAtlasGeometry.ts`), and feed the same
+ * `useRecovery()` snapshot through `mapDomainMuscleToAtlas` /
+ * `aggregateRecoveryToAtlas`. The data layer is platform-agnostic; only the
+ * SVG host (`<svg>` vs `react-native-svg`) differs.
  */
 
-/** Canonical BodyAtlas muscle ids (mirror `body-highlighter` web keys). */
+import type { MuscleState, RecoveryStatus } from "../domain/types.js";
+
+/** Canonical BodyAtlas muscle ids (the shared web/mobile keyspace). */
 export const BODY_ATLAS_MUSCLE_IDS = [
   "neck",
   "trapezius",
@@ -175,4 +174,55 @@ export function statusToIntensity(status: BodyAtlasStatus): number {
     default:
       return 0;
   }
+}
+
+/** Recovery metrics aggregated onto a single atlas muscle group. */
+export interface AtlasMuscleAggregate {
+  fatigue: number;
+  load7d: number;
+  daysSince: number | null;
+  status: RecoveryStatus;
+}
+
+function worstStatus(a: RecoveryStatus, b: RecoveryStatus): RecoveryStatus {
+  if (a === "red" || b === "red") return "red";
+  if (a === "yellow" || b === "yellow") return "yellow";
+  return "green";
+}
+
+/**
+ * Fold a list of domain `MuscleState`s onto the canonical atlas keyspace.
+ * Several domain muscles can map to one atlas group, so fatigue takes the
+ * max, volume sums, recency takes the most recent (min daysSince), and
+ * status takes the worst case. The single source of truth for both web and
+ * mobile atlas renderers — neither re-implements the domain→atlas fold.
+ */
+export function aggregateRecoveryToAtlas(
+  states: Iterable<MuscleState>,
+): Partial<Record<BodyAtlasMuscleId, AtlasMuscleAggregate>> {
+  const out: Partial<Record<BodyAtlasMuscleId, AtlasMuscleAggregate>> = {};
+  for (const m of states) {
+    const key = mapDomainMuscleToAtlas(m.id);
+    if (!key) continue;
+    const prev = out[key];
+    if (!prev) {
+      out[key] = {
+        fatigue: m.fatigue,
+        load7d: m.load7d,
+        daysSince: m.daysSince,
+        status: m.status,
+      };
+      continue;
+    }
+    prev.fatigue = Math.max(prev.fatigue, m.fatigue);
+    prev.load7d += m.load7d;
+    prev.daysSince =
+      m.daysSince == null
+        ? prev.daysSince
+        : prev.daysSince == null
+          ? m.daysSince
+          : Math.min(prev.daysSince, m.daysSince);
+    prev.status = worstStatus(prev.status, m.status);
+  }
+  return out;
 }

--- a/packages/fizruk-domain/src/data/bodyAtlasGeometry.ts
+++ b/packages/fizruk-domain/src/data/bodyAtlasGeometry.ts
@@ -1,0 +1,306 @@
+/**
+ * Vector geometry for the Fizruk BodyAtlas — platform-agnostic polygon data.
+ *
+ * Each muscle group is a list of SVG polygon point-strings (the `points`
+ * attribute of `<polygon>` / react-native-svg `<Polygon>`). The silhouette
+ * is built entirely from these polygons plus a few neutral shapes (head,
+ * knees) that are never highlighted.
+ *
+ * Points were vendored from the MIT-licensed `body-highlighter` package
+ * (its anterior/posterior muscle outlines) and frozen here so the runtime
+ * dependency can be dropped: the data is static, the rendering is ours, and
+ * both `apps/web` (`<svg>`) and `apps/mobile` (`react-native-svg`) can paint
+ * the same shapes from one source. Coordinates live in a 0..100 (x) ×
+ * 0..220 (y) space; `ATLAS_VIEWBOX` pads it for the leader-line labels.
+ *
+ * The muscle-id keyspace is the canonical `BodyAtlasMuscleId` union from
+ * `bodyAtlas.ts`, so recovery data (`mapDomainMuscleToAtlas`) feeds straight
+ * into the renderer.
+ */
+
+import type { BodyAtlasMuscleId, BodyAtlasSide } from "./bodyAtlas.js";
+
+/** One highlightable muscle group: its canonical id + constituent polygons. */
+export interface AtlasMuscleGroup {
+  id: BodyAtlasMuscleId;
+  /** SVG `points` strings — one per polygon (e.g. left + right side). */
+  polygons: string[];
+}
+
+/** A non-interactive silhouette shape (head, knees) drawn in neutral fill. */
+export interface AtlasNeutralShape {
+  id: string;
+  points: string;
+}
+
+/** Where a leader-line label sits: left/right column + vertical position. */
+export interface AtlasLabelSlot {
+  id: BodyAtlasMuscleId;
+  column: "L" | "R";
+  y: number;
+}
+
+/** Complete geometry for one side (anterior or posterior) of the body. */
+export interface AtlasSideGeometry {
+  muscles: AtlasMuscleGroup[];
+  neutral: AtlasNeutralShape[];
+  labels: AtlasLabelSlot[];
+}
+
+/** SVG viewBox sized to fit both the silhouette and the flanking labels. */
+export const ATLAS_VIEWBOX = "-32 -4 164 232";
+
+const FRONT_MUSCLES: AtlasMuscleGroup[] = [
+  {
+    id: "chest",
+    polygons: [
+      "51.8 41.6 51 55.1 58 58 67.8 55.5 70.6 47.3 62 41.6",
+      "29.8 46.5 31.4 55.5 40.8 58 48.2 55.1 47.8 42 37.6 42",
+    ],
+  },
+  {
+    id: "obliques",
+    polygons: [
+      "68.6 63.3 67.3 57.1 58.8 59.6 60 64.1 60.4 83.3 65.7 78.8 66.5 69.8",
+      "33.9 78.4 33.1 71.8 31 63.3 32.2 57.1 40.8 59.2 39.2 63.3 39.2 83.7",
+    ],
+  },
+  {
+    id: "abs",
+    polygons: [
+      "56.3 59.2 58 64.1 58.4 78 58.4 92.7 56.3 98.4 55.1 104.1 51.4 107.8 51 84.5 50.6 67.3 51 57.1",
+      "43.7 58.8 48.6 57.1 49 67.3 48.6 84.5 48.2 107.3 44.5 103.7 40.8 91.4 40.8 78.4 41.2 64.5",
+    ],
+  },
+  {
+    id: "biceps",
+    polygons: [
+      "16.7 68.2 18 71.4 22.9 66.1 29 53.9 27.8 49.4 20.4 55.9",
+      "71.4 49.4 70.2 54.7 76.3 66.1 81.6 71.8 82.9 69 78.8 55.5",
+    ],
+  },
+  {
+    id: "triceps",
+    polygons: [
+      "69.4 55.5 69.4 61.6 75.9 72.7 77.6 70.2 75.5 67.3",
+      "22.4 69.4 29.8 55.5 29.8 60.8 22.9 73.1",
+    ],
+  },
+  {
+    id: "neck",
+    polygons: [
+      "55.5 23.7 50.6 33.5 50.6 39.2 61.6 40 70.6 44.9 69.4 36.7 63.3 35.1 58.4 30.6",
+      "29 44.9 30.2 37.1 36.3 35.1 41.2 30.2 44.5 24.5 49 33.9 48.6 39.2 38 39.6",
+    ],
+  },
+  {
+    id: "front-deltoids",
+    polygons: [
+      "78.4 53.1 79.6 47.8 79.2 41.2 75.9 38 71 36.3 72.2 42.9 71.4 47.3",
+      "28.2 47.3 21.2 53.1 20 47.8 20.4 40.8 24.5 37.1 28.6 37.1 26.9 43.3",
+    ],
+  },
+  {
+    id: "adductor",
+    polygons: [
+      "52.7 110.2 54.3 124.9 60 110.2 62 100 64.9 94.3 60 92.7 56.7 104.5",
+      "47.8 110.6 44.9 125.3 42 115.9 40.4 113.1 39.6 107.3 38 102.4 34.7 93.9 39.6 92.2 41.6 99.2 43.7 105.3",
+    ],
+  },
+  {
+    id: "quadriceps",
+    polygons: [
+      "34.7 98.8 37.1 108.2 37.1 127.8 34.3 137.1 31 132.7 29.4 120 28.2 111.4 29.4 100.8 32.2 94.7",
+      "63.3 105.7 64.5 100 66.9 94.7 70.2 101.2 71 111.8 68.2 133.1 65.3 137.6 62.4 128.6 62 111.4",
+      "38.8 129.4 38.4 112.2 41.2 118.4 44.5 129.4 42.9 135.1 40 146.1 36.3 146.5 35.5 140",
+      "59.6 145.7 55.5 129 60.8 113.9 61.2 130.2 64.1 139.6 62.9 146.5",
+      "32.7 138.4 26.5 145.7 25.7 136.7 25.7 127.3 26.9 114.3 29.4 133.5",
+      "71.8 113.1 73.9 124.1 73.9 140.4 72.7 145.7 66.5 138.4 70.2 133.5",
+    ],
+  },
+  {
+    id: "calves",
+    polygons: [
+      "71.4 160.4 73.5 153.5 76.7 161.2 79.6 167.8 78.4 187.8 79.6 195.5 74.7 195.5",
+      "24.9 194.7 27.8 164.9 28.2 160.4 26.1 154.3 24.9 157.6 22.4 161.6 20.8 167.8 22 188.2 20.8 195.5",
+      "72.7 195.1 69.8 159.2 65.3 158.4 64.1 162.4 64.1 165.3 65.7 177.1",
+      "35.5 158.4 35.9 162.4 35.9 166.9 35.1 172.2 35.1 176.7 32.2 182 30.6 187.3 26.9 194.7 27.3 187.8 28.2 180.4 28.6 175.5 29 169.8 29.8 164.1 30.2 158.8",
+    ],
+  },
+  {
+    id: "forearm",
+    polygons: [
+      "6.1 88.6 10.2 75.1 14.7 70.2 16.3 74.3 19.2 73.5 4.5 97.6 0 100",
+      "84.5 69.8 83.3 73.5 80 73.1 95.1 98.4 100 100.4 93.5 89.4 89.8 76.3",
+      "77.6 72.2 77.6 77.6 80.4 84.1 85.3 89.8 92.2 101.2 94.7 99.6",
+      "6.9 101.2 13.5 90.6 18.8 84.1 21.6 77.1 21.2 71.8 4.9 98.8",
+    ],
+  },
+];
+
+const FRONT_NEUTRAL: AtlasNeutralShape[] = [
+  {
+    id: "head",
+    points:
+      "42.4 2.9 40 11.8 42 19.6 46.1 23.3 49.8 25.3 54.7 22.4 57.6 19.2 59.2 10.2 57.1 2.4 49.8 0",
+  },
+  {
+    id: "knee-left",
+    points:
+      "33.9 140 34.7 143.3 35.5 147.3 36.3 151 35.1 156.7 29.8 156.7 27.3 152.7 27.3 147.3 30.2 144.1",
+  },
+  {
+    id: "knee-right",
+    points: "65.7 140 72.2 147.8 72.2 152.2 69.8 157.1 64.9 156.7 62.9 151",
+  },
+];
+
+const BACK_MUSCLES: AtlasMuscleGroup[] = [
+  {
+    id: "trapezius",
+    polygons: [
+      "44.7 21.7 47.7 21.7 47.2 38.3 47.7 64.7 38.3 53.2 35.3 40.9 31.1 36.6 39.1 33.2 43.8 27.2",
+      "52.3 21.7 55.7 21.7 56.6 27.2 60.9 32.8 68.9 36.6 64.7 40.4 61.7 53.2 52.3 64.7 53.2 38.3",
+    ],
+  },
+  {
+    id: "back-deltoids",
+    polygons: [
+      "29.4 37 23 39.1 17.4 44.3 18.3 53.6 24.3 49.4 27.2 46.4",
+      "71.1 37 78.3 39.6 82.6 44.7 81.7 53.6 74.9 48.9 72.3 45.1",
+    ],
+  },
+  {
+    id: "upper-back",
+    polygons: [
+      "31.1 38.7 28.1 48.9 28.5 55.3 34 75.3 47.2 71.1 47.2 66.4 36.6 54 33.6 41.3",
+      "68.9 38.7 71.9 49.4 71.5 56.2 66 75.3 52.8 71.1 52.8 66.4 63.4 54.5 66.4 41.7",
+    ],
+  },
+  {
+    id: "triceps",
+    polygons: [
+      "26.8 49.8 17.9 55.7 14.5 72.3 16.6 81.7 21.7 63.8 26.8 55.7",
+      "73.6 50.2 82.1 55.7 86 73.2 83.4 82.1 77.9 63 73.2 55.7",
+      "26.8 58.3 26.8 68.5 23 75.3 19.1 77.4 22.6 65.5",
+      "72.8 58.3 77 64.7 80.4 77.4 76.6 75.3 72.8 68.9",
+    ],
+  },
+  {
+    id: "lower-back",
+    polygons: [
+      "47.7 72.8 34.5 77 35.3 83.4 49.4 102.1 46.8 83",
+      "52.3 72.8 65.5 77 64.7 83.4 50.6 102.1 53.2 83.8",
+    ],
+  },
+  {
+    id: "forearm",
+    polygons: [
+      "86.4 75.7 91.1 83.4 93.2 94 100 106.4 96.2 104.3 88.1 89.4 84.3 83.8",
+      "13.6 75.7 8.9 83.8 6.8 93.6 0 106.4 3.8 104.3 12.3 88.5 15.7 83",
+      "81.3 79.6 77.4 77.9 79.1 84.7 91.1 103.8 93.2 108.9 94.5 104.7",
+      "18.7 79.6 22.1 77.9 20.9 84.3 9.4 103 6.8 108.5 5.1 104.7",
+    ],
+  },
+  {
+    id: "gluteal",
+    polygons: [
+      "44.7 99.6 30.2 108.5 29.8 118.7 31.5 126 47.2 121.3 49.4 114.9",
+      "55.3 99.1 51.1 114.5 52.3 120.9 68.1 126 69.8 119.1 69.4 108.5",
+    ],
+  },
+  {
+    id: "abductors",
+    polygons: [
+      "48.1 123 44.7 123 41.3 125.5 45.1 144.3 48.5 135.7 48.9 129.4",
+      "51.9 122.6 55.7 123.4 59.1 126 54.9 144.3 51.9 136.2 51.1 129.4",
+    ],
+  },
+  {
+    id: "hamstring",
+    polygons: [
+      "28.9 122.1 31.1 129.4 36.6 126 35.3 135.3 34.5 150.2 29.4 158.3 28.9 146.8 27.7 141.3 27.2 131.5",
+      "71.5 121.7 69.4 128.9 63.8 126 65.5 136.6 66.4 150.2 71.1 158.3 71.5 147.7 72.8 142.1 73.6 131.9",
+      "38.7 125.5 44.3 146 40.4 166.8 36.2 152.8 37 135.3",
+      "61.7 125.5 63.4 136.2 64.3 153.2 60 166.8 56.2 146.4",
+    ],
+  },
+  {
+    id: "calves",
+    polygons: [
+      "29.4 160.4 28.5 167.2 24.7 179.6 23.8 192.8 25.5 197 28.5 193.2 29.8 180 31.9 171.1 31.9 166.8",
+      "37.4 165.1 35.3 167.7 33.2 171.9 31.1 180.4 30.2 191.9 34 200 38.7 190.6 39.1 168.9",
+      "63 165.1 61.3 168.5 61.7 190.6 66.4 199.6 70.6 191.9 68.9 179.6 66.8 170.2",
+      "70.6 160.4 72.3 168.5 75.7 179.1 76.6 192.8 74.5 196.6 72.3 193.6 70.6 179.6 68.1 168.1",
+      "28.5 195.7 30.2 195.7 33.6 201.7 30.6 220 28.5 213.6 26.8 198.3",
+      "69.8 195.7 71.9 195.7 73.6 198.3 71.9 213.2 70.2 219.6 67.2 202.1",
+    ],
+  },
+];
+
+const BACK_NEUTRAL: AtlasNeutralShape[] = [
+  {
+    id: "head",
+    points:
+      "50.6 0 46 0.9 40.9 5.5 40.4 12.8 45.1 20 55.7 20 59.1 13.6 59.6 4.7 55.7 1.3",
+  },
+  { id: "knee-left", points: "34.5 153.2 31.1 159.1 33.6 166.4 37.4 162.6" },
+  { id: "knee-right", points: "66.4 153.6 63 163 66.8 166.4 69.4 159.1" },
+];
+
+const FRONT_LABELS: AtlasLabelSlot[] = [
+  { id: "neck", column: "L", y: 26 },
+  { id: "front-deltoids", column: "L", y: 44 },
+  { id: "chest", column: "L", y: 62 },
+  { id: "biceps", column: "L", y: 82 },
+  { id: "forearm", column: "L", y: 100 },
+  { id: "obliques", column: "R", y: 62 },
+  { id: "abs", column: "R", y: 80 },
+  { id: "adductor", column: "R", y: 112 },
+  { id: "quadriceps", column: "R", y: 134 },
+  { id: "calves", column: "R", y: 185 },
+];
+
+const BACK_LABELS: AtlasLabelSlot[] = [
+  { id: "trapezius", column: "L", y: 26 },
+  { id: "back-deltoids", column: "L", y: 44 },
+  { id: "triceps", column: "L", y: 64 },
+  { id: "upper-back", column: "L", y: 84 },
+  { id: "forearm", column: "L", y: 104 },
+  { id: "lower-back", column: "R", y: 86 },
+  { id: "gluteal", column: "R", y: 112 },
+  { id: "abductors", column: "R", y: 134 },
+  { id: "hamstring", column: "R", y: 156 },
+  { id: "calves", column: "R", y: 188 },
+];
+
+/** Geometry for both views, keyed by canonical `BodyAtlasSide`. */
+export const BODY_ATLAS_GEOMETRY: Record<BodyAtlasSide, AtlasSideGeometry> = {
+  front: {
+    muscles: FRONT_MUSCLES,
+    neutral: FRONT_NEUTRAL,
+    labels: FRONT_LABELS,
+  },
+  back: { muscles: BACK_MUSCLES, neutral: BACK_NEUTRAL, labels: BACK_LABELS },
+};
+
+/**
+ * Average centroid of a muscle group (mean of every vertex across all its
+ * polygons). Used to anchor leader-line labels — recomputed from geometry
+ * so swapping in a richer asset needs no hand-tuned label coordinates.
+ */
+export function atlasGroupCentroid(polygons: string[]): [number, number] {
+  let x = 0;
+  let y = 0;
+  let count = 0;
+  for (const poly of polygons) {
+    const nums = poly.trim().split(/\s+/).map(Number);
+    for (let i = 0; i + 1 < nums.length; i += 2) {
+      x += nums[i] ?? 0;
+      y += nums[i + 1] ?? 0;
+      count += 1;
+    }
+  }
+  if (count === 0) return [0, 0];
+  return [x / count, y / count];
+}

--- a/packages/fizruk-domain/src/data/index.ts
+++ b/packages/fizruk-domain/src/data/index.ts
@@ -15,6 +15,10 @@ import type { ExerciseDef } from "../domain/types.js";
 // into by default, and the import attribute proposal is a runtime-only
 // hint that the bundled JSON emitters already honour.
 import exercisesCatalog from "./exercises.gymup.json";
+import { mapDomainMuscleToAtlas } from "./bodyAtlas.js";
+
+export * from "./bodyAtlas.js";
+export * from "./bodyAtlasGeometry.js";
 
 /** JSON-каталог «як є» (з `labels` + `exercises`). */
 export interface ExerciseCatalog {
@@ -163,6 +167,31 @@ export function mergeExerciseCatalog(
     if (!id || seen.has(id)) continue;
     seen.add(id);
     out.push(ex);
+  }
+  return out;
+}
+
+/**
+ * Up to `limit` Ukrainian exercise names whose primary muscles map to the
+ * given canonical atlas muscle id. Powers the selected-muscle card in the
+ * BodyAtlas without the web layer re-deriving the muscle→exercise join.
+ */
+export function getExerciseNamesByAtlasMuscle(
+  atlasMuscleId: string,
+  limit = 5,
+): string[] {
+  if (!atlasMuscleId) return [];
+  const out: string[] = [];
+  for (const ex of EXERCISES) {
+    const primary = ex?.muscles?.primary;
+    if (!Array.isArray(primary)) continue;
+    const hit = primary.some(
+      (m) => mapDomainMuscleToAtlas(m) === atlasMuscleId,
+    );
+    if (!hit) continue;
+    const name = ex?.name?.uk;
+    if (name && !out.includes(name)) out.push(name);
+    if (out.length >= limit) break;
   }
   return out;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -595,9 +595,6 @@ importers:
       better-auth:
         specifier: ^1.6.14
         version: 1.6.14(@opentelemetry/api@1.9.1)(better-sqlite3@12.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(expo-sqlite@15.1.4(expo@52.0.49(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@18.3.29)(react@18.3.1)))(graphql@16.14.0)(react-native@0.76.9(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@18.3.29)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@types/react@18.3.29)(react@18.3.1))(react@18.3.1))(kysely@0.28.17)(pg@8.20.0))(pg@8.20.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@4.1.5)
-      body-highlighter:
-        specifier: ^3.0.2
-        version: 3.0.2
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -6425,10 +6422,6 @@ packages:
 
   bn.js@4.12.3:
     resolution: {integrity: sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==}
-
-  body-highlighter@3.0.2:
-    resolution: {integrity: sha512-1V32BDCbdEoFL/y3yr3xyO98u3SLPlcRjvbJy0/47E5gKmYezf8w+Hzsnm5M0vu92rArTOPNu0vawEdvruDhcQ==}
-    engines: {node: '>=18'}
 
   body-parser@1.20.5:
     resolution: {integrity: sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==}
@@ -19587,8 +19580,6 @@ snapshots:
   bluebird@3.7.2: {}
 
   bn.js@4.12.3: {}
-
-  body-highlighter@3.0.2: {}
 
   body-parser@1.20.5:
     dependencies:


### PR DESCRIPTION
## Summary

Повний редизайн атласу мʼязів у Фізруку. Imperative-рендер через `body-highlighter` (DOM-маніпуляція поза React) замінено на **чистий React SVG**, керований даними відновлення.

- **Геометрія в домен.** Анатомічні полігони (вендорнуті з MIT `body-highlighter`) заморожено як статичні дані у `@sergeant/fizruk-domain` ([`bodyAtlasGeometry.ts`](packages/fizruk-domain/src/data/bodyAtlasGeometry.ts)) — спільний контракт для web (`<svg>`) і майбутнього mobile (`react-native-svg`). Залежність `body-highlighter` прибрано.
- **Continuous heat map** (`success → warning → danger`) на полі `fatigue` замість 3 кольорів-buckets. Режими фільтра: відновлення / останнє тренування / обʼєм 7д; виноски-лейбли + легенда, що змінюється з режимом.
- **A11y.** Кожна група мʼязів — focusable `role="button"` + `aria-label`; sr-only паралельний список (audit F2 hack) видалено. `<title>` для hover.
- **Картка мʼяза**: статус, давність, обʼєм 7д, втома, вправи з каталогу.
- **DRY.** Fold domain→atlas зведено в один доменний `aggregateRecoveryToAtlas` + web-хелпер `buildAtlasData`; дубльований inline-маппінг прибрано з `Atlas.tsx` **і** `RecoveryFocusCard.tsx` (compact-варіант переюзає той самий рендерер). Раніше було 3 копії маппінгу — стало 1.

## Governing Skill

`sergeant-web-ui` (поверхня `apps/web/**`, RQ-keys/design-tokens/a11y) + `sergeant-data-and-migrations` дотик через `@sergeant/fizruk-domain` (без міграцій — лише pure data/logic).

## Playbook

Немає окремого playbook під фіче-редизайн модульного компонента; слідував surface-routing + hard rules.

## Verification

Локально на NTFS-worktree (E:):
- `pnpm --filter @sergeant/fizruk-domain typecheck` ✅
- `pnpm --filter @sergeant/web typecheck` ✅
- domain tests: **334/334** ✅ (вкл. `bodyAtlas.test.ts`)
- `BodyAtlas.test.tsx`: **8/8** ✅ (переписаний під новий контракт)
- `eslint` на торкнутих файлах ✅ (виправлено `prefer-text-style` + `no-rounded-lg`)
- `prettier --write` застосовано
- `pnpm-lock.yaml` регенеровано (`pnpm install --lockfile-only`) — `body-highlighter` повністю прибрано
- Повний `build` / `size-limit` / Lighthouse — лишаю на CI. Видалення залежності зменшує бандл, не збільшує.

Скриншоти UI — прототип узгоджено з власником ітеративно в чаті перед імплементацією (anatomical SVG, режими, картка).

## Docs and Governance

- Hard Rule #1 (bigint→number): не застосовно — дані вже `number`.
- Hard Rule #2 (RQ keys): новий код не додає inline query-keys.
- Hard Rule #8/#9/#11/#14/#16 (design): heat-кольори — inline SVG `fill`/`style`, не `className` (без arbitrary hex у класах); фокус — нативний на focusable `<g>`; типографіка через `text-style-label`; radius через `rounded-md`/`rounded-2xl`.
- Hard Rule #18 (max-lines 600): web `BodyAtlas.tsx` ~330 рядків.

## Risk and Rollout

Низький. Зміна ізольована в модулі Фізрука (`Atlas` page + dashboard `RecoveryFocusCard` preview). Доменний keyspace незмінний — mobile не зачеплено (перейде на shared-геометрію окремим PR). CTA «Підказати тренування» — опційний проп, наразі прихований (підключиться до coach пізніше). Rollback — revert одного коміту.

## Hard Rule #15

Прочитав governance перед кодом; внутрішні коментарі/доки — де доречно; зміни доку поруч із кодом (оновлено застарілі body-highlighter-згадки в `themeHex.ts` і header `bodyAtlas.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the Body Atlas with a pure React SVG heat map driven by recovery data. Drops `body-highlighter`, centralizes geometry and mapping in `@sergeant/fizruk-domain`, and improves a11y and muscle detail.

- **New Features**
  - Continuous heat map (success → warning → danger) with modes: recovery, last-trained, 7d volume.
  - Leader-line labels, mode-aware legend, and front/back side toggle.
  - Focusable muscle groups (role="button" + Ukrainian `aria-label`), hover `<title>`.
  - Selected muscle card: status, days since, 7d volume, fatigue %, and exercise chips.
  - Compact variant for the dashboard preview.

- **Refactors**
  - Vendored anatomical polygons into `@sergeant/fizruk-domain` (`bodyAtlasGeometry.ts`) and switched to a pure `<svg>` renderer.
  - Added `aggregateRecoveryToAtlas` (domain) and `buildAtlasData` (web) to DRY the domain→atlas fold; removed duplicated mapping in Atlas and RecoveryFocusCard.
  - Removed `body-highlighter` from `apps/web` and `pnpm-lock.yaml` to reduce bundle size.

<sup>Written for commit 8831d86ba9b882d9727907a111909e5eae8b7193. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

