### PR TITLE
fix(web): read canonical routine + nutrition in the AI chat context builder

### DIFF
--- a/apps/web/src/core/lib/hubChatContext/sections.ts
+++ b/apps/web/src/core/lib/hubChatContext/sections.ts
@@ -9,16 +9,16 @@ import {
 } from "@sergeant/fizruk-domain";
 import { safeReadStringLS } from "@shared/lib/storage/storage";
 import { getKyivDateParts, getKyivDayKey } from "@shared/lib/time/kyivTime";
-import { fmt, ls } from "../hubChatUtils";
+import { fmt } from "../hubChatUtils";
+import { loadRoutineState } from "../../../modules/routine/lib/routineStorage";
+import {
+  loadNutritionLog,
+  loadNutritionPrefs,
+} from "../../../modules/nutrition/lib/nutritionStorage";
 import { generateRecommendations } from "../recommendationEngine";
 import { generateInsights } from "../insightsEngine";
 import { CATEGORY_META, readMemoryEntries } from "../../profile/memoryBank";
-import type {
-  HabitState,
-  NutritionDay,
-  NutritionMeal,
-  NutritionPrefs,
-} from "./types";
+import type { NutritionMeal } from "./types";
 
 /**
  * Kyiv day-key (`YYYY-MM-DD`) for `offsetDays` relative to the Europe/Kyiv
@@ -96,17 +96,17 @@ export function appendWorkoutLines(lines: string[]): void {
 
 export function appendRoutineLines(lines: string[], now: Date): void {
   try {
-    const routineState = ls<HabitState | null>("hub_routine_v1", null);
-    if (!routineState) return;
+    // Stage 8 PR #057r-tombstone retired `hub_routine_v1` — read the canonical
+    // SQLite-backed state (same source the Routine UI + queryRoutineActions use)
+    // so the AI chat context isn't blind to the user's habits.
+    const routineState = loadRoutineState();
     const habits = (routineState.habits || []).filter((h) => !h.archived);
     const completions = routineState.completions || {};
     if (habits.length === 0) return;
 
     const todayKey = getKyivDayKey(now);
-    const todayDone = habits.filter(
-      (h) =>
-        Array.isArray(completions[h.id]) &&
-        completions[h.id]!.includes(todayKey),
+    const todayDone = habits.filter((h) =>
+      (completions[h.id] ?? []).includes(todayKey),
     );
     lines.push(
       `[Рутина] ${habits.length} активних звичок, виконано сьогодні: ${todayDone.length} з ${habits.length}`,
@@ -114,9 +114,7 @@ export function appendRoutineLines(lines: string[], now: Date): void {
 
     const habitDetails = habits
       .map((h) => {
-        const done =
-          Array.isArray(completions[h.id]) &&
-          completions[h.id]!.includes(todayKey);
+        const done = (completions[h.id] ?? []).includes(todayKey);
         return `${h.emoji || ""} ${h.name} (id:${h.id}): ${done ? "✓" : "✗"}`;
       })
       .join(", ");
@@ -129,8 +127,7 @@ export function appendRoutineLines(lines: string[], now: Date): void {
       const dk = kyivDayKeyOffset(now, -dow + i);
       weekTotal += habits.length;
       for (const h of habits) {
-        if (Array.isArray(completions[h.id]) && completions[h.id]!.includes(dk))
-          weekDone++;
+        if ((completions[h.id] ?? []).includes(dk)) weekDone++;
       }
     }
     const weekPct =
@@ -142,12 +139,7 @@ export function appendRoutineLines(lines: string[], now: Date): void {
     let streak = 0;
     for (let i = 0; i < 365; i++) {
       const dk = kyivDayKeyOffset(now, -1 - i);
-      if (
-        habits.every(
-          (h) =>
-            Array.isArray(completions[h.id]) && completions[h.id]!.includes(dk),
-        )
-      ) {
+      if (habits.every((h) => (completions[h.id] ?? []).includes(dk))) {
         streak++;
       } else {
         break;
@@ -160,14 +152,10 @@ export function appendRoutineLines(lines: string[], now: Date): void {
 
 export function appendNutritionLines(lines: string[], now: Date): void {
   try {
-    const nutritionLog = ls<Record<string, NutritionDay>>(
-      "nutrition_log_v1",
-      {},
-    );
-    const nutritionPrefs = ls<NutritionPrefs | null>(
-      "nutrition_prefs_v1",
-      null,
-    );
+    // Tombstoned (#057n) — read the canonical nutrition cache so the AI sees
+    // today's meals + targets, not an empty LS shim.
+    const nutritionLog = loadNutritionLog();
+    const nutritionPrefs = loadNutritionPrefs();
     const todayKey = getKyivDayKey(now);
     const todayData = nutritionLog[todayKey];
 
@@ -197,9 +185,7 @@ export function appendNutritionLines(lines: string[], now: Date): void {
 
     if (nutritionPrefs) {
       const tKcal = nutritionPrefs.dailyTargetKcal;
-      const tProt =
-        nutritionPrefs.dailyTargetProtein_g ||
-        nutritionPrefs.dailyTargetProtein;
+      const tProt = nutritionPrefs.dailyTargetProtein_g;
       if (tKcal || tProt) {
         lines.push(
           `[Харчування ціль] ${tKcal ? `${tKcal} ккал/день` : ""}${tKcal && tProt ? ", " : ""}${tProt ? `білок: ${tProt}г/день` : ""}`,


### PR DESCRIPTION
## Summary

`hubChatContext/sections.ts` builds the context string handed to the AI assistant. `appendRoutineLines` read `hub_routine_v1` and `appendNutritionLines` read `nutrition_log_v1` + `nutrition_prefs_v1` — all **tombstoned** (#057r / #057n), so the keys are drained on boot and these reads returned empty. The AI was **blind to the user's habits, today's meals, and nutrition targets** when chatting — the read-side counterpart of the AI-write bypass.

They now read the canonical caches (`loadRoutineState`, `loadNutritionLog`, `loadNutritionPrefs`) — the same sources the module UIs and `queryRoutineActions` use. Dropped a legacy `dailyTargetProtein` (no `_g`) field that never existed on canonical `NutritionPrefs`, and replaced non-null assertions on `completions[h.id]` with safe access.

## Governing Skill

`sergeant-web-ui`.

## Playbook

n/a — tombstone read-side bug fix, no playbook applies.

## Verification

- `pnpm --filter @sergeant/web typecheck` — clean.
- eslint `sections.ts` — 0 problems.
- No `hubChatContext` test suite exists, so none to adapt (context builder is exercised via the live chat path).
- Not verified in a live browser (deterministic via typecheck; UI repro needs a running stack + authed session).

## Docs and Governance

- [x] I updated docs that changed with the behavior, contract, workflow, or rollout.
- [x] I checked whether `AGENTS.md` needed an update.
- [x] I checked whether a playbook or skill needed an update.
- [x] I checked whether governance docs or review docs needed an update.

Updated docs:

- n/a — behaviour-preserving bug fix; no documented behaviour, contract, or workflow changed.

## Risk and Rollout

- User-visible risk: low — scoped to one context-builder file; reads only, no writes.
- Rollout / deploy order: standard Vercel preview → merge; no migration ordering.
- Backout plan: revert the single commit.

## Hard Rule #15

- [x] I read `AGENTS.md` before coding.
- [x] Internal docs I touched are in Ukrainian.
- [x] I did not use `--no-verify`.

## Follow-up (separate, broader initiative)

Other surfaces still read the tombstoned `hub_routine_v1` LS key — `RoutineCard`, `hubReports.aggregation`, `search/searchSources`, `insights/useCoachInsight`, `lib/dailyFinykSummary`, `lib/recommendationEngine`. A tombstone read-side audit beyond the chat surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the chat context builder to read canonical routine and nutrition data so the assistant sees current habits, today’s meals, and targets. Replaced tombstoned localStorage reads with the same caches used by the modules.

- **Bug Fixes**
  - Read routine via `loadRoutineState`; nutrition via `loadNutritionLog` and `loadNutritionPrefs`.
  - Dropped legacy `dailyTargetProtein` fallback; use `dailyTargetProtein_g`.
  - Replaced non-null assertions on `completions[h.id]` with safe access.
  - Scoped change to read-only context building; no UI changes.

<sup>Written for commit 0122b8817caecc8ee0e932d6c2ca2d33530d1efb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

