### PR TITLE
fix(web): resolve sync-writer sqlite client per tick to unbreak sync-v2 delivery

### DIFF
--- a/apps/web/src/core/syncEngine/singleton.ts
+++ b/apps/web/src/core/syncEngine/singleton.ts
@@ -3,6 +3,7 @@ import {
   sweepStaleTerminalOutbox,
 } from "@sergeant/shared";
 import type { RecoverDeadLetterSelector } from "@sergeant/db-schema/sqlite";
+import type { SqliteMigrationClient } from "@sergeant/db-schema/migrate/sqlite";
 
 import { webKVStore } from "@shared/lib/storage/storage";
 
@@ -89,9 +90,6 @@ async function createDefaultRuntime(): Promise<SyncEngineWriterRuntime> {
     import("@sergeant/db-schema/migrate/sqlite"),
   ]);
 
-  const db = await getSqliteDb();
-  const client = db.migrationClient();
-
   // `sync_op_outbox` лежить у `ROUTINE_CLIENT_MIGRATIONS` (історично —
   // створене у `001_routine_spike.sql` як перша таблиця SPIKE-у). Раніше
   // воно матеріалізувалося лише після того, як юзер відкривав routine-tab
@@ -117,95 +115,139 @@ async function createDefaultRuntime(): Promise<SyncEngineWriterRuntime> {
   // через 30 секунд у періодичному drain-і (тег глобальний, тож
   // успадковується усіма наступними events у сесії).
 
-  // Pre-state snapshot: перед першим write-ом у схему фіксуємо що
-  // саме було на диску. Розрізняємо "вже-мігрована БД" vs "свіжий
-  // user" vs "post-002 corruption" — інакше всі три зливаються
-  // в один тег і diagnostic value губиться.
-  let hadLegacy = false;
-  try {
-    const initialTables = await client.all<{ name: string }>(
-      `SELECT name FROM sqlite_master
+  // КРИТИЧНО: клієнт НЕ можна захопити один раз на boot. `main.tsx`
+  // викликає `bootSyncEngineWriter` до того, як `AuthContext` резолвить
+  // сесію, тож boot-овий `getSqliteDb()` відкриває **anon**-партицію.
+  // Пізніше `setSqliteUser(userId)` ЗАКРИВАЄ цей handle і перемикає
+  // синглтон на per-user БД — куди dual-write і кладе outbox-рядки.
+  // Захоплений client лишався б навічно прикутим до закритої anon-БД:
+  // drain читав би порожнечу (або кидав на закритому handle) і жоден
+  // push не відбувався б. Тому кожна операція runtime-у резолвить
+  // живий handle через `resolveClient()`; підготовка схеми (repair +
+  // migrations + sweep) кешується per-handle у WeakMap і повторюється
+  // лише після зміни партиції.
+  const prepCache = new WeakMap<
+    Awaited<ReturnType<typeof getSqliteDb>>,
+    Promise<SqliteMigrationClient>
+  >();
+
+  const prepareClient = async (
+    db: Awaited<ReturnType<typeof getSqliteDb>>,
+  ): Promise<SqliteMigrationClient> => {
+    const client = db.migrationClient();
+
+    // Pre-state snapshot: перед першим write-ом у схему фіксуємо що
+    // саме було на диску. Розрізняємо "вже-мігрована БД" vs "свіжий
+    // user" vs "post-002 corruption" — інакше всі три зливаються
+    // в один тег і diagnostic value губиться.
+    let hadLegacy = false;
+    try {
+      const initialTables = await client.all<{ name: string }>(
+        `SELECT name FROM sqlite_master
          WHERE type = 'table'
            AND name IN ('sync_op_outbox', 'sync_op_outbox_legacy')`,
-    );
-    const hadOutbox = initialTables.some((r) => r.name === "sync_op_outbox");
-    hadLegacy = initialTables.some((r) => r.name === "sync_op_outbox_legacy");
-
-    const repaired = await dbSchema.repairPartialOutboxMigration(client, {
-      ledgerTable: dbSchema.ROUTINE_MIGRATIONS_TABLE,
-    });
-    if (repaired.recovered) {
-      sentry.addSentryBreadcrumb({
-        category: "storage",
-        level: "warning",
-        message: "sqlite: recovered sync_op_outbox from partial 002 migration",
-      });
-    }
-
-    await runMigrations({
-      adapter: createSqliteAdapter(client),
-      files: dbSchema.ROUTINE_CLIENT_MIGRATIONS,
-      tableName: dbSchema.ROUTINE_MIGRATIONS_TABLE,
-    });
-
-    // Post-migration smoke check: if `sync_op_outbox` is still missing
-    // after the runner returned, something deeper than the
-    // post-002 corruption is wrong (e.g. a brand-new failure mode in
-    // sqlite-wasm). Throw a typed error here so the
-    // `bootSyncEngineWriter`-owy catch-all routes it to Sentry with a
-    // breadcrumb instead of letting the periodic drain surface a raw
-    // `SQLITE_ERROR: no such table` 30s later (the original WEB-A
-    // shape).
-    const presentTables = await client.all<{ name: string }>(
-      `SELECT name FROM sqlite_master
-         WHERE type = 'table' AND name = 'sync_op_outbox'`,
-    );
-    if (presentTables.length === 0) {
-      throw new Error(
-        "sync_op_outbox missing after running ROUTINE_CLIENT_MIGRATIONS — " +
-          "client SQLite did not converge on the expected schema",
       );
+      const hadOutbox = initialTables.some((r) => r.name === "sync_op_outbox");
+      hadLegacy = initialTables.some((r) => r.name === "sync_op_outbox_legacy");
+
+      const repaired = await dbSchema.repairPartialOutboxMigration(client, {
+        ledgerTable: dbSchema.ROUTINE_MIGRATIONS_TABLE,
+      });
+      if (repaired.recovered) {
+        sentry.addSentryBreadcrumb({
+          category: "storage",
+          level: "warning",
+          message:
+            "sqlite: recovered sync_op_outbox from partial 002 migration",
+        });
+      }
+
+      await runMigrations({
+        adapter: createSqliteAdapter(client),
+        files: dbSchema.ROUTINE_CLIENT_MIGRATIONS,
+        tableName: dbSchema.ROUTINE_MIGRATIONS_TABLE,
+      });
+
+      // Post-migration smoke check: if `sync_op_outbox` is still missing
+      // after the runner returned, something deeper than the
+      // post-002 corruption is wrong (e.g. a brand-new failure mode in
+      // sqlite-wasm). Throw a typed error here so the
+      // `bootSyncEngineWriter`-owy catch-all routes it to Sentry with a
+      // breadcrumb instead of letting the periodic drain surface a raw
+      // `SQLITE_ERROR: no such table` 30s later (the original WEB-A
+      // shape).
+      const presentTables = await client.all<{ name: string }>(
+        `SELECT name FROM sqlite_master
+         WHERE type = 'table' AND name = 'sync_op_outbox'`,
+      );
+      if (presentTables.length === 0) {
+        throw new Error(
+          "sync_op_outbox missing after running ROUTINE_CLIENT_MIGRATIONS — " +
+            "client SQLite did not converge on the expected schema",
+        );
+      }
+
+      sentry.setSentryTag(
+        "outbox.boot.outcome",
+        classifyOutboxBootOutcome({ hadOutbox, recovered: repaired.recovered }),
+      );
+      sentry.setSentryTag("outbox.boot.legacy_seen", String(hadLegacy));
+    } catch (err) {
+      // Tagging *before* re-throwing is intentional: the
+      // `bootSyncEngineWriter` catch arm forwards to
+      // `captureException`, and the global tag we set here ends up on
+      // that event (and any later events in the same session). Saved
+      // search `outbox.boot.outcome:failed` therefore catches both the
+      // direct boot exception and any downstream
+      // `no such table: sync_op_outbox` surfaced by callers that ran
+      // before this boot resolved.
+      sentry.setSentryTag("outbox.boot.outcome", "failed");
+      sentry.setSentryTag("outbox.boot.legacy_seen", String(hadLegacy));
+      throw err;
     }
 
-    sentry.setSentryTag(
-      "outbox.boot.outcome",
-      classifyOutboxBootOutcome({ hadOutbox, recovered: repaired.recovered }),
-    );
-    sentry.setSentryTag("outbox.boot.legacy_seen", String(hadLegacy));
-  } catch (err) {
-    // Tagging *before* re-throwing is intentional: the
-    // `bootSyncEngineWriter` catch arm forwards to
-    // `captureException`, and the global tag we set here ends up on
-    // that event (and any later events in the same session). Saved
-    // search `outbox.boot.outcome:failed` therefore catches both the
-    // direct boot exception and any downstream
-    // `no such table: sync_op_outbox` surfaced by callers that ran
-    // before this boot resolved.
-    sentry.setSentryTag("outbox.boot.outcome", "failed");
-    sentry.setSentryTag("outbox.boot.legacy_seen", String(hadLegacy));
-    throw err;
-  }
+    // Boot-time retention sweep: drop terminal `sync_op_outbox` rows
+    // (dead_letter / rejected / quarantined) older than the TTL window so
+    // the client DLQ cannot grow unbounded on a device that never
+    // reconnects cleanly (docs/audits/2026-08-XX-sync-engine-roast.md).
+    // Best-effort — `sweepStaleTerminalOutbox` swallows purge errors so a
+    // maintenance failure never blocks the writer boot; a non-zero purge
+    // emits a `sync_op_outbox.retention` breadcrumb for the Grafana
+    // counter (same pattern as the quarantine breadcrumb below).
+    await sweepStaleTerminalOutbox({
+      purge: () =>
+        dbSchema.purgeStaleTerminalOutbox(client, {
+          olderThanDays: dbSchema.SYNC_OP_OUTBOX_STALE_TTL_DAYS,
+        }),
+      addBreadcrumb: sentry.addSentryBreadcrumb,
+      captureException: (error, context) =>
+        sentry.captureException(
+          error,
+          context !== undefined ? { extra: context } : undefined,
+        ),
+    });
 
-  // Boot-time retention sweep: drop terminal `sync_op_outbox` rows
-  // (dead_letter / rejected / quarantined) older than the TTL window so
-  // the client DLQ cannot grow unbounded on a device that never
-  // reconnects cleanly (docs/audits/2026-08-XX-sync-engine-roast.md).
-  // Best-effort — `sweepStaleTerminalOutbox` swallows purge errors so a
-  // maintenance failure never blocks the writer boot; a non-zero purge
-  // emits a `sync_op_outbox.retention` breadcrumb for the Grafana
-  // counter (same pattern as the quarantine breadcrumb below).
-  await sweepStaleTerminalOutbox({
-    purge: () =>
-      dbSchema.purgeStaleTerminalOutbox(client, {
-        olderThanDays: dbSchema.SYNC_OP_OUTBOX_STALE_TTL_DAYS,
-      }),
-    addBreadcrumb: sentry.addSentryBreadcrumb,
-    captureException: (error, context) =>
-      sentry.captureException(
-        error,
-        context !== undefined ? { extra: context } : undefined,
-      ),
-  });
+    return client;
+  };
+
+  const resolveClient = (): Promise<SqliteMigrationClient> =>
+    getSqliteDb().then((db) => {
+      let prep = prepCache.get(db);
+      if (!prep) {
+        prep = prepareClient(db);
+        prepCache.set(db, prep);
+        // A failed prep must not poison the cache — drop it so the next
+        // tick retries (mirrors the original "boot throws → next boot
+        // retries" semantics, but per partition handle).
+        prep.catch(() => prepCache.delete(db));
+      }
+      return prep;
+    });
+
+  // Boot-time prep keeps the original fail-fast contract: a broken
+  // schema still rejects `createDefaultRuntime`, so the
+  // `bootSyncEngineWriter` catch-all tags + reports it exactly as before.
+  await resolveClient();
 
   // Per-tick userId resolver. The runtime itself is user-agnostic; the
   // drain wrapper closes over `authClient.getSession()` to scope reads
@@ -261,17 +303,19 @@ async function createDefaultRuntime(): Promise<SyncEngineWriterRuntime> {
       drain: async (options) => {
         const userId = await resolveUserId();
         if (!userId) return [];
-        return dbSchema.drainSyncOpOutbox(client, {
+        return dbSchema.drainSyncOpOutbox(await resolveClient(), {
           ...options,
           userId,
           onQuarantine: onOutboxQuarantine,
         });
       },
       push: (ops, options) => apiClient.syncV2.pushV2(ops, options),
-      markSuccess: (id) => dbSchema.markOutboxSuccess(client, id),
-      markRetry: (id, plan) => dbSchema.markOutboxRetry(client, id, plan),
-      markRejected: (id, reason) =>
-        dbSchema.markOutboxRejected(client, id, reason),
+      markSuccess: async (id) =>
+        dbSchema.markOutboxSuccess(await resolveClient(), id),
+      markRetry: async (id, plan) =>
+        dbSchema.markOutboxRetry(await resolveClient(), id, plan),
+      markRejected: async (id, reason) =>
+        dbSchema.markOutboxRejected(await resolveClient(), id, reason),
       planRetry: dbSchema.planRetry,
       now: () => new Date(),
       // Retry jitter on transient batch failures. Spreads each row's
@@ -285,9 +329,9 @@ async function createDefaultRuntime(): Promise<SyncEngineWriterRuntime> {
     setInterval: (handler, ms) => window.setInterval(handler, ms),
     clearInterval: (handle) => window.clearInterval(handle as number),
     eventTarget: window,
-    getStatus: () => dbSchema.countOutboxByStatus(client),
-    recoverDeadLetter: (selector: RecoverDeadLetterSelector) =>
-      dbSchema.recoverDeadLetter(client, selector),
+    getStatus: async () => dbSchema.countOutboxByStatus(await resolveClient()),
+    recoverDeadLetter: async (selector: RecoverDeadLetterSelector) =>
+      dbSchema.recoverDeadLetter(await resolveClient(), selector),
     addBreadcrumb: sentry.addSentryBreadcrumb,
     captureException: (error, context) =>
       sentry.captureException(

--- a/packages/api-client/pacts/sergeant-api-client-sergeant-server.json
+++ b/packages/api-client/pacts/sergeant-api-client-sergeant-server.json
@@ -400,7 +400,7 @@
           "accept": "application/json"
         },
         "method": "GET",
-        "path": "/api/v1/v2/sync/pull",
+        "path": "/api/v2/sync/pull",
         "query": {
           "limit": [
             "2"
@@ -465,7 +465,7 @@
           "accept": "application/json"
         },
         "method": "GET",
-        "path": "/api/v1/v2/sync/pull",
+        "path": "/api/v2/sync/pull",
         "query": {
           "since": [
             "1002"
@@ -511,7 +511,7 @@
           "accept": "application/json"
         },
         "method": "GET",
-        "path": "/api/v1/v2/sync/pull",
+        "path": "/api/v2/sync/pull",
         "query": {
           "since": [
             "9999"
@@ -911,7 +911,7 @@
           "content-type": "application/json"
         },
         "method": "POST",
-        "path": "/api/v1/v2/sync/push"
+        "path": "/api/v2/sync/push"
       },
       "response": {
         "body": {
@@ -971,7 +971,7 @@
           "content-type": "application/json"
         },
         "method": "POST",
-        "path": "/api/v1/v2/sync/push"
+        "path": "/api/v2/sync/push"
       },
       "response": {
         "body": {
@@ -1038,7 +1038,7 @@
           "content-type": "application/json"
         },
         "method": "POST",
-        "path": "/api/v1/v2/sync/push"
+        "path": "/api/v2/sync/push"
       },
       "response": {
         "body": {

--- a/packages/api-client/src/__tests__/contracts/sync-v2.contract.test.ts
+++ b/packages/api-client/src/__tests__/contracts/sync-v2.contract.test.ts
@@ -48,12 +48,10 @@ describe("contract @ POST /api/v2/sync/push", CONTRACT_SUITE_OPTIONS, () => {
       .uponReceiving(
         "a POST /api/v2/sync/push with two new routine_entries insert ops",
       )
-      // The httpClient rewrites /api/v2/sync/push → /api/v1/v2/sync/push
-      // (applyApiPrefix with default prefix /api/v1). The server's
-      // apiVersionRewrite middleware strips /api/v1 back to /api on the
-      // server side, so the round trip is transparent. Pact sees the
-      // wire path the client actually sends.
-      .withRequest("POST", "/api/v1/v2/sync/push", (req) => {
+      // applyApiPrefix leaves already-versioned paths (/api/v2/...)
+      // untouched, so the wire path matches the server's v2 mount
+      // directly. Pact sees the wire path the client actually sends.
+      .withRequest("POST", "/api/v2/sync/push", (req) => {
         req.headers({
           accept: "application/json",
           "content-type": "application/json",
@@ -153,7 +151,7 @@ describe("contract @ POST /api/v2/sync/push", CONTRACT_SUITE_OPTIONS, () => {
       .uponReceiving(
         "a POST /api/v2/sync/push where one op is table_not_allowed",
       )
-      .withRequest("POST", "/api/v1/v2/sync/push", (req) => {
+      .withRequest("POST", "/api/v2/sync/push", (req) => {
         req.headers({
           accept: "application/json",
           "content-type": "application/json",
@@ -242,7 +240,7 @@ describe("contract @ POST /api/v2/sync/push", CONTRACT_SUITE_OPTIONS, () => {
       .uponReceiving(
         "a POST /api/v2/sync/push replaying an already-applied idempotency_key",
       )
-      .withRequest("POST", "/api/v1/v2/sync/push", (req) => {
+      .withRequest("POST", "/api/v2/sync/push", (req) => {
         req.headers({
           accept: "application/json",
           "content-type": "application/json",
@@ -321,7 +319,7 @@ describe("contract @ GET /api/v2/sync/pull", CONTRACT_SUITE_OPTIONS, () => {
       .uponReceiving(
         "a GET /api/v2/sync/pull?since=0&limit=2 request (first page, more data)",
       )
-      .withRequest("GET", "/api/v1/v2/sync/pull", (req) => {
+      .withRequest("GET", "/api/v2/sync/pull", (req) => {
         req.headers({ accept: "application/json" });
         req.query({ since: "0", limit: "2" });
       })
@@ -390,7 +388,7 @@ describe("contract @ GET /api/v2/sync/pull", CONTRACT_SUITE_OPTIONS, () => {
       .uponReceiving(
         "a GET /api/v2/sync/pull?since=1002 request (last page, no more data)",
       )
-      .withRequest("GET", "/api/v1/v2/sync/pull", (req) => {
+      .withRequest("GET", "/api/v2/sync/pull", (req) => {
         req.headers({ accept: "application/json" });
         req.query({ since: "1002" });
       })
@@ -439,7 +437,7 @@ describe("contract @ GET /api/v2/sync/pull", CONTRACT_SUITE_OPTIONS, () => {
       .uponReceiving(
         "a GET /api/v2/sync/pull?since=9999 request (since ahead of log)",
       )
-      .withRequest("GET", "/api/v1/v2/sync/pull", (req) => {
+      .withRequest("GET", "/api/v2/sync/pull", (req) => {
         req.headers({ accept: "application/json" });
         req.query({ since: "9999" });
       })

--- a/packages/api-client/src/httpClient.test.ts
+++ b/packages/api-client/src/httpClient.test.ts
@@ -212,6 +212,18 @@ describe("httpClient — apiPrefix versioning", () => {
     expect(firstCall(fn)[0]).toBe("/api/v1/push/register");
   });
 
+  it("інша версія /api/v2/sync/push НЕ переписується у /api/v1/v2/… (sync-v2 e2e)", async () => {
+    const fn = mockFetchOnce(jsonResponse({ ok: true }));
+    await http.post("/api/v2/sync/push", { ops: [] });
+    expect(firstCall(fn)[0]).toBe("/api/v2/sync/push");
+  });
+
+  it("голий версіонований корінь /api/v2 — теж як є", async () => {
+    const fn = mockFetchOnce(jsonResponse({ ok: true }));
+    await http.get("/api/v2");
+    expect(firstCall(fn)[0]).toBe("/api/v2");
+  });
+
   it("не-/api/ шляхи прокидаються без змін", async () => {
     const fn = mockFetchOnce(jsonResponse({ ok: true }));
     await http.get("/healthz");

--- a/packages/api-client/src/httpClient.ts
+++ b/packages/api-client/src/httpClient.ts
@@ -86,10 +86,15 @@ function normalizeApiPrefix(prefix: string): string {
  * Правила (консистентно з `apps/web/src/shared/lib/api/apiUrl.ts`):
  *   - не починається з `/api/` → повертаємо як є (fully-qualified URL, asset, ...);
  *   - `/api/auth` або `/api/auth/...` → як є (Better Auth basePath);
+ *   - уже явно версіонований (`/api/v1/...`, `/api/v2/...`, …) → як є:
+ *     v2+ маунти сервера живуть поза `${prefix}`, і переписування дало б
+ *     `/api/v1/v2/...` — 404 у проді (саме так sync-v2 push губив маршрут);
  *   - уже починається з `prefix/` або дорівнює `prefix` → як є (ідемпотентність);
  *   - `prefix === "/api"` → як є (legacy mode, нічого не робимо);
  *   - інакше: `/api<rest>` → `${prefix}<rest>`.
  */
+const API_VERSIONED_PATH_RE = /^\/api\/v\d+(\/|$)/;
+
 export function applyApiPrefix(path: string, prefix: string): string {
   const normalizedPrefix = normalizeApiPrefix(prefix);
   if (normalizedPrefix === LEGACY_API_PREFIX) return path;
@@ -99,6 +104,9 @@ export function applyApiPrefix(path: string, prefix: string): string {
     return path;
   }
   if (path === AUTH_PATH_PREFIX || path.startsWith(`${AUTH_PATH_PREFIX}/`)) {
+    return path;
+  }
+  if (API_VERSIONED_PATH_RE.test(path)) {
     return path;
   }
   if (path === normalizedPrefix || path.startsWith(`${normalizedPrefix}/`)) {


### PR DESCRIPTION
## Summary

Makes sync-v2 actually deliver. After #3539 wired routine completions into the outbox, a deeper bug meant **no signed-in user ever pushed anything** — the outbox was written to one SQLite partition while the drain loop read another. Independently verified end-to-end (see below).

### Root cause 1 — writer pinned to the anon partition
`bootSyncEngineWriter` runs from `main.tsx` **before** `AuthContext` resolves the session, so the boot-time `getSqliteDb().migrationClient()` opened the **anon** partition and captured that client for the writer's whole lifetime. When auth resolves, `setSqliteUser(userId)` **closes** that handle and switches the singleton to the **per-user** DB — which is where dualWrite enqueues outbox rows. The captured client stayed bound to the closed anon DB forever, so drain read an empty (or closed) database and never pushed. This affected every authenticated user regardless of the #3539 wiring.

**Fix:** `createDefaultRuntime` no longer captures the client once. Every runtime op (`drain`, `markSuccess/Retry/Rejected`, `getStatus`, `recoverDeadLetter`) resolves the **current** client via `getSqliteDb()` at call time, so the writer follows partition switches. Schema prep (repair + `ROUTINE_CLIENT_MIGRATIONS` + retention sweep) is cached per `SqliteDbHandle` in a `WeakMap` — re-runs idempotently on first use of each new partition; failed prep is evicted so the next tick retries. Boot still awaits one prep (fail-fast + Sentry tags preserved).

### Root cause 2 — versioned paths double-prefixed
`applyApiPrefix` rewrote `/api/v2/sync/push` → `/api/v1/v2/sync/push`. The server tolerated it via `apiVersionRewrite`, but it contradicted the syncV2 contract and broke strict proxies/mocks. Versioned paths (`/api/v{N}/…`) now pass through untouched; the api-client contract/pact is re-pinned to `/api/v2/sync/*`.

## Governing Skill
`sergeant-server-api` / sync-engine (writer wiring design spec).

## Verification
**Independent e2e by the lead** on a clean `VERCEL=1` preview built from this commit, fresh browser context (`serviceWorkers: "block"` — a stale SW from a prior visit was silently bypassing route mocks and serving 401s), mocked auth (`/me`, `/api/auth/get-session`) + capturing `/api/v2/sync/push`:
- Create habit → toggle "Виконано" → within ~30s **one** `POST /api/v2/sync/push` fired, body: `{ ops: [{ table: "routine_entries", op: "insert", row: { id: "hab_…:2026-06-13", user_id: "test-user-1", … }, idempotency_key, client_ts }] }`.
- Pre-fix bundle pushed to `/api/v1/v2/sync/push` (confirms RC2).

Gates (agent + spot-checked): `pnpm --filter @sergeant/web typecheck` ✅; vitest 92/92 (syncEngine + routine dualWrite) + 43/43 (api-client incl. sync-v2 pact) ✅; eslint 0 warnings; no instrumentation left.

## Docs and Governance
- [x] api-client contract triplet kept in sync (httpClient + contract test + pact JSON all moved together) — Hard Rule #3.
- [x] No schema/migration change.

## Risk and Rollout
Touches the sync writer's client lifecycle — but the pre-state is "sync delivers nothing for anyone", so this only enables a dormant path. Fire-and-forget enqueue still cannot break local writes. After merge, watch a real signed-in session: a habit toggle should produce a `routine_entries` op visible on `/api/v2/sync/pull` from a second device.

## Hard Rule #15 acknowledgement
Governance read; WHY captured in the singleton.ts partition-switch comment and the `applyApiPrefix` versioned-path note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sync-v2 delivery by resolving the SQLite client on each operation so the writer follows auth partition switches. Also stops double-prefixing versioned `/api/v2/sync/*` routes so pushes and pulls hit the correct endpoints.

- **Bug Fixes**
  - Resolve the live SQLite migration client via `getSqliteDb()` on every call; cache schema prep per handle in a WeakMap. Boot remains fail-fast; Sentry tags preserved.
  - Drain/mark/status/recover now use the current DB handle, fixing reads from the closed anon partition and enabling pushes for signed-in users.
  - `applyApiPrefix` no longer rewrites versioned paths (`/api/v{n}/...`), so the client sends `/api/v2/sync/*` directly. Updated pact and tests to the canonical v2 paths.

<sup>Written for commit 04488b58401bd6326a99fd03c78fbe4f751df78f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected API sync endpoint paths to use proper v2 versioning instead of double-prefixed paths.
  * Improved HTTP client to prevent incorrect path prefixing for already-versioned endpoints.

* **Tests**
  * Updated API contract tests to reflect corrected versioning paths.
  * Added validation tests to ensure v2 endpoints are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->