### PR TITLE
fix(web): restore green main CI after #3590 merge

### DIFF
--- a/apps/web/src/modules/finyk/components/ManualExpenseSheet.tsx
+++ b/apps/web/src/modules/finyk/components/ManualExpenseSheet.tsx
@@ -362,112 +362,112 @@ export function ManualExpenseSheet({
         panelClassName="finyk-sheet"
         bodyClassName="space-y-4"
         footer={
-        <div className="space-y-2">
-          <div className="flex gap-3">
-            <Button
-              variant="secondary"
-              className="flex-1"
-              onClick={onClose}
-              disabled={isSubmitting}
-            >
-              Скасувати
-            </Button>
-            <Button
-              className="flex-1"
-              onClick={handleSubmit}
-              disabled={isSubmitting}
-            >
-              {isEditing ? "Зберегти" : "Додати"}
-            </Button>
+          <div className="space-y-2">
+            <div className="flex gap-3">
+              <Button
+                variant="secondary"
+                className="flex-1"
+                onClick={onClose}
+                disabled={isSubmitting}
+              >
+                Скасувати
+              </Button>
+              <Button
+                className="flex-1"
+                onClick={handleSubmit}
+                disabled={isSubmitting}
+              >
+                {isEditing ? "Зберегти" : "Додати"}
+              </Button>
+            </div>
+            {isEditing && onDelete && initialExpense?.id ? (
+              <Button
+                variant="danger"
+                className="w-full"
+                onClick={() => setConfirmDelete(true)}
+                disabled={isSubmitting}
+              >
+                Видалити
+              </Button>
+            ) : null}
           </div>
-          {isEditing && onDelete && initialExpense?.id ? (
-            <Button
-              variant="danger"
-              className="w-full"
-              onClick={() => setConfirmDelete(true)}
-              disabled={isSubmitting}
-            >
-              Видалити
-            </Button>
-          ) : null}
-        </div>
         }
       >
         <div className="space-y-3">
-        {/* S15: amount is the only «must-fill» field — it used to live
+          {/* S15: amount is the only «must-fill» field — it used to live
             under the name input, so new users had to scroll past an
             optional field before they could do the single thing that
             makes an expense valid. Amount is now the first block on the
             sheet; the mic stays near it because dictation typically
             produces both the amount and the description in one shot. */}
-        <div className="flex gap-2 items-end">
-          <div className="flex-1">
-            <Label htmlFor={amountId}>Сума ₴</Label>
-            {amountSuggestions.length > 0 && (
-              <div
-                className="flex flex-wrap items-center gap-1.5 mb-2"
-                role="group"
-                aria-label="Швидкі суми"
-              >
-                {amountSuggestions.map(({ value, personal }) => (
-                  <button
-                    key={`${personal ? "f" : "q"}-${value}`}
-                    type="button"
-                    onClick={() =>
-                      setValue("amount", String(value), {
-                        shouldDirty: true,
-                        shouldValidate: Boolean(amountError),
-                      })
-                    }
-                    className={
-                      personal
-                        ? "inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-style-caption bg-success/10 text-success-strong dark:text-success border border-success/30 hover:bg-success/15 transition-colors tabular-nums"
-                        : "px-2.5 py-1 rounded-full text-style-caption bg-panelHi text-muted border border-line hover:border-muted/50 transition-colors tabular-nums"
-                    }
-                    aria-label={
-                      personal
-                        ? `${formatMoney(value)} — часта сума`
-                        : `${formatMoney(value)}`
-                    }
-                  >
-                    {personal ? (
-                      <span
-                        aria-hidden
-                        className="w-1.5 h-1.5 rounded-full bg-finyk"
-                      />
-                    ) : null}
-                    {formatMoney(value)}
-                  </button>
-                ))}
-              </div>
-            )}
-            {/* 6.2: display-hero preview anchors the sheet on the single
+          <div className="flex gap-2 items-end">
+            <div className="flex-1">
+              <Label htmlFor={amountId}>Сума ₴</Label>
+              {amountSuggestions.length > 0 && (
+                <div
+                  className="flex flex-wrap items-center gap-1.5 mb-2"
+                  role="group"
+                  aria-label="Швидкі суми"
+                >
+                  {amountSuggestions.map(({ value, personal }) => (
+                    <button
+                      key={`${personal ? "f" : "q"}-${value}`}
+                      type="button"
+                      onClick={() =>
+                        setValue("amount", String(value), {
+                          shouldDirty: true,
+                          shouldValidate: Boolean(amountError),
+                        })
+                      }
+                      className={
+                        personal
+                          ? "inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-style-caption bg-success/10 text-success-strong dark:text-success border border-success/30 hover:bg-success/15 transition-colors tabular-nums"
+                          : "px-2.5 py-1 rounded-full text-style-caption bg-panelHi text-muted border border-line hover:border-muted/50 transition-colors tabular-nums"
+                      }
+                      aria-label={
+                        personal
+                          ? `${formatMoney(value)} — часта сума`
+                          : `${formatMoney(value)}`
+                      }
+                    >
+                      {personal ? (
+                        <span
+                          aria-hidden
+                          className="w-1.5 h-1.5 rounded-full bg-finyk"
+                        />
+                      ) : null}
+                      {formatMoney(value)}
+                    </button>
+                  ))}
+                </div>
+              )}
+              {/* 6.2: display-hero preview anchors the sheet on the single
                 "must-fill" field. Input stays editable below so users can
                 tap to correct without losing the visual emphasis. Hidden
                 from screen readers (aria-hidden) — the editable input
                 below carries the accessible label + value. */}
-            {amountHeroVisible ? (
-              <div
-                aria-hidden
-                className="text-style-display-hero font-mono tabular-nums text-finyk-strong dark:text-finyk leading-none mb-2 select-none"
-              >
-                {formatMoney(amountNumeric)}
-              </div>
-            ) : null}
-            <Input
-              id={amountId}
-              type="number"
-              inputMode="decimal"
-              placeholder="0"
-              min="0"
-              step="0.01"
-              aria-invalid={amountError ? true : undefined}
-              disabled={isSubmitting}
-              helperText={amountError ?? undefined}
-              {...register("amount")}
-            />
-          </div>
-          {/* Mic-only icon was indistinguishable from the rest of the form
+              {amountHeroVisible ? (
+                <div
+                  aria-hidden
+                  className="text-style-display-hero font-mono tabular-nums text-finyk-strong dark:text-finyk leading-none mb-2 select-none"
+                >
+                  {formatMoney(amountNumeric)}
+                </div>
+              ) : null}
+              <Input
+                id={amountId}
+                type="number"
+                inputMode="decimal"
+                placeholder="0"
+                min="0"
+                step="0.01"
+                aria-invalid={amountError ? true : undefined}
+                disabled={isSubmitting}
+                helperText={amountError ?? undefined}
+                {...register("amount")}
+              />
+            </div>
+            {/* Mic-only icon was indistinguishable from the rest of the form
               chrome — users didn't realise they could dictate the whole
               expense. Pair the mic with a "Сказати" label so the affordance
               is visible at rest. `VoiceMicButton` hides itself when the
@@ -475,127 +475,127 @@ export function ManualExpenseSheet({
               that case via `hidden:*`-style absent fallback (the button
               returns null and the flex container collapses to the input
               alone). */}
-          <div className="flex flex-col items-center gap-0.5 pb-1">
-            <VoiceMicButton
-              size="md"
-              label="Сказати голосом"
-              promptHint="Витрата у гривнях: кава 60 гривень, продукти 350 грн, таксі 200, обід 150."
-              onResult={(transcript) => {
-                const parsed = parseExpenseSpeech(transcript);
-                if (!parsed) return;
-                if (parsed.name) {
-                  setValue("description", parsed.name, { shouldDirty: true });
-                }
-                if (parsed.amount != null) {
-                  setValue("amount", String(Math.round(parsed.amount)), {
-                    shouldDirty: true,
-                    shouldValidate: Boolean(amountError),
-                  });
-                }
-              }}
-            />
-            <span
-              className="text-style-caption text-subtle select-none"
-              aria-hidden
-            >
-              Сказати
-            </span>
-          </div>
-        </div>
-
-        <div>
-          <Label htmlFor={descId} optional>
-            Назва
-          </Label>
-          <Input
-            id={descId}
-            placeholder="Кава, продукти, таксі…"
-            disabled={isSubmitting}
-            aria-controls={
-              showMerchantHints ? `${formId}-merchants` : undefined
-            }
-            aria-autocomplete="list"
-            {...register("description", {
-              onBlur: () => setDescFocused(false),
-            })}
-            onFocus={() => setDescFocused(true)}
-          />
-          {showMerchantHints && (
-            <div
-              id={`${formId}-merchants`}
-              className="flex flex-wrap gap-1.5 mt-2"
-              role="group"
-              aria-label="Нещодавні мерчанти"
-            >
-              {merchantSuggestions.map((m) => (
-                <button
-                  key={m.key}
-                  type="button"
-                  onMouseDown={(e) => e.preventDefault()}
-                  onClick={() => {
-                    setValue("description", m.name, { shouldDirty: true });
-                    // Якщо є впевнений підпис manual-категорії для цього
-                    // мерчанта — підставляємо його, щоб економити тапи.
-                    // suggestedManualCategory може бути Era 1/2/3 — upgradeCategory
-                    // нормалізує до slug.
-                    const suggestedRaw = m.suggestedManualCategory;
-                    const suggested =
-                      suggestedRaw &&
-                      CATEGORY_SLUGS.includes(upgradeCategory(suggestedRaw))
-                        ? upgradeCategory(suggestedRaw)
-                        : null;
-                    if (suggested) {
-                      setValue("category", suggested, { shouldDirty: true });
-                      // 6.3: surface the auto-applied category via an AI
-                      // badge near the category section so users can see
-                      // why their category changed and dismiss if wrong.
-                      setAiAppliedCategory(suggested);
-                    }
-                  }}
-                  className="px-2.5 py-1 rounded-full text-style-caption bg-panelHi text-muted border border-line hover:border-muted/50 transition-colors"
-                  title={`${m.count} ${pluralTimes(m.count)} · ${formatMoney(m.total)}`}
-                >
-                  {m.name}
-                </button>
-              ))}
+            <div className="flex flex-col items-center gap-0.5 pb-1">
+              <VoiceMicButton
+                size="md"
+                label="Сказати голосом"
+                promptHint="Витрата у гривнях: кава 60 гривень, продукти 350 грн, таксі 200, обід 150."
+                onResult={(transcript) => {
+                  const parsed = parseExpenseSpeech(transcript);
+                  if (!parsed) return;
+                  if (parsed.name) {
+                    setValue("description", parsed.name, { shouldDirty: true });
+                  }
+                  if (parsed.amount != null) {
+                    setValue("amount", String(Math.round(parsed.amount)), {
+                      shouldDirty: true,
+                      shouldValidate: Boolean(amountError),
+                    });
+                  }
+                }}
+              />
+              <span
+                className="text-style-caption text-subtle select-none"
+                aria-hidden
+              >
+                Сказати
+              </span>
             </div>
-          )}
-        </div>
+          </div>
 
-        {/* Date is "today" 95%+ of the time — the always-visible picker
+          <div>
+            <Label htmlFor={descId} optional>
+              Назва
+            </Label>
+            <Input
+              id={descId}
+              placeholder="Кава, продукти, таксі…"
+              disabled={isSubmitting}
+              aria-controls={
+                showMerchantHints ? `${formId}-merchants` : undefined
+              }
+              aria-autocomplete="list"
+              {...register("description", {
+                onBlur: () => setDescFocused(false),
+              })}
+              onFocus={() => setDescFocused(true)}
+            />
+            {showMerchantHints && (
+              <div
+                id={`${formId}-merchants`}
+                className="flex flex-wrap gap-1.5 mt-2"
+                role="group"
+                aria-label="Нещодавні мерчанти"
+              >
+                {merchantSuggestions.map((m) => (
+                  <button
+                    key={m.key}
+                    type="button"
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={() => {
+                      setValue("description", m.name, { shouldDirty: true });
+                      // Якщо є впевнений підпис manual-категорії для цього
+                      // мерчанта — підставляємо його, щоб економити тапи.
+                      // suggestedManualCategory може бути Era 1/2/3 — upgradeCategory
+                      // нормалізує до slug.
+                      const suggestedRaw = m.suggestedManualCategory;
+                      const suggested =
+                        suggestedRaw &&
+                        CATEGORY_SLUGS.includes(upgradeCategory(suggestedRaw))
+                          ? upgradeCategory(suggestedRaw)
+                          : null;
+                      if (suggested) {
+                        setValue("category", suggested, { shouldDirty: true });
+                        // 6.3: surface the auto-applied category via an AI
+                        // badge near the category section so users can see
+                        // why their category changed and dismiss if wrong.
+                        setAiAppliedCategory(suggested);
+                      }
+                    }}
+                    className="px-2.5 py-1 rounded-full text-style-caption bg-panelHi text-muted border border-line hover:border-muted/50 transition-colors"
+                    title={`${m.count} ${pluralTimes(m.count)} · ${formatMoney(m.total)}`}
+                  >
+                    {m.name}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Date is "today" 95%+ of the time — the always-visible picker
             forced a tap out to a native date sheet just to confirm what
             was already true. Collapse behind a chip; reveal only when the
             user explicitly says "not today" or when editing an older
             entry where the date is already not today. */}
-        {date !== toLocalISODate() || showDateField ? (
-          <div>
-            <Label htmlFor={dateId}>Дата</Label>
-            <Input
-              id={dateId}
-              type="date"
-              disabled={isSubmitting}
-              {...register("date")}
-            />
-          </div>
-        ) : (
-          <button
-            type="button"
-            onClick={() => setShowDateField(true)}
-            className="text-xs text-muted hover:text-text underline decoration-dotted underline-offset-2 transition-colors"
-          >
-            Не сьогодні? Змінити дату
-          </button>
-        )}
+          {date !== toLocalISODate() || showDateField ? (
+            <div>
+              <Label htmlFor={dateId}>Дата</Label>
+              <Input
+                id={dateId}
+                type="date"
+                disabled={isSubmitting}
+                {...register("date")}
+              />
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setShowDateField(true)}
+              className="text-xs text-muted hover:text-text underline decoration-dotted underline-offset-2 transition-colors"
+            >
+              Не сьогодні? Змінити дату
+            </button>
+          )}
 
-        <div>
-          <div
-            id={catLabelId}
-            // eslint-disable-next-line sergeant-design/no-eyebrow-drift -- Category group label needs a stable id (catLabelId) for aria-labelledby; Label would require dropping htmlFor.
-            className="block text-xs text-muted uppercase tracking-wide font-semibold mb-1"
-          >
-            Категорія
-          </div>
-          {/* 6.3: AI-applied badge surfaces the silent merchant→category
+          <div>
+            <div
+              id={catLabelId}
+              // eslint-disable-next-line sergeant-design/no-eyebrow-drift -- Category group label needs a stable id (catLabelId) for aria-labelledby; Label would require dropping htmlFor.
+              className="block text-xs text-muted uppercase tracking-wide font-semibold mb-1"
+            >
+              Категорія
+            </div>
+            {/* 6.3: AI-applied badge surfaces the silent merchant→category
               auto-application. Renders only when AI applied and current
               category still matches the AI suggestion (so dismissal +
               manual overrides hide it). Dismiss = clear local state only;
@@ -603,77 +603,77 @@ export function ManualExpenseSheet({
               below).
               motion-safe wrappers — reduced-motion users see a static
               badge without the fade-in. */}
-          {aiAppliedCategory && categorySlug === aiAppliedCategory ? (
-            <div className="motion-safe:animate-in motion-safe:fade-in motion-safe:duration-200 mb-2">
-              <Badge
-                variant="finyk"
-                tone="soft"
-                size="sm"
-                className="inline-flex items-center gap-1.5"
-              >
-                <Icon name="sparkles" size={12} aria-hidden />
-                AI ·{" "}
-                {CATEGORY_DISPLAY[aiAppliedCategory]?.label ??
-                  aiAppliedCategory}
+            {aiAppliedCategory && categorySlug === aiAppliedCategory ? (
+              <div className="motion-safe:animate-in motion-safe:fade-in motion-safe:duration-200 mb-2">
+                <Badge
+                  variant="finyk"
+                  tone="soft"
+                  size="sm"
+                  className="inline-flex items-center gap-1.5"
+                >
+                  <Icon name="sparkles" size={12} aria-hidden />
+                  AI ·{" "}
+                  {CATEGORY_DISPLAY[aiAppliedCategory]?.label ??
+                    aiAppliedCategory}
+                  <button
+                    type="button"
+                    onClick={() => setAiAppliedCategory(null)}
+                    aria-label="Сховати AI-підказку"
+                    className="ml-0.5 inline-flex h-4 w-4 items-center justify-center rounded-full hover:bg-finyk/20 transition-colors"
+                  >
+                    <Icon name="close" size={10} aria-hidden />
+                  </button>
+                </Badge>
+              </div>
+            ) : null}
+            <div
+              className="flex flex-wrap gap-2"
+              role="group"
+              aria-labelledby={catLabelId}
+            >
+              {visibleCategories.map((slug) => {
+                const display = CATEGORY_DISPLAY[slug];
+                return (
+                  <button
+                    key={slug}
+                    type="button"
+                    onClick={() => {
+                      setValue("category", slug, { shouldDirty: true });
+                      // Manual category pick supersedes any AI suggestion;
+                      // clear the badge so it doesn't linger after an
+                      // explicit user choice.
+                      if (slug !== aiAppliedCategory) {
+                        setAiAppliedCategory(null);
+                      }
+                    }}
+                    className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-style-caption border transition-[background-color,border-color,color,opacity,transform] duration-150 ease-smooth active:scale-95 ${
+                      categorySlug === slug
+                        ? "bg-finyk-strong text-white border-finyk-strong shadow-sm"
+                        : "bg-panelHi text-muted border-line hover:border-muted/50 hover:bg-panelHi/80"
+                    }`}
+                  >
+                    <Icon
+                      name={display?.iconName ?? "tag"}
+                      size="xs"
+                      aria-hidden
+                    />
+                    {display?.label ?? slug}
+                  </button>
+                );
+              })}
+              {hasHiddenCategories && (
                 <button
                   type="button"
-                  onClick={() => setAiAppliedCategory(null)}
-                  aria-label="Сховати AI-підказку"
-                  className="ml-0.5 inline-flex h-4 w-4 items-center justify-center rounded-full hover:bg-finyk/20 transition-colors"
+                  onClick={() => setCategoriesExpanded((v) => !v)}
+                  aria-expanded={categoriesExpanded}
+                  className="px-3 py-1.5 rounded-full text-style-caption border border-line bg-panel text-muted hover:text-text hover:border-muted/50 hover:bg-panelHi transition-[background-color,border-color,color,opacity,transform] duration-150 ease-smooth active:scale-95"
                 >
-                  <Icon name="close" size={10} aria-hidden />
+                  {categoriesExpanded ? "Менше ▴" : "Більше ▾"}
                 </button>
-              </Badge>
+              )}
             </div>
-          ) : null}
-          <div
-            className="flex flex-wrap gap-2"
-            role="group"
-            aria-labelledby={catLabelId}
-          >
-            {visibleCategories.map((slug) => {
-              const display = CATEGORY_DISPLAY[slug];
-              return (
-                <button
-                  key={slug}
-                  type="button"
-                  onClick={() => {
-                    setValue("category", slug, { shouldDirty: true });
-                    // Manual category pick supersedes any AI suggestion;
-                    // clear the badge so it doesn't linger after an
-                    // explicit user choice.
-                    if (slug !== aiAppliedCategory) {
-                      setAiAppliedCategory(null);
-                    }
-                  }}
-                  className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-style-caption border transition-[background-color,border-color,color,opacity,transform] duration-150 ease-smooth active:scale-95 ${
-                    categorySlug === slug
-                      ? "bg-finyk-strong text-white border-finyk-strong shadow-sm"
-                      : "bg-panelHi text-muted border-line hover:border-muted/50 hover:bg-panelHi/80"
-                  }`}
-                >
-                  <Icon
-                    name={display?.iconName ?? "tag"}
-                    size="xs"
-                    aria-hidden
-                  />
-                  {display?.label ?? slug}
-                </button>
-              );
-            })}
-            {hasHiddenCategories && (
-              <button
-                type="button"
-                onClick={() => setCategoriesExpanded((v) => !v)}
-                aria-expanded={categoriesExpanded}
-                className="px-3 py-1.5 rounded-full text-style-caption border border-line bg-panel text-muted hover:text-text hover:border-muted/50 hover:bg-panelHi transition-[background-color,border-color,color,opacity,transform] duration-150 ease-smooth active:scale-95"
-              >
-                {categoriesExpanded ? "Менше ▴" : "Більше ▾"}
-              </button>
-            )}
           </div>
         </div>
-      </div>
       </Sheet>
       <ConfirmDialog
         open={confirmDelete}

--- a/apps/web/src/modules/finyk/pages/transactions/useTransactionFilters.test.ts
+++ b/apps/web/src/modules/finyk/pages/transactions/useTransactionFilters.test.ts
@@ -207,7 +207,14 @@ describe("useTransactionFilters", () => {
 
     it("uses historyTx when navigated to non-current month", () => {
       const realTx = [mkTx("real", -100)];
-      const historyTx = [mkTx("history", -200)];
+      // history row must be dated inside the navigated-to month (May 2025):
+      // the hook clamps bank rows to selMonth (monthBankTxs), so a row dated
+      // in the current month would be correctly filtered out of May.
+      const historyTx = [
+        mkTx("history", -200, {
+          time: Math.floor(new Date("2025-05-15T09:00:00Z").getTime() / 1000),
+        }),
+      ];
       const { result } = renderHook(() =>
         useTransactionFilters(buildDefaultParams({ realTx, historyTx })),
       );

--- a/apps/web/src/modules/fizruk/components/workouts/WorkoutsHome.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/WorkoutsHome.tsx
@@ -82,7 +82,11 @@ export function WorkoutsHome({
                 {(activeWorkout?.items || []).length} вправ
               </div>
             </div>
-            <Button module="fizruk" className="h-11 px-4" onClick={onOpenSession}>
+            <Button
+              module="fizruk"
+              className="h-11 px-4"
+              onClick={onOpenSession}
+            >
               Відкрити →
             </Button>
           </div>


### PR DESCRIPTION
## Summary

PR #3590 merged with a red CI matrix; two real regressions reached `main` and now break every downstream PR (`prettier --check .` and the vitest gate run repo-wide, not just on the diff).

- **format:check** — `ManualExpenseSheet.tsx` + `WorkoutsHome.tsx` landed unformatted (defect #17's new «Видалити» block shifted JSX nesting; `Button` props un-wrapped). Pure Prettier reflow, zero logic change — `git diff -w` is empty.
- **Test coverage (vitest)** — `useTransactionFilters.test.ts` › "uses historyTx when navigated to non-current month" failed. Defect #4 made `monthBankTxs` clamp bank rows to `selMonth`; the fixture dated its history row in the current month (June) then navigated to May, so the row is now correctly clamped out. Updated the fixture to a May date — the test still asserts the realTx→historyTx source switch.

Out of scope (not regressions from #3590): Lighthouse `NO_FCP` is a flaky vite-preview boot; detox iOS/Android are chronically red on `main` (this change is web-only).

## Governing Skill

- Primary skill: `sergeant-bugfix-and-regression` (CI regression reached `main`)
- Secondary skill (if truly needed): `sergeant-web-ui` (touched surface is `apps/web`)

## Playbook

- Primary playbook: n/a
- Why this playbook: —
- If no playbook matched, why: No playbook covers "repair red CI after a merge". The fix is a scoped Prettier reflow + a test-fixture date correction, both verified directly against the two failing gates.

## Verification

```bash
pnpm exec prettier --check \
  apps/web/src/modules/finyk/components/ManualExpenseSheet.tsx \
  apps/web/src/modules/fizruk/components/workouts/WorkoutsHome.tsx \
  apps/web/src/modules/finyk/pages/transactions/useTransactionFilters.test.ts
# → All matched files use Prettier code style!

cd apps/web && TZ=Europe/Kyiv npx vitest run \
  src/modules/finyk/pages/transactions/useTransactionFilters.test.ts
# → Test Files 1 passed (1) | Tests 25 passed (25)
```

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a — no behavior/contract/workflow change; scoped formatting + test-fixture fix.

## Risk and Rollout

- User-visible risk: None — Prettier reflow is runtime-equivalent; the only behavioral file is the test, and only its fixture date moved.
- Rollout / deploy order: Merge to `main` to restore green CI; no deploy ordering, no migrations.
- Backout plan: Revert this commit — returns to the prior (red) state.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

The `ManualExpenseSheet.tsx` diff looks large (~540 lines) but is 100% Prettier whitespace — `git diff -w` returns nothing. No migrations, env, auth, or HubChat changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore green main CI by applying Prettier reflow and fixing a test fixture date to align with month-clamping logic in transaction filters.

- **Bug Fixes**
  - Formatted `apps/web/src/modules/finyk/components/ManualExpenseSheet.tsx` and `apps/web/src/modules/fizruk/components/workouts/WorkoutsHome.tsx` with `prettier` (no logic changes).
  - Updated `apps/web/src/modules/finyk/pages/transactions/useTransactionFilters.test.ts` to date the `history` row in the selected month so the hook correctly switches to `historyTx` and `vitest` passes.

<sup>Written for commit 548c524b484bd480922867c7cff5c2298b581c4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

