### PR TITLE
fix(web): raise dark-mode module subtitle contrast to WCAG AA

### DIFF
--- a/apps/web/src/shared/components/layout/ModuleHeader.tsx
+++ b/apps/web/src/shared/components/layout/ModuleHeader.tsx
@@ -69,7 +69,7 @@ const MODULE_HEADER_TOKENS: Record<
   finyk: {
     gradient: "from-finyk/5",
     border: "border-finyk/15",
-    subtitle: "text-finyk-strong dark:text-finyk/70",
+    subtitle: "text-finyk-strong dark:text-finyk-300/70",
     accentDot: "bg-finyk",
     accentStrip: "bg-finyk/45",
   },
@@ -83,7 +83,7 @@ const MODULE_HEADER_TOKENS: Record<
   routine: {
     gradient: "from-routine/5",
     border: "border-routine/15",
-    subtitle: "text-routine-strong dark:text-routine/70",
+    subtitle: "text-routine-strong dark:text-routine-300/70",
     accentDot: "bg-routine",
     accentStrip: "bg-routine/45",
   },

--- a/apps/web/src/shared/components/ui/SectionHeading.test.tsx
+++ b/apps/web/src/shared/components/ui/SectionHeading.test.tsx
@@ -58,7 +58,9 @@ describe("SectionHeading", () => {
     );
     const cls = container.querySelector("h3")!.className;
     expect(cls).toContain("text-finyk-strong");
-    expect(cls).toContain("dark:text-finyk/70");
+    // Dark subtitle rides the lighter emerald-300 tier so the de-emphasised
+    // /70 slot still clears WCAG AA on `--c-panel` (emerald-300/70 ≈ 6.05:1).
+    expect(cls).toContain("dark:text-finyk-300/70");
   });
 
   it("action prop wraps the heading in a flex-row with a trailing slot", () => {

--- a/apps/web/src/shared/components/ui/SectionHeading.tsx
+++ b/apps/web/src/shared/components/ui/SectionHeading.tsx
@@ -87,10 +87,13 @@ const variants: Record<SectionHeadingVariant, string> = {
   // contract test that pins the className.
   accent: "text-brand-strong",
   // Module-branded tints — normalised to /70 so callers don't drift
-  // between /70, /80, /90.
-  finyk: "text-finyk-strong dark:text-finyk/70",
+  // between /70, /80, /90. In dark mode the de-emphasised /70 subtitle
+  // must still clear WCAG AA (4.5:1) for normal text on `--c-panel`:
+  // finyk/routine/fizruk ride the lighter `-300` tier (emerald/coral/cyan-300
+  // /70 ≈ 5.5–6.3:1), while nutrition's lime-500/70 already clears AA (≈4.9:1).
+  finyk: "text-finyk-strong dark:text-finyk-300/70",
   fizruk: "text-fizruk-strong dark:text-fizruk-300/70",
-  routine: "text-routine-strong dark:text-routine/70",
+  routine: "text-routine-strong dark:text-routine-300/70",
   nutrition: "text-nutrition-strong dark:text-nutrition/70",
 };
 

--- a/docs/05-design/design/design-system/04-components.md
+++ b/docs/05-design/design/design-system/04-components.md
@@ -1,6 +1,6 @@
 # Design System — Примітиви UI, Focus, A11y та Gestures
 
-> **Last validated:** 2026-06-12 by @claude. **Next review:** 2026-09-10.
+> **Last touched:** 2026-06-14 by @claude. **Next review:** 2026-09-12.
 > **Status:** Active (v2 redesign foundation merged 2026-05)
 
 Цей документ охоплює UI-примітиви, focus/disabled/loading контракт, правила кодування, міграційні патерни, нові компоненти та хуки, gestures/a11y, та keyboard-first overlays (DropdownMenu, CommandPalette).
@@ -175,10 +175,12 @@ Home/End, `role="tablist"`.
 | `muted`     | `text-muted`                                   | послаблений підпис                    |
 | `text` \*   | `text-text`                                    | за замовчуванням для `md`/`lg`/`xl`   |
 | `accent`    | `text-accent`                                  | глобальний фокус/лінк (emerald)       |
-| `finyk`     | `text-finyk-strong dark:text-finyk/70`         | brand-tint у модулі ФІНІК             |
-| `fizruk`    | `text-fizruk-strong dark:text-fizruk/70`       | brand-tint у модулі ФІЗРУК            |
-| `routine`   | `text-routine-strong dark:text-routine/70`     | brand-tint у модулі Рутина            |
+| `finyk`     | `text-finyk-strong dark:text-finyk-300/70`     | brand-tint у модулі ФІНІК             |
+| `fizruk`    | `text-fizruk-strong dark:text-fizruk-300/70`   | brand-tint у модулі ФІЗРУК            |
+| `routine`   | `text-routine-strong dark:text-routine-300/70` | brand-tint у модулі Рутина            |
 | `nutrition` | `text-nutrition-strong dark:text-nutrition/70` | brand-tint у модулі Харчування        |
+
+> **Dark-mode AA (Hard Rule a11y):** де-емфазований `/70` підпис має тримати ≥4.5:1 на `--c-panel` (#201c19). `finyk`/`routine`/`fizruk` беруть світліший `-300`-тир (emerald/coral/cyan-300 @ /70 ≈ 5.5–6.3:1); `nutrition` лишається на lime-500 (/70 ≈ 4.9:1, вже AA). DEFAULT-500 у finyk/routine чистий AA лише на повній непрозорості — `-300` застосовуємо **тільки** в `dark:` `/70`-слоті підпису.
 
 Зірочкою (\*) — це значення за замовчуванням; їх можна не передавати.
 

--- a/packages/design-tokens/tailwind-preset.js
+++ b/packages/design-tokens/tailwind-preset.js
@@ -242,6 +242,14 @@ const preset = {
           hover: brandColors.emerald[600],
           strong: brandColors.emerald[700],
           ring: brandColors.emerald[200],
+          // Dark-mode subtitle companion. The DEFAULT emerald-500 clears AA
+          // for full-opacity dark text (≈6.7:1 on `--c-panel`), but the
+          // de-emphasised `/70` subtitle slot dips to ≈3.9:1 — sub-AA for
+          // normal text. `text-finyk-300` (emerald-300) is the lighter tier
+          // used ONLY in the `dark:` `/70` subtitle slot (emerald-300/70 ≈
+          // 6.05:1). Mirrors the `fizruk-300` precedent; do NOT use it for
+          // full-opacity finyk text — the DEFAULT already passes AA there.
+          300: brandColors.emerald[300],
           // `soft` / `soft-border` / `soft-hover` are now theme-adaptive
           // via `--c-finyk-soft*` (Wave 1b). Light values mirror the
           // legacy hex (`emerald[50]` / `[200]` / `[100]`); dark values
@@ -301,6 +309,11 @@ const preset = {
           ring: brandColors.coral[300],
           done: brandColors.coral[700],
           nav: brandColors.coral[500],
+          // Dark-mode subtitle companion — same rationale as `finyk.300`.
+          // coral-500/70 ≈ 3.6:1 (sub-AA for normal text); coral-300/70 ≈
+          // 5.5:1. Used ONLY in the `dark:` `/70` subtitle slot — the DEFAULT
+          // coral-500 already clears AA for full-opacity dark text.
+          300: brandColors.coral[300],
           // Theme-adaptive soft tint trio (Wave 1b).
           soft: "rgb(var(--c-routine-soft) / <alpha-value>)",
           "soft-border": "rgb(var(--c-routine-soft-border) / <alpha-value>)",


### PR DESCRIPTION
## Summary

The de-emphasised `/70` module-subtitle pattern (`text-<module>-strong dark:text-<module>/70`) measured **below WCAG AA (4.5:1)** for normal text on the dark warm-charcoal panel (`--c-panel` = `#201c19`):

| variant | before | after | Δ |
| --- | --- | --- | --- |
| finyk (emerald-500/70) | **3.90:1** ✗ | emerald-300/70 **6.05:1** ✓ | +2.15 |
| routine (coral-500/70) | **3.64:1** ✗ | coral-300/70 **5.51:1** ✓ | +1.87 |
| fizruk | 6.33:1 ✓ (already fixed in `78d984d67`) | unchanged | — |
| nutrition (lime-500/70) | 4.94:1 ✓ | unchanged | — |

**First confirmed the subtitles are normal-size text, not large text** (so the 3:1 large-text exemption does *not* apply): both render at **12px** in dark mode — `ModuleHeader` subtitle is `text-style-caption` (12px) + `font-medium` (500), `SectionHeading` eyebrow is `text-xs` (12px) + `font-bold`. Verified live in a headless Chromium against a real `#201c19` panel (pixel-sampled compositing), which reproduced the reported before-numbers exactly. → normal text → needs ≥4.5:1 → the finyk/routine subtitles were genuinely sub-AA → change needed.

### Fix

Move only the **dark `/70` subtitle slot** for finyk/routine onto the lighter `-300` tier (emerald-300 / coral-300), mirroring the existing **`fizruk-300` precedent**. This keeps the intended `/70` de-emphasis transparency while clearing AA with comfortable headroom (5.5–6.0:1).

Scoped strictly per the task brief:
- The DEFAULT-500 accents (finyk/routine) **already clear AA at full opacity** (6–9:1) and are **untouched** — `-300` is used *only* in the `dark:` `/70` subtitle slot.
- `nutrition` lime-500/70 already passes (4.94:1) and is left as-is.
- A naive `/80` opacity bump was rejected: it **fails for routine** (coral-500/80 = 4.35 < 4.5).

### Sites changed
- `apps/web/src/shared/components/ui/SectionHeading.tsx` — `finyk`/`routine` variants → `dark:text-{module}-300/70`
- `apps/web/src/shared/components/layout/ModuleHeader.tsx` — finyk/routine subtitle map → `dark:text-{module}-300/70`
- `packages/design-tokens/tailwind-preset.js` — add `finyk.300` (emerald-300) + `routine.300` (coral-300) dark-subtitle companion tokens (shape mirrors `fizruk.300`)

## Governing Skill

`sergeant-web-ui` (apps/web, Tailwind, a11y, design tokens).

## Playbook

None — targeted a11y contrast fix.

## Verification

- ✅ `vitest run SectionHeading.test.tsx` — 13/13 pass (contract test updated to pin `dark:text-finyk-300/70`)
- ✅ `pnpm --filter @sergeant/web typecheck`
- ✅ `eslint` on all touched files (new `-300/70` classes pass the opacity-scale + design rules; `-300` tokens now resolve)
- ✅ `prettier --check` on all touched files
- ✅ Live headless-Chromium pixel sampling over `#201c19`: finyk-300/70 = 6.04:1, routine-300/70 = 5.51:1, fizruk-300/70 = 6.32:1, nutrition/70 = 4.93:1 — all PASS

## Docs and Governance

- Updated `docs/05-design/design/design-system/04-components.md` SectionHeader variant table to the new classes (also fixed a **pre-existing fizruk drift** in that table — it still showed `dark:text-fizruk/70`) + added a dark-mode AA note.

## Risk and Rollout

Low. Dark-mode-only, visual-token change confined to the de-emphasised module subtitle. Light mode (`text-<module>-strong`) is untouched. No runtime/logic changes.

## Out of scope (follow-up)

`apps/mobile/src/components/ui/SectionHeading.tsx` carries the identical `dark:text-{module}/70` pattern; its dark panel/contrast wasn't part of this task's measurement (separate `sergeant-mobile-expo` surface), so it's left for a follow-up.

## Hard Rule #15 acknowledgement

Read governance before coding; docs updated alongside code; internal doc note added in Ukrainian.

https://claude.ai/code/session_015LDzAgQUVH2AMBPCSg6sqb

---
_Generated by [Claude Code](https://claude.ai/code/session_015LDzAgQUVH2AMBPCSg6sqb)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises dark‑mode module subtitle contrast to meet WCAG AA on the warm‑charcoal panel by switching the `/70` subtitle tint for `finyk` and `routine` to their `-300` variants. Light mode and full‑opacity accents remain unchanged; matches the existing `fizruk-300` pattern.

- **Bug Fixes**
  - `SectionHeading` and `ModuleHeader`: use `dark:text-finyk-300/70` and `dark:text-routine-300/70`; `fizruk` unchanged on `-300`, `nutrition` stays `-500/70`.
  - `packages/design-tokens/tailwind-preset.js`: add `finyk.300` and `routine.300` tokens for dark `/70` subtitles only.
  - Update SectionHeading contract test and the design‑system table; fix prior `fizruk` doc drift.

<sup>Written for commit f62f1105acb5d8c04e08ee611dddf30d5b3e3ae2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

