### PR TITLE
fix(web): scope AppLock PIN credential per user (audit F16)

### DIFF
--- a/apps/web/eslint.i18n-allowlist.json
+++ b/apps/web/eslint.i18n-allowlist.json
@@ -88,6 +88,7 @@
   "apps/web/src/core/settings/NutritionSection.tsx",
   "apps/web/src/core/settings/PWASection.tsx",
   "apps/web/src/core/settings/PlanSection.tsx",
+  "apps/web/src/core/settings/PrivacySection.tsx",
   "apps/web/src/core/settings/RoutineSection.tsx",
   "apps/web/src/core/stories/components/StoriesProgressHeader.tsx",
   "apps/web/src/core/stories/components/slides/FinykSlide.tsx",

--- a/apps/web/src/core/app/RootLayout.tsx
+++ b/apps/web/src/core/app/RootLayout.tsx
@@ -55,6 +55,7 @@ function AppShell({ children }: { children: React.ReactNode }) {
       <AppLock
         state={appLock.state}
         onUnlock={appLock.unlock}
+        onSavePin={appLock.savePin}
         onSetupDone={appLock.finishSetup}
         onSetupCancel={() => {
           setFlag("app-lock-enabled", false);

--- a/apps/web/src/core/security/AppLock.tsx
+++ b/apps/web/src/core/security/AppLock.tsx
@@ -4,7 +4,6 @@ import { Button } from "@shared/components/ui/Button";
 import { Icon } from "@shared/components/ui/Icon";
 import { messages } from "@shared/i18n/uk";
 import { type LockState } from "./useAppLock";
-import { savePinHash } from "./lockStorage";
 
 const m = messages.privacy.lock;
 
@@ -111,9 +110,11 @@ function PinPad({
 interface PinSetupFlowProps {
   onDone: () => void;
   onCancel: () => void;
+  /** Persist the confirmed PIN — bound to the current user (audit F16). */
+  onSave: (pin: string) => Promise<void>;
 }
 
-function PinSetupFlow({ onDone, onCancel }: PinSetupFlowProps) {
+function PinSetupFlow({ onDone, onCancel, onSave }: PinSetupFlowProps) {
   const [step, setStep] = useState<"enter" | "confirm">("enter");
   const [first, setFirst] = useState("");
   const [second, setSecond] = useState("");
@@ -134,7 +135,7 @@ function PinSetupFlow({ onDone, onCancel }: PinSetupFlowProps) {
       setSecond("");
       return;
     }
-    await savePinHash(first);
+    await onSave(first);
     onDone();
   };
 
@@ -260,6 +261,8 @@ export interface AppLockProps {
   onUnlock: (pin: string) => Promise<boolean>;
   onSetupDone: () => void;
   onSetupCancel: () => void;
+  /** Persist a new PIN, scoped to the current user (audit F16). */
+  onSavePin: (pin: string) => Promise<void>;
 }
 
 export function AppLock({
@@ -267,6 +270,7 @@ export function AppLock({
   onUnlock,
   onSetupDone,
   onSetupCancel,
+  onSavePin,
 }: AppLockProps) {
   const panelRef = useRef<HTMLDivElement>(null);
   const visible = state === "locked" || state === "setup" || state === "change";
@@ -311,7 +315,11 @@ export function AppLock({
         {state === "locked" ? (
           <UnlockScreen onUnlock={onUnlock} />
         ) : (
-          <PinSetupFlow onDone={onSetupDone} onCancel={onSetupCancel} />
+          <PinSetupFlow
+            onDone={onSetupDone}
+            onCancel={onSetupCancel}
+            onSave={onSavePin}
+          />
         )}
       </div>
     </div>

--- a/apps/web/src/core/security/lockStorage.test.ts
+++ b/apps/web/src/core/security/lockStorage.test.ts
@@ -74,6 +74,39 @@ describe("lockStorage", () => {
     expect(await verifyPin("1234")).toBe(true);
   });
 
+  describe("F16 — per-user credential partitioning", () => {
+    it("a PIN saved for one user is invisible to another user (and to anon)", async () => {
+      await savePinHash("1234", "user-a");
+      expect(await hasPinSet("user-a")).toBe(true);
+      expect(await hasPinSet("user-b")).toBe(false);
+      expect(await hasPinSet(null)).toBe(false);
+    }, 15_000);
+
+    it("verifyPin only matches within the same user partition", async () => {
+      await savePinHash("1234", "user-a");
+      expect(await verifyPin("1234", "user-a")).toBe(true);
+      // Wrong partition → no credential there → never matches (no derive).
+      expect(await verifyPin("1234", "user-b")).toBe(false);
+    }, 15_000);
+
+    it("clearPinHash only clears the targeted user's partition", async () => {
+      await savePinHash("1234", "user-a");
+      await savePinHash("5678", "user-b");
+      await clearPinHash("user-a");
+      expect(await hasPinSet("user-a")).toBe(false);
+      expect(await hasPinSet("user-b")).toBe(true);
+      expect(await verifyPin("5678", "user-b")).toBe(true);
+    }, 30_000);
+
+    it("anon (signed-out) slot is independent of any user slot", async () => {
+      await savePinHash("0000"); // default → anon
+      await savePinHash("1111", "user-a");
+      expect(await verifyPin("0000", null)).toBe(true);
+      expect(await verifyPin("0000", "user-a")).toBe(false);
+      expect(await verifyPin("1111", "user-a")).toBe(true);
+    }, 30_000);
+  });
+
   describe("Decision #4 — 10-failed-attempts brute-force wipe", () => {
     it("MAX_FAILED_UNLOCK_ATTEMPTS is pinned at 10", () => {
       expect(MAX_FAILED_UNLOCK_ATTEMPTS).toBe(10);

--- a/apps/web/src/core/security/lockStorage.ts
+++ b/apps/web/src/core/security/lockStorage.ts
@@ -5,8 +5,14 @@
 // The hash (not the PIN) is stored so brute-force requires running PBKDF2
 // locally — no plaintext anywhere.
 //
-// IDB schema: db "sergeant_app_lock" / store "lock_cred" / key "v1"
-//   value: { salt: Uint8Array, hash: Uint8Array, v?: 1 | 2 }
+// IDB schema: db "sergeant_app_lock" / store "lock_cred"
+//   key:   "v1:<userKey>" — the credential record is partitioned per
+//          Better-Auth user id so user A's PIN is never read or cleared from
+//          user B's slot on a shared device (audit F16). `<userKey>` is the
+//          signed-in user id, or "anon" when signed out. The "v1" prefix is
+//          the *key-namespace* version (bumpable independently of the value
+//          `v` below).
+//   value: { salt: Uint8Array, hash: Uint8Array, v?: 1 | 2, failed?: number }
 //
 // `v` is the credential format version, not the IDB schema version (the
 // store layout is unchanged). `v` controls which PBKDF2 iteration count
@@ -19,7 +25,19 @@
 
 const DB_NAME = "sergeant_app_lock";
 const STORE = "lock_cred";
-const KEY = "v1";
+
+// Audit F16: per-user record-key partitioning. The "v1" prefix is the
+// key-namespace version; `<userKey>` is the Better-Auth user id (or "anon"
+// when signed out). Every public entry point takes an optional trailing
+// `userId` so callers in an authenticated context never touch the `anon`
+// slot (and vice-versa).
+const KEY_PREFIX = "v1";
+const ANON_USER_KEY = "anon";
+
+function recordKey(userId?: string | null): string {
+  const userKey = userId && userId.length > 0 ? userId : ANON_USER_KEY;
+  return `${KEY_PREFIX}:${userKey}`;
+}
 
 export const LATEST_CRED_VERSION = 2;
 export type CredVersion = 1 | 2;
@@ -110,21 +128,24 @@ function timingSafeEqual(a: Uint8Array, b: Uint8Array): boolean {
   return diff === 0;
 }
 
-async function writeCred(cred: LockCredV2): Promise<void> {
+async function writeCred(cred: LockCredV2, key: string): Promise<void> {
   const db = await openDb();
   await new Promise<void>((resolve, reject) => {
     const tx = db.transaction(STORE, "readwrite");
-    tx.objectStore(STORE).put(cred, KEY);
+    tx.objectStore(STORE).put(cred, key);
     tx.oncomplete = () => resolve();
     tx.onerror = () => reject(tx.error);
   });
   db.close();
 }
 
-export async function savePinHash(pin: string): Promise<void> {
+export async function savePinHash(
+  pin: string,
+  userId?: string | null,
+): Promise<void> {
   const salt = crypto.getRandomValues(new Uint8Array(16));
   const hash = await deriveHash(pin, salt, CURRENT_PBKDF2_ITERATIONS);
-  await writeCred({ salt, hash, v: LATEST_CRED_VERSION });
+  await writeCred({ salt, hash, v: LATEST_CRED_VERSION }, recordKey(userId));
 }
 
 /**
@@ -132,7 +153,7 @@ export async function savePinHash(pin: string): Promise<void> {
  *
  *   - Success → resets the persisted `failed` counter to 0.
  *   - Failure → increments. On the `MAX_FAILED_UNLOCK_ATTEMPTS`-th
- *     consecutive failure the credential is wiped (`clearPinHash`) and
+ *     consecutive failure the credential is wiped (`deleteCred`) and
  *     the result is `{ ok: false, wiped: true }`. The next mount of
  *     `useAppLock` will see `hasPinSet() === false` and fall through
  *     to "idle"; Settings shows the un-configured state and the user
@@ -141,6 +162,9 @@ export async function savePinHash(pin: string): Promise<void> {
  * `verifyPin` is preserved as the legacy boolean entry point for
  * `useAppLock` and the existing tests. New call sites should prefer
  * `verifyPinAttempt` so the wipe signal is observable.
+ *
+ * All reads/writes target the `userId` partition (audit F16) — the wipe
+ * therefore only ever clears the credential of the user being verified.
  */
 export interface VerifyPinResult {
   ok: boolean;
@@ -148,8 +172,12 @@ export interface VerifyPinResult {
   wiped: boolean;
 }
 
-export async function verifyPinAttempt(pin: string): Promise<VerifyPinResult> {
-  const cred = await loadCred();
+export async function verifyPinAttempt(
+  pin: string,
+  userId?: string | null,
+): Promise<VerifyPinResult> {
+  const key = recordKey(userId);
+  const cred = await loadCred(key);
   if (!cred) return { ok: false, failed: 0, wiped: false };
   const version = credVersion(cred);
   const candidate = await deriveHash(
@@ -160,15 +188,18 @@ export async function verifyPinAttempt(pin: string): Promise<VerifyPinResult> {
   const ok = timingSafeEqual(candidate, cred.hash);
   if (ok) {
     if (version < LATEST_CRED_VERSION) {
-      await migrateCredIfNeeded(pin);
+      await migrateCredIfNeeded(pin, key);
     } else if ((cred.failed ?? 0) > 0) {
       try {
-        await writeCred({
-          salt: cred.salt,
-          hash: cred.hash,
-          v: LATEST_CRED_VERSION,
-          failed: 0,
-        });
+        await writeCred(
+          {
+            salt: cred.salt,
+            hash: cred.hash,
+            v: LATEST_CRED_VERSION,
+            failed: 0,
+          },
+          key,
+        );
       } catch {
         // best-effort reset
       }
@@ -178,7 +209,7 @@ export async function verifyPinAttempt(pin: string): Promise<VerifyPinResult> {
   const nextFailed = (cred.failed ?? 0) + 1;
   if (nextFailed >= MAX_FAILED_UNLOCK_ATTEMPTS) {
     try {
-      await clearPinHash();
+      await deleteCred(key);
     } catch {
       // best-effort wipe
     }
@@ -186,12 +217,15 @@ export async function verifyPinAttempt(pin: string): Promise<VerifyPinResult> {
   }
   try {
     if (version >= LATEST_CRED_VERSION) {
-      await writeCred({
-        salt: cred.salt,
-        hash: cred.hash,
-        v: LATEST_CRED_VERSION,
-        failed: nextFailed,
-      });
+      await writeCred(
+        {
+          salt: cred.salt,
+          hash: cred.hash,
+          v: LATEST_CRED_VERSION,
+          failed: nextFailed,
+        },
+        key,
+      );
     }
     // Legacy v=1 records: skip the counter persist so the migration
     // path stays focused on the single-pass re-derive. The counter
@@ -202,45 +236,52 @@ export async function verifyPinAttempt(pin: string): Promise<VerifyPinResult> {
   return { ok: false, failed: nextFailed, wiped: false };
 }
 
-export async function verifyPin(pin: string): Promise<boolean> {
-  return (await verifyPinAttempt(pin)).ok;
+export async function verifyPin(
+  pin: string,
+  userId?: string | null,
+): Promise<boolean> {
+  return (await verifyPinAttempt(pin, userId)).ok;
 }
 
 // Re-derive an already-verified PIN at the current iteration count and
 // persist the upgraded credential. Best-effort: if the write fails we
 // swallow so a transient IDB error never blocks unlock — the next
 // successful verify will retry the migration.
-async function migrateCredIfNeeded(pin: string): Promise<void> {
+async function migrateCredIfNeeded(pin: string, key: string): Promise<void> {
   try {
     const salt = crypto.getRandomValues(new Uint8Array(16));
     const hash = await deriveHash(pin, salt, CURRENT_PBKDF2_ITERATIONS);
-    await writeCred({ salt, hash, v: LATEST_CRED_VERSION });
+    await writeCred({ salt, hash, v: LATEST_CRED_VERSION }, key);
   } catch {
     // ignore
   }
 }
 
-export async function hasPinSet(): Promise<boolean> {
-  const cred = await loadCred();
+export async function hasPinSet(userId?: string | null): Promise<boolean> {
+  const cred = await loadCred(recordKey(userId));
   return cred !== null;
 }
 
-export async function clearPinHash(): Promise<void> {
+export async function clearPinHash(userId?: string | null): Promise<void> {
+  await deleteCred(recordKey(userId));
+}
+
+async function deleteCred(key: string): Promise<void> {
   const db = await openDb();
   await new Promise<void>((resolve, reject) => {
     const tx = db.transaction(STORE, "readwrite");
-    tx.objectStore(STORE).delete(KEY);
+    tx.objectStore(STORE).delete(key);
     tx.oncomplete = () => resolve();
     tx.onerror = () => reject(tx.error);
   });
   db.close();
 }
 
-async function loadCred(): Promise<LockCred | null> {
+async function loadCred(key: string): Promise<LockCred | null> {
   const db = await openDb();
   const cred = await new Promise<LockCred | null>((resolve, reject) => {
     const tx = db.transaction(STORE, "readonly");
-    const req = tx.objectStore(STORE).get(KEY);
+    const req = tx.objectStore(STORE).get(key);
     req.onsuccess = () => resolve(req.result ?? null);
     req.onerror = () => reject(req.error);
   });
@@ -249,20 +290,28 @@ async function loadCred(): Promise<LockCred | null> {
 }
 
 // Test-only: read the raw stored credential to assert migration outcome.
-export async function __readRawCredForTests(): Promise<LockCred | null> {
-  return loadCred();
+export async function __readRawCredForTests(
+  userId?: string | null,
+): Promise<LockCred | null> {
+  return loadCred(recordKey(userId));
 }
 
 // Test-only: write a legacy v=1 credential (derived with 200k iterations)
 // to seed migration tests.
-export async function __seedLegacyCredForTests(pin: string): Promise<void> {
+export async function __seedLegacyCredForTests(
+  pin: string,
+  userId?: string | null,
+): Promise<void> {
   const salt = crypto.getRandomValues(new Uint8Array(16));
   const hash = await deriveHash(pin, salt, ITERATIONS_BY_VERSION[1]);
   const db = await openDb();
   await new Promise<void>((resolve, reject) => {
     const tx = db.transaction(STORE, "readwrite");
     // Intentionally omit `v` so the stored shape matches pre-S6 records.
-    tx.objectStore(STORE).put({ salt, hash } satisfies LockCredV1, KEY);
+    tx.objectStore(STORE).put(
+      { salt, hash } satisfies LockCredV1,
+      recordKey(userId),
+    );
     tx.oncomplete = () => resolve();
     tx.onerror = () => reject(tx.error);
   });

--- a/apps/web/src/core/security/useAppLock.test.ts
+++ b/apps/web/src/core/security/useAppLock.test.ts
@@ -28,11 +28,20 @@ vi.mock("../lib/featureFlags", () => ({
   setFlag: vi.fn(),
 }));
 
+// Mock auth — `useAppLock` reads `user?.id` to partition the credential
+// store per user (audit F16). Default to signed-out (`anon`); individual
+// tests override with a concrete user id.
+const { useAuth } = vi.hoisted(() => ({
+  useAuth: vi.fn().mockReturnValue({ user: null }),
+}));
+vi.mock("../auth/AuthContext", () => ({ useAuth }));
+
 import { useFlag } from "../lib/featureFlags";
 import { savePinHash, clearPinHash } from "./lockStorage";
 import { useAppLock } from "./useAppLock";
 
 const mockUseFlag = useFlag as unknown as MockInstance;
+const mockUseAuth = useAuth as unknown as MockInstance;
 
 const originalIndexedDB = (globalThis as { indexedDB?: unknown }).indexedDB;
 
@@ -44,6 +53,7 @@ describe("useAppLock", () => {
   beforeEach(() => {
     installFakeIDB();
     mockUseFlag.mockReturnValue(false);
+    mockUseAuth.mockReturnValue({ user: null });
   });
 
   afterEach(async () => {
@@ -143,5 +153,44 @@ describe("useAppLock", () => {
     const { result } = renderHook(() => useAppLock());
     act(() => result.current.lock());
     expect(result.current.state).toBe("locked");
+  });
+
+  describe("F16 — per-user credential partitioning", () => {
+    it("locks when the PIN belongs to the signed-in user", async () => {
+      // PIN stored in user-x's partition...
+      await savePinHash("1234", "user-x");
+      mockUseAuth.mockReturnValue({ user: { id: "user-x" } });
+      mockUseFlag.mockReturnValue(true);
+      const { result } = renderHook(() => useAppLock());
+      // ...and the hook bound to user-x sees it → locked.
+      await waitFor(() => expect(result.current.state).toBe("locked"));
+    });
+
+    it("does NOT lock when the PIN belongs to a different user", async () => {
+      await savePinHash("1234", "user-x");
+      // A different user signed in — must not inherit user-x's lock.
+      mockUseAuth.mockReturnValue({ user: { id: "user-y" } });
+      mockUseFlag.mockReturnValue(true);
+      const { result } = renderHook(() => useAppLock());
+      await act(async () => {});
+      expect(result.current.state).toBe("idle");
+    });
+
+    it("savePin / hasPin / disablePin round-trip the signed-in user's slot", async () => {
+      mockUseAuth.mockReturnValue({ user: { id: "user-z" } });
+      const { result } = renderHook(() => useAppLock());
+
+      expect(await result.current.hasPin()).toBe(false);
+      await result.current.savePin("4242");
+      expect(await result.current.hasPin()).toBe(true);
+      // The credential really landed in user-z's partition, not anon.
+      const { hasPinSet } = await import("./lockStorage");
+      expect(await hasPinSet("user-z")).toBe(true);
+      expect(await hasPinSet(null)).toBe(false);
+
+      await result.current.disablePin();
+      expect(await result.current.hasPin()).toBe(false);
+      expect(await hasPinSet("user-z")).toBe(false);
+    }, 30_000);
   });
 });

--- a/apps/web/src/core/security/useAppLock.ts
+++ b/apps/web/src/core/security/useAppLock.ts
@@ -2,7 +2,13 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { ANALYTICS_EVENTS } from "@sergeant/shared";
 import { capturePostHogEvent } from "../observability/posthog";
 import { useFlag } from "../lib/featureFlags";
-import { hasPinSet, verifyPinAttempt } from "./lockStorage";
+import { useAuth } from "../auth/AuthContext";
+import {
+  clearPinHash,
+  hasPinSet,
+  savePinHash,
+  verifyPinAttempt,
+} from "./lockStorage";
 
 export type LockState = "idle" | "locked" | "setup" | "change";
 
@@ -26,10 +32,28 @@ export interface UseAppLockReturn {
   finishSetup: () => void;
   /** Force-lock immediately (e.g. from PrivacySection "Lock now"). */
   lock: () => void;
+  /**
+   * Persist a new PIN hash scoped to the current user (audit F16). Called
+   * by the `AppLock` setup/change flow so the credential lands in the
+   * signed-in user's partition, not `anon`.
+   */
+  savePin: (pin: string) => Promise<void>;
+  /** Whether the current user has a PIN configured (called by PrivacySection). */
+  hasPin: () => Promise<boolean>;
+  /**
+   * Clear the current user's PIN credential (called by PrivacySection when
+   * disabling the lock). Scoped to `user?.id` so the right slot is wiped.
+   */
+  disablePin: () => Promise<void>;
 }
 
 export function useAppLock(): UseAppLockReturn {
   const enabled = useFlag("app-lock-enabled");
+  // Audit F16: the credential store is partitioned per Better-Auth user id.
+  // Resolve it once here so every storage call below — and the closures we
+  // hand to `AppLock` / `PrivacySection` — target the right partition.
+  const { user } = useAuth();
+  const userId = user?.id ?? null;
   const [state, setState] = useState<LockState>("idle");
   const idleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastIdleResetRef = useRef(0);
@@ -43,27 +67,27 @@ export function useAppLock(): UseAppLockReturn {
       return;
     }
     let cancelled = false;
-    hasPinSet().then((has) => {
+    hasPinSet(userId).then((has) => {
       if (!cancelled && has) setState("locked");
     });
     return () => {
       cancelled = true;
     };
-  }, [enabled]);
+  }, [enabled, userId]);
 
   // visibilitychange → lock when tab returns to foreground while a PIN is set.
   useEffect(() => {
     if (!enabled) return;
     const handleVisibility = () => {
       if (document.visibilityState !== "visible") return;
-      hasPinSet().then((has) => {
+      hasPinSet(userId).then((has) => {
         if (has) setState("locked");
       });
     };
     document.addEventListener("visibilitychange", handleVisibility);
     return () =>
       document.removeEventListener("visibilitychange", handleVisibility);
-  }, [enabled]);
+  }, [enabled, userId]);
 
   // Idle timer — reset on any user interaction; lock after IDLE_TIMEOUT_MS.
   // Throttled by IDLE_RESET_THROTTLE_MS so capture-phase scroll/pointer
@@ -75,11 +99,11 @@ export function useAppLock(): UseAppLockReturn {
     lastIdleResetRef.current = now;
     if (idleTimer.current) clearTimeout(idleTimer.current);
     idleTimer.current = setTimeout(() => {
-      hasPinSet().then((has) => {
+      hasPinSet(userId).then((has) => {
         if (has) setState("locked");
       });
     }, IDLE_TIMEOUT_MS);
-  }, [enabled]);
+  }, [enabled, userId]);
 
   useEffect(() => {
     if (!enabled) return;
@@ -127,7 +151,7 @@ export function useAppLock(): UseAppLockReturn {
 
   const unlock = useCallback(
     async (pin: string): Promise<boolean> => {
-      const result = await verifyPinAttempt(pin);
+      const result = await verifyPinAttempt(pin, userId);
       if (result.ok) {
         setState("idle");
         capturePostHogEvent(ANALYTICS_EVENTS.APP_LOCK_UNLOCK_SUCCESS, {
@@ -155,8 +179,28 @@ export function useAppLock(): UseAppLockReturn {
       }
       return false;
     },
-    [resetIdleTimer],
+    [resetIdleTimer, userId],
   );
 
-  return { state, startSetup, startChange, unlock, finishSetup, lock };
+  // Audit F16 closures — bind the storage helpers to the resolved `userId`
+  // so consumers (`AppLock` setup flow, `PrivacySection`) never have to
+  // know the partitioning scheme or import `lockStorage` themselves.
+  const savePin = useCallback(
+    (pin: string) => savePinHash(pin, userId),
+    [userId],
+  );
+  const hasPin = useCallback(() => hasPinSet(userId), [userId]);
+  const disablePin = useCallback(() => clearPinHash(userId), [userId]);
+
+  return {
+    state,
+    startSetup,
+    startChange,
+    unlock,
+    finishSetup,
+    lock,
+    savePin,
+    hasPin,
+    disablePin,
+  };
 }

--- a/apps/web/src/core/settings/PrivacySection.test.tsx
+++ b/apps/web/src/core/settings/PrivacySection.test.tsx
@@ -1,0 +1,134 @@
+/** @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+
+import type { UserPreferences } from "@shared/api";
+import type { UseAppLockReturn } from "../security/useAppLock";
+
+// --- Mocks -----------------------------------------------------------------
+//
+// The point of this suite is to lock in the audit-F16 fix: PrivacySection
+// must drive PIN state through the *user-scoped* `useAppLockContext` helpers
+// (`hasPin` / `disablePin`), never the bare `lockStorage` functions that
+// default to the `anon` partition. We therefore stub the context and assert
+// the right closures are invoked.
+
+const appLock: UseAppLockReturn = {
+  state: "idle",
+  startSetup: vi.fn(),
+  startChange: vi.fn(),
+  unlock: vi.fn().mockResolvedValue(true),
+  finishSetup: vi.fn(),
+  lock: vi.fn(),
+  savePin: vi.fn().mockResolvedValue(undefined),
+  hasPin: vi.fn().mockResolvedValue(false),
+  disablePin: vi.fn().mockResolvedValue(undefined),
+};
+vi.mock("../security/AppLockContext", () => ({
+  useAppLockContext: () => appLock,
+}));
+
+const { mockUseFlag, mockSetFlag } = vi.hoisted(() => ({
+  mockUseFlag: vi.fn().mockReturnValue(false),
+  mockSetFlag: vi.fn(),
+}));
+vi.mock("../lib/featureFlags", () => ({
+  useFlag: mockUseFlag,
+  setFlag: mockSetFlag,
+}));
+
+vi.mock("@shared/api", () => {
+  // Inlined inside the factory — `vi.mock` is hoisted above module-level
+  // consts, so referencing `DEFAULT_PREFS` here would hit a TDZ error.
+  const prefs: UserPreferences = {
+    analytics: true,
+    aiMemory: true,
+    pushNotifications: false,
+    updatedAt: null,
+  };
+  return {
+    meApi: {
+      getPreferences: vi.fn().mockResolvedValue(prefs),
+      updatePreferences: vi.fn().mockResolvedValue(prefs),
+    },
+  };
+});
+
+// LegalLinks pulls in router-aware navigation we don't exercise here.
+vi.mock("../legal/LegalLinks", () => ({
+  LegalLinks: () => null,
+}));
+
+import { PrivacySection } from "./PrivacySection";
+
+async function openSection() {
+  const trigger = await screen.findByRole("button", {
+    name: /Конфіденційність/i,
+  });
+  fireEvent.click(trigger);
+}
+
+describe("PrivacySection — audit F16 (per-user PIN scoping)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseFlag.mockReturnValue(false);
+    appLock.hasPin = vi.fn().mockResolvedValue(false);
+    appLock.disablePin = vi.fn().mockResolvedValue(undefined);
+    appLock.startSetup = vi.fn();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("enabling the lock checks the user-scoped partition (appLock.hasPin), not anon", async () => {
+    render(<PrivacySection />);
+    await openSection();
+
+    const toggle = screen.getByRole("switch", { name: /Блокування додатку/i });
+    fireEvent.click(toggle);
+
+    // hasPin() (scoped to user?.id) drives the setup decision — and with no
+    // PIN on file the setup flow opens.
+    await waitFor(() => expect(appLock.hasPin).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(appLock.startSetup).toHaveBeenCalledTimes(1));
+    expect(mockSetFlag).toHaveBeenCalledWith("app-lock-enabled", true);
+  });
+
+  it("does NOT open setup when the signed-in user already has a PIN", async () => {
+    appLock.hasPin = vi.fn().mockResolvedValue(true);
+    render(<PrivacySection />);
+    await openSection();
+
+    fireEvent.click(
+      screen.getByRole("switch", { name: /Блокування додатку/i }),
+    );
+
+    await waitFor(() => expect(appLock.hasPin).toHaveBeenCalledTimes(1));
+    expect(appLock.startSetup).not.toHaveBeenCalled();
+  });
+
+  it("disabling the lock clears the user-scoped credential (appLock.disablePin)", async () => {
+    // Flag already on → the toggle renders checked; clicking it disables.
+    mockUseFlag.mockReturnValue(true);
+    render(<PrivacySection />);
+    await openSection();
+
+    fireEvent.click(
+      screen.getByRole("switch", { name: /Блокування додатку/i }),
+    );
+
+    // Confirm the destructive action in the modal.
+    const confirm = await screen.findByRole("button", { name: "Вимкнути" });
+    fireEvent.click(confirm);
+
+    await waitFor(() => expect(appLock.disablePin).toHaveBeenCalledTimes(1));
+    expect(mockSetFlag).toHaveBeenCalledWith("app-lock-enabled", false);
+  });
+});

--- a/apps/web/src/core/settings/PrivacySection.tsx
+++ b/apps/web/src/core/settings/PrivacySection.tsx
@@ -3,7 +3,6 @@ import { Button } from "@shared/components/ui/Button";
 import { meApi, type UserPreferences } from "@shared/api";
 import { messages } from "@shared/i18n/uk";
 import { useFlag, setFlag } from "../lib/featureFlags";
-import { clearPinHash, hasPinSet } from "../security/lockStorage";
 import { useAppLockContext } from "../security/AppLockContext";
 import { LegalLinks } from "../legal/LegalLinks";
 import { ConfirmModal, SettingsGroup, ToggleRow } from "./SettingsPrimitives";
@@ -54,7 +53,9 @@ export function PrivacySection() {
   const handleToggle = async (checked: boolean) => {
     if (checked) {
       setFlag("app-lock-enabled", true);
-      const has = await hasPinSet();
+      // Audit F16: check the *current user's* PIN partition, not `anon`.
+      // `appLock.hasPin()` closes over `user?.id` from `useAppLock`.
+      const has = await appLock.hasPin();
       if (!has) {
         appLock.startSetup();
       }
@@ -66,7 +67,8 @@ export function PrivacySection() {
   const handleDisableConfirm = async () => {
     setDisableConfirmOpen(false);
     setFlag("app-lock-enabled", false);
-    await clearPinHash();
+    // Audit F16: clear the current user's credential, not the `anon` slot.
+    await appLock.disablePin();
   };
 
   const updatePreference = async (key: PreferenceKey, checked: boolean) => {


### PR DESCRIPTION
## Summary

Closes audit finding **F16 — per-user AppLock PIN scoping**. The app-lock credential was stored under a single fixed IndexedDB key (`"v1"`), so on a shared device user A's PIN was read and cleared from the same slot as user B and the signed-out `anon` session.

- **`lockStorage.ts`** — partition the credential record key as `v1:<userKey>` (`"anon"` when signed out). `savePinHash`, `verifyPin`, `verifyPinAttempt`, `hasPinSet`, and `clearPinHash` gained an optional trailing `userId?: string | null`. The 10-attempt brute-force wipe now clears only the partition being verified (previously called the no-arg `clearPinHash`).
- **`useAppLock.ts`** — resolve `user?.id` via `useAuth()` once and thread it through every storage call (mount / `visibilitychange` / idle-timer `hasPinSet`, and `verifyPinAttempt`). Exposes `savePin` / `hasPin` / `disablePin` closures bound to that user.
- **`AppLock.tsx`** — persist the new PIN via an `onSavePin` prop instead of importing `savePinHash` directly, so setup writes to the signed-in user's partition.
- **`RootLayout.tsx`** — pass `appLock.savePin` into `<AppLock onSavePin>`.
- **`PrivacySection.tsx`** (the actual F16 gap) — drive enable/disable through `appLock.hasPin()` / `appLock.disablePin()` instead of the bare `lockStorage` helpers, which previously read/cleared the `anon` slot for an authenticated user. Keeps the `lockStorage` import out of `core/settings`.

**Why the diff is larger than "one file":** the F16 base (key partitioning + `useAppLock`/`AppLock` wiring) the original report assumed had landed was **not present on `main`** — `lockStorage` still used a single `"v1"` key with no `userId` params. The `PrivacySection`-only fix could not compile against that, so the full partitioning is implemented here.

## Governing Skill

- Primary skill: `sergeant-web-ui`
- Secondary skill (if truly needed): `sergeant-security-audit` (credential-storage surface)

## Playbook

- Primary playbook: n/a
- If no playbook matched, why: targeted security/correctness fix to an existing client-side credential store; no add-feature / migration / release recipe applies.

## Verification

```bash
pnpm --filter @sergeant/web typecheck            # ✓ clean
pnpm --filter @sergeant/web exec vitest run \
  src/core/security/lockStorage.test.ts \
  src/core/security/useAppLock.test.ts \
  src/core/settings/PrivacySection.test.tsx       # ✓ 38 passed
pnpm --filter @sergeant/web exec vitest run \
  src/core/security src/core/settings              # ✓ 63 passed
pnpm exec eslint <changed files>                  # ✓ 0 errors
pnpm exec prettier --check <changed files>        # ✓
```

New test coverage:

- `lockStorage.test.ts` — per-user partition isolation (one user's PIN invisible to another and to `anon`; `clearPinHash` scoped to one slot).
- `useAppLock.test.ts` — locks only for the signed-in user's PIN; `savePin`/`hasPin`/`disablePin` round-trip the right partition. Mocks `useAuth` (default signed-out).
- `PrivacySection.test.tsx` (new) — asserts the toggle drives `appLock.hasPin()` and the disable action drives `appLock.disablePin()`.

Additional checks:

- [x] Local smoke / manual validation completed (unit + RTL coverage of the set-while-signed-in → settings shows lock ON → disable clears `v1:<userId>` path)
- [x] Surface-specific checks completed (typecheck, scoped vitest, eslint, prettier)

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout. *(no doc behavior changed; IDB key-schema comment in `lockStorage.ts` updated inline)*
- [x] I checked whether `AGENTS.md` needed an update. *(no)*
- [x] I checked whether a playbook or skill needed an update. *(no)*
- [x] I checked whether governance docs or review docs needed an update. *(no)*

Updated docs:

- n/a

## Risk and Rollout

- **User-visible risk:** App-lock is feature-flag gated (`app-lock-enabled`). Any PIN that was enrolled before this change (stored under the bare `"v1"` key) is not auto-migrated to `v1:<userKey>` and will read as "no PIN" until re-enrolled. The credential is a local PIN hash, not a recoverable secret, so re-enrollment is a benign one-time prompt. No server/data migration.
- **Rollout / deploy order:** standard web deploy; no ordering constraints.
- **Backout plan:** revert the PR — no schema or persisted-format gate; the IDB store layout is unchanged (only the record key differs).

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian. *(no internal docs touched)*
- [x] I did not use `--no-verify`.

## Reviewer Notes

- `apps/web/eslint.i18n-allowlist.json` gains `PrivacySection.tsx`. Those Cyrillic JSX literals are **pre-existing** (verbatim on `main`) in the consent section I did not touch; the file predates the `no-cyrillic-jsx-literal` rule and was the only settings section missing from the burndown allowlist (13 siblings already listed). This registers existing debt for the tracked Q3 i18n burndown — it does not add new strings.
- No DB migration, no API contract change, no HubChat/auth surface change. Client-side IndexedDB credential store only.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FTFDsVWi1CQ6DkufZfLiC7)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes the AppLock PIN per user by partitioning the IndexedDB credential key (`v1:<userId>`). Fixes audit F16 and prevents PIN leakage between accounts and the signed-out session on shared devices.

- Bug Fixes
  - Partition credential key as `v1:<userKey>` (`anon` when signed out); 10-fail wipe clears only that partition.
  - `lockStorage` APIs accept `userId`; `verifyPinAttempt`/`hasPinSet`/`savePinHash`/`clearPinHash` are user-scoped with new tests for isolation.
  - `useAppLock` reads `user?.id` via `useAuth()` and exposes user-bound `savePin`, `hasPin`, `disablePin`; all checks (mount/visibility/idle) use the scoped partition.
  - `AppLock` saves via an `onSavePin` prop; `RootLayout` wires `appLock.savePin`.
  - `PrivacySection` now uses `appLock.hasPin()`/`appLock.disablePin()` instead of direct storage; adds tests; i18n allowlist updated for the file.

- Migration
  - Existing PINs stored under `v1` are not auto-migrated; users will be prompted to re-enroll once.
  - No server changes or IDB schema changes; feature remains behind the `app-lock-enabled` flag.

<sup>Written for commit d16a92b1ce0984d3f650c557edb6aaffe8a778d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

