### PR TITLE
feat(web): calmer hub home + light-theme contrast fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ storybook-static/
 # Playwright (a11y tests)
 playwright-report/
 test-results/
+# Playwright MCP scratch (snapshots + console logs from agent browser sessions)
+.playwright-mcp/
 
 # Lighthouse CI reports (uploaded as workflow artifact + to temporary-public-storage)
 .lighthouseci/

--- a/apps/web/src/core/app/HubHeader.tsx
+++ b/apps/web/src/core/app/HubHeader.tsx
@@ -12,6 +12,8 @@ import { BrandLogo } from "./BrandLogo";
 import { messages } from "@shared/i18n/uk";
 import type { User } from "@sergeant/shared";
 import { getKyivDateParts } from "@shared/lib/time/kyivTime";
+import { useHubPref } from "../settings/hubPrefs";
+import { NotificationBell, type HubNotification } from "./NotificationBell";
 
 // WCAG 2.5.5 AAA «Target Size (Enhanced)» рекомендує ≥44×44 пкс для hit-areas;
 // Material 3 / iOS HIG — 48 dp / 44 pt як thumb-comfort бейзлайн. На мобільному
@@ -75,6 +77,8 @@ interface HubHeaderProps {
   authLoading?: boolean;
   onShowAuth?: () => void;
   hideAuthButton?: boolean;
+  /** System notifications (SW update / PWA install) surfaced in the bell. */
+  notifications?: readonly HubNotification[];
 }
 
 export function HubHeader({
@@ -84,6 +88,7 @@ export function HubHeader({
   authLoading,
   onShowAuth,
   hideAuthButton = false,
+  notifications,
 }: HubHeaderProps) {
   const greetingText = useMemo(() => {
     const tod = getTimeOfDay();
@@ -94,6 +99,12 @@ export function HubHeader({
 
   const dateStr = useMemo(formatUkrainianDate, []);
   const { modK } = useShortcutGlyph();
+
+  // C · Контроль: «Чистий режим» — один тап ховає весь сигнальний шар
+  // головної (інсайти, app-lock-промпт, мотиваційний футер), лишаючи модулі
+  // + AI-pill. Стан живе у HUB_PREFS і реактивно ділиться з HubDashboard
+  // через `useHubPref` (StorageEvent same-tab).
+  const [calmMode, setCalmMode] = useHubPref<boolean>("calmMode", false);
 
   return (
     <header
@@ -126,6 +137,33 @@ export function HubHeader({
               <Icon name="search" size="lg" />
             </button>
           </Tooltip>
+
+          <Tooltip
+            content={
+              calmMode
+                ? "Показати підказки та інсайти"
+                : "Чистий вигляд — сховати підказки"
+            }
+            placement="bottom-center"
+          >
+            <button
+              type="button"
+              onClick={() => setCalmMode(!calmMode)}
+              aria-pressed={calmMode}
+              aria-label={
+                calmMode ? "Чистий режим: увімкнено" : "Чистий режим: вимкнено"
+              }
+              className={cn(
+                ICON_BUTTON_CLS,
+                calmMode &&
+                  "bg-brand-soft text-brand-strong hover:bg-brand-soft",
+              )}
+            >
+              <Icon name={calmMode ? "eye-off" : "eye"} size="lg" />
+            </button>
+          </Tooltip>
+
+          <NotificationBell notifications={notifications ?? []} />
 
           {onOpenPrivacy && (
             <Tooltip

--- a/apps/web/src/core/app/HubHomeView.tsx
+++ b/apps/web/src/core/app/HubHomeView.tsx
@@ -5,6 +5,7 @@ import { MeshBackground } from "@shared/components/layout/MeshBackground";
 import { ActiveWorkoutBanner } from "./ActiveWorkoutBanner";
 import { HubBottomNav } from "./HubBottomNav";
 import { HubHeader } from "./HubHeader";
+import { type HubNotification } from "./NotificationBell";
 import { HubMainContent } from "./HubMainContent";
 import { HubModals } from "./HubModals";
 import { OfflineBanner } from "./OfflineBanner";
@@ -98,6 +99,35 @@ export function HubHomeView(props: HubHomeViewProps) {
     enabled: hasFirstRealEntry && !inFtuxSession,
   });
 
+  // C · Контроль (home redesign 2026-06): system chrome banners (SW update,
+  // PWA install) move out of the content flow into the header bell. Suppressed
+  // during the FTUX session like the old inline banners were, so the first
+  // signal stays the FirstAction CTA. iOS-install + Trial keep their inline
+  // banners (bespoke UX).
+  const notifications: HubNotification[] = [];
+  if (!inFtuxSession && updateAvailable) {
+    notifications.push({
+      id: "sw-update",
+      icon: "refresh-cw",
+      title: "Доступна нова версія",
+      actionLabel: "Оновити",
+      onAction: onApplyUpdate,
+    });
+  }
+  if (!inFtuxSession && canInstall) {
+    notifications.push({
+      id: "pwa-install",
+      icon: "download",
+      title: "Встановити додаток",
+      description: "Офлайн · пуш-нагадування · ярлик на екрані",
+      actionLabel: "Встановити",
+      onAction: () => {
+        void onInstall();
+      },
+      onDismiss: onDismissInstall,
+    });
+  }
+
   return (
     // Sergeant v2 redesign (2026-05, PR-5) — wraps the hub shell in
     // <MeshBackground> so the mesh-gradient surface (`.bg-mesh` utility
@@ -127,14 +157,10 @@ export function HubHomeView(props: HubHomeViewProps) {
         authLoading={authLoading}
         onShowAuth={onOpenAuth}
         hideAuthButton={shouldShowOnboarding() && !user && inFtuxSession}
+        notifications={notifications}
       />
 
       <HubMainContent
-        updateAvailable={updateAvailable}
-        onApplyUpdate={onApplyUpdate}
-        canInstall={canInstall}
-        onInstall={onInstall}
-        onDismissInstall={onDismissInstall}
         onOpenModule={openModule}
         iosVisible={iosVisible}
         onDismissIos={onDismissIos}

--- a/apps/web/src/core/app/HubMainContent.test.tsx
+++ b/apps/web/src/core/app/HubMainContent.test.tsx
@@ -34,17 +34,10 @@ vi.mock("./IOSInstallBanner", () => ({
   IOSInstallBanner: () => <section data-testid="ios-install-banner" />,
 }));
 
-const replacementCharPattern = new RegExp(String.fromCharCode(0xfffd));
-
 function props(
   overrides: Partial<HubMainContentProps> = {},
 ): HubMainContentProps {
   return {
-    updateAvailable: false,
-    onApplyUpdate: vi.fn(),
-    canInstall: false,
-    onInstall: vi.fn(async () => undefined),
-    onDismissInstall: vi.fn(),
     onOpenModule: vi.fn(),
     iosVisible: false,
     onDismissIos: vi.fn(),
@@ -55,50 +48,25 @@ function props(
   };
 }
 
-describe("HubMainContent chrome banners", () => {
+// SW-update + PWA-install chrome moved to the header `NotificationBell`
+// (C · Контроль home redesign) — their banner behaviour is covered by the
+// bell's own surface now. HubMainContent only owns the inline iOS-install
+// banner + its FTUX suppression.
+describe("HubMainContent iOS install banner", () => {
   afterEach(() => cleanup());
 
-  it("suppresses all install/update chrome while the user is in FTUX", () => {
+  it("suppresses the iOS install banner while the user is in FTUX", () => {
     renderWithClient(
-      <HubMainContent
-        {...props({
-          updateAvailable: true,
-          canInstall: true,
-          iosVisible: true,
-          inFtuxSession: true,
-        })}
-      />,
+      <HubMainContent {...props({ iosVisible: true, inFtuxSession: true })} />,
     );
 
-    expect(screen.queryByText("Доступна нова версія")).toBeNull();
-    expect(screen.queryByText("Встановити додаток")).toBeNull();
     expect(screen.queryByTestId("ios-install-banner")).toBeNull();
     expect(screen.getByTestId("hub-dashboard")).toBeInTheDocument();
   });
 
-  it("shows only the highest-priority available banner", () => {
-    renderWithClient(
-      <HubMainContent
-        {...props({
-          updateAvailable: true,
-          canInstall: true,
-          iosVisible: true,
-        })}
-      />,
-    );
+  it("shows the iOS install banner outside FTUX when iosVisible is set", () => {
+    renderWithClient(<HubMainContent {...props({ iosVisible: true })} />);
 
-    expect(screen.getByText("Доступна нова версія")).toBeInTheDocument();
-    expect(screen.queryByText("Встановити додаток")).toBeNull();
-    expect(screen.queryByTestId("ios-install-banner")).toBeNull();
-  });
-
-  it("renders clean Ukrainian install copy without replacement characters", () => {
-    renderWithClient(<HubMainContent {...props({ canInstall: true })} />);
-
-    expect(screen.getByText("Встановити додаток")).toBeInTheDocument();
-    expect(
-      screen.getByText("Офлайн · пуш-нагадування · ярлик на екрані"),
-    ).toBeInTheDocument();
-    expect(screen.queryByText(replacementCharPattern)).toBeNull();
+    expect(screen.getByTestId("ios-install-banner")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/core/app/HubMainContent.tsx
+++ b/apps/web/src/core/app/HubMainContent.tsx
@@ -1,9 +1,6 @@
-import { memo, useCallback, useEffect, useRef, type ReactNode } from "react";
+import { memo, useCallback, useEffect, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { type User } from "@sergeant/shared";
-import { Button } from "@shared/components/ui/Button";
-import { Card } from "@shared/components/ui/Card";
-import { Icon } from "@shared/components/ui/Icon";
 import { SuspenseWithMinDelay } from "@shared/components/ui/SuspenseWithMinDelay";
 import { ErrorBoundary } from "../ErrorBoundary";
 import { HubDashboard } from "../hub/HubDashboard";
@@ -68,13 +65,6 @@ interface HubSectionFallbackProps {
   resetError: () => void;
 }
 
-interface HubChromeBannerProps {
-  iconName: string;
-  title: string;
-  description?: string;
-  children: ReactNode;
-}
-
 // Дешевий inline-fallback для секцій хаба: повідомляємо про збій і
 // даємо кнопку `reset`, щоб спробувати перемонтувати секцію без
 // перезавантаження вкладки. Шапка/таби лишаються робочими, бо
@@ -94,39 +84,7 @@ function HubSectionFallback({ resetError }: HubSectionFallbackProps) {
   );
 }
 
-function HubChromeBanner({
-  iconName,
-  title,
-  description,
-  children,
-}: HubChromeBannerProps) {
-  return (
-    <div className="px-5 max-w-lg mx-auto w-full mb-2">
-      <Card
-        variant="default"
-        radius="lg"
-        padding="none"
-        className="px-4 py-3 flex items-center gap-3"
-      >
-        <div className="w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center shrink-0">
-          <Icon name={iconName} size={20} className="text-primary" />
-        </div>
-        <div className="min-w-0 flex-1">
-          <p className="text-style-label text-text">{title}</p>
-          {description && <p className="text-xs text-muted">{description}</p>}
-        </div>
-        {children}
-      </Card>
-    </div>
-  );
-}
-
 export interface HubMainContentProps {
-  updateAvailable: boolean;
-  onApplyUpdate: () => void;
-  canInstall: boolean;
-  onInstall: () => Promise<void>;
-  onDismissInstall: () => void;
   onOpenModule: (
     id: string | null | undefined,
     opts?: OpenModuleOptions,
@@ -140,11 +98,6 @@ export interface HubMainContentProps {
 }
 
 export const HubMainContent = memo(function HubMainContent({
-  updateAvailable,
-  onApplyUpdate,
-  canInstall,
-  onInstall,
-  onDismissInstall,
   onOpenModule,
   iosVisible,
   onDismissIos,
@@ -197,63 +150,17 @@ export const HubMainContent = memo(function HubMainContent({
     ]);
   }, [queryClient]);
 
-  // Banner budget: at most one chrome banner above the hub content.
-  // Priority: update > install (PWA) > iOS install.
-  //
-  // During the FTUX session — between the splash and the user's first
-  // real (non-demo) entry — we suppress all three so the dashboard
-  // delivers one signal: the FirstActionRow. Otherwise a first-time
-  // install would see update + install + iOS stack three chrome rows
-  // before any data is visible, which contradicts the 30-second
-  // promise. Banners rehydrate the moment the user logs their first
-  // real entry (see `isFirstRealEntryDone`).
-  const showUpdate = !inFtuxSession && !!updateAvailable;
-  const showInstall = !inFtuxSession && !showUpdate && !!canInstall;
-  const showIos = !inFtuxSession && !showUpdate && !showInstall && iosVisible;
+  // SW-update + PWA-install chrome banners moved to the header bell
+  // (`NotificationBell`) as part of the C · Контроль home redesign — they
+  // were the loudest inline «шум» above the dashboard. The iOS-install
+  // banner keeps its inline placement (bespoke step-by-step instructions
+  // that don't compress into a bell row). Suppressed during the FTUX
+  // session so the one signal on screen stays the FirstAction CTA.
+  const showIos = !inFtuxSession && iosVisible;
 
   return (
     <>
       {!inFtuxSession && <TrialBanner />}
-
-      {showUpdate && (
-        <HubChromeBanner iconName="refresh-cw" title="Доступна нова версія">
-          <Button
-            variant="secondary"
-            size="xs"
-            onClick={onApplyUpdate}
-            className="shrink-0 font-semibold"
-          >
-            Оновити
-          </Button>
-        </HubChromeBanner>
-      )}
-
-      {showInstall && (
-        <HubChromeBanner
-          iconName="download"
-          title="Встановити додаток"
-          description="Офлайн · пуш-нагадування · ярлик на екрані"
-        >
-          <Button
-            variant="primary"
-            size="sm"
-            onClick={onInstall}
-            className="shrink-0 font-semibold"
-          >
-            Так
-          </Button>
-          <Button
-            variant="ghost"
-            size="xs"
-            iconOnly
-            onClick={onDismissInstall}
-            aria-label="Закрити"
-            className="shrink-0 text-muted hover:text-text"
-          >
-            <Icon name="close" size={16} />
-          </Button>
-        </HubChromeBanner>
-      )}
 
       {showIos && <IOSInstallBanner onDismiss={onDismissIos} />}
 

--- a/apps/web/src/core/app/NotificationBell.tsx
+++ b/apps/web/src/core/app/NotificationBell.tsx
@@ -1,0 +1,170 @@
+/**
+ * Last validated: 2026-06-20
+ * Status: Active
+ *
+ * C · Контроль (home redesign 2026-06): consolidates the system chrome
+ * banners (SW update, PWA install) that previously stacked inline above
+ * the dashboard into a single header bell with a count badge. The banners
+ * were the loudest part of the «шум» on the home tab — a fresh install
+ * could see an update + install row before any data was visible. Here they
+ * become on-demand: the bell only renders when something is pending, and a
+ * tap reveals the same actions inside a dropdown.
+ *
+ * Dropdown chrome (trigger a11y, outside-click + ESC close, focus return)
+ * mirrors `ThemeSwitcher`'s `DropdownSwitcher` so the header keeps one
+ * popover idiom. iOS-install and Trial banners stay inline for now — they
+ * carry their own bespoke UX (step-by-step instructions / billing CTA).
+ */
+
+import { useCallback, useEffect, useId, useRef, useState } from "react";
+import { cn } from "@shared/lib/ui/cn";
+import { Icon } from "@shared/components/ui/Icon";
+import { Button } from "@shared/components/ui/Button";
+import { messages } from "@shared/i18n/uk";
+
+const FOCUS_RING =
+  "focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-bg";
+
+export interface HubNotification {
+  /** Stable id for the React key + analytics. */
+  id: string;
+  /** Lucide/Tabler icon token rendered in the row badge. */
+  icon: string;
+  title: string;
+  description?: string;
+  /** Primary action label (e.g. «Оновити», «Встановити»). */
+  actionLabel: string;
+  onAction: () => void;
+  /** When present, renders a «Пізніше» dismiss affordance. */
+  onDismiss?: () => void;
+}
+
+export interface NotificationBellProps {
+  notifications: readonly HubNotification[];
+}
+
+export function NotificationBell({ notifications }: NotificationBellProps) {
+  const [open, setOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const menuId = useId();
+  const count = notifications.length;
+
+  const close = useCallback(() => setOpen(false), []);
+
+  // Close on outside click + ESC; focus returns to the trigger.
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (event: MouseEvent) => {
+      const target = event.target as Node | null;
+      if (!target) return;
+      if (menuRef.current?.contains(target)) return;
+      if (buttonRef.current?.contains(target)) return;
+      close();
+    };
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        close();
+        buttonRef.current?.focus();
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [open, close]);
+
+  // If the last pending notification clears while the menu is open (e.g. the
+  // user installs the PWA → `canInstall` flips false), collapse the popover
+  // so it doesn't linger empty.
+  useEffect(() => {
+    if (count === 0) setOpen(false);
+  }, [count]);
+
+  if (count === 0) return null;
+
+  return (
+    <div className="relative inline-block text-left">
+      <button
+        ref={buttonRef}
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={menuId}
+        aria-label={`Сповіщення: ${count}`}
+        onClick={() => setOpen((value) => !value)}
+        className={cn(
+          "relative w-12 h-12 sm:w-11 sm:h-11 flex items-center justify-center rounded-xl",
+          "text-muted hover:text-text hover:bg-panelHi transition-colors",
+          FOCUS_RING,
+        )}
+      >
+        <Icon name="bell" size="lg" />
+        <span
+          aria-hidden="true"
+          className="absolute top-1.5 right-1.5 min-w-[18px] h-[18px] px-1 rounded-full bg-brand-strong text-white text-xs font-bold leading-[18px] text-center"
+        >
+          {count}
+        </span>
+      </button>
+
+      {open && (
+        <div
+          ref={menuRef}
+          id={menuId}
+          role="menu"
+          // eslint-disable-next-line sergeant-design/no-cyrillic-jsx-literal -- single-use a11y label; i18n catalog reserves entries for strings on ≥2 surfaces
+          aria-label="Сповіщення"
+          className="absolute right-0 mt-2 w-80 max-w-[calc(100vw-2rem)] rounded-2xl border border-line bg-panel shadow-float p-1.5 z-50"
+        >
+          {notifications.map((n) => (
+            <div
+              key={n.id}
+              role="menuitem"
+              className="flex items-start gap-3 px-2.5 py-2.5 rounded-xl"
+            >
+              <span className="shrink-0 mt-0.5 w-8 h-8 inline-flex items-center justify-center rounded-md border border-line bg-panel/60">
+                <Icon name={n.icon} size="md" />
+              </span>
+              <div className="flex-1 min-w-0">
+                <p className="text-style-label text-text leading-tight">
+                  {n.title}
+                </p>
+                {n.description && (
+                  <p className="text-xs text-muted leading-snug mt-0.5">
+                    {n.description}
+                  </p>
+                )}
+                <div className="flex items-center gap-2 mt-2">
+                  <Button
+                    variant="secondary"
+                    size="xs"
+                    onClick={() => {
+                      n.onAction();
+                      close();
+                    }}
+                    className="font-semibold"
+                  >
+                    {n.actionLabel}
+                  </Button>
+                  {n.onDismiss && (
+                    <Button
+                      variant="ghost"
+                      size="xs"
+                      onClick={() => n.onDismiss?.()}
+                      className="text-muted hover:text-text"
+                    >
+                      {messages.actions.later}
+                    </Button>
+                  )}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/core/hub/HubDashboard.tsx
+++ b/apps/web/src/core/hub/HubDashboard.tsx
@@ -12,6 +12,7 @@ import { HubInsightsBlock } from "./HubInsightsBlock";
 import { useHubDashboardState } from "./useHubDashboardState";
 import { DENSITY_OUTER_SPACE, type HubDashboardProps } from "./hub.types";
 import { PrivacyLockBanner } from "../security/PrivacyLockBanner";
+import { useHubPref } from "../settings/hubPrefs";
 
 export const DASHBOARD_MODULE_LABELS = SHARED_DASHBOARD_MODULE_LABELS;
 export {
@@ -26,63 +27,98 @@ export function HubDashboard({
   onShowAuth,
 }: HubDashboardProps) {
   const s = useHubDashboardState({ onOpenModule, user, onShowAuth });
+  // C · Контроль: «Чистий режим» (toggle у HubHeader) ховає весь сигнальний
+  // шар головної — лишаються лише модулі (+ hero для FTUX). Реактивно
+  // оновлюється через спільний HUB_PREFS-стан.
+  const [calmMode] = useHubPref<boolean>("calmMode", false);
+  // C · Контроль (per-section visibility): постійне тонке налаштування з
+  // Settings → Дашборд — на відміну від тимчасового «Чистого режиму», ці
+  // прапори назавжди прибирають конкретні секції. Today-focus ховаємо лише
+  // для досвідченого юзача; у FTUX hero — єдиний CTA, його не чіпаємо.
+  const [showTodayFocus] = useHubPref<boolean>("showTodayFocus", true);
+  const [showInsights] = useHubPref<boolean>("showInsights", true);
+  const [showMotivational] = useHubPref<boolean>("showMotivational", true);
+
+  // A · Тихо (redesign 2026-06): для досвідченого юзача (hasRealEntry)
+  // головна = пульт — модулі піднімаються над hero, а today-focus стає
+  // другорядним під ними. Новачок у FTUX-вікні бачить hero-CTA першим, бо
+  // там немає модульних даних і єдиний сигнал має бути дія. Виносимо обидва
+  // блоки у змінні, щоб не дублювати довгі props-списки між гілками.
+  const hero = (
+    <StaggerChild index={s.hasRealEntry ? 1 : 0}>
+      <HubHeroBlock
+        onOpenModule={onOpenModule}
+        onShowAuth={onShowAuth}
+        user={user}
+        hasRealEntry={s.hasRealEntry}
+        sessionDays={s.sessionDays}
+        entryCount={s.entryCount}
+        onboardingState={s.onboardingState}
+        reengagement={s.reengagement}
+        dismissReengagement={s.dismissReengagement}
+        crossModulePreviewSource={s.crossModulePreviewSource}
+        dismissCrossModulePreview={s.dismissCrossModulePreview}
+        focus={s.focus}
+        dismiss={s.dismiss}
+        primaryModule={s.primaryModule}
+        showChecklist={s.showChecklist}
+        activeModules={s.activeModules}
+        goals={s.goals}
+        hasValueBar={s.hasValueBar}
+      />
+    </StaggerChild>
+  );
+
+  const modules = (
+    <StaggerChild index={s.hasRealEntry ? 0 : 1}>
+      <HubModulesGrid
+        density={s.density}
+        editMode={s.editMode}
+        toggleEditMode={s.toggleEditMode}
+        displayOrder={s.displayOrder}
+        sensors={s.sensors}
+        handleDragStart={s.handleDragStart}
+        handleDragEnd={s.handleDragEnd}
+        onOpenModule={onOpenModule}
+        quickAddByModule={s.quickAddByModule}
+        activeModules={s.activeModules}
+        adaptive={s.adaptive}
+        hasInactive={s.hasInactive}
+        hideInactive={s.hideInactive}
+        toggleHideInactive={s.toggleHideInactive}
+      />
+    </StaggerChild>
+  );
 
   return (
     <div className={DENSITY_OUTER_SPACE[s.density]}>
       <DemoModeBanner />
 
-      {/* GROUP 0 — Hero block */}
-      <StaggerChild index={0}>
-        <HubHeroBlock
-          onOpenModule={onOpenModule}
-          onShowAuth={onShowAuth}
-          user={user}
-          hasRealEntry={s.hasRealEntry}
-          sessionDays={s.sessionDays}
-          entryCount={s.entryCount}
-          onboardingState={s.onboardingState}
-          reengagement={s.reengagement}
-          dismissReengagement={s.dismissReengagement}
-          crossModulePreviewSource={s.crossModulePreviewSource}
-          dismissCrossModulePreview={s.dismissCrossModulePreview}
-          focus={s.focus}
-          dismiss={s.dismiss}
-          primaryModule={s.primaryModule}
-          showChecklist={s.showChecklist}
-          activeModules={s.activeModules}
-          goals={s.goals}
-          hasValueBar={s.hasValueBar}
-        />
-      </StaggerChild>
+      {s.hasRealEntry ? (
+        <>
+          {modules}
+          {showTodayFocus && hero}
+        </>
+      ) : (
+        <>
+          {hero}
+          {modules}
+        </>
+      )}
 
-      {/* GROUP 1 — Module bento grid */}
-      <StaggerChild index={1}>
-        <HubModulesGrid
-          density={s.density}
-          editMode={s.editMode}
-          toggleEditMode={s.toggleEditMode}
-          displayOrder={s.displayOrder}
-          sensors={s.sensors}
-          handleDragStart={s.handleDragStart}
-          handleDragEnd={s.handleDragEnd}
-          onOpenModule={onOpenModule}
-          quickAddByModule={s.quickAddByModule}
-          activeModules={s.activeModules}
-          adaptive={s.adaptive}
-          hasInactive={s.hasInactive}
-          hideInactive={s.hideInactive}
-          toggleHideInactive={s.toggleHideInactive}
-        />
-      </StaggerChild>
+      {/* G4 — App-lock soft-prompt. Self-hides via LS dismissal. Hidden
+          entirely in calm mode. */}
+      {!calmMode && <PrivacyLockBanner />}
 
-      {/* G4 — App-lock soft-prompt. Self-hides via LS dismissal. */}
-      <PrivacyLockBanner />
-
-      {/* GROUP 2 — Insights (post-first-entry) */}
-      {s.hasRealEntry && (
+      {/* GROUP 2 — Insights (post-first-entry). A · Тихо: завжди згорнуті
+          за замовчуванням — увесь розумний шум (інсайти, AI-порада, nudge,
+          дайджест) живе під одним згорнутим pill, який користувач розгортає
+          на вимогу, а не зустрічає розгорнутим на кожному вході.
+          C · Контроль: у «Чистому режимі» прибирається повністю. */}
+      {s.hasRealEntry && !calmMode && showInsights && (
         <StaggerChild index={2}>
           <HubInsightsBlock
-            insightsDefaultOpen={s.insightsDefaultOpen}
+            insightsDefaultOpen={false}
             coachLoading={s.coachLoading}
             coachError={s.coachError}
             coachInsightText={s.coachInsightText}
@@ -102,7 +138,7 @@ export function HubDashboard({
         </StaggerChild>
       )}
 
-      <MotivationalFooter />
+      {!calmMode && showMotivational && <MotivationalFooter />}
 
       <FirstEntryCelebrationModal
         open={s.celebration.open}

--- a/apps/web/src/core/hub/HubReports.tsx
+++ b/apps/web/src/core/hub/HubReports.tsx
@@ -9,6 +9,7 @@
 import { useState, useMemo, useCallback, lazy, Suspense } from "react";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Button } from "@shared/components/ui/Button";
+import { Segmented } from "@shared/components/ui/Segmented";
 import { Icon, type IconName } from "@shared/components/ui/Icon";
 import { cn } from "@shared/lib/ui/cn";
 import { exportToPDF } from "@shared/lib/ui/export";
@@ -132,26 +133,21 @@ export function HubReports() {
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between gap-2">
-        <div className="flex rounded-xl overflow-hidden border border-line shrink-0">
-          {(["week", "month"] as const).map((p) => (
-            <button
-              key={p}
-              type="button"
-              onClick={() => {
-                setPeriod(p);
-                setOffset(0);
-              }}
-              className={cn(
-                "px-3 py-1.5 text-style-caption transition-colors",
-                period === p
-                  ? "bg-brand-strong text-white"
-                  : "text-muted hover:text-text hover:bg-panelHi",
-              )}
-            >
-              {p === "week" ? "Тиждень" : "Місяць"}
-            </button>
-          ))}
-        </div>
+        <Segmented<Period>
+          size="sm"
+          style="solid"
+          ariaLabel="Період звіту"
+          value={period}
+          onChange={(p) => {
+            setPeriod(p);
+            setOffset(0);
+          }}
+          items={[
+            { value: "week", label: "Тиждень" },
+            { value: "month", label: "Місяць" },
+          ]}
+          className="shrink-0"
+        />
 
         <div className="flex items-center gap-1">
           <Button

--- a/apps/web/src/core/lib/featureFlags.ts
+++ b/apps/web/src/core/lib/featureFlags.ts
@@ -63,7 +63,7 @@ export const FLAG_REGISTRY: readonly FlagDefinition[] = [
     id: "ftux_outcome_card_v1",
     label: "FTUX outcome-card",
     description:
-      "РџРѕРєР°Р·СѓС” outcome-card Р·Р°РјС–СЃС‚СЊ РїСЂРѕРіСЂРµСЃСѓ РґР»СЏ cold-start cohort Р±РµР· РїРµСЂС€РѕРіРѕ Р·Р°РїРёСЃСѓ.",
+      "Показує outcome-card замість прогресу для cold-start cohort без першого запису.",
     defaultValue: false,
     experimental: true,
   },

--- a/apps/web/src/core/settings/DashboardSection.tsx
+++ b/apps/web/src/core/settings/DashboardSection.tsx
@@ -34,6 +34,18 @@ export function DashboardSection() {
     "adaptiveBento",
     true,
   );
+  const [showTodayFocus, setShowTodayFocus] = useHubPref<boolean>(
+    "showTodayFocus",
+    true,
+  );
+  const [showInsights, setShowInsights] = useHubPref<boolean>(
+    "showInsights",
+    true,
+  );
+  const [showMotivational, setShowMotivational] = useHubPref<boolean>(
+    "showMotivational",
+    true,
+  );
   const [density, setDensityState] = useState<DashboardDensity>(() => {
     const raw = safeReadStringLS(STORAGE_KEYS.DASHBOARD_DENSITY);
     return raw === null
@@ -86,6 +98,24 @@ export function DashboardSection() {
           description="Піднімає в топ модуль, актуальний зараз — за часом дня та сигналами. Ваш порядок зберігається."
           checked={adaptiveBento !== false}
           onChange={setAdaptiveBento}
+        />
+        <ToggleRow
+          label="Картка «Сьогодні»"
+          description="Фокус дня над модулями. Вимкни, щоб головна починалася одразу з модулів."
+          checked={showTodayFocus !== false}
+          onChange={setShowTodayFocus}
+        />
+        <ToggleRow
+          label="Інсайти та AI-поради"
+          description="Згорнутий блок з інсайтами, порадою коуча та звітом тижня внизу головної."
+          checked={showInsights !== false}
+          onChange={setShowInsights}
+        />
+        <ToggleRow
+          label="Мотиваційний підпис"
+          description="Короткий заохочувальний рядок у самому низу головної."
+          checked={showMotivational !== false}
+          onChange={setShowMotivational}
         />
         <div className="space-y-2">
           <p className="text-xs text-subtle leading-snug">

--- a/apps/web/src/shared/components/ui/CollapsibleSection.tsx
+++ b/apps/web/src/shared/components/ui/CollapsibleSection.tsx
@@ -109,7 +109,7 @@ export function CollapsibleSection({
           className={cn(
             "flex items-center gap-3 w-full text-left",
             "px-3.5 py-3 rounded-2xl",
-            "bg-panel/70 hover:bg-panelHi border border-line/70",
+            "bg-panel hover:bg-panelHi border border-line shadow-soft",
             "transition-colors active:scale-[0.99]",
             "focus:outline-none focus-visible:ring-2 focus-visible:ring-focus/60",
           )}

--- a/apps/web/src/styles/theme.css
+++ b/apps/web/src/styles/theme.css
@@ -783,7 +783,12 @@
     --surface-glass: rgba(255, 255, 255, 0.82); /* default card */
     --surface-strong-glass: rgba(255, 255, 255, 0.92); /* navs, pills */
     --surface-soft-glass: rgba(255, 255, 255, 0.5); /* tinted backgrounds */
-    --surface-line: rgba(255, 255, 255, 0.55); /* card hairline (inset) */
+    /* Card hairline — warm dark edge so glass cards read against the cream
+       mesh background (and against each other) in light mode. The white
+       inset highlight that sells the "glass" look lives in --shadow-card-v2,
+       so the border can be a real visible edge here. Previously
+       rgba(255,255,255,0.55) — invisible white-on-cream (user report). */
+    --surface-line: rgba(20, 40, 30, 0.12);
 
     /* Hairlines — soft + strong dividers tuned for glass surfaces. */
     --line-v2: rgba(0, 0, 0, 0.06);
@@ -799,7 +804,7 @@
 
     /* Shadows — glass-surface recipes (inset highlight + outer drop). */
     --shadow-card-v2:
-      0 1px 0 rgba(255, 255, 255, 0.5) inset, 0 4px 14px rgba(20, 40, 30, 0.05);
+      0 1px 0 rgba(255, 255, 255, 0.5) inset, 0 4px 14px rgba(20, 40, 30, 0.09);
     --shadow-pill:
       0 1px 0 rgba(255, 255, 255, 0.8) inset, 0 10px 26px rgba(20, 40, 30, 0.12);
     --shadow-nav:


### PR DESCRIPTION
## Summary

Two-part hub-home improvement from a UX-feedback session («шум та розміщення підказок на головній»).

**Light-theme defect fixes** (commit 1 — `fix(web)`):
- featureFlags: repair cp1251 mojibake in the FTUX outcome-card flag description (rendered as `РџРѕРєР°Р·…` in Settings → Advanced)
- theme.css: visible warm hairline + slightly stronger card shadow in light mode — white-on-cream `--surface-line` was invisible, so glass cards blended into the mesh and each other
- HubReports: week/month toggle → canonical `Segmented` (clear active fill, visible inactive pill on cream)
- CollapsibleSection: opaque panel + shadow on the collapsed Profile pills (were `bg-panel/70` + invisible border → read "raw")

**Calmer hub home** (commit 2 — `feat(web)`):
- **A · Тихо** — experienced users (post-first-entry) get the module bento above the today-focus hero; insights collapse by default. FTUX first-run hero stays the single CTA.
- **C · Контроль** — calm-mode header toggle (eye) hides the whole signal layer in one tap; SW-update / PWA-install chrome banners consolidated into a header `NotificationBell` (count badge + dropdown), inline banners removed; per-section visibility toggles in Settings → Dashboard (today-focus / insights / motivational footer).

iOS-install + Trial banners intentionally stay inline (bespoke UX).

## Governing Skill
`sergeant-web-ui`

## Playbook
N/A — UX-feedback-driven iteration, no single playbook.

## Verification
- `pnpm --filter @sergeant/web typecheck` — clean (all runs, exit 0)
- `pnpm --filter @sergeant/web lint` — 0 errors; every changed file 0 warnings (lint-staged `--max-warnings=0` passed on both commits)
- `vitest run HubMainContent.test.tsx` — 2/2 passed (rewritten for iOS-only inline contract)
- Browser (Playwright on local db+server+web stack): calm toggle on/off, notification bell badge + dropdown + action/dismiss, per-section toggles present, light-theme contrast via `getComputedStyle`. Full-page screenshots time out in this env, so visual checks are computed-style measurements.

## Docs and Governance
No canonical-doc changes. `.gitignore`: added `.playwright-mcp/` (agent browser scratch).

## Risk and Rollout
- Light-theme token change (`--surface-line`, `--shadow-card-v2`) is **light-mode only** — dark + HC values untouched (verified via computed `getPropertyValue`).
- Banner consolidation removes the inline update/install rows; same actions available in the bell. iOS-install + Trial unchanged.
- Calm-mode + all per-section toggles default to "show" → **no behaviour change unless the user opts in**.
- No DB migrations, no API contract changes.

## Hard Rule #15
Governance read before coding; the only doc touched (`.gitignore`) is updated alongside. No internal-doc bodies changed (language rule N/A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Calmed the hub home by moving modules above the Today card for experienced users, collapsing insights by default, and adding a one-tap Calm Mode. Also fixed light-theme contrast and replaced the reports period switch with a clearer `Segmented` control.

- **New Features**
  - Modules-first layout after the first real entry; FTUX keeps the single CTA hero.
  - Calm Mode toggle in the header hides insights, app-lock prompt, and the motivational footer.
  - Header `NotificationBell` consolidates SW update and PWA install; inline banners removed (iOS install + Trial remain inline).
  - New dashboard visibility toggles in Settings → Dashboard (Today card, Insights, Motivational footer).
  - Reports: replaced the ad‑hoc week/month switch with the canonical `Segmented` control.

- **Bug Fixes**
  - Light theme: visible card hairline and slightly stronger card shadow for better contrast.
  - Fixed mojibake in the FTUX outcome-card flag description in `featureFlags`.
  - `CollapsibleSection`: opaque panel and shadow on collapsed rows for proper separation.

<sup>Written for commit 7940f265690b310e2dd00fb14e65e41c14ba4a05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/3662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notification bell to header displaying system notifications (app updates and PWA installation prompts)
  * New "Calm Mode" toggle to customize dashboard visibility
  * Dashboard section preferences to control visibility of Today card, Insights, and Motivational footer

* **UI/Style Improvements**
  * Redesigned report period selector interface
  * Enhanced glass effect styling for improved visual hierarchy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->