### PR TITLE
chore(deps): remove dead @grpc/grpc-js pnpm override

### DIFF
--- a/package.json
+++ b/package.json
@@ -204,8 +204,7 @@
       "esbuild@<0.28.1": ">=0.28.1",
       "ajv@>=7.0.0-alpha.0 <8.18.0": ">=8.18.0",
       "tmp@<0.2.6": ">=0.2.6",
-      "shell-quote@<1.8.4": ">=1.8.4",
-      "@grpc/grpc-js@<1.14.4": ">=1.14.4"
+      "shell-quote@<1.8.4": ">=1.8.4"
     },
     "patchedDependencies": {
       "@expo/cli@0.22.28": "patches/@expo__cli@0.22.28.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,6 @@ overrides:
   ajv@>=7.0.0-alpha.0 <8.18.0: '>=8.18.0'
   tmp@<0.2.6: '>=0.2.6'
   shell-quote@<1.8.4: '>=1.8.4'
-  '@grpc/grpc-js@<1.14.4': '>=1.14.4'
 
 patchedDependencies:
   '@expo/cli@0.22.28':


### PR DESCRIPTION
## Summary

**Scope slimmed (2026-06-14):** this PR was a broad drift sweep, but `main` (now `8a4af40`) has since independently absorbed almost all of it — the knowledge-graph no longer references `0019`, `retrieval-index.json` / `STATUS.md` / the freshness dashboard are regenerated, and the dangling `0019-agent-routing.md` links are healed by [#3577](https://github.com/Skords-01/Sergeant/pull/3577). To avoid duplicate, perpetually-conflicting doc churn, the redundant auto-doc regeneration commit was dropped.

**What remains — the one unique, still-applicable change:**

- Remove the dead `@grpc/grpc-js` pnpm override. No package depends on it directly; it resolves transitively via the OpenTelemetry exporters already at `>=1.14.4`, so the security pin was a no-op. Lockfile reconciled with zero version churn.

## Verification

- `pnpm install --frozen-lockfile` → clean (lockfile consistent after override removal).
- Rebased onto current `main`; conflict-free.

## Risk and Rollout

Minimal. Dead-override removal only; no runtime code, no migrations, no API contract change. Backout = revert.

## Hard Rule #15

Read governance before acting; no internal docs changed in this slimmed scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application dependency version constraints to allow for newer library versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->