### PR TITLE
fix(web): resolve 16 prod QA defects across modules and i18n

### DIFF
--- a/apps/web/src/core/app/RootLayout.tsx
+++ b/apps/web/src/core/app/RootLayout.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
 import { useTheme } from "@shared/hooks/useTheme";
 import { useKeyboardShortcutsModal } from "@shared/components/ui/KeyboardShortcutsModal";
@@ -15,7 +15,7 @@ import {
   useHubChatOverlay,
   useHubChatOverlayState,
 } from "../hub/useHubChatOverlay";
-import { SIGN_IN_PATH } from "./appPaths";
+import { APP_TITLE, SIGN_IN_PATH } from "./appPaths";
 import { useHubKeyboardShortcuts } from "../hooks/useHubKeyboardShortcuts";
 import { useBrowserLocation } from "../hooks/useBrowserLocation";
 import { useHubNavigation } from "../hooks/useHubNavigation";
@@ -132,6 +132,17 @@ function RootLayoutInner() {
   // Global side effects
   useTheme();
   useActivationV2Boot();
+
+  // Keep the tab title pinned to the app name on every navigation. The
+  // static <title> in index.html is set once at load; some sub-routes
+  // (e.g. /nutrition/log) were observed dropping it, so the browser fell
+  // back to showing the raw URL. Re-asserting it per pathname covers all
+  // routes — module shells, standalone routes, and the 404.
+  useEffect(() => {
+    if (document.title !== APP_TITLE) {
+      document.title = APP_TITLE;
+    }
+  }, [location.pathname]);
 
   // Registers the `?` hotkey for keyboard shortcuts modal (side-effect only).
   useKeyboardShortcutsModal();

--- a/apps/web/src/core/app/StandaloneRoutes.tsx
+++ b/apps/web/src/core/app/StandaloneRoutes.tsx
@@ -38,10 +38,12 @@ const ResetPasswordPage = lazyImport(
   () => import("../auth/ResetPasswordPage"),
   "ResetPasswordPage",
 );
-const DesignShowcase = lazyImport(
-  () => import("../DesignShowcase"),
-  "DesignShowcase",
-);
+// Internal styleguide — dev-only. The `import.meta.env.DEV` guard lets Vite
+// statically drop the `import()` (and the whole DesignShowcase chunk) from
+// the production bundle, mirroring `ReactQueryDevtools` in `main.tsx`.
+const DesignShowcase = import.meta.env.DEV
+  ? lazyImport(() => import("../DesignShowcase"), "DesignShowcase")
+  : null;
 const AssistantCataloguePage = lazyImport(
   () => import("../AssistantCataloguePage"),
   "AssistantCataloguePage",
@@ -203,13 +205,23 @@ const STANDALONE_ROUTES: ReadonlyArray<StandaloneRoute> = [
     },
   }),
 
+  // `/design` is the internal Design System 2.0 styleguide — it exposes
+  // internal Hard Rules, raw tokens and per-section maturity (BETA) badges
+  // that are not meant for end users. Gate it to dev builds: `DesignShowcase`
+  // is `null` in production (see its dev-only declaration above), so the
+  // route renders the 404 page there instead of the styleguide.
   defineStandaloneRoute({
     paths: [DESIGN_PATH],
-    render: () => (
-      <Suspense fallback={<PageLoader />}>
-        <DesignShowcase />
-      </Suspense>
-    ),
+    render: () =>
+      DesignShowcase ? (
+        <Suspense fallback={<PageLoader />}>
+          <DesignShowcase />
+        </Suspense>
+      ) : (
+        <Suspense fallback={<PageLoader />}>
+          <NotFoundPage />
+        </Suspense>
+      ),
   }),
 
   // `/pricing` — Phase 0 monetization рейки: статична сторінка з тарифами

--- a/apps/web/src/core/app/appPaths.ts
+++ b/apps/web/src/core/app/appPaths.ts
@@ -6,6 +6,12 @@
 // that adding a new route to `StandaloneRoutes.tsx` automatically updates the
 // allowlist without a parallel edit here.
 
+// Canonical document title. Mirrors `apps/web/index.html` <title> and the
+// PWA manifest `name` (vite.config.js). Some sub-routes were observed losing
+// the static title (browser falling back to the URL), so `RootLayout` keeps
+// it pinned to this value on every navigation.
+export const APP_TITLE = "Sergeant — Твій персональний хаб життя";
+
 // Auth lives at `/sign-in` rather than as an in-page overlay. This keeps
 // the FTUX splash (`/`) as the true cold-start surface — the old
 // `showAuth` boolean meant that a first-time visitor who tapped

--- a/apps/web/src/core/insights/useCoachInsight.test.ts
+++ b/apps/web/src/core/insights/useCoachInsight.test.ts
@@ -79,7 +79,10 @@ function makeWrapper(qc: QueryClient) {
 function makeQueryClient() {
   return new QueryClient({
     defaultOptions: {
-      queries: { retry: false, gcTime: 0 },
+      // `retryDelay: 0` — хук задає власний `retry`-predicate, що перекриває
+      // глобальний `retry: false`; без нуль-затримки RQ-backoff (~1с) лишає
+      // query у `loading` довше за вікно `waitFor` і retry-тести флакають.
+      queries: { retry: false, retryDelay: 0, gcTime: 0 },
       mutations: { retry: false },
     },
   });
@@ -221,5 +224,44 @@ describe("useCoachInsight", () => {
 
     expect(result.current.insight).toBe("Insight without memory");
     expect(result.current.error).toBeNull();
+  });
+
+  it("does NOT retry on 429 (rate-limit / quota) — single attempt", async () => {
+    mockGetMemory.mockResolvedValue({ memory: null });
+    const rateLimited = Object.assign(new Error("Too Many Requests"), {
+      kind: "http",
+      status: 429,
+    });
+    mockPostInsight.mockRejectedValue(rateLimited);
+
+    const { useCoachInsight } = await import("./useCoachInsight");
+
+    const { result } = renderHook(() => useCoachInsight(), {
+      wrapper: makeWrapper(qc),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.insight).toBeNull();
+    expect(mockPostInsight).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries once on a transient network error", async () => {
+    mockGetMemory.mockResolvedValue({ memory: null });
+    const network = Object.assign(new Error("Failed to fetch"), {
+      kind: "network",
+    });
+    mockPostInsight.mockRejectedValue(network);
+
+    const { useCoachInsight } = await import("./useCoachInsight");
+
+    const { result } = renderHook(() => useCoachInsight(), {
+      wrapper: makeWrapper(qc),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.insight).toBeNull();
+    expect(mockPostInsight).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/web/src/core/insights/useCoachInsight.ts
+++ b/apps/web/src/core/insights/useCoachInsight.ts
@@ -299,6 +299,16 @@ export function useCoachInsight(): UseCoachInsightResult {
   const query = useQuery({
     queryKey,
     queryFn: fetchCoachInsight,
+    // Не ретраїмо 429: ліміт (`api:coach` rate-limit + денна AI-квота)
+    // має годинне/добове вікно, тож негайний повтор гарантовано впаде
+    // знову, спалить ще один хіт у спільному `api:coach` бакеті й затягне
+    // спінер. Інші 4xx — теж детермінований fail. Transient network/5xx
+    // лишаємо на одну спробу.
+    retry: (failureCount, error) => {
+      if (failureCount >= 1) return false;
+      if (isApiError(error) && error.kind === "http") return false;
+      return true;
+    },
     staleTime: Infinity,
     gcTime: 24 * 60 * 60_000,
     initialData: () => loadInitialInsight(todayKey),

--- a/apps/web/src/core/pricing/WaitlistForm.test.tsx
+++ b/apps/web/src/core/pricing/WaitlistForm.test.tsx
@@ -132,7 +132,7 @@ describe("WaitlistForm — submit flow", () => {
     });
     await waitFor(() => {
       expect(toastSuccessMock).toHaveBeenCalledWith(
-        "Дякуємо! Повідомимо щойно Pro буде готовий.",
+        "Дякуємо! Повідомимо, щойно Premium буде готовий.",
       );
     });
     expect(onSuccess).toHaveBeenCalledWith(true);
@@ -144,7 +144,7 @@ describe("WaitlistForm — submit flow", () => {
         created: true,
       }),
     );
-    // Email очищено, tier лишився `pro`.
+    // Email очищено, tier лишився `pro` (user-facing label = "Premium").
     await waitFor(() => {
       expect((screen.getByLabelText("Email") as HTMLInputElement).value).toBe(
         "",
@@ -152,7 +152,7 @@ describe("WaitlistForm — submit flow", () => {
     });
     expect(
       (
-        screen.getByLabelText(/Pro — AI-чат/, {
+        screen.getByLabelText(/Premium — AI-чат/, {
           selector: "label",
         }) as HTMLLabelElement
       ).className,

--- a/apps/web/src/core/pricing/WaitlistForm.tsx
+++ b/apps/web/src/core/pricing/WaitlistForm.tsx
@@ -16,24 +16,31 @@ import {
 } from "@sergeant/shared";
 import { ANALYTICS_EVENTS, trackEvent } from "../observability/analytics";
 
+// User-facing labels follow the locked Free + Premium scheme (Phase 7 D3).
+// `value` maps to the server `tier_interest` enum, where the paid tier is
+// still `"pro"` under the hood — same internal name the Premium checkout
+// sends. No standalone Plus/Pro tiers exist on the public funnel.
 const TIER_OPTIONS: ReadonlyArray<{
   value: WaitlistTier;
   label: string;
   hint: string;
 }> = [
-  { value: "pro", label: "Pro", hint: "AI-чат, авто-Mono, повні звіти" },
-  { value: "plus", label: "Plus", hint: "Базовий AI + cloud sync" },
+  {
+    value: "pro",
+    label: "Premium",
+    hint: "AI-чат, авто-Mono, повні звіти, cloud sync",
+  },
   {
     value: "free",
     label: "Залишусь на Free",
     hint: "Просто слідкувати за новинами",
   },
-  { value: "unsure", label: "Ще не знаю", hint: "Розкажіть мені більше" },
+  { value: "unsure", label: "Ще не знаю", hint: "Розкажи мені більше" },
 ];
 
 /**
  * Phase 0 monetization rails: форма для збору waitlist-ів на майбутній
- * Pro-тір. Анонімна (не вимагає логіну) — основний траффік сюди йтиме з
+ * Premium-тір. Анонімна (не вимагає логіну) — основний траффік сюди йтиме з
  * `/pricing`, де неавторизовані відвідувачі мають мати змогу залишити email.
  *
  * Аналітика: `WAITLIST_SUBMITTED` шлемо тільки після успішної відповіді
@@ -132,7 +139,7 @@ export function WaitlistForm({
         created: res.created,
       });
       if (res.created) {
-        toast.success("Дякуємо! Повідомимо щойно Pro буде готовий.");
+        toast.success("Дякуємо! Повідомимо, щойно Premium буде готовий.");
       } else {
         toast.info("Ми вже памʼятаємо твій інтерес — жодних дублікатів.");
       }
@@ -177,7 +184,7 @@ export function WaitlistForm({
       onSubmit={submit}
       className={className}
       noValidate
-      aria-label="Підписатись на waitlist Pro-тіру"
+      aria-label="Підписатись на waitlist Premium-тіру"
     >
       <div className="space-y-3">
         <div>
@@ -266,9 +273,8 @@ export function WaitlistForm({
         </Button>
 
         <p className="text-xs text-muted">
-          Без спаму. Один лист, коли Pro запуститься. Ціни теж покажемо
-          фіналізовано — поки в
-          `docs/launch/business/01-monetization-and-pricing.md` лише драфт.
+          Без спаму. Один лист, коли Premium запуститься. Ціну оголосимо на
+          запуску.
         </p>
       </div>
     </form>

--- a/apps/web/src/modules/finyk/FinykApp.tsx
+++ b/apps/web/src/modules/finyk/FinykApp.tsx
@@ -409,6 +409,11 @@ export default function App({
             handleExpenseSave(expense);
             handlePostSavePrompt(expense);
           }}
+          onDelete={(id) => {
+            storage.removeManualExpense(id);
+            setEditingManualExpenseId(null);
+            toast.success("Витрату видалено.");
+          }}
         />
 
         <ModuleBottomNav

--- a/apps/web/src/modules/finyk/components/ManualExpenseSheet.tsx
+++ b/apps/web/src/modules/finyk/components/ManualExpenseSheet.tsx
@@ -9,6 +9,7 @@ import { Input } from "@shared/components/ui/Input";
 import { useApiForm } from "@shared/forms/useApiForm";
 import { Label } from "@shared/components/ui/FormField";
 import { Sheet } from "@shared/components/ui/Sheet";
+import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
 import { VoiceMicButton } from "@shared/components/ui/VoiceMicButton";
 import {
   parseExpenseSpeech,
@@ -16,7 +17,7 @@ import {
   useVisualKeyboardInset,
 } from "@sergeant/shared";
 import { hapticSuccess } from "@shared/lib/adapters/haptic";
-import { formatMoney } from "@sergeant/shared";
+import { formatMoney, pluralTimes } from "@sergeant/shared";
 import { Icon } from "@shared/components/ui/Icon";
 import { Badge } from "@shared/components/ui/Badge";
 import {
@@ -131,6 +132,13 @@ interface ManualExpenseSheetProps {
     category: string;
     date: string;
   }) => void;
+  /**
+   * Delete the expense currently being edited. Only wired in edit mode
+   * (`initialExpense.id` present) — the desktop path has no swipe gesture,
+   * so the in-sheet "Видалити" action is the only way to remove a manual
+   * expense without a touch device.
+   */
+  onDelete?: (id: string) => void;
   initialExpense?: {
     id?: string;
     description?: string;
@@ -148,6 +156,7 @@ export function ManualExpenseSheet({
   open,
   onClose,
   onSave,
+  onDelete,
   initialExpense,
   frequentCategories = [],
   frequentMerchants = [],
@@ -225,6 +234,8 @@ export function ManualExpenseSheet({
   // чистою (description/amount/category/date).
   const [showDateField, setShowDateField] = useState(false);
 
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
   useEffect(() => {
     if (open) {
       if (initialExpense?.id) {
@@ -273,6 +284,7 @@ export function ManualExpenseSheet({
       setCategoriesExpanded(false);
       setDescFocused(false);
       setShowDateField(false);
+      setConfirmDelete(false);
       // 6.3: clear AI-applied state when the sheet reopens — stale
       // suggestion from a previous session shouldn't carry over.
       setAiAppliedCategory(null);
@@ -341,34 +353,47 @@ export function ManualExpenseSheet({
   };
 
   return (
-    <Sheet
-      open={open}
-      onClose={onClose}
-      title={isEditing ? "Редагувати витрату" : "Додати витрату"}
-      kbInsetPx={kbInsetPx}
-      panelClassName="finyk-sheet"
-      bodyClassName="space-y-4"
-      footer={
-        <div className="flex gap-3">
-          <Button
-            variant="secondary"
-            className="flex-1"
-            onClick={onClose}
-            disabled={isSubmitting}
-          >
-            Скасувати
-          </Button>
-          <Button
-            className="flex-1"
-            onClick={handleSubmit}
-            disabled={isSubmitting}
-          >
-            {isEditing ? "Зберегти" : "Додати"}
-          </Button>
+    <>
+      <Sheet
+        open={open}
+        onClose={onClose}
+        title={isEditing ? "Редагувати витрату" : "Додати витрату"}
+        kbInsetPx={kbInsetPx}
+        panelClassName="finyk-sheet"
+        bodyClassName="space-y-4"
+        footer={
+        <div className="space-y-2">
+          <div className="flex gap-3">
+            <Button
+              variant="secondary"
+              className="flex-1"
+              onClick={onClose}
+              disabled={isSubmitting}
+            >
+              Скасувати
+            </Button>
+            <Button
+              className="flex-1"
+              onClick={handleSubmit}
+              disabled={isSubmitting}
+            >
+              {isEditing ? "Зберегти" : "Додати"}
+            </Button>
+          </div>
+          {isEditing && onDelete && initialExpense?.id ? (
+            <Button
+              variant="danger"
+              className="w-full"
+              onClick={() => setConfirmDelete(true)}
+              disabled={isSubmitting}
+            >
+              Видалити
+            </Button>
+          ) : null}
         </div>
-      }
-    >
-      <div className="space-y-3">
+        }
+      >
+        <div className="space-y-3">
         {/* S15: amount is the only «must-fill» field — it used to live
             under the name input, so new users had to scroll past an
             optional field before they could do the single thing that
@@ -528,7 +553,7 @@ export function ManualExpenseSheet({
                     }
                   }}
                   className="px-2.5 py-1 rounded-full text-style-caption bg-panelHi text-muted border border-line hover:border-muted/50 transition-colors"
-                  title={`${m.count} разів · ${formatMoney(m.total)}`}
+                  title={`${m.count} ${pluralTimes(m.count)} · ${formatMoney(m.total)}`}
                 >
                   {m.name}
                 </button>
@@ -649,6 +674,20 @@ export function ManualExpenseSheet({
           </div>
         </div>
       </div>
-    </Sheet>
+      </Sheet>
+      <ConfirmDialog
+        open={confirmDelete}
+        title="Видалити витрату?"
+        description="Цю ручну витрату буде видалено без можливості відновлення."
+        confirmLabel="Видалити"
+        cancelLabel="Скасувати"
+        onCancel={() => setConfirmDelete(false)}
+        onConfirm={() => {
+          setConfirmDelete(false);
+          if (initialExpense?.id) onDelete?.(String(initialExpense.id));
+          onClose();
+        }}
+      />
+    </>
   );
 }

--- a/apps/web/src/modules/finyk/components/analytics/CategoryPieChart.tsx
+++ b/apps/web/src/modules/finyk/components/analytics/CategoryPieChart.tsx
@@ -75,12 +75,20 @@ interface CategoryPieChartProps {
   data?: CategorySlice[];
   size?: number;
   className?: string;
+  /**
+   * Authoritative expense total, rounded once upstream. When omitted the
+   * chart falls back to summing per-slice `spent`, but those are each
+   * rounded independently and drift a hryvnia from the "Підсумок" card —
+   * pass the shared total to keep the donut centre in lockstep.
+   */
+  total?: number;
 }
 
 function CategoryPieChartComponent({
   data = [],
   size = 160,
   className,
+  total: totalProp,
 }: CategoryPieChartProps) {
   const [showAll, setShowAll] = useState(false);
   const hasOverflow = (data?.length ?? 0) > TOP_N;
@@ -93,7 +101,11 @@ function CategoryPieChartComponent({
   const outerR = size / 2 - 1;
   const innerR = outerR * 0.62;
 
-  const total = data.reduce((s, d) => s + d.spent, 0);
+  const sliceTotal = data.reduce((s, d) => s + d.spent, 0);
+  // Geometry uses the slice sum so sweeps still add up to 360°; only the
+  // centre label uses the authoritative total when provided.
+  const total = sliceTotal;
+  const displayTotal = totalProp ?? sliceTotal;
   if (total === 0) return null;
 
   const expanded = showAll && hasOverflow;
@@ -183,7 +195,7 @@ function CategoryPieChartComponent({
             fontWeight="600"
             className="fill-text"
           >
-            {total.toLocaleString("uk-UA")} ₴
+            {displayTotal.toLocaleString("uk-UA")} ₴
           </text>
         </svg>
 

--- a/apps/web/src/modules/finyk/components/analytics/MerchantList.tsx
+++ b/apps/web/src/modules/finyk/components/analytics/MerchantList.tsx
@@ -4,6 +4,7 @@
  */
 import { memo } from "react";
 import { cn } from "@shared/lib/ui/cn";
+import { pluralTimes } from "@sergeant/shared";
 
 interface MerchantStat {
   name: string;
@@ -52,7 +53,7 @@ function MerchantListComponent({
                   />
                 </div>
                 <span className="text-style-caption text-subtle shrink-0">
-                  {m.count} разів
+                  {m.count} {pluralTimes(m.count)}
                 </span>
               </div>
             </div>

--- a/apps/web/src/modules/finyk/hooks/useAnalytics.ts
+++ b/apps/web/src/modules/finyk/hooks/useAnalytics.ts
@@ -84,6 +84,16 @@ export function useAnalytics({
     [categorySpendIndex, customCategories],
   );
 
+  // Authoritative expense total, rounded once from the raw index sum. The
+  // per-category `spent` values are each rounded independently, so summing
+  // them (as the donut chart did) drifts by a hryvnia from `summary.spent`
+  // (which is `Math.round` of the same raw total). Sharing this single
+  // value keeps the donut centre and the "Підсумок" card in lockstep.
+  const distributionTotal = useMemo(
+    () => Math.round(categorySpendIndex.totalSpent),
+    [categorySpendIndex],
+  );
+
   // Cache: top merchants by total spend. Depends on tx list + excludedTxIds
   // + txSplits — сплітовані транзакції (напр. оренда з поверненнями) вже
   // нормалізуються до чистої частки користувача, щоб цифри збігалися з
@@ -121,6 +131,7 @@ export function useAnalytics({
     summary,
     topCategories,
     distribution,
+    distributionTotal,
     topMerchants,
     monthlyTrend,
     comparison,

--- a/apps/web/src/modules/finyk/hooks/useFinykStorageMutations.ts
+++ b/apps/web/src/modules/finyk/hooks/useFinykStorageMutations.ts
@@ -1,4 +1,6 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { notifyFinykRoutineCalendarSync } from "../hubRoutineSync";
+import { hubKeys } from "@shared/lib/api/queryKeys";
 import {
   trackEvent,
   ANALYTICS_EVENTS,
@@ -29,6 +31,7 @@ import type { FinykStorageSlots } from "./useFinykStorageSlots";
  * (initiative 0001 — module decomposition).
  */
 export function useFinykStorageMutations(slots: FinykStorageSlots) {
+  const queryClient = useQueryClient();
   const {
     setBudgets,
     setSubscriptions,
@@ -45,6 +48,14 @@ export function useFinykStorageMutations(slots: FinykStorageSlots) {
     setDismissedRecurring,
   } = slots;
 
+  // Manual expenses feed the Hub finyk preview (overview/networth/month
+  // aggregates). The mono webhook hook only invalidates this key on bank-tx
+  // changes, so a manual add/edit/delete must fan out the same invalidation
+  // or the Hub card stays stale until the next bank sync.
+  const invalidateFinykPreview = () => {
+    void queryClient.invalidateQueries({ queryKey: hubKeys.preview("finyk") });
+  };
+
   const addManualExpense = (
     expense: Partial<ManualExpense> & { id?: unknown },
   ) => {
@@ -56,6 +67,7 @@ export function useFinykStorageMutations(slots: FinykStorageSlots) {
       category: expense.category || "інше",
     };
     setManualExpenses((prev) => [entry, ...prev]);
+    invalidateFinykPreview();
     // Product analytics: payload intentionally minimal (category + flag
     // whether a custom description was provided) — no amounts, no text.
     trackEvent(ANALYTICS_EVENTS.EXPENSE_ADDED, {
@@ -79,6 +91,7 @@ export function useFinykStorageMutations(slots: FinykStorageSlots) {
 
   const removeManualExpense = (id: string) => {
     setManualExpenses((prev) => prev.filter((e) => e.id !== id));
+    invalidateFinykPreview();
     trackEvent(ANALYTICS_EVENTS.EXPENSE_DELETED, { source: "manual" });
   };
 
@@ -100,6 +113,7 @@ export function useFinykStorageMutations(slots: FinykStorageSlots) {
         return next;
       }),
     );
+    invalidateFinykPreview();
   };
 
   const toggleHideAccount = (id: string) =>

--- a/apps/web/src/modules/finyk/pages/Analytics.tsx
+++ b/apps/web/src/modules/finyk/pages/Analytics.tsx
@@ -316,10 +316,11 @@ export function Analytics({ mono, storage }: AnalyticsProps) {
     [mono, activeTx, loading],
   );
 
-  const { summary, distribution, topMerchants } = useAnalytics({
-    mono: analyticsMono,
-    storage,
-  });
+  const { summary, distribution, distributionTotal, topMerchants } =
+    useAnalytics({
+      mono: analyticsMono,
+      storage,
+    });
 
   const comparison = useMemo(() => {
     if (!(prevKey in monthCache)) return null;
@@ -447,7 +448,11 @@ export function Analytics({ mono, storage }: AnalyticsProps) {
             />
           ) : (
             <Suspense fallback={<ChartFallback className="h-40" />}>
-              <CategoryPieChart data={distribution} className="" />
+              <CategoryPieChart
+                data={distribution}
+                total={distributionTotal}
+                className=""
+              />
             </Suspense>
           )}
         </Section>

--- a/apps/web/src/modules/finyk/pages/overview/useOverviewData.ts
+++ b/apps/web/src/modules/finyk/pages/overview/useOverviewData.ts
@@ -24,7 +24,10 @@ import {
   isBudgetAlert,
   getCurrentMonthContext,
 } from "@sergeant/finyk-domain/domain/budget";
-import { filterStatTransactions } from "@sergeant/finyk-domain/domain/transactions";
+import {
+  filterStatTransactions,
+  manualExpenseToTransaction,
+} from "@sergeant/finyk-domain/domain/transactions";
 import { safeReadStringLS, safeWriteLS } from "@shared/lib/storage/storage";
 import { THEME_HEX } from "@shared/lib/ui/themeHex";
 import { logger } from "@shared/lib";
@@ -104,17 +107,47 @@ export function useOverviewData({
   const now = new Date();
   const { daysInMonth, daysPassed } = getCurrentMonthContext(now);
 
+  // Manual expenses live in storage (LS + React state), not in the bank tx
+  // stream, so the spend/summary selectors must merge them in explicitly —
+  // otherwise the Overview totals ignore a manually added expense entirely
+  // and the page looks frozen after the add/edit sheet closes. Mirrors the
+  // merge pattern Transactions/Analytics already use; scoped to the current
+  // calendar month to match `getMonthlySummary`'s implicit window.
+  const manualExpenseTxs = useMemo(() => {
+    const monthStart = new Date(now.getFullYear(), now.getMonth(), 1).getTime();
+    const monthEnd = new Date(
+      now.getFullYear(),
+      now.getMonth() + 1,
+      1,
+    ).getTime();
+    return manualExpenses
+      .filter((e) => {
+        const ts = new Date(e.date).getTime();
+        return ts >= monthStart && ts < monthEnd;
+      })
+      .map((e) => manualExpenseToTransaction(e));
+    // `now` is recreated each render but its month window is stable within a
+    // render pass; depend on the primitives so the memo doesn't thrash.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [manualExpenses, now.getFullYear(), now.getMonth()]);
+
+  const txForStats = useMemo(
+    () =>
+      manualExpenseTxs.length > 0 ? [...realTx, ...manualExpenseTxs] : realTx,
+    [realTx, manualExpenseTxs],
+  );
+
   const statTx = useMemo(
-    () => filterStatTransactions(realTx, excludedTxIds),
-    [realTx, excludedTxIds],
+    () => filterStatTransactions(txForStats, excludedTxIds),
+    [txForStats, excludedTxIds],
   );
   const spent = useMemo(
     () => calcFinykSpendingTotal(statTx, { txSplits }),
     [statTx, txSplits],
   );
   const monthlySummary = useMemo(
-    () => getMonthlySummary(realTx, { excludedTxIds, txSplits }),
-    [realTx, excludedTxIds, txSplits],
+    () => getMonthlySummary(txForStats, { excludedTxIds, txSplits }),
+    [txForStats, excludedTxIds, txSplits],
   );
   const income = monthlySummary.income;
   const projectedSpend =
@@ -366,8 +399,13 @@ export function useOverviewData({
         ? "bg-warning"
         : "bg-success";
 
-  const spendPlanRatio = expenseTarget > 0 ? spent / expenseTarget : 0;
-  const hasExpensePlan = expenseTarget > 0;
+  // "Has a plan" must reflect a real user-set monthly plan, not the
+  // forecast fallback baked into `expenseTarget` (which is only for the
+  // day-budget math). Otherwise the plan progress bar renders "N% з плану
+  // 0 ₴" — a percentage against a zero plan — and the Hero status claims
+  // "Понад 50% запланованого" with nothing planned.
+  const hasExpensePlan = planExpense > 0;
+  const spendPlanRatio = hasExpensePlan ? spent / planExpense : 0;
 
   const dateLabel = now.toLocaleDateString("uk-UA", {
     day: "numeric",

--- a/apps/web/src/modules/finyk/pages/transactions/transactionsLib.ts
+++ b/apps/web/src/modules/finyk/pages/transactions/transactionsLib.ts
@@ -124,6 +124,22 @@ export function computeDaySummary(
   return { total, count: items.length, statCount };
 }
 
+// Nominative weekday names, indexed by `Date.getDay()` (0=Sunday).
+// As a group heading the weekday must read nominative ("субота, 2 травня").
+// `toLocaleDateString(weekday:"long")` is unreliable here: some browser
+// CLDR builds emit the accusative standalone form for uk ("суботу"), so we
+// supply the weekday ourselves and let Intl format only the day + month
+// (the genitive month "травня" is stable across engines).
+const STICKY_WEEKDAYS_NOMINATIVE = [
+  "неділя",
+  "понеділок",
+  "вівторок",
+  "середа",
+  "четвер",
+  "пʼятниця",
+  "субота",
+] as const;
+
 /**
  * Localised day label rendered inside the sticky header.
  * Today / Yesterday get word labels; everything else falls back to
@@ -139,9 +155,10 @@ export function formatStickyDayLabel(key: string): string {
   const diffDays = Math.round((t0.getTime() - d0.getTime()) / 86400000);
   if (diffDays === 0) return "Сьогодні";
   if (diffDays === 1) return "Вчора";
-  return d.toLocaleDateString("uk-UA", {
-    weekday: "long",
+  const weekday = STICKY_WEEKDAYS_NOMINATIVE[d.getDay()] ?? "";
+  const dayMonth = d.toLocaleDateString("uk-UA", {
     day: "numeric",
     month: "long",
   });
+  return `${weekday}, ${dayMonth}`;
 }

--- a/apps/web/src/modules/finyk/pages/transactions/transactionsLibHelpers.test.ts
+++ b/apps/web/src/modules/finyk/pages/transactions/transactionsLibHelpers.test.ts
@@ -102,6 +102,15 @@ describe("formatStickyDayLabel", () => {
     expect(label.length).toBeGreaterThan(0);
   });
 
+  it("uses the nominative weekday case, not the accusative", () => {
+    // As a group heading it must read "субота" (nominative), not "суботу"
+    // (accusative) — some browser CLDR builds emit the accusative form for
+    // toLocaleDateString(weekday:"long"), which this helper avoids.
+    expect(formatStickyDayLabel("2026-05-02")).toBe("субота, 2 травня");
+    expect(formatStickyDayLabel("2026-05-01")).toBe("пʼятниця, 1 травня");
+    expect(formatStickyDayLabel("2026-05-06")).toBe("середа, 6 травня");
+  });
+
   it("does not throw for a well-formed YYYY-MM-DD input", () => {
     expect(() => formatStickyDayLabel("2024-12-25")).not.toThrow();
   });

--- a/apps/web/src/modules/finyk/pages/transactions/useTransactionFilters.ts
+++ b/apps/web/src/modules/finyk/pages/transactions/useTransactionFilters.ts
@@ -112,9 +112,26 @@ export function useTransactionFilters({
       .map((e) => manualExpenseToTransaction(e));
   }, [manualExpenses, selMonth]);
 
+  // The bank-side slice can carry rows outside `selMonth`: the read-overlay
+  // in `useMonobankWebhook` falls back to the full SQLite mirror on a cold
+  // start, and `historyTx` keeps the last fetched month while a new fetch is
+  // in flight. Clamp to the selected month so the rendered rows always match
+  // `monthLabel` instead of leaking adjacent-month groups under the header.
+  const monthBankTxs = useMemo(() => {
+    const monthStartSec =
+      new Date(selMonth.year, selMonth.month, 1).getTime() / 1000;
+    const monthEndSec =
+      new Date(selMonth.year, selMonth.month + 1, 1).getTime() / 1000;
+    const source = isCurrentMonth ? realTx : historyTx;
+    return source.filter((t) => {
+      const ts = t.time ?? 0;
+      return ts >= monthStartSec && ts < monthEndSec;
+    });
+  }, [isCurrentMonth, realTx, historyTx, selMonth]);
+
   const activeTx = useMemo(
-    () => [...(isCurrentMonth ? realTx : historyTx), ...manualExpenseTxs],
-    [isCurrentMonth, realTx, historyTx, manualExpenseTxs],
+    () => [...monthBankTxs, ...manualExpenseTxs],
+    [monthBankTxs, manualExpenseTxs],
   );
   const activeLoading = isCurrentMonth ? loadingTx : loadingHistory;
 

--- a/apps/web/src/modules/fizruk/components/WorkoutTemplatesSection.tsx
+++ b/apps/web/src/modules/fizruk/components/WorkoutTemplatesSection.tsx
@@ -182,7 +182,11 @@ export function WorkoutTemplatesSection({
       </div>
 
       {!editingId && (
-        <Button className="w-full h-12 min-h-[44px]" onClick={startNew}>
+        <Button
+          module="fizruk"
+          className="w-full h-12 min-h-[44px]"
+          onClick={startNew}
+        >
           + Новий шаблон
         </Button>
       )}
@@ -384,6 +388,7 @@ export function WorkoutTemplatesSection({
 
           <div className="flex gap-2">
             <Button
+              module="fizruk"
               className="flex-1 h-12 min-h-[44px]"
               onClick={save}
               disabled={!orderIds.length}

--- a/apps/web/src/modules/fizruk/components/workouts/ActiveWorkoutHeader.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/ActiveWorkoutHeader.tsx
@@ -49,6 +49,7 @@ export function ActiveWorkoutHeader({
       <div className="flex items-center gap-2">
         {!activeWorkout.endedAt ? (
           <Button
+            module="fizruk"
             size="sm"
             className="h-9 px-4"
             type="button"

--- a/apps/web/src/modules/fizruk/components/workouts/AddExerciseSheet.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/AddExerciseSheet.tsx
@@ -250,6 +250,7 @@ export function AddExerciseSheet({
 
       <div className="mt-5 grid grid-cols-1 sm:grid-cols-2 gap-2">
         <Button
+          module="fizruk"
           className="h-12 min-h-[44px]"
           onClick={() => {
             const nameUk = (form.nameUk || "").trim();

--- a/apps/web/src/modules/fizruk/components/workouts/ExerciseDetailSheet.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/ExerciseDetailSheet.tsx
@@ -227,7 +227,7 @@ export function ExerciseDetailSheet({
       )}
 
       <div className="mt-5 grid grid-cols-2 gap-2">
-        <Button className="h-12" onClick={onClose}>
+        <Button variant="secondary" className="h-12" onClick={onClose}>
           Закрити
         </Button>
         <Button

--- a/apps/web/src/modules/fizruk/components/workouts/QuickStartSheet.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/QuickStartSheet.tsx
@@ -253,6 +253,7 @@ export function QuickStartSheet({
             Скасувати
           </Button>
           <Button
+            module="fizruk"
             className="h-12 min-h-[44px] sm:flex-1"
             onClick={handleConfirm}
             disabled={selectedCount === 0}

--- a/apps/web/src/modules/fizruk/components/workouts/WorkoutFinishSheets.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/WorkoutFinishSheets.tsx
@@ -149,6 +149,7 @@ export function WorkoutFinishSheets({
                 Пропустити
               </Button>
               <Button
+                module="fizruk"
                 className="flex-1 h-12 min-h-[44px]"
                 type="button"
                 onClick={() => {

--- a/apps/web/src/modules/fizruk/components/workouts/WorkoutJournalSection.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/WorkoutJournalSection.tsx
@@ -208,6 +208,7 @@ export function WorkoutJournalSection({
             </div>
             <div className="mt-3 flex gap-2">
               <Button
+                module="fizruk"
                 className="flex-1 h-11"
                 onClick={() => {
                   const w = createWorkout();
@@ -402,6 +403,7 @@ export function WorkoutJournalSection({
                 </div>
               </div>
               <Button
+                module="fizruk"
                 type="button"
                 className="w-full h-11"
                 onClick={submitRetroWorkout}

--- a/apps/web/src/modules/fizruk/components/workouts/WorkoutsHeader.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/WorkoutsHeader.tsx
@@ -61,6 +61,7 @@ export function WorkoutsHeader({
       </div>
       {view === "catalog" ? (
         <Button
+          module="fizruk"
           size="sm"
           className="h-9 min-h-[44px] px-4"
           onClick={onAddCatalog}

--- a/apps/web/src/modules/fizruk/components/workouts/WorkoutsHome.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/WorkoutsHome.tsx
@@ -82,7 +82,7 @@ export function WorkoutsHome({
                 {(activeWorkout?.items || []).length} вправ
               </div>
             </div>
-            <Button className="h-11 px-4" onClick={onOpenSession}>
+            <Button module="fizruk" className="h-11 px-4" onClick={onOpenSession}>
               Відкрити →
             </Button>
           </div>
@@ -96,7 +96,11 @@ export function WorkoutsHome({
             Почни нове — обереш шаблон або підбереш вправи перед стартом.
           </div>
           <div className="mt-3 grid grid-cols-1 gap-2">
-            <Button className="h-12 text-base" onClick={onRequestStart}>
+            <Button
+              module="fizruk"
+              className="h-12 text-base"
+              onClick={onRequestStart}
+            >
               ▶︎ Почати тренування
             </Button>
             <Button

--- a/apps/web/src/modules/fizruk/pages/Body.tsx
+++ b/apps/web/src/modules/fizruk/pages/Body.tsx
@@ -482,9 +482,14 @@ export function Body({ onOpenMeasurements, onOpenAtlas }: BodyProps) {
               disabled={isSubmitting}
               className={cn(
                 "focus-ring w-full py-3 rounded-xl text-style-label transition-[background-color,box-shadow,opacity,transform]",
+                // WHY: the resting CTA carries the module accent (fizruk teal)
+                // for module-accent containment (Hard Rule #12) — it was
+                // emerald (`success-strong`), Finyk's accent. The confirmed
+                // state stays green because that green is success semantics
+                // (shared across modules), not a module accent.
                 submitSuccess
                   ? "bg-success-strong text-white"
-                  : "bg-success-strong text-white active:scale-[0.98]",
+                  : "bg-fizruk-strong text-white hover:bg-teal-800 active:scale-[0.98]",
                 isSubmitting && "opacity-60",
               )}
             >

--- a/apps/web/src/modules/fizruk/pages/Dashboard.tsx
+++ b/apps/web/src/modules/fizruk/pages/Dashboard.tsx
@@ -532,6 +532,7 @@ export function Dashboard({
               Скасувати
             </Button>
             <Button
+              module="fizruk"
               className="flex-1 h-12 min-h-[44px]"
               onClick={() => {
                 const picks = pendingPicks ?? [];

--- a/apps/web/src/modules/fizruk/pages/Programs.tsx
+++ b/apps/web/src/modules/fizruk/pages/Programs.tsx
@@ -144,7 +144,7 @@ export function Programs({
                     {!isActive ? (
                       <button
                         type="button"
-                        className="focus-ring flex-1 py-2.5 rounded-xl bg-success-strong text-white text-style-label transition-[background-color,opacity,transform] active:scale-[0.98]"
+                        className="focus-ring flex-1 py-2.5 rounded-xl bg-fizruk-strong text-white text-style-label transition-[background-color,opacity,transform] active:scale-[0.98]"
                         onClick={() => activateProgram(prog.id)}
                       >
                         Активувати

--- a/apps/web/src/modules/nutrition/components/NutritionDashboard.tsx
+++ b/apps/web/src/modules/nutrition/components/NutritionDashboard.tsx
@@ -23,6 +23,7 @@ import type {
   PantryItem,
 } from "@sergeant/nutrition-domain";
 import {
+  addDaysISODate,
   getDayMacros,
   getDaySummary,
   getMacrosForDateRange,
@@ -31,7 +32,7 @@ import {
 import { WaterTrackerCard } from "./WaterTrackerCard";
 import { useToast } from "@shared/hooks/useToast";
 import { safeReadStringLS, safeWriteLS } from "@shared/lib/storage/storage";
-import { getKyivDayKey } from "@shared/lib/time/kyivTime";
+import { getKyivDayKey, getKyivWeekStartKey } from "@shared/lib/time/kyivTime";
 
 type WeekRow = MacrosRow;
 
@@ -168,10 +169,16 @@ export function NutritionDashboard({
 
   const macros = useMemo(() => getDayMacros(log, today), [log, today]);
   const summary = useMemo(() => getDaySummary(log, today), [log, today]);
-  const weekRows = useMemo(
-    () => getMacrosForDateRange(log, today, 7),
-    [log, today],
-  );
+  // Calendar ISO week (Mon→Sun, Kyiv), not a rolling-7 window — keeps the
+  // weekly chart consistent with Routine's Monday-first week (domain
+  // invariant: week starts Monday). `getMacrosForDateRange` fills oldest→
+  // newest ending at the given day, so anchoring `endIso` on Sunday yields
+  // Mon…Sun in order.
+  const weekRows = useMemo(() => {
+    const weekStart = getKyivWeekStartKey();
+    const weekEnd = addDaysISODate(weekStart, 6);
+    return getMacrosForDateRange(log, weekEnd, 7);
+  }, [log]);
 
   const hasGoal = (prefs.dailyTargetKcal || 0) > 0;
 

--- a/apps/web/src/modules/routine/components/RoutineCalendarHero.tsx
+++ b/apps/web/src/modules/routine/components/RoutineCalendarHero.tsx
@@ -53,7 +53,7 @@ export function RoutineCalendarHero({
       module="routine"
       radius="r-2xl"
       aria-label={rangeLabel}
-      className="relative"
+      className="routine-hero relative"
     >
       {flame.visible && (
         <span

--- a/apps/web/src/shared/i18n/en.ts
+++ b/apps/web/src/shared/i18n/en.ts
@@ -634,6 +634,6 @@ export const messagesEn: Partial<MessageCatalog> = {
       subtitle: "One email when Premium launches. No spam, no auto-charges.",
     },
     footer:
-      "Prices in EUR; Stripe charges the UAH-equivalent for the UA market. Final number lives in the pricing-strategy PR after market research.",
+      "Prices in EUR; Stripe charges the UAH-equivalent for the UA market. The exact price will be announced at launch.",
   },
 };

--- a/apps/web/src/shared/i18n/uk.ts
+++ b/apps/web/src/shared/i18n/uk.ts
@@ -731,7 +731,7 @@ export const messages = {
         "Чат, що знає твої фінанси, тренування, харчування і рутину — і пропонує наступний крок.",
       localFirstTitle: "Local-first за замовчуванням",
       localFirstBody:
-        "Дані живуть на твоєму пристрої. Cloud sync — опціональний (Pro), не вмикається без твого підтвердження.",
+        "Дані живуть на твоєму пристрої. Cloud sync — опціональний (Premium), не вмикається без твого підтвердження.",
       noHiddenTitle: "Без зайвих списань",
       noHiddenBody:
         "Free-тір — назавжди. Premium — один платний план без прихованих списань. Ціну оголосимо на запуску.",
@@ -739,7 +739,7 @@ export const messages = {
 
     // Waitlist section
     waitlistAriaLabel: "Підписатися на запуск Sergeant",
-    waitlistHeadline: "Лист, коли Pro буде готовий",
+    waitlistHeadline: "Лист, коли Premium буде готовий",
     waitlistSubcopy:
       "Залиш email для launch-апдейту. Це той самий список інтересу, але" +
       " тепер із attribution `source=landing`.",
@@ -748,7 +748,7 @@ export const messages = {
     pricingAriaLabel: "Перехід до тарифів",
     pricingHeadline: "Подивись на тарифи",
     pricingSubcopy:
-      "Free назавжди для повсякденного використання. Pro відкриває" +
+      "Free назавжди для повсякденного використання. Premium відкриває" +
       " безлімітний AI-чат, авто-Mono sync і CloudSync між пристроями.",
     pricingCta: "Дивитись тарифи",
 
@@ -834,7 +834,7 @@ export const messages = {
       subtitle: "Один лист, коли Premium стартує. Без спаму, без авто-списань.",
     },
     footer:
-      "Ціни у EUR; для UA-ринку Stripe виставляє ₴-еквівалент. Фінальна цифра — у pricing-strategy PR після market-research.",
+      "Ціни у EUR; для UA-ринку Stripe виставляє ₴-еквівалент. Точну ціну оголосимо на запуску.",
   },
 } as const satisfies MessageCatalog;
 

--- a/apps/web/src/styles/module-surfaces.css
+++ b/apps/web/src/styles/module-surfaces.css
@@ -97,6 +97,25 @@
   );
 }
 
+/* ── Routine calendar hero — dark-mode on-color text ─────────────────────
+   WHY: in dark mode the routine hero Card resolves to a saturated, opaque
+   coral-900 fill (`dark:bg-routine-soft`, rgb(159 36 30)). The shared
+   `KpiRowCompact` labels and the `HeroValueLine` narrative paint with the
+   neutral `text-subtle` tertiary token (rgb(135 128 121)) — tuned for the
+   app's dark panel, not for a coloured surface — yielding only ~1.96:1
+   against the coral fill (WCAG AA fails small text). We can't retint the
+   shared token (it would shift every other surface) so we scope an on-color
+   override to this hero only. coral-100 lands ~6.6:1 on coral-900; the
+   `tabular-nums` value/metric already use `text-text` (warm-white, ~7.8:1)
+   so they stay untouched. Light theme keeps the soft-pink hero where the
+   neutral subtle token is already compliant — hence `.dark`-only. */
+.dark .routine-hero .text-subtle {
+  color: rgb(255 232 227); /* coral-100 — ≥4.5:1 on coral-900 */
+}
+.dark .routine-hero .text-routine {
+  color: rgb(255 176 168); /* coral-300 — visible separator on coral-900 */
+}
+
 /* ── Routine heatmap cells ───────────────────────────────────────────────
    Wave 2b: chart-side palette tokens for the routine activity heatmap.
    The CSS layer owns the per-theme (light, dark) pair so consumers in

--- a/packages/shared/src/utils/ukrainianPlural.test.ts
+++ b/packages/shared/src/utils/ukrainianPlural.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { pluralDays, pluralUa } from "./ukrainianPlural";
+import { pluralDays, pluralTimes, pluralUa } from "./ukrainianPlural";
 
 describe("pluralDays", () => {
   it("one: 1, 21, 31, 101", () => {
@@ -36,6 +36,20 @@ describe("pluralDays", () => {
     expect(pluralDays(-1)).toBe("день");
     expect(pluralDays(-3)).toBe("дні");
     expect(pluralDays(-11)).toBe("днів");
+  });
+
+  it("pluralTimes: 1 раз / 2-4 рази / 5+ разів", () => {
+    expect(pluralTimes(1)).toBe("раз");
+    expect(pluralTimes(21)).toBe("раз");
+    expect(pluralTimes(2)).toBe("рази");
+    expect(pluralTimes(3)).toBe("рази");
+    expect(pluralTimes(4)).toBe("рази");
+    expect(pluralTimes(22)).toBe("рази");
+    expect(pluralTimes(0)).toBe("разів");
+    expect(pluralTimes(5)).toBe("разів");
+    expect(pluralTimes(11)).toBe("разів");
+    expect(pluralTimes(14)).toBe("разів");
+    expect(pluralTimes(25)).toBe("разів");
   });
 
   it("працює як загальний helper на інших формах", () => {

--- a/packages/shared/src/utils/ukrainianPlural.ts
+++ b/packages/shared/src/utils/ukrainianPlural.ts
@@ -29,3 +29,9 @@ const DAYS_FORMS: UaPluralForms = { one: "день", few: "дні", many: "дн�
 export function pluralDays(n: number): string {
   return pluralUa(n, DAYS_FORMS);
 }
+
+const TIMES_FORMS: UaPluralForms = { one: "раз", few: "рази", many: "разів" };
+
+export function pluralTimes(n: number): string {
+  return pluralUa(n, TIMES_FORMS);
+}


### PR DESCRIPTION
## Summary

Manual browser QA on prod (`sergeant.vercel.app`) surfaced **16 defects** across light/dark themes, desktop + mobile, and functional flows. Fixed by 6 parallel agents over non-overlapping file boundaries. 37 files.

| Sev | # | Fix |
|-----|---|-----|
| major | #4 | finyk Операції: period header «Червень» now matches listed txns (bank-tx clipped to selected month) |
| major | #7 | i18n: correct Ukrainian plural (`pluralTimes`: раз/рази/разів) |
| major | #11 | routine red hero: label contrast 1.96→~6.6:1 (dark theme on-color token) |
| major | #12 | pricing: removed leaked internal dev-notes (`docs/...md`, "pricing-strategy PR") from UI |
| major | #13 | pricing: unified tier naming to Free/Premium (dropped Pro/Plus from waitlist + i18n) |
| major | #17 | finyk: added desktop «Видалити» action + confirm in edit sheet |
| minor | #1 | coach: drop pointless 429 retry in `useCoachInsight` |
| minor | #3 | finyk: hide plan-bar when budget = 0 |
| minor | #8 | fizruk: CTA buttons use module teal accent (not green) |
| minor | #9 | nutrition: weekly kcal chart aligned to ISO Monday-start |
| minor | #14 | hide `/design` internal styleguide in production |
| minor | #16 | finyk: overview invalidates `hubKeys.preview` after txn mutation |
| nit | #5 | i18n: nominative weekday names in day-group headers |
| nit | #6 | finyk analytics: single-round donut total (8197→8196 consistency) |
| nit | #10 | core: per-route `document.title` |

## Governing Skill
`sergeant-web-ui` (web surfaces) + `sergeant-server-api` (coach 429 diagnosis — root was in-app AI quota/rate-limit, fix landed web-side).

## Verification
- `pnpm --filter @sergeant/web --filter @sergeant/shared typecheck` → **0 errors**
- `pnpm --filter @sergeant/web --filter @sergeant/shared lint` → **0 errors** (700 pre-existing baseline warnings, untouched files)
- Targeted vitest: `ukrainianPlural` 6/6, `useCoachInsight` 8/8, `WaitlistForm` 6/6, `transactionsLibHelpers` ✅
- Full `pnpm check`/build not run locally (slow-HW hook) — CI runs the full matrix on push.

## Docs and Governance
No canonical docs touched; no Hard Rule registry / pr-ledger changes required.

## Risk and Rollout
Low — scoped UI/logic bugfixes. New affordances: desktop txn delete (#17), `/design` gated to dev (#14). **Two owner follow-ups (out of scope, need separate PRs):** (1) coach-insight shares the free-tier 5/day AI quota → consider a dedicated bucket; (2) `WaitlistTier` DB enum still has `plus/pro` (server + migration).

## Hard Rule #15
Read governing skill before coding; docs/code in sync; no internal-doc language regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 16 production QA issues across core, Finyk, Routine, Nutrition, Fizruk, Pricing, and i18n to improve correctness and polish. Adds a desktop “Delete” action for manual expenses and hides the internal `/design` styleguide in production.

- **New Features**
  - Manual expenses: desktop “Видалити” action with confirm in the edit sheet.

- **Bug Fixes**
  - Finyk
    - Transactions list now clamps bank transactions to the selected month; the header matches visible groups.
    - Overview and Hub preview refresh after manual expense add/edit/delete.
    - Category donut center uses a shared rounded total to match the “Підсумок” card.
  - Nutrition
    - Weekly kcal chart aligned to ISO Monday–Sunday (Kyiv) instead of a rolling 7-day window.
  - Routine
    - Dark theme hero card: on-color label contrast fixed for WCAG AA.
  - Fizruk
    - CTAs use the module’s teal accent instead of green.
  - Pricing & i18n
    - Unified tier naming to Free/Premium and removed leaked dev notes; updated waitlist copy.
    - Added `pluralTimes` (раз/рази/разів) and nominative weekday names for sticky headers.
  - Core & Coach
    - Tab title stays pinned to `APP_TITLE` on navigation.
    - Internal `/design` route is dev-only; 404 in production.
    - `useCoachInsight` no longer retries on 429; still retries once on transient network errors.

<sup>Written for commit 69c3f0d712bb07b6a18b507b11fc41e128d7a8d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to delete manual expenses
  * Manual expenses now reflected in overview totals and analytics
  * Fixed weekly nutrition dashboard to use calendar weeks

* **Bug Fixes**
  * Document title now persists when navigating between pages
  * Design showcase route properly restricted to development builds
  * Improved error handling and retry logic for coach insights
  * Transaction filters now correctly respect selected month
  * Donut chart totals now calculated consistently

* **UI/Style Updates**
  * Rebranded "Pro" tier to "Premium" throughout pricing and waitlist
  * Updated button styling for workout module
  * Enhanced routine calendar hero styling
  * Improved Ukrainian date formatting in transaction headers

* **Localization**
  * Updated pricing copy and messaging for Premium tier
  * Added Ukrainian plural support for time references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->