### PR TITLE
fix(web): restore AI read/query chat tools (allow-list + routine SQLite source)

### DIFF
--- a/apps/web/src/core/hub/chat/toolCallSchema.test.ts
+++ b/apps/web/src/core/hub/chat/toolCallSchema.test.ts
@@ -64,3 +64,55 @@ describe("parseToolCalls — name allow-list (C1)", () => {
     expect(KNOWN_TOOL_NAMES.has("recall_memory")).toBe(true);
   });
 });
+
+describe("parseToolCalls — talk-to-your-data read/query tools (regression)", () => {
+  // Regression for the prod-QA report: read/query tool-calls returned the bare
+  // "Немає відповіді." fallback while writes worked. Root cause — PR #3598
+  // added these read tools (server defs + `handleQuery*Action` executors) but
+  // never added their names to `KNOWN_TOOL_NAMES`, so `parseToolCalls` dropped
+  // the whole batch at the Step-2 name check and `useChatSend` rendered the
+  // empty-response fallback (the first-turn response carries `text: null`
+  // alongside a tool_use). Every one of these must be dispatchable.
+  const QUERY_TOOLS = [
+    "query_transactions",
+    "aggregate_spending",
+    "compare_periods",
+    "query_habits",
+    "habit_correlation",
+    "query_workouts",
+    "exercise_progress",
+    "training_stats",
+    "query_nutrition",
+    "nutrition_averages",
+  ] as const;
+
+  it.each(QUERY_TOOLS)("allow-lists the read/query tool %s", (name) => {
+    expect(KNOWN_TOOL_NAMES.has(name)).toBe(true);
+  });
+
+  it("accepts an aggregate_spending call (the 'скільки я витратив' path)", () => {
+    const result = parseToolCalls([
+      {
+        id: "t1",
+        name: "aggregate_spending",
+        input: { group_by: "category", date_from: "2026-06-01" },
+      },
+    ]);
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts a query_habits call (the 'перелічи мої звички' path)", () => {
+    const result = parseToolCalls([
+      { id: "t1", name: "query_habits", input: { period_days: 30 } },
+    ]);
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts a batch mixing a read query with a known mutator", () => {
+    const result = parseToolCalls([
+      { id: "t1", name: "query_workouts", input: { period_days: 7 } },
+      { id: "t2", name: "create_habit", input: { name: "Біг" } },
+    ]);
+    expect(result.ok).toBe(true);
+  });
+});

--- a/apps/web/src/core/hub/chat/toolCallSchema.ts
+++ b/apps/web/src/core/hub/chat/toolCallSchema.ts
@@ -254,6 +254,30 @@ export const KNOWN_TOOL_NAMES: ReadonlySet<string> = new Set([
   "remember",
   "forget",
   "my_profile",
+  // talk-to-your-data read-only query tools (PR #3598). Defined server-side
+  // in `apps/server/src/modules/chat/toolDefs/query*.ts` and dispatched by the
+  // `handleQuery*Action` executors through `hubChatActions.dispatch`. They are
+  // read-only, so they need no `MUTATOR_INPUT_SCHEMAS` entry — the envelope
+  // firewall plus this allow-list line are sufficient. Omitting them here was a
+  // PR #3598 oversight: every read/query call failed the Step 2 name check, the
+  // whole batch was dropped, and (because the first-turn response carries
+  // `text: null` next to a tool_use) the user saw the bare "Немає відповіді."
+  // fallback in `useChatSend`. Writes worked only because they were already
+  // listed. Keep in sync with the `query*` tool defs and executors.
+  // finyk
+  "query_transactions",
+  "aggregate_spending",
+  "compare_periods",
+  // routine
+  "query_habits",
+  "habit_correlation",
+  // fizruk
+  "query_workouts",
+  "exercise_progress",
+  "training_stats",
+  // nutrition
+  "query_nutrition",
+  "nutrition_averages",
   // async (server-side) — ASYNC_CHAT_ACTION_NAMES in serverActions.ts
   "recall_memory",
 ]);

--- a/apps/web/src/core/lib/chatActions/queryRoutineActions.test.ts
+++ b/apps/web/src/core/lib/chatActions/queryRoutineActions.test.ts
@@ -1,16 +1,30 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { Habit } from "@sergeant/routine-domain";
 import { handleQueryRoutineAction } from "./queryRoutineActions";
+import {
+  __setRoutineSqliteStateCacheForTests,
+  __setRoutineSqliteCompletionsCacheForTests,
+  clearSqliteRoutineStateCache,
+  clearSqliteCompletionsCache,
+} from "../../../modules/routine/lib/sqliteReader";
 import type { ChatAction } from "./types";
 
 beforeEach(() => {
+  // Stage 8 PR #057r-tombstone — routine state is backed by the SQLite warm
+  // cache, not the retired `hub_routine_v1` LS key. Reset both caches so each
+  // spec starts clean.
   localStorage.clear();
+  clearSqliteRoutineStateCache();
+  clearSqliteCompletionsCache();
   vi.useFakeTimers();
   // 2026-04-22 is a Wednesday (Kyiv).
   vi.setSystemTime(new Date("2026-04-22T12:00:00"));
 });
 afterEach(() => {
   localStorage.clear();
+  clearSqliteRoutineStateCache();
+  clearSqliteCompletionsCache();
   vi.useRealTimers();
 });
 
@@ -22,7 +36,12 @@ function call(action: ChatAction): string {
   return typeof out === "string" ? out : out.result;
 }
 
-/** Seed the compat `hub_routine_v1` key (read by the briefing/query handlers). */
+/**
+ * Seed the canonical SQLite-backed routine state (the source `readRoutine`
+ * now reads via `loadRoutineState`). Replaces the pre-tombstone
+ * `localStorage.setItem("hub_routine_v1", …)` round-trip — that key is deleted
+ * on boot in production, which is the bug this suite now guards against.
+ */
 function seedRoutine(
   habits: Array<{
     id: string;
@@ -33,10 +52,11 @@ function seedRoutine(
   }>,
   completions: Record<string, string[]>,
 ): void {
-  localStorage.setItem(
-    "hub_routine_v1",
-    JSON.stringify({ habits, completions }),
-  );
+  __setRoutineSqliteStateCacheForTests({
+    habits: habits as unknown as Habit[],
+    habitOrder: habits.map((h) => h.id),
+  });
+  __setRoutineSqliteCompletionsCacheForTests({ completions });
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/core/lib/chatActions/queryRoutineActions.ts
+++ b/apps/web/src/core/lib/chatActions/queryRoutineActions.ts
@@ -1,5 +1,5 @@
 import { getTxStatAmount } from "../../../modules/finyk/utils";
-import { STORAGE_KEYS } from "@sergeant/shared";
+import { loadRoutineState } from "../../../modules/routine/lib/routineStorage";
 import {
   getKyivDayKey,
   getKyivMondayIndex,
@@ -7,19 +7,15 @@ import {
 } from "@shared/lib/time/kyivTime";
 import { ls } from "../hubChatUtils";
 import { readWorkouts } from "./fizrukActions/shared";
-import type {
-  ChatAction,
-  ChatActionResult,
-  HabitState,
-  Workout,
-} from "./types";
+import type { ChatAction, ChatActionResult, Workout } from "./types";
 
 /**
  * Read-only "talk to your data" виконавці для Рутини (PR3 talk-to-your-data).
  * Дзеркало серверних `QUERY_ROUTINE_TOOLS` (`toolDefs/queryRoutine.ts`). Жоден
- * з них НЕ пише — лише читають журнал звичок (`hub_routine_v1`, як у
- * `crossActions/briefingHandlers.ts`) і, для кореляцій, журнал тренувань
- * (`readWorkouts`) та банк-кеш транзакцій (`finyk_tx_cache`).
+ * з них НЕ пише — лише читають канонічний стан звичок через `loadRoutineState()`
+ * (SQLite-backed, той самий source, що й мутаційний `handleRoutineAction`) і,
+ * для кореляцій, журнал тренувань (`readWorkouts`) та банк-кеш транзакцій
+ * (`finyk_tx_cache`).
  *
  * Реєструється у `hubChatActions.ts` dispatch-chain окремою гілкою, не
  * чіпаючи мутаційний `handleRoutineAction`. Дні рахуються від `Date.now()`
@@ -66,17 +62,29 @@ interface RoutineHabit {
   paused?: boolean;
 }
 
-/** Read-only routine snapshot from the compat `hub_routine_v1` LS key. */
+/**
+ * Read-only routine snapshot from the canonical SQLite-backed state.
+ *
+ * Stage 8 PR #057r-tombstone retired the legacy `hub_routine_v1` LS key — it is
+ * deleted on boot after the one-time SQLite import (`residualImport.ts`) and
+ * `saveRoutineState()` (used by the routine write tools) no longer writes it.
+ * Reading that key here returned an empty journal in production, so
+ * `query_habits` / `habit_correlation` answered "Немає звичок" even for users
+ * with habits, and a habit just created via the `create_habit` write tool
+ * (which persists through `loadRoutineState`/`saveRoutineState`) was invisible
+ * to this read tool. We read `loadRoutineState()` — the same canonical source
+ * the routine UI and `handleRoutineAction` use — so reads and writes agree.
+ */
 function readRoutine(): {
   habits: RoutineHabit[];
   completions: Record<string, string[]>;
 } {
-  const state = ls<HabitState | null>(STORAGE_KEYS.ROUTINE, null);
-  const habits = Array.isArray(state?.habits)
+  const state = loadRoutineState();
+  const habits = Array.isArray(state.habits)
     ? (state.habits as RoutineHabit[])
     : [];
   const completions =
-    state?.completions && typeof state.completions === "object"
+    state.completions && typeof state.completions === "object"
       ? state.completions
       : {};
   return { habits, completions };


### PR DESCRIPTION
## Summary

Prod QA (2026-06-17, `/chat`, authed): AI **write** tool-calls worked, but every **read/query** («Перелічи мої звички», «Скільки я витратив сьогодні?») returned the bare `«Немає відповіді.»` fallback. Two layered client-side bugs; **no server change needed** — the server correctly proposes the `tool_use`, the client was dropping it.

**Fix 1 — allow-list the read/query tools (the reported bug).** PR #3598 added 10 talk-to-your-data query tools (server `toolDefs/query*.ts` + `handleQuery*Action` executors wired into `hubChatActions.dispatch`) but never added their names to `KNOWN_TOOL_NAMES` in `toolCallSchema.ts`. So `parseToolCalls` failed the Step-2 name check and dropped the whole batch; the first-turn response carries `text: null` next to the `tool_use`, so `useChatSend` rendered the empty-response fallback. (`«Немає відповіді.»` with no «від AI» is the **client** string; the server's is `«Немає відповіді від AI.»` — confirming the model *did* call the tool.) Added all 10 read-only names; read-only payloads can't corrupt data, so no `MUTATOR_INPUT_SCHEMAS` entry needed.

**Fix 2 — routine query reads from the canonical SQLite source.** `queryRoutineActions.readRoutine()` read the retired `hub_routine_v1` localStorage key, which Stage 8 PR #057r-tombstone deletes on boot; the routine write tools persist via `loadRoutineState`/`saveRoutineState` (SQLite). So even after Fix 1 a habit created by `create_habit` was invisible to `query_habits` — the exact "AI creates a habit it then can't list or delete" deadlock. Now reads `loadRoutineState()`, the same source the routine UI and `handleRoutineAction` use.

## Governing Skill

- Primary skill: `sergeant-hubchat`
- Secondary skill (if truly needed): `sergeant-server-api` (confirmed the server is a correct pass-through; no server change)

## Playbook

- Primary playbook: `docs/00-start/playbooks/debug-chat-tool.md`
- Why this playbook: localized the break to Q2 (handler never reached) — the structural/name firewall rejected the batch before any executor ran.
- If no playbook matched, why: n/a

## Verification

```bash
pnpm --filter @sergeant/web exec vitest run src/core/lib/chatActions/ src/core/hub/chat/   # 16 files, 386 tests pass
pnpm --filter @sergeant/web typecheck                                                       # clean
pnpm --filter @sergeant/web exec eslint <4 changed files>                                   # clean
```

New regression coverage: `toolCallSchema.test.ts` (all 10 query tools dispatch; the `aggregate_spending` / `query_habits` paths parse ok); `queryRoutineActions.test.ts` now seeds the SQLite cache instead of the dead LS key (the old seeding gave false confidence).

Additional checks:

- [x] Local smoke / manual validation completed
- [x] Surface-specific checks completed

## Docs and Governance

- [ ] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a — code-comment-level fix (rationale inline at both sites); no contract/schema/workflow surface changed, so no canonical-doc or PR-ledger update required.

## Risk and Rollout

- User-visible risk: Low. Fix 1 is additive allow-list data; Fix 2 switches one read to the same canonical API the rest of routine already uses. No server / API-contract / migration / bundle changes.
- Rollout / deploy order: standard, web-only.
- Backout plan: revert the commit; no migrations or stateful changes.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Reviewer Notes

**Known related issues NOT fixed here (need separate, live-verified work):**

1. **Bug 2 — AI write → module UI visibility.** For routine, `create_habit` persists via `saveRoutineState` (SQLite + `ROUTINE_EVENT`), so this PR makes chat read/write consistent, but the report's "not visible in Routine UI even after reload" needs live repro of the dual-write→SQLite path (out of scope for a static fix). For finyk, `create_transaction` already writes server + an LS mirror.
2. **fizruk / nutrition query reads** hit the same retired-LS-key class (`fizruk_workouts_v1`, `nutrition_log_v1`). Unlike routine, their entire chat-action layer (read *and* write) is still on LS — internally consistent but divorced from their SQLite UIs; migrating them is a larger, Bug-2-adjacent change. (Same for `crossActions/briefingHandlers.ts` + `exportHandler.ts` reading `hub_routine_v1`.)
3. **Chat-history persistence** — full reload of `/chat` resets the thread; separate surface.
4. **Cleanup debt** — orphan prod row `DELETE FROM routine_habits WHERE id='habmqh9az3uf1jod1z'` requires prod DB access (no psql / postgres-MCP here).

> ⚠️ **Two failing CI checks are pre-existing on `main`, unrelated to this PR's 4-file web change:** "Playbook trigger index (in sync)" fails because `docs/00-start/playbooks/cutover-openclaw-gateway.md`'s freshness header was rewritten to `Last touched:` by `@github-actions[bot]` (2026-06-16) while the schema wants `Last validated:`; "Daily brief + WIP + trust badge (in sync)" fails because `docs/STATUS.md` is stale (`pnpm docs:gen-status`). Both should be fixed separately (they affect every open PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQ641PuDZDDQimBQd62NfS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled support for read-only query tools in chat interactions, including transactions, spending analysis, habits, workouts, and nutrition data queries.
  * Improved data consistency by aligning backend read operations with the system's primary data storage mechanism.

* **Tests**
  * Added comprehensive regression test coverage for tool call parsing and query tool validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->