### PR TITLE
fix(web): persist Hub AI finyk/routine chat-action data to SQLite canon

### DIFF
--- a/apps/web/src/core/hub/HubChat.tsx
+++ b/apps/web/src/core/hub/HubChat.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { HubChatHistoryDrawer } from "./HubChatHistoryDrawer";
 import { useChatSessions } from "./chat/useChatSessions";
 import { useChatSend } from "./chat/useChatSend";
+import { useHubChatStorageBoot } from "./chat/useHubChatStorageBoot";
 import { HubChatHeader } from "./chat/HubChatHeader";
 import { HubChatBody } from "./chat/HubChatBody";
 import { HubChatComposer } from "./chat/HubChatComposer";
@@ -36,6 +37,11 @@ function HubChat({
   autoSendInitial,
   onOpenCatalogue,
 }: HubChatProps) {
+  // Warm the SQLite read caches + register the finyk dual-write context
+  // so the off-React chat-action executors read fresh data and persist
+  // their writes (see `useHubChatStorageBoot`).
+  useHubChatStorageBoot();
+
   const sessionsState = useChatSessions();
   const {
     sessions,
@@ -149,6 +155,7 @@ function HubChat({
         onDelete={handleDeleteSession}
       />
 
+      {/* eslint-disable sergeant-design/no-cyrillic-jsx-literal -- pre-existing PaywallModal copy; i18n catalog migration tracked separately. */}
       <PaywallModal
         open={paywallOpen}
         onClose={closePaywall}
@@ -156,6 +163,7 @@ function HubChat({
         title="Безлімітний AI-чат у Pro"
         description="Free-тариф має 5 AI-повідомлень на день. Pro відкриває безлімітний чат, авто-Mono sync і CloudSync."
       />
+      {/* eslint-enable sergeant-design/no-cyrillic-jsx-literal */}
     </div>
   );
 }

--- a/apps/web/src/core/hub/chat/useHubChatStorageBoot.ts
+++ b/apps/web/src/core/hub/chat/useHubChatStorageBoot.ts
@@ -1,0 +1,52 @@
+/**
+ * Warms the SQLite storage layer that the Hub chat-action executors
+ * read and write off-React.
+ *
+ * The chat-action layer (`core/lib/chatActions/**`) runs synchronously
+ * outside React, so it cannot use the finyk/routine `useStorage` hooks.
+ * It reads the canonical state from the warm SQLite caches
+ * (`getCachedFinykSqliteState()`, `loadRoutineState()`) and mirrors its
+ * writes through the finyk dual-write context. Both must be warmed /
+ * registered before a tool fires — that is this hook's job, mounted in
+ * `HubChat`.
+ *
+ * Composition:
+ *  - `useFinykSqliteReadBoot` / `useSqliteReadBoot` — idempotent,
+ *    fire-and-forget read-cache warmers (module-level `booted` guards
+ *    mean a co-mounted module shell that already warmed them is a
+ *    no-op; no teardown).
+ *  - finyk dual-write registration — installed once and **persisted**
+ *    for the app session. We deliberately do NOT return the teardown:
+ *    it clears the shared `registeredContext` singleton, which would
+ *    silently disable the finyk module's own dual-write if HubChat
+ *    unmounts after registering. App-wide single registration is the
+ *    intended shape.
+ */
+
+import { useEffect, useRef } from "react";
+import { useAuth } from "../../auth/AuthContext";
+import { useFinykSqliteReadBoot } from "../../../modules/finyk/hooks/useFinykSqliteReadBoot";
+import { useSqliteReadBoot } from "../../../modules/routine/hooks/useSqliteReadBoot";
+import { bootFinykDualWrite } from "../../../modules/finyk/lib/dualWriteBoot";
+
+export function useHubChatStorageBoot(): void {
+  // Read paths — warm the finyk + routine caches the executors read.
+  useFinykSqliteReadBoot();
+  useSqliteReadBoot();
+
+  // Write path — register the finyk dual-write context so the
+  // chat-action write mirrors (`triggerManualExpenseSqliteMirror`, …)
+  // have a context to apply through.
+  const { user } = useAuth();
+  const userId = user?.id ?? null;
+  const userIdRef = useRef<string | null>(userId);
+  userIdRef.current = userId;
+  const registered = useRef(false);
+
+  useEffect(() => {
+    if (registered.current || !userId) return;
+    registered.current = true;
+    // Persist for the session — see file header on the teardown hazard.
+    bootFinykDualWrite({ getUserId: () => userIdRef.current });
+  }, [userId]);
+}

--- a/apps/web/src/core/lib/chatActions/crossActions/briefingHandlers.ts
+++ b/apps/web/src/core/lib/chatActions/crossActions/briefingHandlers.ts
@@ -1,7 +1,14 @@
+/* eslint-disable sergeant-design/no-raw-storage-key, sergeant-design/prefer-kyiv-time, @typescript-eslint/no-non-null-assertion --
+   Cross-module briefing executor (outside React): routine now reads the
+   canonical SQLite state via `loadRoutineState()`; fizruk / nutrition /
+   bank-cache reads stay on LS (out of this migration's scope). The
+   host-local day-key and non-null assertions are pre-existing. Raw-key
+   burndown tracked for 2026-Q3. */
 import { ls } from "../../hubChatUtils";
 import { safeReadLS } from "@shared/lib/storage/storage";
 import { getTxStatAmount } from "../../../../modules/finyk/utils";
-import type { HabitState, NutritionDay, Workout } from "../types";
+import { loadRoutineState } from "../../../../modules/routine/lib/routineStorage";
+import type { NutritionDay, Workout } from "../types";
 
 export function morningBriefing(): string {
   const now = new Date();
@@ -13,11 +20,9 @@ export function morningBriefing(): string {
   const parts: string[] = [
     `Доброго ранку! Сьогодні ${now.toLocaleDateString("uk-UA", { weekday: "long", day: "numeric", month: "long" })}`,
   ];
-  const routineState = ls<HabitState | null>("hub_routine_v1", null);
-  if (routineState?.habits) {
-    const activeHabits = routineState.habits.filter(
-      (h) => !(h as Record<string, unknown>)["archived"],
-    );
+  const routineState = loadRoutineState();
+  if (routineState.habits.length > 0) {
+    const activeHabits = routineState.habits.filter((h) => !h.archived);
     const completions = routineState.completions || {};
     const done = activeHabits.filter(
       (h) =>
@@ -77,11 +82,9 @@ export function weeklySummary(): string {
     0,
   );
   if (totalVolume > 0) parts.push(`Об'єм: ${Math.round(totalVolume)} кг×повт`);
-  const routineState = ls<HabitState | null>("hub_routine_v1", null);
-  if (routineState?.habits) {
-    const activeHabits = routineState.habits.filter(
-      (h) => !(h as Record<string, unknown>)["archived"],
-    );
+  const routineState = loadRoutineState();
+  if (routineState.habits.length > 0) {
+    const activeHabits = routineState.habits.filter((h) => !h.archived);
     const completions = routineState.completions || {};
     let totalDone = 0;
     let totalPossible = 0;

--- a/apps/web/src/core/lib/chatActions/crossActions/exportHandler.ts
+++ b/apps/web/src/core/lib/chatActions/crossActions/exportHandler.ts
@@ -1,4 +1,5 @@
 import { safeReadStringLS } from "@shared/lib/storage/storage";
+import { loadRoutineState } from "../../../../modules/routine/lib/routineStorage";
 import type { ExportModuleDataAction } from "../types";
 
 export function exportModuleData(action: ExportModuleDataAction): string {
@@ -17,6 +18,17 @@ export function exportModuleData(action: ExportModuleDataAction): string {
       return `${label}: ${raw.slice(0, 3000)}`;
     }
   };
+  // Same formatting as `exportData` but for an in-memory value rather
+  // than a raw LS string — used for SQLite-backed modules whose legacy
+  // LS key no longer exists (routine: `hub_routine_v1` is tombstoned).
+  const exportValue = (value: unknown, label: string) => {
+    const raw = JSON.stringify(value);
+    if (!raw || raw === "null" || raw === "{}") return `${label}: немає даних.`;
+    if (fmt === "json")
+      return `${label} (JSON):\n${raw.slice(0, 3000)}${raw.length > 3000 ? "\n…(обрізано)" : ""}`;
+    const pretty = JSON.stringify(value, null, 2);
+    return `${label}: ${pretty.slice(0, 3000)}${raw.length > 3000 ? "\n…(обрізано)" : ""}`;
+  };
   switch (mod) {
     case "finyk": {
       const parts: string[] = ["Експорт Фінік:"];
@@ -31,7 +43,9 @@ export function exportModuleData(action: ExportModuleDataAction): string {
     }
     case "routine": {
       const parts: string[] = ["Експорт Рутина:"];
-      parts.push(exportData("hub_routine_v1", "Звички та виконання"));
+      // SQLite-backed (PR #057r-tombstone) — `hub_routine_v1` is deleted
+      // on boot; read the canonical state via `loadRoutineState()`.
+      parts.push(exportValue(loadRoutineState(), "Звички та виконання"));
       return parts.join("\n");
     }
     case "nutrition": {

--- a/apps/web/src/core/lib/chatActions/crossActions/financeAnalytics.ts
+++ b/apps/web/src/core/lib/chatActions/crossActions/financeAnalytics.ts
@@ -1,3 +1,7 @@
+/* eslint-disable sergeant-design/no-raw-storage-key --
+   Chat-action executor (outside React): the bank tx cache + splits stay
+   on LS (no SQLite canon); hidden-tx / custom-category / per-tx-category
+   reads moved to the SQLite cache. Raw-key burndown tracked for 2026-Q3. */
 import { ls } from "../../hubChatUtils";
 import {
   calcCategorySpent,
@@ -7,6 +11,7 @@ import {
   INTERNAL_TRANSFER_ID,
   mergeExpenseCategoryDefinitions,
 } from "../../../../modules/finyk/constants";
+import { getCachedFinykSqliteState } from "../../../../modules/finyk/lib/sqliteReader";
 import type {
   CategoryBreakdownAction,
   DetectAnomaliesAction,
@@ -29,7 +34,7 @@ export function spendingTrend(action: SpendingTrendAction): string {
     }>;
   } | null>("finyk_tx_cache", null);
   const allTxs = txCache?.txs || [];
-  const hiddenTxIds = ls<string[]>("finyk_hidden_txs", []);
+  const hiddenTxIds = getCachedFinykSqliteState().hiddenTransactions;
   const trendSplits = ls<Record<string, unknown>>("finyk_tx_splits", {});
   const txs = allTxs.filter((t) => !hiddenTxIds.includes(t.id || ""));
   const currentPeriod = txs.filter((t) => {
@@ -76,9 +81,9 @@ export function categoryBreakdown(action: CategoryBreakdownAction): string {
       mcc?: number;
     }>;
   } | null>("finyk_tx_cache", null);
-  const hiddenTxIds = ls<string[]>("finyk_hidden_txs", []);
-  const customC = ls<unknown[]>("finyk_custom_cats_v1", []);
-  const catMap = ls<Record<string, string>>("finyk_tx_cats", {});
+  const hiddenTxIds = getCachedFinykSqliteState().hiddenTransactions;
+  const customC = getCachedFinykSqliteState().customCategories;
+  const catMap = getCachedFinykSqliteState().txCategories;
   const breakdownSplits = ls<Record<string, unknown>>("finyk_tx_splits", {});
   const expenses = (txCache?.txs || []).filter((t) => {
     if (hiddenTxIds.includes(t.id || "")) return false;
@@ -129,7 +134,7 @@ export function detectAnomalies(action: DetectAnomaliesAction): string {
       mcc?: number;
     }>;
   } | null>("finyk_tx_cache", null);
-  const hiddenTxIds = ls<string[]>("finyk_hidden_txs", []);
+  const hiddenTxIds = getCachedFinykSqliteState().hiddenTransactions;
   const anomalySplits = ls<Record<string, unknown>>("finyk_tx_splits", {});
   const expenses = (txCache?.txs || []).filter((t) => {
     if (hiddenTxIds.includes(t.id || "")) return false;

--- a/apps/web/src/core/lib/chatActions/finykActions.test.ts
+++ b/apps/web/src/core/lib/chatActions/finykActions.test.ts
@@ -1,15 +1,21 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { handleFinykAction } from "./finykActions";
+import {
+  __setFinykSqliteStateCacheForTests,
+  clearFinykSqliteCache,
+} from "../../../modules/finyk/lib/sqliteReader";
 import type { ChatAction } from "./types";
 
 beforeEach(() => {
   localStorage.clear();
+  clearFinykSqliteCache();
   vi.useFakeTimers();
   vi.setSystemTime(new Date("2026-04-22T12:00:00"));
 });
 afterEach(() => {
   localStorage.clear();
+  clearFinykSqliteCache();
   vi.useRealTimers();
 });
 
@@ -60,9 +66,8 @@ describe("change_category", () => {
 // ---------------------------------------------------------------------------
 describe("find_transaction", () => {
   it("happy: finds transactions matching query", () => {
-    localStorage.setItem(
-      "finyk_manual_expenses_v1",
-      JSON.stringify([
+    __setFinykSqliteStateCacheForTests({
+      manualExpenses: [
         {
           id: "m_1",
           date: "2026-04-22",
@@ -70,8 +75,8 @@ describe("find_transaction", () => {
           amount: 200,
           category: "food",
         },
-      ]),
-    );
+      ],
+    });
     const out = call({
       name: "find_transaction",
       input: { query: "АТБ" },
@@ -101,12 +106,17 @@ describe("find_transaction", () => {
 // ---------------------------------------------------------------------------
 describe("batch_categorize", () => {
   it("happy: dry-run returns preview string", () => {
-    localStorage.setItem(
-      "finyk_manual_expenses_v1",
-      JSON.stringify([
-        { id: "m_1", date: "2026-04-22", description: "Сільпо", amount: 100 },
-      ]),
-    );
+    __setFinykSqliteStateCacheForTests({
+      manualExpenses: [
+        {
+          id: "m_1",
+          date: "2026-04-22",
+          description: "Сільпо",
+          amount: 100,
+          category: "",
+        },
+      ],
+    });
     const out = call({
       name: "batch_categorize",
       input: { pattern: "Сільпо", category_id: "food" },

--- a/apps/web/src/core/lib/chatActions/finykActions/budgets.ts
+++ b/apps/web/src/core/lib/chatActions/finykActions/budgets.ts
@@ -1,5 +1,10 @@
+/* eslint-disable sergeant-design/no-raw-storage-key --
+   Chat-action executor (outside React). Budget / monthly-plan LS writes
+   are out of this migration's scope (custom-category read moved to the
+   SQLite cache). Raw-key → `STORAGE_KEYS` burndown tracked for 2026-Q3. */
 import { ls, lsSet } from "../../hubChatUtils";
 import { resolveExpenseCategoryMeta } from "../../../../modules/finyk/utils";
+import { getCachedFinykSqliteState } from "../../../../modules/finyk/lib/sqliteReader";
 import type {
   SetBudgetLimitAction,
   SetMonthlyPlanAction,
@@ -28,7 +33,7 @@ export function setBudgetLimit(action: SetBudgetLimitAction): ChatActionResult {
     });
   }
   lsSet("finyk_budgets", budgets);
-  const customC = ls<unknown[]>("finyk_custom_cats_v1", []);
+  const customC = getCachedFinykSqliteState().customCategories;
   const cat = resolveExpenseCategoryMeta(category_id, customC);
   return `Ліміт ${cat?.label || category_id} встановлено: ${limit} грн`;
 }
@@ -68,7 +73,7 @@ export function updateBudget(action: UpdateBudgetAction): ChatActionResult {
       });
     }
     lsSet("finyk_budgets", budgets);
-    const customC = ls<unknown[]>("finyk_custom_cats_v1", []);
+    const customC = getCachedFinykSqliteState().customCategories;
     const cat = resolveExpenseCategoryMeta(categoryId, customC);
     return `Ліміт ${cat?.label || categoryId} оновлено: ${limitN} грн`;
   }

--- a/apps/web/src/core/lib/chatActions/finykActions/debts.ts
+++ b/apps/web/src/core/lib/chatActions/finykActions/debts.ts
@@ -1,4 +1,10 @@
+/* eslint-disable sergeant-design/no-raw-storage-key, @typescript-eslint/no-non-null-assertion --
+   Chat-action executor (outside React): LS writes are the dual-write
+   safety net, the manual-expense write is mirrored into SQLite (see
+   `triggerManualExpenseSqliteMirror`). The non-null assertion is
+   pre-existing. Raw-key burndown tracked for 2026-Q3. */
 import { ls, lsSet } from "../../hubChatUtils";
+import { triggerManualExpenseSqliteMirror } from "../../../../modules/finyk/lib/dualWrite";
 import type {
   CreateDebtAction,
   CreateReceivableAction,
@@ -82,15 +88,19 @@ export function markDebtPaid(action: MarkDebtPaidAction): ChatActionResult {
       type?: string;
     }>
   >("finyk_manual_expenses_v1", []);
-  manualExpenses.unshift({
+  const payEntry = {
     id: txId,
     date: new Date().toISOString(),
     description: (note && String(note).trim()) || `Погашення: ${debt.name}`,
     amount: payAmount,
     category: "",
     type: "expense",
-  });
+  };
+  manualExpenses.unshift(payEntry);
   lsSet("finyk_manual_expenses_v1", manualExpenses);
+  // Mirror the debt-payment expense into SQLite so it shows up in the
+  // migrated manual-expense reads (amount in грн).
+  triggerManualExpenseSqliteMirror(payEntry);
   debt.linkedTxIds = [...(debt.linkedTxIds || []), txId];
   const prevPaid = debt.linkedTxIds
     .filter((lid) => lid !== txId)

--- a/apps/web/src/core/lib/chatActions/finykActions/report.ts
+++ b/apps/web/src/core/lib/chatActions/finykActions/report.ts
@@ -1,5 +1,10 @@
+/* eslint-disable sergeant-design/no-raw-storage-key, sergeant-design/prefer-kyiv-time --
+   Chat-action executor (outside React): the bank tx cache + splits stay
+   on LS (no SQLite canon); the hidden-tx read moved to the SQLite cache.
+   Host-local period math is pre-existing. Raw-key burndown: 2026-Q3. */
 import { ls } from "../../hubChatUtils";
 import { getTxStatAmount } from "../../../../modules/finyk/utils";
+import { getCachedFinykSqliteState } from "../../../../modules/finyk/lib/sqliteReader";
 import type { ExportReportAction, ChatActionResult } from "../types";
 
 export function exportReport(action: ExportReportAction): ChatActionResult {
@@ -32,7 +37,7 @@ export function exportReport(action: ExportReportAction): ChatActionResult {
     const ts = (t.time || 0) * 1000;
     return ts >= fromTs && ts <= toTs;
   });
-  const hiddenTxIds = ls<string[]>("finyk_hidden_txs", []);
+  const hiddenTxIds = getCachedFinykSqliteState().hiddenTransactions;
   const filtered = txs.filter((t) => !hiddenTxIds.includes(t.id));
   const expenses = filtered.filter((t) => t.amount < 0);
   const income = filtered.filter((t) => t.amount > 0);

--- a/apps/web/src/core/lib/chatActions/finykActions/search.ts
+++ b/apps/web/src/core/lib/chatActions/finykActions/search.ts
@@ -1,5 +1,12 @@
+/* eslint-disable sergeant-design/no-raw-storage-key, sergeant-design/prefer-kyiv-time --
+   Chat-action executor (outside React): the bank tx cache stays on LS
+   (no SQLite canon) and the `finyk_tx_cats` write is mirrored into SQLite
+   (see `triggerTxCategorySqliteMirror`). The host-local date parts in
+   `toIsoDay` are pre-existing display/parse code. Raw-key burndown: 2026-Q3. */
 import { ls, lsSet } from "../../hubChatUtils";
 import { resolveExpenseCategoryMeta } from "../../../../modules/finyk/utils";
+import { getCachedFinykSqliteState } from "../../../../modules/finyk/lib/sqliteReader";
+import { triggerTxCategorySqliteMirror } from "../../../../modules/finyk/lib/dualWrite";
 import type {
   BatchCategorizeAction,
   ChangeCategoryAction,
@@ -14,7 +21,25 @@ export type FinykSearchTx = {
   description: string;
   category?: string | undefined;
   type?: string | undefined;
+  /**
+   * Origin of the row, tagged at read time. Manual expenses (грн) come
+   * from the SQLite `manualExpenses` slice; bank rows (kopiykas) from
+   * the `finyk_tx_cache` LS bundle. Drives kopiyka normalisation and
+   * income/expense direction — never re-derive it from the `m_` id
+   * prefix (AI/server manual expenses use a server UUID).
+   */
+  source?: "manual" | "bank" | undefined;
 };
+
+/**
+ * Resolve a row's source. Prefers the read-time `source` tag; falls
+ * back to the `type` field (manual rows carry income/expense), NOT the
+ * `m_` id prefix — AI/server-created manual expenses use a server UUID.
+ */
+export function txSourceOf(tx: FinykSearchTx): "manual" | "bank" {
+  if (tx.source) return tx.source;
+  return tx.type === "income" || tx.type === "expense" ? "manual" : "bank";
+}
 
 export function toIsoDay(value: unknown): string {
   if (typeof value === "string" && /^\d{4}-\d{2}-\d{2}/.test(value)) {
@@ -43,17 +68,28 @@ function normalizeText(value: unknown): string {
     .toLowerCase();
 }
 
+/**
+ * Unified read of Finyk transactions for the search/categorize tools.
+ *
+ * Manual expenses come from the canonical SQLite `manualExpenses` slice
+ * (the finyk module reads the same overlay; the legacy
+ * `finyk_manual_expenses_v1` LS key is drained + tombstoned on boot, so
+ * an AI/server-created expense would otherwise be invisible here). Bank
+ * rows stay on the `finyk_tx_cache` LS bundle — it has no SQLite canon.
+ * Per-tx category overrides and hidden-tx ids also come from SQLite.
+ */
 function readSearchTransactions(): FinykSearchTx[] {
-  const manual = ls<
-    Array<{
-      id?: string;
-      date?: string;
-      description?: string;
-      amount?: number | string;
-      category?: string;
-      type?: string;
-    }>
-  >("finyk_manual_expenses_v1", []);
+  const sqlite = getCachedFinykSqliteState();
+  const manual = sqlite.manualExpenses as ReadonlyArray<{
+    id?: string;
+    date?: string;
+    description?: string;
+    amount?: number | string;
+    category?: string;
+    type?: string;
+  }>;
+  const txCategories = sqlite.txCategories;
+  const hidden = new Set(sqlite.hiddenTransactions);
   const cached = ls<
     | Array<{
         id?: string;
@@ -83,8 +119,6 @@ function readSearchTransactions(): FinykSearchTx[] {
     : Array.isArray(cached.txs)
       ? cached.txs
       : [];
-  const txCategories = ls<Record<string, string>>("finyk_tx_cats", {});
-  const hidden = new Set(ls<string[]>("finyk_hidden_txs", []));
 
   const manualTxs = manual.map((tx): FinykSearchTx | null => {
     const id = String(tx.id || "").trim();
@@ -97,6 +131,7 @@ function readSearchTransactions(): FinykSearchTx[] {
       description: String(tx.description || ""),
       category: txCategories[id] || tx.category || "",
       type: tx.type,
+      source: "manual",
     };
   });
   const cachedTxs = bankTxs.map((tx): FinykSearchTx | null => {
@@ -110,6 +145,7 @@ function readSearchTransactions(): FinykSearchTx[] {
       description: String(tx.description || tx.merchant || ""),
       category: txCategories[id] || tx.category || "",
       type: tx.type,
+      source: "bank",
     };
   });
 
@@ -136,7 +172,7 @@ function matchesFinykSearch(
     if (!haystack.includes(query)) return false;
   }
   if (filters.amount !== undefined) {
-    const source = tx.id.startsWith("m_") ? "manual" : "bank";
+    const source = txSourceOf(tx);
     const diff = Math.abs(toDisplayAmount(tx, source) - filters.amount);
     if (diff > filters.amountTolerance) return false;
   }
@@ -156,7 +192,7 @@ function formatTxList(items: FinykSearchTx[]): string {
     .map((tx) => {
       const category = tx.category ? ` · ${tx.category}` : "";
       const desc = tx.description ? ` · ${tx.description}` : "";
-      const source = tx.id.startsWith("m_") ? "manual" : "bank";
+      const source = txSourceOf(tx);
       return `${tx.id}: ${tx.date || "без дати"} · ${toDisplayAmount(tx, source)} грн${desc}${category}`;
     })
     .join("; ");
@@ -167,7 +203,13 @@ export function changeCategory(action: ChangeCategoryAction): ChatActionResult {
   const cats = ls<Record<string, string>>("finyk_tx_cats", {});
   cats[tx_id] = category_id;
   lsSet("finyk_tx_cats", cats);
-  const customC = ls<unknown[]>("finyk_custom_cats_v1", []);
+  // Mirror into the canonical SQLite `finyk_tx_categories` table — the
+  // migrated category read (here + financeAnalytics) overlays from
+  // SQLite, so an LS-only write would be invisible.
+  triggerTxCategorySqliteMirror([
+    { transactionId: tx_id, categoryId: category_id },
+  ]);
+  const customC = getCachedFinykSqliteState().customCategories;
   const cat = resolveExpenseCategoryMeta(category_id, customC);
   return `Категорію транзакції ${tx_id} змінено на ${cat?.label || category_id}`;
 }
@@ -244,5 +286,10 @@ export function batchCategorize(
   const cats = ls<Record<string, string>>("finyk_tx_cats", {});
   for (const tx of matches) cats[tx.id] = categoryId;
   lsSet("finyk_tx_cats", cats);
+  // Same key as `change_category` — mirror every override into SQLite so
+  // the migrated category read reflects the batch write.
+  triggerTxCategorySqliteMirror(
+    matches.map((tx) => ({ transactionId: tx.id, categoryId })),
+  );
   return `Категорію ${matches.length} транзакц. змінено на ${categoryId}: ${preview}`;
 }

--- a/apps/web/src/core/lib/chatActions/finykActions/transactions.ts
+++ b/apps/web/src/core/lib/chatActions/finykActions/transactions.ts
@@ -1,5 +1,15 @@
+/* eslint-disable sergeant-design/no-raw-storage-key --
+   Chat-action executors run outside React (the finyk `useStorage` hooks
+   are unavailable). LS writes here are kept as the dual-write safety net
+   and mirrored into SQLite alongside (see the `trigger*SqliteMirror`
+   calls). Raw-key → `STORAGE_KEYS` migration is tracked for 2026-Q3. */
 import { ls, lsSet } from "../../hubChatUtils";
 import { resolveExpenseCategoryMeta } from "../../../../modules/finyk/utils";
+import {
+  triggerHiddenTransactionSqliteMirror,
+  triggerManualExpenseDeleteSqliteMirror,
+  triggerManualExpenseSqliteMirror,
+} from "../../../../modules/finyk/lib/dualWrite";
 import type {
   CreateTransactionAction,
   DeleteTransactionAction,
@@ -54,6 +64,11 @@ export function createTransaction(
   };
   manualExpenses.unshift(entry);
   lsSet("finyk_manual_expenses_v1", manualExpenses);
+  // Mirror into the canonical SQLite `finyk_manual_expenses` table —
+  // the migrated reads (query/search/analytics) overlay from SQLite, so
+  // an LS-only write would be invisible to the module UI and the AI's
+  // own follow-up reads. Amount stays in грн (×100 is server-only).
+  triggerManualExpenseSqliteMirror(entry);
   const label = categoryLabel ? ` (${categoryLabel})` : "";
   const human = txType === "income" ? "Дохід" : "Витрату";
   const result = `${human} ${amt} грн${description ? ` "${description.trim()}"` : ""}${label} записано (id:${manualId})`;
@@ -69,6 +84,10 @@ export function createTransaction(
       if (next.length !== current.length) {
         lsSet("finyk_manual_expenses_v1", next);
       }
+      // Keep SQLite in step with the LS undo so the row stops showing up
+      // in the overlay read. Soft-delete is idempotent — safe to fire
+      // even if the LS entry was already removed elsewhere.
+      triggerManualExpenseDeleteSqliteMirror(manualId);
     },
   };
 }
@@ -82,6 +101,9 @@ export function hideTransaction(
     hidden.push(tx_id);
     lsSet("finyk_hidden_txs", hidden);
   }
+  // Mirror into `finyk_hidden_transactions` — the hidden-tx read
+  // (search / analytics / report) overlays from SQLite. Idempotent.
+  triggerHiddenTransactionSqliteMirror(tx_id);
   return `Транзакцію ${tx_id} приховано зі статистики`;
 }
 
@@ -100,6 +122,8 @@ export function deleteTransaction(
   const next = list.slice();
   next.splice(idx, 1);
   lsSet("finyk_manual_expenses_v1", next);
+  // Mirror the removal so the migrated manual-expense read drops it too.
+  triggerManualExpenseDeleteSqliteMirror(id);
   return `Транзакцію ${id} видалено`;
 }
 

--- a/apps/web/src/core/lib/chatActions/queryFinykActions.test.ts
+++ b/apps/web/src/core/lib/chatActions/queryFinykActions.test.ts
@@ -1,15 +1,22 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { handleQueryFinykAction } from "./queryFinykActions";
+import {
+  __setFinykSqliteStateCacheForTests,
+  clearFinykSqliteCache,
+} from "../../../modules/finyk/lib/sqliteReader";
+import type { ManualExpense } from "../../../modules/finyk/hooks/useStorage.types";
 import type { ChatAction } from "./types";
 
 beforeEach(() => {
   localStorage.clear();
+  clearFinykSqliteCache();
   vi.useFakeTimers();
   vi.setSystemTime(new Date("2026-04-22T12:00:00"));
 });
 afterEach(() => {
   localStorage.clear();
+  clearFinykSqliteCache();
   vi.useRealTimers();
 });
 
@@ -21,11 +28,15 @@ function call(action: ChatAction): string {
   return typeof out === "string" ? out : out.result;
 }
 
-/** Seed manual (грн) + bank (kopiykas) transactions for a deterministic dataset. */
+/**
+ * Seed manual (грн) + bank (kopiykas) transactions for a deterministic
+ * dataset. Manual expenses come from the canonical SQLite warm cache
+ * (the executors read it off-React, not LS); the bank cache stays on LS
+ * (`finyk_tx_cache` — no SQLite canon).
+ */
 function seed(): void {
-  localStorage.setItem(
-    "finyk_manual_expenses_v1",
-    JSON.stringify([
+  __setFinykSqliteStateCacheForTests({
+    manualExpenses: [
       {
         id: "m_atb",
         date: "2026-04-10",
@@ -45,6 +56,7 @@ function seed(): void {
         date: "2026-04-01",
         description: "Зарплата",
         amount: 5000,
+        category: "",
         type: "income",
       },
       {
@@ -54,8 +66,8 @@ function seed(): void {
         amount: 120,
         category: "food",
       },
-    ]),
-  );
+    ] as unknown as ManualExpense[],
+  });
   localStorage.setItem(
     "finyk_tx_cache",
     JSON.stringify({
@@ -247,6 +259,45 @@ describe("compare_periods", () => {
     });
     expect(typeof out).toBe("string");
     expect(out.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// txSource regression — AI/server manual expenses carry a server UUID id
+// (no `m_` prefix). The old prefix heuristic misclassified them as bank
+// rows, so direction came from amount-sign instead of `type`, counting an
+// expense (positive amount + type:"expense") as income.
+// ---------------------------------------------------------------------------
+describe("aggregate_spending · AI-created manual expense (UUID id)", () => {
+  it("counts a UUID-id expense as expense, not income", () => {
+    __setFinykSqliteStateCacheForTests({
+      manualExpenses: [
+        {
+          id: "5f3c9b2e-1a4d-4c7e-9f21-abc123def456",
+          date: "2026-04-12",
+          description: "AI витрата",
+          amount: 320,
+          category: "food",
+          type: "expense",
+        },
+      ] as unknown as ManualExpense[],
+    });
+    const expense = call({
+      name: "aggregate_spending",
+      input: {
+        type: "expense",
+        date_from: "2026-04-01",
+        date_to: "2026-04-30",
+      },
+    });
+    expect(expense).toContain("Витрати");
+    expect(expense).toMatch(/320/); // грн, not kopiyka-divided
+
+    const income = call({
+      name: "aggregate_spending",
+      input: { type: "income", date_from: "2026-04-01", date_to: "2026-04-30" },
+    });
+    expect(income).toContain("Немає доходів");
   });
 });
 

--- a/apps/web/src/core/lib/chatActions/queryFinykActions.ts
+++ b/apps/web/src/core/lib/chatActions/queryFinykActions.ts
@@ -1,15 +1,19 @@
 /* eslint-disable sergeant-design/no-raw-storage-key --
    Chat-action executors run synchronously outside React, so the canonical
    Finyk storage wrappers (`modules/finyk/hooks/useStorage`) — which are hooks —
-   are unavailable here. We read the same localStorage keys directly, mirroring
-   the sibling reader in `finykActions/search.ts` (read-only). */
+   are unavailable here. Manual expenses / per-tx categories / hidden-tx ids
+   now read from the canonical SQLite warm cache; only the bank tx cache
+   (`finyk_tx_cache`, no SQLite canon) is still read raw from localStorage,
+   mirroring the sibling reader in `finykActions/search.ts` (read-only). */
 import { getWeekKey } from "@sergeant/shared";
 import { resolveExpenseCategoryMeta } from "@sergeant/finyk-domain/utils";
 import { getKyivDateParts, getKyivDayKey } from "@shared/lib/time/kyivTime";
 import { ls } from "../hubChatUtils";
+import { getCachedFinykSqliteState } from "../../../modules/finyk/lib/sqliteReader";
 import {
   toDisplayAmount,
   toIsoDay,
+  txSourceOf,
   type FinykSearchTx,
 } from "./finykActions/search";
 import type { ChatAction, ChatActionResult } from "./types";
@@ -89,18 +93,19 @@ type RawTx = {
  * `readSearchTransactions` in `finykActions/search.ts`.
  */
 function readQueryTransactions(): FinykSearchTx[] {
-  const manual = ls<RawTx[]>("finyk_manual_expenses_v1", []);
+  const sqlite = getCachedFinykSqliteState();
+  const manual = sqlite.manualExpenses as RawTx[];
   const cached = ls<RawTx[] | { txs?: RawTx[] }>("finyk_tx_cache", []);
   const bankTxs = Array.isArray(cached)
     ? cached
     : Array.isArray(cached.txs)
       ? cached.txs
       : [];
-  const txCategories = ls<Record<string, string>>("finyk_tx_cats", {});
-  const hidden = new Set(ls<string[]>("finyk_hidden_txs", []));
+  const txCategories = sqlite.txCategories;
+  const hidden = new Set(sqlite.hiddenTransactions);
 
   const map =
-    (dateField: (tx: RawTx) => unknown) =>
+    (source: "manual" | "bank", dateField: (tx: RawTx) => unknown) =>
     (tx: RawTx): FinykSearchTx | null => {
       const id = String(tx.id || "").trim();
       if (!id || hidden.has(id)) return null;
@@ -112,12 +117,13 @@ function readQueryTransactions(): FinykSearchTx[] {
         description: String(tx.description || tx.merchant || ""),
         category: txCategories[id] || tx.category || "",
         type: tx.type,
+        source,
       };
     };
 
   return [
-    ...manual.map(map((tx) => tx.date)),
-    ...bankTxs.map(map((tx) => tx.date || tx.time)),
+    ...manual.map(map("manual", (tx) => tx.date)),
+    ...bankTxs.map(map("bank", (tx) => tx.date || tx.time)),
   ].filter((tx): tx is FinykSearchTx => tx !== null);
 }
 
@@ -170,7 +176,12 @@ function normalizeMetric(value: unknown): CompareMetric {
 }
 
 function txSource(tx: FinykSearchTx): "manual" | "bank" {
-  return tx.id.startsWith("m_") ? "manual" : "bank";
+  // Classify by the read-time `source` tag / `type` field — NOT the
+  // `m_` id prefix. AI/server-created manual expenses use a server UUID
+  // (no `m_`), so the old prefix check misread them as bank rows and
+  // `txDirection` then used amount-sign instead of `type`, counting an
+  // AI expense (positive amount + type:"expense") as income.
+  return txSourceOf(tx);
 }
 
 /** Напрям транзакції: manual — за полем `type`, bank — за знаком суми. */
@@ -187,7 +198,7 @@ function txAmountGrn(tx: FinykSearchTx): number {
 }
 
 function readCustomCats(): unknown[] {
-  return ls<unknown[]>("finyk_custom_cats_v1", []);
+  return getCachedFinykSqliteState().customCategories;
 }
 
 function categoryLabel(

--- a/apps/web/src/core/lib/chatActions/serverActions.ts
+++ b/apps/web/src/core/lib/chatActions/serverActions.ts
@@ -25,6 +25,7 @@ import {
   getTransactions,
   saveTransactions,
 } from "../../../modules/finyk/lib/finykStorage";
+import { triggerManualExpenseSqliteMirror } from "../../../modules/finyk/lib/dualWrite";
 import { createTransaction as createTransactionLocal } from "./finykActions/transactions";
 import type { Transaction } from "@sergeant/finyk-domain/domain/types";
 import type {
@@ -206,6 +207,10 @@ async function handleCreateTransaction(
     // saveTransactions — debounced; flush одразу, щоб запис не загубився
     // при швидкому закритті вкладки після відповіді чату.
     flushPendingWrites();
+    // `saveTransactions` пише лише LS; дзеркалимо у канонічний SQLite,
+    // щоб витрата була видима у модульному UI та власних read-tool-ах AI
+    // (amount у грн — ×100 лише для серверного API вище, Hard Rule #1).
+    triggerManualExpenseSqliteMirror(entry);
     const meta = category?.trim()
       ? resolveExpenseCategoryMeta(category.trim(), getCategories())
       : undefined;

--- a/apps/web/src/core/lib/hubChatActionsExtended.test.ts
+++ b/apps/web/src/core/lib/hubChatActionsExtended.test.ts
@@ -14,14 +14,21 @@ import {
   clearSqliteCompletionsCache,
   clearSqliteRoutineStateCache,
 } from "../../modules/routine/lib/sqliteReader";
+import {
+  __setFinykSqliteStateCacheForTests,
+  clearFinykSqliteCache,
+} from "../../modules/finyk/lib/sqliteReader";
+import type { ManualExpense } from "../../modules/finyk/hooks/useStorage.types";
 import { executeAction } from "./hubChatActions";
 
 beforeEach(() => {
-  // Stage 8 PR #057r-tombstone — routine state lives in the SQLite
-  // warm cache, not localStorage. Reset both so each spec starts clean.
+  // Stage 8 PR #057r/#057k-tombstone — routine + finyk canonical state
+  // lives in the SQLite warm caches, not localStorage. Reset all so each
+  // spec starts clean.
   localStorage.clear();
   clearSqliteCompletionsCache();
   clearSqliteRoutineStateCache();
+  clearFinykSqliteCache();
   vi.useFakeTimers();
   vi.setSystemTime(new Date("2024-06-15T12:00:00Z"));
 });
@@ -29,6 +36,7 @@ afterEach(() => {
   localStorage.clear();
   clearSqliteCompletionsCache();
   clearSqliteRoutineStateCache();
+  clearFinykSqliteCache();
   vi.useRealTimers();
 });
 
@@ -46,9 +54,8 @@ function readLS<T>(key: string, fallback: T): T {
 
 describe("find_transaction", () => {
   it("шукає ручну транзакцію за описом і сумою", () => {
-    localStorage.setItem(
-      "finyk_manual_expenses_v1",
-      JSON.stringify([
+    __setFinykSqliteStateCacheForTests({
+      manualExpenses: [
         {
           id: "m_atb",
           amount: 450,
@@ -65,8 +72,8 @@ describe("find_transaction", () => {
           date: "2024-06-15T12:00:00.000Z",
           type: "expense",
         },
-      ]),
-    );
+      ] as unknown as ManualExpense[],
+    });
     const msg = executeAction({
       name: "find_transaction",
       input: { query: "атб", amount: 450 },
@@ -96,7 +103,8 @@ describe("find_transaction", () => {
         ],
       }),
     );
-    localStorage.setItem("finyk_hidden_txs", JSON.stringify(["mono_hidden"]));
+    // Bank tx cache stays on LS; hidden-tx ids are read from SQLite now.
+    __setFinykSqliteStateCacheForTests({ hiddenTransactions: ["mono_hidden"] });
     const msg = executeAction({
       name: "find_transaction",
       input: { query: "сільпо", amount: 125 },
@@ -108,13 +116,12 @@ describe("find_transaction", () => {
 
 describe("batch_categorize", () => {
   it("у dry-run показує preview і не пише категорії", () => {
-    localStorage.setItem(
-      "finyk_manual_expenses_v1",
-      JSON.stringify([
+    __setFinykSqliteStateCacheForTests({
+      manualExpenses: [
         { id: "m_silpo_1", amount: 300, description: "Сільпо центр" },
         { id: "m_silpo_2", amount: 200, description: "Сільпо доставка" },
-      ]),
-    );
+      ] as unknown as ManualExpense[],
+    });
     const msg = executeAction({
       name: "batch_categorize",
       input: { pattern: "сільпо", category_id: "food" },
@@ -125,13 +132,12 @@ describe("batch_categorize", () => {
   });
 
   it("з dry_run=false записує категорію для matched транзакцій", () => {
-    localStorage.setItem(
-      "finyk_manual_expenses_v1",
-      JSON.stringify([
+    __setFinykSqliteStateCacheForTests({
+      manualExpenses: [
         { id: "m_silpo_1", amount: 300, description: "Сільпо центр" },
         { id: "m_taxi", amount: 150, description: "Uklon" },
-      ]),
-    );
+      ] as unknown as ManualExpense[],
+    });
     const msg = executeAction({
       name: "batch_categorize",
       input: { pattern: "сільпо", category_id: "food", dry_run: false },

--- a/apps/web/src/modules/finyk/lib/dualWrite/__tests__/integration.test.ts
+++ b/apps/web/src/modules/finyk/lib/dualWrite/__tests__/integration.test.ts
@@ -3,10 +3,14 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   __clearFinykDualWriteContextForTests,
   applyFinykDualWriteOps,
+  applyFinykDualWriteOpsViaContext,
   dualWriteFinykState,
   isFinykDualWriteRegistered,
   registerFinykDualWriteContext,
   triggerFinykDualWrite,
+  triggerHiddenTransactionSqliteMirror,
+  triggerManualExpenseSqliteMirror,
+  triggerTxCategorySqliteMirror,
   type FinykDualWriteContext,
   type FinykDualWriteState,
 } from "../index.js";
@@ -295,5 +299,109 @@ describe("Finyk dual-write — orchestrator (registerFinykDualWriteContext)", ()
     expect(() =>
       triggerFinykDualWrite(EMPTY_FINYK_STATE, EMPTY_FINYK_STATE),
     ).not.toThrow();
+  });
+});
+
+describe("Finyk dual-write — applyFinykDualWriteOpsViaContext + mirrors", () => {
+  // The mirror helpers are fire-and-forget; drain microtasks + one
+  // macrotask so the async apply chain settles before we read SQLite.
+  const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+  it("skips when no context is registered", async () => {
+    const outcome = await applyFinykDualWriteOpsViaContext([
+      {
+        kind: "id-upsert",
+        table: "finyk_hidden_transactions",
+        entry: { id: "t-1" },
+      },
+    ]);
+    expect(outcome).toEqual({ status: "skipped", reason: "context-unset" });
+  });
+
+  it("applies a pre-built op list through the context (no diff, no parity probe)", async () => {
+    registerFinykDualWriteContext(makeCtx());
+    const outcome = await applyFinykDualWriteOpsViaContext([
+      {
+        kind: "blob-upsert",
+        table: "finyk_manual_expenses",
+        entry: {
+          id: "ai-uuid-1",
+          dataJson: JSON.stringify({
+            id: "ai-uuid-1",
+            amount: 320,
+            type: "expense",
+          }),
+        },
+      },
+    ]);
+    expect(outcome.status).toBe("applied");
+    const rows = await handle.client.all<{ id: string; data_json: string }>(
+      "SELECT id, data_json FROM finyk_manual_expenses WHERE id = ?",
+      ["ai-uuid-1"],
+    );
+    expect(rows).toHaveLength(1);
+    expect(JSON.parse(rows[0]!.data_json).amount).toBe(320);
+  });
+
+  it("triggerManualExpenseSqliteMirror upserts a manual-expense blob (грн)", async () => {
+    registerFinykDualWriteContext(makeCtx());
+    triggerManualExpenseSqliteMirror({
+      id: "m_x",
+      date: "2026-05-04",
+      description: "кава",
+      amount: 120,
+      category: "restaurant",
+      type: "expense",
+    });
+    await flush();
+    const rows = await handle.client.all<{ data_json: string }>(
+      "SELECT data_json FROM finyk_manual_expenses WHERE id = ?",
+      ["m_x"],
+    );
+    expect(rows).toHaveLength(1);
+    // Amount mirrored verbatim in грн — no ×100 (server-API-only).
+    expect(JSON.parse(rows[0]!.data_json).amount).toBe(120);
+  });
+
+  it("triggerHiddenTransactionSqliteMirror upserts a hidden-tx row", async () => {
+    registerFinykDualWriteContext(makeCtx());
+    triggerHiddenTransactionSqliteMirror("tx-hide-1");
+    await flush();
+    const rows = await handle.client.all<{ transaction_id: string }>(
+      "SELECT transaction_id FROM finyk_hidden_transactions WHERE transaction_id = ?",
+      ["tx-hide-1"],
+    );
+    expect(rows).toHaveLength(1);
+  });
+
+  it("triggerTxCategorySqliteMirror upserts per-tx category overrides", async () => {
+    registerFinykDualWriteContext(makeCtx());
+    triggerTxCategorySqliteMirror([
+      { transactionId: "tx-1", categoryId: "food" },
+      { transactionId: "tx-2", categoryId: "transport" },
+    ]);
+    await flush();
+    const rows = await handle.client.all<{
+      transaction_id: string;
+      category_id: string;
+    }>(
+      "SELECT transaction_id, category_id FROM finyk_tx_categories ORDER BY transaction_id",
+    );
+    expect(rows).toEqual([
+      { transaction_id: "tx-1", category_id: "food" },
+      { transaction_id: "tx-2", category_id: "transport" },
+    ]);
+  });
+
+  it("triggerManualExpenseSqliteMirror no-ops with no context registered", async () => {
+    expect(() =>
+      triggerManualExpenseSqliteMirror({ id: "m_none", amount: 10 }),
+    ).not.toThrow();
+    await flush();
+    const rows = await handle.client.all(
+      "SELECT id FROM finyk_manual_expenses WHERE id = ?",
+      ["m_none"],
+    );
+    expect(rows).toHaveLength(0);
   });
 });

--- a/apps/web/src/modules/finyk/lib/dualWrite/index.ts
+++ b/apps/web/src/modules/finyk/lib/dualWrite/index.ts
@@ -14,6 +14,7 @@ import {
 import {
   diffFinykDualWriteOps,
   EMPTY_FINYK_STATE,
+  type FinykDualWriteOp,
   type FinykDualWriteState,
 } from "./diff.js";
 import { probeFinykParity } from "./parity.js";
@@ -173,6 +174,143 @@ export function triggerFinykDualWrite(
 ): void {
   if (!registeredContext) return;
   void Promise.resolve().then(() => dualWriteFinykState(prev, next));
+}
+
+/**
+ * Apply a pre-built op list through the registered context, SKIPPING
+ * the `prev → next` diff and the Stage 8 parity probe that
+ * {@link dualWriteFinykState} runs.
+ *
+ * Off-React callers (Hub chat-action executors) mutate a single entity
+ * and have no full LS-state snapshot to diff. Routing them through
+ * `dualWriteFinykState(EMPTY, next)` would diff against an empty state
+ * (re-emitting every row) and the parity probe would compare a partial
+ * `next` against the full SQLite table and falsely report a mismatch.
+ * This entry point hands the ops straight to the adapter instead.
+ *
+ * Best-effort: never rejects; a missing context / user id / sqlite
+ * client is a no-op. Records the terminal outcome on the shared Sentry
+ * scope like the orchestrator does.
+ */
+export async function applyFinykDualWriteOpsViaContext(
+  ops: readonly FinykDualWriteOp[],
+): Promise<DualWriteOutcome> {
+  const ctx = registeredContext;
+  if (!ctx) return { status: "skipped", reason: "context-unset" };
+  if (ops.length === 0) return { status: "skipped", reason: "no-ops" };
+
+  const userId = ctx.getUserId();
+  if (!userId) {
+    logSafe(ctx, "warn", "dual-write skipped: user id unavailable", {
+      ops: ops.length,
+    });
+    return { status: "skipped", reason: "user-id-missing" };
+  }
+
+  let client: SqliteMigrationClient | null = null;
+  try {
+    client = await ctx.getMigrationClient();
+  } catch (err) {
+    logSafe(ctx, "warn", "dual-write skipped: sqlite unavailable", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return { status: "skipped", reason: "sqlite-unavailable" };
+  }
+  if (!client) {
+    logSafe(ctx, "warn", "dual-write skipped: sqlite returned null", {});
+    return { status: "skipped", reason: "sqlite-unavailable" };
+  }
+
+  const result = await applyFinykDualWriteOps(client, ops, {
+    userId,
+    clientTs: ctx.getNow(),
+    logger: ctx.logger,
+  });
+  const outcome: DualWriteOutcome = { status: "applied", result };
+  recordDualWriteOutcome("finyk", outcome);
+  return outcome;
+}
+
+/** Shape of a manual-expense entry as persisted in the LS bundle (грн). */
+export interface ManualExpenseMirrorEntry {
+  readonly id: string;
+  readonly date?: string;
+  readonly description?: string;
+  /** Amount in **гривні** (minor-unit ×100 is server-only — Hard Rule #1). */
+  readonly amount: number;
+  readonly category?: string;
+  readonly type?: string;
+  readonly [extra: string]: unknown;
+}
+
+/**
+ * Fire-and-forget: mirror a manual-expense create/update into the
+ * `finyk_manual_expenses` SQLite table (blob-upsert). The blob is the
+ * verbatim LS shape — amount stays in **гривні**, matching what the
+ * finyk module's own dual-write extractor writes for the same key.
+ */
+export function triggerManualExpenseSqliteMirror(
+  expense: ManualExpenseMirrorEntry,
+): void {
+  if (!registeredContext || !expense?.id) return;
+  const op: FinykDualWriteOp = {
+    kind: "blob-upsert",
+    table: "finyk_manual_expenses",
+    entry: { id: expense.id, dataJson: JSON.stringify(expense) },
+  };
+  void Promise.resolve().then(() => applyFinykDualWriteOpsViaContext([op]));
+}
+
+/**
+ * Fire-and-forget: mirror a manual-expense removal (undo / delete tool)
+ * into SQLite (blob soft-delete) so the off-React delete agrees with
+ * the create mirror and the row stops showing up in the overlay read.
+ */
+export function triggerManualExpenseDeleteSqliteMirror(id: string): void {
+  if (!registeredContext || !id) return;
+  const op: FinykDualWriteOp = {
+    kind: "blob-delete",
+    table: "finyk_manual_expenses",
+    id,
+  };
+  void Promise.resolve().then(() => applyFinykDualWriteOpsViaContext([op]));
+}
+
+/**
+ * Fire-and-forget: mirror per-tx category overrides (`finyk_tx_cats`)
+ * into SQLite (`tx-category-upsert`). Sibling of
+ * {@link triggerManualExpenseSqliteMirror} for the `change_category` /
+ * `batch_categorize` tools.
+ */
+export function triggerTxCategorySqliteMirror(
+  entries: ReadonlyArray<{ transactionId: string; categoryId: string }>,
+): void {
+  if (!registeredContext) return;
+  const ops: FinykDualWriteOp[] = [];
+  for (const e of entries) {
+    if (!e.transactionId || !e.categoryId) continue;
+    ops.push({
+      kind: "tx-category-upsert",
+      entry: { transactionId: e.transactionId, categoryId: e.categoryId },
+    });
+  }
+  if (ops.length === 0) return;
+  void Promise.resolve().then(() => applyFinykDualWriteOpsViaContext(ops));
+}
+
+/**
+ * Fire-and-forget: mirror a hide-transaction into SQLite
+ * (`id-upsert` on `finyk_hidden_transactions`) so the AI `hide` tool
+ * agrees with the migrated hidden-tx read.
+ */
+export function triggerHiddenTransactionSqliteMirror(txId: string): void {
+  if (!registeredContext || !txId) return;
+  const op: FinykDualWriteOp = {
+    kind: "id-upsert",
+    table: "finyk_hidden_transactions",
+    entry: { id: txId },
+  };
+  void Promise.resolve().then(() => applyFinykDualWriteOpsViaContext([op]));
 }
 
 export type DualWriteOutcome =

--- a/apps/web/src/modules/finyk/lib/sqliteReader.ts
+++ b/apps/web/src/modules/finyk/lib/sqliteReader.ts
@@ -411,6 +411,7 @@ export async function refreshFinykSqliteState(
     showBalance,
     excludedStatTxIds,
     dismissedRecurring,
+    // eslint-disable-next-line no-restricted-syntax -- UTC-anchored refresh timestamp (updatedAt-style), not a Kyiv day boundary; pre-existing
     refreshedAt: new Date().toISOString(),
   };
   return cache;
@@ -429,6 +430,23 @@ function safeStringArray(raw: string | null | undefined): string[] {
 /** Reset cache — used by tests and when the flag is toggled off. */
 export function clearFinykSqliteCache(): void {
   cache = { ...EMPTY_CACHE };
+}
+
+/**
+ * Test-only seeder — overlays `partial` onto the empty cache and marks
+ * it warm (`refreshedAt`). Lets unit tests for the off-React readers
+ * (Hub chat-action executors) seed the canonical SQLite state without a
+ * real sqlite-wasm round trip. Mirrors the routine
+ * `__setRoutineSqliteStateCacheForTests` helper.
+ */
+export function __setFinykSqliteStateCacheForTests(
+  partial: Partial<SqliteFinykCache>,
+): void {
+  cache = {
+    ...EMPTY_CACHE,
+    ...partial,
+    refreshedAt: partial.refreshedAt ?? "2026-01-01T00:00:00.000Z",
+  };
 }
 
 // Suppress unused-warning for the IdRow alias kept above for future


### PR DESCRIPTION
## Summary

Hub AI chat-action executors (`apps/web/src/core/lib/chatActions/**`) run synchronously outside React and still read/wrote **legacy localStorage** for Finyk and Routine, even though both modules moved their canonical store to **SQLite** (Finyk: dual-write tables + `getCachedFinykSqliteState()` overlay; Routine: `hub_routine_v1` tombstoned on boot). So AI reads were stale/empty and AI writes were overwritten by the SQLite overlay or never persisted.

This migrates the remaining handlers to the canonical SQLite source, mirroring the pattern established by #3635 (`queryRoutineActions` → `loadRoutineState()`) and the Finyk dual-write overlay.

- **Reads** → canonical warm caches: `getCachedFinykSqliteState()` slices (`manualExpenses` / `hiddenTransactions` / `txCategories` / `customCategories`) and `loadRoutineState()`. Covered: `queryFinykActions`, `finykActions/{search,budgets,report}`, `crossActions/{financeAnalytics,briefingHandlers,exportHandler}`. The Mono bank cache `finyk_tx_cache` stays on LS (no SQLite canon).
- **Writes** keep the LS write **and** mirror into SQLite via new exports in `modules/finyk/lib/dualWrite/index.ts`:
  - `applyFinykDualWriteOpsViaContext(ops)` — applies a pre-built op list through the registered context, **skipping the diff + full-state parity probe** (a single-entity off-React write has no full snapshot to diff; the probe would false-flag a mismatch).
  - `triggerManualExpenseSqliteMirror` / `triggerManualExpenseDeleteSqliteMirror` / `triggerTxCategorySqliteMirror` / `triggerHiddenTransactionSqliteMirror`.
  - All writers of each migrated key are mirrored: create + undo-delete + delete + debt-paid + server expense (`finyk_manual_expenses`); `change_category` + `batch_categorize` (`finyk_tx_categories`); `hide_transaction` (`finyk_hidden_transactions`).
- **Boot**: `core/hub/chat/useHubChatStorageBoot.ts` (mounted in `HubChat.tsx`) warms the Finyk + Routine read caches and registers the Finyk dual-write context (persisted — no teardown — so it can't null the shared singleton on unmount).
- **Bug fix**: `queryFinykActions.txSource` classified a tx as manual only by the `m_` id prefix → AI/server manual expenses (server UUID id) were read as bank rows and `txDirection` used amount-sign instead of `type`, so an AI expense (positive amount + `type:"expense"`) was counted as income (and ÷100'd). Now classified by a read-time `source` tag (+ `type` fallback).

## Governing Skill

`sergeant-hubchat` — HubChat tool defs / executors / chat side-effects.

## Playbook

No single playbook; follows the storage-roadmap dual-write pattern and the read/write migration shape established by #3635.

## Verification

- `pnpm --filter @sergeant/web typecheck` ✅
- web tests ✅ — **573 passed**. Adapted Finyk seeds to `__setFinykSqliteStateCacheForTests`; added a `txSource` regression test (UUID-id AI expense counted as expense, not income) + dual-write mirror coverage in `dualWrite/__tests__/integration.test.ts`.
- Pre-commit (`eslint --max-warnings=0` + staged typecheck + commitlint) green. In-pattern `eslint-disable` directives were added for **pre-existing** raw-storage-key (Q3 burndown) / kyiv-time / non-null warnings that re-staging the touched files surfaced — mirrors the existing directive in `queryFinykActions.ts`.

## Docs and Governance

Code-only change; no governed docs touched. Hard Rules respected: **#1** (kopiykas as `number` — amounts mirrored in грн verbatim; ×100 stays server-API-only), **#2** (no inline RQ keys), **#5** (conventional scope `web`), **#7** (no `--no-verify`).

## Risk and Rollout

Low. LS writes are retained as the dual-write safety net; mirrors are fire-and-forget and no-op when no context is registered (SSR / pre-boot). No schema migration. Rides on the Finyk dual-write + Routine SQLite read infrastructure already on `main`.

## Hard Rule #15

Read the relevant governance (AGENTS.md, `sergeant-hubchat`, storage-roadmap) before coding; no internal docs changed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move Hub chat-action executors for Finyk and Routine from legacy localStorage to the canonical SQLite caches and mirror writes into SQLite. This makes reads fresh and ensures changes persist across the app.

- **Migration**
  - Reads now use `getCachedFinykSqliteState()` (manualExpenses, hiddenTransactions, txCategories, customCategories) and `loadRoutineState()` across query/search/budgets/report/analytics/briefing/export; the bank cache `finyk_tx_cache` stays on localStorage.
  - Writes keep LS and also mirror to SQLite via `applyFinykDualWriteOpsViaContext`, `triggerManualExpenseSqliteMirror`/`triggerManualExpenseDeleteSqliteMirror`, `triggerTxCategorySqliteMirror`, `triggerHiddenTransactionSqliteMirror`.
  - Boot: `useHubChatStorageBoot` (mounted in `HubChat`) warms the caches and registers the Finyk dual-write context for the session.

- **Bug Fixes**
  - Corrected transaction source detection: classify by a read-time `source` tag (with `type` fallback) instead of the `m_` id prefix, so UUID-id manual expenses are treated as expenses and amounts are interpreted in грн correctly.

<sup>Written for commit e112dd4b093de6e794dc965618df36ade7d637c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

