### PR TITLE
test(web): make date-gated rec tests TZ-robust, deflake shell-deeplink

### DIFF
--- a/apps/web/src/core/lib/recommendationEngine.test.ts
+++ b/apps/web/src/core/lib/recommendationEngine.test.ts
@@ -14,6 +14,29 @@ function clearAll() {
   localStorage.clear();
 }
 
+// Fixed fake-clock anchor built from *local* calendar components.
+//
+// `recommendationEngine` reads the host-local wall clock directly
+// (`new Date().getHours()` / `getDay()`, and `localDateKey()` via local
+// Y/M/D), so every time-gated rule — 21:00 streak-at-risk, 13:00
+// no-meals-today, the Monday 07:00–12:00 weekly digest — depends on the
+// host timezone. CI runs in `Europe/Kyiv` (the repo's domain timezone, see
+// docs/02-engineering/architecture/domain-invariants.md), where a UTC `…Z`
+// literal lands +2/+3 h off and trips these gate boundaries (e.g. 22:00Z →
+// 01:00 Kyiv, 09:00Z → 12:00 Kyiv). Anchoring from local components keeps
+// the engine's local-time math identical in any host TZ — a UTC dev box and
+// a Kyiv CI runner both read the intended wall-clock hour. `month` is
+// 1-indexed for readability (April = 4).
+function localClock(
+  year: number,
+  month: number,
+  day: number,
+  hour = 0,
+  minute = 0,
+): Date {
+  return new Date(year, month - 1, day, hour, minute, 0, 0);
+}
+
 // ---------------------------------------------------------------------------
 // generateRecommendations – structural guarantees
 // ---------------------------------------------------------------------------
@@ -305,8 +328,8 @@ describe("generateRecommendations", () => {
 
   it("НЕ генерує fizruk_no_week_workout на початку тижня (пн/вт)", () => {
     vi.useFakeTimers();
-    // Monday 2026-04-27 10:00 UTC
-    vi.setSystemTime(new Date("2026-04-27T10:00:00Z"));
+    // Monday 2026-04-27 10:00 host-local
+    vi.setSystemTime(localClock(2026, 4, 27, 10));
 
     const old = new Date("2026-04-18T10:00:00Z");
     setLS("fizruk_workouts_v1", [
@@ -515,14 +538,14 @@ describe("generateRecommendations", () => {
 
   it("генерує streak_at_risk після 21:00 при серії 7+ і незавершених звичках", () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-04-27T22:00:00Z"));
+    vi.setSystemTime(localClock(2026, 4, 27, 22));
 
     const habits = [{ id: "h1" }];
     const completions: Record<string, string[]> = {};
     completions["h1"] = [];
     // 7-day streak — today NOT completed → streak at risk
     for (let i = 1; i <= 7; i++) {
-      const d = new Date("2026-04-27T22:00:00Z");
+      const d = localClock(2026, 4, 27, 22);
       d.setDate(d.getDate() - i);
       const dk = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
       completions["h1"].push(dk);
@@ -539,13 +562,13 @@ describe("generateRecommendations", () => {
 
   it("routine_streak_at_risk використовує правильну форму множини для 1 звички", () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-04-27T22:00:00Z"));
+    vi.setSystemTime(localClock(2026, 4, 27, 22));
 
     const habits = [{ id: "h1" }];
     const completions: Record<string, string[]> = {};
     completions["h1"] = [];
     for (let i = 1; i <= 7; i++) {
-      const d = new Date("2026-04-27T22:00:00Z");
+      const d = localClock(2026, 4, 27, 22);
       d.setDate(d.getDate() - i);
       const dk = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
       completions["h1"].push(dk);
@@ -562,14 +585,14 @@ describe("generateRecommendations", () => {
 
   it("routine_streak_at_risk використовує множину для >1 звичок", () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-04-27T22:00:00Z"));
+    vi.setSystemTime(localClock(2026, 4, 27, 22));
 
     const habits = [{ id: "h1" }, { id: "h2" }, { id: "h3" }];
     const completions: Record<string, string[]> = {};
     for (const h of habits) {
       completions[h.id] = [];
       for (let i = 1; i <= 7; i++) {
-        const d = new Date("2026-04-27T22:00:00Z");
+        const d = localClock(2026, 4, 27, 22);
         d.setDate(d.getDate() - i);
         const dk = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
         completions[h.id]!.push(dk);
@@ -587,13 +610,13 @@ describe("generateRecommendations", () => {
 
   it("НЕ генерує streak_at_risk якщо серія < 7 днів", () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-04-27T22:00:00Z"));
+    vi.setSystemTime(localClock(2026, 4, 27, 22));
 
     const habits = [{ id: "h1" }];
     const completions: Record<string, string[]> = {};
     completions["h1"] = [];
     for (let i = 1; i <= 5; i++) {
-      const d = new Date("2026-04-27T22:00:00Z");
+      const d = localClock(2026, 4, 27, 22);
       d.setDate(d.getDate() - i);
       const dk = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
       completions["h1"].push(dk);
@@ -624,7 +647,7 @@ describe("generateRecommendations", () => {
 
   it("НЕ генерує nutrition_no_meals_today до 13:00", () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-04-27T10:00:00Z"));
+    vi.setSystemTime(localClock(2026, 4, 27, 10));
 
     setLS("nutrition_log_v1", {});
 
@@ -814,8 +837,8 @@ describe("generateRecommendations", () => {
 
   it("генерує weekly_digest у понеділок 7-12 якщо є дані за минулий тиждень", () => {
     vi.useFakeTimers();
-    // Monday 2026-04-27 09:00 UTC
-    vi.setSystemTime(new Date("2026-04-27T09:00:00Z"));
+    // Monday 2026-04-27 09:00 host-local
+    vi.setSystemTime(localClock(2026, 4, 27, 9));
 
     // Workout last week (Monday-Sunday: Apr 20-26)
     const lastWeek = new Date("2026-04-23T10:00:00Z");
@@ -879,7 +902,7 @@ describe("generateRecommendations", () => {
 
   it("weekly_digest включає витрати та звички", () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-04-27T09:00:00Z"));
+    vi.setSystemTime(localClock(2026, 4, 27, 9));
 
     // Mon prev = Apr 20, Sun prev = Apr 26 23:59:59
     const txTime = Math.floor(

--- a/apps/web/src/core/lib/recommendations/financeContext.test.ts
+++ b/apps/web/src/core/lib/recommendations/financeContext.test.ts
@@ -20,7 +20,14 @@ describe("buildFinanceContext — defaults", () => {
   it("returns sane empty defaults when no LS data is present", () => {
     const ctx = buildFinanceContext();
     expect(ctx.now.toISOString()).toBe(FIXED_NOW.toISOString());
-    expect(ctx.monthStart.toISOString()).toBe("2026-04-01T00:00:00.000Z");
+    // `monthStart` is the *local* first-of-month at 00:00 (see
+    // `startOfCurrentMonth`). Compare against a locally-constructed instant
+    // rather than a hard-coded UTC string: under the repo's domain timezone
+    // (Europe/Kyiv, +3 in summer) the UTC serialization of local April-1
+    // midnight is `2026-03-31T21:00:00.000Z`, so a fixed `…Z` literal only
+    // holds on a UTC host. `new Date(year, monthIndex, 1)` tracks the host
+    // zone the same way the SUT does, keeping this green on UTC and Kyiv.
+    expect(ctx.monthStart.getTime()).toBe(new Date(2026, 3, 1).getTime());
     expect(ctx.transactions).toEqual([]);
     expect(ctx.manualExpenses).toEqual([]);
     expect(ctx.budgets).toEqual([]);

--- a/apps/web/src/test/integration/shell-deeplink.test.tsx
+++ b/apps/web/src/test/integration/shell-deeplink.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { act, render } from "@testing-library/react";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { SHELL_DEEPLINK_CHANNEL } from "@sergeant/shared";
 
@@ -47,7 +47,19 @@ beforeEach(async () => {
   ).__sergeantShellDeepLinkQueue;
 });
 
-afterEach(() => {
+afterEach(async () => {
+  // Unmount the bridge first — its effect-cleanup unsubscribes the
+  // BroadcastChannel listener and closes the channel. Then yield one
+  // event-loop turn so any *in-flight* BroadcastChannel delivery posted by
+  // this test is flushed (and dropped, now that the listener is gone) before
+  // the next test mounts a fresh bridge on the same channel name. Without
+  // this drain a late async message from one test navigates the next test's
+  // router and flakes its assertion (the channel name is a shared constant,
+  // so messages cross test boundaries unless explicitly drained).
+  cleanup();
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
   vi.restoreAllMocks();
 });
 
@@ -80,9 +92,15 @@ describe("ShellDeepLinkBridge — BroadcastChannel listener (PR-29)", () => {
       source: "shell",
       timestamp: Date.now(),
     });
-    await new Promise((r) => setTimeout(r, 10));
-
-    expect(loc.textContent).toBe("/finyk/transactions/42");
+    // Poll instead of a fixed delay: BroadcastChannel delivery + the
+    // router re-render is async, and on a throttled CI runner a fixed
+    // 10ms wait races the navigation (the documented flake).
+    await waitFor(
+      () => expect(loc.textContent).toBe("/finyk/transactions/42"),
+      {
+        timeout: 2000,
+      },
+    );
     sender.close();
   });
 
@@ -126,10 +144,11 @@ describe("ShellDeepLinkBridge — BroadcastChannel listener (PR-29)", () => {
       source: "shell",
       timestamp: Date.now(),
     });
-    await new Promise((r) => setTimeout(r, 10));
-
+    // Wait on the observable side-effect (the rejection warning) rather than
+    // a fixed delay — that deterministically proves the message was delivered
+    // and handled before we assert that no navigation happened.
+    await waitFor(() => expect(warnSpy).toHaveBeenCalled(), { timeout: 2000 });
     expect(loc.textContent).toBe("/");
-    expect(warnSpy).toHaveBeenCalled();
     sender.close();
     warnSpy.mockRestore();
   });
@@ -153,11 +172,11 @@ describe("ShellDeepLinkBridge — backward-compat (window-global)", () => {
       window as Window & { __sergeantShellDeepLinkQueue?: string[] }
     ).__sergeantShellDeepLinkQueue = ["/welcome"];
     const loc = renderBridge();
-    // Дочекаємось React state-update після useEffect-у
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 0));
+    // Дочекаємось React state-update після useEffect-у (poll замість
+    // фіксованої затримки — drain + re-render асинхронні).
+    await waitFor(() => expect(loc.textContent).toBe("/welcome"), {
+      timeout: 2000,
     });
-    expect(loc.textContent).toBe("/welcome");
     // Drained
     expect(
       (window as Window & { __sergeantShellDeepLinkQueue?: string[] })
@@ -179,8 +198,9 @@ describe("ShellDeepLinkBridge — coalescing window", () => {
       source: "shell",
       timestamp: ts,
     });
-    await new Promise((r) => setTimeout(r, 10));
-    expect(loc.textContent).toBe("/chat");
+    await waitFor(() => expect(loc.textContent).toBe("/chat"), {
+      timeout: 2000,
+    });
 
     // window-global with the SAME timestamp → must be coalesced.
     // (NOTE: mobile-shell sends BC with the message's `Date.now()` but

--- a/docs/04-governance/governance/knowledge-graph.html
+++ b/docs/04-governance/governance/knowledge-graph.html
@@ -3,7 +3,7 @@
 <html lang="uk">
   <head>
     <meta charset="utf-8" />
-    <title>Sergeant — Knowledge Graph (2026-06-14)</title>
+    <title>Sergeant — Knowledge Graph (2026-06-15)</title>
     <style>
       body {
         font-family:
@@ -97,7 +97,7 @@
   <body>
     <h1>Sergeant — Knowledge Graph</h1>
     <p class="auto-gen">
-      Generated 2026-06-14 · schema v1 · do not edit by hand — regenerate via
+      Generated 2026-06-15 · schema v1 · do not edit by hand — regenerate via
       <code>pnpm docs:gen-graph</code>.
     </p>
     <div class="summary">

--- a/docs/04-governance/governance/knowledge-graph.json
+++ b/docs/04-governance/governance/knowledge-graph.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schemas/knowledge-graph.schema.json",
   "version": 1,
-  "generated_at": "2026-06-14",
+  "generated_at": "2026-06-15",
   "counts": {
     "adr": 63,
     "audit": 19,


### PR DESCRIPTION
## Summary

Three `apps/web` suites failed the full `@sergeant/web` test run (and the `test:coverage` CI gate) under the repo's domain timezone **Europe/Kyiv** — confirmed failing on 2026-06-15. None were caused by feature work; `git diff` shows the sources and tests were unchanged. This PR fixes the **tests only** so they are deterministic in any host timezone.

### Root causes (reproduced)

- **`recommendationEngine.test.ts` (6 failures)** & **`recommendations/financeContext.test.ts` (1 failure)** — the suites pinned fake clocks with **UTC `…Z` instants**, but the engine reads the **host-local** wall clock directly (`new Date().getHours()`/`getDay()`, and `localDateKey()` via local Y/M/D). In Europe/Kyiv (+3 in summer) the offset pushed every time-gated instant across its boundary:
  - `22:00Z → 01:00` (kills the `>=21:00` streak-at-risk gate)
  - `10:00Z → 13:00` (trips the `<13:00` no-meals gate)
  - `09:00Z → 12:00` (falls outside the Mon 07:00–12:00 weekly-digest window)
  - and serialized local month-start as the DST artifact `2026-03-31T21:00:00.000Z` vs the hard-coded `2026-04-01T00:00:00.000Z`.
- **`test/integration/shell-deeplink.test.tsx`** — a fixed `setTimeout(10)` raced async **BroadcastChannel** delivery + the router re-render under full-suite load, and a late message could bleed into the next test (the channel name is a shared constant).

### Fix

- Anchor fake clocks from **local calendar components** via a small `localClock(y, m, d, h, …)` helper, so the engine's local-time math resolves identically on a UTC dev box and a Kyiv CI runner (no reliance on the host offset).
- Assert `monthStart` against a **locally-constructed** instant instead of a hard-coded UTC string.
- Replace fixed `setTimeout` waits with `waitFor` (poll), wait on the reject **warning** to prove delivery for the unsafe-path case, and **drain in-flight BroadcastChannel messages in an async `afterEach`** (unmount → flush one event-loop turn) to prevent cross-test bleed.

## Governing Skill

- Primary skill: `sergeant-bugfix-and-regression` (flaky / date-dependent test failures)
- Secondary skill (if truly needed): `sergeant-web-ui` (surface owner for `apps/web`)

## Playbook

- Primary playbook: none
- Why this playbook: n/a
- If no playbook matched, why: followed the bugfix four-phase flow (root cause → reproduce → hypothesis → minimal fix at the root); reproduced both ways — `TZ=Europe/Kyiv` (fail) vs UTC (pass) — before and after.

## Verification

All run from `apps/web` (with built upstream packages):

| Check | UTC | `TZ=Europe/Kyiv` |
| --- | --- | --- |
| 3 target files | 82 passed | 82 passed |
| Full suite (`vitest run`) | 351 files / 3881 tests, exit 0 | 351 files / 3881 tests |
| `test:coverage` (lines ≥ 50 gate) | — | green, **lines 50.33%** |

```bash
TZ=Europe/Kyiv pnpm --filter @sergeant/web exec vitest run   # full suite green
TZ=Europe/Kyiv pnpm --filter @sergeant/web test:coverage     # lines 50.33% ≥ 50
pnpm --filter @sergeant/web typecheck                        # clean
```

Also clean: `prettier --check`, `eslint`. Husky pre-commit ran (staged-typecheck passed) — no `--no-verify`.

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. (N/A — test-only change; no behavior/contract/workflow/rollout changed.)
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a — the Europe/Kyiv day-boundary invariant is already documented in `docs/02-engineering/architecture/domain-invariants.md` (and `shared/lib/time/kyivTime.ts`). No API/contract, schema, or RQ-key surface touched.

## Risk and Rollout

- User-visible risk: none — changes are confined to three test files; no production code touched.
- Rollout / deploy order: n/a (test-only).
- Backout plan: revert this commit; the prior (flaky) behavior returns with no production impact.

> Note: the engine itself still reads the host-local clock rather than the canonical `kyivTime` helpers (a pre-existing invariant gap, out of scope here). Tests now validate the engine's actual host-local contract deterministically; tightening the engine to Kyiv time can be a separate follow-up.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

Test-only fix. No migrations, env changes, HubChat tools, or auth touched. The three suites are now green in both UTC and Europe/Kyiv, removing the date/TZ-dependent flake from the `test:coverage` gate.

https://claude.ai/code/session_011xpiUWNwqscH2GLSwNxDMo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by implementing timezone-deterministic helpers for time-gated rules and replacing fixed delays with polling.
  * Enhanced async cleanup between tests to prevent cross-test interference.

* **Documentation**
  * Updated auto-generated knowledge graph timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->