### PR TITLE
fix(web): readable dark-mode foreground for module soft buttons

### DIFF
--- a/apps/web/src/shared/components/ui/Button.test.tsx
+++ b/apps/web/src/shared/components/ui/Button.test.tsx
@@ -129,10 +129,10 @@ describe("Button", () => {
     );
 
     it.each([
-      ["finyk", "text-finyk-strong"],
-      ["fizruk", "text-fizruk-strong"],
-      ["routine", "text-routine-strong"],
-      ["nutrition", "text-nutrition-strong"],
+      ["finyk", "text-finyk-soft-fg"],
+      ["fizruk", "text-fizruk-soft-fg"],
+      ["routine", "text-routine-soft-fg"],
+      ["nutrition", "text-nutrition-soft-fg"],
     ] as const)(
       "module=%s + variant=secondary → renders %s soft",
       (module, expectedFg) => {

--- a/apps/web/src/shared/components/ui/Button.tsx
+++ b/apps/web/src/shared/components/ui/Button.tsx
@@ -87,17 +87,24 @@ const variants: Record<ButtonVariant, string> = {
     "bg-nutrition-strong text-white shadow-sm hover:bg-lime-900 hover:shadow-glow-lime active:scale-[0.98]",
 
   // Soft module variants (for secondary actions within modules).
-  // Dark mode swaps the light pastel surface for the saturated accent at
-  // low opacity so the button blends with the warm dark panel instead of
-  // reading as an acidic pastel — same convention used by Badge/Tabs.
+  // Dark mode keeps the saturated accent at low opacity for the FILL so the
+  // button blends with the warm dark panel instead of reading as an acidic
+  // pastel — same convention used by Badge/Tabs. The FOREGROUND, however,
+  // is the theme-aware `text-<m>-soft-fg` token (NOT the mid accent): in
+  // dark mode the old `dark:text-<m>` ink sat at the same tone as the
+  // `bg-<m>/15` fill and measured ~1.77:1 (fizruk) — an a11y fail.
+  // `text-<m>-soft-fg` resolves to the `-strong` ink in light and the
+  // bright `-300` accent in dark, clearing WCAG AA in both themes from a
+  // single class (see `--c-<m>-soft-fg` in theme.css). Readability wins
+  // over the blend aesthetic.
   "finyk-soft":
-    "bg-finyk-soft text-finyk-strong dark:bg-finyk/15 dark:text-finyk border border-finyk-ring/50 dark:border-finyk/30 hover:bg-brand-100 dark:hover:bg-finyk/25 active:scale-[0.98]",
+    "bg-finyk-soft text-finyk-soft-fg dark:bg-finyk/15 border border-finyk-ring/50 dark:border-finyk/30 hover:bg-brand-100 dark:hover:bg-finyk/25 active:scale-[0.98]",
   "fizruk-soft":
-    "bg-fizruk-soft text-fizruk-strong dark:bg-fizruk/15 dark:text-fizruk-300 border border-fizruk-ring/50 dark:border-fizruk/30 hover:bg-teal-100 dark:hover:bg-fizruk/25 active:scale-[0.98]",
+    "bg-fizruk-soft text-fizruk-soft-fg dark:bg-fizruk/15 border border-fizruk-ring/50 dark:border-fizruk/30 hover:bg-teal-100 dark:hover:bg-fizruk/25 active:scale-[0.98]",
   "routine-soft":
-    "bg-routine-surface text-routine-strong dark:bg-routine/15 dark:text-routine border border-routine-ring/50 dark:border-routine/30 hover:bg-coral-100 dark:hover:bg-routine/25 active:scale-[0.98]",
+    "bg-routine-surface text-routine-soft-fg dark:bg-routine/15 border border-routine-ring/50 dark:border-routine/30 hover:bg-coral-100 dark:hover:bg-routine/25 active:scale-[0.98]",
   "nutrition-soft":
-    "bg-nutrition-soft text-nutrition-strong dark:bg-nutrition/15 dark:text-nutrition border border-nutrition-ring/50 dark:border-nutrition/30 hover:bg-lime-100 dark:hover:bg-nutrition/25 active:scale-[0.98]",
+    "bg-nutrition-soft text-nutrition-soft-fg dark:bg-nutrition/15 border border-nutrition-ring/50 dark:border-nutrition/30 hover:bg-lime-100 dark:hover:bg-nutrition/25 active:scale-[0.98]",
 
   // Sergeant v2 inverted primary — see `ButtonVariant` JSDoc above.
   // `bg-ink-strong` is emerald-900 in light + white in dark (HC: pure

--- a/apps/web/src/styles/theme.css
+++ b/apps/web/src/styles/theme.css
@@ -277,6 +277,19 @@
     --c-nutrition-soft-border: 217 249 157; /* lime-200 */
     --c-nutrition-soft-hover: 239 252 203; /* lime-100 */
 
+    /* `-soft-fg` — theme-aware FOREGROUND ink for soft-fill module controls
+       (`Button` `*-soft`, soft Badges/Tabs) that pair with the `-soft`
+       surface above. Light scope = the module `-strong` ink on the pale
+       `-soft` surface (≥4.5:1 AA — identical to the prior
+       `text-<m>-strong`). The dark + HC scopes flip to a lighter accent
+       (see `.dark` / `html.hc*` below) so one `text-<m>-soft-fg` utility
+       replaces the old `text-<m>-strong dark:text-<m>` pair — the saturated
+       mid-accent in dark mode measured ~1.8:1 and was illegible. */
+    --c-finyk-soft-fg: 4 120 87; /* emerald-700 */
+    --c-fizruk-soft-fg: 21 94 117; /* cyan-800 */
+    --c-routine-soft-fg: 194 58 58; /* coral-700 */
+    --c-nutrition-soft-fg: 70 98 18; /* lime-800 */
+
     /* Celebration / gamification tokens */
     --c-celebration: 251 191 36; /* amber-400 — confetti, stars, rewards */
     --c-streak-glow: 249 112 102; /* coral-500 — streak flame glow */
@@ -499,6 +512,18 @@
     --c-nutrition-soft-border: 86 124 15; /* lime-700 */
     --c-nutrition-soft-hover: 86 124 15; /* lime-700 */
 
+    /* Soft-fill FOREGROUND (dark) — bright `-300` accent tier. The module
+       DEFAULT accent used previously (`dark:text-<m>` = emerald-500 /
+       cyan-700 / coral-500 / lime-500) sat at the SAME tone as the
+       translucent `bg-<m>/15` fill composited over the warm-charcoal panel
+       — the fizruk soft button measured ~1.77:1 on prod (a11y fail). The
+       `-300` tier clears WCAG AA with margin (≈7.9–10.3:1 on `bg-<m>/15`
+       over `--c-panel`) while staying the module's own hue. */
+    --c-finyk-soft-fg: 110 231 183; /* emerald-300 */
+    --c-fizruk-soft-fg: 103 232 249; /* cyan-300 */
+    --c-routine-soft-fg: 255 180 165; /* coral-300 */
+    --c-nutrition-soft-fg: 200 242 100; /* lime-300 */
+
     /* Chart series — brighter -400 tier for visibility on dark warm bg.
        Sync with `:root` chart vars + `chart-{module}` Tailwind palette. */
     --c-chart-finyk: 52 211 153; /* emerald-400 */
@@ -656,6 +681,15 @@
     --c-nutrition-soft: 217 249 157; /* lime-200 */
     --c-nutrition-soft-border: 63 98 18;
 
+    /* Soft-fill foreground (HC light) — deepest `-900` ink for ≥7:1 AAA on
+       the bumped `-200` soft surface. Coral is hue-capped at ≈6.4:1 (still
+       AA, and a lift over the base `-strong`): a warm coral ink can't reach
+       AAA on a coral-200 surface within the registered palette. */
+    --c-finyk-soft-fg: 6 78 59; /* emerald-900 */
+    --c-fizruk-soft-fg: 22 78 99; /* cyan-900 */
+    --c-routine-soft-fg: 134 46 46; /* coral-900 — hue-capped ≈6.4:1 (AA) */
+    --c-nutrition-soft-fg: 59 83 20; /* lime-900 */
+
     /* Chart series — HC light keeps the AA-strong tier from `:root`
        (already 5+ contrast on cream). 4 hues stay distinguishable. */
     --c-chart-finyk: 4 120 87; /* emerald-700 */
@@ -695,6 +729,13 @@
     --c-routine-soft-border: 255 140 120;
     --c-nutrition-soft: 86 124 15; /* lime-700 */
     --c-nutrition-soft-border: 176 230 54;
+
+    /* Soft-fill foreground (HC dark) — brightest `-200` accent for ≥7:1
+       AAA on the `bg-<m>/15` fill over the dark panel (≈10–12:1). */
+    --c-finyk-soft-fg: 167 243 208; /* emerald-200 */
+    --c-fizruk-soft-fg: 165 243 252; /* cyan-200 */
+    --c-routine-soft-fg: 255 212 203; /* coral-200 */
+    --c-nutrition-soft-fg: 223 249 157; /* lime-200 */
 
     /* Chart series — HC dark uses brighter -300 tier so 4 hues stay
        distinguishable against high-contrast dark bg + meet ≥7:1 AAA. */

--- a/packages/design-tokens/tailwind-preset.js
+++ b/packages/design-tokens/tailwind-preset.js
@@ -250,6 +250,11 @@ const preset = {
           soft: "rgb(var(--c-finyk-soft) / <alpha-value>)",
           "soft-border": "rgb(var(--c-finyk-soft-border) / <alpha-value>)",
           "soft-hover": "rgb(var(--c-finyk-soft-hover) / <alpha-value>)",
+          // Theme-aware foreground for soft-fill controls (`Button`
+          // `finyk-soft`). Light = emerald-700 ink; dark = emerald-300 so
+          // text clears WCAG AA on `bg-finyk/15` over the dark panel.
+          // Backed by `--c-finyk-soft-fg` (light/dark/HC in theme.css).
+          "soft-fg": "rgb(var(--c-finyk-soft-fg) / <alpha-value>)",
         },
 
         /** Фізрук — Cyan fitness tracker (v2 redesign 2026-05; was teal). */
@@ -275,6 +280,12 @@ const preset = {
           soft: "rgb(var(--c-fizruk-soft) / <alpha-value>)",
           "soft-border": "rgb(var(--c-fizruk-soft-border) / <alpha-value>)",
           "soft-hover": "rgb(var(--c-fizruk-soft-hover) / <alpha-value>)",
+          // Theme-aware foreground for soft-fill controls (`Button`
+          // `fizruk-soft`). Light = cyan-800 ink; dark = cyan-300 so text
+          // clears WCAG AA on `bg-fizruk/15` over the dark panel/hero (the
+          // prior cyan-700 ink measured ~1.77:1). Backed by
+          // `--c-fizruk-soft-fg`.
+          "soft-fg": "rgb(var(--c-fizruk-soft-fg) / <alpha-value>)",
           // `tile` + `tile-border` — subtle stat-tile wash on the
           // fizruk hero gradient (Wave 2a). Light=teal-800,
           // dark=white. Apply with the registered opacity scale,
@@ -305,6 +316,11 @@ const preset = {
           soft: "rgb(var(--c-routine-soft) / <alpha-value>)",
           "soft-border": "rgb(var(--c-routine-soft-border) / <alpha-value>)",
           "soft-hover": "rgb(var(--c-routine-soft-hover) / <alpha-value>)",
+          // Theme-aware foreground for soft-fill controls (`Button`
+          // `routine-soft`). Light = coral-700 ink; dark = coral-300 so text
+          // clears WCAG AA on `bg-routine/15` over the dark panel. Backed by
+          // `--c-routine-soft-fg`.
+          "soft-fg": "rgb(var(--c-routine-soft-fg) / <alpha-value>)",
         },
 
         /** Харчування — Fresh lime nutrition tracker */
@@ -320,6 +336,11 @@ const preset = {
           soft: "rgb(var(--c-nutrition-soft) / <alpha-value>)",
           "soft-border": "rgb(var(--c-nutrition-soft-border) / <alpha-value>)",
           "soft-hover": "rgb(var(--c-nutrition-soft-hover) / <alpha-value>)",
+          // Theme-aware foreground for soft-fill controls (`Button`
+          // `nutrition-soft`). Light = lime-800 ink; dark = lime-300 so text
+          // clears WCAG AA on `bg-nutrition/15` over the dark panel. Backed
+          // by `--c-nutrition-soft-fg`.
+          "soft-fg": "rgb(var(--c-nutrition-soft-fg) / <alpha-value>)",
         },
 
         // ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

The four `*-soft` Button variants (`finyk-soft` / `fizruk-soft` / `routine-soft` / `nutrition-soft`) failed WCAG contrast in **dark mode**. Each used `dark:text-<module>` — the **mid module accent** (e.g. `text-fizruk` = cyan-700, `rgb(14 116 144)`) — rendered on the translucent `bg-<module>/15` fill over the warm-charcoal panel. The `fizruk-soft` «До програм» button on the `/fizruk` hero measured **~1.77:1** on prod (near-illegible). Module accents have **no numbered palette step** (`text-fizruk-300` doesn't exist), so the `dark:text-brand-300` trick the `success` variant uses doesn't translate.

Fix: introduce a theme-aware **`--c-<module>-soft-fg`** token (light / dark / HC scopes in `theme.css`), exposed as `text-<module>-soft-fg`, and collapse the prior `text-<m>-strong dark:text-<m>` pair into a single class on each soft variant. The `dark:bg-<m>/15` FILL is unchanged.

- light: module `-strong` ink (**unchanged** — 4.95–6.97:1 AA)
- dark: bright `-300` accent → **7.9–10.3:1 AA**
- HC dark: `-200` accent → **≥9.9:1 AAA**
- HC light: `-900` ink → AAA for finyk/fizruk/nutrition; coral hue-capped at ≈6.4:1 (AA — a warm coral ink can't reach AAA on a coral-200 surface in-palette)

## Governing Skill

- Primary skill: `sergeant-web-ui` (apps/web, Tailwind, a11y, design tokens)
- Secondary skill (if truly needed): n/a

## Playbook

- Primary playbook: n/a
- Why this playbook: —
- If no playbook matched, why: focused design-token + component a11y fix; no playbook covers per-module contrast-token tuning.

## Verification

The contrast scan is unreliable on translucent glass and the live `/fizruk` empty-state requires auth, so I measured by **compositing** (the method the task specifies) — `text-<m>-soft-fg` on `bg-<m>/15` composited over the dark `--c-panel` read from the shipped CSS bundle (`32 28 25`):

```bash
pnpm --filter @sergeant/web typecheck          # ✓
pnpm --filter @sergeant/web build              # ✓ (4 utilities + 16 token decls emitted)
node_modules/.bin/eslint Button.tsx tailwind-preset.js   # ✓ clean
node_modules/.bin/vitest run Button.test.tsx Card.test.tsx  # ✓ 43 passed
```

- Dark mode (composited WCAG): finyk **8.78:1** · fizruk **10.29:1** · routine **7.90:1** · nutrition **9.73:1** — all clear AA (was ~1.77:1 for fizruk).
- Light mode re-checked — no regression (5.21–6.97:1 AA; same `-strong` ink).
- HC dark ≥9.9:1 AAA; HC light AAA except coral (AA by hue ceiling, documented inline).

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a — no canonical doc behavior changed. Token intent + the coral HC hue ceiling are documented inline in `theme.css` / `tailwind-preset.js` comments. Honored `theme.css`'s "every new semantic token MUST get an HC override" rule (HC light + HC dark scopes added).

## Risk and Rollout

- User-visible risk: Low. Light mode is byte-for-byte equivalent (`text-<m>-soft-fg` resolves to the same `-strong` ink); only the dark/HC foreground brightens. No API/contract/migration impact.
- Rollout / deploy order: standard web deploy; no ordering constraints.
- Backout plan: revert the commit — purely additive token + className swap.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian. (No internal `.md` docs touched — code-comment intent is EN per repo convention; vacuously satisfied.)
- [x] I did not use `--no-verify`.

## Reviewer Notes

- Shared `tailwind-preset.js` gains a `soft-fg` key per module; mobile doesn't back `--c-<m>-soft*` and doesn't use these web classes, so it's a no-op there (same as the existing `soft`/`soft-border`/`soft-hover` keys).
- The `[data-theme-preview]` sandbox blocks are intentionally not touched — they mirror only `--c-brand-soft*` today (the existing `--c-<module>-soft*` family is already absent), so DesignShowcase tiles don't consume module-soft tokens.
- Hard Rules respected: **#8** opacity scale (`/15` on-scale, unchanged), **#11** no arbitrary hex (token-only), **#12** module-accent containment, **#13** no raw light/dark palette pairs — the single token **removes** the `dark:text-*` override entirely.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XoYKXhuVCEXWx9ysHUFhTA)_