### PR TITLE
fix(server): keep pino family external in dist-server bundles (deploy hotfix)

### DIFF
--- a/apps/server/build.mjs
+++ b/apps/server/build.mjs
@@ -31,6 +31,13 @@ const base = {
   // dist-server/*.js валить контейнер ERR_MODULE_NOT_FOUND ще на pre-deploy
   // migrate. Саме це поклало всі деплої 2026-06-05…06-12 (прод застряг на
   // образі від 05-23), коли сюди додали `external: ["@sergeant/*"]`.
+  //
+  // pino-сімейство — навпаки, МУСИТЬ лишатись external: worker-транспорти
+  // (pino/file + pino-loki через thread-stream) резолвлять свої runtime-файли
+  // (`worker.js`) відносно пакета на диску, і забандлені падають у контейнері
+  // з ERR_AMBIGUOUS_MODULE_SYNTAX. Це справжні npm-deps сервера — deps-stage
+  // ставить їх у node_modules образу, тож external тут безпечний.
+  external: ["pino", "pino-http", "pino-loki", "pino-pretty"],
 };
 
 await build({


### PR DESCRIPTION
## Summary

Follow-up to #3539 (workspace bundling). The first deploy after that fix got PAST module resolution but died in pre-deploy migrate with `ERR_AMBIGUOUS_MODULE_SYNTAX` inside the bundled pino worker bootstrap (`thread-stream` → `join(__dirname, "worker.js")`). Worker-based pino transports (pino/file + pino-loki) resolve their runtime worker files relative to the package on disk and fundamentally cannot be bundled.

Fix: mark `pino`, `pino-http`, `pino-loki`, `pino-pretty` as esbuild externals. They are real npm dependencies installed into the runtime image's `node_modules` by the deps-stage `pnpm install --prod`, so external is safe — pino resolves its workers normally. Workspace packages (`@sergeant/*`) remain bundled per #3539.

## Governing Skill
`sergeant-deploy-and-observability`.

## Playbook
Hotfix (deploy pipeline).

## Verification
- Local rebuild: 0 residual `@sergeant/*` imports; only `pino*` bare imports remain in bundles.
- `node dist-server/migrate.js` smoke: clean `migrate_database_url_missing` (no module/transport errors).
- Railway deploy log of 6492bf19 (16:03) confirms the exact failure this fixes.

## Docs and Governance
- [x] No governance docs affected. WHY comment added next to the external list.

## Risk and Rollout
One-line bundler config + comment. Current baseline: deploys are red. After merge, watch Railway: pre-deploy must log `migrate_ok`; then `/api/v1/push/vapid-public` should turn 200 (VAPID_EMAIL already set).

## Hard Rule #15 acknowledgement
Read; WHY captured inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mark the `pino` family as external in dist-server bundles so worker transports resolve their runtime `worker.js` from `node_modules`. Fixes the pre-deploy migrate crash (ERR_AMBIGUOUS_MODULE_SYNTAX) caused by bundling `pino`.

- **Bug Fixes**
  - Set `external` in `apps/server/build.mjs` for `pino`, `pino-http`, `pino-loki`, `pino-pretty`; workspace packages remain bundled.

<sup>Written for commit 06bdc2b6e2dd71ff1431b150787e490f716f9074. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated server build configuration to ensure proper runtime handling of logging dependencies in deployed environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->