### PR TITLE
fix(fizruk-domain): anchor ISO-week boundaries to Europe/Kyiv via shared helper

### DIFF
--- a/apps/web/src/modules/fizruk/pages/Progress.tsx
+++ b/apps/web/src/modules/fizruk/pages/Progress.tsx
@@ -14,18 +14,11 @@ import { MiniLineChart } from "../components/MiniLineChart";
 import { WellbeingChart } from "../components/WellbeingChart";
 import { WeeklyVolumeChart } from "../components/WeeklyVolumeChart";
 import { epley1rm, weeklyVolumeSeriesNow } from "@sergeant/fizruk-domain";
+import { kyivMondayStartMs } from "@sergeant/shared/utils";
 import { statusColors } from "@shared/charts";
 import { Card } from "@shared/components/ui/Card";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Stat } from "@shared/components/ui/Stat";
-import { getKyivWeekStart } from "@shared/lib/time/kyivTime";
-
-function weekStartMs(d: number | string | Date) {
-  // Domain-correct (Kyiv) week boundary so weekly-volume bars don't
-  // shift when the user roams (consolidated page-audit § Theme 1 — 07 F1).
-  const ts = typeof d === "number" ? d : new Date(d).getTime();
-  return getKyivWeekStart(ts).getTime();
-}
 
 // F36: minimum bar width (%) so the smallest muscle-volume bar stays
 // visible and tap-able even when its value is a tiny fraction of the max.
@@ -96,7 +89,9 @@ export function Progress({ onNavigate }: ProgressProps) {
     for (const w of workouts || []) {
       const t = w.startedAt ? Date.parse(w.startedAt) : NaN;
       if (!Number.isFinite(t) || t < cutoff) continue;
-      const wk = weekStartMs(t);
+      // Domain-correct (Kyiv) week boundary so weekly-volume bars don't
+      // shift when the user roams (consolidated page-audit § Theme 1 — 07 F1).
+      const wk = kyivMondayStartMs(t);
       if (!weeks.has(wk)) weeks.set(wk, {});
       const bucket = weeks.get(wk);
       if (!bucket) continue;

--- a/apps/web/src/modules/fizruk/pages/Progress.tsx
+++ b/apps/web/src/modules/fizruk/pages/Progress.tsx
@@ -14,7 +14,7 @@ import { MiniLineChart } from "../components/MiniLineChart";
 import { WellbeingChart } from "../components/WellbeingChart";
 import { WeeklyVolumeChart } from "../components/WeeklyVolumeChart";
 import { epley1rm, weeklyVolumeSeriesNow } from "@sergeant/fizruk-domain";
-import { kyivMondayStartMs } from "@sergeant/shared/utils";
+import { kyivMondayStartMs } from "@sergeant/shared";
 import { statusColors } from "@shared/charts";
 import { Card } from "@shared/components/ui/Card";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";

--- a/apps/web/src/shared/lib/time/kyivTime.ts
+++ b/apps/web/src/shared/lib/time/kyivTime.ts
@@ -19,7 +19,7 @@
  * @see docs/audits/2026-05-13-consolidated-page-audit.md § Theme 1
  */
 
-import { kyivMondayStartMs } from "@sergeant/shared/utils";
+import { kyivMondayStartMs } from "@sergeant/shared";
 
 const KYIV_TZ = "Europe/Kyiv";
 

--- a/apps/web/src/shared/lib/time/kyivTime.ts
+++ b/apps/web/src/shared/lib/time/kyivTime.ts
@@ -19,6 +19,8 @@
  * @see docs/audits/2026-05-13-consolidated-page-audit.md § Theme 1
  */
 
+import { kyivMondayStartMs } from "@sergeant/shared/utils";
+
 const KYIV_TZ = "Europe/Kyiv";
 
 /**
@@ -177,22 +179,14 @@ export function parseKyivDate(key: string): Date | null {
  * Monday-anchored week start (00:00 Kyiv local) for the week containing
  * `input`. Matches ISO-8601 week convention used by `date.getDay()`
  * with the Monday-first remapping `(getDay() + 6) % 7`.
+ *
+ * Delegates to the monorepo-wide `kyivMondayStartMs` so packages
+ * (`fizruk-domain` weekly buckets) and web pages share one DST-safe
+ * implementation — the previous local `dayStart − N×24h` step-back drifted
+ * one hour on weeks containing a DST transition.
  */
 export function getKyivWeekStart(input?: Date | number): Date {
-  const { year, month, day, weekday } = getKyivDateParts(input);
-  // `weekday` is 0=Sun..6=Sat; offset to Monday-anchored
-  const mondayOffset = (weekday + 6) % 7;
-  const dayKey = `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
-  const dayStart = parseKyivDate(dayKey);
-  if (!dayStart) {
-    // Should never happen — `getKyivDateParts` returned a valid date,
-    // so `parseKyivDate` must accept it. Fall back to host-local midnight
-    // to avoid throwing, but this is a hard logic error if it ever fires.
-    const d = coerce(input);
-    d.setHours(0, 0, 0, 0);
-    return d;
-  }
-  return new Date(dayStart.getTime() - mondayOffset * 24 * 60 * 60 * 1000);
+  return new Date(kyivMondayStartMs(coerce(input)));
 }
 
 /**

--- a/packages/fizruk-domain/package.json
+++ b/packages/fizruk-domain/package.json
@@ -22,6 +22,9 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage"
   },
+  "dependencies": {
+    "@sergeant/shared": "workspace:*"
+  },
   "devDependencies": {
     "@sergeant/config": "workspace:*",
     "@types/node": "^20.19.41",

--- a/packages/fizruk-domain/src/domain/dashboard/dashboardKpis.test.ts
+++ b/packages/fizruk-domain/src/domain/dashboard/dashboardKpis.test.ts
@@ -128,6 +128,36 @@ describe("computeWeeklyTotals", () => {
       volumeKg: 250,
     });
   });
+
+  // Domain invariant: week boundaries are Europe/Kyiv, not the host tz.
+  // Mon 2026-06-08 00:00 Kyiv (EEST, UTC+3) = 2026-06-07T21:00:00Z.
+  it("anchors the week boundary to Europe/Kyiv regardless of host tz", () => {
+    const now = new Date("2026-06-10T12:00:00Z"); // Wed of that week
+    const workouts = [
+      strengthWorkout("2026-06-07T20:30:00Z", [[100, 1]]), // Sun 23:30 Kyiv → out
+      strengthWorkout("2026-06-07T21:30:00Z", [[60, 5]]), // Mon 00:30 Kyiv → in
+    ];
+    expect(computeWeeklyTotals(workouts, now)).toEqual({
+      count: 1,
+      volumeKg: 300,
+    });
+  });
+
+  // DST week: Kyiv springs forward Sun 2026-03-29 03:00 EET → 04:00 EEST,
+  // so this week is 167 hours long. A naive `weekStart + 7×24h` end bound
+  // would leak the first hour of next Monday into the current week.
+  it("keeps the 167-hour spring-forward DST week tight at both ends", () => {
+    const now = new Date("2026-03-25T12:00:00Z"); // Wed of DST week
+    const workouts = [
+      strengthWorkout("2026-03-22T22:30:00Z", [[60, 5]]), // Mon 00:30 Kyiv (EET) → in
+      strengthWorkout("2026-03-29T20:30:00Z", [[100, 1]]), // Sun 23:30 Kyiv (EEST) → in
+      strengthWorkout("2026-03-29T21:30:00Z", [[999, 1]]), // Mon 00:30 Kyiv next week → out
+    ];
+    expect(computeWeeklyTotals(workouts, now)).toEqual({
+      count: 2,
+      volumeKg: 60 * 5 + 100,
+    });
+  });
 });
 
 describe("computeWeightChangeKg", () => {

--- a/packages/fizruk-domain/src/domain/dashboard/dashboardKpis.ts
+++ b/packages/fizruk-domain/src/domain/dashboard/dashboardKpis.ts
@@ -17,6 +17,8 @@
  *    window (default 30 days).
  */
 
+import { kyivMondayStartMs } from "@sergeant/shared/utils";
+
 import type {
   DashboardKpis,
   DashboardMeasurementInput,
@@ -40,14 +42,6 @@ function localYmdKey(ms: number): string {
   const m = String(d.getMonth() + 1).padStart(2, "0");
   const day = String(d.getDate()).padStart(2, "0");
   return `${y}-${m}-${day}`;
-}
-
-function mondayStartMs(ms: number): number {
-  const d = new Date(ms);
-  d.setHours(0, 0, 0, 0);
-  const dow = (d.getDay() + 6) % 7; // 0 = Mon
-  d.setDate(d.getDate() - dow);
-  return d.getTime();
 }
 
 function isCompletedWorkout(
@@ -134,6 +128,7 @@ export function computeStreakDays(
 
 /**
  * Current Mon-first-week counts (completed workouts + volume).
+ * Week boundaries are anchored to Europe/Kyiv (domain invariant).
  */
 export function computeWeeklyTotals(
   workouts: readonly DashboardWorkoutInput[] | null | undefined,
@@ -142,8 +137,13 @@ export function computeWeeklyTotals(
   const list = Array.isArray(workouts) ? workouts : [];
   if (list.length === 0) return { count: 0, volumeKg: 0 };
 
-  const weekStart = mondayStartMs(now.getTime());
-  const weekEnd = weekStart + 7 * MS_PER_DAY;
+  const weekStart = kyivMondayStartMs(now.getTime());
+  // Не `weekStart + 7×24h`: DST-тиждень триває 167/169 год. Середина
+  // наступного понеділка (±1h DST-люфт не виводить за межі дня) → його
+  // київський старт.
+  const weekEnd = kyivMondayStartMs(
+    weekStart + 7 * MS_PER_DAY + MS_PER_DAY / 2,
+  );
 
   let count = 0;
   let volumeKg = 0;

--- a/packages/fizruk-domain/src/domain/dashboard/dashboardKpis.ts
+++ b/packages/fizruk-domain/src/domain/dashboard/dashboardKpis.ts
@@ -17,7 +17,7 @@
  *    window (default 30 days).
  */
 
-import { kyivMondayStartMs } from "@sergeant/shared/utils";
+import { kyivMondayStartMs } from "@sergeant/shared";
 
 import type {
   DashboardKpis,

--- a/packages/fizruk-domain/src/domain/workouts/exerciseDetail.test.ts
+++ b/packages/fizruk-domain/src/domain/workouts/exerciseDetail.test.ts
@@ -175,7 +175,46 @@ describe("computeExerciseBest", () => {
 });
 
 describe("computeExerciseWeeklyTrend", () => {
-  it("buckets sessions by local Monday and caps at 12 weeks", () => {
+  // Domain invariant: week buckets are Europe/Kyiv-anchored.
+  // Mon 2026-06-08 00:00 Kyiv (EEST, UTC+3) = 2026-06-07T21:00:00Z.
+  it("splits Sun 23:30 vs Mon 00:30 (Kyiv) into separate week buckets", () => {
+    const history = [
+      {
+        // Mon 2026-06-08 00:30 Kyiv → bucket 2026-06-08
+        workout: w("w_mon", "2026-06-07T21:30:00Z", []),
+        item: strength("i_mon", "squat", [{ weightKg: 60, reps: 5 }]),
+      },
+      {
+        // Sun 2026-06-07 23:30 Kyiv → bucket 2026-06-01
+        workout: w("w_sun", "2026-06-07T20:30:00Z", []),
+        item: strength("i_sun", "squat", [{ weightKg: 100, reps: 1 }]),
+      },
+    ];
+    const { rmPoints } = computeExerciseWeeklyTrend(history);
+    expect(rmPoints.map((p) => p.weekKey)).toEqual([
+      "2026-06-01",
+      "2026-06-08",
+    ]);
+    // The label must show the Kyiv Monday's day-of-month even for users
+    // west of Kyiv (Kyiv Mon 00:00 is still Sunday in UTC and westwards).
+    expect(rmPoints[0]!.dateLabel).toMatch(/^1\s/);
+    expect(rmPoints[1]!.dateLabel).toMatch(/^8\s/);
+  });
+
+  // DST week: Kyiv springs forward Sun 2026-03-29 03:00 EET → 04:00 EEST.
+  it("keeps the spring-forward DST Sunday inside its Kyiv week bucket", () => {
+    const history = [
+      {
+        // Sun 2026-03-29 23:30 Kyiv (EEST) → bucket Mon 2026-03-23
+        workout: w("w_dst", "2026-03-29T20:30:00Z", []),
+        item: strength("i_dst", "squat", [{ weightKg: 80, reps: 3 }]),
+      },
+    ];
+    const { rmPoints } = computeExerciseWeeklyTrend(history);
+    expect(rmPoints.map((p) => p.weekKey)).toEqual(["2026-03-23"]);
+  });
+
+  it("buckets sessions by Kyiv Monday and caps at 12 weeks", () => {
     const history = [
       {
         // Wed 2026-04-08 groups with Mon 2026-04-06

--- a/packages/fizruk-domain/src/domain/workouts/exerciseDetail.ts
+++ b/packages/fizruk-domain/src/domain/workouts/exerciseDetail.ts
@@ -16,7 +16,7 @@
  * helpers in `@sergeant/shared`.
  */
 
-import { kyivMondayStartMs, toLocalISODate } from "@sergeant/shared/utils";
+import { kyivMondayStartMs, toLocalISODate } from "@sergeant/shared";
 
 import {
   epley1rm,

--- a/packages/fizruk-domain/src/domain/workouts/exerciseDetail.ts
+++ b/packages/fizruk-domain/src/domain/workouts/exerciseDetail.ts
@@ -9,10 +9,14 @@
  *   - cardio (distance) trend buckets (pace / distance),
  *   - load-calculator zones (strength / hypertrophy / endurance).
  *
- * Kept DOM-free: no `window` / `localStorage` / `Intl.DateTimeFormat`
- * consumers here. Date labels are formatted via `Date#toLocaleDateString`
- * which is safe in Node and React Native runtimes.
+ * Kept DOM-free: no `window` / `localStorage` consumers here. Date labels
+ * are formatted via `Date#toLocaleDateString` (with an explicit
+ * `Europe/Kyiv` timeZone — domain invariant) which is safe in Node and
+ * React Native runtimes; week buckets come from the shared Kyiv-anchored
+ * helpers in `@sergeant/shared`.
  */
+
+import { kyivMondayStartMs, toLocalISODate } from "@sergeant/shared/utils";
 
 import {
   epley1rm,
@@ -51,9 +55,16 @@ function toNum(v: unknown): number {
 
 function formatUkDateShort(d: Date): string {
   try {
-    return d.toLocaleDateString("uk-UA", { day: "numeric", month: "short" });
+    // Explicit Kyiv timezone: week starts are Kyiv Monday 00:00, which is
+    // still Sunday evening in UTC and westwards — rendering in the runtime
+    // timezone would shift the label a day back for those users.
+    return d.toLocaleDateString("uk-UA", {
+      day: "numeric",
+      month: "short",
+      timeZone: "Europe/Kyiv",
+    });
   } catch {
-    // Fallback for minimal ICU runtimes — YYYY-MM-DD prefix.
+    // Fallback for minimal ICU runtimes — host-local DD.MM (best effort).
     const pad = (n: number) => String(n).padStart(2, "0");
     return `${pad(d.getDate())}.${pad(d.getMonth() + 1)}`;
   }
@@ -228,25 +239,7 @@ export function computeExerciseBest(
 }
 
 /**
- * Start-of-Monday local-time timestamp for the given date (ms). Uses
- * the local tz, matching the web page's `getDay() - ((+6)%7)` trick.
- */
-function mondayStartLocalMs(d: Date): number {
-  const x = new Date(d);
-  const offset = (x.getDay() + 6) % 7;
-  x.setHours(0, 0, 0, 0);
-  x.setDate(x.getDate() - offset);
-  return x.getTime();
-}
-
-function weekKeyFromMondayMs(ms: number): string {
-  const d = new Date(ms);
-  const pad = (n: number) => String(n).padStart(2, "0");
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
-}
-
-/**
- * Group the strength history into Monday-starting weekly buckets and
+ * Group the strength history into Monday-starting (Europe/Kyiv) weekly buckets and
  * return up to the **last 12** buckets as two aligned series:
  *  - `rmPoints.value` = round(max Epley-1RM in the week, kg);
  *  - `volPoints.value` = round(sum of `weightKg × reps`, kg).
@@ -266,8 +259,8 @@ export function computeExerciseWeeklyTrend(
     if (!iso) continue;
     const t = Date.parse(iso);
     if (!Number.isFinite(t)) continue;
-    const weekStart = mondayStartLocalMs(new Date(t));
-    const key = weekKeyFromMondayMs(weekStart);
+    const weekStart = kyivMondayStartMs(t);
+    const key = toLocalISODate(weekStart);
     const sets = Array.isArray(item.sets) ? item.sets : [];
     let maxRm = 0;
     let vol = 0;

--- a/packages/fizruk-domain/src/lib/workoutStats.test.ts
+++ b/packages/fizruk-domain/src/lib/workoutStats.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   completedWorkoutsCount,
+  countCompletedInCurrentWeek,
   formatCompactKg,
   getExercisePR,
   personalRecordsExerciseCount,
@@ -61,9 +62,78 @@ describe("personalRecordsExerciseCount", () => {
 });
 
 describe("weeklyVolumeSeriesNow", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("returns 7 volume slots", () => {
     const { volumeKg } = weeklyVolumeSeriesNow([]);
     expect(volumeKg).toHaveLength(7);
+  });
+
+  function done(startedAt: string, weightKg: number, reps: number) {
+    return {
+      startedAt,
+      endedAt: startedAt,
+      items: [{ type: "strength", sets: [{ weightKg, reps }] }],
+    };
+  }
+
+  // Domain invariant: week boundaries are Europe/Kyiv, not the host tz.
+  // Mon 2026-06-08 00:00 Kyiv (EEST, UTC+3) = 2026-06-07T21:00:00Z.
+  it("anchors the Mon..Sun week to Europe/Kyiv regardless of host tz", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-10T12:00:00Z")); // Wed of that week
+
+    const { weekStartMs, volumeKg } = weeklyVolumeSeriesNow([
+      done("2026-06-07T20:30:00Z", 100, 1), // Sun 23:30 Kyiv → previous week
+      done("2026-06-07T21:30:00Z", 60, 5), // Mon 00:30 Kyiv → idx 0
+      done("2026-06-10T10:00:00Z", 40, 10), // Wed 13:00 Kyiv → idx 2
+    ]);
+
+    expect(weekStartMs).toBe(Date.parse("2026-06-07T21:00:00Z"));
+    expect(volumeKg).toEqual([300, 0, 400, 0, 0, 0, 0]);
+  });
+
+  // DST week: Kyiv springs forward Sun 2026-03-29 03:00 EET → 04:00 EEST,
+  // so the week Mon 2026-03-23 .. Sun 2026-03-29 is 167 hours long.
+  it("buckets days correctly across the spring-forward DST week", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-26T12:00:00Z")); // Thu of DST week
+
+    const { weekStartMs, volumeKg } = weeklyVolumeSeriesNow([
+      done("2026-03-22T22:30:00Z", 60, 5), // Mon 00:30 Kyiv (EET) → idx 0
+      done("2026-03-29T20:30:00Z", 100, 1), // Sun 23:30 Kyiv (EEST) → idx 6
+      done("2026-03-29T21:30:00Z", 999, 1), // Mon 00:30 Kyiv next week → out
+    ]);
+
+    // Mon 2026-03-23 00:00 Kyiv (EET, UTC+2) = 2026-03-22T22:00:00Z.
+    expect(weekStartMs).toBe(Date.parse("2026-03-22T22:00:00Z"));
+    expect(volumeKg).toEqual([300, 0, 0, 0, 0, 0, 100]);
+  });
+});
+
+describe("countCompletedInCurrentWeek", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("uses the Kyiv week boundary, not the host-local one", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-10T12:00:00Z"));
+
+    const mk = (startedAt: string) => ({
+      startedAt,
+      endedAt: startedAt,
+      items: [],
+    });
+    expect(
+      countCompletedInCurrentWeek([
+        mk("2026-06-07T20:30:00Z"), // Sun 23:30 Kyiv → previous week
+        mk("2026-06-07T21:30:00Z"), // Mon 00:30 Kyiv → this week
+        mk("2026-06-12T10:00:00Z"), // Fri → this week
+      ]),
+    ).toBe(2);
   });
 });
 

--- a/packages/fizruk-domain/src/lib/workoutStats.ts
+++ b/packages/fizruk-domain/src/lib/workoutStats.ts
@@ -1,6 +1,6 @@
 /** Pure helpers for dashboard / analytics (kg, Kyiv-anchored week Mon–Sun). */
 
-import { kyivDayStartMs, kyivMondayStartMs } from "@sergeant/shared/utils";
+import { kyivDayStartMs, kyivMondayStartMs } from "@sergeant/shared";
 
 interface StatsSet {
   weightKg?: number | null | undefined;

--- a/packages/fizruk-domain/src/lib/workoutStats.ts
+++ b/packages/fizruk-domain/src/lib/workoutStats.ts
@@ -1,4 +1,6 @@
-/** Pure helpers for dashboard / analytics (kg, local week Mon–Sun). */
+/** Pure helpers for dashboard / analytics (kg, Kyiv-anchored week Mon–Sun). */
+
+import { kyivDayStartMs, kyivMondayStartMs } from "@sergeant/shared/utils";
 
 interface StatsSet {
   weightKg?: number | null | undefined;
@@ -150,36 +152,34 @@ export function personalRecordsExerciseCount(
   return Object.keys(by).length;
 }
 
-/** Початок поточного ISO-тижня (Пн 00:00) у мс. */
-export function mondayStartMs(d: number | string | Date): number {
-  const x = new Date(d);
-  const day = (x.getDay() + 6) % 7;
-  x.setHours(0, 0, 0, 0);
-  x.setDate(x.getDate() - day);
-  return x.getTime();
-}
-
 const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Індекс дня (0=Пн … 6=Нд) усередині тижня, що починається з `week0`
+ * (Пн 00:00 Europe/Kyiv). `Math.round` навмисний — компенсує 23/25-годинні
+ * DST-дні, де відстань між стартами днів не кратна рівно 24 год.
+ */
+function kyivDayIndexInWeek(t: number, week0: number): number {
+  return Math.round((kyivDayStartMs(t) - week0) / DAY_MS);
+}
 
 export interface WeeklyVolumeSeries {
   weekStartMs: number;
   volumeKg: number[];
 }
 
-/** 7 значень (Пн…Нд) для поточного календарного тижня, кг×повторення за день. */
+/** 7 значень (Пн…Нд) для поточного календарного тижня (Europe/Kyiv), кг×повторення за день. */
 export function weeklyVolumeSeriesNow(
   workouts: readonly StatsWorkout[] | null | undefined,
 ): WeeklyVolumeSeries {
-  const week0 = mondayStartMs(Date.now());
+  const week0 = kyivMondayStartMs(Date.now());
   const vol = [0, 0, 0, 0, 0, 0, 0];
 
   for (const w of workouts || []) {
     if (!w.endedAt) continue;
     const t = w.startedAt ? Date.parse(w.startedAt) : NaN;
     if (!Number.isFinite(t)) continue;
-    const d = new Date(t);
-    const d0 = new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
-    const idx = Math.round((d0 - week0) / DAY_MS);
+    const idx = kyivDayIndexInWeek(t, week0);
     if (idx < 0 || idx > 6) continue;
     // Під strict-index `vol[idx]` дає `number | undefined`, хоча
     // інваріант 0..6 гарантує визначеність — narrow-имо явно через
@@ -205,15 +205,13 @@ export function completedWorkoutsCount(
 export function countCompletedInCurrentWeek(
   workouts: readonly StatsWorkout[] | null | undefined,
 ): number {
-  const week0 = mondayStartMs(Date.now());
+  const week0 = kyivMondayStartMs(Date.now());
   let n = 0;
   for (const w of workouts || []) {
     if (!w.endedAt) continue;
     const t = w.startedAt ? Date.parse(w.startedAt) : NaN;
     if (!Number.isFinite(t)) continue;
-    const d = new Date(t);
-    const d0 = new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
-    const idx = Math.round((d0 - week0) / DAY_MS);
+    const idx = kyivDayIndexInWeek(t, week0);
     if (idx >= 0 && idx <= 6) n += 1;
   }
   return n;

--- a/packages/shared/src/utils/date.test.ts
+++ b/packages/shared/src/utils/date.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { toLocalISODate } from "./date";
+import { kyivDayStartMs, kyivMondayStartMs, toLocalISODate } from "./date";
 
 describe("shared/lib/date – toLocalISODate", () => {
   it("formats a Date object with zero-padded month and day", () => {
@@ -41,5 +41,88 @@ describe("shared/lib/date – toLocalISODate", () => {
   it("handles year boundaries correctly", () => {
     expect(toLocalISODate(new Date(2024, 11, 31))).toBe("2024-12-31");
     expect(toLocalISODate(new Date(2025, 0, 1))).toBe("2025-01-01");
+  });
+});
+
+// All expectations below are expressed as UTC instants so they hold under
+// any host timezone — the helpers must be anchored to Europe/Kyiv only.
+describe("shared/lib/date – kyivDayStartMs", () => {
+  it("returns Kyiv midnight of the day containing the instant (EEST, UTC+3)", () => {
+    // 2026-06-10 15:00 Kyiv → day start 2026-06-10 00:00 Kyiv = 09T21:00Z
+    expect(kyivDayStartMs("2026-06-10T12:00:00Z")).toBe(
+      Date.parse("2026-06-09T21:00:00Z"),
+    );
+  });
+
+  it("rolls into the next Kyiv day before the UTC day does", () => {
+    // 2026-06-07T21:30Z = Mon 2026-06-08 00:30 Kyiv
+    expect(kyivDayStartMs("2026-06-07T21:30:00Z")).toBe(
+      Date.parse("2026-06-07T21:00:00Z"),
+    );
+  });
+
+  it("is exact on the spring-forward day (2026-03-29, 23h long)", () => {
+    // Sun 2026-03-29 12:00 Kyiv (EEST after the 03:00→04:00 jump) = 09:00Z;
+    // that day's midnight was still EET: 2026-03-28T22:00:00Z.
+    expect(kyivDayStartMs("2026-03-29T09:00:00Z")).toBe(
+      Date.parse("2026-03-28T22:00:00Z"),
+    );
+  });
+
+  it("is exact on the fall-back day (2026-10-25, 25h long)", () => {
+    // Sun 2026-10-25 12:00 Kyiv (EET after the 04:00→03:00 roll-back) = 10:00Z;
+    // that day's midnight was still EEST: 2026-10-24T21:00:00Z.
+    expect(kyivDayStartMs("2026-10-25T10:00:00Z")).toBe(
+      Date.parse("2026-10-24T21:00:00Z"),
+    );
+  });
+
+  it("returns NaN for unparseable input", () => {
+    expect(kyivDayStartMs("not-a-date")).toBeNaN();
+    expect(kyivDayStartMs(NaN)).toBeNaN();
+  });
+});
+
+describe("shared/lib/date – kyivMondayStartMs", () => {
+  // Mon 2026-06-08 00:00 Kyiv (EEST) = 2026-06-07T21:00:00Z.
+  const MON_JUN_8 = Date.parse("2026-06-07T21:00:00Z");
+
+  it("Sun 23:30 Kyiv still belongs to the previous week", () => {
+    expect(kyivMondayStartMs("2026-06-07T20:30:00Z")).toBe(
+      Date.parse("2026-05-31T21:00:00Z"), // Mon 2026-06-01 00:00 Kyiv
+    );
+  });
+
+  it("Mon 00:30 Kyiv opens the new week", () => {
+    expect(kyivMondayStartMs("2026-06-07T21:30:00Z")).toBe(MON_JUN_8);
+  });
+
+  it("is idempotent and Monday maps to itself", () => {
+    expect(kyivMondayStartMs(MON_JUN_8)).toBe(MON_JUN_8);
+    expect(kyivMondayStartMs(kyivMondayStartMs("2026-06-12T08:00:00Z"))).toBe(
+      MON_JUN_8,
+    );
+  });
+
+  it("spring-forward week (2026-03-23..29) is 167h and ends on time", () => {
+    const monBefore = Date.parse("2026-03-22T22:00:00Z"); // Mon 23.03 00:00 EET
+    const monAfter = Date.parse("2026-03-29T21:00:00Z"); // Mon 30.03 00:00 EEST
+    // Sunday late evening after the DST jump still belongs to the DST week.
+    expect(kyivMondayStartMs("2026-03-29T20:30:00Z")).toBe(monBefore);
+    // First minutes of the next Kyiv Monday open the next week.
+    expect(kyivMondayStartMs("2026-03-29T21:30:00Z")).toBe(monAfter);
+    expect(monAfter - monBefore).toBe(167 * 60 * 60 * 1000);
+  });
+
+  it("fall-back week (2026-10-19..25) is 169h and ends on time", () => {
+    const monBefore = Date.parse("2026-10-18T21:00:00Z"); // Mon 19.10 00:00 EEST
+    const monAfter = Date.parse("2026-10-25T22:00:00Z"); // Mon 26.10 00:00 EET
+    expect(kyivMondayStartMs("2026-10-25T21:30:00Z")).toBe(monBefore);
+    expect(kyivMondayStartMs("2026-10-25T22:30:00Z")).toBe(monAfter);
+    expect(monAfter - monBefore).toBe(169 * 60 * 60 * 1000);
+  });
+
+  it("returns NaN for unparseable input", () => {
+    expect(kyivMondayStartMs("not-a-date")).toBeNaN();
   });
 });

--- a/packages/shared/src/utils/date.ts
+++ b/packages/shared/src/utils/date.ts
@@ -13,3 +13,112 @@ export function toLocalISODate(d: Date | number | string = new Date()): string {
     dt,
   );
 }
+
+const KYIV_TZ = "Europe/Kyiv";
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const KYIV_CLOCK_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  timeZone: KYIV_TZ,
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+  weekday: "short",
+  hour12: false,
+});
+
+const WEEKDAY_INDEX: Record<string, number> = {
+  Sun: 0,
+  Mon: 1,
+  Tue: 2,
+  Wed: 3,
+  Thu: 4,
+  Fri: 5,
+  Sat: 6,
+};
+
+/** Kyiv wall clock at the given instant: Monday-first weekday index (0=Mon)
+ *  and milliseconds elapsed on the wall clock since Kyiv midnight. */
+function kyivClockOf(ms: number): {
+  mondayIndex: number;
+  wallMsSinceMidnight: number;
+} {
+  let weekday = 0;
+  let h = 0;
+  let m = 0;
+  let s = 0;
+  for (const p of KYIV_CLOCK_FORMATTER.formatToParts(new Date(ms))) {
+    switch (p.type) {
+      case "weekday":
+        weekday = WEEKDAY_INDEX[p.value] ?? 0;
+        break;
+      case "hour":
+        // Some ICU builds render midnight as "24".
+        h = Number(p.value) % 24;
+        break;
+      case "minute":
+        m = Number(p.value);
+        break;
+      case "second":
+        s = Number(p.value);
+        break;
+      default:
+        break;
+    }
+  }
+  const subSecond = ((ms % 1000) + 1000) % 1000;
+  return {
+    mondayIndex: (weekday + 6) % 7,
+    wallMsSinceMidnight: (h * 3600 + m * 60 + s) * 1000 + subSecond,
+  };
+}
+
+function toMs(d: Date | number | string): number {
+  return (d instanceof Date ? d : new Date(d)).getTime();
+}
+
+/**
+ * Start of the **Europe/Kyiv** calendar day (00:00 Kyiv wall clock)
+ * containing the given instant, as a Unix-epoch millisecond timestamp.
+ *
+ * DST-safe: subtracting the wall-clock time-of-day is only a first
+ * approximation (on a DST-transition day wall time ≠ elapsed time), so the
+ * candidate is re-checked against the Kyiv wall clock and corrected by the
+ * residue. Returns `NaN` for unparseable input.
+ */
+export function kyivDayStartMs(d: Date | number | string = Date.now()): number {
+  const ms = toMs(d);
+  if (Number.isNaN(ms)) return NaN;
+  let candidate = ms - kyivClockOf(ms).wallMsSinceMidnight;
+  // Up to two correction passes: a DST shift between the candidate and the
+  // original instant leaves the candidate slightly off midnight (±1h).
+  for (let i = 0; i < 2; i += 1) {
+    const wall = kyivClockOf(candidate).wallMsSinceMidnight;
+    if (wall === 0) break;
+    // Shortly after midnight → step back by the residue; shortly before
+    // midnight of the target day (wall near 24h) → step forward.
+    candidate -= wall <= DAY_MS / 2 ? wall : wall - DAY_MS;
+  }
+  return candidate;
+}
+
+/**
+ * Start of the ISO week (Monday 00:00 **Europe/Kyiv**) containing the given
+ * instant, as a Unix-epoch millisecond timestamp.
+ *
+ * Single source of truth for "this week" bucketing per the domain invariant
+ * (AGENTS.md § Domain invariants): week boundaries are Kyiv-anchored and
+ * Monday-first, never the runtime timezone. DST-safe — stepping back to
+ * Monday goes through that day's local noon, which is immune to the ±1h
+ * wobble of 23/25-hour DST days. Returns `NaN` for unparseable input.
+ */
+export function kyivMondayStartMs(
+  d: Date | number | string = Date.now(),
+): number {
+  const ms = toMs(d);
+  if (Number.isNaN(ms)) return NaN;
+  const { mondayIndex } = kyivClockOf(ms);
+  const dayStart = kyivDayStartMs(ms);
+  if (mondayIndex === 0) return dayStart;
+  const approxMondayNoon = dayStart - mondayIndex * DAY_MS + DAY_MS / 2;
+  return kyivDayStartMs(approxMondayNoon);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -843,6 +843,10 @@ importers:
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@20.19.41)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.3(@types/node@20.19.41)(typescript@6.0.3))(vite@8.0.10(@types/node@20.19.41)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/fizruk-domain:
+    dependencies:
+      '@sergeant/shared':
+        specifier: workspace:*
+        version: link:../shared
     devDependencies:
       '@sergeant/config':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

У Фізрука було **чотири** копії «початку ISO-тижня», і всі рахували тиждень у runtime-таймзоні замість Europe/Kyiv (домен-інваріант, AGENTS.md § Domain invariants):

1. `packages/fizruk-domain/src/lib/workoutStats.ts` — `mondayStartMs()` + бакетинг днів через `new Date(y,m,d)` у локальній TZ;
2. `packages/fizruk-domain/src/domain/dashboard/dashboardKpis.ts` — приватна копія `mondayStartMs` + наївний `weekEnd = weekStart + 7×24h` (тече на DST-тижнях, які тривають 167/169 год);
3. `packages/fizruk-domain/src/domain/workouts/exerciseDetail.ts` — `mondayStartLocalMs` + `weekKeyFromMondayMs` (четверта копія, знайдена в процесі);
4. `apps/web/.../Progress.tsx` — wrapper `weekStartMs` над `getKyivWeekStart`.

Для юзера західніше/східніше Києва це зсувало weekly-volume серію, тижневі KPI дашборда і weekly-trend бакети вправи через межу Нд/Пн.

### Що зроблено

- **Єдиний хелпер:** `kyivMondayStartMs` + `kyivDayStartMs` у `@sergeant/shared/utils` (`packages/shared/src/utils/date.ts`). DST-safe: корекційний цикл обробляє 23/25-годинні дні; крок назад до понеділка йде через локальний полудень дня, нечутливий до ±1h DST-люфту.
- `weeklyVolumeSeriesNow` / `countCompletedInCurrentWeek` (workoutStats), `computeWeeklyTotals` (dashboardKpis, включно з точним `weekEnd` = старт наступного київського понеділка) і `computeExerciseWeeklyTrend` (exerciseDetail) переключені на нього. `@sergeant/fizruk-domain` тепер залежить від `@sergeant/shared` (workspace).
- **Лейбли дат:** `formatUkDateShort` (exerciseDetail) рендерить з явним `timeZone: "Europe/Kyiv"` — київський Пн 00:00 це ще неділя в UTC і західніше, без цього лейбл з'їжджав на день назад.
- **Бонус-фікс:** `getKyivWeekStart` у `apps/web/.../kyivTime.ts` делегує в shared-хелпер — його власний step-back `dayStart − N×24h` дрейфував на 1 год на тижнях із DST-переходом. `Progress.tsx` викликає `kyivMondayStartMs` напряму (wrapper видалено).
- `Math.round` у day-index збережений навмисно — компенсує DST-дні (тепер з пояснювальним коментарем у `kyivDayIndexInWeek`).

### Поза скоупом (відомий борг)

`computeStreakDays` (`localYmdKey`), `programs.weekdayIndex`, `journal.groupWorkoutsByDate` — досі host-TZ-залежні: під `TZ=Pacific/Auckland` падають 7 **існуючих** тестів (відтворюється і на main). Тижневих меж не стосується; кандидат на окремий follow-up.

## Governing Skill

`sergeant-bugfix-and-regression` — root cause → failing-тести (6 нових тестів червоні на старому коді під UTC-хостом) → мінімальний фікс у джерелі.

## Playbook

Немає прямого playbook; виконано за чотирифазним процесом bugfix-скіла.

## Verification

- `pnpm --filter @sergeant/fizruk-domain exec vitest run` — **28 files / 341 tests passed** (UTC); також зелено під `TZ=America/Los_Angeles`.
- `pnpm --filter @sergeant/fizruk-domain typecheck`, `pnpm --filter @sergeant/shared typecheck`, `pnpm --filter @sergeant/web typecheck` — чисто.
- `pnpm --filter @sergeant/shared test` — 737 passed (включно з новими тестами межі тижня Нд 23:30 vs Пн 00:30 Kyiv та обох DST-переходів 2026-03-29 / 2026-10-25).
- apps/web: `kyivTime.test.ts` (25) і весь `src/modules/fizruk` (32 files / 251 tests) — зелено.
- ESLint + Prettier по всіх torkнутих файлах — чисто.

## Docs and Governance

Канонічні доки не змінювались (фікс реалізує вже задокументований інваріант `docs/02-engineering/architecture/domain-invariants.md`). PR-ledger update не потрібен.

## Risk and Rollout

- Поведінкова зміна видима лише юзерам поза Києвом (бакети стають коректними) і на DST-тижнях.
- `mondayStartMs` видалений з public API `@sergeant/fizruk-domain/lib` — grep по монорепо: зовнішніх споживачів не було.
- Rollback: revert одного коміту.

## Hard Rule #15

Прочитано governance до кодингу; доки оновлювати не потрібно — інваріант уже канонічний. Acknowledged.

https://claude.ai/code/session_01TDtc6zxsNzwt3J3FEjcpWy

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDtc6zxsNzwt3J3FEjcpWy)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Anchored ISO-week boundaries to Europe/Kyiv via a shared, DST-safe helper. Fixes shifted weekly buckets in charts and KPIs, unifies week logic across web and domain, and avoids Vite alias issues by importing from the root `@sergeant/shared` barrel.

- **Bug Fixes**
  - Added `kyivMondayStartMs` and `kyivDayStartMs` in `@sergeant/shared` as the single source of truth (DST-safe; 167/169h weeks handled).
  - Switched `weeklyVolumeSeriesNow`, `countCompletedInCurrentWeek`, `computeWeeklyTotals` (end = next Kyiv Monday), and `computeExerciseWeeklyTrend` to the shared helper.
  - Formatted week labels with `timeZone: "Europe/Kyiv"` to prevent a 1‑day slip west of Kyiv.
  - Web: `getKyivWeekStart` now delegates to the shared helper; `Progress.tsx` calls `kyivMondayStartMs` directly. Removed duplicate helpers.
  - Added regression tests across shared and all Fizruk consumers for Sun 23:30 vs Mon 00:30 Kyiv and both DST transitions.

- **Dependencies**
  - `@sergeant/fizruk-domain` now depends on `@sergeant/shared` (workspace).

<sup>Written for commit 0ee092098220905768d51986d516a525d655d37c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

