### PR TITLE
refactor(server): extract chat prompt-cache helpers into a dedicated module

### DIFF
--- a/apps/server/src/modules/chat/chat.ts
+++ b/apps/server/src/modules/chat/chat.ts
@@ -14,7 +14,12 @@ import {
   recordAnthropicUsage,
 } from "../../lib/anthropic.js";
 import type { WithAiQuotaRefund } from "./aiQuota.js";
-import { TOOLS, SYSTEM_PREFIX, SYSTEM_PROMPT_VERSION } from "./tools.js";
+import { SYSTEM_PROMPT_VERSION } from "./tools.js";
+import {
+  applyMessagesCacheBreakpoint,
+  buildSystem,
+  TOOLS_WITH_CACHE,
+} from "./promptCache.js";
 import { recordToolProposals, recordToolExecutions } from "./toolMetrics.js";
 import { truncateToolResults } from "./toolResultTruncation.js";
 import { wrapAndScanToolResults } from "./toolOutputWrapping.js";
@@ -37,77 +42,10 @@ type WithAnthropicKey = Request & { anthropicKey?: string };
  */
 const CHAT_TOOL_TIMEOUT_MS = 30_000;
 
-/**
- * Anthropic prompt-caching, три точки розриву (cache breakpoints). Порядок
- * рендеру в Anthropic — `tools` → `system` → `messages`; кожен `cache_control`
- * кешує весь префікс ДО себе включно. Мінімальний кешований префікс залежить
- * від моделі: Haiku 4.5 (перший тур) — 4096 токенів, Sonnet 4.6 (tool-result
- * тур) — 2048. TTL ephemeral = 5 хв. Ліміт Anthropic — max 4 breakpoint-и/запит.
- *
- * 1. **SYSTEM_PREFIX** (`buildSystem`) — окремий cached `text`-блок. Сам по собі
- *    ~987 токенів, нижче обох мінімумів, тому власного слоту не реєструє; але
- *    оскільки tools рендеряться ПЕРЕД system, сумарний префікс tools+SYSTEM_PREFIX
- *    перевищує поріг і кешується.
- *
- * 2. **Останній tool** (`applyToolsCacheBreakpoint`) — кешує всі tools (~19 шт).
- *    Tools + SYSTEM_PREFIX разом — стабільний блок ~6000+ токенів, спільний між
- *    усіма запитами; основний cache-read на кожному турі.
- *
- * 3. **Останнє повідомлення** (`applyMessagesCacheBreakpoint`) — кешує префікс
- *    історії діалогу. На наступному турі клієнт дошле історію як префікс, і
- *    Anthropic віддасть її з кешу (~0.1× ціни input) замість повторного білінгу.
- *    Застосовується ЛИШЕ на першому турі (`cleaned` несе повну історію); на
- *    tool-result турі шлеться ефемерний one-shot (останній user + tool-раунд),
- *    тож кеш там був би марним 1.25× write без re-read.
- *
- * Per-user `context` рендериться другим блоком system — **без** `cache_control`,
- * щоб не створювати власного cache slot per-user-ом. Але оскільки cache key
- * охоплює весь system, різний context між юзерами все одно фрагментує кеш (один слот
- * на user). Це ОК: юзер в межах своєї сесії (5хв) отримує багато cache_read.
- *
- * Коли `context` порожній, Anthropic API відхиляє `text`-блоки з empty `text`,
- * тому під cap-ом повертаємо лише самий cached prefix.
- */
-interface AnthropicSystemBlock {
-  type: "text";
-  text: string;
-  cache_control?: { type: "ephemeral" };
-}
-
-function buildSystem(context: string): AnthropicSystemBlock[] {
-  const cached: AnthropicSystemBlock = {
-    type: "text",
-    text: SYSTEM_PREFIX,
-    cache_control: { type: "ephemeral" },
-  };
-  if (!context) return [cached];
-  return [cached, { type: "text", text: context }];
-}
-
-/**
- * Клонує `TOOLS` і додає `cache_control: ephemeral` до останнього tool. Не
- * мутує імпортований масив, бо він реєкспортиться в інших місцях.
- *
- * Anthropic кешує весь префікс ДО цього блоку включно (порядок рендеру:
- * tools → system → messages). Разом із cache_control на SYSTEM_PREFIX це кешує
- * стабільний блок tools + system на кожному турі.
- */
-function applyToolsCacheBreakpoint(
-  tools: typeof TOOLS,
-): Array<(typeof TOOLS)[number] & { cache_control?: { type: "ephemeral" } }> {
-  if (tools.length === 0) return tools;
-  const cloned = tools.slice();
-  const last = cloned[cloned.length - 1];
-  cloned[cloned.length - 1] = {
-    ...last,
-    cache_control: { type: "ephemeral" },
-  } as typeof last & { cache_control: { type: "ephemeral" } };
-  return cloned as Array<
-    (typeof TOOLS)[number] & { cache_control?: { type: "ephemeral" } }
-  >;
-}
-
-const TOOLS_WITH_CACHE = applyToolsCacheBreakpoint(TOOLS);
+// Anthropic prompt-caching хелпери (buildSystem / TOOLS_WITH_CACHE /
+// applyMessagesCacheBreakpoint) винесені в `./promptCache.ts` — три cache
+// breakpoint-и (system prefix, останній tool, останнє повідомлення) задокументовані
+// там. Винесення тримає chat.ts під module-size cap (Hard Rule #18).
 
 /**
  * Якщо Anthropic повернув не-2xx або виклик упав (timeout/abort), викликаємо
@@ -146,43 +84,6 @@ interface AnthropicMessagesResponseData {
 interface ClientChatMessage {
   role: "user" | "assistant";
   content: string;
-}
-
-/**
- * Message-content shape після того, як останньому повідомленню додали
- * cache-breakpoint: або сирий string (як прийшло від клієнта), або масив
- * content-блоків з `cache_control` на одному з них.
- */
-type CachedMessage =
-  | { role: "user" | "assistant"; content: string }
-  | { role: "user" | "assistant"; content: Array<Record<string, unknown>> };
-
-/**
- * Третій cache breakpoint (див. § doc вгорі): додає `cache_control: ephemeral`
- * до ОСТАННЬОГО повідомлення, щоб префікс історії діалогу читався з кешу на
- * наступному турі. String-content обгортається в один `text`-блок із
- * cache_control; масив-content (tool_use / tool_result) отримує cache_control на
- * останній блок (defensive — `cleaned` завжди має string-content, тож у проді
- * спрацьовує перша гілка). Чистий: повертає НОВИЙ масив, вхід не мутується.
- */
-function applyMessagesCacheBreakpoint(
-  messages: ClientChatMessage[],
-): CachedMessage[] {
-  if (messages.length === 0) return messages;
-  const out: CachedMessage[] = messages.slice();
-  const lastIdx = out.length - 1;
-  const last = messages[lastIdx]!;
-  out[lastIdx] = {
-    role: last.role,
-    content: [
-      {
-        type: "text",
-        text: last.content,
-        cache_control: { type: "ephemeral" },
-      },
-    ],
-  };
-  return out;
 }
 
 interface StreamUsage {

--- a/apps/server/src/modules/chat/promptCache.test.ts
+++ b/apps/server/src/modules/chat/promptCache.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit tests для чистих prompt-caching хелперів (`promptCache.ts`), винесених
+ * із chat-handler-а. Поведінкові інтеграційні перевірки (через handler) живуть
+ * у `chat.test.ts`; тут — прямі property-тести на pure-функції.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  applyMessagesCacheBreakpoint,
+  applyToolsCacheBreakpoint,
+  buildSystem,
+  TOOLS_WITH_CACHE,
+  type CacheableInputMessage,
+} from "./promptCache.js";
+
+const EPHEMERAL = { type: "ephemeral" } as const;
+
+describe("buildSystem", () => {
+  it("без context повертає лише cached SYSTEM_PREFIX-блок", () => {
+    const blocks = buildSystem("");
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]!.type).toBe("text");
+    expect(blocks[0]!.cache_control).toEqual(EPHEMERAL);
+    expect(blocks[0]!.text.length).toBeGreaterThan(0);
+  });
+
+  it("з context додає другий, НЕ кешований блок", () => {
+    const blocks = buildSystem("[Профіль] Алергія на горіхи");
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]!.cache_control).toEqual(EPHEMERAL);
+    expect(blocks[1]!.cache_control).toBeUndefined();
+    expect(blocks[1]!.text).toContain("Алергія на горіхи");
+  });
+});
+
+describe("applyToolsCacheBreakpoint", () => {
+  it("додає cache_control лише до останнього tool", () => {
+    expect(TOOLS_WITH_CACHE.length).toBeGreaterThan(0);
+    const last = TOOLS_WITH_CACHE[TOOLS_WITH_CACHE.length - 1]!;
+    expect(last.cache_control).toEqual(EPHEMERAL);
+    for (let i = 0; i < TOOLS_WITH_CACHE.length - 1; i++) {
+      expect(TOOLS_WITH_CACHE[i]!.cache_control).toBeUndefined();
+    }
+  });
+
+  it("порожній масив повертає порожній (без падіння)", () => {
+    expect(applyToolsCacheBreakpoint([])).toEqual([]);
+  });
+});
+
+describe("applyMessagesCacheBreakpoint", () => {
+  it("порожній масив → порожній", () => {
+    expect(applyMessagesCacheBreakpoint([])).toEqual([]);
+  });
+
+  it("обгортає ОСТАННЄ повідомлення в cached text-блок, попередні лишає string", () => {
+    const input: CacheableInputMessage[] = [
+      { role: "user", content: "перше" },
+      { role: "assistant", content: "відповідь" },
+      { role: "user", content: "останнє" },
+    ];
+    const out = applyMessagesCacheBreakpoint(input);
+
+    const last = out[out.length - 1]!;
+    expect(Array.isArray(last.content)).toBe(true);
+    const block = (
+      last.content as Array<{ text?: string; cache_control?: { type: string } }>
+    )[0]!;
+    expect(block).toMatchObject({
+      type: "text",
+      text: "останнє",
+      cache_control: EPHEMERAL,
+    });
+    for (let i = 0; i < out.length - 1; i++) {
+      expect(typeof out[i]!.content).toBe("string");
+    }
+  });
+
+  it("не мутує вхідний масив (чиста функція)", () => {
+    const input: CacheableInputMessage[] = [{ role: "user", content: "x" }];
+    const snapshot = structuredClone(input);
+    applyMessagesCacheBreakpoint(input);
+    expect(input).toEqual(snapshot);
+  });
+
+  it("повідомлення з одного елемента кешує саме його", () => {
+    const out = applyMessagesCacheBreakpoint([
+      { role: "user", content: "тільки одне" },
+    ]);
+    expect(out).toHaveLength(1);
+    const block = (
+      out[0]!.content as Array<{
+        text?: string;
+        cache_control?: { type: string };
+      }>
+    )[0]!;
+    expect(block.text).toBe("тільки одне");
+    expect(block.cache_control).toEqual(EPHEMERAL);
+  });
+});

--- a/apps/server/src/modules/chat/promptCache.ts
+++ b/apps/server/src/modules/chat/promptCache.ts
@@ -1,0 +1,130 @@
+// AI-CONTEXT: prompt-caching хелпери для chat-handler-а, винесені з `chat.ts`
+// (Hard Rule #18 — module-size discipline; chat.ts давно понад 600-рядковий
+// cap). Чисті функції без side-effects: легко юніт-тестувати окремо
+// (`promptCache.test.ts`) і тримати `chat.ts` тоншим. Поведінка ідентична до
+// інлайн-версії: жодна не мутує вхід.
+
+import { TOOLS, SYSTEM_PREFIX } from "./tools.js";
+
+/**
+ * Anthropic prompt-caching, три точки розриву (cache breakpoints). Порядок
+ * рендеру в Anthropic — `tools` → `system` → `messages`; кожен `cache_control`
+ * кешує весь префікс ДО себе включно. Мінімальний кешований префікс залежить
+ * від моделі: Haiku 4.5 (перший тур) — 4096 токенів, Sonnet 4.6 (tool-result
+ * тур) — 2048. TTL ephemeral = 5 хв. Ліміт Anthropic — max 4 breakpoint-и/запит.
+ *
+ * 1. **SYSTEM_PREFIX** (`buildSystem`) — окремий cached `text`-блок. Сам по собі
+ *    ~987 токенів, нижче обох мінімумів, тому власного слоту не реєструє; але
+ *    оскільки tools рендеряться ПЕРЕД system, сумарний префікс tools+SYSTEM_PREFIX
+ *    перевищує поріг і кешується.
+ *
+ * 2. **Останній tool** (`applyToolsCacheBreakpoint`) — кешує всі tools (~19 шт).
+ *    Tools + SYSTEM_PREFIX разом — стабільний блок ~6000+ токенів, спільний між
+ *    усіма запитами; основний cache-read на кожному турі.
+ *
+ * 3. **Останнє повідомлення** (`applyMessagesCacheBreakpoint`) — кешує префікс
+ *    історії діалогу. На наступному турі клієнт дошле історію як префікс, і
+ *    Anthropic віддасть її з кешу (~0.1× ціни input) замість повторного білінгу.
+ *    Застосовується ЛИШЕ на першому турі (`cleaned` несе повну історію); на
+ *    tool-result турі шлеться ефемерний one-shot (останній user + tool-раунд),
+ *    тож кеш там був би марним 1.25× write без re-read.
+ *
+ * Per-user `context` рендериться другим блоком system — **без** `cache_control`,
+ * щоб не створювати власного cache slot per-user-ом. Але оскільки cache key
+ * охоплює весь system, різний context між юзерами все одно фрагментує кеш (один слот
+ * на user). Це ОК: юзер в межах своєї сесії (5хв) отримує багато cache_read.
+ *
+ * Коли `context` порожній, Anthropic API відхиляє `text`-блоки з empty `text`,
+ * тому під cap-ом повертаємо лише самий cached prefix.
+ */
+export interface AnthropicSystemBlock {
+  type: "text";
+  text: string;
+  cache_control?: { type: "ephemeral" };
+}
+
+export function buildSystem(context: string): AnthropicSystemBlock[] {
+  const cached: AnthropicSystemBlock = {
+    type: "text",
+    text: SYSTEM_PREFIX,
+    cache_control: { type: "ephemeral" },
+  };
+  if (!context) return [cached];
+  return [cached, { type: "text", text: context }];
+}
+
+/**
+ * Клонує `TOOLS` і додає `cache_control: ephemeral` до останнього tool. Не
+ * мутує імпортований масив, бо він реєкспортиться в інших місцях.
+ *
+ * Anthropic кешує весь префікс ДО цього блоку включно (порядок рендеру:
+ * tools → system → messages). Разом із cache_control на SYSTEM_PREFIX це кешує
+ * стабільний блок tools + system на кожному турі.
+ */
+export function applyToolsCacheBreakpoint(
+  tools: typeof TOOLS,
+): Array<(typeof TOOLS)[number] & { cache_control?: { type: "ephemeral" } }> {
+  if (tools.length === 0) return tools;
+  const cloned = tools.slice();
+  const last = cloned[cloned.length - 1];
+  cloned[cloned.length - 1] = {
+    ...last,
+    cache_control: { type: "ephemeral" },
+  } as typeof last & { cache_control: { type: "ephemeral" } };
+  return cloned as Array<
+    (typeof TOOLS)[number] & { cache_control?: { type: "ephemeral" } }
+  >;
+}
+
+/**
+ * Tools із cache breakpoint на останньому — обчислюється один раз при імпорті
+ * модуля (TOOLS статичний), щоб не клонувати масив на кожен запит.
+ */
+export const TOOLS_WITH_CACHE = applyToolsCacheBreakpoint(TOOLS);
+
+/**
+ * Вхід для `applyMessagesCacheBreakpoint` — мінімальна структурна форма
+ * повідомлення (string-content). `ClientChatMessage` із `chat.ts` структурно
+ * сумісний; тримаємо тип локальним, щоб уникнути циклічного імпорту.
+ */
+export interface CacheableInputMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+/**
+ * Message-content shape після того, як останньому повідомленню додали
+ * cache-breakpoint: або сирий string (як прийшло від клієнта), або масив
+ * content-блоків з `cache_control` на одному з них.
+ */
+export type CachedMessage =
+  | { role: "user" | "assistant"; content: string }
+  | { role: "user" | "assistant"; content: Array<Record<string, unknown>> };
+
+/**
+ * Третій cache breakpoint (див. § doc вгорі): додає `cache_control: ephemeral`
+ * до ОСТАННЬОГО повідомлення, щоб префікс історії діалогу читався з кешу на
+ * наступному турі. String-content обгортається в один `text`-блок із
+ * cache_control; масив-content (tool_use / tool_result) отримує cache_control на
+ * останній блок (defensive — `cleaned` завжди має string-content, тож у проді
+ * спрацьовує перша гілка). Чистий: повертає НОВИЙ масив, вхід не мутується.
+ */
+export function applyMessagesCacheBreakpoint(
+  messages: CacheableInputMessage[],
+): CachedMessage[] {
+  if (messages.length === 0) return messages;
+  const out: CachedMessage[] = messages.slice();
+  const lastIdx = out.length - 1;
+  const last = messages[lastIdx]!;
+  out[lastIdx] = {
+    role: last.role,
+    content: [
+      {
+        type: "text",
+        text: last.content,
+        cache_control: { type: "ephemeral" },
+      },
+    ],
+  };
+  return out;
+}


### PR DESCRIPTION
## Summary

Follow-up to #3557. Extracts the chat prompt-caching helpers out of the handler into a dedicated module `apps/server/src/modules/chat/promptCache.ts`:

- Moved: `buildSystem`, `applyToolsCacheBreakpoint` + `TOOLS_WITH_CACHE`, `applyMessagesCacheBreakpoint`, the `AnthropicSystemBlock` / `CachedMessage` types, and the three-breakpoint strategy doc comment.
- `chat.ts` imports them back; **behavior unchanged** (the helpers were already pure and non-mutating).
- `ClientChatMessage` stays in `chat.ts` (used by `sanitizeMessages`); the extracted helper takes a structural `CacheableInputMessage` to avoid a circular import.
- `chat.ts`: **965 → 866 lines**, clearer separation of concerns.

Addresses the CodeRabbit review comment on #3557 (module-size discipline / Hard Rule #18). **Accuracy note:** the configured `max-lines` rule uses `skipBlankLines: true, skipComments: true`, so `chat.ts` was never actually failing the lint nor present in `eslint.baseline.js` — this is a maintainability/structure improvement, not a lint fix.

No API contract / response-shape change.

## Governing Skill

- Primary skill: `sergeant-server-api`
- Secondary skill (if truly needed): `sergeant-tech-debt` (module-size discipline)

## Playbook

- Primary playbook: n/a
- Why this playbook: n/a
- If no playbook matched, why: small, mechanical module extraction; no procedural recipe applies.

## Verification

```bash
pnpm --filter @sergeant/server typecheck                                   # ✓
pnpm --filter @sergeant/server exec vitest run src/modules/chat            # 183 passed | 5 skipped (175 existing + 8 new)
pnpm --filter @sergeant/server exec eslint src/modules/chat/chat.ts src/modules/chat/promptCache.ts src/modules/chat/promptCache.test.ts  # ✓
# proactive: docs:check-symbols / check-graph / check-pr-ledger / agent:check-index — all in sync
```

New `promptCache.test.ts`: direct unit tests for the now-exported pure functions (`buildSystem`, `applyToolsCacheBreakpoint`, `applyMessagesCacheBreakpoint` — empty input, last-message wrapping, prior-messages-stay-string, non-mutation). The existing handler-level caching assertions in `chat.test.ts` still pass unchanged.

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a (in-code doc comment moved alongside the helpers; no canonical-doc surface affected)

## Risk and Rollout

- User-visible risk: None. Pure code-move; the helpers were already pure/non-mutating and are covered by both the existing handler tests and new unit tests.
- Rollout / deploy order: standard (server-only, Railway).
- Backout plan: revert this PR; no data, schema, or migration impact.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

Mechanical extraction. The only non-obvious choice: the moved `applyMessagesCacheBreakpoint` takes a structural `CacheableInputMessage` rather than importing `ClientChatMessage` from `chat.ts`, which avoids a `chat.ts ↔ promptCache.ts` circular import while staying structurally compatible with the `cleaned: ClientChatMessage[]` call-site.

https://claude.ai/code/session_01Nfm9e6ocRKUAbAFYwHSjZY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nfm9e6ocRKUAbAFYwHSjZY)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted chat prompt-caching helpers into `apps/server/src/modules/chat/promptCache.ts` to keep `chat.ts` smaller and easier to test. No behavior or API changes; added unit tests for the helpers.

- **Refactors**
  - Moved `buildSystem`, `applyToolsCacheBreakpoint` + `TOOLS_WITH_CACHE`, `applyMessagesCacheBreakpoint`, and related types/doc into `promptCache.ts`.
  - `chat.ts` now imports these; `ClientChatMessage` stays local. The helper uses `CacheableInputMessage` to avoid a circular import.
  - Trimmed `chat.ts` from 965 to 866 lines.

<sup>Written for commit 5cfd8d4fb7f15a462a1640a58df50f5225276d66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

