### PR TITLE
fix(server): restore production chat backend

### DIFF
--- a/apps/server/src/modules/chat/promptCache.test.ts
+++ b/apps/server/src/modules/chat/promptCache.test.ts
@@ -8,6 +8,7 @@ import {
   applyMessagesCacheBreakpoint,
   applyToolsCacheBreakpoint,
   buildSystem,
+  stripStrictModeForAnthropic,
   TOOLS_WITH_CACHE,
   type CacheableInputMessage,
 } from "./promptCache.js";
@@ -44,6 +45,21 @@ describe("applyToolsCacheBreakpoint", () => {
 
   it("порожній масив повертає порожній (без падіння)", () => {
     expect(applyToolsCacheBreakpoint([])).toEqual([]);
+  });
+
+  it("strips strict mode from the live Anthropic payload", () => {
+    const input = [
+      { name: "strict_tool", strict: true, input_schema: { type: "object" } },
+      { name: "regular_tool", input_schema: { type: "object" } },
+    ];
+    const snapshot = structuredClone(input);
+
+    expect(stripStrictModeForAnthropic(input)).toEqual([
+      { name: "strict_tool", input_schema: { type: "object" } },
+      { name: "regular_tool", input_schema: { type: "object" } },
+    ]);
+    expect(input).toEqual(snapshot);
+    expect(TOOLS_WITH_CACHE.some((tool) => "strict" in tool)).toBe(false);
   });
 });
 

--- a/apps/server/src/modules/chat/promptCache.ts
+++ b/apps/server/src/modules/chat/promptCache.ts
@@ -61,26 +61,39 @@ export function buildSystem(context: string): AnthropicSystemBlock[] {
  * tools → system → messages). Разом із cache_control на SYSTEM_PREFIX це кешує
  * стабільний блок tools + system на кожному турі.
  */
-export function applyToolsCacheBreakpoint(
-  tools: typeof TOOLS,
-): Array<(typeof TOOLS)[number] & { cache_control?: { type: "ephemeral" } }> {
-  if (tools.length === 0) return tools;
-  const cloned = tools.slice();
+export function applyToolsCacheBreakpoint<T extends object>(
+  tools: readonly T[],
+): Array<T & { cache_control?: { type: "ephemeral" } }> {
+  if (tools.length === 0) return [];
+  const cloned = tools.slice() as Array<
+    T & { cache_control?: { type: "ephemeral" } }
+  >;
   const last = cloned[cloned.length - 1];
   cloned[cloned.length - 1] = {
     ...last,
     cache_control: { type: "ephemeral" },
-  } as typeof last & { cache_control: { type: "ephemeral" } };
-  return cloned as Array<
-    (typeof TOOLS)[number] & { cache_control?: { type: "ephemeral" } }
-  >;
+  } as T & { cache_control: { type: "ephemeral" } };
+  return cloned;
+}
+
+/**
+ * Anthropic strict-mode schemas currently compile reliably only for very small
+ * subsets. Keep the full registry annotated for internal validation, but send
+ * the live provider payload in non-strict mode so `/api/chat` stays available.
+ */
+export function stripStrictModeForAnthropic<T extends { strict?: unknown }>(
+  tools: readonly T[],
+): Array<Omit<T, "strict">> {
+  return tools.map(({ strict: _strict, ...tool }) => tool);
 }
 
 /**
  * Tools із cache breakpoint на останньому — обчислюється один раз при імпорті
  * модуля (TOOLS статичний), щоб не клонувати масив на кожен запит.
  */
-export const TOOLS_WITH_CACHE = applyToolsCacheBreakpoint(TOOLS);
+export const TOOLS_WITH_CACHE = applyToolsCacheBreakpoint(
+  stripStrictModeForAnthropic(TOOLS),
+);
 
 /**
  * Вхід для `applyMessagesCacheBreakpoint` — мінімальна структурна форма

--- a/apps/server/src/modules/chat/toolDefs/crossModule.ts
+++ b/apps/server/src/modules/chat/toolDefs/crossModule.ts
@@ -15,7 +15,6 @@ export const CROSS_MODULE_TOOLS: AnthropicTool[] = [
     name: "weekly_summary",
     description:
       "Тижневий підсумок по всіх модулях: фінанси, тренування, звички, харчування. Повертає текстовий звіт.",
-    strict: true,
     input_schema: {
       type: "object",
       properties: {
@@ -143,7 +142,6 @@ export const CROSS_MODULE_TOOLS: AnthropicTool[] = [
     name: "compare_weeks",
     description:
       "Порівняти два тижні по всіх модулях: витрати, вага, виконання звичок, калорії. Викликай коли користувач каже 'порівняй цей тиждень з минулим' або 'як я провів тиждень порівняно з попереднім'.",
-    strict: true,
     input_schema: {
       type: "object",
       properties: {

--- a/apps/server/src/modules/chat/toolDefs/finyk.ts
+++ b/apps/server/src/modules/chat/toolDefs/finyk.ts
@@ -24,7 +24,6 @@ export const FINYK_TOOLS: AnthropicTool[] = [
     name: "find_transaction",
     description:
       "Знайти транзакції у Фініку за описом/мерчантом, сумою або датою. Використовуй перед категоризацією, коли користувач каже 'знайди покупку в АТБ' або 'транзакція на 450 грн позавчора'. Не змінює дані.",
-    strict: true,
     input_schema: {
       type: "object",
       properties: {
@@ -61,7 +60,6 @@ export const FINYK_TOOLS: AnthropicTool[] = [
     name: "batch_categorize",
     description:
       "Масово змінити категорію транзакцій за текстовим патерном і фільтрами. За замовчуванням dry_run=true — спершу показує preview без запису. Виконуй з dry_run=false тільки коли користувач підтвердив застосування.",
-    strict: true,
     input_schema: {
       type: "object",
       properties: {

--- a/apps/server/src/modules/chat/toolDefs/fizruk.ts
+++ b/apps/server/src/modules/chat/toolDefs/fizruk.ts
@@ -5,7 +5,6 @@ export const FIZRUK_TOOLS: AnthropicTool[] = [
     name: "plan_workout",
     description:
       "Створити (запланувати) тренування у Фізруку на сьогодні або вказану дату/час. Можна додати список вправ із підходами/повтореннями/вагою.",
-    strict: true,
     input_schema: {
       type: "object",
       properties: {

--- a/apps/server/src/modules/chat/toolDefs/nutrition.ts
+++ b/apps/server/src/modules/chat/toolDefs/nutrition.ts
@@ -118,7 +118,6 @@ export const NUTRITION_TOOLS: AnthropicTool[] = [
     name: "set_daily_plan",
     description:
       "Задати/оновити щоденні цілі Харчування: ккал, білок, жири, вуглеводи, ціль по воді (мл). Можна передавати лише ті поля, які змінюються.",
-    strict: true,
     input_schema: {
       type: "object",
       properties: {
@@ -134,7 +133,6 @@ export const NUTRITION_TOOLS: AnthropicTool[] = [
     name: "suggest_meal",
     description:
       "Порадити їжу на основі того що залишилось від денної цілі по макронутрієнтах. Наприклад: 'Що з'їсти щоб добити білок?'",
-    strict: true,
     input_schema: {
       type: "object",
       properties: {

--- a/apps/server/src/modules/chat/toolDefs/strict-normalize.test.ts
+++ b/apps/server/src/modules/chat/toolDefs/strict-normalize.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import { TOOLS } from "../tools.js";
+import { normalizeStrictTools } from "./strict.js";
+import type { AnthropicTool } from "./types.js";
+
+function objectSchemas(
+  schema: Record<string, unknown>,
+): Array<Record<string, unknown>> {
+  const out: Array<Record<string, unknown>> = [];
+  const walk = (node: unknown): void => {
+    if (Array.isArray(node)) {
+      node.forEach(walk);
+      return;
+    }
+    if (node === null || typeof node !== "object") return;
+    const obj = node as Record<string, unknown>;
+    if (obj["type"] === "object") out.push(obj);
+    for (const value of Object.values(obj)) walk(value);
+  };
+  walk(schema);
+  return out;
+}
+
+function optionalParameterCount(schema: Record<string, unknown>): number {
+  let count = 0;
+
+  const walk = (node: unknown): void => {
+    if (node === null || typeof node !== "object") return;
+    const obj = node as Record<string, unknown>;
+
+    if (
+      obj["type"] === "object" &&
+      obj["properties"] !== null &&
+      typeof obj["properties"] === "object" &&
+      !Array.isArray(obj["properties"])
+    ) {
+      const required = new Set(
+        Array.isArray(obj["required"]) ? obj["required"] : [],
+      );
+      for (const [key, value] of Object.entries(
+        obj["properties"] as Record<string, unknown>,
+      )) {
+        if (!required.has(key)) count += 1;
+        walk(value);
+      }
+    }
+
+    if (obj["type"] === "array") walk(obj["items"]);
+  };
+
+  walk(schema);
+  return count;
+}
+
+describe("normalizeStrictTools", () => {
+  it("normalizes only tools that explicitly opted into strict mode", () => {
+    const tools: AnthropicTool[] = [
+      {
+        name: "strict_tool",
+        description: "strict",
+        strict: true,
+        input_schema: { type: "object", properties: {} },
+      },
+      {
+        name: "regular_tool",
+        description: "regular",
+        input_schema: { type: "object", properties: {} },
+      },
+    ];
+
+    const result = normalizeStrictTools(tools);
+
+    expect(result[0]!.strict).toBe(true);
+    expect(result[0]!.input_schema["additionalProperties"]).toBe(false);
+    expect(result[1]).toBe(tools[1]);
+    expect(result[1]!.strict).toBeUndefined();
+    expect(result[1]!.input_schema).not.toHaveProperty("additionalProperties");
+  });
+
+  it("does not mutate the input array", () => {
+    const tools: AnthropicTool[] = [
+      {
+        name: "strict_tool",
+        description: "strict",
+        strict: true,
+        input_schema: { type: "object", properties: {} },
+      },
+    ];
+    const snapshot = JSON.parse(JSON.stringify(tools));
+
+    normalizeStrictTools(tools);
+
+    expect(JSON.parse(JSON.stringify(tools))).toEqual(snapshot);
+  });
+});
+
+describe("TOOLS strict-mode Anthropic contract", () => {
+  it("keeps strict tools under Anthropic's 20-tool cap", () => {
+    const strictTools = TOOLS.filter((tool) => tool.strict === true);
+
+    expect(
+      strictTools.length,
+      `strict tools (${strictTools.length}): ${strictTools
+        .map((tool) => tool.name)
+        .join(", ")}`,
+    ).toBeLessThanOrEqual(20);
+  });
+
+  it("keeps strict optional parameters within Anthropic's grammar budget", () => {
+    const strictTools = TOOLS.filter((tool) => tool.strict === true);
+    const total = strictTools.reduce(
+      (sum, tool) => sum + optionalParameterCount(tool.input_schema),
+      0,
+    );
+
+    expect(
+      total,
+      strictTools
+        .map(
+          (tool) => `${tool.name}:${optionalParameterCount(tool.input_schema)}`,
+        )
+        .join(", "),
+    ).toBeLessThanOrEqual(24);
+  });
+
+  it("sets additionalProperties=false on every strict object schema", () => {
+    for (const tool of TOOLS.filter((item) => item.strict === true)) {
+      for (const schema of objectSchemas(tool.input_schema)) {
+        expect(
+          schema["additionalProperties"],
+          `strict tool "${tool.name}" has an object schema without additionalProperties=false: ${JSON.stringify(
+            schema,
+          ).slice(0, 160)}`,
+        ).toBe(false);
+      }
+    }
+  });
+});

--- a/apps/server/src/modules/chat/toolDefs/strict.ts
+++ b/apps/server/src/modules/chat/toolDefs/strict.ts
@@ -46,6 +46,27 @@ export function applyStrictModeToAll(tools: AnthropicTool[]): AnthropicTool[] {
 }
 
 /**
+ * Normalize only tools that already opted into Anthropic strict mode.
+ *
+ * This is the production-safe variant for the aggregate chat registry:
+ * `applyStrictModeToAll()` intentionally turns every tool strict (useful for
+ * tests/experiments), but the live `/api/chat` payload must stay under
+ * Anthropic's 20 strict-tool cap. Selective normalization keeps non-strict
+ * tools untouched while making every `strict: true` schema acceptable to the
+ * provider.
+ */
+export function normalizeStrictTools(tools: AnthropicTool[]): AnthropicTool[] {
+  return tools.map((tool) =>
+    tool.strict === true
+      ? {
+          ...tool,
+          input_schema: addAdditionalPropertiesFalse(tool.input_schema),
+        }
+      : tool,
+  );
+}
+
+/**
  * Recursively clone a JSON Schema fragment and ensure every `type: "object"`
  * has `additionalProperties: false`. Walks both `properties.*` (object members)
  * and `items` / `items[i]` (array element schemas). Pre-existing

--- a/apps/server/src/modules/chat/tools.ts
+++ b/apps/server/src/modules/chat/tools.ts
@@ -29,10 +29,11 @@ import { NUTRITION_TOOLS } from "./toolDefs/nutrition.js";
 import { CROSS_MODULE_TOOLS } from "./toolDefs/crossModule.js";
 import { UTILITY_TOOLS } from "./toolDefs/utility.js";
 import { MEMORY_TOOLS } from "./toolDefs/memory.js";
+import { normalizeStrictTools } from "./toolDefs/strict.js";
 
 import type { AnthropicTool } from "./toolDefs/types.js";
 
-export const TOOLS: AnthropicTool[] = [
+export const TOOLS: AnthropicTool[] = normalizeStrictTools([
   ...FINYK_TOOLS,
   ...QUERY_FINYK_TOOLS,
   ...ROUTINE_TOOLS,
@@ -42,7 +43,7 @@ export const TOOLS: AnthropicTool[] = [
   ...CROSS_MODULE_TOOLS,
   ...UTILITY_TOOLS,
   ...MEMORY_TOOLS,
-];
+]);
 
 /**
  * Validate tool registry at startup:

--- a/apps/web/src/core/activation/useActivationV2Boot.ts
+++ b/apps/web/src/core/activation/useActivationV2Boot.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import type { MonoAccountDto, MonoTransactionDto } from "@sergeant/shared";
 
@@ -47,6 +47,24 @@ export function useActivationV2Boot(options: UseActivationV2Options = {}) {
   const { user } = useAuth();
   const queryClient = useQueryClient();
   const [cacheTick, setCacheTick] = useState(0);
+  const tickTimerRef = useRef<number | null>(null);
+
+  const scheduleCacheTick = useCallback((): void => {
+    if (tickTimerRef.current !== null) return;
+    tickTimerRef.current = window.setTimeout(() => {
+      tickTimerRef.current = null;
+      setCacheTick((t) => t + 1);
+    }, 0);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (tickTimerRef.current !== null) {
+        window.clearTimeout(tickTimerRef.current);
+        tickTimerRef.current = null;
+      }
+    };
+  }, []);
 
   // Subscribe to the React Query cache so we re-evaluate when the
   // source queries (`monoWebhookAccounts`, `monoWebhookTransactions`)
@@ -75,16 +93,16 @@ export function useActivationV2Boot(options: UseActivationV2Options = {}) {
         event.type === "removed" ||
         event.type === "updated"
       ) {
-        setCacheTick((t) => t + 1);
+        scheduleCacheTick();
       }
     });
-  }, [queryClient]);
+  }, [queryClient, scheduleCacheTick]);
 
   useEffect(() => {
     return webKVStore.onChange("finyk_budgets", () => {
-      setCacheTick((t) => t + 1);
+      scheduleCacheTick();
     });
-  }, []);
+  }, [scheduleCacheTick]);
 
   const input = useMemo<ActivationInput | null>(() => {
     if (!user) return null;

--- a/apps/web/src/core/app/HubHeader.tsx
+++ b/apps/web/src/core/app/HubHeader.tsx
@@ -104,10 +104,10 @@ export function HubHeader({
       )}
     >
       {/* ── Row 1: Mark + Wordmark + Action icons ─────────────── */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2.5">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2.5">
           <BrandLogo as="span" size="lg" variant="mark" />
-          <h1 className="text-xl leading-none font-extrabold tracking-tight text-text select-none">
+          <h1 className="truncate text-xl leading-none font-extrabold tracking-tight text-text select-none">
             Sergeant
           </h1>
         </div>
@@ -137,7 +137,8 @@ export function HubHeader({
                 onClick={onOpenPrivacy}
                 aria-label={messages.privacy.chip}
                 className={cn(
-                  "inline-flex items-center gap-1.5 h-8 px-2.5 rounded-full touch-target",
+                  "inline-flex h-11 w-11 items-center justify-center rounded-xl touch-target",
+                  "min-[420px]:h-8 min-[420px]:w-auto min-[420px]:gap-1.5 min-[420px]:rounded-full min-[420px]:px-2.5",
                   "bg-brand-soft text-brand-strong dark:text-brand-300 border border-brand-soft-border",
                   "text-style-caption font-semibold",
                   "hover:bg-brand-soft-hover transition-colors",
@@ -145,7 +146,9 @@ export function HubHeader({
                 )}
               >
                 <Icon name="shield" size="xs" strokeWidth={2} aria-hidden />
-                <span>{messages.privacy.chip}</span>
+                <span className="hidden min-[420px]:inline">
+                  {messages.privacy.chip}
+                </span>
               </button>
             </Tooltip>
           )}
@@ -165,7 +168,7 @@ export function HubHeader({
               narrow phones — see bug report 2026-05-18. Settings →
               GeneralSection keeps the segmented variant where space
               allows. */}
-          <ThemeSwitcher variant="dropdown" className="mx-1" />
+          <ThemeSwitcher variant="dropdown" />
 
           {/* Sign-in entry-point for guests only. Signed-in users reach
               their account via the `Профіль` bottom-nav tab. */}

--- a/apps/web/src/core/components/ChatQuickActions.tsx
+++ b/apps/web/src/core/components/ChatQuickActions.tsx
@@ -52,7 +52,7 @@ function chipClassName({
   hubLike: boolean;
 }): string {
   return cn(
-    "inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-full whitespace-nowrap shrink-0 transition-colors",
+    "inline-flex min-h-10 items-center gap-1.5 text-xs px-3 py-1.5 rounded-full whitespace-nowrap transition-colors",
     "focus:outline-none focus-visible:ring-2 focus-visible:ring-focus/45",
     active
       ? "bg-brand-500/10 border border-brand-500/40 text-brand-600 hover:bg-brand-500/15"
@@ -128,7 +128,7 @@ export function ChatQuickActions({
       role="group"
       aria-label={messages.hub.chatQuickActions}
     >
-      <div className="flex gap-2 overflow-x-auto scrollbar-hide">
+      <div className="flex flex-wrap gap-2">
         {topActions.map(renderChip)}
         {moreActions.length > 0 && (
           <button

--- a/apps/web/src/core/legal/LegalLinks.tsx
+++ b/apps/web/src/core/legal/LegalLinks.tsx
@@ -36,7 +36,7 @@ export function LegalLinks({
         <Link
           key={link.href}
           to={link.href}
-          className="text-muted underline-offset-4 transition-colors hover:text-text focus-visible:outline-none focus-visible:underline"
+          className="inline-flex min-h-11 min-w-11 items-center justify-center px-1 text-muted underline-offset-4 transition-colors hover:text-text focus-visible:outline-none focus-visible:underline"
         >
           {link.label}
         </Link>

--- a/apps/web/src/core/legal/LegalPage.tsx
+++ b/apps/web/src/core/legal/LegalPage.tsx
@@ -231,7 +231,7 @@ export function LegalPage({ pathname }: LegalPageProps) {
         <header className="text-center space-y-5">
           <Link
             to="/"
-            className="inline-flex justify-center rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus/45"
+            className="inline-flex min-h-11 items-center justify-center rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus/45"
             aria-label={messages.legal.homeLogoAria}
           >
             <BrandLogo size="lg" />
@@ -275,7 +275,7 @@ export function LegalPage({ pathname }: LegalPageProps) {
           <div className="flex flex-wrap items-center justify-center gap-3 text-style-body-sm">
             <Link
               to={PRICING_PATH}
-              className="text-brand-strong underline-offset-4 hover:underline focus-visible:outline-none focus-visible:underline"
+              className="inline-flex min-h-11 items-center px-1 text-brand-strong underline-offset-4 hover:underline focus-visible:outline-none focus-visible:underline"
             >
               {messages.legal.goToPricing}
             </Link>
@@ -284,7 +284,7 @@ export function LegalPage({ pathname }: LegalPageProps) {
             </span>
             <Link
               to={SIGN_IN_PATH}
-              className="text-brand-strong underline-offset-4 hover:underline focus-visible:outline-none focus-visible:underline"
+              className="inline-flex min-h-11 items-center px-1 text-brand-strong underline-offset-4 hover:underline focus-visible:outline-none focus-visible:underline"
             >
               {messages.legal.signInOrCreate}
             </Link>

--- a/apps/web/src/core/pricing/WaitlistForm.tsx
+++ b/apps/web/src/core/pricing/WaitlistForm.tsx
@@ -181,7 +181,12 @@ export function WaitlistForm({
     >
       <div className="space-y-3">
         <div>
-          <Label htmlFor="waitlist-email">Email</Label>
+          <Label
+            htmlFor="waitlist-email"
+            className="inline-flex min-h-11 min-w-11 items-center"
+          >
+            Email
+          </Label>
           <Input
             id="waitlist-email"
             type="email"
@@ -220,7 +225,7 @@ export function WaitlistForm({
                   htmlFor={inputId}
                   aria-label={`${opt.label} — ${opt.hint}`}
                   className={
-                    "flex items-start gap-3 rounded-2xl border p-3 cursor-pointer transition-colors " +
+                    "flex min-h-[56px] items-start gap-3 rounded-2xl border p-3 cursor-pointer transition-colors " +
                     (checked
                       ? "border-brand-500 bg-brand/10 dark:bg-brand/15"
                       : "border-line bg-panel hover:bg-panelHi")
@@ -230,10 +235,26 @@ export function WaitlistForm({
                     id={inputId}
                     type="radio"
                     value={opt.value}
-                    className="mt-1 accent-brand-strong"
+                    className="peer sr-only"
                     disabled={isSubmitting}
                     {...register("tier_interest")}
                   />
+                  <span
+                    className={
+                      "mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border transition-colors " +
+                      (checked
+                        ? "border-brand-500 bg-brand-500"
+                        : "border-muted bg-panel")
+                    }
+                    aria-hidden="true"
+                  >
+                    <span
+                      className={
+                        "h-2 w-2 rounded-full bg-white transition-opacity " +
+                        (checked ? "opacity-100" : "opacity-0")
+                      }
+                    />
+                  </span>
                   <span className="flex flex-col">
                     <span className="text-style-label text-text">
                       {opt.label}

--- a/apps/web/src/modules/nutrition/components/WaterTrackerCard.tsx
+++ b/apps/web/src/modules/nutrition/components/WaterTrackerCard.tsx
@@ -156,7 +156,7 @@ export function WaterTrackerCard({ goalMl = 2000 }: WaterTrackerCardProps) {
           }}
           placeholder="мл"
           inputMode="numeric"
-          className="h-9 flex-1"
+          className="h-11 flex-1"
           aria-label="Свій об'єм у мл"
         />
         <button
@@ -164,7 +164,7 @@ export function WaterTrackerCard({ goalMl = 2000 }: WaterTrackerCardProps) {
           onClick={handleCustomAdd}
           disabled={!customMl || Number(customMl) <= 0}
           className={cn(
-            "h-9 px-3 rounded-xl text-style-caption transition-colors",
+            "h-11 px-3 rounded-xl text-style-caption transition-colors",
             "bg-info-soft text-info-strong dark:text-info border border-info/20",
             "hover:bg-info/20 disabled:opacity-50 active:scale-95",
           )}
@@ -175,7 +175,7 @@ export function WaterTrackerCard({ goalMl = 2000 }: WaterTrackerCardProps) {
           <button
             type="button"
             onClick={handleUndo}
-            className="h-9 px-3 rounded-xl text-style-caption text-subtle hover:text-text border border-line transition-colors"
+            className="h-11 px-3 rounded-xl text-style-caption text-subtle hover:text-text border border-line transition-colors"
             aria-label={`Відмінити останнє додавання (${lastAddedMl} мл)`}
           >
             ↶ {lastAddedMl}

--- a/apps/web/src/shared/components/ui/ThemeSwitcher.tsx
+++ b/apps/web/src/shared/components/ui/ThemeSwitcher.tsx
@@ -257,7 +257,8 @@ function DropdownSwitcher({
         aria-label={`Тема: ${fullLabel}`}
         onClick={() => setOpen((value) => !value)}
         className={cn(
-          "inline-flex items-center gap-2 h-10 px-3 rounded-2xl touch-target border border-line bg-panel text-style-label text-text hover:bg-panelHi transition-colors motion-reduce:transition-none",
+          "inline-flex h-11 w-11 items-center justify-center gap-1 rounded-xl touch-target border border-line bg-panel text-style-label text-text hover:bg-panelHi transition-colors motion-reduce:transition-none",
+          "min-[420px]:h-10 min-[420px]:w-auto min-[420px]:gap-2 min-[420px]:rounded-2xl min-[420px]:px-3",
           FOCUS_RING,
         )}
       >
@@ -281,7 +282,7 @@ function DropdownSwitcher({
           name="chevron-down"
           size="sm"
           aria-hidden="true"
-          className="text-muted"
+          className="hidden text-muted min-[420px]:block"
         />
       </button>
       {open && (


### PR DESCRIPTION
## Summary
- send the live Anthropic chat tool payload without strict mode so /api/chat no longer fails schema compilation
- keep strict schema normalization and regression tests around the internal tool registry
- reduce strict annotations on broad/high-optional tool definitions to stay within Anthropic grammar limits if strict mode is re-enabled later

## Verification
- pnpm --filter @sergeant/server test -- src/modules/chat/toolDefs/strict-normalize.test.ts src/modules/chat/toolDefs/strict.test.ts src/modules/chat/promptCache.test.ts src/modules/chat/chat.test.ts
- pnpm --filter @sergeant/server typecheck
- Railway production-env Anthropic probe with TOOLS_WITH_CACHE: both cached and non-cached message variants returned HTTP 200

## Notes
- /api/status still reports OpenClaw bot as degraded when there is no recent openclaw_invocations activity; that is a config/activity signal, not fixed in this code change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the production chat backend by sending Anthropic tool payloads without strict mode, preventing schema compilation failures in `/api/chat`. Also fixes mobile PWA tap-target and small-screen layout issues across the web app.

- **Bug Fixes**
  - Server: Strip `strict` from the live Anthropic tools payload and precompute `TOOLS_WITH_CACHE` after stripping to keep `/api/chat` stable; keep strict normalization/tests for opted-in tools and trim strict annotations to stay within Anthropic limits.
  - Web: Improve tap targets and responsiveness on small screens—responsive ThemeSwitcher/Privacy chip, truncated header title, wrapping quick actions; larger labels/inputs and custom radios in waitlist and water tracker; coalesce activation cache ticks to reduce extra renders.

<sup>Written for commit c9c8a070f6985dff5e4b51ef967fa666893d466b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

