### PR TITLE
feat(nutrition-domain): shared uom/density pantry-consume conversion

### DIFF
--- a/apps/mobile-shell/symbols.json
+++ b/apps/mobile-shell/symbols.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../docs/04-governance/governance/schemas/symbol-catalog.schema.json",
   "version": 1,
-  "generated_at": "2026-06-14",
+  "generated_at": "2026-06-15",
   "package": "@sergeant/mobile-shell",
   "entryFile": "apps/mobile-shell/src/index.ts",
   "stats": {

--- a/apps/mobile/symbols.json
+++ b/apps/mobile/symbols.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../docs/04-governance/governance/schemas/symbol-catalog.schema.json",
   "version": 1,
-  "generated_at": "2026-06-14",
+  "generated_at": "2026-06-15",
   "package": "@sergeant/mobile",
   "entryFile": null,
   "stats": {

--- a/apps/server/symbols.json
+++ b/apps/server/symbols.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../docs/04-governance/governance/schemas/symbol-catalog.schema.json",
   "version": 1,
-  "generated_at": "2026-06-14",
+  "generated_at": "2026-06-15",
   "package": "@sergeant/server",
   "entryFile": "apps/server/src/index.ts",
   "stats": {

--- a/apps/web/src/modules/nutrition/hooks/useNutritionPantries.consume.test.tsx
+++ b/apps/web/src/modules/nutrition/hooks/useNutritionPantries.consume.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+vi.mock("@shared/api", async () => {
+  const actual =
+    await vi.importActual<typeof import("@shared/api")>("@shared/api");
+  return {
+    ...actual,
+    nutritionApi: { parsePantry: vi.fn() },
+  };
+});
+
+import { useNutritionPantries } from "./useNutritionPantries";
+import type { Pantry } from "../lib/nutritionStorage";
+import {
+  __setNutritionSqliteCacheForTests,
+  clearNutritionSqliteCache,
+} from "../lib/sqliteReader";
+import { notifyNutritionSqliteCacheRefresh } from "../lib/sqliteReadGate";
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function seedPantries(items: any[]) {
+  __setNutritionSqliteCacheForTests({
+    pantries: [{ id: "home", name: "Дім", items, text: "" }],
+    activePantryId: "home",
+  });
+  notifyNutritionSqliteCacheRefresh();
+}
+
+function renderHarness() {
+  const { result } = renderHook(
+    () =>
+      useNutritionPantries({
+        setBusy: vi.fn(),
+        setErr: vi.fn(),
+        setStatusText: vi.fn(),
+      }),
+    { wrapper: makeWrapper() },
+  );
+  return result;
+}
+
+function activeItems(result: { current: { pantries: Pantry[] } }) {
+  return result.current.pantries.find((p) => p.id === "home")?.items ?? [];
+}
+
+describe("useNutritionPantries.consumePantryItem (F15 uom-conversion)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    clearNutritionSqliteCache();
+    vi.clearAllMocks();
+  });
+
+  it("г: списує грами 1:1, округлює до 0.1", () => {
+    seedPantries([{ name: "рис", qty: 500, unit: "г", notes: null }]);
+    const result = renderHarness();
+    act(() => result.current.consumePantryItem("рис", 120));
+    expect(activeItems(result)[0]).toMatchObject({ qty: 380, unit: "г" });
+  });
+
+  it("кг: конвертує грами в кілограми", () => {
+    seedPantries([{ name: "рис", qty: 1, unit: "кг", notes: null }]);
+    const result = renderHarness();
+    act(() => result.current.consumePantryItem("рис", 250));
+    expect(activeItems(result)[0]).toMatchObject({ qty: 0.8, unit: "кг" });
+  });
+
+  it("мл: списує через густину молока (1.03 г/мл)", () => {
+    seedPantries([{ name: "молоко", qty: 500, unit: "мл", notes: null }]);
+    const result = renderHarness();
+    act(() => result.current.consumePantryItem("молоко", 200));
+    // 500 - 200/1.03 = 305.8 (округлено до 0.1)
+    expect(activeItems(result)[0]?.qty).toBeCloseTo(305.8, 1);
+  });
+
+  it("л: 2 л молока − 206 г ≈ 1.8 л (F15 H2 — більше не з'їдає всю пляшку)", () => {
+    seedPantries([{ name: "молоко", qty: 2, unit: "л", notes: null }]);
+    const result = renderHarness();
+    act(() => result.current.consumePantryItem("молоко", 206));
+    expect(activeItems(result)[0]?.qty).toBe(1.8);
+  });
+
+  it("шт: 10 шт яєць − 120 г (60 г/шт) = 8 шт", () => {
+    seedPantries([{ name: "яйце", qty: 10, unit: "шт", notes: null }]);
+    const result = renderHarness();
+    act(() => result.current.consumePantryItem("яйце", 120));
+    expect(activeItems(result)[0]).toMatchObject({ qty: 8, unit: "шт" });
+  });
+
+  it("уп: одиниця без масового відображення — позиція без змін", () => {
+    seedPantries([{ name: "печиво", qty: 2, unit: "уп", notes: null }]);
+    const result = renderHarness();
+    act(() => result.current.consumePantryItem("печиво", 300));
+    expect(activeItems(result)[0]).toMatchObject({ qty: 2, unit: "уп" });
+  });
+
+  it("залишок ≤ 0 → позицію видалено", () => {
+    seedPantries([{ name: "рис", qty: 100, unit: "г", notes: null }]);
+    const result = renderHarness();
+    act(() => result.current.consumePantryItem("рис", 150));
+    expect(activeItems(result)).toHaveLength(0);
+  });
+
+  it("невідома назва → no-op", () => {
+    seedPantries([{ name: "рис", qty: 100, unit: "г", notes: null }]);
+    const result = renderHarness();
+    act(() => result.current.consumePantryItem("гречка", 50));
+    expect(activeItems(result)[0]).toMatchObject({ qty: 100, unit: "г" });
+  });
+});

--- a/apps/web/src/modules/nutrition/hooks/useNutritionPantries.ts
+++ b/apps/web/src/modules/nutrition/hooks/useNutritionPantries.ts
@@ -26,6 +26,7 @@ import {
   parseLoosePantryText,
   type PantryItem,
 } from "../lib/pantryTextParser";
+import { gramsToUnitQty } from "@sergeant/nutrition-domain";
 import type {
   PantryForm,
   PantryFormMode,
@@ -270,7 +271,13 @@ export function useNutritionPantries({
     setItemEdit((s) => ({ ...s, open: false }));
   };
 
-  // AI-CONTEXT: deducts gramsConsumed from a mass-based pantry item (г/кг only); non-mass units are intentionally skipped to avoid unit-mismatch bugs
+  // AI-CONTEXT: списує gramsConsumed зі складської позиції, конвертуючи грами
+  // в її одиницю через `gramsToUnitQty` (@sergeant/nutrition-domain): г/кг —
+  // маса 1:1, мл/л — через грубу таблицю густин, шт — через вагу однієї штуки.
+  // `null` означає одиницю без масового відображення (напр. уп) — лишаємо
+  // позицію без змін. Раніше тут пропускались усі немасові одиниці; конверсія
+  // закриває inventory-drift із F15 (page-audit-08-nutrition) і коректно
+  // обробляє кейс H2 ("200 г молока" зі "2 л" ≈ 0.19 л, а не вся пляшка).
   const consumePantryItem = (name: string, gramsConsumed: number) => {
     const norm = normalizeFoodName(name);
     if (!norm) return;
@@ -283,16 +290,9 @@ export function useNutritionPantries({
         if (!item) return p;
         const qty = Number(item.qty);
         if (!Number.isFinite(qty) || qty <= 0) return p;
-        const unit = String(item.unit || "г")
-          .toLowerCase()
-          .trim();
-        // Only deduct from mass-based units (грами/кілограми). Inventory in
-        // штуках, мл/л, чи будь-яких інших одиницях не має одно-однозначної
-        // конверсії з "грамів спожитого", тому лишаємо позицію як є —
-        // інакше "200г молока" з'їдало б всю пляшку "2 л" (див. H2 з аудиту).
-        if (unit !== "г" && unit !== "кг") return p;
-        const remaining =
-          unit === "кг" ? qty - gramsConsumed / 1000 : qty - gramsConsumed;
+        const deduct = gramsToUnitQty(gramsConsumed, item.unit, item.name);
+        if (deduct == null) return p;
+        const remaining = qty - deduct;
         if (remaining <= 0) {
           items.splice(idx, 1);
         } else {

--- a/apps/web/symbols.json
+++ b/apps/web/symbols.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../docs/04-governance/governance/schemas/symbol-catalog.schema.json",
   "version": 1,
-  "generated_at": "2026-06-14",
+  "generated_at": "2026-06-15",
   "package": "@sergeant/web",
   "entryFile": null,
   "stats": {

--- a/docs/04-governance/governance/symbol-index.html
+++ b/docs/04-governance/governance/symbol-index.html
@@ -2,7 +2,7 @@
 <html lang="uk">
   <head>
     <meta charset="utf-8" />
-    <title>Sergeant — Symbol Index (2026-06-14)</title>
+    <title>Sergeant — Symbol Index (2026-06-15)</title>
     <style>
       body {
         font-family:
@@ -66,7 +66,7 @@
   <body>
     <h1>Sergeant — Symbol Index</h1>
     <p class="auto-gen">
-      Generated 2026-06-14 · schema v1 · regenerate via
+      Generated 2026-06-15 · schema v1 · regenerate via
       <code>pnpm docs:gen-symbols</code>.
     </p>
     <div class="summary">
@@ -192,7 +192,7 @@
           </td>
           <td><code>packages/nutrition-domain/src/index.ts</code></td>
           <td class="num">1</td>
-          <td class="num">83</td>
+          <td class="num">84</td>
           <td class="num">0</td>
         </tr>
         <tr>
@@ -236,7 +236,7 @@
           </td>
           <td><code>packages/shared/src/index.ts</code></td>
           <td class="num">1</td>
-          <td class="num">339</td>
+          <td class="num">340</td>
           <td class="num">0</td>
         </tr>
         <tr>

--- a/docs/04-governance/governance/symbol-index.json
+++ b/docs/04-governance/governance/symbol-index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_at": "2026-06-14",
+  "generated_at": "2026-06-15",
   "summary": {
     "packages": 16,
     "totalExports": 303,
@@ -1842,7 +1842,7 @@
       "entryFile": "packages/nutrition-domain/src/index.ts",
       "stats": {
         "exportCount": 1,
-        "totalImporters": 83,
+        "totalImporters": 84,
         "deadExports": 0
       },
       "exports": [
@@ -2035,7 +2035,7 @@
       "entryFile": "packages/shared/src/index.ts",
       "stats": {
         "exportCount": 1,
-        "totalImporters": 339,
+        "totalImporters": 340,
         "deadExports": 0
       },
       "exports": [

--- a/docs/90-work/audits/2026-05-13-page-audit-08-nutrition.md
+++ b/docs/90-work/audits/2026-05-13-page-audit-08-nutrition.md
@@ -405,6 +405,8 @@ return { page, subTab: validSub };
 
 ### F15 — Hardcoded magic-numbers у consume-pantry без uom-conversion test [severity: medium] [perspective: bug]
 
+> ✅ **Closed 2026-06-15** — uom-конверсію винесено в DOM-free доменний модуль `packages/nutrition-domain/src/pantryConsume.ts` (`gramsToUnitQty` + грубі таблиці `DENSITY_G_PER_ML` 1.0 г/мл за замовчуванням і `PIECE_WEIGHT_G` 100 г/шт за замовчуванням, з канонізацією назви через `canonicalFoodKey`). `consumePantryItem` у `useNutritionPantries.ts` тепер списує через `gramsToUnitQty` для всіх масово-відображуваних одиниць: г/кг (1:1), мл/л (через густину), шт (через вагу штуки); `уп`/невідомі одиниці повертають `null` і лишаються без змін. Кейс H2 коректний: «200 г молока» зі «2 л» ≈ 0.19 л, а не вся пляшка. Покриття: 13 доменних unit-кейсів (`pantryConsume.test.ts`: г/кг/мл/л/шт/без-одиниці/уп/non-finite/нормалізація/канонізація) + 8 hook-інтеграційних (`useNutritionPantries.consume.test.tsx`). Таблиці навмисно грубі — розширювати лише на запит продукту щодо точнішого обліку.
+
 **Page:** Log, Menu (через `addMealFromPlan` → `wrappedSaveMeal` → consume hook)
 **File:** `apps/web/src/modules/nutrition/hooks/useNutritionPantries.ts`
 **Lines:** 269–298

--- a/packages/api-client/symbols.json
+++ b/packages/api-client/symbols.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../docs/04-governance/governance/schemas/symbol-catalog.schema.json",
   "version": 1,
-  "generated_at": "2026-06-14",
+  "generated_at": "2026-06-15",
   "package": "@sergeant/api-client",
   "entryFile": "packages/api-client/src/index.ts",
   "stats": {

--- a/packages/config/symbols.json
+++ b/packages/config/symbols.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../docs/04-governance/governance/schemas/symbol-catalog.schema.json",
   "version": 1,
-  "generated_at": "2026-06-14",
+  "generated_at": "2026-06-15",
   "package": "@sergeant/config",
   "entryFile": null,
   "stats": {

--- a/packages/db-schema/symbols.json
+++ b/packages/db-schema/symbols.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../docs/04-governance/governance/schemas/symbol-catalog.schema.json",
   "version": 1,
-  "generated_at": "2026-06-14",
+  "generated_at": "2026-06-15",
   "package": "@sergeant/db-schema",
   "entryFile": "packages/db-schema/src/index.ts",
   "stats": {

--- a/packages/design-tokens/symbols.json
+++ b/packages/design-tokens/symbols.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../docs/04-governance/governance/schemas/symbol-catalog.schema.json",
   "version": 1,
-  "generated_at": "2026-06-14",
+  "generated_at": "2026-06-15",
   "package": "@sergeant/design-tokens",
   "entryFile": "packages/design-tokens/index.d.ts",
   "stats": {

--- a/packages/eslint-plugin-sergeant-design/symbols.json
+++ b/packages/eslint-plugin-sergeant-design/symbols.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../docs/04-governance/governance/schemas/symbol-catalog.schema.json",
   "version": 1,
-  "generated_at": "2026-06-14",
+  "generated_at": "2026-06-15",
   "package": "eslint-plugin-sergeant-design",
   "entryFile": "packages/eslint-plugin-sergeant-design/index.js",
   "stats": {

--- a/packages/finyk-domain/symbols.json
+++ b/packages/finyk-domain/symbols.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../docs/04-governance/governance/schemas/symbol-catalog.schema.json",
   "version": 1,
-  "generated_at": "2026-06-14",
+  "generated_at": "2026-06-15",
   "package": "@sergeant/finyk-domain",
   "entryFile": "packages/finyk-domain/src/index.ts",
   "stats": {

--- a/packages/fizruk-domain/symbols.json
+++ b/packages/fizruk-domain/symbols.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../docs/04-governance/governance/schemas/symbol-catalog.schema.json",
   "version": 1,
-  "generated_at": "2026-06-14",
+  "generated_at": "2026-06-15",
   "package": "@sergeant/fizruk-domain",
   "entryFile": "packages/fizruk-domain/src/index.ts",
   "stats": {

--- a/packages/insights/symbols.json
+++ b/packages/insights/symbols.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../docs/04-governance/governance/schemas/symbol-catalog.schema.json",
   "version": 1,
-  "generated_at": "2026-06-14",
+  "generated_at": "2026-06-15",
   "package": "@sergeant/insights",
   "entryFile": "packages/insights/src/index.ts",
   "stats": {

--- a/packages/nutrition-domain/package.json
+++ b/packages/nutrition-domain/package.json
@@ -15,6 +15,7 @@
     "./nutrition-pantries": "./src/nutritionPantries.ts",
     "./nutrition-prefs": "./src/nutritionPrefs.ts",
     "./nutrition-types": "./src/nutritionTypes.ts",
+    "./pantry-consume": "./src/pantryConsume.ts",
     "./pantry-text-parser": "./src/pantryTextParser.ts",
     "./recipe-ids": "./src/recipeIds.ts",
     "./shopping-list": "./src/shoppingList.ts",

--- a/packages/nutrition-domain/src/index.ts
+++ b/packages/nutrition-domain/src/index.ts
@@ -11,6 +11,7 @@
 // власного KVStore.
 export * from "./mealTypes.js";
 export * from "./pantryTextParser.js";
+export * from "./pantryConsume.js";
 export * from "./mergeItems.js";
 export * from "./recipeIds.js";
 export * from "./foodCategories.js";

--- a/packages/nutrition-domain/src/pantryConsume.test.ts
+++ b/packages/nutrition-domain/src/pantryConsume.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import {
+  gramsToUnitQty,
+  densityFor,
+  pieceWeightFor,
+  DEFAULT_DENSITY_G_PER_ML,
+  DEFAULT_PIECE_WEIGHT_G,
+} from "./pantryConsume.js";
+
+describe("gramsToUnitQty", () => {
+  it("г: 1:1", () => {
+    expect(gramsToUnitQty(200, "г", "рис")).toBe(200);
+  });
+
+  it("кг: ділить на 1000", () => {
+    expect(gramsToUnitQty(250, "кг", "рис")).toBeCloseTo(0.25, 6);
+  });
+
+  it("мл: default-густина (невідомий продукт) → 1.0 г/мл", () => {
+    expect(gramsToUnitQty(200, "мл", "вода")).toBeCloseTo(200, 6);
+  });
+
+  it("мл: молоко 1.03 г/мл → ~194 мл за 200 г", () => {
+    expect(gramsToUnitQty(200, "мл", "молоко")).toBeCloseTo(200 / 1.03, 4);
+  });
+
+  it("л: молоко → грами/густину/1000", () => {
+    expect(gramsToUnitQty(206, "л", "молоко")).toBeCloseTo(
+      206 / 1.03 / 1000,
+      6,
+    );
+  });
+
+  it("шт: default-вага (невідомий продукт) → 100 г/шт", () => {
+    expect(gramsToUnitQty(250, "шт", "щось")).toBeCloseTo(2.5, 6);
+  });
+
+  it("шт: яйце 60 г/шт → 1 шт за 60 г", () => {
+    expect(gramsToUnitQty(60, "шт", "яйце")).toBeCloseTo(1, 6);
+  });
+
+  it("відсутня одиниця → трактується як грами (1:1)", () => {
+    expect(gramsToUnitQty(150, null, "борошно")).toBe(150);
+    expect(gramsToUnitQty(150, undefined, "борошно")).toBe(150);
+  });
+
+  it("уп / невідома одиниця → null (без грубого масового відображення)", () => {
+    expect(gramsToUnitQty(200, "уп", "печиво")).toBeNull();
+    expect(gramsToUnitQty(200, "пучок", "кріп")).toBeNull();
+  });
+
+  it("не-додатні / не-скінченні грами → null", () => {
+    expect(gramsToUnitQty(0, "г", "рис")).toBeNull();
+    expect(gramsToUnitQty(-50, "г", "рис")).toBeNull();
+    expect(gramsToUnitQty(Number.NaN, "г", "рис")).toBeNull();
+    expect(gramsToUnitQty(Number.POSITIVE_INFINITY, "г", "рис")).toBeNull();
+  });
+
+  it("нормалізує одиницю (велика літера / повна форма)", () => {
+    expect(gramsToUnitQty(100, "Г", "рис")).toBe(100);
+    expect(gramsToUnitQty(1000, "грам", "рис")).toBe(1000);
+    expect(gramsToUnitQty(2, "кілограм", "рис")).toBeCloseTo(0.002, 6);
+  });
+
+  it("канонізує назву: відмінкова форма «молока» бере густину молока", () => {
+    expect(gramsToUnitQty(200, "мл", "молока")).toBeCloseTo(200 / 1.03, 4);
+  });
+});
+
+describe("densityFor / pieceWeightFor", () => {
+  it("повертає табличне значення для відомого продукту", () => {
+    expect(densityFor("олія")).toBe(0.92);
+    expect(pieceWeightFor("яблуко")).toBe(180);
+  });
+
+  it("повертає default для невідомого продукту", () => {
+    expect(densityFor("невідома рідина")).toBe(DEFAULT_DENSITY_G_PER_ML);
+    expect(pieceWeightFor("невідомий продукт")).toBe(DEFAULT_PIECE_WEIGHT_G);
+  });
+});

--- a/packages/nutrition-domain/src/pantryConsume.ts
+++ b/packages/nutrition-domain/src/pantryConsume.ts
@@ -1,0 +1,103 @@
+/**
+ * Конверсія «спожитих грамів» у кількість для списання зі складської позиції,
+ * вираженої в її власній одиниці (`г`/`кг` — маса 1:1, `мл`/`л` — через
+ * густину, `шт` — через вагу однієї штуки).
+ *
+ * DOM-free доменна логіка: споживають і `apps/web`, і майбутній pantry-surface
+ * `apps/mobile`. Раніше жила inline у web-хуку `useNutritionPantries` і свідомо
+ * пропускала немасові одиниці (див. F15 аудиту page-audit-08-nutrition).
+ *
+ * AI-CONTEXT: таблиці навмисно грубі — default 1.0 г/мл для рідин і 100 г/шт
+ * для штучних продуктів. Це закриває inventory-drift із F15 (раніше «2 л
+ * молока» чи «10 шт яєць» не списувались узагалі), не претендуючи на
+ * нутриціологічну точність. Розширюй записи лише на запит продукту щодо
+ * точнішого обліку залишків, а не «про всяк випадок».
+ */
+import { canonicalFoodKey, normalizeUnit } from "./pantryTextParser.js";
+
+/** Густина за замовчуванням (вода-подібна), коли продукту немає в таблиці. г/мл. */
+export const DEFAULT_DENSITY_G_PER_ML = 1.0;
+
+/** Вага однієї штуки за замовчуванням, коли продукту немає в таблиці. г. */
+export const DEFAULT_PIECE_WEIGHT_G = 100;
+
+/**
+ * Груба таблиця густин (г/мл) для позицій у `мл`/`л`.
+ * Ключ — `canonicalFoodKey(name)`, тож відмінкові/множинні форми
+ * («молока», «олії») зводяться до канонічної форми перед пошуком.
+ */
+export const DENSITY_G_PER_ML: Readonly<Record<string, number>> = {
+  молоко: 1.03,
+  кефір: 1.03,
+  ряжанка: 1.03,
+  йогурт: 1.03,
+  вершки: 1.01,
+  олія: 0.92,
+  "оливкова олія": 0.92,
+  мед: 1.42,
+};
+
+/**
+ * Груба таблиця ваги однієї штуки (г) для позицій у `шт`.
+ * Ключ — `canonicalFoodKey(name)`.
+ */
+export const PIECE_WEIGHT_G: Readonly<Record<string, number>> = {
+  яйце: 60,
+  яблуко: 180,
+  груша: 180,
+  банан: 120,
+  апельсин: 200,
+  мандарин: 80,
+  помідор: 120,
+  картопля: 120,
+  морква: 80,
+  цибуля: 90,
+  перець: 150,
+  кабачок: 300,
+  баклажан: 250,
+};
+
+/** Густина (г/мл) для продукту; default `DEFAULT_DENSITY_G_PER_ML`. */
+export function densityFor(name: unknown): number {
+  return DENSITY_G_PER_ML[canonicalFoodKey(name)] ?? DEFAULT_DENSITY_G_PER_ML;
+}
+
+/** Вага однієї штуки (г) для продукту; default `DEFAULT_PIECE_WEIGHT_G`. */
+export function pieceWeightFor(name: unknown): number {
+  return PIECE_WEIGHT_G[canonicalFoodKey(name)] ?? DEFAULT_PIECE_WEIGHT_G;
+}
+
+/**
+ * Скільки списати з позиції в одиниці `unit`, споживши `gramsConsumed` грамів.
+ *
+ * - `г` → 1:1, `кг` → /1000.
+ * - `мл`/`л` → ділимо на густину продукту (`л` ще /1000).
+ * - `шт` → ділимо на вагу однієї штуки.
+ * - відсутня одиниця → трактуємо як `г` (узгоджено з legacy-дефолтом consume).
+ *
+ * Повертає `null`, коли списання порахувати не можна: не-додатні/не-скінченні
+ * грами, або одиниця без грубого масового відображення (напр. `уп` — пакет
+ * може важити будь-що). Викликач у такому разі лишає позицію без змін.
+ */
+export function gramsToUnitQty(
+  gramsConsumed: number,
+  unit: string | null | undefined,
+  name: unknown,
+): number | null {
+  if (!Number.isFinite(gramsConsumed) || gramsConsumed <= 0) return null;
+  const u = normalizeUnit(unit) ?? "г";
+  switch (u) {
+    case "г":
+      return gramsConsumed;
+    case "кг":
+      return gramsConsumed / 1000;
+    case "мл":
+      return gramsConsumed / densityFor(name);
+    case "л":
+      return gramsConsumed / densityFor(name) / 1000;
+    case "шт":
+      return gramsConsumed / pieceWeightFor(name);
+    default:
+      return null;
+  }
+}

--- a/packages/nutrition-domain/symbols.json
+++ b/packages/nutrition-domain/symbols.json
@@ -1,12 +1,12 @@
 {
   "$schema": "../../docs/04-governance/governance/schemas/symbol-catalog.schema.json",
   "version": 1,
-  "generated_at": "2026-06-14",
+  "generated_at": "2026-06-15",
   "package": "@sergeant/nutrition-domain",
   "entryFile": "packages/nutrition-domain/src/index.ts",
   "stats": {
     "exportCount": 1,
-    "totalImporters": 83,
+    "totalImporters": 84,
     "deadExports": 0
   },
   "exports": [

--- a/packages/openclaw-plugin/symbols.json
+++ b/packages/openclaw-plugin/symbols.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../docs/04-governance/governance/schemas/symbol-catalog.schema.json",
   "version": 1,
-  "generated_at": "2026-06-14",
+  "generated_at": "2026-06-15",
   "package": "@sergeant/openclaw-plugin",
   "entryFile": "packages/openclaw-plugin/src/index.ts",
   "stats": {

--- a/packages/routine-domain/symbols.json
+++ b/packages/routine-domain/symbols.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../docs/04-governance/governance/schemas/symbol-catalog.schema.json",
   "version": 1,
-  "generated_at": "2026-06-14",
+  "generated_at": "2026-06-15",
   "package": "@sergeant/routine-domain",
   "entryFile": "packages/routine-domain/src/index.ts",
   "stats": {

--- a/packages/shared/symbols.json
+++ b/packages/shared/symbols.json
@@ -1,12 +1,12 @@
 {
   "$schema": "../../docs/04-governance/governance/schemas/symbol-catalog.schema.json",
   "version": 1,
-  "generated_at": "2026-06-14",
+  "generated_at": "2026-06-15",
   "package": "@sergeant/shared",
   "entryFile": "packages/shared/src/index.ts",
   "stats": {
     "exportCount": 1,
-    "totalImporters": 339,
+    "totalImporters": 340,
     "deadExports": 0
   },
   "exports": [


### PR DESCRIPTION
## Summary

Promotes the pantry-consume unit-of-measure / density conversion into the shared `@sergeant/nutrition-domain` package as DOM-free domain logic, so both `apps/web` and a future `apps/mobile` pantry surface can reuse it.

- **New `packages/nutrition-domain/src/pantryConsume.ts`** — `gramsToUnitQty(gramsConsumed, unit, name)` plus coarse `DENSITY_G_PER_ML` (default `1.0` g/ml) and `PIECE_WEIGHT_G` (default `100` g/piece) tables, keyed by `canonicalFoodKey` so відмінкові/множинні forms resolve. `г`/`кг` convert 1:1, `мл`/`л` via density, `шт` via per-piece weight; `уп`/unknown units and non-finite/non-positive grams return `null` (caller leaves the item untouched).
- **Rewired `useNutritionPantries.consumePantryItem`** to delegate to `gramsToUnitQty` for all mass-mappable units instead of silently skipping `мл`/`л`/`шт`. Imports directly from `@sergeant/nutrition-domain` (no thin web re-export needed since none existed).
- **Closes audit finding F15** (`docs/90-work/audits/2026-05-13-page-audit-08-nutrition.md`) and correctly resolves the H2 case: "200 г молока" deducted from a 2 л bottle ≈ 0.19 л, not the whole bottle.
- Regenerated the symbol catalog via `pnpm docs:gen-symbols`.

> ⚠️ **Premise note for reviewers:** the task described promoting an *existing* `apps/web/.../lib/pantryConsume.ts` (with `gramsToUnitQty`) that "already closed F15". That file/helper **never existed on any branch**, and **F15 was still open** — the live `consumePantryItem` deliberately skipped non-mass units. The intent and end-state were unambiguous, so I built the helper directly in the domain package (strictly better than the assumed "add to web → promote" two-step) and closed F15 in the same PR. Net effect is a **behavior change**: liquid/piece pantry items now decrement on meal logging.

## Governing Skill

- Primary skill: `sergeant-monorepo-boundaries` (deciding the home for shared domain logic — the core rationale of the task)
- Secondary skill: `sergeant-bugfix-and-regression` (closes audit bug finding F15) + `sergeant-web-ui` (consume-hook rewire)

## Playbook

- Primary playbook: n/a
- Why this playbook: —
- If no playbook matched, why: no playbook covers "promote in-module helper to a shared domain package"; followed `sergeant-start-here` routing + the package's existing `pantryTextParser`/`nutritionPantries` precedent.

## Verification

Full `pnpm lint` / `pnpm check` are blocked locally by the repo's slow-hardware guard hook and run in CI; I ran the scoped equivalents:

```bash
pnpm --filter @sergeant/nutrition-domain typecheck         # ✓ pass
pnpm --filter @sergeant/web typecheck                      # ✓ pass
pnpm --filter @sergeant/nutrition-domain exec vitest run src/pantryConsume.test.ts   # ✓ 14 passed
pnpm --filter @sergeant/web exec vitest run \
  src/modules/nutrition/hooks/useNutritionPantries.consume.test.tsx \
  src/modules/nutrition/hooks/useNutritionPantries.test.tsx          # ✓ 11 passed (8 new + 3 existing)
pnpm --filter @sergeant/nutrition-domain lint              # ✓ clean
pnpm --filter @sergeant/web exec eslint <changed files>    # ✓ exit 0
npx prettier --check <changed files>                       # ✓ clean
pnpm docs:gen-symbols                                      # regenerated catalog
```

Additional checks:

- [x] Local smoke / manual validation completed (unit + hook integration tests)
- [x] Surface-specific checks completed (typecheck + scoped lint both surfaces)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. (F15 marked ✅ Closed)
- [x] I checked whether `AGENTS.md` needed an update. (no — no new hard rule/scope)
- [x] I checked whether a playbook or skill needed an update. (no)
- [x] I checked whether governance docs or review docs needed an update. (symbol catalog regenerated)

Updated docs:

- `docs/90-work/audits/2026-05-13-page-audit-08-nutrition.md` — F15 closed marker
- `docs/04-governance/governance/symbol-index.{json,html}` + per-package `symbols.json` — `pnpm docs:gen-symbols` output

## Risk and Rollout

- User-visible risk: **behavior change** — pantry items measured in `мл`/`л`/`шт` now decrement on meal logging (previously frozen). Conversion is coarse by design; worst case is slightly inaccurate remaining quantities, never a crash (`null` → no-op). `уп`/unknown units stay frozen.
- Rollout / deploy order: standard web deploy; no migration, no env, no server change.
- Backout plan: revert this commit — the helper is additive and the hook reverts to mass-only deduction.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

- See the **Premise note** above — this PR both *creates* and *promotes* the helper because the assumed pre-existing web file never existed, and it changes consume behavior for non-mass units (the F15 fix).
- The symbol-catalog diff includes `generated_at` date bumps across all packages — that is deterministic `pnpm docs:gen-symbols` output (the `--check` gate compares full content incl. date); the only semantic deltas are `totalImporters` (nutrition-domain 83→84, shared 339→340).
- Density/per-piece tables are intentionally coarse — widen only on a product request for tighter inventory accuracy.

https://claude.ai/code/session_01N6jyVU3Pk72y4Dy6N2gYzC

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6jyVU3Pk72y4Dy6N2gYzC)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved pantry consumption unit conversion into shared `@sergeant/nutrition-domain` and rewired the web consume hook to use it. Liquids (`мл`/`л`) and piece-count (`шт`) items now decrement correctly when logging meals.

- **New Features**
  - Added `gramsToUnitQty(gramsConsumed, unit, name)` in `@sergeant/nutrition-domain`: `г/кг` 1:1, `мл/л` via density, `шт` via per‑piece weight; returns null for `уп`/unknown units or non‑positive grams; coarse defaults are 1.0 g/ml and 100 g/piece.
  - `useNutritionPantries.consumePantryItem` now delegates to `gramsToUnitQty`; added unit and hook integration tests; exported as `./pantry-consume`; regenerated symbol catalog.

- **Bug Fixes**
  - Closes audit finding F15: applies conversion for `мл/л/шт`. Example: “200 г молока” from a 2 л bottle now deducts ≈0.19 л instead of the whole bottle.

<sup>Written for commit d3906704a097a54e9dafda22c0d298c7d64e6a15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

