### PR TITLE
refactor(web): declutter empty module cards + drop redundant FTUX hint

### DIFF
--- a/apps/web/src/core/hub/HubDashboard.test.tsx
+++ b/apps/web/src/core/hub/HubDashboard.test.tsx
@@ -14,7 +14,6 @@ import {
 } from "@sergeant/shared";
 import { getModulePrimaryAction } from "@shared/lib/modules/moduleQuickActions";
 import { ToastProvider } from "@shared/hooks/useToast";
-import { MODULE_CONFIGS } from "./dashboard/moduleConfigs";
 
 type TestRec = Rec & { actionHash?: string };
 
@@ -373,9 +372,11 @@ describe("HubDashboard", () => {
     expect(screen.getByText(EXPECTED_FINYK_SUB)).toBeInTheDocument();
     expect(screen.getByText("2/4")).toBeInTheDocument();
     expect(screen.getByText(EXPECTED_ROUTINE_SUB)).toBeInTheDocument();
-    expect(screen.getAllByText(MODULE_CONFIGS.fizruk.emptyLabel)).toHaveLength(
-      2,
-    );
+    // Empty cards (fizruk, nutrition) no longer render visible «Почни тут →»
+    // CTA copy — the tile itself is the affordance. The empty-state intent
+    // is exposed only through each card's accessible name
+    // (`<label>: <emptyLabel>`), so assert both empty modules announce it.
+    expect(screen.getAllByLabelText(/Почни тут/)).toHaveLength(2);
   });
 
   it("keeps the pre-FTUX dashboard focused on first-entry guidance", () => {

--- a/apps/web/src/core/hub/HubDashboard.tsx
+++ b/apps/web/src/core/hub/HubDashboard.tsx
@@ -59,7 +59,6 @@ export function HubDashboard({
       <StaggerChild index={1}>
         <HubModulesGrid
           density={s.density}
-          hasRealEntry={s.hasRealEntry}
           editMode={s.editMode}
           toggleEditMode={s.toggleEditMode}
           displayOrder={s.displayOrder}

--- a/apps/web/src/core/hub/HubModulesGrid.tsx
+++ b/apps/web/src/core/hub/HubModulesGrid.tsx
@@ -5,19 +5,13 @@
 /**
  * Module bento grid for the Hub Dashboard (T1 decomposition).
  *
- * Drag-and-drop reordering, edit mode, inactive-module toggle, and
- * FTUX inline hint.
+ * Drag-and-drop reordering, edit mode, and inactive-module toggle.
  */
 
 import { cn } from "@shared/lib/ui/cn";
 import { Icon } from "@shared/components/ui/Icon";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
-import { useLocalStorageState } from "@shared/hooks/useLocalStorageState";
-import {
-  STORAGE_KEYS,
-  isActiveModule,
-  type DashboardModuleId,
-} from "@sergeant/shared";
+import { isActiveModule, type DashboardModuleId } from "@sergeant/shared";
 import {
   DndContext,
   closestCenter,
@@ -32,57 +26,11 @@ import type { DashboardDensity } from "./hub.types";
 import { DENSITY_BENTO_GAP } from "./hub.types";
 
 // ─────────────────────────────────────────────────────────────────────
-// FTUX inline hint
-// ─────────────────────────────────────────────────────────────────────
-
-function FtuxModulesHint() {
-  const [dismissed, setDismissed] = useLocalStorageState<boolean>(
-    STORAGE_KEYS.FTUX_MODULES_HINT_DISMISSED,
-    false,
-    { validate: (v): v is boolean => typeof v === "boolean" },
-  );
-  if (dismissed) return null;
-  return (
-    <div
-      role="note"
-      className={cn(
-        "flex items-start gap-2 rounded-2xl border border-line bg-panel/70 px-3 py-2",
-        "text-style-caption leading-snug text-muted",
-      )}
-    >
-      <Icon
-        name="info"
-        size={14}
-        strokeWidth={2}
-        aria-hidden
-        className="mt-0.5 shrink-0 text-brand-strong"
-      />
-      <p className="flex-1 min-w-0">
-        Тут усі твої розділи поруч — обери будь-який, щоб почати.
-      </p>
-      <button
-        type="button"
-        onClick={() => setDismissed(true)}
-        aria-label="Сховати підказку"
-        className={cn(
-          "shrink-0 -mr-1 -mt-0.5 w-6 h-6 touch-target inline-flex items-center justify-center rounded-md",
-          "text-muted hover:text-text hover:bg-panelHi transition-colors",
-          "focus:outline-none focus-visible:ring-2 focus-visible:ring-focus/60",
-        )}
-      >
-        <Icon name="close" size={14} strokeWidth={2} aria-hidden />
-      </button>
-    </div>
-  );
-}
-
-// ─────────────────────────────────────────────────────────────────────
 // Props
 // ─────────────────────────────────────────────────────────────────────
 
 export interface HubModulesGridProps {
   density: DashboardDensity;
-  hasRealEntry: boolean;
   editMode: boolean;
   toggleEditMode: () => void;
   displayOrder: readonly string[];
@@ -103,7 +51,6 @@ export interface HubModulesGridProps {
 
 export function HubModulesGrid({
   density,
-  hasRealEntry,
   editMode,
   toggleEditMode,
   displayOrder,
@@ -151,8 +98,6 @@ export function HubModulesGrid({
           {editMode ? <span>Готово</span> : null}
         </button>
       </div>
-
-      {!hasRealEntry && <FtuxModulesHint />}
 
       <DndContext
         sensors={sensors}

--- a/apps/web/src/core/hub/dashboard/BentoCard.tsx
+++ b/apps/web/src/core/hub/dashboard/BentoCard.tsx
@@ -152,7 +152,12 @@ export const BentoCard = memo(function BentoCard({
 
         <span
           className={cn(
-            "text-xs font-semibold",
+            "font-semibold",
+            // Empty cards have no preview number, so the module name is the
+            // focal point and is sized up; once data lands the big
+            // `preview.main` number takes over as the hero and the name
+            // recedes to a caption above it.
+            hasData ? "text-xs" : "text-sm",
             inactive ? "text-muted" : "text-text",
           )}
         >
@@ -160,7 +165,7 @@ export const BentoCard = memo(function BentoCard({
         </span>
 
         {!inactive && (
-          <span className="text-style-meta text-muted truncate mt-0.5">
+          <span className="text-style-meta text-muted mt-0.5 leading-snug">
             {config.description}
           </span>
         )}
@@ -208,43 +213,13 @@ export const BentoCard = memo(function BentoCard({
               </span>
             )}
           </>
-        ) : !editMode ? (
-          // Empty-state CTA — promoted from a single inline pill (icon + label
-          // glyph) to a two-row layout with a tinted leading icon-box and an
-          // explicit «Натисни, щоб почати» helper. The richer treatment makes
-          // the card read as an *invitation* (clear affordance + verb) instead
-          // of a generic «+ Почни тут →» eyebrow that the eye skipped past.
-          // Rendered for every empty card (with or without a quick-add
-          // affordance) so the bento grid does not visibly mix two empty-
-          // state heights — the previous split between rich/simple variants
-          // produced the uneven row the IA pass is fixing.
-          <div className="mt-1.5 flex flex-col gap-1">
-            <div className="flex items-center gap-1.5">
-              <span
-                className={cn(
-                  "w-5 h-5 rounded-xl flex items-center justify-center",
-                  config.iconClass,
-                  "opacity-60",
-                )}
-              >
-                <Icon name="plus" size="xs" strokeWidth={2.5} aria-hidden />
-              </span>
-              <span
-                className={cn(
-                  "text-xs font-semibold",
-                  config.accentClass.replace("bg-", "text-"),
-                )}
-              >
-                {config.emptyLabel}
-              </span>
-            </div>
-            <span className="text-style-caption text-subtle">
-              Натисни, щоб почати
-            </span>
-          </div>
-        ) : (
-          <span className="text-xs text-muted mt-1">{config.emptyLabel}</span>
-        )}
+        ) : null}
+        {/* Empty cards intentionally render no CTA copy: the whole tile is a
+            button (hover-lift on desktop, full tap target on touch) and the
+            quick-add `+` sits in the corner for modules that support it. The
+            module name + description carry the invitation — the previous
+            «Почни тут →» / «Натисни, щоб почати» pair was triple-redundant
+            with the card affordance and crowded the tile. */}
 
         {showProgress && (
           <div


### PR DESCRIPTION
## Summary
Дизайн-чистка головної (продовження UI/UX роботи після #3541). Порожня картка модуля несла **4 текстові рівні + 2 іконки** на тайлі 120px: назва, опис, «Почни тут →» і «Натисни, щоб почати» — три заклики клікнути, що конкурували з самою карткою-кнопкою, плюс обрізаний опис.

- **BentoCard**: прибрано двоярусний empty-state CTA повністю (тайл сам — кнопка; кутовий quick-add `+` несе афорданс). Назва модуля піднята до `text-sm` у порожньому стані → стає фокусом; лишається `text-xs` коли є дані й героєм стає велике число прев'ю. Прибрано `truncate` з опису — тепер переноситься, а не ріжеться. Інтент порожньої картки лишається в `aria-label`.
- **HubModulesGrid**: прибрано `FtuxModulesHint` («Тут усі твої розділи поруч…») — дублював і hero-блок, і афорданс карток. Прибрано тепер-непотрібний проп `hasRealEntry` + імпорти `useLocalStorageState`/`STORAGE_KEYS`.
- **HubDashboard**: перестав прокидати `hasRealEntry` у грід.
- **HubDashboard.test**: асерт порожніх карток через accessible name (`aria-label`) замість видимої CTA-копії.

## Governing Skill
sergeant-web-ui

## Verification
- `pnpm --filter @sergeant/web typecheck` ✔
- ESLint торкнутих файлів ✔ (0 порушень)
- Vitest: HubDashboard.test.tsx 10/10 ✔
- **Live-browser (Claude Preview проти dev)**: порожня картка — назва 14px, лише «Назва | Опис», без CTA-шуму; картка з даними — назва 12px + герой-число «1 250 ₴» + sub; опис без обрізання (`white-space: normal`); FTUX-note зник; жодної нової console-помилки (лишився той самий pre-existing setState-warning, не з цього діффа).

## Risk and Rollout
Низький — суто візуальний/копірайт-рефактор empty-state карток. Поведінкових змін нема (картки навігують як раніше; quick-add не чіпали). Rollback: revert коміта.

## Hard Rule #15 acknowledgement
Governance прочитано; правки в межах Rule #16 (typography 12px floor дотримано — 14px/12px), #18 (файли не виросли — −80 рядків).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the first-time user experience hint from the modules grid.
  * Updated styling for module card headers and descriptions based on content state.
  * Simplified empty state display for cards without preview data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->