### PR TITLE
docs(agents): reconcile skills roadmap drift with merged PRs

### DIFF
--- a/docs/00-start/agents/skills-evolution-roadmap.md
+++ b/docs/00-start/agents/skills-evolution-roadmap.md
@@ -1,6 +1,6 @@
 # Skills Evolution Roadmap — запозичення з ecosystem-у agent skills
 
-> **Last validated:** 2026-05-13 by Devin. **Next review:** 2026-08-11.
+> **Last validated:** 2026-06-14 by Claude (drift reconcile: PR 4/10/11 merged #2925; PR 7 superseded by central eval harness). **Next review:** 2026-08-11.
 > **Status:** Active (proposal — sequencing only; кожен пункт окремий PR із власним acceptance criteria)
 
 > **Що це.** Курований план, як еволюціонувати repo-owned skill-систему Sergeant (`.agents/skills/**`) запозичивши перевірені патерни з широкого agent-skills ecosystem-у — без розмиття існуючих 12 specialist-skill-ів і без імпорту generic-обгорток. Документ працює як roadmap для будь-якого AI-агента (Claude Code, Devin, Codex, Cursor, Gemini CLI), що візьметься за конкретний пункт.
@@ -43,6 +43,8 @@ PR проходить у roadmap, якщо він задовольняє всі 
 Дев'ять незалежних PR-ів, від найдешевшого до найдорожчого. Кожен — окремий branch, окремий PR, окремий verify-step. **Один PR на одну проблему** (Hard Rule #15 sub-clause). Ніяких bundled-changes.
 
 > **Drift policy.** Якщо план відстає реальності, фіксуй це errata-блоком у цій секції з датою і коротким поясненням, як у `docs/90-work/initiatives/0011-…md`. Не переписуй мовчки, не видаляй "невзяті" пункти.
+>
+> **Errata 2026-06-14 (Claude).** Reconcile зі станом репо: PR 4 / 10 / 11 змерджено одним commit `f0581fa8e` у [#2925](https://github.com/Skords-01/Sergeant/pull/2925) (2026-05-16) — статуси оновлено з «in progress» на ✅; усі три скіли (`sergeant-e2e-testing`, `sergeant-security-audit`, `sergeant-tech-debt`) уже в `.agents/skills/` і в routing-таблиці `AGENTS.md`. **PR 7 (Skill evals substring) — superseded**: централізований harness `docs/00-start/agents/skill-trigger-evals.json` + `pnpm eval:skills` уже покриває 2 trigger + 1 anti-trigger + 1 workflow-compliance prompt на **кожен** repo-owned skill (ширше за per-skill `evals/evals.json` із початкового плану) і вшитий у `pnpm lint:skills`. Окремий PR 7 не беремо. PR 8 (real-LLM runner) залежав від PR 7 → переоцінити проти наявного harness-у, а не від нуля.
 
 ### PR 1 — Pushy descriptions audit (≈30 хв, S) ✅ (merged: #2374, 2026-05-10)
 
@@ -146,7 +148,7 @@ PR проходить у roadmap, якщо він задовольняє всі 
 
 ---
 
-### PR 4 — `sergeant-e2e-testing` skill (≈2 дні, M) ✅ (in progress: claude/review-ai-agents-templates-JQOrZ, 2026-05-16)
+### PR 4 — `sergeant-e2e-testing` skill (≈2 дні, M) ✅ (merged: #2925, 2026-05-16)
 
 **Проблема.** Sergeant використовує Playwright для E2E (див. `apps/web` test-stack), але немає specialist-skill-у про Playwright-discipline. `sergeant-web-ui` згадує a11y і design tokens, але golden-rules для Playwright (web-first assertions, fixtures over globals, traces='on-first-retry', retries=2-in-CI/0-locally, ніколи `page.waitForTimeout()`) — розкидані по PR-описах і не enforce-ні.
 
@@ -259,7 +261,7 @@ PR проходить у roadmap, якщо він задовольняє всі 
 
 ---
 
-### PR 7 — Skill evals: quantitative trigger-testing (≈2 дні, L)
+### PR 7 — Skill evals: quantitative trigger-testing (≈2 дні, L) ⛔ superseded (див. Errata 2026-06-14 — реалізовано централізованим harness-ом)
 
 **Проблема.** Зараз ми не маємо способу перевірити **чи правильно тригериться** скіл. `pnpm lint:skills` перевіряє shape, але не behavior. Якщо хтось зламає `description:` (PR 1 робить його pushy → потім хтось downgrade-ить), не дізнаємось доки агент не помиляється у проді.
 
@@ -342,7 +344,7 @@ PR проходить у roadmap, якщо він задовольняє всі 
 
 ---
 
-### PR 10 — `sergeant-security-audit` skill (≈1 день, M) 🔄 (in progress: claude/review-ai-agents-templates-JQOrZ, 2026-05-16)
+### PR 10 — `sergeant-security-audit` skill (≈1 день, M) ✅ (merged: #2925, 2026-05-16)
 
 **Проблема.** Sergeant має Hard Rules #20 (PAT safety), #21 (Pino redaction), #22 (skill security scan) і playbook `security-pen-test-checklist.md`, але немає specialist-skill-у, що веде агента через security review. Агент без цього skill-у системно пропускає Sergeant-specific вектори: перевірку `REDACT_KEY_NAMES` у `@sergeant/shared/lib/pii.ts`, Drizzle `sql\`...\``injection,`pnpm audit`(не`npm audit`) для workspace-монорепо.
 
@@ -371,7 +373,7 @@ PR проходить у roadmap, якщо він задовольняє всі 
 
 ---
 
-### PR 11 — `sergeant-tech-debt` skill (≈1 день, M) 🔄 (in progress: claude/review-ai-agents-templates-JQOrZ, 2026-05-16)
+### PR 11 — `sergeant-tech-debt` skill (≈1 день, M) ✅ (merged: #2925, 2026-05-16)
 
 **Проблема.** 26 hard rules визначають taxonomy технічного боргу, але немає specialist-skill-у, що систематично веде агента через `eslint-baseline.js`, Knip, Hard Rule #18 (module-size), Hard Rule #19 (noUncheckedIndexedAccess). Агент без цього skill-у міксує різні класи боргу в один PR або видаляє код без перевірки lifecycle markers.
 
@@ -402,21 +404,21 @@ PR проходить у roadmap, якщо він задовольняє всі 
 
 ## Priority matrix
 
-| #   | PR                                | Effort | Value-per-hour | Dependencies        | Status         |
-| --- | --------------------------------- | ------ | -------------- | ------------------- | -------------- |
-| 1   | Pushy descriptions audit          | S      | High           | none                | ✅ #2374       |
-| 2   | Verification gate in review skill | S      | **Highest**    | none                | ✅ #2373       |
-| 3   | Postgres references               | M      | High           | (no hard dep)       |                |
-| 4   | E2E testing skill                 | M      | Medium         | (no hard dep)       | 🔄 in progress |
-| 5   | Security body-scan in lint:skills | M      | High           | none                | ✅ #2378       |
-| 6   | References folder convention      | S      | Medium         | depends on PR 3 / 4 |                |
-| 7   | Skill evals (substring)           | L      | Medium-High    | depends on PR 1     |                |
-| 8   | Real-LLM eval runner              | L      | Medium         | depends on PR 7     |                |
-| 9   | PR template cross-link            | S      | High           | depends on PR 2     | ✅ #2375       |
-| 10  | `sergeant-security-audit` skill   | M      | High           | none                | 🔄 in progress |
-| 11  | `sergeant-tech-debt` skill        | M      | High           | none                | 🔄 in progress |
+| #   | PR                                | Effort | Value-per-hour | Dependencies        | Status        |
+| --- | --------------------------------- | ------ | -------------- | ------------------- | ------------- |
+| 1   | Pushy descriptions audit          | S      | High           | none                | ✅ #2374      |
+| 2   | Verification gate in review skill | S      | **Highest**    | none                | ✅ #2373      |
+| 3   | Postgres references               | M      | High           | (no hard dep)       |               |
+| 4   | E2E testing skill                 | M      | Medium         | (no hard dep)       | ✅ #2925      |
+| 5   | Security body-scan in lint:skills | M      | High           | none                | ✅ #2378      |
+| 6   | References folder convention      | S      | Medium         | depends on PR 3 / 4 |               |
+| 7   | Skill evals (substring)           | L      | Medium-High    | depends on PR 1     | ⛔ superseded |
+| 8   | Real-LLM eval runner              | L      | Medium         | depends on PR 7     |               |
+| 9   | PR template cross-link            | S      | High           | depends on PR 2     | ✅ #2375      |
+| 10  | `sergeant-security-audit` skill   | M      | High           | none                | ✅ #2925      |
+| 11  | `sergeant-tech-debt` skill        | M      | High           | none                | ✅ #2925      |
 
-**Recommended starting order:** PR 2 → PR 1 → PR 5 → PR 9 → PR 3 → PR 6 → PR 4 → PR 7 → PR 8.
+**Recommended starting order:** ~~PR 2 → PR 1 → PR 5 → PR 9~~ (merged) → ~~PR 4 / 10 / 11~~ (merged #2925) → **PR 3 → PR 6** (єдині відкриті) → ~~PR 7~~ (superseded) → PR 8 (переоцінити). Тобто лишилися тільки **PR 3** (Postgres references) і залежний від нього **PR 6** (references-convention governance page).
 
 **Найдешевший quality-bump:** PR 2 (Verification gate) — лінгвістична дисципліна, що ловить 60-70% "Should pass now" / "Looks correct" хибних completion claims одним прочитанням SKILL.md.
 

--- a/docs/90-work/planning/ai-coding-improvements.md
+++ b/docs/90-work/planning/ai-coding-improvements.md
@@ -1,33 +1,33 @@
 # Roadmap покращень AI-coding
 
-> **Last validated:** 2026-05-19 by Codex (додано перший виконуваний skill-trigger eval harness). **Next review:** 2026-08-17.
+> **Last validated:** 2026-06-14 by Claude (drift fix: discoverability gate `next` → `done` — `pnpm lint:discoverability` уже в CI). **Next review:** 2026-08-17.
 > **Status:** Active
 
 Roadmap для агентської інфраструктури Sergeant. Це не продуктовий roadmap; це план, як зробити AI-assisted development швидшим, безпечнішим і дисциплінованішим.
 
 ## Уже зроблено
 
-| Блок                                 | Статус | Нотатки                                                                                           |
-| ------------------------------------ | ------ | ------------------------------------------------------------------------------------------------- |
-| Repo-level контракт і hard rules     | done   | `AGENTS.md` + registry + matrix + CI sync gates                                                   |
-| Перша хвиля playbook-ів              | done   | початкові execution recipes у `docs/00-start/playbooks/`                                          |
-| AI-маркери й enforcement             | done   | lifecycle / generation markers під CI                                                             |
-| Preview / test інфраструктура        | done   | Playwright, visual regression, CI coverage                                                        |
-| Оновлення repo-owned skills          | done   | вузька Sergeant-specific skill surface без generic-дублювання                                     |
-| Консолідація entrypoint-ів           | done   | `README`, `CONTRIBUTING`, `AGENTS`, `CLAUDE`, `DEVIN` вирівняні за ролями                         |
-| Оновлення playbook-ів                | done   | taxonomy, catalog, priority playbooks, routing clarity                                            |
-| Cleanup governance source-of-truth   | done   | ownership split між `AGENTS.md`, `hard-rules.json`, generated matrix, review docs                 |
-| PR / review hardening                | done   | PR template, review checklist, CODEOWNERS alignment                                               |
-| Хвиля операційної зрілості           | done   | service catalog, release policy, incident system, feature flag registry, DR, engineering metrics  |
-| Operating system для security access | done   | privileged access policy, access matrix, secret ownership register, compromise-response playbooks |
+| Блок                                 | Статус | Нотатки                                                                                                                                    |
+| ------------------------------------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| Repo-level контракт і hard rules     | done   | `AGENTS.md` + registry + matrix + CI sync gates                                                                                            |
+| Перша хвиля playbook-ів              | done   | початкові execution recipes у `docs/00-start/playbooks/`                                                                                   |
+| AI-маркери й enforcement             | done   | lifecycle / generation markers під CI                                                                                                      |
+| Preview / test інфраструктура        | done   | Playwright, visual regression, CI coverage                                                                                                 |
+| Оновлення repo-owned skills          | done   | вузька Sergeant-specific skill surface без generic-дублювання                                                                              |
+| Консолідація entrypoint-ів           | done   | `README`, `CONTRIBUTING`, `AGENTS`, `CLAUDE`, `DEVIN` вирівняні за ролями                                                                  |
+| Оновлення playbook-ів                | done   | taxonomy, catalog, priority playbooks, routing clarity                                                                                     |
+| Cleanup governance source-of-truth   | done   | ownership split між `AGENTS.md`, `hard-rules.json`, generated matrix, review docs                                                          |
+| PR / review hardening                | done   | PR template, review checklist, CODEOWNERS alignment                                                                                        |
+| Хвиля операційної зрілості           | done   | service catalog, release policy, incident system, feature flag registry, DR, engineering metrics                                           |
+| Operating system для security access | done   | privileged access policy, access matrix, secret ownership register, compromise-response playbooks                                          |
+| Discoverability gate                 | done   | `scripts/check-discoverability.mjs` + `pnpm lint:discoverability` (≤2-hop role×target reachability), в aggregate `pnpm lint` + CI `ci.yml` |
 
 ## Наступні блоки
 
 | Блок                               | Статус | Нотатки                                                                                                                                        |
 | ---------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | Eval harness для skill trigger-ів  | active | `docs/00-start/agents/skill-trigger-evals.json` + `pnpm eval:skills`: 2 trigger + 1 anti-trigger + 1 workflow-compliance prompt на кожен skill |
-| Eval harness для playbook routing  | next   | один очевидний playbook match для priority-сценаріїв                                                                                           |
-| Discoverability tests              | next   | new contributor / new agent знаходить потрібний route менш ніж за два кліки                                                                    |
+| Eval harness для playbook routing  | next   | один очевидний playbook match для priority-сценаріїв (частково покрито `check-discoverability.mjs`, але obvious-match routing-eval окремо)     |
 | Sampling відповідності PR template | next   | dry-run quality gate для PR descriptions                                                                                                       |
 | Автоматизація operator dashboards  | next   | saved searches / issue views для lead time, stale flags, postmortem actions                                                                    |
 | Privacy and data-rights operations | next   | перетворити launch/privacy draft на канонічні retention, consent, export, delete surface-и                                                     |


### PR DESCRIPTION
## Summary

Reconciles two agent-OS roadmap docs with the actual state of the repo (status drift only — no behavior change).

- **`ai-coding-improvements.md`**: «Discoverability tests» was `next`, but the gate already ships — `scripts/check-discoverability.mjs` + `pnpm lint:discoverability` (≤2-hop role×target reachability), wired into aggregate `pnpm lint` and `ci.yml`. Moved to **done**.
- **`skills-evolution-roadmap.md`**: PR 4 / 10 / 11 (`e2e-testing`, `security-audit`, `tech-debt` skills) were marked `in progress`, but all three merged via **#2925** (`f0581fa8e`, 2026-05-16) and are live in `.agents/skills/` + `AGENTS.md` routing. Set to **merged**. **PR 7 (substring skill evals) → superseded** by the central `skill-trigger-evals.json` + `pnpm eval:skills` harness (2 trigger + 1 anti-trigger + 1 workflow prompt per skill). Added a dated **errata block** per the file's own drift policy.

## Governing Skill

`sergeant-writing-skills` (docs/freshness discipline).

## Playbook

N/A — doc reconciliation.

## Verification

- `pnpm lint:discoverability` — green (confirms the gate the doc now marks done).
- Husky pre-commit: `bump-last-validated` + Prettier ran on both `.md` files.

## Docs and Governance

Both files carry refreshed `Last validated` markers. No code, no hard-rule changes.

## Risk and Rollout

None — documentation only.

## Hard Rule #15

Read governance before editing; docs updated alongside the reconciliation; internal docs remain in Ukrainian.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reconciles the agent skills roadmaps with the current repo: marks the discoverability gate as done (`scripts/check-discoverability.mjs` + `pnpm lint:discoverability` in `ci.yml`) and sets the e2e-testing, security-audit, and tech-debt skills to merged. Marks the substring trigger‑evals item as superseded by the central `skill-trigger-evals.json` + `pnpm eval:skills` harness, updates the priority matrix and “Last validated” notes, and adds a dated errata block; docs-only.

<sup>Written for commit a96ca50511efb8237cee01b0a7a077946ea75c3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated skills evolution roadmap to reflect current status of merged and superseded items
  * Clarified evaluation harness approach and task dependencies for remaining development items
  * Refreshed planning documentation with latest progress and implementation details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->